### PR TITLE
DFE-665 Fix null pointer when moving to and from previous step

### DIFF
--- a/src/explore-education-statistics-common/src/components/Button.tsx
+++ b/src/explore-education-statistics-common/src/components/Button.tsx
@@ -7,7 +7,7 @@ export interface ButtonProps {
   className?: string;
   disabled?: boolean;
   id?: string;
-  onClick?: MouseEventHandler;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
   variant?: 'secondary' | 'warning';
   type?: 'button' | 'submit' | 'reset';
 }

--- a/src/explore-education-statistics-common/src/components/form/Form.tsx
+++ b/src/explore-education-statistics-common/src/components/form/Form.tsx
@@ -62,18 +62,17 @@ const Form = ({
       onReset={formik.handleReset}
       onSubmit={async event => {
         event.preventDefault();
-        formik.setSubmitting(true);
 
         try {
           await formik.submitForm();
         } catch (error) {
-          setSubmitError({
-            id: submitId,
-            message: error.message,
-          });
+          if (error) {
+            setSubmitError({
+              id: submitId,
+              message: error.message,
+            });
+          }
         }
-
-        formik.setSubmitting(false);
       }}
     >
       <ErrorSummary errors={allErrors} id={`${id}-summary`} />

--- a/src/explore-education-statistics-common/src/components/form/Formik.tsx
+++ b/src/explore-education-statistics-common/src/components/form/Formik.tsx
@@ -1,0 +1,60 @@
+import {
+  Formik as BaseFormik,
+  FormikTouched,
+  FormikValues,
+  setNestedObjectValues,
+} from 'formik';
+
+/**
+ * Component extending Formik to workaround various
+ * limitations with the current v1 API.
+ *
+ * It would be preferable if Formik would provide these
+ * parts for us instead (maybe in the upcoming v2 release...)
+ */
+class Formik<FormValues = FormikValues> extends BaseFormik<FormValues> {
+  /**
+   * Hack to get around Formik's `submitForm` method not
+   * chaining promises if `onSubmit` handler also returns a promise.
+   *
+   * The following issues describes this better, but
+   * has not been addressed since March 2018!!!
+   * @see https://github.com/jaredpalmer/formik/issues/486
+   */
+  public submitForm = () => {
+    // Recursively set all values to `true`.
+    this.setState(prevState => ({
+      touched: setNestedObjectValues<FormikTouched<FormValues>>(
+        prevState.values,
+        true,
+      ),
+      isSubmitting: true,
+      isValidating: true,
+      submitCount: prevState.submitCount + 1,
+    }));
+
+    return this.runValidations(this.state.values).then(async combinedErrors => {
+      if (this.didMount) {
+        this.setState({ isValidating: false });
+      }
+      const isValid = Object.keys(combinedErrors).length === 0;
+
+      try {
+        if (isValid) {
+          await this.executeSubmit();
+        }
+      } finally {
+        if (this.didMount) {
+          // ^^^ Make sure Formik is still mounted before calling setState
+          this.setState({ isSubmitting: false });
+        }
+      }
+    });
+  };
+
+  public executeSubmit = () => {
+    return this.props.onSubmit(this.state.values, this.getFormikActions());
+  };
+}
+
+export default Formik;

--- a/src/explore-education-statistics-common/src/components/form/index.ts
+++ b/src/explore-education-statistics-common/src/components/form/index.ts
@@ -24,4 +24,6 @@ export { default as FormRadio } from './FormRadio';
 export { default as FormRadioGroup } from './FormRadioGroup';
 export { default as FormSelect } from './FormSelect';
 export { default as FormTextInput } from './FormTextInput';
+export { default as FormTextSearchInput } from './FormTextSearchInput';
 export { default as FormFieldTextInput } from './FormFieldTextInput';
+export { default as Formik } from './Formik';

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/FiltersForm.tsx
@@ -1,9 +1,14 @@
-import { Form, FormFieldset, FormGroup } from '@common/components/form';
-import FormFieldCheckboxSearchSubGroups from '@common/components/form/FormFieldCheckboxSearchSubGroups';
+import {
+  Form,
+  FormFieldCheckboxSearchSubGroups,
+  FormFieldset,
+  FormGroup,
+  Formik,
+} from '@common/components/form';
 import createErrorHelper from '@common/lib/validation/createErrorHelper';
 import Yup from '@common/lib/validation/yup';
 import { PublicationSubjectMeta } from '@common/services/tableBuilderService';
-import { Formik, FormikProps } from 'formik';
+import { FormikProps } from 'formik';
 import camelCase from 'lodash/camelCase';
 import mapValues from 'lodash/mapValues';
 import React, { useRef } from 'react';

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/FiltersForm.tsx
@@ -42,13 +42,15 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
     <WizardStepHeading {...props}>Choose your filters</WizardStepHeading>
   );
 
+  const initialValues = {
+    filters: mapValues(specification.filters, () => []),
+    indicators: [],
+  };
+
   return (
     <Formik<FormValues>
       enableReinitialize
-      initialValues={{
-        filters: mapValues(specification.filters, () => []),
-        indicators: [],
-      }}
+      initialValues={initialValues}
       validationSchema={Yup.object<FormValues>({
         filters: Yup.object(
           mapValues(specification.filters, () =>
@@ -138,6 +140,12 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
                 formId={formId}
                 submitText="Create table"
                 submittingText="Creating table"
+                onPreviousStep={() => {
+                  form.resetForm({
+                    filters: mapValues(specification.filters, () => []),
+                    indicators: [],
+                  });
+                }}
               />
             </Form>
           </div>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -50,6 +50,15 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
     </WizardStepHeading>
   );
 
+  const initialValues = {
+    locations: Object.keys(options).reduce((acc, level) => {
+      return {
+        ...acc,
+        [level]: [],
+      };
+    }, {}),
+  };
+
   return (
     <Formik<FormValues>
       enableReinitialize
@@ -57,14 +66,7 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
         await onSubmit(values);
         goToNextStep();
       }}
-      initialValues={{
-        locations: Object.keys(options).reduce((acc, level) => {
-          return {
-            ...acc,
-            [level]: [],
-          };
-        }, {}),
-      }}
+      initialValues={initialValues}
       validationSchema={Yup.object<FormValues>({
         locations: Yup.mixed().test(
           'required',
@@ -131,7 +133,17 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
               </div>
             </FormFieldset>
 
-            <WizardStepFormActions {...props} form={form} formId={formId} />
+            <WizardStepFormActions
+              {...props}
+              form={form}
+              formId={formId}
+              onPreviousStep={() => {
+                form.resetForm(initialValues);
+                updateLocationLevels(() => {
+                  return {};
+                });
+              }}
+            />
           </Form>
         ) : (
           <>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -1,10 +1,10 @@
-import { Form, FormFieldset } from '@common/components/form';
+import { Form, FormFieldset, Formik } from '@common/components/form';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import Yup from '@common/lib/validation/yup';
 import { PublicationSubjectMeta } from '@common/services/tableBuilderService';
 import { Dictionary } from '@common/types/util';
-import { Formik, FormikProps } from 'formik';
+import { FormikProps } from 'formik';
 import sortBy from 'lodash/sortBy';
 import React, { useEffect } from 'react';
 import { useImmer } from 'use-immer';

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationForm.tsx
@@ -1,16 +1,17 @@
 import DetailsMenu from '@common/components/DetailsMenu';
 import {
+  Form,
   FormFieldRadioGroup,
   FormFieldset,
   FormGroup,
+  Formik,
+  FormTextSearchInput,
 } from '@common/components/form';
-import Form from '@common/components/form/Form';
-import FormTextSearchInput from '@common/components/form/FormTextSearchInput';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import createErrorHelper from '@common/lib/validation/createErrorHelper';
 import Yup from '@common/lib/validation/yup';
-import { Formik, FormikProps } from 'formik';
+import { FormikProps } from 'formik';
 import camelCase from 'lodash';
 import React, { useState } from 'react';
 import { PublicationOptions } from '../TableToolPage';

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationSubjectForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationSubjectForm.tsx
@@ -35,6 +35,10 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
     </WizardStepHeading>
   );
 
+  const initialValues = {
+    subjectId: '',
+  };
+
   return (
     <Formik
       enableReinitialize
@@ -45,9 +49,7 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
         });
         goToNextStep();
       }}
-      initialValues={{
-        subjectId: '',
-      }}
+      initialValues={initialValues}
       validationSchema={Yup.object<FormValues>({
         subjectId: Yup.string().required('Choose a publication subject'),
       })}
@@ -67,7 +69,15 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
               }}
             />
 
-            <WizardStepFormActions {...props} form={form} formId={formId} />
+            <WizardStepFormActions
+              {...props}
+              form={form}
+              formId={formId}
+              onPreviousStep={() => {
+                form.resetForm(initialValues);
+                setSubjectName('');
+              }}
+            />
           </Form>
         ) : (
           <>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationSubjectForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationSubjectForm.tsx
@@ -1,9 +1,9 @@
-import { Form, FormFieldRadioGroup } from '@common/components/form';
+import { Form, FormFieldRadioGroup, Formik } from '@common/components/form';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import Yup from '@common/lib/validation/yup';
 import { PublicationSubject } from '@common/services/tableBuilderService';
-import { Formik, FormikProps } from 'formik';
+import { FormikProps } from 'formik';
 import React, { useState } from 'react';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableHeadersForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableHeadersForm.tsx
@@ -1,6 +1,7 @@
 import Button from '@common/components/Button';
 import Details from '@common/components/Details';
-import { Form, Formik } from 'formik';
+import { Formik } from '@common/components/form';
+import { Form } from 'formik';
 import React from 'react';
 import FormFieldSortableList from './FormFieldSortableList';
 import { SortableOption } from './FormSortableList';

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TimePeriodForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TimePeriodForm.tsx
@@ -1,4 +1,9 @@
-import { Form, FormFieldSelect, FormFieldset } from '@common/components/form';
+import {
+  Form,
+  FormFieldSelect,
+  FormFieldset,
+  Formik,
+} from '@common/components/form';
 import { SelectOption } from '@common/components/form/FormSelect';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
@@ -6,7 +11,7 @@ import Yup from '@common/lib/validation/yup';
 import { PublicationSubjectMeta } from '@common/services/tableBuilderService';
 import TimePeriod from '@common/services/types/TimePeriod';
 import { Comparison } from '@common/types/util';
-import { Formik, FormikProps } from 'formik';
+import { FormikProps } from 'formik';
 import React from 'react';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TimePeriodForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TimePeriodForm.tsx
@@ -51,16 +51,18 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
     </WizardStepHeading>
   );
 
+  const initialValues = {
+    start: '',
+    end: '',
+  };
+
   return (
     <Formik<FormValues>
       onSubmit={async values => {
         await onSubmit(values);
         goToNextStep();
       }}
-      initialValues={{
-        start: '',
-        end: '',
-      }}
+      initialValues={initialValues}
       validationSchema={Yup.object<FormValues>({
         end: Yup.string()
           .required('End date is required')
@@ -135,7 +137,14 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
               />
             </FormFieldset>
 
-            <WizardStepFormActions {...props} form={form} formId={formId} />
+            <WizardStepFormActions
+              {...props}
+              form={form}
+              formId={formId}
+              onPreviousStep={() => {
+                form.resetForm(initialValues);
+              }}
+            />
           </Form>
         ) : (
           <>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStepFormActions.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStepFormActions.tsx
@@ -1,13 +1,14 @@
 import Button from '@common/components/Button';
 import { FormGroup } from '@common/components/form';
 import { FormikProps } from 'formik';
-import React from 'react';
+import React, { MouseEventHandler } from 'react';
 import { InjectedWizardProps } from './Wizard';
 
 interface Props {
   form: FormikProps<{}>;
   formId: string;
   goToPreviousStep: InjectedWizardProps['goToPreviousStep'];
+  onPreviousStep?: MouseEventHandler;
   stepNumber: InjectedWizardProps['stepNumber'];
   submitText?: string;
   submittingText?: string;
@@ -17,6 +18,7 @@ const WizardStepFormActions = ({
   form,
   formId,
   goToPreviousStep,
+  onPreviousStep,
   stepNumber,
   submitText = 'Next step',
   submittingText = 'Submitting',
@@ -28,15 +30,21 @@ const WizardStepFormActions = ({
         id={`${formId}-submit`}
         type="submit"
       >
-        {form.isSubmitting && form.isValid ? submittingText : submitText}
+        {form.isSubmitting ? submittingText : submitText}
       </Button>
 
       {stepNumber > 1 && (
         <Button
           type="button"
           variant="secondary"
-          onClick={() => {
-            goToPreviousStep();
+          onClick={event => {
+            if (onPreviousStep) {
+              onPreviousStep(event);
+            }
+
+            if (!event.isDefaultPrevented()) {
+              goToPreviousStep();
+            }
           }}
         >
           Previous step

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStepFormActions.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStepFormActions.tsx
@@ -1,11 +1,11 @@
 import Button from '@common/components/Button';
 import { FormGroup } from '@common/components/form';
-import { FormikProps } from 'formik';
+import { FormikState } from 'formik';
 import React, { MouseEventHandler } from 'react';
 import { InjectedWizardProps } from './Wizard';
 
 interface Props {
-  form: FormikProps<{}>;
+  form: FormikState<{}>;
   formId: string;
   goToPreviousStep: InjectedWizardProps['goToPreviousStep'];
   onPreviousStep?: MouseEventHandler;

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/WizardStepFormActions.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/WizardStepFormActions.test.tsx
@@ -1,0 +1,143 @@
+import { Formik, FormikProps } from 'formik';
+import React from 'react';
+import { fireEvent, render } from 'react-testing-library';
+import WizardStepFormActions from '../WizardStepFormActions';
+
+describe('WizardStepFormActions', () => {
+  test('when submitting, `Next step` button changes to `Submitting`', async () => {
+    const { queryByText } = render(
+      <Formik
+        onSubmit={() => {}}
+        initialValues={{}}
+        render={(form: FormikProps<{}>) => {
+          return (
+            <WizardStepFormActions
+              form={{ ...form, isSubmitting: true }}
+              formId="form"
+              goToPreviousStep={() => {}}
+              onPreviousStep={() => {}}
+              stepNumber={1}
+            />
+          );
+        }}
+      />,
+    );
+
+    expect(queryByText('Next step')).toBeNull();
+    expect(queryByText('Submitting')).toHaveAttribute('disabled');
+  });
+
+  test('when submitting, `Next step` button changes to custom submitting text', () => {
+    const { queryByText } = render(
+      <Formik
+        onSubmit={() => {}}
+        initialValues={{}}
+        render={(form: FormikProps<{}>) => {
+          return (
+            <WizardStepFormActions
+              form={{ ...form, isSubmitting: true }}
+              formId="form"
+              goToPreviousStep={() => {}}
+              onPreviousStep={() => {}}
+              stepNumber={1}
+              submittingText="Processing..."
+            />
+          );
+        }}
+      />,
+    );
+
+    expect(queryByText('Next step')).toBeNull();
+    expect(queryByText('Processing...')).toHaveAttribute('disabled');
+  });
+
+  test('does not render `Previous step` button when not on step 2', () => {
+    const { queryByText, rerender } = render(
+      <Formik
+        onSubmit={() => {}}
+        initialValues={{}}
+        render={(form: FormikProps<{}>) => (
+          <WizardStepFormActions
+            form={form}
+            formId="form"
+            goToPreviousStep={() => {}}
+            onPreviousStep={() => {}}
+            stepNumber={1}
+          />
+        )}
+      />,
+    );
+
+    expect(queryByText('Previous step')).toBeNull();
+
+    rerender(
+      <Formik
+        onSubmit={() => {}}
+        initialValues={{}}
+        render={(form: FormikProps<{}>) => (
+          <WizardStepFormActions
+            form={form}
+            formId="form"
+            goToPreviousStep={() => {}}
+            onPreviousStep={() => {}}
+            stepNumber={2}
+          />
+        )}
+      />,
+    );
+
+    expect(queryByText('Previous step')).not.toBeNull();
+  });
+
+  test('clicking `Previous step` button calls `goToPreviousStep` handler', () => {
+    const goToPreviousStep = jest.fn();
+
+    const { getByText } = render(
+      <Formik
+        onSubmit={() => {}}
+        initialValues={{}}
+        render={(form: FormikProps<{}>) => (
+          <WizardStepFormActions
+            form={form}
+            formId="form"
+            goToPreviousStep={goToPreviousStep}
+            onPreviousStep={() => {}}
+            stepNumber={2}
+          />
+        )}
+      />,
+    );
+
+    expect(goToPreviousStep).not.toHaveBeenCalled();
+
+    fireEvent.click(getByText('Previous step'));
+
+    expect(goToPreviousStep).toHaveBeenCalled();
+  });
+
+  test('preventing default `Previous step` button event does not call `goToPreviousStep` handler', () => {
+    const goToPreviousStep = jest.fn();
+
+    const { getByText } = render(
+      <Formik
+        onSubmit={() => {}}
+        initialValues={{}}
+        render={(form: FormikProps<{}>) => (
+          <WizardStepFormActions
+            form={form}
+            formId="form"
+            goToPreviousStep={goToPreviousStep}
+            onPreviousStep={event => event.preventDefault()}
+            stepNumber={2}
+          />
+        )}
+      />,
+    );
+
+    expect(goToPreviousStep).not.toHaveBeenCalled();
+
+    fireEvent.click(getByText('Previous step'));
+
+    expect(goToPreviousStep).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR fixes the null pointer that is thrown due to residual form state when the 'Previous step' button for a wizard step is clicked. Each step's form state is now cleared down to avoid this issue.

## Other changes

A Formik extension component has been created to enable us to handle a form's submission in an async. manner. 

Previously, in Formik's v1 API, Formik automatically resolves the `onSubmit` handler without caring if `onSubmit` is async (i.e. returns a promise). Consequently, this has meant that the form submitting state (changes 'Next step' button to a disabled 'Submitting' button) has not been triggering correctly and hasn't stopped users from accidentally double-submitting.

This has now been rectified and should work as expected, although the solution is somewhat undesirable as we have to get a bit too close to Formik's internals to make this work. Hopefully when v2 is released, they will have rectified this issue...

Related issues:
- https://github.com/jaredpalmer/formik/issues/486
- https://github.com/jaredpalmer/formia/pull/1229

