### PR TITLE
DFE-402 Make checkbox 'Select all' option more obvious

### DIFF
--- a/src/explore-education-statistics-common/src/components/ButtonText.module.scss
+++ b/src/explore-education-statistics-common/src/components/ButtonText.module.scss
@@ -7,9 +7,11 @@
   border-width: 0;
   color: govuk-colour('blue');
   cursor: pointer;
-  display: inline;
+  display: inline-block;
+  margin-bottom: govuk-spacing(2);
+  padding: govuk-spacing(1) 0;
 
   &:hover {
-    color: $govuk-link-hover-colour;
+    text-decoration: underline;
   }
 }

--- a/src/explore-education-statistics-common/src/components/ButtonText.tsx
+++ b/src/explore-education-statistics-common/src/components/ButtonText.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { ButtonProps } from './Button';
 import styles from './ButtonText.module.scss';
 
-const ButtonText = ({ children, ...props }: ButtonProps) => {
+const ButtonText = ({ children, type = 'button', ...props }: ButtonProps) => {
   return (
     // eslint-disable-next-line react/button-has-type
-    <button {...props} className={styles.button}>
+    <button {...props} className={styles.button} type={type}>
       {children}
     </button>
   );

--- a/src/explore-education-statistics-common/src/components/ButtonText.tsx
+++ b/src/explore-education-statistics-common/src/components/ButtonText.tsx
@@ -1,11 +1,21 @@
+import classNames from 'classnames';
 import React from 'react';
 import { ButtonProps } from './Button';
 import styles from './ButtonText.module.scss';
 
-const ButtonText = ({ children, type = 'button', ...props }: ButtonProps) => {
+const ButtonText = ({
+  children,
+  className,
+  type = 'button',
+  ...props
+}: ButtonProps) => {
   return (
     // eslint-disable-next-line react/button-has-type
-    <button {...props} className={styles.button} type={type}>
+    <button
+      {...props}
+      className={classNames(styles.button, className)}
+      type={type}
+    >
       {children}
     </button>
   );

--- a/src/explore-education-statistics-common/src/components/form/FormCheckbox.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckbox.tsx
@@ -5,6 +5,7 @@ export type CheckboxChangeEventHandler = ChangeEventHandler<HTMLInputElement>;
 
 export interface FormCheckboxProps {
   checked?: boolean;
+  className?: string;
   conditional?: ReactNode;
   id: string;
   hint?: string;
@@ -16,6 +17,7 @@ export interface FormCheckboxProps {
 
 const FormCheckbox = ({
   checked,
+  className,
   conditional,
   id,
   hint,
@@ -26,7 +28,7 @@ const FormCheckbox = ({
 }: FormCheckboxProps) => {
   return (
     <>
-      <div className="govuk-checkboxes__item">
+      <div className={classNames('govuk-checkboxes__item', className)}>
         <input
           aria-describedby={hint ? `${id}-item-hint` : undefined}
           className="govuk-checkboxes__input"

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.module.scss
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.module.scss
@@ -1,0 +1,3 @@
+.selectAll {
+  float: left;
+}

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -15,6 +15,7 @@ import FormCheckbox, {
   CheckboxChangeEventHandler,
   FormCheckboxProps,
 } from './FormCheckbox';
+import styles from './FormCheckboxGroup.module.scss';
 import FormFieldset, { FormFieldsetProps } from './FormFieldset';
 
 export type CheckboxOption = PartialBy<
@@ -130,7 +131,11 @@ export class BaseFormCheckboxGroup extends PureComponent<
         ref={this.ref}
       >
         {options.length > 1 && selectAll && (
-          <ButtonText id={`${id}-all`} onClick={this.handleAllChange}>
+          <ButtonText
+            id={`${id}-all`}
+            onClick={this.handleAllChange}
+            className={styles.selectAll}
+          >
             {isAllChecked ? 'Unselect' : 'Select'} all {options.length} options
           </ButtonText>
         )}

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -1,9 +1,16 @@
+import ButtonText from '@common/components/ButtonText';
 import { Omit, PartialBy } from '@common/types/util';
 import classNames from 'classnames';
 import kebabCase from 'lodash/kebabCase';
 import sortBy from 'lodash/sortBy';
 import memoize from 'memoizee';
-import React, { ChangeEvent, createRef, PureComponent } from 'react';
+import React, {
+  ChangeEvent,
+  createRef,
+  MouseEvent,
+  MouseEventHandler,
+  PureComponent,
+} from 'react';
 import FormCheckbox, {
   CheckboxChangeEventHandler,
   FormCheckboxProps,
@@ -15,8 +22,9 @@ export type CheckboxOption = PartialBy<
   'id'
 >;
 
+export type CheckboxGroupAllChangeEvent = MouseEvent<HTMLButtonElement>;
 export type CheckboxGroupAllChangeEventHandler = (
-  event: ChangeEvent<HTMLInputElement>,
+  event: CheckboxGroupAllChangeEvent,
   options: CheckboxOption[],
 ) => void;
 
@@ -76,7 +84,7 @@ export class BaseFormCheckboxGroup extends PureComponent<
     }
   }
 
-  private handleAllChange: CheckboxChangeEventHandler = event => {
+  private handleAllChange: MouseEventHandler<HTMLButtonElement> = event => {
     const { onAllChange, options } = this.props;
 
     if (onAllChange) {
@@ -122,14 +130,9 @@ export class BaseFormCheckboxGroup extends PureComponent<
         ref={this.ref}
       >
         {options.length > 1 && selectAll && (
-          <FormCheckbox
-            id={`${id}-all`}
-            label="Select all"
-            name={name}
-            value="select-all"
-            checked={isAllChecked}
-            onChange={this.handleAllChange}
-          />
+          <ButtonText id={`${id}-all`} onClick={this.handleAllChange}>
+            {isAllChecked ? 'Unselect' : 'Select'} all {options.length} options
+          </ButtonText>
         )}
 
         {sortBy(options, sort).map(option => (

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.module.scss
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.module.scss
@@ -2,7 +2,7 @@
 
 .optionsContainer {
   margin: govuk-spacing(4) 0 govuk-spacing(1);
-  max-height: 15vh;
+  max-height: 20vh;
   overflow-y: auto;
   padding: govuk-spacing(2);
 }

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.module.scss
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.module.scss
@@ -1,0 +1,3 @@
+.optionsContainer {
+  composes: optionsContainer from './FormCheckboxSearchGroup.module.scss';
+}

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.tsx
@@ -6,7 +6,7 @@ import useMounted from '@common/hooks/useMounted';
 import camelCase from 'lodash/camelCase';
 import sum from 'lodash/sum';
 import React, { useState } from 'react';
-import styles from './FormCheckboxSearchGroup.module.scss';
+import styles from './FormCheckboxSearchSubGroups.module.scss';
 import FormCheckboxSubGroups, {
   FormCheckboxSubGroupsProps,
 } from './FormCheckboxSubGroups';

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSubGroups.tsx
@@ -1,7 +1,8 @@
 import { Overwrite } from '@common/types/util';
 import camelCase from 'lodash/camelCase';
-import React, { ChangeEvent } from 'react';
+import React from 'react';
 import FormCheckboxGroup, {
+  CheckboxGroupAllChangeEvent,
   CheckboxOption,
   FormCheckboxGroupProps,
 } from './FormCheckboxGroup';
@@ -16,7 +17,7 @@ export type FormCheckboxSubGroupsProps = Overwrite<
       options: CheckboxOption[];
     }[];
     onAllChange?: (
-      event: ChangeEvent<HTMLInputElement>,
+      event: CheckboxGroupAllChangeEvent,
       options: CheckboxOption[],
     ) => void;
   }

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxGroup.test.tsx
@@ -84,8 +84,8 @@ describe('FormCheckboxGroup', () => {
     expect(container).toMatchSnapshot();
   });
 
-  test('renders unchecked `Select all` option when `selectAll` is true', () => {
-    const { container, getByLabelText } = render(
+  test('renders `Select all 3 options` button when `selectAll` is true', () => {
+    const { container, queryByText } = render(
       <FormCheckboxGroup
         value={[]}
         id="test-checkboxes"
@@ -100,15 +100,14 @@ describe('FormCheckboxGroup', () => {
       />,
     );
 
-    const selectAllCheckbox = getByLabelText('Select all') as HTMLInputElement;
-
-    expect(selectAllCheckbox.checked).toBe(false);
+    expect(queryByText('Select all 3 options')).not.toBeNull();
+    expect(queryByText('Unselect all 3 options')).toBeNull();
 
     expect(container.innerHTML).toMatchSnapshot();
   });
 
-  test('renders checked `Select all` checkbox when all options are pre-checked', () => {
-    const { getByLabelText } = render(
+  test('renders `Unselect all 3 options` button when all options are pre-checked', () => {
+    const { queryByText } = render(
       <FormCheckboxGroup
         value={['1', '2', '3']}
         id="test-checkboxes"
@@ -123,33 +122,12 @@ describe('FormCheckboxGroup', () => {
       />,
     );
 
-    const selectAllCheckbox = getByLabelText('Select all') as HTMLInputElement;
-
-    expect(selectAllCheckbox.checked).toBe(true);
+    expect(queryByText('Unselect all 3 options')).not.toBeNull();
+    expect(queryByText('Select all 3 options')).toBeNull();
   });
 
-  test('renders `Select all` with small variant', () => {
-    const { container } = render(
-      <FormCheckboxGroup
-        id="test-checkboxes"
-        name="test-checkboxes"
-        legend="Test checkboxes"
-        selectAll
-        small
-        value={[]}
-        options={[
-          { id: 'checkbox-1', label: 'Test checkbox 1', value: '1' },
-          { id: 'checkbox-2', label: 'Test checkbox 2', value: '2' },
-          { id: 'checkbox-3', label: 'Test checkbox 3', value: '3' },
-        ]}
-      />,
-    );
-
-    expect(container.querySelector('.govuk-checkboxes--small')).not.toBeNull();
-  });
-
-  test('does not render checked `Select all` checkbox when checked values do not match options', () => {
-    const { getByLabelText } = render(
+  test('does not render `Unselect all 3 options` button when checked values do not match options', () => {
+    const { queryByText } = render(
       <FormCheckboxGroup
         id="test-checkboxes"
         name="test-checkboxes"
@@ -164,12 +142,11 @@ describe('FormCheckboxGroup', () => {
       />,
     );
 
-    const selectAllCheckbox = getByLabelText('Select all') as HTMLInputElement;
-
-    expect(selectAllCheckbox.checked).toBe(false);
+    expect(queryByText('Unselect all 3 options')).toBeNull();
+    expect(queryByText('Select all 3 options')).not.toBeNull();
   });
 
-  test('does not render `Select all` checkbox when there is only one option', () => {
+  test('does not render `Select all 3 options` button when there is only one option', () => {
     const { queryByLabelText } = render(
       <FormCheckboxGroup
         id="test-checkboxes"
@@ -181,7 +158,8 @@ describe('FormCheckboxGroup', () => {
       />,
     );
 
-    expect(queryByLabelText('Select all')).toBeNull();
+    expect(queryByLabelText('Select all 3 options')).toBeNull();
+    expect(queryByLabelText('Unselect all 3 options')).toBeNull();
     expect(queryByLabelText('Test checkbox 1')).not.toBeNull();
   });
 

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxSubGroups.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxSubGroups.test.tsx
@@ -44,8 +44,8 @@ describe('FormCheckboxSubGroups', () => {
     expect(container.innerHTML).toMatchSnapshot();
   });
 
-  test('renders unchecked `Select all` checkboxes when `selectAll` is true', () => {
-    const { container, getAllByLabelText } = render(
+  test('renders `Unselect all options` buttons when `selectAll` is true', () => {
+    const { container, getAllByText } = render(
       <FormCheckboxSubGroups
         value={[]}
         id="test-checkboxes"
@@ -65,26 +65,27 @@ describe('FormCheckboxSubGroups', () => {
             options: [
               { label: 'Checkbox 3', value: '3' },
               { label: 'Checkbox 4', value: '4' },
+              { label: 'Checkbox 5', value: '5' },
             ],
           },
         ]}
       />,
     );
 
-    const selectAllCheckboxes = getAllByLabelText(
-      'Select all',
-    ) as HTMLInputElement[];
+    const selectAllCheckboxes = getAllByText(
+      /Select all/,
+    ) as HTMLButtonElement[];
 
-    expect(selectAllCheckboxes[0].checked).toBe(false);
-    expect(selectAllCheckboxes[1].checked).toBe(false);
+    expect(selectAllCheckboxes[0]).toHaveTextContent('Select all 2 options');
+    expect(selectAllCheckboxes[1]).toHaveTextContent('Select all 3 options');
 
     expect(container.innerHTML).toMatchSnapshot();
   });
 
-  test('renders checked `Select all` checkboxes when all options are pre-checked', () => {
-    const { getAllByLabelText } = render(
+  test('renders `Unselect all options` buttons when all options are pre-checked', () => {
+    const { getAllByText } = render(
       <FormCheckboxSubGroups
-        value={['1', '2', '3', '4']}
+        value={['1', '2', '3', '4', '5']}
         id="test-checkboxes"
         name="test-checkboxes"
         legend="Test checkboxes"
@@ -102,21 +103,22 @@ describe('FormCheckboxSubGroups', () => {
             options: [
               { label: 'Checkbox 3', value: '3' },
               { label: 'Checkbox 4', value: '4' },
+              { label: 'Checkbox 5', value: '5' },
             ],
           },
         ]}
       />,
     );
 
-    const selectAllCheckboxes = getAllByLabelText(
-      'Select all',
+    const selectAllCheckboxes = getAllByText(
+      /Unselect all/,
     ) as HTMLInputElement[];
 
-    expect(selectAllCheckboxes[0].checked).toBe(true);
-    expect(selectAllCheckboxes[1].checked).toBe(true);
+    expect(selectAllCheckboxes[0]).toHaveTextContent('Unselect all 2 options');
+    expect(selectAllCheckboxes[1]).toHaveTextContent('Unselect all 3 options');
   });
 
-  test('does not render `Select all` checkboxes when there is only one option', () => {
+  test('does not render `Select all options`  when there is only one option', () => {
     const { queryAllByLabelText } = render(
       <FormCheckboxSubGroups
         id="test-checkboxes"
@@ -137,7 +139,7 @@ describe('FormCheckboxSubGroups', () => {
       />,
     );
 
-    expect(queryAllByLabelText('Select all')).toHaveLength(0);
+    expect(queryAllByLabelText(/Select all/)).toHaveLength(0);
   });
 
   test('generates group IDs from group legends if none provided', () => {

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxGroup.test.tsx
@@ -75,8 +75,8 @@ describe('FormFieldCheckboxGroup', () => {
     expect(checkbox.checked).toBe(false);
   });
 
-  test('checking `Select all` option checks all values', () => {
-    const { getByLabelText } = render(
+  test('clicking `Select all 3 options` button checks all values', () => {
+    const { getByLabelText, getByText } = render(
       <Formik
         initialValues={{
           test: [],
@@ -106,15 +106,15 @@ describe('FormFieldCheckboxGroup', () => {
     expect(checkbox2.checked).toBe(false);
     expect(checkbox3.checked).toBe(false);
 
-    fireEvent.click(getByLabelText('Select all'));
+    fireEvent.click(getByText('Select all 3 options'));
 
     expect(checkbox1.checked).toBe(true);
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(true);
   });
 
-  test('un-checking `Select all` option un-checks all values', () => {
-    const { getByLabelText } = render(
+  test('clicking `Unselect all 3 options` button un-checks all values', () => {
+    const { getByLabelText, getByText } = render(
       <Formik
         initialValues={{
           test: ['1', '2', '3'],
@@ -144,15 +144,15 @@ describe('FormFieldCheckboxGroup', () => {
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(true);
 
-    fireEvent.click(getByLabelText('Select all'));
+    fireEvent.click(getByText('Unselect all 3 options'));
 
     expect(checkbox1.checked).toBe(false);
     expect(checkbox2.checked).toBe(false);
     expect(checkbox3.checked).toBe(false);
   });
 
-  test('checking all options checks the `Select all` checkbox', async () => {
-    const { getByLabelText } = render(
+  test('checking all options renders the `Unselect all 3 options` button', async () => {
+    const { getByLabelText, queryByText } = render(
       <Formik
         initialValues={{
           test: [],
@@ -177,10 +177,10 @@ describe('FormFieldCheckboxGroup', () => {
     const checkbox1 = getByLabelText('Checkbox 1') as HTMLInputElement;
     const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
     const checkbox3 = getByLabelText('Checkbox 3') as HTMLInputElement;
-    const selectAll = getByLabelText('Select all') as HTMLInputElement;
 
     expect(checkbox1.checked).toBe(false);
-    expect(selectAll.checked).toBe(false);
+    expect(queryByText('Select all 3 options')).not.toBeNull();
+    expect(queryByText('Unselect all 3 options')).toBeNull();
 
     fireEvent.click(checkbox1);
     fireEvent.click(checkbox2);
@@ -191,11 +191,12 @@ describe('FormFieldCheckboxGroup', () => {
     expect(checkbox1.checked).toBe(true);
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(true);
-    expect(selectAll.checked).toBe(true);
+    expect(queryByText('Select all 3 options')).toBeNull();
+    expect(queryByText('Unselect all 3 options')).not.toBeNull();
   });
 
-  test('un-checking any options un-checks the `Select all` checkbox ', async () => {
-    const { getByLabelText } = render(
+  test('un-checking any options renders the `Select all 3 options` button', async () => {
+    const { getByLabelText, queryByText } = render(
       <Formik
         initialValues={{
           test: ['1', '2', '3'],
@@ -218,17 +219,18 @@ describe('FormFieldCheckboxGroup', () => {
     );
 
     const checkbox = getByLabelText('Checkbox 1') as HTMLInputElement;
-    const selectAll = getByLabelText('Select all') as HTMLInputElement;
 
     expect(checkbox.checked).toBe(true);
-    expect(selectAll.checked).toBe(true);
+    expect(queryByText('Select all 3 options')).toBeNull();
+    expect(queryByText('Unselect all 3 options')).not.toBeNull();
 
     fireEvent.click(checkbox);
 
     await wait();
 
     expect(checkbox.checked).toBe(false);
-    expect(selectAll.checked).toBe(false);
+    expect(queryByText('Select all 3 options')).not.toBeNull();
+    expect(queryByText('Unselect all 3 options')).toBeNull();
   });
 
   describe('error messages', () => {

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSearchGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSearchGroup.test.tsx
@@ -77,8 +77,8 @@ describe('FormFieldCheckboxSearchGroup', () => {
     expect(checkbox.checked).toBe(false);
   });
 
-  test('checking `Select all` option checks all values', () => {
-    const { getByLabelText } = render(
+  test('clicking `Select all 3 options` button checks all values', () => {
+    const { getByLabelText, getByText } = render(
       <Formik
         initialValues={{
           test: [],
@@ -100,7 +100,7 @@ describe('FormFieldCheckboxSearchGroup', () => {
       />,
     );
 
-    fireEvent.click(getByLabelText('Select all'));
+    fireEvent.click(getByText('Select all 3 options'));
 
     expect((getByLabelText('Checkbox 1') as HTMLInputElement).checked).toBe(
       true,
@@ -113,8 +113,8 @@ describe('FormFieldCheckboxSearchGroup', () => {
     );
   });
 
-  test('un-checking `Select all` option un-checks all values', () => {
-    const { getByLabelText } = render(
+  test('clicking `Unselect all 3 options` button un-checks all values', () => {
+    const { getByLabelText, getByText } = render(
       <Formik
         initialValues={{
           test: ['1', '2', '3'],
@@ -144,15 +144,15 @@ describe('FormFieldCheckboxSearchGroup', () => {
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(true);
 
-    fireEvent.click(getByLabelText('Select all'));
+    fireEvent.click(getByText('Unselect all 3 options'));
 
     expect(checkbox1.checked).toBe(false);
     expect(checkbox2.checked).toBe(false);
     expect(checkbox3.checked).toBe(false);
   });
 
-  test('checking all options checks the `Select all` checkbox', async () => {
-    const { getByLabelText } = render(
+  test('checking all options renders the `Unselect all 3 options` button', async () => {
+    const { getByLabelText, queryByText } = render(
       <Formik
         initialValues={{
           test: [],
@@ -177,10 +177,10 @@ describe('FormFieldCheckboxSearchGroup', () => {
     const checkbox1 = getByLabelText('Checkbox 1') as HTMLInputElement;
     const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
     const checkbox3 = getByLabelText('Checkbox 3') as HTMLInputElement;
-    const selectAll = getByLabelText('Select all') as HTMLInputElement;
 
     expect(checkbox1.checked).toBe(false);
-    expect(selectAll.checked).toBe(false);
+    expect(queryByText('Select all 3 options')).not.toBeNull();
+    expect(queryByText('Unselect all 3 options')).toBeNull();
 
     fireEvent.click(checkbox1);
     fireEvent.click(checkbox2);
@@ -191,11 +191,13 @@ describe('FormFieldCheckboxSearchGroup', () => {
     expect(checkbox1.checked).toBe(true);
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(true);
-    expect(selectAll.checked).toBe(true);
+
+    expect(queryByText('Select all 3 options')).toBeNull();
+    expect(queryByText('Unselect all 3 options')).not.toBeNull();
   });
 
-  test('un-checking any options un-checks the `Select all` checkbox ', async () => {
-    const { getByLabelText } = render(
+  test('un-checking any options renders the `Select all 3 options` button ', async () => {
+    const { getByLabelText, queryByText } = render(
       <Formik
         initialValues={{
           test: ['1', '2', '3'],
@@ -218,17 +220,18 @@ describe('FormFieldCheckboxSearchGroup', () => {
     );
 
     const checkbox = getByLabelText('Checkbox 1') as HTMLInputElement;
-    const selectAll = getByLabelText('Select all') as HTMLInputElement;
 
     expect(checkbox.checked).toBe(true);
-    expect(selectAll.checked).toBe(true);
+    expect(queryByText('Unselect all 3 options')).not.toBeNull();
+    expect(queryByText('Select all 3 options')).toBeNull();
 
     fireEvent.click(checkbox);
 
     await wait();
 
     expect(checkbox.checked).toBe(false);
-    expect(selectAll.checked).toBe(false);
+    expect(queryByText('Unselect all 3 options')).toBeNull();
+    expect(queryByText('Select all 3 options')).not.toBeNull();
   });
 
   describe('error messages', () => {

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSearchSubGroups.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSearchSubGroups.test.tsx
@@ -97,8 +97,8 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     expect(checkbox.checked).toBe(false);
   });
 
-  test('checking `Select all` option checks all values for that group', () => {
-    const { getByLabelText } = render(
+  test('clicking `Select all options` button checks all values for that group', () => {
+    const { getByLabelText, getByText } = render(
       <Formik
         initialValues={{
           test: [],
@@ -122,6 +122,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
                 options: [
                   { value: '3', label: 'Checkbox 3' },
                   { value: '4', label: 'Checkbox 4' },
+                  { value: '5', label: 'Checkbox 5' },
                 ],
               },
             ]}
@@ -141,7 +142,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     expect(checkbox3.checked).toBe(false);
     expect(checkbox4.checked).toBe(false);
 
-    fireEvent.click(getByLabelText('Select all'));
+    fireEvent.click(getByText('Select all 2 options'));
 
     expect(checkbox1.checked).toBe(true);
     expect(checkbox2.checked).toBe(true);
@@ -149,8 +150,8 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     expect(checkbox4.checked).toBe(false);
   });
 
-  test('un-checking `Select all` option un-checks all values for that group', () => {
-    const { getByLabelText } = render(
+  test('clicking `Unselect all` option un-checks all values for that group', () => {
+    const { getByLabelText, getByText } = render(
       <Formik
         initialValues={{
           test: ['1', '2'],
@@ -187,22 +188,25 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
     const checkbox3 = getByLabelText('Checkbox 3') as HTMLInputElement;
     const checkbox4 = getByLabelText('Checkbox 4') as HTMLInputElement;
+    const checkbox5 = getByLabelText('Checkbox 5') as HTMLInputElement;
 
     expect(checkbox1.checked).toBe(true);
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(false);
     expect(checkbox4.checked).toBe(false);
+    expect(checkbox5.checked).toBe(false);
 
-    fireEvent.click(getByLabelText('Select all'));
+    fireEvent.click(getByText('Unselect all 2 options'));
 
     expect(checkbox1.checked).toBe(false);
     expect(checkbox2.checked).toBe(false);
     expect(checkbox3.checked).toBe(false);
     expect(checkbox4.checked).toBe(false);
+    expect(checkbox5.checked).toBe(false);
   });
 
-  test('checking all options for a group checks the corresponding `Select all` checkbox', async () => {
-    const { getByLabelText } = render(
+  test('checking all options for a group renders the corresponding `Unselect all options` button', async () => {
+    const { getByLabelText, queryByText } = render(
       <Formik
         initialValues={{
           test: [],
@@ -227,6 +231,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
                 options: [
                   { value: '3', label: 'Checkbox 3' },
                   { value: '4', label: 'Checkbox 4' },
+                  { value: '5', label: 'Checkbox 5' },
                 ],
               },
             ]}
@@ -237,11 +242,12 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
 
     const checkbox1 = getByLabelText('Checkbox 1') as HTMLInputElement;
     const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
-    const selectAll = getByLabelText('Select all') as HTMLInputElement;
 
     expect(checkbox1.checked).toBe(false);
     expect(checkbox2.checked).toBe(false);
-    expect(selectAll.checked).toBe(false);
+
+    expect(queryByText('Select all 2 options')).not.toBeNull();
+    expect(queryByText('Unselect all 2 options')).toBeNull();
 
     fireEvent.click(checkbox1);
     fireEvent.click(checkbox2);
@@ -250,11 +256,13 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
 
     expect(checkbox1.checked).toBe(true);
     expect(checkbox2.checked).toBe(true);
-    expect(selectAll.checked).toBe(true);
+
+    expect(queryByText('Select all 2 options')).toBeNull();
+    expect(queryByText('Unselect all 2 options')).not.toBeNull();
   });
 
-  test('un-checking any options un-checks the `Select all` checkbox ', () => {
-    const { getByLabelText } = render(
+  test('un-checking any options renders the corresponding `Unselect all options` button', () => {
+    const { getByLabelText, queryByText } = render(
       <Formik
         initialValues={{
           test: ['1', '2'],
@@ -279,6 +287,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
                 options: [
                   { value: '3', label: 'Checkbox 3' },
                   { value: '4', label: 'Checkbox 4' },
+                  { value: '5', label: 'Checkbox 5' },
                 ],
               },
             ]}
@@ -289,17 +298,20 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
 
     const checkbox1 = getByLabelText('Checkbox 1') as HTMLInputElement;
     const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
-    const selectAll = getByLabelText('Select all') as HTMLInputElement;
 
     expect(checkbox1.checked).toBe(true);
     expect(checkbox2.checked).toBe(true);
-    expect(selectAll.checked).toBe(true);
+
+    expect(queryByText('Select all 2 options')).toBeNull();
+    expect(queryByText('Unselect all 2 options')).not.toBeNull();
 
     fireEvent.click(checkbox1);
 
     expect(checkbox1.checked).toBe(false);
     expect(checkbox2.checked).toBe(true);
-    expect(selectAll.checked).toBe(false);
+
+    expect(queryByText('Select all 2 options')).not.toBeNull();
+    expect(queryByText('Unselect all 2 options')).toBeNull();
   });
 
   describe('error messages', () => {

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSearchSubGroups.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSearchSubGroups.test.tsx
@@ -176,6 +176,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
                 options: [
                   { value: '3', label: 'Checkbox 3' },
                   { value: '4', label: 'Checkbox 4' },
+                  { value: '5', label: 'Checkbox 5' },
                 ],
               },
             ]}

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSubGroups.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSubGroups.test.tsx
@@ -97,8 +97,8 @@ describe('FormFieldCheckboxSubGroups', () => {
     expect(checkbox.checked).toBe(false);
   });
 
-  test('checking `Select all` option checks all values for that group', () => {
-    const { getByLabelText } = render(
+  test('clicking `Select all 2 options` button checks all values for that group', () => {
+    const { getByLabelText, getByText } = render(
       <Formik
         initialValues={{
           test: [],
@@ -122,6 +122,7 @@ describe('FormFieldCheckboxSubGroups', () => {
                 options: [
                   { value: '3', label: 'Checkbox 3' },
                   { value: '4', label: 'Checkbox 4' },
+                  { value: '5', label: 'Checkbox 5' },
                 ],
               },
             ]}
@@ -135,22 +136,25 @@ describe('FormFieldCheckboxSubGroups', () => {
     const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
     const checkbox3 = getByLabelText('Checkbox 3') as HTMLInputElement;
     const checkbox4 = getByLabelText('Checkbox 4') as HTMLInputElement;
+    const checkbox5 = getByLabelText('Checkbox 5') as HTMLInputElement;
 
     expect(checkbox1.checked).toBe(false);
     expect(checkbox2.checked).toBe(false);
     expect(checkbox3.checked).toBe(false);
     expect(checkbox4.checked).toBe(false);
+    expect(checkbox5.checked).toBe(false);
 
-    fireEvent.click(getByLabelText('Select all'));
+    fireEvent.click(getByText('Select all 2 options'));
 
     expect(checkbox1.checked).toBe(true);
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(false);
     expect(checkbox4.checked).toBe(false);
+    expect(checkbox5.checked).toBe(false);
   });
 
-  test('un-checking `Select all` option un-checks all values for that group', () => {
-    const { getByLabelText } = render(
+  test('clicking `Unselect all 2 options` button un-checks all values for that group', () => {
+    const { getByLabelText, getByText } = render(
       <Formik
         initialValues={{
           test: ['1', '2'],
@@ -175,6 +179,7 @@ describe('FormFieldCheckboxSubGroups', () => {
                 options: [
                   { value: '3', label: 'Checkbox 3' },
                   { value: '4', label: 'Checkbox 4' },
+                  { value: '5', label: 'Checkbox 5' },
                 ],
               },
             ]}
@@ -187,22 +192,25 @@ describe('FormFieldCheckboxSubGroups', () => {
     const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
     const checkbox3 = getByLabelText('Checkbox 3') as HTMLInputElement;
     const checkbox4 = getByLabelText('Checkbox 4') as HTMLInputElement;
+    const checkbox5 = getByLabelText('Checkbox 5') as HTMLInputElement;
 
     expect(checkbox1.checked).toBe(true);
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(false);
     expect(checkbox4.checked).toBe(false);
+    expect(checkbox5.checked).toBe(false);
 
-    fireEvent.click(getByLabelText('Select all'));
+    fireEvent.click(getByText('Unselect all 2 options'));
 
     expect(checkbox1.checked).toBe(false);
     expect(checkbox2.checked).toBe(false);
     expect(checkbox3.checked).toBe(false);
     expect(checkbox4.checked).toBe(false);
+    expect(checkbox5.checked).toBe(false);
   });
 
-  test('checking all options for a group checks the corresponding `Select all` checkbox', async () => {
-    const { getByLabelText } = render(
+  test('checking all options for a group renders the corresponding `Unselect all options` button', async () => {
+    const { getByLabelText, queryByText } = render(
       <Formik
         initialValues={{
           test: [],
@@ -227,6 +235,7 @@ describe('FormFieldCheckboxSubGroups', () => {
                 options: [
                   { value: '3', label: 'Checkbox 3' },
                   { value: '4', label: 'Checkbox 4' },
+                  { value: '5', label: 'Checkbox 5' },
                 ],
               },
             ]}
@@ -237,11 +246,12 @@ describe('FormFieldCheckboxSubGroups', () => {
 
     const checkbox1 = getByLabelText('Checkbox 1') as HTMLInputElement;
     const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
-    const selectAll = getByLabelText('Select all') as HTMLInputElement;
 
     expect(checkbox1.checked).toBe(false);
     expect(checkbox2.checked).toBe(false);
-    expect(selectAll.checked).toBe(false);
+
+    expect(queryByText('Unselect all 2 options')).toBeNull();
+    expect(queryByText('Select all 2 options')).not.toBeNull();
 
     fireEvent.click(checkbox1);
     fireEvent.click(checkbox2);
@@ -250,11 +260,13 @@ describe('FormFieldCheckboxSubGroups', () => {
 
     expect(checkbox1.checked).toBe(true);
     expect(checkbox2.checked).toBe(true);
-    expect(selectAll.checked).toBe(true);
+
+    expect(queryByText('Unselect all 2 options')).not.toBeNull();
+    expect(queryByText('Select all 2 options')).toBeNull();
   });
 
-  test('un-checking any options un-checks the `Select all` checkbox ', async () => {
-    const { getByLabelText } = render(
+  test('un-checking any options renders the corresponding `Select all options` button', async () => {
+    const { getByLabelText, queryByText } = render(
       <Formik
         initialValues={{
           test: ['1', '2'],
@@ -279,6 +291,7 @@ describe('FormFieldCheckboxSubGroups', () => {
                 options: [
                   { value: '3', label: 'Checkbox 3' },
                   { value: '4', label: 'Checkbox 4' },
+                  { value: '5', label: 'Checkbox 5' },
                 ],
               },
             ]}
@@ -289,11 +302,12 @@ describe('FormFieldCheckboxSubGroups', () => {
 
     const checkbox1 = getByLabelText('Checkbox 1') as HTMLInputElement;
     const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
-    const selectAll = getByLabelText('Select all') as HTMLInputElement;
 
     expect(checkbox1.checked).toBe(true);
     expect(checkbox2.checked).toBe(true);
-    expect(selectAll.checked).toBe(true);
+
+    expect(queryByText('Unselect all 2 options')).not.toBeNull();
+    expect(queryByText('Select all 2 options')).toBeNull();
 
     fireEvent.click(checkbox1);
 
@@ -301,7 +315,9 @@ describe('FormFieldCheckboxSubGroups', () => {
 
     expect(checkbox1.checked).toBe(false);
     expect(checkbox2.checked).toBe(true);
-    expect(selectAll.checked).toBe(false);
+
+    expect(queryByText('Unselect all 2 options')).toBeNull();
+    expect(queryByText('Select all 2 options')).not.toBeNull();
   });
 
   describe('error messages', () => {

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxGroup.test.tsx.snap
@@ -55,6 +55,67 @@ exports[`FormCheckboxGroup generates option IDs from id and value if none specif
 
 `;
 
+exports[`FormCheckboxGroup renders \`Select all 3 options\` button when \`selectAll\` is true 1`] = `
+
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset"
+            id="test-checkboxes"
+  >
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      Test checkboxes
+    </legend>
+    <div class="govuk-checkboxes">
+      <button id="test-checkboxes-all"
+              class="button"
+              type="button"
+      >
+        Select all 3 options
+      </button>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input"
+               id="checkbox-1"
+               name="test-checkboxes"
+               type="checkbox"
+               value="1"
+        >
+        <label class="govuk-label govuk-checkboxes__label"
+               for="checkbox-1"
+        >
+          Test checkbox 1
+        </label>
+      </div>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input"
+               id="checkbox-2"
+               name="test-checkboxes"
+               type="checkbox"
+               value="2"
+        >
+        <label class="govuk-label govuk-checkboxes__label"
+               for="checkbox-2"
+        >
+          Test checkbox 2
+        </label>
+      </div>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input"
+               id="checkbox-3"
+               name="test-checkboxes"
+               type="checkbox"
+               value="3"
+        >
+        <label class="govuk-label govuk-checkboxes__label"
+               for="checkbox-3"
+        >
+          Test checkbox 3
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>
+
+`;
+
 exports[`FormCheckboxGroup renders checkboxes with some pre-checked 1`] = `
 
 <div class="govuk-form-group">
@@ -299,74 +360,6 @@ exports[`FormCheckboxGroup renders option with conditional contents 1`] = `
         <p>
           Conditional 3
         </p>
-      </div>
-    </div>
-  </fieldset>
-</div>
-
-`;
-
-exports[`FormCheckboxGroup renders unchecked \`Select all\` option when \`selectAll\` is true 1`] = `
-
-<div class="govuk-form-group">
-  <fieldset class="govuk-fieldset"
-            id="test-checkboxes"
-  >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-      Test checkboxes
-    </legend>
-    <div class="govuk-checkboxes">
-      <div class="govuk-checkboxes__item">
-        <input class="govuk-checkboxes__input"
-               id="test-checkboxes-all"
-               name="test-checkboxes"
-               type="checkbox"
-               value="select-all"
-        >
-        <label class="govuk-label govuk-checkboxes__label"
-               for="test-checkboxes-all"
-        >
-          Select all
-        </label>
-      </div>
-      <div class="govuk-checkboxes__item">
-        <input class="govuk-checkboxes__input"
-               id="checkbox-1"
-               name="test-checkboxes"
-               type="checkbox"
-               value="1"
-        >
-        <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-1"
-        >
-          Test checkbox 1
-        </label>
-      </div>
-      <div class="govuk-checkboxes__item">
-        <input class="govuk-checkboxes__input"
-               id="checkbox-2"
-               name="test-checkboxes"
-               type="checkbox"
-               value="2"
-        >
-        <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-2"
-        >
-          Test checkbox 2
-        </label>
-      </div>
-      <div class="govuk-checkboxes__item">
-        <input class="govuk-checkboxes__input"
-               id="checkbox-3"
-               name="test-checkboxes"
-               type="checkbox"
-               value="3"
-        >
-        <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-3"
-        >
-          Test checkbox 3
-        </label>
       </div>
     </div>
   </fieldset>

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxGroup.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`FormCheckboxGroup renders \`Select all 3 options\` button when \`select
     </legend>
     <div class="govuk-checkboxes">
       <button id="test-checkboxes-all"
-              class="button"
+              class="button selectAll"
               type="button"
       >
         Select all 3 options

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSubGroups.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSubGroups.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`FormCheckboxSubGroups renders \`Unselect all options\` buttons when \`s
         </legend>
         <div class="govuk-checkboxes">
           <button id="test-checkboxes-groupA-all"
-                  class="button"
+                  class="button selectAll"
                   type="button"
           >
             Select all 2 options
@@ -61,7 +61,7 @@ exports[`FormCheckboxSubGroups renders \`Unselect all options\` buttons when \`s
         </legend>
         <div class="govuk-checkboxes">
           <button id="test-checkboxes-groupB-all"
-                  class="button"
+                  class="button selectAll"
                   type="button"
           >
             Select all 3 options

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSubGroups.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSubGroups.test.tsx.snap
@@ -1,5 +1,118 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FormCheckboxSubGroups renders \`Unselect all options\` buttons when \`selectAll\` is true 1`] = `
+
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset"
+            id="test-checkboxes"
+  >
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+      Test checkboxes
+    </legend>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset"
+                id="test-checkboxes-groupA"
+      >
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          Group A
+        </legend>
+        <div class="govuk-checkboxes">
+          <button id="test-checkboxes-groupA-all"
+                  class="button"
+                  type="button"
+          >
+            Select all 2 options
+          </button>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input"
+                   id="test-checkboxes-groupA-1"
+                   name="test-checkboxes"
+                   type="checkbox"
+                   value="1"
+            >
+            <label class="govuk-label govuk-checkboxes__label"
+                   for="test-checkboxes-groupA-1"
+            >
+              Checkbox 1
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input"
+                   id="test-checkboxes-groupA-2"
+                   name="test-checkboxes"
+                   type="checkbox"
+                   value="2"
+            >
+            <label class="govuk-label govuk-checkboxes__label"
+                   for="test-checkboxes-groupA-2"
+            >
+              Checkbox 2
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset"
+                id="test-checkboxes-groupB"
+      >
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+          Group B
+        </legend>
+        <div class="govuk-checkboxes">
+          <button id="test-checkboxes-groupB-all"
+                  class="button"
+                  type="button"
+          >
+            Select all 3 options
+          </button>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input"
+                   id="test-checkboxes-groupB-3"
+                   name="test-checkboxes"
+                   type="checkbox"
+                   value="3"
+            >
+            <label class="govuk-label govuk-checkboxes__label"
+                   for="test-checkboxes-groupB-3"
+            >
+              Checkbox 3
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input"
+                   id="test-checkboxes-groupB-4"
+                   name="test-checkboxes"
+                   type="checkbox"
+                   value="4"
+            >
+            <label class="govuk-label govuk-checkboxes__label"
+                   for="test-checkboxes-groupB-4"
+            >
+              Checkbox 4
+            </label>
+          </div>
+          <div class="govuk-checkboxes__item">
+            <input class="govuk-checkboxes__input"
+                   id="test-checkboxes-groupB-5"
+                   name="test-checkboxes"
+                   type="checkbox"
+                   value="5"
+            >
+            <label class="govuk-label govuk-checkboxes__label"
+                   for="test-checkboxes-groupB-5"
+            >
+              Checkbox 5
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+  </fieldset>
+</div>
+
+`;
+
 exports[`FormCheckboxSubGroups renders groups of checkboxes in correct order 1`] = `
 
 <div class="govuk-form-group">
@@ -71,120 +184,6 @@ exports[`FormCheckboxSubGroups renders groups of checkboxes in correct order 1`]
             <input class="govuk-checkboxes__input"
                    id="test-checkboxes-groupB-4"
                    name="test"
-                   type="checkbox"
-                   value="4"
-            >
-            <label class="govuk-label govuk-checkboxes__label"
-                   for="test-checkboxes-groupB-4"
-            >
-              Checkbox 4
-            </label>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-  </fieldset>
-</div>
-
-`;
-
-exports[`FormCheckboxSubGroups renders unchecked \`Select all\` checkboxes when \`selectAll\` is true 1`] = `
-
-<div class="govuk-form-group">
-  <fieldset class="govuk-fieldset"
-            id="test-checkboxes"
-  >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-      Test checkboxes
-    </legend>
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset"
-                id="test-checkboxes-groupA"
-      >
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-          Group A
-        </legend>
-        <div class="govuk-checkboxes">
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input"
-                   id="test-checkboxes-groupA-all"
-                   name="test-checkboxes"
-                   type="checkbox"
-                   value="select-all"
-            >
-            <label class="govuk-label govuk-checkboxes__label"
-                   for="test-checkboxes-groupA-all"
-            >
-              Select all
-            </label>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input"
-                   id="test-checkboxes-groupA-1"
-                   name="test-checkboxes"
-                   type="checkbox"
-                   value="1"
-            >
-            <label class="govuk-label govuk-checkboxes__label"
-                   for="test-checkboxes-groupA-1"
-            >
-              Checkbox 1
-            </label>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input"
-                   id="test-checkboxes-groupA-2"
-                   name="test-checkboxes"
-                   type="checkbox"
-                   value="2"
-            >
-            <label class="govuk-label govuk-checkboxes__label"
-                   for="test-checkboxes-groupA-2"
-            >
-              Checkbox 2
-            </label>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset"
-                id="test-checkboxes-groupB"
-      >
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-          Group B
-        </legend>
-        <div class="govuk-checkboxes">
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input"
-                   id="test-checkboxes-groupB-all"
-                   name="test-checkboxes"
-                   type="checkbox"
-                   value="select-all"
-            >
-            <label class="govuk-label govuk-checkboxes__label"
-                   for="test-checkboxes-groupB-all"
-            >
-              Select all
-            </label>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input"
-                   id="test-checkboxes-groupB-3"
-                   name="test-checkboxes"
-                   type="checkbox"
-                   value="3"
-            >
-            <label class="govuk-label govuk-checkboxes__label"
-                   for="test-checkboxes-groupB-3"
-            >
-              Checkbox 3
-            </label>
-          </div>
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input"
-                   id="test-checkboxes-groupB-4"
-                   name="test-checkboxes"
                    type="checkbox"
                    value="4"
             >

--- a/src/explore-education-statistics-common/src/components/form/util/checkboxGroupFieldHelpers.ts
+++ b/src/explore-education-statistics-common/src/components/form/util/checkboxGroupFieldHelpers.ts
@@ -2,23 +2,26 @@ import { FieldArrayRenderProps } from 'formik';
 import difference from 'lodash/difference';
 import get from 'lodash/get';
 import { ChangeEvent } from 'react';
-import { CheckboxOption } from '../FormCheckboxGroup';
+import {
+  CheckboxGroupAllChangeEvent,
+  CheckboxOption,
+} from '../FormCheckboxGroup';
 
 export const onAllChange = (
   { form, name }: FieldArrayRenderProps,
   options: CheckboxOption[],
 ) => {
-  return (event: ChangeEvent<HTMLInputElement>) => {
+  return (event: CheckboxGroupAllChangeEvent) => {
     if (event.isDefaultPrevented()) {
       return;
     }
 
-    const currentValues = get(form.values, name);
+    const currentValues: string[] = get(form.values, name);
 
     const allOptionValues = options.map(option => option.value);
     const restValues = difference(currentValues, allOptionValues);
 
-    if (event.target.checked) {
+    if (currentValues.length < allOptionValues.length) {
       form.setFieldValue(name, [...restValues, ...allOptionValues]);
     } else {
       form.setFieldValue(name, restValues);

--- a/src/explore-education-statistics-frontend/next.config.js
+++ b/src/explore-education-statistics-frontend/next.config.js
@@ -75,7 +75,6 @@ const withSassModules = createPlugin((config, options) => {
         },
       ],
       cssLoaderOptions: {
-        importLoaders: 1,
         localIdentName: 'dfe-[name]__[local]--[hash:base64:5]',
       },
     });

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/FiltersForm.tsx
@@ -114,6 +114,7 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
                       legendSize="s"
                       hint="Select at least one indicator"
                       error={getError('indicators')}
+                      selectAll
                       options={Object.entries(specification.indicators).map(
                         ([_, group]) => {
                           return {

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/FormFieldCheckboxMenu.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/FormFieldCheckboxMenu.tsx
@@ -31,17 +31,17 @@ const FormFieldCheckboxMenu = <T extends {}>(
     >
       {options.length > 1 ? (
         <FormFieldCheckboxSearchGroup
-          {...props}
+          selectAll
           hideCount
           legendHidden
-          selectAll
+          {...props}
           name={name}
           options={options}
         />
       ) : (
         <FormFieldCheckboxGroup
-          {...props}
           selectAll
+          {...props}
           name={name}
           options={options}
         />

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -98,11 +98,13 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
                         id={`${formId}-levels-${levelKey}`}
                         legend={level.legend}
                         legendHidden
-                        onAllChange={event => {
+                        selectAll={false}
+                        onAllChange={() => {
                           updateLocationLevels(draft => {
-                            draft[levelKey] = event.target.checked
-                              ? level.options
-                              : [];
+                            draft[levelKey] =
+                              draft[levelKey].length < level.options.length
+                                ? level.options
+                                : [];
                           });
                         }}
                         onChange={(event, option) => {

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -81,7 +81,7 @@ const TimePeriodDataTable = ({
             return Boolean(
               result.measures[row.value] !== undefined &&
                 result.filters.every(filter =>
-                  [colGroup.value, rowGroup.value].includes(filter.toString()),
+                  [colGroup.value, rowGroup.value].includes(filter),
                 ) &&
                 result.timeIdentifier === column.code &&
                 result.year === column.year,


### PR DESCRIPTION
This PR makes the 'Select all' option more obvious by changing it to a button instead that states if you want to 'Select all X options' or 'Unselect all X options'.