### PR TITLE
Feature/dfe 717 cleanup

### DIFF
--- a/src/explore-education-statistics-common/src/components/PublicationList.tsx
+++ b/src/explore-education-statistics-common/src/components/PublicationList.tsx
@@ -44,14 +44,7 @@ function PublicationList({ publications }: Props) {
           </li>
         ))
       ) : (
-        <div className="govuk-inset-text">
-          These statistics and data are not yet available on the explore
-          education statistics service. To find and download these statistics
-          and data browse{' '}
-          <a href="https://www.gov.uk/government/organisations/department-for-education/about/statistics#statistical-collections">
-            Statistics at DfE
-          </a>
-        </div>
+        <></>
       )}
     </>
   );

--- a/src/explore-education-statistics-common/src/components/PublicationList.tsx
+++ b/src/explore-education-statistics-common/src/components/PublicationList.tsx
@@ -19,31 +19,26 @@ function PublicationList({ publications }: Props) {
       {publications.length > 0 ? (
         publications.map(({ id, slug, summary, title }) => (
           <li key={id}>
-            <h3 className="govuk-heading-m govuk-!-margin-bottom-0">{title}</h3>
-            <p className="govuk-caption-m govuk-!-margin-top-0 govuk-!-margin-bottom-1">
-              {summary}
-            </p>
-            <div className="govuk-!-margin-top-0 govuk-!-margin-bottom-5">
-              <div className="govuk-grid-row">
-                <div className="govuk-grid-column-one-third">
-                  <Link
-                    className="govuk-link govuk-!-margin-right-9"
-                    to={`/statistics/publication?publication=${slug}`}
-                    as={`/statistics/${slug}`}
-                    data-testid={`view-stats-${slug}`}
-                  >
-                    View statistics and data
-                  </Link>
-                </div>
-                <div className="govuk-grid-column-one-third">
-                  <Link
-                    className="govuk-link govuk-!-margin-right-9"
-                    to={`/table-tool/${slug}`}
-                    data-testid={`create-table-${slug}`}
-                  >
-                    Create your own tables online
-                  </Link>
-                </div>
+            <strong>{title}</strong>
+            <div className="govuk-!-margin-top-0 govuk-!-margin-bottom-4">
+              <div className="govuk-grid-column-one-third">
+                <Link
+                  className="govuk-link govuk-!-margin-right-9"
+                  to={`/statistics/publication?publication=${slug}`}
+                  as={`/statistics/${slug}`}
+                  data-testid={`view-stats-${slug}`}
+                >
+                  View statistics and data
+                </Link>
+              </div>
+              <div className="govuk-grid-column-one-third">
+                <Link
+                  className="govuk-link"
+                  to={`/table-tool/${slug}`}
+                  data-testid={`create-table-${slug}`}
+                >
+                  Create your own tables online
+                </Link>
               </div>
             </div>
           </li>

--- a/src/explore-education-statistics-common/src/components/PublicationList.tsx
+++ b/src/explore-education-statistics-common/src/components/PublicationList.tsx
@@ -1,9 +1,9 @@
-import Details from '@common/components/Details';
 import Link from '@frontend/components/Link';
 import React from 'react';
 
 export interface Publication {
   id: string;
+  legacyPublicationUrl: string | null;
   slug: string;
   summary: string;
   title: string;
@@ -17,30 +17,37 @@ function PublicationList({ publications }: Props) {
   return (
     <>
       {publications.length > 0 ? (
-        publications.map(({ id, slug, summary, title }) => (
+        publications.map(({ id, legacyPublicationUrl, slug, title }) => (
           <li key={id}>
             <strong>{title}</strong>
-            <div className="govuk-!-margin-top-0 govuk-!-margin-bottom-4">
-              <div className="govuk-grid-column-one-third">
-                <Link
-                  className="govuk-link govuk-!-margin-right-9"
-                  to={`/statistics/publication?publication=${slug}`}
-                  as={`/statistics/${slug}`}
-                  data-testid={`view-stats-${slug}`}
-                >
-                  View statistics and data
-                </Link>
+            {legacyPublicationUrl ? (
+              <span>
+                - currently available via{' '}
+                <a href={legacyPublicationUrl}>Statistics at DfE</a>
+              </span>
+            ) : (
+              <div className="govuk-grid-row govuk-!-margin-top-0 govuk-!-margin-bottom-4">
+                <div className="govuk-grid-column-one-third">
+                  <Link
+                    className="govuk-link govuk-!-margin-right-9"
+                    to={`/statistics/publication?publication=${slug}`}
+                    as={`/statistics/${slug}`}
+                    data-testid={`view-stats-${slug}`}
+                  >
+                    View statistics and data
+                  </Link>
+                </div>
+                <div className="govuk-grid-column-one-third">
+                  <Link
+                    className="govuk-link"
+                    to={`/table-tool/${slug}`}
+                    data-testid={`create-table-${slug}`}
+                  >
+                    Create your own tables online
+                  </Link>
+                </div>
               </div>
-              <div className="govuk-grid-column-one-third">
-                <Link
-                  className="govuk-link"
-                  to={`/table-tool/${slug}`}
-                  data-testid={`create-table-${slug}`}
-                >
-                  Create your own tables online
-                </Link>
-              </div>
-            </div>
+            )}
           </li>
         ))
       ) : (

--- a/src/explore-education-statistics-common/src/components/PublicationList.tsx
+++ b/src/explore-education-statistics-common/src/components/PublicationList.tsx
@@ -44,27 +44,6 @@ function PublicationList({ publications }: Props) {
                     Create your own tables online
                   </Link>
                 </div>
-                <div className="govuk-grid-column-one-third">
-                  <Details summary="Download data files">
-                    <ul className="govuk-list-bullet">
-                      <li>
-                        <a href="#" className="govuk-link">
-                          Download Excel files
-                        </a>
-                      </li>
-                      <li>
-                        <a href="#" className="govuk-link">
-                          Download .csv files
-                        </a>
-                      </li>
-                      <li>
-                        <a href="#" className="govuk-link">
-                          Access API
-                        </a>
-                      </li>
-                    </ul>
-                  </Details>
-                </div>
               </div>
             </div>
           </li>

--- a/src/explore-education-statistics-common/src/components/TopicList.tsx
+++ b/src/explore-education-statistics-common/src/components/TopicList.tsx
@@ -23,7 +23,7 @@ function TopicList({ theme, topics }: Props) {
         <Accordion id={theme}>
           {topics.map(({ id, title, summary, publications }) => (
             <AccordionSection heading={title} caption={summary} key={id}>
-              <ul className="govuk-!-margin-top-0 govuk-!-padding-top-0">
+              <ul className="govuk-bullet-list govuk-!-margin-top-0">
                 <PublicationList publications={publications} />
               </ul>
             </AccordionSection>


### PR DESCRIPTION
This updates the find statistics page:

* display of legacy publication link
* removal of download link
* style tweak on publication list to match prototype

Additional work will be needed to implement the full styling changes once user testing has been completed however this change is consistient across all versions being tested.