### PR TITLE
DFE-631 Id data type should be consistent with meta data

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/TableBuilder/ResultBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/TableBuilder/ResultBuilder.cs
@@ -28,14 +28,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services.TableBuil
             };
         }
 
-        private static IEnumerable<long> FilterItems(Observation observation)
+        private static IEnumerable<string> FilterItems(Observation observation)
         {
-            return observation.FilterItems.Select(item => item.FilterItemId).OrderBy(l => l);
+            return observation.FilterItems.Select(item => item.FilterItemId).OrderBy(l => l).Select(l => l.ToString());
         }
 
-        private static Dictionary<long, string> Measures(Observation observation, IEnumerable<long> indicators)
+        private static Dictionary<string, string> Measures(Observation observation, IEnumerable<long> indicators)
         {
-            return indicators.Any() ? QueryUtil.FilterMeasures(observation.Measures, indicators) : observation.Measures;
+            var measures = indicators.Any()
+                ? QueryUtil.FilterMeasures(observation.Measures, indicators)
+                : observation.Measures;
+            return measures.ToDictionary(pair => pair.Key.ToString(), pair => pair.Value);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/ViewModels/TableBuilder/TableBuilderObservationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/ViewModels/TableBuilder/TableBuilderObservationViewModel.cs
@@ -7,11 +7,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.ViewModels.TableBu
 {
     public class TableBuilderObservationViewModel
     {
-        public IEnumerable<long> Filters { get; set; }
+        public IEnumerable<string> Filters { get; set; }
         
         public LocationViewModel Location { get; set; }
 
-        public Dictionary<long, string> Measures { get; set; }
+        public Dictionary<string, string> Measures { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public TimeIdentifier TimeIdentifier { get; set; }


### PR DESCRIPTION
Filters and indicator id's should be the same data type in the query response as they are in the meta data.

They are strings in the meta data to be consistent with geographic attribute values which come from the data and may not always be numeric.