### PR TITLE
DFE-664 Order select, checkbox and radio groups by label by default

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -2,7 +2,7 @@ import ButtonText from '@common/components/ButtonText';
 import { Omit, PartialBy } from '@common/types/util';
 import classNames from 'classnames';
 import kebabCase from 'lodash/kebabCase';
-import sortBy from 'lodash/sortBy';
+import orderBy from 'lodash/orderBy';
 import memoize from 'memoizee';
 import React, {
   ChangeEvent,
@@ -42,9 +42,10 @@ interface BaseFormCheckboxGroupProps {
   options: CheckboxOption[];
   selectAll?: boolean;
   small?: boolean;
-  sort?:
-    | string[]
+  order?:
+    | (keyof CheckboxOption)[]
     | ((option: CheckboxOption) => CheckboxOption[keyof CheckboxOption])[];
+  orderDirection?: ('asc' | 'desc')[];
   value: string[];
 }
 
@@ -67,7 +68,8 @@ export class BaseFormCheckboxGroup extends PureComponent<
     legendSize: 'm',
     selectAll: false,
     small: false,
-    sort: ['label'],
+    order: ['label'],
+    orderDirection: ['asc'],
     value: [],
   };
 
@@ -115,7 +117,8 @@ export class BaseFormCheckboxGroup extends PureComponent<
       id,
       options,
       selectAll,
-      sort = [],
+      order,
+      orderDirection,
       small,
     } = this.props;
 
@@ -140,7 +143,7 @@ export class BaseFormCheckboxGroup extends PureComponent<
           </ButtonText>
         )}
 
-        {sortBy(options, sort).map(option => (
+        {orderBy(options, order, orderDirection).map(option => (
           <FormCheckbox
             {...option}
             id={option.id ? option.id : `${id}-${kebabCase(option.value)}`}

--- a/src/explore-education-statistics-common/src/components/form/FormRadioGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormRadioGroup.tsx
@@ -1,7 +1,7 @@
 import { Omit, PartialBy } from '@common/types/util';
 import classNames from 'classnames';
 import kebabCase from 'lodash/kebabCase';
-import sortBy from 'lodash/sortBy';
+import orderBy from 'lodash/orderBy';
 import memoize from 'memoizee';
 import React, { ChangeEvent, createRef, PureComponent } from 'react';
 import FormFieldset, { FormFieldsetProps } from './FormFieldset';
@@ -26,7 +26,10 @@ export type FormRadioGroupProps = {
   onChange?: RadioGroupChangeEventHandler;
   options: RadioOption[];
   small?: boolean;
-  sort?: string[] | ((option: RadioOption) => RadioOption[keyof RadioOption])[];
+  order?:
+    | (keyof RadioOption)[]
+    | ((option: RadioOption) => RadioOption[keyof RadioOption])[];
+  orderDirection?: ('asc' | 'desc')[];
   value: string | null;
 } & FormFieldsetProps;
 
@@ -35,7 +38,8 @@ class FormRadioGroup extends PureComponent<FormRadioGroupProps> {
     inline: false,
     legendSize: 'm',
     small: false,
-    sort: ['label'],
+    order: ['label'],
+    orderDirection: ['asc'],
     value: '',
   };
 
@@ -66,7 +70,16 @@ class FormRadioGroup extends PureComponent<FormRadioGroupProps> {
   }
 
   public render() {
-    const { id, inline, name, options, small, sort = [], value } = this.props;
+    const {
+      id,
+      inline,
+      name,
+      options,
+      small,
+      order,
+      orderDirection,
+      value,
+    } = this.props;
 
     return (
       <FormFieldset {...this.props}>
@@ -77,7 +90,7 @@ class FormRadioGroup extends PureComponent<FormRadioGroupProps> {
           })}
           ref={this.ref}
         >
-          {sortBy(options, sort).map(option => (
+          {orderBy(options, order, orderDirection).map(option => (
             <FormRadio
               {...option}
               id={option.id ? option.id : `${id}-${kebabCase(option.value)}`}

--- a/src/explore-education-statistics-common/src/components/form/FormSelect.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormSelect.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import orderBy from 'lodash/orderBy';
 import React, { ChangeEventHandler, FocusEventHandler, ReactNode } from 'react';
 import ErrorMessage from '../ErrorMessage';
 import styles from './FormSelect.module.scss';
@@ -18,6 +19,10 @@ export interface FormSelectProps {
   onBlur?: FocusEventHandler;
   onChange?: SelectChangeEventHandler;
   options: SelectOption[];
+  order?:
+    | (keyof SelectOption)[]
+    | ((option: SelectOption) => SelectOption[keyof SelectOption])[];
+  orderDirection?: ('asc' | 'desc')[];
   value?: string | number;
 }
 
@@ -29,6 +34,8 @@ const FormSelect = ({
   onBlur,
   onChange,
   options,
+  order = ['label'],
+  orderDirection = ['asc'],
   value,
 }: FormSelectProps) => {
   return (
@@ -47,7 +54,7 @@ const FormSelect = ({
         onChange={onChange}
         value={value}
       >
-        {options.map(option => (
+        {orderBy(options, order, orderDirection).map(option => (
           <option value={option.value} key={`${option.value}-${option.label}`}>
             {option.label}
           </option>

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxGroup.test.tsx
@@ -28,6 +28,55 @@ describe('FormCheckboxGroup', () => {
     expect(container.innerHTML).toMatchSnapshot();
   });
 
+  test('renders list of checkboxes in reverse order', () => {
+    const { getAllByLabelText } = render(
+      <FormCheckboxGroup
+        id="test-checkboxes"
+        name="test-checkboxes"
+        legend="Test checkboxes"
+        value={[]}
+        orderDirection={['desc']}
+        options={[
+          { id: 'checkbox-1', label: 'Test checkbox 1', value: '1' },
+          { id: 'checkbox-2', label: 'Test checkbox 2', value: '2' },
+          { id: 'checkbox-3', label: 'Test checkbox 3', value: '3' },
+        ]}
+      />,
+    );
+
+    const checkboxes = getAllByLabelText(/Test checkbox/);
+
+    expect(checkboxes).toHaveLength(3);
+    expect(checkboxes[0]).toHaveAttribute('value', '3');
+    expect(checkboxes[1]).toHaveAttribute('value', '2');
+    expect(checkboxes[2]).toHaveAttribute('value', '1');
+  });
+
+  test('renders list of checkboxes in custom order', () => {
+    const { getAllByLabelText } = render(
+      <FormCheckboxGroup
+        id="test-checkboxes"
+        name="test-checkboxes"
+        legend="Test checkboxes"
+        value={[]}
+        order={['value']}
+        orderDirection={['desc']}
+        options={[
+          { id: 'checkbox-1', label: 'Test checkbox 1', value: '2' },
+          { id: 'checkbox-2', label: 'Test checkbox 2', value: '3' },
+          { id: 'checkbox-3', label: 'Test checkbox 3', value: '1' },
+        ]}
+      />,
+    );
+
+    const radios = getAllByLabelText(/Test checkbox/);
+
+    expect(radios).toHaveLength(3);
+    expect(radios[0]).toHaveAttribute('value', '3');
+    expect(radios[1]).toHaveAttribute('value', '2');
+    expect(radios[2]).toHaveAttribute('value', '1');
+  });
+
   test('renders checkboxes with some pre-checked', () => {
     const { container, getAllByLabelText } = render(
       <FormCheckboxGroup

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormRadioGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormRadioGroup.test.tsx
@@ -30,6 +30,55 @@ describe('FormRadioGroup', () => {
     expect(container.innerHTML).toMatchSnapshot();
   });
 
+  test('renders list of radios in reverse order', () => {
+    const { getAllByLabelText } = render(
+      <FormRadioGroup
+        value={null}
+        id="test-radios"
+        name="test-radios"
+        legend="Test radios"
+        orderDirection={['desc']}
+        options={[
+          { id: 'radio-1', label: 'Test radio 1', value: '1' },
+          { id: 'radio-2', label: 'Test radio 2', value: '2' },
+          { id: 'radio-3', label: 'Test radio 3', value: '3' },
+        ]}
+      />,
+    );
+
+    const radios = getAllByLabelText(/Test radio/);
+
+    expect(radios).toHaveLength(3);
+    expect(radios[0]).toHaveAttribute('value', '3');
+    expect(radios[1]).toHaveAttribute('value', '2');
+    expect(radios[2]).toHaveAttribute('value', '1');
+  });
+
+  test('renders list of radios in custom order', () => {
+    const { getAllByLabelText } = render(
+      <FormRadioGroup
+        value={null}
+        id="test-radios"
+        name="test-radios"
+        legend="Test radios"
+        order={['value']}
+        orderDirection={['desc']}
+        options={[
+          { id: 'radio-1', label: 'Test radio 1', value: '2' },
+          { id: 'radio-2', label: 'Test radio 2', value: '3' },
+          { id: 'radio-3', label: 'Test radio 3', value: '1' },
+        ]}
+      />,
+    );
+
+    const radios = getAllByLabelText(/Test radio/);
+
+    expect(radios).toHaveLength(3);
+    expect(radios[0]).toHaveAttribute('value', '3');
+    expect(radios[1]).toHaveAttribute('value', '2');
+    expect(radios[2]).toHaveAttribute('value', '1');
+  });
+
   test('clicking a radio checks it', () => {
     class RadioWrapper extends Component {
       public state = {

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormSelect.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormSelect.test.tsx
@@ -21,6 +21,71 @@ describe('FormSelect', () => {
     expect(container.innerHTML).toMatchSnapshot();
   });
 
+  test('renders list of options in alphabetical order by default', () => {
+    const { getAllByText } = render(
+      <FormSelect
+        id="test-select"
+        label="Test select"
+        name="testSelect"
+        options={[
+          { value: 'option-2', label: 'Option 2' },
+          { value: 'option-3', label: 'Option 3' },
+          { value: 'option-1', label: 'Option 1' },
+        ]}
+      />,
+    );
+
+    const options = getAllByText(/Option/);
+
+    expect(options[0]).toHaveTextContent('Option 1');
+    expect(options[1]).toHaveTextContent('Option 2');
+    expect(options[2]).toHaveTextContent('Option 3');
+  });
+
+  test('renders list of options in reverse alphabetical order', () => {
+    const { getAllByText } = render(
+      <FormSelect
+        id="test-select"
+        label="Test select"
+        name="testSelect"
+        orderDirection={['desc']}
+        options={[
+          { value: 'option-2', label: 'Option 2' },
+          { value: 'option-3', label: 'Option 3' },
+          { value: 'option-1', label: 'Option 1' },
+        ]}
+      />,
+    );
+
+    const options = getAllByText(/Option/);
+
+    expect(options[0]).toHaveTextContent('Option 3');
+    expect(options[1]).toHaveTextContent('Option 2');
+    expect(options[2]).toHaveTextContent('Option 1');
+  });
+
+  test('renders list of options in custom order', () => {
+    const { getAllByText } = render(
+      <FormSelect
+        id="test-select"
+        label="Test select"
+        name="testSelect"
+        order={['value']}
+        options={[
+          { value: '1', label: 'Option 2' },
+          { value: '2', label: 'Option 3' },
+          { value: '3', label: 'Option 1' },
+        ]}
+      />,
+    );
+
+    const options = getAllByText(/Option/);
+
+    expect(options[0]).toHaveTextContent('Option 2');
+    expect(options[1]).toHaveTextContent('Option 3');
+    expect(options[2]).toHaveTextContent('Option 1');
+  });
+
   test('renders with error message', () => {
     const { container, getByText, getByLabelText } = render(
       <FormSelect


### PR DESCRIPTION
This PR add new `order` and `orderDirection` props to `FormSelect`, `FormCheckboxGroup` and `FormRadioGroup` to enable custom ordering of options. By default these will sort by label in ascending order. This should be a sensible default for most forms.