### PR TITLE
DFE-320 Open accordion section if URL hash matches a section content element

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/Accordion.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Accordion.tsx
@@ -1,6 +1,9 @@
 import React, { cloneElement, Component, createRef, ReactNode } from 'react';
 import isComponentType from '../lib/type-guards/components/isComponentType';
-import AccordionSection, { AccordionSectionProps } from './AccordionSection';
+import AccordionSection, {
+  AccordionSectionProps,
+  classes,
+} from './AccordionSection';
 
 export interface AccordionProps {
   children: ReactNode;
@@ -8,12 +11,12 @@ export interface AccordionProps {
 }
 
 interface State {
-  hash: string;
+  openSectionId: string;
 }
 
 class Accordion extends Component<AccordionProps, State> {
   public state = {
-    hash: '',
+    openSectionId: '',
   };
 
   private ref = createRef<HTMLDivElement>();
@@ -36,41 +39,58 @@ class Accordion extends Component<AccordionProps, State> {
   }
 
   private goToHash = () => {
-    this.setState({ hash: location.hash });
-
     if (this.ref.current && location.hash) {
-      const anchor = this.ref.current.querySelector(
-        location.hash,
-      ) as HTMLButtonElement;
+      const locationHashEl = this.ref.current.querySelector(location.hash);
 
-      if (anchor) {
-        anchor.scrollIntoView();
+      if (locationHashEl) {
+        const sectionEl = locationHashEl.closest(`.${classes.section}`);
+
+        if (sectionEl) {
+          const contentEl = sectionEl.querySelector(
+            `.${classes.sectionContent}`,
+          );
+
+          if (contentEl) {
+            if (window.sessionStorage.getItem(contentEl.id) === 'false') {
+              window.sessionStorage.removeItem(contentEl.id);
+            }
+
+            this.setState(
+              {
+                openSectionId: contentEl.id,
+              },
+              () => {
+                locationHashEl.scrollIntoView({ block: 'start' });
+              },
+            );
+          }
+        }
       }
     }
   };
 
   public render() {
     const { children, id } = this.props;
-    const { hash } = this.state;
+    const { openSectionId } = this.state;
 
-    let sectionId = 0;
+    let sectionCounter = 0;
 
     return (
       <div className="govuk-accordion" ref={this.ref} id={id}>
         {React.Children.map(children, child => {
           if (isComponentType(child, AccordionSection)) {
-            sectionId += 1;
+            sectionCounter += 1;
 
-            const contentId = `${id}-content-${sectionId}`;
-            const headingId = `${id}-heading-${sectionId}`;
+            const contentId = `${id}-content-${sectionCounter}`;
+            const headingId = `${id}-heading-${sectionCounter}`;
 
-            const isLocationHashMatching =
-              hash === `#${headingId}` || hash === `#${contentId}`;
+            const isSectionOpen =
+              openSectionId === headingId || openSectionId === contentId;
 
             return cloneElement<AccordionSectionProps>(child, {
               contentId,
               headingId,
-              open: child.props.open || isLocationHashMatching,
+              open: child.props.open || isSectionOpen,
             });
           }
 

--- a/src/explore-education-statistics-frontend/src/components/AccordionSection.tsx
+++ b/src/explore-education-statistics-frontend/src/components/AccordionSection.tsx
@@ -18,6 +18,12 @@ export interface AccordionSectionProps {
   onToggle?: (open: boolean) => void;
 }
 
+export const classes = {
+  section: 'govuk-accordion__section',
+  sectionButton: 'govuk-accordion__section-button',
+  sectionContent: 'govuk-accordion__section-content',
+};
+
 const AccordionSection = ({
   caption,
   className,
@@ -41,7 +47,7 @@ const AccordionSection = ({
           );
         }
       }}
-      className={classNames('govuk-accordion__section', className, {
+      className={classNames(classes.section, className, {
         'govuk-accordion__section--expanded': open,
       })}
     >
@@ -54,7 +60,7 @@ const AccordionSection = ({
           {
             className: 'govuk-accordion__section-heading',
           },
-          <span className="govuk-accordion__section-button" id={headingId}>
+          <span className={classes.sectionButton} id={headingId}>
             {heading}
           </span>,
         )}
@@ -64,7 +70,7 @@ const AccordionSection = ({
       </div>
 
       <div
-        className="govuk-accordion__section-content"
+        className={classes.sectionContent}
         aria-labelledby={headingId}
         id={contentId}
       >

--- a/src/explore-education-statistics-frontend/src/components/__tests__/Accordion.test.tsx
+++ b/src/explore-education-statistics-frontend/src/components/__tests__/Accordion.test.tsx
@@ -137,4 +137,30 @@ describe('Accordion', () => {
 
     expect(content.scrollIntoView).toHaveBeenCalled();
   });
+
+  test('scrolls to and opens section if location hash matches an element in the section content', async () => {
+    location.hash = '#test-heading';
+
+    const { container, getByText } = render(
+      <Accordion id="test-sections">
+        <AccordionSection heading="Test heading 1">
+          Test content 1
+        </AccordionSection>
+        <AccordionSection heading="Test heading 2">
+          <h2 id="test-heading">Test content heading</h2>
+        </AccordionSection>
+      </Accordion>,
+    );
+
+    await wait();
+
+    expect(getByText('Test heading 2')).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+
+    const element = container.querySelector('#test-heading') as HTMLElement;
+
+    expect(element.scrollIntoView).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
This PR adds additional logic to open the nearest `AccordionSection` when an element in the section's content has an ID that matches the URL hash. The element can then be scrolled to in the section.