### PR TITLE
DFE-660 Save location with id as this entity is already tracked. This…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterService.cs
@@ -125,7 +125,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             {
                 FilterItems = GetFilterItems(line, headers, subjectMeta.Filters),
                 GeographicLevel = GetGeographicLevel(line, headers),
-                Location = GetLocation(line, headers),
+                LocationId = GetLocationId(line, headers),
                 Measures = GetMeasures(line, headers, subjectMeta.Indicators),
                 School = GetSchool(line, headers),
                 Subject = subject,
@@ -172,13 +172,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             return GeographicLevels.EnumFromStringForImport(CsvUtil.Value(line, headers, "geographic_level"));
         }
 
-        private Location GetLocation(IReadOnlyList<string> line, List<string> headers)
+        private long GetLocationId(IReadOnlyList<string> line, List<string> headers)
         {
             return _importerLocationService.Find(
                 GetCountry(line, headers),
                 GetRegion(line, headers),
                 GetLocalAuthority(line, headers),
-                GetLocalAuthorityDistrict(line, headers));
+                GetLocalAuthorityDistrict(line, headers)).Id;
         }
 
         private static School GetSchool(IReadOnlyList<string> line, List<string> headers)


### PR DESCRIPTION
… was previously resulting in the error 'Cannot insert explicit value for identity column in table 'Location' when IDENTITY_INSERT is set to OFF'.