### PR TITLE
DFE-285: Disable Affinity cookie on content API

### DIFF
--- a/armTemplates/service-template.json
+++ b/armTemplates/service-template.json
@@ -154,6 +154,7 @@
       ],
       "properties": {
         "siteConfig": {
+          "clientAffinityEnabled": false,
           "appSettings": [
             {
               "name": "APPINSIGHTS_INSTRUMENTATIONKEY",


### PR DESCRIPTION
Disables the ARR Affinity cookie on content api as it is a stateless application