### PR TITLE
DFE-441 Fix window jumping on clicking Tab links

### DIFF
--- a/src/explore-education-statistics-admin/test/setupTests.js
+++ b/src/explore-education-statistics-admin/test/setupTests.js
@@ -15,6 +15,16 @@ global.localStorage = localStorageMock;
 
 Element.prototype.scrollIntoView = jest.fn();
 
+beforeEach(() => {
+  window.matchMedia = jest.fn(() => {
+    return {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      matches: true,
+    };
+  });
+});
+
 afterEach(() => {
   location.hash = '';
 });

--- a/src/explore-education-statistics-common/src/components/Accordion.tsx
+++ b/src/explore-education-statistics-common/src/components/Accordion.tsx
@@ -42,7 +42,13 @@ class Accordion extends Component<AccordionProps, State> {
 
   private goToHash = () => {
     if (this.ref.current && location.hash) {
-      const locationHashEl = this.ref.current.querySelector(location.hash);
+      let locationHashEl: HTMLElement | null = null;
+
+      try {
+        locationHashEl = this.ref.current.querySelector(location.hash);
+      } catch (_) {
+        return;
+      }
 
       if (locationHashEl) {
         const sectionEl = locationHashEl.closest(`.${classes.section}`);
@@ -62,7 +68,9 @@ class Accordion extends Component<AccordionProps, State> {
                 openSectionId: contentEl.id,
               },
               () => {
-                locationHashEl.scrollIntoView({ block: 'start' });
+                (locationHashEl as HTMLElement).scrollIntoView({
+                  block: 'start',
+                });
               },
             );
           }

--- a/src/explore-education-statistics-common/src/components/Tabs.tsx
+++ b/src/explore-education-statistics-common/src/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import useMounted from '@common/hooks/useMounted';
+import { useDesktopMedia } from '@common/hooks/useMedia';
 import isComponentType from '@common/lib/type-guards/components/isComponentType';
 import classNames from 'classnames';
 import React, {
@@ -33,12 +33,14 @@ const Tabs = ({ children }: Props) => {
   const [loadedSections, setLoadedSections] = useState(new Set<number>());
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
 
-  const { onMounted } = useMounted();
+  const { onMedia } = useDesktopMedia();
 
   const tabElements: HTMLAnchorElement[] = [];
   const sectionElements: HTMLElement[] = [];
 
   const setSelectedTab = (index: number) => {
+    window.location.hash = sectionElements[index].id;
+
     setLoadedSections(loadedSections.add(index));
     setSelectedTabIndex(index);
   };
@@ -55,16 +57,20 @@ const Tabs = ({ children }: Props) => {
             role="presentation"
           >
             <a
-              aria-controls={onMounted(props.id)}
-              aria-selected={onMounted(selectedTabIndex === index)}
+              aria-controls={onMedia(props.id)}
+              aria-selected={onMedia(selectedTabIndex === index)}
+              role={onMedia('tab')}
               className={classNames('govuk-tabs__tab', {
                 'govuk-tabs__tab--selected': selectedTabIndex === index,
               })}
               href={`#${props.id}`}
               id={`${props.id}-tab`}
               ref={(element: HTMLAnchorElement) => tabElements.push(element)}
-              role={onMounted('tab')}
-              onClick={() => setSelectedTab(index)}
+              tabIndex={selectedTabIndex !== index ? -1 : undefined}
+              onClick={event => {
+                event.preventDefault();
+                setSelectedTab(index);
+              }}
               onKeyDown={event => {
                 switch (event.key) {
                   case 'ArrowLeft': {
@@ -94,7 +100,6 @@ const Tabs = ({ children }: Props) => {
                     break;
                 }
               }}
-              tabIndex={selectedTabIndex !== index ? -1 : undefined}
             >
               {props.title}
             </a>

--- a/src/explore-education-statistics-common/src/components/Tabs.tsx
+++ b/src/explore-education-statistics-common/src/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import useRendered from '@common/hooks/useRendered';
+import useMounted from '@common/hooks/useMounted';
 import isComponentType from '@common/lib/type-guards/components/isComponentType';
 import classNames from 'classnames';
 import React, {
@@ -33,7 +33,7 @@ const Tabs = ({ children }: Props) => {
   const [loadedSections, setLoadedSections] = useState(new Set<number>());
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
 
-  const { onRendered } = useRendered();
+  const { onMounted } = useMounted();
 
   const tabElements: HTMLAnchorElement[] = [];
   const sectionElements: HTMLElement[] = [];
@@ -55,15 +55,15 @@ const Tabs = ({ children }: Props) => {
             role="presentation"
           >
             <a
-              aria-controls={onRendered(props.id)}
-              aria-selected={onRendered(selectedTabIndex === index)}
+              aria-controls={onMounted(props.id)}
+              aria-selected={onMounted(selectedTabIndex === index)}
               className={classNames('govuk-tabs__tab', {
                 'govuk-tabs__tab--selected': selectedTabIndex === index,
               })}
               href={`#${props.id}`}
               id={`${props.id}-tab`}
               ref={(element: HTMLAnchorElement) => tabElements.push(element)}
-              role={onRendered('tab')}
+              role={onMounted('tab')}
               onClick={() => setSelectedTab(index)}
               onKeyDown={event => {
                 switch (event.key) {

--- a/src/explore-education-statistics-common/src/components/TabsSection.tsx
+++ b/src/explore-education-statistics-common/src/components/TabsSection.tsx
@@ -1,12 +1,6 @@
-import useMounted from '@common/hooks/useMounted';
+import { useDesktopMedia } from '@common/hooks/useMedia';
 import classNames from 'classnames';
-import React, {
-  forwardRef,
-  FunctionComponent,
-  HTMLAttributes,
-  ReactNode,
-  Ref,
-} from 'react';
+import React, { forwardRef, HTMLAttributes, ReactNode } from 'react';
 import styles from './TabsSection.module.scss';
 
 export interface TabsSectionProps {
@@ -20,9 +14,9 @@ export interface TabsSectionProps {
   title: string;
 }
 
-const TabsSection: FunctionComponent<TabsSectionProps> = forwardRef(
-  ({ children, id, ...restProps }: TabsSectionProps, ref: Ref<HTMLElement>) => {
-    const { onMounted } = useMounted();
+const TabsSection = forwardRef<HTMLElement, TabsSectionProps>(
+  ({ children, id, ...restProps }, ref) => {
+    const { onMedia } = useDesktopMedia();
 
     // Hide additional props from the component's public API to
     // avoid any confusion over this component's usage as
@@ -31,15 +25,14 @@ const TabsSection: FunctionComponent<TabsSectionProps> = forwardRef(
 
     return (
       <section
-        aria-labelledby={onMounted(tabProps['aria-labelledby'])}
+        aria-labelledby={onMedia(tabProps['aria-labelledby'])}
         className={classNames('govuk-tabs__panel', styles.panel, {
           'govuk-tabs__panel--hidden': tabProps.hidden,
         })}
         id={id}
-        hidden={tabProps.hidden}
         ref={ref}
-        role={onMounted('tabpanel')}
-        tabIndex={onMounted(-1)}
+        role={onMedia('tabpanel')}
+        tabIndex={onMedia(-1)}
         data-testid={tabProps.title}
       >
         {children}

--- a/src/explore-education-statistics-common/src/components/TabsSection.tsx
+++ b/src/explore-education-statistics-common/src/components/TabsSection.tsx
@@ -1,4 +1,4 @@
-import useRendered from '@common/hooks/useRendered';
+import useMounted from '@common/hooks/useMounted';
 import classNames from 'classnames';
 import React, {
   forwardRef,
@@ -22,7 +22,7 @@ export interface TabsSectionProps {
 
 const TabsSection: FunctionComponent<TabsSectionProps> = forwardRef(
   ({ children, id, ...restProps }: TabsSectionProps, ref: Ref<HTMLElement>) => {
-    const { onRendered } = useRendered();
+    const { onMounted } = useMounted();
 
     // Hide additional props from the component's public API to
     // avoid any confusion over this component's usage as
@@ -31,15 +31,15 @@ const TabsSection: FunctionComponent<TabsSectionProps> = forwardRef(
 
     return (
       <section
-        aria-labelledby={onRendered(tabProps['aria-labelledby'])}
+        aria-labelledby={onMounted(tabProps['aria-labelledby'])}
         className={classNames('govuk-tabs__panel', styles.panel, {
           'govuk-tabs__panel--hidden': tabProps.hidden,
         })}
         id={id}
         hidden={tabProps.hidden}
         ref={ref}
-        role={onRendered('tabpanel')}
-        tabIndex={onRendered(-1)}
+        role={onMounted('tabpanel')}
+        tabIndex={onMounted(-1)}
         data-testid={tabProps.title}
       >
         {children}

--- a/src/explore-education-statistics-common/src/components/TabsSection.tsx
+++ b/src/explore-education-statistics-common/src/components/TabsSection.tsx
@@ -1,6 +1,11 @@
 import { useDesktopMedia } from '@common/hooks/useMedia';
 import classNames from 'classnames';
-import React, { forwardRef, HTMLAttributes, ReactNode } from 'react';
+import React, {
+  createElement,
+  forwardRef,
+  HTMLAttributes,
+  ReactNode,
+} from 'react';
 import styles from './TabsSection.module.scss';
 
 export interface TabsSectionProps {
@@ -12,10 +17,14 @@ export interface TabsSectionProps {
    */
   lazy?: boolean;
   title: string;
+  headingTag?: 'h2' | 'h3' | 'h4';
 }
 
 const TabsSection = forwardRef<HTMLElement, TabsSectionProps>(
-  ({ children, id, ...restProps }, ref) => {
+  (
+    { children, id, title, headingTag = 'h3', ...restProps }: TabsSectionProps,
+    ref,
+  ) => {
     const { onMedia } = useDesktopMedia();
 
     // Hide additional props from the component's public API to
@@ -33,8 +42,9 @@ const TabsSection = forwardRef<HTMLElement, TabsSectionProps>(
         ref={ref}
         role={onMedia('tabpanel')}
         tabIndex={onMedia(-1)}
-        data-testid={tabProps.title}
+        data-testid={title}
       >
+        {createElement(headingTag, { children: title })}
         {children}
       </section>
     );

--- a/src/explore-education-statistics-common/src/components/__tests__/Tabs.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Tabs.test.tsx
@@ -3,6 +3,8 @@ import { fireEvent, render } from 'react-testing-library';
 import Tabs from '../Tabs';
 import TabsSection from '../TabsSection';
 
+const hiddenSectionClass = 'govuk-tabs__panel--hidden';
+
 describe('Tabs', () => {
   test('renders single tab correctly', () => {
     const { container } = render(
@@ -78,13 +80,32 @@ describe('Tabs', () => {
     const tabSection1 = container.querySelector('#section-1') as HTMLElement;
     const tabSection2 = container.querySelector('#section-2') as HTMLElement;
 
-    expect(tabSection1.hidden).toBe(false);
-    expect(tabSection2.hidden).toBe(true);
+    expect(tabSection1).not.toHaveClass(hiddenSectionClass);
+    expect(tabSection2).toHaveClass(hiddenSectionClass);
 
     fireEvent.click(getByText('Tab 2'));
 
-    expect(tabSection1.hidden).toBe(true);
-    expect(tabSection2.hidden).toBe(false);
+    expect(tabSection1).toHaveClass(hiddenSectionClass);
+    expect(tabSection2).not.toHaveClass(hiddenSectionClass);
+  });
+
+  test('clicking tab changes location hash', () => {
+    const { getByText } = render(
+      <Tabs>
+        <TabsSection id="section-1" title="Tab 1">
+          <p>Test section 1 content</p>
+        </TabsSection>
+        <TabsSection id="section-2" title="Tab 2">
+          <p>Test section 2 content</p>
+        </TabsSection>
+      </Tabs>,
+    );
+
+    expect(location.hash).toBe('');
+
+    fireEvent.click(getByText('Tab 2'));
+
+    expect(location.hash).toBe('#section-2');
   });
 
   test('clicking tab renders lazy section', () => {
@@ -143,8 +164,11 @@ describe('Tabs', () => {
 
       expect(tab1).toHaveAttribute('aria-selected', 'false');
       expect(tab2).toHaveAttribute('aria-selected', 'true');
-      expect(tabSection1.hidden).toBe(true);
-      expect(tabSection2.hidden).toBe(false);
+
+      expect(tabSection1).toHaveClass(hiddenSectionClass);
+      expect(tabSection2).not.toHaveClass(hiddenSectionClass);
+
+      expect(location.hash).toBe('#section-2');
 
       fireEvent.keyDown(tab2, { key: 'ArrowLeft' });
 
@@ -152,15 +176,22 @@ describe('Tabs', () => {
       expect(tab1).toHaveFocus();
       expect(tab2).toHaveAttribute('aria-selected', 'false');
 
-      expect(tabSection1.hidden).toBe(false);
-      expect(tabSection2.hidden).toBe(true);
+      expect(tabSection1).not.toHaveClass(hiddenSectionClass);
+      expect(tabSection2).toHaveClass(hiddenSectionClass);
+
+      expect(location.hash).toBe('#section-1');
     });
 
     test('pressing left arrow key cycles to end of tabs', () => {
+      fireEvent.click(tab1);
+
       expect(tab1).toHaveAttribute('aria-selected', 'true');
       expect(tab3).toHaveAttribute('aria-selected', 'false');
-      expect(tabSection1.hidden).toBe(false);
-      expect(tabSection3.hidden).toBe(true);
+
+      expect(tabSection1).not.toHaveClass(hiddenSectionClass);
+      expect(tabSection3).toHaveClass(hiddenSectionClass);
+
+      expect(location.hash).toBe('#section-1');
 
       fireEvent.keyDown(tab1, { key: 'ArrowLeft' });
 
@@ -168,8 +199,10 @@ describe('Tabs', () => {
       expect(tab3).toHaveAttribute('aria-selected', 'true');
       expect(tab3).toHaveFocus();
 
-      expect(tabSection1.hidden).toBe(true);
-      expect(tabSection3.hidden).toBe(false);
+      expect(tabSection1).toHaveClass(hiddenSectionClass);
+      expect(tabSection3).not.toHaveClass(hiddenSectionClass);
+
+      expect(location.hash).toBe('#section-3');
     });
 
     test('pressing right arrow key moves to next tab', () => {
@@ -177,8 +210,11 @@ describe('Tabs', () => {
 
       expect(tab2).toHaveAttribute('aria-selected', 'true');
       expect(tab3).toHaveAttribute('aria-selected', 'false');
-      expect(tabSection2.hidden).toBe(false);
-      expect(tabSection3.hidden).toBe(true);
+
+      expect(tabSection2).not.toHaveClass(hiddenSectionClass);
+      expect(tabSection3).toHaveClass(hiddenSectionClass);
+
+      expect(location.hash).toBe('#section-2');
 
       fireEvent.keyDown(tab2, { key: 'ArrowRight' });
 
@@ -186,8 +222,10 @@ describe('Tabs', () => {
       expect(tab3).toHaveAttribute('aria-selected', 'true');
       expect(tab3).toHaveFocus();
 
-      expect(tabSection2.hidden).toBe(true);
-      expect(tabSection3.hidden).toBe(false);
+      expect(tabSection2).toHaveClass(hiddenSectionClass);
+      expect(tabSection3).not.toHaveClass(hiddenSectionClass);
+
+      expect(location.hash).toBe('#section-3');
     });
 
     test('pressing right arrow key cycles to beginning of tabs', () => {
@@ -195,16 +233,22 @@ describe('Tabs', () => {
 
       expect(tab1).toHaveAttribute('aria-selected', 'false');
       expect(tab3).toHaveAttribute('aria-selected', 'true');
-      expect(tabSection1.hidden).toBe(true);
-      expect(tabSection3.hidden).toBe(false);
+
+      expect(tabSection1).toHaveClass(hiddenSectionClass);
+      expect(tabSection3).not.toHaveClass(hiddenSectionClass);
+
+      expect(location.hash).toBe('#section-3');
 
       fireEvent.keyDown(tab3, { key: 'ArrowRight' });
 
       expect(tab1).toHaveAttribute('aria-selected', 'true');
       expect(tab1).toHaveFocus();
       expect(tab3).toHaveAttribute('aria-selected', 'false');
-      expect(tabSection1.hidden).toBe(false);
-      expect(tabSection3.hidden).toBe(true);
+
+      expect(tabSection1).not.toHaveClass(hiddenSectionClass);
+      expect(tabSection3).toHaveClass(hiddenSectionClass);
+
+      expect(location.hash).toBe('#section-1');
     });
 
     test('pressing down arrow key focuses the tab section', async () => {

--- a/src/explore-education-statistics-common/src/components/__tests__/Tabs.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Tabs.test.tsx
@@ -33,6 +33,25 @@ describe('Tabs', () => {
     expect(container.innerHTML).toMatchSnapshot();
   });
 
+  test('setting `headingTag` changes section heading size', () => {
+    const { container } = render(
+      <Tabs>
+        <TabsSection id="section-1" title="Tab 1">
+          <p>Test section 1 content</p>
+        </TabsSection>
+        <TabsSection id="section-2" title="Tab 2" headingTag="h2">
+          <p>Test section 2 content</p>
+        </TabsSection>
+      </Tabs>,
+    );
+
+    const heading1 = container.querySelector('h3') as HTMLHeadingElement;
+    const heading2 = container.querySelector('h2') as HTMLHeadingElement;
+
+    expect(heading1).toHaveTextContent('Tab 1');
+    expect(heading2).toHaveTextContent('Tab 2');
+  });
+
   test('does not immediately render lazy tab section', () => {
     const { queryByText } = render(
       <Tabs>

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -47,7 +47,6 @@ exports[`Tabs renders multiple tabs correctly 1`] = `
   </section>
   <section class="govuk-tabs__panel panel govuk-tabs__panel--hidden"
            id="section-2"
-           hidden
            data-testid="Tab 2"
            aria-labelledby="section-2-tab"
            role="tabpanel"

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -41,6 +41,9 @@ exports[`Tabs renders multiple tabs correctly 1`] = `
            role="tabpanel"
            tabindex="-1"
   >
+    <h3>
+      Tab 1
+    </h3>
     <p>
       Test section 1 content
     </p>
@@ -52,6 +55,9 @@ exports[`Tabs renders multiple tabs correctly 1`] = `
            role="tabpanel"
            tabindex="-1"
   >
+    <h3>
+      Tab 2
+    </h3>
     <p>
       Test section 2 content
     </p>
@@ -87,6 +93,9 @@ exports[`Tabs renders single tab correctly 1`] = `
            role="tabpanel"
            tabindex="-1"
   >
+    <h3>
+      Tab 1
+    </h3>
     <p>
       Test section 1 content
     </p>

--- a/src/explore-education-statistics-common/src/hooks/useMedia.ts
+++ b/src/explore-education-statistics-common/src/hooks/useMedia.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Hook that detects if the window currently
+ * matches a given media {@param query} string.
+ */
+export default function useMedia(query: string) {
+  const [isMedia, setMedia] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const onChange = (event: MediaQueryListEvent) => {
+      if (!mounted) {
+        return;
+      }
+
+      setMedia(event.matches);
+    };
+
+    const mediaQueryList = window.matchMedia(query);
+    setMedia(mediaQueryList.matches);
+
+    mediaQueryList.addEventListener('change', onChange);
+
+    return () => {
+      mounted = false;
+      mediaQueryList.removeEventListener('change', onChange);
+    };
+  }, [query]);
+
+  return {
+    isMedia,
+    onMedia<T, R>(value: T, defaultValue?: R): T | R | undefined {
+      return isMedia ? value : defaultValue;
+    },
+  };
+}
+
+export const useDesktopMedia = () => useMedia('(min-width: 40.0625em)');

--- a/src/explore-education-statistics-common/src/hooks/useMounted.ts
+++ b/src/explore-education-statistics-common/src/hooks/useMounted.ts
@@ -2,25 +2,25 @@ import { useEffect, useState } from 'react';
 
 /**
  * Simple hook that returns true once a component
- * has rendered.
+ * has mounted.
  *
  * This is particularly useful for progressively
  * enhancing components in SSR where not all attributes
  * should be set until the client-side JS loads.
  */
-function useRendered() {
-  const [isRendered, setRendered] = useState(false);
+function useMounted() {
+  const [isMounted, setMounted] = useState(false);
 
   useEffect(() => {
-    setRendered(true);
+    setMounted(true);
   }, []);
 
   return {
-    isRendered,
-    onRendered<T, R>(value: T, defaultValue?: R): T | R | undefined {
-      return isRendered ? value : defaultValue;
+    isMounted,
+    onMounted<T, R>(value: T, defaultValue?: R): T | R | undefined {
+      return isMounted ? value : defaultValue;
     },
   };
 }
 
-export default useRendered;
+export default useMounted;

--- a/src/explore-education-statistics-common/test/setupTests.js
+++ b/src/explore-education-statistics-common/test/setupTests.js
@@ -15,6 +15,16 @@ global.localStorage = localStorageMock;
 
 Element.prototype.scrollIntoView = jest.fn();
 
+beforeEach(() => {
+  window.matchMedia = jest.fn(() => {
+    return {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      matches: true,
+    };
+  });
+});
+
 afterEach(() => {
   location.hash = '';
 });

--- a/src/explore-education-statistics-frontend/test/setupTests.js
+++ b/src/explore-education-statistics-frontend/test/setupTests.js
@@ -15,6 +15,16 @@ global.localStorage = localStorageMock;
 
 Element.prototype.scrollIntoView = jest.fn();
 
+beforeEach(() => {
+  window.matchMedia = jest.fn(() => {
+    return {
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      matches: true,
+    };
+  });
+});
+
 afterEach(() => {
   location.hash = '';
 });


### PR DESCRIPTION
This PR primarily fixes the window jumping to the respective tab sections when the tab links are clicked. 

## Minor changes

- Tab section headings are now automatically generated from the `title` prop and will use `h3`s by default. This sizing can be changed with the `headingTag` if necessary. This is important as it makes it obvious where the user has jumped to when they click a tab link on the mobile/non-Javascript version.