### PR TITLE
FRONTEND: Add methodology and glossary page placeholders

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/glossary/GlossaryIndexPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/glossary/GlossaryIndexPage.tsx
@@ -1,0 +1,15 @@
+import Page from '@frontend/components/Page';
+import PageTitle from '@frontend/components/PageTitle';
+import React, { Component } from 'react';
+
+class GlossaryIndexPage extends Component {
+  public render() {
+    return (
+      <Page breadcrumbs={[{ name: 'Glossary' }]}>
+        <PageTitle title="Education statistics: glossary" />
+      </Page>
+    );
+  }
+}
+
+export default GlossaryIndexPage;

--- a/src/explore-education-statistics-frontend/src/modules/methodology/MethodologyIndexPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodology/MethodologyIndexPage.tsx
@@ -24,9 +24,10 @@ class MethodologyIndexPage extends Component {
               <nav role="navigation" aria-labelledby="subsection-title">
                 <ul className="govuk-list">
                   <li>
-                    <Link to="/statistics">
-                      Find statistics and data
-                    </Link>
+                    <Link to="/statistics">Find statistics and data</Link>
+                  </li>
+                  <li>
+                    <Link to="/glossary">Glossary</Link>
                   </li>
                 </ul>
               </nav>

--- a/src/explore-education-statistics-frontend/src/modules/methodology/MethodologyIndexPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodology/MethodologyIndexPage.tsx
@@ -1,0 +1,41 @@
+import Link from '@frontend/components/Link';
+import Page from '@frontend/components/Page';
+import PageTitle from '@frontend/components/PageTitle';
+import React, { Component } from 'react';
+
+class MethodologyIndexPage extends Component {
+  public render() {
+    return (
+      <Page breadcrumbs={[{ name: 'Methodology' }]}>
+        <PageTitle title="Education statistics: methodology" />
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-two-thirds">
+            <p className="govuk-body-l">
+              Browse to find out about the methodology behind specific education
+              statistics and data and how and why they're collected and
+              published.
+            </p>
+          </div>
+          <div className="govuk-grid-column-one-third">
+            <aside className="app-related-items">
+              <h2 className="govuk-heading-m" id="releated-content">
+                Related content
+              </h2>
+              <nav role="navigation" aria-labelledby="subsection-title">
+                <ul className="govuk-list">
+                  <li>
+                    <Link to="/statistics">
+                      Find statistics and data
+                    </Link>
+                  </li>
+                </ul>
+              </nav>
+            </aside>
+          </div>
+        </div>
+      </Page>
+    );
+  }
+}
+
+export default MethodologyIndexPage;

--- a/src/explore-education-statistics-frontend/src/pages/glossary/index.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/glossary/index.tsx
@@ -1,0 +1,3 @@
+import GlossaryIndexPage from '@frontend/modules/glossary/GlossaryIndexPage';
+
+export default GlossaryIndexPage;

--- a/src/explore-education-statistics-frontend/src/pages/index.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/index.tsx
@@ -52,7 +52,33 @@ class HomePage extends Component {
         </div>
 
         <hr />
-        <h3 className="govuk-heading-m govuk-!-margin-top-9">
+        <h3 className="govuk-heading-l govuk-!-margin-top-9">
+          Help and support
+        </h3>
+        <div className="govuk-grid-row">
+          <div className="govuk-grid-column-one-half">
+            <h2 className="govuk-heading-m govuk-!-margin-bottom-0">
+              <Link to="/methodology">Methodology</Link>
+            </h2>
+            <p className="govuk-caption-m govuk-!-margin-top-2">
+              Browse to find out about the methodology behind specific education
+              statistics and data and how and why they're collected and
+              published.
+            </p>
+          </div>
+          <div className="govuk-grid-column-one-half">
+            <h2 className="govuk-heading-m govuk-!-margin-bottom-0">
+              <Link to="/glossary">Glossary</Link>
+            </h2>
+            <p className="govuk-caption-m govuk-!-margin-top-2">
+              Browse our A to Z list of definitions for terms used across
+              education statistics and data.
+            </p>
+          </div>
+        </div>
+
+        <hr />
+        <h3 className="govuk-heading-l govuk-!-margin-top-9">
           Related services
         </h3>
         <p className="govuk-body">

--- a/src/explore-education-statistics-frontend/src/pages/methodology/index.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/methodology/index.tsx
@@ -1,0 +1,3 @@
+import MethodologyIndexPage from '@frontend/modules/methodology/MethodologyIndexPage';
+
+export default MethodologyIndexPage;


### PR DESCRIPTION
Placeholder pages in functioning app to support further development of methodology and the glossary