### PR TITLE
DFE-675 + DFE-595 Add polyfill for Array.flat and remove MediaQueryLister.add/removeEventListener polyfill

### DIFF
--- a/src/explore-education-statistics-admin/test/setupTests.js
+++ b/src/explore-education-statistics-admin/test/setupTests.js
@@ -19,8 +19,8 @@ Element.prototype.scrollIntoView = jest.fn();
 beforeEach(() => {
   window.matchMedia = jest.fn(() => {
     return {
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
       matches: true,
     };
   });

--- a/src/explore-education-statistics-common/src/hooks/useMedia.ts
+++ b/src/explore-education-statistics-common/src/hooks/useMedia.ts
@@ -21,11 +21,11 @@ export default function useMedia(query: string) {
     const mediaQueryList = window.matchMedia(query);
     setMedia(mediaQueryList.matches);
 
-    mediaQueryList.addEventListener('change', onChange);
+    mediaQueryList.addListener(onChange);
 
     return () => {
       mounted = false;
-      mediaQueryList.removeEventListener('change', onChange);
+      mediaQueryList.removeListener(onChange);
     };
   }, [query]);
 

--- a/src/explore-education-statistics-common/src/polyfill.js
+++ b/src/explore-education-statistics-common/src/polyfill.js
@@ -1,4 +1,5 @@
 import 'cross-fetch/polyfill';
+import 'core-js/fn/array/virtual/flatten';
 import 'core-js/fn/array/virtual/flat-map';
 
 if (typeof Promise === 'undefined') {
@@ -21,6 +22,13 @@ if (
 
 if (!('repeat' in String.prototype)) {
   require('core-js/fn/string/repeat');
+}
+
+// Alias Array.flat to Array.flatten as
+// core-js@2 uses the older proposal
+if (!Array.prototype.flat) {
+  // eslint-disable-next-line no-extend-native
+  Array.prototype.flat = Array.prototype.flatten;
 }
 
 // NodeList.forEach

--- a/src/explore-education-statistics-common/src/polyfill.js
+++ b/src/explore-education-statistics-common/src/polyfill.js
@@ -36,17 +36,6 @@ if (window.NodeList && !NodeList.prototype.forEach) {
   NodeList.prototype.forEach = Array.prototype.forEach;
 }
 
-// Alias addListener/removeListener (as these are deprecated)
-if (
-  typeof MediaQueryList.prototype.addEventListener === 'undefined' ||
-  typeof MediaQueryList.prototype.removeEventListener === 'undefined'
-) {
-  MediaQueryList.prototype.addEventListener =
-    MediaQueryList.prototype.addListener;
-  MediaQueryList.prototype.removeEventListener =
-    MediaQueryList.prototype.removeListener;
-}
-
 // For IE11
 
 if (!Element.prototype.matches) {

--- a/src/explore-education-statistics-common/src/polyfill.js
+++ b/src/explore-education-statistics-common/src/polyfill.js
@@ -11,16 +11,16 @@ if (typeof Promise === 'undefined') {
 // This probably shouldn't be needed as long
 // as babel-preset-env is working correctly.
 if (
-  !('startsWith' in String.prototype) ||
-  !('endsWith' in String.prototype) ||
-  !('includes' in Array.prototype) ||
-  !('assign' in Object) ||
-  !('keys' in Object)
+  !String.prototype.startsWith ||
+  !String.prototype.endsWith ||
+  !Array.prototype.includes ||
+  !Object.assign ||
+  !Object.keys
 ) {
   require('core-js');
 }
 
-if (!('repeat' in String.prototype)) {
+if (!String.prototype.repeat) {
   require('core-js/fn/string/repeat');
 }
 

--- a/src/explore-education-statistics-common/test/setupTests.js
+++ b/src/explore-education-statistics-common/test/setupTests.js
@@ -31,8 +31,8 @@ beforeAll(() => {
 beforeEach(() => {
   window.matchMedia = jest.fn(() => {
     return {
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
       matches: true,
     };
   });

--- a/src/explore-education-statistics-frontend/test/setupTests.js
+++ b/src/explore-education-statistics-frontend/test/setupTests.js
@@ -19,8 +19,8 @@ Element.prototype.scrollIntoView = jest.fn();
 beforeEach(() => {
   window.matchMedia = jest.fn(() => {
     return {
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
       matches: true,
     };
   });


### PR DESCRIPTION
This PR:

- Adds the `Array.flat` polyfill that previously was breaking on Edge. We have to alias it to the old `Array.flatten` proposal (that has been superceded by `Array.flat`)  as we are stuck on CoreJS v2 for the time being (due to Next's dependencies).
- Removes the `MediaQueryList.addEventListener/removeEventListener` polyfills as these do not work with Safari. Instead we should just use the older `addListener/removeListener` methods when applicable as these are well supported (despite being deprecated).