### PR TITLE
DFE-514 Validate that all filter groups must have one option selected

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/FiltersForm.tsx
@@ -3,7 +3,6 @@ import FormFieldCheckboxSearchSubGroups from '@common/components/form/FormFieldC
 import createErrorHelper from '@common/lib/validation/createErrorHelper';
 import Yup from '@common/lib/validation/yup';
 import { PublicationSubjectMeta } from '@common/services/tableBuilderService';
-import { Dictionary } from '@common/types/util';
 import { Formik, FormikProps } from 'formik';
 import camelCase from 'lodash/camelCase';
 import mapValues from 'lodash/mapValues';
@@ -40,18 +39,18 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
 
   return (
     <Formik<FormValues>
+      enableReinitialize
       initialValues={{
         filters: mapValues(specification.filters, () => []),
         indicators: [],
       }}
       validationSchema={Yup.object<FormValues>({
-        filters: Yup.mixed().test(
-          'required',
-          'Must select options from only two categories',
-          (value: Dictionary<string[]>) =>
-            Object.values(value)
-              .map(group => group.length > 0)
-              .filter(Boolean).length === 2,
+        filters: Yup.object(
+          mapValues(specification.filters, () =>
+            Yup.array()
+              .of(Yup.string())
+              .min(1, 'Must select at least one option'),
+          ),
         ),
         indicators: Yup.array()
           .of(Yup.string())
@@ -76,7 +75,7 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
                       id={`${formId}-filters`}
                       legend="Categories"
                       legendSize="s"
-                      hint="Select options from two categories"
+                      hint="Select at least one option from all categories"
                       error={getError('filters')}
                     >
                       {Object.entries(specification.filters).map(

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -54,6 +54,7 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
 
   return (
     <Formik<FormValues>
+      enableReinitialize
       onSubmit={async values => {
         await onSubmit(values.locations);
         goToNextStep();

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationForm.tsx
@@ -55,6 +55,7 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
 
   return (
     <Formik<FormValues>
+      enableReinitialize
       initialValues={{
         publicationId: '',
       }}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationSubjectForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationSubjectForm.tsx
@@ -37,6 +37,7 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
 
   return (
     <Formik
+      enableReinitialize
       onSubmit={async ({ subjectId }) => {
         await onSubmit({
           subjectId,


### PR DESCRIPTION
This PR fixes the validation rules for selecting filters by forcing the user to select at least one option from every category before they can create a table.