### PR TITLE
Feature/dfe 717 content api changes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/ContentService.cs
@@ -25,7 +25,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
                 {
                     Id = x.Id, Title = x.Title, Summary = x.Summary,
                     Publications = x.Publications
-                        .Where(p => p.Releases.Count > 0)
                         .Select(p => new PublicationTree
                             {Id = p.Id, Title = p.Title, Summary = p.Summary, Slug = p.Slug}).OrderBy(publication => publication.Title).ToList()
                 }).OrderBy(topic => topic.Title).ToList()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/ContentService.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
     public class ContentService : IContentService
     {
         private readonly ApplicationDbContext _context;
-        
+
         public ContentService(
             ApplicationDbContext context)
         {
@@ -26,7 +26,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
                     Id = x.Id, Title = x.Title, Summary = x.Summary,
                     Publications = x.Publications
                         .Select(p => new PublicationTree
-                            {Id = p.Id, Title = p.Title, Summary = p.Summary, Slug = p.Slug}).OrderBy(publication => publication.Title).ToList()
+                        {
+                            Id = p.Id,
+                            Title = p.Title,
+                            Summary = p.Summary,
+                            Slug = p.Slug,
+                            LegacyPublicationUrl = p.LegacyPublicationUrl != null ? p.LegacyPublicationUrl.ToString() : null
+                        }).OrderBy(publication => publication.Title).ToList()
                 }).OrderBy(topic => topic.Title).ToList()
             }).OrderBy(theme => theme.Title).ToList();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/ViewModels/PublicationTree.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/ViewModels/PublicationTree.cs
@@ -9,5 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels
         public string Title { get; set; }
         public string Slug { get; set; }
         public string Summary { get; set; }
+        
+        public string LegacyPublicationUrl { get; set; }
     }
 }


### PR DESCRIPTION
This amends the content api to include publications if no releases exist within the service. 

It also provides a legacy publication url as a link to be used in the above case within the find statistics ui.