### PR TITLE
DFE-704 Add confirmation modal when moving to previous steps

### DIFF
--- a/src/explore-education-statistics-admin/package.json
+++ b/src/explore-education-statistics-admin/package.json
@@ -130,8 +130,8 @@
       "<rootDir>/test/setupTests.js"
     ],
     "testMatch": [
-      "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
-      "<rootDir>/src/**/?(*.)(spec|test).{js,jsx,ts,tsx}"
+      "<rootDir>/src/**/(*.)(spec|test).{js,jsx,ts,tsx}",
+      "<rootDir>/test/**/(*.)(spec|test).{js,jsx,ts,tsx}"
     ],
     "testEnvironment": "jsdom",
     "testURL": "http://localhost",

--- a/src/explore-education-statistics-admin/src/index.tsx
+++ b/src/explore-education-statistics-admin/src/index.tsx
@@ -4,6 +4,8 @@ import ReactDOM from 'react-dom';
 
 import * as serviceWorker from './serviceWorker';
 
+process.env.APP_ROOT_ID = 'root';
+
 import('./App').then(({ default: App }) => {
   ReactDOM.render(<App />, document.getElementById('root'));
 });

--- a/src/explore-education-statistics-admin/test/setupTests.js
+++ b/src/explore-education-statistics-admin/test/setupTests.js
@@ -2,6 +2,7 @@ import 'react-testing-library/cleanup-after-each';
 import 'jest-dom/extend-expect';
 import 'core-js/fn/array/virtual/flat-map';
 import '@common-test/setupGlobals';
+import '@common-test/extend-expect';
 
 if (typeof window !== 'undefined') {
   // fetch polyfill for making API calls.

--- a/src/explore-education-statistics-admin/test/types.d.ts
+++ b/src/explore-education-statistics-admin/test/types.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="jest-dom/extend-expect" />
+
+import '@common-test/types';

--- a/src/explore-education-statistics-common/package-lock.json
+++ b/src/explore-education-statistics-common/package-lock.json
@@ -1729,6 +1729,15 @@
         "csstype": "^2.2.0"
       }
     },
+    "@types/react-aria-modal": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@types/react-aria-modal/-/react-aria-modal-2.12.2.tgz",
+      "integrity": "sha512-RfzM1O8+QG8SB9onPKU5Da9M0dcUQexmuWWuc8+NYrcQuXUg6tI4IV9kgjVPxOntxDkU9/1Tj8lG50/VfJvgbQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-dom": {
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.8.4.tgz",
@@ -5508,6 +5517,25 @@
       "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
       "dev": true
     },
+    "focus-trap": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-4.0.2.tgz",
+      "integrity": "sha512-HtLjfAK7Hp2qbBtLS6wEznID1mPT+48ZnP2nkHzgjpL4kroYHg0CdqJ5cTXk+UO5znAxF5fRUkhdyfgrhh8Lzw==",
+      "dev": true,
+      "requires": {
+        "tabbable": "^3.1.2",
+        "xtend": "^4.0.1"
+      }
+    },
+    "focus-trap-react": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-6.0.0.tgz",
+      "integrity": "sha512-mvEYxmP75PMx0vOqoIAmJHO/qUEvdTAdz6gLlEZyxxODnuKQdnKea2RWTYxghAPrV+ibiIq2o/GTSgQycnAjcw==",
+      "dev": true,
+      "requires": {
+        "focus-trap": "^4.0.2"
+      }
+    },
     "follow-redirects": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
@@ -9037,6 +9065,12 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "no-scroll": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/no-scroll/-/no-scroll-2.1.1.tgz",
+      "integrity": "sha512-YTzGAJOo/B6hkodeT5SKKHpOhAzjMfkUCCXjLJwjWk2F4/InIg+HbdH9kmT7bKpleDuqLZDTRy2OdNtAj0IVyQ==",
+      "dev": true
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -10095,6 +10129,23 @@
         "prop-types": "^15.6.2",
         "scheduler": "^0.13.6"
       }
+    },
+    "react-aria-modal": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/react-aria-modal/-/react-aria-modal-4.0.0.tgz",
+      "integrity": "sha512-crdEAIHc5xXi6YqZeUgRDJN1uromSehU1XSEegVPU8/okmf1tEDwnzb6ULl+PJy4aS6sb6fUiWEdMNTLAX2HBA==",
+      "dev": true,
+      "requires": {
+        "focus-trap-react": "^6.0.0",
+        "no-scroll": "^2.1.1",
+        "react-displace": "^2.3.0"
+      }
+    },
+    "react-displace": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-displace/-/react-displace-2.3.0.tgz",
+      "integrity": "sha512-T8g/lyn3IX8kxLO4k4vJ/oIO9G72pRTc9GYslqKsfPcN4gY5+FYR5OHxeTH1skPjVylJrveGE3OC2qCt3BuHeA==",
+      "dev": true
     },
     "react-dom": {
       "version": "16.8.6",
@@ -11804,6 +11855,12 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.7.tgz",
       "integrity": "sha512-16GbgwTmFMYFyQMLvtQjvNWh30dsFe1cAW5Fg1wm5+dg84L9Pe36mftsIRU95/W2YsISxsz/xq4VB23sqpgb/A==",
+      "dev": true
+    },
+    "tabbable": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.2.tgz",
+      "integrity": "sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ==",
       "dev": true
     },
     "table": {

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -39,6 +39,7 @@
     "jest": "^24.8.0",
     "jest-dom": "^3.4.0",
     "jest-junit": "^6.4.0",
+    "jest-matcher-utils": "^24.8.0",
     "jest-resolve": "^24.8.0",
     "jest-serializer-html": "^6.0.0",
     "jest-watch-typeahead": "^0.3.1",
@@ -89,8 +90,8 @@
       "<rootDir>/test/setupTests.js"
     ],
     "testMatch": [
-      "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
-      "<rootDir>/src/**/(*.)(spec|test).{js,jsx,ts,tsx}"
+      "<rootDir>/src/**/(*.)(spec|test).{js,jsx,ts,tsx}",
+      "<rootDir>/test/**/(*.)(spec|test).{js,jsx,ts,tsx}"
     ],
     "testPathIgnorePatterns": [
       "node_modules",

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -71,7 +71,6 @@
     "test:watch": "jest --watch",
     "test:snapshot": "jest --updateSnapshot"
   },
-  "types": "src/types",
   "author": "",
   "license": "MIT",
   "private": true,

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -10,6 +10,7 @@
     "@types/next": "^8.0.5",
     "@types/node": "^11.13.13",
     "@types/react": "^16.8.19",
+    "@types/react-aria-modal": "^2.12.2",
     "@types/react-dom": "^16.8.4",
     "@types/react-helmet": "^5.0.8",
     "@types/react-leaflet": "^2.2.1",
@@ -47,6 +48,7 @@
     "next": "^8.1.0",
     "next-server": "^8.1.0",
     "react": "^16.8.6",
+    "react-aria-modal": "^4.0.0",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.1",
     "react-leaflet": "^2.3.0",
@@ -68,6 +70,7 @@
     "test:watch": "jest --watch",
     "test:snapshot": "jest --updateSnapshot"
   },
+  "types": "src/types",
   "author": "",
   "license": "MIT",
   "private": true,

--- a/src/explore-education-statistics-common/src/components/Modal.module.scss
+++ b/src/explore-education-statistics-common/src/components/Modal.module.scss
@@ -1,0 +1,7 @@
+@import '../styles/govuk-base';
+
+.dialog {
+  background: #fff;
+  min-width: 30vh;
+  padding: govuk-spacing(6);
+}

--- a/src/explore-education-statistics-common/src/components/Modal.tsx
+++ b/src/explore-education-statistics-common/src/components/Modal.tsx
@@ -23,7 +23,7 @@ const Modal = ({ children, dialogClass, title, ...props }: Props) => {
         return document.getElementById(process.env.APP_ROOT_ID) as HTMLElement;
       }}
     >
-      <h1>{title}</h1>
+      <h1 className="govuk-heading-l">{title}</h1>
       {children}
     </AriaModal>
   );

--- a/src/explore-education-statistics-common/src/components/Modal.tsx
+++ b/src/explore-education-statistics-common/src/components/Modal.tsx
@@ -1,0 +1,32 @@
+import { OmitStrict } from '@common/types';
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+import AriaModal, { AriaModalProps } from 'react-aria-modal';
+import styles from './Modal.module.scss';
+
+type Props = {
+  children: ReactNode;
+  title: string;
+} & OmitStrict<
+  AriaModalProps,
+  'getApplicationNode' | 'verticallyCenter' | 'titleText' | 'titleId'
+>;
+
+const Modal = ({ children, dialogClass, title, ...props }: Props) => {
+  return (
+    <AriaModal
+      {...props}
+      dialogClass={classNames(styles.dialog, dialogClass)}
+      titleText={title}
+      verticallyCenter
+      getApplicationNode={() => {
+        return document.getElementById(process.env.APP_ROOT_ID) as HTMLElement;
+      }}
+    >
+      <h1>{title}</h1>
+      {children}
+    </AriaModal>
+  );
+};
+
+export default Modal;

--- a/src/explore-education-statistics-common/src/components/ModalConfirm.tsx
+++ b/src/explore-education-statistics-common/src/components/ModalConfirm.tsx
@@ -1,0 +1,44 @@
+import { useConfirmContext } from '@common/context/ConfirmContext';
+import React, { ReactNode } from 'react';
+import Button from './Button';
+import Modal from './Modal';
+
+interface Props {
+  children?: ReactNode;
+  cancelText?: string;
+  confirmText?: string;
+  title: string;
+}
+
+const ModalConfirm = ({
+  children,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  title,
+}: Props) => {
+  const { isConfirming, confirm, cancel } = useConfirmContext();
+
+  return (
+    <Modal title={title} onExit={() => cancel()} mounted={isConfirming}>
+      {children}
+
+      <Button
+        onClick={() => {
+          confirm();
+        }}
+      >
+        {confirmText}
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={() => {
+          cancel();
+        }}
+      >
+        {cancelText}
+      </Button>
+    </Modal>
+  );
+};
+
+export default ModalConfirm;

--- a/src/explore-education-statistics-common/src/components/ModalConfirm.tsx
+++ b/src/explore-education-statistics-common/src/components/ModalConfirm.tsx
@@ -1,4 +1,3 @@
-import { useConfirmContext } from '@common/context/ConfirmContext';
 import React, { ReactNode } from 'react';
 import Button from './Button';
 import Modal from './Modal';
@@ -7,6 +6,10 @@ interface Props {
   children?: ReactNode;
   cancelText?: string;
   confirmText?: string;
+  mounted?: boolean;
+  onConfirm(): void;
+  onCancel?(): void;
+  onExit(): void;
   title: string;
 }
 
@@ -14,27 +17,18 @@ const ModalConfirm = ({
   children,
   confirmText = 'Confirm',
   cancelText = 'Cancel',
+  mounted,
+  onConfirm,
+  onCancel,
+  onExit,
   title,
 }: Props) => {
-  const { isConfirming, confirm, cancel } = useConfirmContext();
-
   return (
-    <Modal title={title} onExit={() => cancel()} mounted={isConfirming}>
+    <Modal title={title} onExit={onExit} mounted={mounted}>
       {children}
 
-      <Button
-        onClick={() => {
-          confirm();
-        }}
-      >
-        {confirmText}
-      </Button>
-      <Button
-        variant="secondary"
-        onClick={() => {
-          cancel();
-        }}
-      >
+      <Button onClick={onConfirm}>{confirmText}</Button>
+      <Button variant="secondary" onClick={onCancel}>
         {cancelText}
       </Button>
     </Modal>

--- a/src/explore-education-statistics-common/src/components/__tests__/Modal.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Modal.test.tsx
@@ -1,0 +1,164 @@
+import Modal from '@common/components/Modal';
+import React from 'react';
+import { fireEvent, render, wait } from 'react-testing-library';
+
+describe('Modal', () => {
+  const originalAppRootId = process.env.APP_ROOT_ID;
+
+  afterEach(() => {
+    process.env.APP_ROOT_ID = originalAppRootId;
+  });
+
+  test('renders when `mounted` prop changes from false to true', () => {
+    const { rerender, queryByText } = render(
+      <Modal title="Test modal" onExit={() => {}} mounted={false}>
+        <button type="button">Close</button>
+      </Modal>,
+    );
+
+    expect(queryByText('Test modal')).toBeNull();
+
+    rerender(
+      <Modal title="Test modal" onExit={() => {}} mounted>
+        <button type="button">Close</button>
+      </Modal>,
+    );
+
+    expect(queryByText('Test modal')).not.toBeNull();
+  });
+
+  test('does not render when `mounted` prop changes from true to false', () => {
+    const { rerender, queryByText } = render(
+      <Modal title="Test modal" onExit={() => {}} mounted>
+        <button type="button">Close</button>
+      </Modal>,
+    );
+
+    expect(queryByText('Test modal')).not.toBeNull();
+
+    rerender(
+      <Modal title="Test modal" onExit={() => {}} mounted={false}>
+        <button type="button">Close</button>
+      </Modal>,
+    );
+
+    expect(queryByText('Test modal')).toBeNull();
+  });
+
+  test('when mounted, `onEnter` handler is called', () => {
+    const onEnter = jest.fn();
+
+    const { rerender } = render(
+      <Modal
+        title="Test modal"
+        onEnter={onEnter}
+        onExit={() => {}}
+        mounted={false}
+      >
+        <button type="button">Close</button>
+      </Modal>,
+    );
+
+    expect(onEnter).not.toHaveBeenCalled();
+
+    rerender(
+      <Modal title="Test modal" onEnter={onEnter} onExit={() => {}} mounted>
+        <button type="button">Close</button>
+      </Modal>,
+    );
+
+    expect(onEnter).toHaveBeenCalled();
+  });
+
+  test('pressing Esc key calls `onExit` handler', async () => {
+    const onExit = jest.fn();
+
+    const { container } = render(
+      <Modal title="Test modal" onExit={onExit} mounted>
+        <button type="button">Close</button>
+      </Modal>,
+    );
+
+    await wait();
+
+    expect(onExit).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(container, {
+      key: 'Esc',
+    });
+
+    expect(onExit).toHaveBeenCalled();
+  });
+
+  test('mouseDown on underlay of modal calls `onExit` handler', async () => {
+    const onExit = jest.fn();
+
+    const { baseElement } = render(
+      <Modal
+        title="Test modal"
+        underlayClass="underlay"
+        onExit={onExit}
+        mounted
+      >
+        <button type="button">Close</button>
+      </Modal>,
+    );
+
+    expect(onExit).not.toHaveBeenCalled();
+
+    fireEvent.mouseDown(baseElement.querySelector('.underlay') as HTMLElement);
+
+    expect(onExit).toHaveBeenCalled();
+  });
+
+  test('when mounted, root element has aria-hidden=true', async () => {
+    process.env.APP_ROOT_ID = 'root';
+
+    const { container } = render(
+      <div id="root">
+        <Modal title="Test modal" onExit={() => {}} mounted>
+          <button type="button">Close</button>
+        </Modal>
+      </div>,
+    );
+
+    await wait();
+
+    expect(container.querySelector('#root')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+  });
+
+  test('when unmounted, root element has aria-hidden=false', async () => {
+    process.env.APP_ROOT_ID = 'root';
+
+    const { container, rerender } = render(
+      <div id="root">
+        <Modal title="Test modal" onExit={() => {}} mounted>
+          <button type="button">Close</button>
+        </Modal>
+      </div>,
+    );
+
+    await wait();
+
+    expect(container.querySelector('#root')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+
+    rerender(
+      <div id="root">
+        <Modal title="Test modal" onExit={() => {}} mounted={false}>
+          <button type="button">Close</button>
+        </Modal>
+      </div>,
+    );
+
+    expect(container.querySelector('#root')).toHaveAttribute(
+      'aria-hidden',
+      'false',
+    );
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/Form.tsx
+++ b/src/explore-education-statistics-common/src/components/form/Form.tsx
@@ -61,6 +61,7 @@ const Form = ({
       id={id}
       onReset={formik.handleReset}
       onSubmit={async event => {
+        setSubmitError(undefined);
         event.preventDefault();
 
         try {

--- a/src/explore-education-statistics-common/src/components/form/__tests__/Form.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/Form.test.tsx
@@ -143,7 +143,7 @@ describe('Form', () => {
     expect(queryByText('Line 2 of address is required')).not.toBeNull();
   });
 
-  test('calls onSubmit handler when form is submitted successfully', async () => {
+  test('calls `onSubmit` handler when form is submitted successfully', async () => {
     const handleSubmit = jest.fn();
 
     const { container } = render(
@@ -204,5 +204,47 @@ describe('Form', () => {
     );
 
     expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('removes submit error when form can be submitted successfully', async () => {
+    const onSubmit = jest.fn(() => {
+      throw new Error('Something went wrong');
+    });
+
+    const { container, queryByText } = render(
+      <Formik
+        initialValues={{
+          firstName: 'Firstname',
+        }}
+        validationSchema={Yup.object({
+          firstName: Yup.string().required(),
+        })}
+        onSubmit={onSubmit}
+      >
+        {() => <Form id="test-form">The form</Form>}
+      </Formik>,
+    );
+
+    const form = container.querySelector('#test-form') as HTMLFormElement;
+
+    fireEvent.submit(form, {
+      current: form,
+      target: form,
+    });
+
+    await wait();
+
+    expect(queryByText('Something went wrong')).not.toBeNull();
+
+    onSubmit.mockImplementation();
+
+    fireEvent.submit(form, {
+      current: form,
+      target: form,
+    });
+
+    await wait();
+
+    expect(queryByText('Something went wrong')).toBeNull();
   });
 });

--- a/src/explore-education-statistics-common/src/context/ConfirmContext.tsx
+++ b/src/explore-education-statistics-common/src/context/ConfirmContext.tsx
@@ -1,0 +1,94 @@
+import useToggle from '@common/hooks/useToggle';
+import React, {
+  createContext,
+  ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+export interface ConfirmContextValue {
+  isConfirming: boolean;
+  toggleConfirming(confirming?: boolean): void;
+  handleConfirm(): void;
+  handleCancel(): void;
+  setHandlers(handlers: { onConfirm?(): void; onCancel?(): void }): void;
+}
+
+export const ConfirmContext = createContext<ConfirmContextValue | undefined>(
+  undefined,
+);
+
+interface Props {
+  children: ReactNode;
+}
+
+export const ConfirmContextProvider = ({ children }: Props) => {
+  const [isConfirming, toggleConfirming] = useToggle(false);
+  const [handlers, setHandlers] = useState<{
+    onConfirm?(): void;
+    onCancel?(): void;
+  }>({});
+
+  const value = useMemo<ConfirmContextValue>(() => {
+    return {
+      isConfirming,
+      toggleConfirming,
+      setHandlers,
+      handleConfirm() {
+        if (handlers.onConfirm) {
+          handlers.onConfirm();
+        }
+
+        setHandlers({});
+      },
+      handleCancel() {
+        if (handlers.onCancel) {
+          handlers.onCancel();
+        }
+
+        setHandlers({});
+      },
+    };
+  }, [isConfirming, toggleConfirming, handlers]);
+
+  return (
+    <ConfirmContext.Provider value={value}>{children}</ConfirmContext.Provider>
+  );
+};
+
+export function useConfirmContext() {
+  const context = useContext(ConfirmContext);
+
+  if (!context) {
+    throw new Error('Must be used with a ConfirmContextProvider');
+  }
+
+  const {
+    isConfirming,
+    toggleConfirming,
+    handleCancel,
+    handleConfirm,
+    setHandlers,
+  } = context;
+
+  return {
+    isConfirming,
+    askConfirm(onConfirm?: () => void, onCancel?: () => void) {
+      setHandlers({
+        onConfirm,
+        onCancel,
+      });
+
+      toggleConfirming(true);
+    },
+    confirm() {
+      handleConfirm();
+      toggleConfirming(false);
+    },
+    cancel() {
+      handleCancel();
+      toggleConfirming(false);
+    },
+  };
+}

--- a/src/explore-education-statistics-common/src/types/react-app-env.d.ts
+++ b/src/explore-education-statistics-common/src/types/react-app-env.d.ts
@@ -4,6 +4,7 @@
 
 declare namespace NodeJS {
   interface ProcessEnv {
+    APP_ROOT_ID: string;
     NODE_ENV: 'development' | 'production' | 'test';
     PUBLIC_URL: string;
   }

--- a/src/explore-education-statistics-common/test/extend-expect/__tests__/toHaveScrolledIntoView.test.tsx
+++ b/src/explore-education-statistics-common/test/extend-expect/__tests__/toHaveScrolledIntoView.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { fireEvent, render } from 'react-testing-library';
+
+describe('toHaveScrolledIntoView', () => {
+  test('asserts that element scrolls into view successfully', () => {
+    const { getByText } = render(
+      <div>
+        <div id="test">Test element</div>
+
+        <button
+          type="button"
+          onClick={() => {
+            const el = document.querySelector('#test');
+
+            if (el) {
+              el.scrollIntoView();
+            }
+          }}
+        >
+          Scroll to element
+        </button>
+      </div>,
+    );
+
+    const element = getByText('Test element');
+
+    expect(element).not.toHaveScrolledIntoView();
+
+    fireEvent.click(getByText('Scroll to element'));
+
+    expect(element).toHaveScrolledIntoView();
+  });
+
+  test('throws when assertions are incorrect', () => {
+    const { getByText } = render(
+      <div>
+        <div id="test">Test element</div>
+
+        <button
+          type="button"
+          onClick={() => {
+            const el = document.querySelector('#test');
+
+            if (el) {
+              el.scrollIntoView();
+            }
+          }}
+        >
+          Scroll to element
+        </button>
+      </div>,
+    );
+
+    const element = getByText('Test element');
+
+    expect(() => expect(element).toHaveScrolledIntoView()).toThrow();
+
+    fireEvent.click(getByText('Scroll to element'));
+
+    expect(() => expect(element).not.toHaveScrolledIntoView()).toThrow();
+  });
+});

--- a/src/explore-education-statistics-common/test/extend-expect/index.ts
+++ b/src/explore-education-statistics-common/test/extend-expect/index.ts
@@ -1,0 +1,5 @@
+import toHaveScrolledIntoView from './toHaveScrolledIntoView';
+
+expect.extend({
+  toHaveScrolledIntoView,
+});

--- a/src/explore-education-statistics-common/test/extend-expect/toHaveScrolledIntoView.ts
+++ b/src/explore-education-statistics-common/test/extend-expect/toHaveScrolledIntoView.ts
@@ -1,0 +1,44 @@
+import { checkHtmlElement } from 'jest-dom/dist/utils';
+import {
+  matcherHint,
+  printReceived,
+  RECEIVED_COLOR as receivedColor,
+} from 'jest-matcher-utils/build';
+
+const toHaveScrolledIntoView: jest.CustomMatcher = function toHaveScrolledIntoView(
+  element: HTMLElement,
+) {
+  checkHtmlElement(element, toHaveScrolledIntoView, this);
+
+  const scrollIntoViewMock = element.scrollIntoView as jest.Mock;
+
+  if (!jest.isMockFunction(scrollIntoViewMock)) {
+    throw new TypeError(
+      [
+        `${this.isNot ? '.not' : ''}.${toHaveScrolledIntoView.name}`,
+        '',
+        `${receivedColor('received')} value must be a mock instance`,
+      ].join('\n'),
+    );
+  }
+
+  return {
+    pass: scrollIntoViewMock.mock.instances.indexOf(element) > -1,
+    message: () => {
+      return [
+        matcherHint(
+          `${this.isNot ? '.not' : ''}.${toHaveScrolledIntoView.name}`,
+          'element',
+          '',
+        ),
+        '',
+        `Received element ${
+          this.isNot ? 'should not' : 'should'
+        } have scrolled into view:`,
+        ` ${printReceived(element.cloneNode(false))}`,
+      ].join('\n');
+    },
+  };
+};
+
+export default toHaveScrolledIntoView;

--- a/src/explore-education-statistics-common/test/setupTests.js
+++ b/src/explore-education-statistics-common/test/setupTests.js
@@ -2,6 +2,7 @@ import 'react-testing-library/cleanup-after-each';
 import 'jest-dom/extend-expect';
 import 'core-js/fn/array/virtual/flat-map';
 import './setupGlobals';
+import './extend-expect';
 
 if (typeof window !== 'undefined') {
   // fetch polyfill for making API calls.

--- a/src/explore-education-statistics-common/test/types.d.ts
+++ b/src/explore-education-statistics-common/test/types.d.ts
@@ -1,1 +1,16 @@
 /// <reference types="jest-dom/extend-expect" />
+
+declare module 'jest-dom/dist/utils' {
+  export const checkHasWindow: (element: unknown) => void;
+  export const checkHtmlElement: (
+    element: unknown,
+    matcherFn?: Function,
+    context?: jest.MatcherUtils,
+  ) => void;
+}
+
+declare namespace jest {
+  interface Matchers<R> {
+    toHaveScrolledIntoView(): R;
+  }
+}

--- a/src/explore-education-statistics-frontend/package.json
+++ b/src/explore-education-statistics-frontend/package.json
@@ -129,8 +129,8 @@
       "<rootDir>/test/setupTests.js"
     ],
     "testMatch": [
-      "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
-      "<rootDir>/src/**/?(*.)(spec|test).{js,jsx,ts,tsx}"
+      "<rootDir>/src/**/(*.)(spec|test).{js,jsx,ts,tsx}",
+      "<rootDir>/test/**/(*.)(spec|test).{js,jsx,ts,tsx}"
     ],
     "testEnvironment": "jsdom",
     "testURL": "http://localhost",

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -1,4 +1,3 @@
-import ModalConfirm from '@common/components/ModalConfirm';
 import { ConfirmContextProvider } from '@common/context/ConfirmContext';
 import mapValuesWithKeys from '@common/lib/utils/mapValuesWithKeys';
 import tableBuilderService, {
@@ -13,6 +12,7 @@ import TimePeriod from '@common/services/types/TimePeriod';
 import { Dictionary } from '@common/types/util';
 import Page from '@frontend/components/Page';
 import PageTitle from '@frontend/components/PageTitle';
+import PreviousStepModalConfirm from '@frontend/modules/table-tool/components/PreviousStepModalConfirm';
 import mapValues from 'lodash/mapValues';
 import React, { Component } from 'react';
 import FiltersForm, { FilterFormSubmitHandler } from './components/FiltersForm';
@@ -208,109 +208,123 @@ class TableToolPage extends Component<Props, State> {
         </p>
 
         <ConfirmContextProvider>
-          <Wizard id="tableTool-steps">
-            <WizardStep>
-              {stepProps => (
-                <PublicationForm
-                  {...stepProps}
-                  options={themeMeta}
-                  onSubmit={this.handlePublicationFormSubmit}
-                />
-              )}
-            </WizardStep>
-            <WizardStep>
-              {stepProps => (
-                <PublicationSubjectForm
-                  {...stepProps}
-                  options={subjects}
-                  onSubmit={this.handlePublicationSubjectFormSubmit}
-                />
-              )}
-            </WizardStep>
-            <WizardStep>
-              {stepProps => (
-                <LocationFiltersForm
-                  {...stepProps}
-                  options={subjectMeta.locations}
-                  onSubmit={this.handleLocationFiltersFormSubmit}
-                />
-              )}
-            </WizardStep>
-            <WizardStep>
-              {stepProps => (
-                <TimePeriodForm
-                  {...stepProps}
-                  options={subjectMeta.timePeriod.options}
-                  onSubmit={values => {
-                    this.setState({
-                      timePeriods: TimePeriod.createRange(
-                        TimePeriod.fromString(values.start),
-                        TimePeriod.fromString(values.end),
-                      ),
-                    });
-                  }}
-                />
-              )}
-            </WizardStep>
-            <WizardStep>
-              {stepProps => (
-                <FiltersForm
-                  {...stepProps}
-                  onSubmit={this.handleFiltersFormSubmit}
-                  specification={subjectMeta}
-                />
-              )}
-            </WizardStep>
-            <WizardStep>
-              {stepProps => (
-                <>
-                  <WizardStepHeading {...stepProps}>
-                    Explore data
-                  </WizardStepHeading>
+          {({ askConfirm }) => (
+            <>
+              <Wizard
+                id="tableTool-steps"
+                onStepChange={async (nextStep, previousStep) => {
+                  if (nextStep < previousStep) {
+                    const confirmed = await askConfirm();
+                    return confirmed ? nextStep : previousStep;
+                  }
 
-                  {tableData.length > 0 && (
+                  return nextStep;
+                }}
+              >
+                <WizardStep>
+                  {stepProps => (
+                    <PublicationForm
+                      {...stepProps}
+                      options={themeMeta}
+                      onSubmit={this.handlePublicationFormSubmit}
+                    />
+                  )}
+                </WizardStep>
+                <WizardStep>
+                  {stepProps => (
+                    <PublicationSubjectForm
+                      {...stepProps}
+                      options={subjects}
+                      onSubmit={this.handlePublicationSubjectFormSubmit}
+                    />
+                  )}
+                </WizardStep>
+                <WizardStep>
+                  {stepProps => (
+                    <LocationFiltersForm
+                      {...stepProps}
+                      options={subjectMeta.locations}
+                      onSubmit={this.handleLocationFiltersFormSubmit}
+                    />
+                  )}
+                </WizardStep>
+                <WizardStep>
+                  {stepProps => (
+                    <TimePeriodForm
+                      {...stepProps}
+                      options={subjectMeta.timePeriod.options}
+                      onSubmit={values => {
+                        this.setState({
+                          timePeriods: TimePeriod.createRange(
+                            TimePeriod.fromString(values.start),
+                            TimePeriod.fromString(values.end),
+                          ),
+                        });
+                      }}
+                    />
+                  )}
+                </WizardStep>
+                <WizardStep>
+                  {stepProps => (
+                    <FiltersForm
+                      {...stepProps}
+                      onSubmit={this.handleFiltersFormSubmit}
+                      specification={subjectMeta}
+                    />
+                  )}
+                </WizardStep>
+                <WizardStep>
+                  {stepProps => (
                     <>
-                      <div className="govuk-!-margin-bottom-2">
-                        <TimePeriodDataTable
-                          filters={filters}
-                          indicators={indicators}
-                          publicationName={publication ? publication.title : ''}
-                          subjectName={subjectName}
-                          locations={locations}
-                          timePeriods={timePeriods}
-                          results={tableData}
-                        />
-                      </div>
+                      <WizardStepHeading {...stepProps}>
+                        Explore data
+                      </WizardStepHeading>
 
-                      <ul className="govuk-list">
-                        {publication && (
-                          <li>
-                            <a href={publication.slug}>Go to publication</a>
-                          </li>
-                        )}
-                        <li>
-                          <a href="#download">Download data (.csv)</a>
-                        </li>
-                        <li>
-                          <a href="#api">Access developer API</a>
-                        </li>
-                        <li>
-                          <a href="#methodology">Methodology</a>
-                        </li>
-                        <li>
-                          <a href="#contact">Contact</a>
-                        </li>
-                      </ul>
+                      {tableData.length > 0 && (
+                        <>
+                          <div className="govuk-!-margin-bottom-2">
+                            <TimePeriodDataTable
+                              filters={filters}
+                              indicators={indicators}
+                              publicationName={
+                                publication ? publication.title : ''
+                              }
+                              subjectName={subjectName}
+                              locations={locations}
+                              timePeriods={timePeriods}
+                              results={tableData}
+                            />
+                          </div>
+
+                          <ul className="govuk-list">
+                            {publication && (
+                              <li>
+                                <a href={publication.slug}>Go to publication</a>
+                              </li>
+                            )}
+                            <li>
+                              <a href="#download">Download data (.csv)</a>
+                            </li>
+                            <li>
+                              <a href="#api">Access developer API</a>
+                            </li>
+                            <li>
+                              <a href="#methodology">Methodology</a>
+                            </li>
+                            <li>
+                              <a href="#contact">Contact</a>
+                            </li>
+                          </ul>
+                        </>
+                      )}
                     </>
                   )}
-                </>
-              )}
-            </WizardStep>
-          </Wizard>
+                </WizardStep>
+              </Wizard>
 
-          <ModalConfirm title="Go back to previous step">
-            <p>You will lose any changes you have made in the current step.</p>
-          </ModalConfirm>
+              <PreviousStepModalConfirm />
+            </>
+          )}
         </ConfirmContextProvider>
       </Page>
     );

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -1,3 +1,5 @@
+import ModalConfirm from '@common/components/ModalConfirm';
+import { ConfirmContextProvider } from '@common/context/ConfirmContext';
 import mapValuesWithKeys from '@common/lib/utils/mapValuesWithKeys';
 import tableBuilderService, {
   FilterOption,
@@ -205,105 +207,111 @@ class TableToolPage extends Component<Props, State> {
           for your own offline analysis.
         </p>
 
-        <Wizard id="tableTool-steps">
-          <WizardStep>
-            {stepProps => (
-              <PublicationForm
-                {...stepProps}
-                options={themeMeta}
-                onSubmit={this.handlePublicationFormSubmit}
-              />
-            )}
-          </WizardStep>
-          <WizardStep>
-            {stepProps => (
-              <PublicationSubjectForm
-                {...stepProps}
-                options={subjects}
-                onSubmit={this.handlePublicationSubjectFormSubmit}
-              />
-            )}
-          </WizardStep>
-          <WizardStep>
-            {stepProps => (
-              <LocationFiltersForm
-                {...stepProps}
-                options={subjectMeta.locations}
-                onSubmit={this.handleLocationFiltersFormSubmit}
-              />
-            )}
-          </WizardStep>
-          <WizardStep>
-            {stepProps => (
-              <TimePeriodForm
-                {...stepProps}
-                options={subjectMeta.timePeriod.options}
-                onSubmit={values => {
-                  this.setState({
-                    timePeriods: TimePeriod.createRange(
-                      TimePeriod.fromString(values.start),
-                      TimePeriod.fromString(values.end),
-                    ),
-                  });
-                }}
-              />
-            )}
-          </WizardStep>
-          <WizardStep>
-            {stepProps => (
-              <FiltersForm
-                {...stepProps}
-                onSubmit={this.handleFiltersFormSubmit}
-                specification={subjectMeta}
-              />
-            )}
-          </WizardStep>
-          <WizardStep>
-            {stepProps => (
-              <>
-                <WizardStepHeading {...stepProps}>
-                  Explore data
-                </WizardStepHeading>
+        <ConfirmContextProvider>
+          <Wizard id="tableTool-steps">
+            <WizardStep>
+              {stepProps => (
+                <PublicationForm
+                  {...stepProps}
+                  options={themeMeta}
+                  onSubmit={this.handlePublicationFormSubmit}
+                />
+              )}
+            </WizardStep>
+            <WizardStep>
+              {stepProps => (
+                <PublicationSubjectForm
+                  {...stepProps}
+                  options={subjects}
+                  onSubmit={this.handlePublicationSubjectFormSubmit}
+                />
+              )}
+            </WizardStep>
+            <WizardStep>
+              {stepProps => (
+                <LocationFiltersForm
+                  {...stepProps}
+                  options={subjectMeta.locations}
+                  onSubmit={this.handleLocationFiltersFormSubmit}
+                />
+              )}
+            </WizardStep>
+            <WizardStep>
+              {stepProps => (
+                <TimePeriodForm
+                  {...stepProps}
+                  options={subjectMeta.timePeriod.options}
+                  onSubmit={values => {
+                    this.setState({
+                      timePeriods: TimePeriod.createRange(
+                        TimePeriod.fromString(values.start),
+                        TimePeriod.fromString(values.end),
+                      ),
+                    });
+                  }}
+                />
+              )}
+            </WizardStep>
+            <WizardStep>
+              {stepProps => (
+                <FiltersForm
+                  {...stepProps}
+                  onSubmit={this.handleFiltersFormSubmit}
+                  specification={subjectMeta}
+                />
+              )}
+            </WizardStep>
+            <WizardStep>
+              {stepProps => (
+                <>
+                  <WizardStepHeading {...stepProps}>
+                    Explore data
+                  </WizardStepHeading>
 
-                {tableData.length > 0 && (
-                  <>
-                    <div className="govuk-!-margin-bottom-2">
-                      <TimePeriodDataTable
-                        filters={filters}
-                        indicators={indicators}
-                        publicationName={publication ? publication.title : ''}
-                        subjectName={subjectName}
-                        locations={locations}
-                        timePeriods={timePeriods}
-                        results={tableData}
-                      />
-                    </div>
+                  {tableData.length > 0 && (
+                    <>
+                      <div className="govuk-!-margin-bottom-2">
+                        <TimePeriodDataTable
+                          filters={filters}
+                          indicators={indicators}
+                          publicationName={publication ? publication.title : ''}
+                          subjectName={subjectName}
+                          locations={locations}
+                          timePeriods={timePeriods}
+                          results={tableData}
+                        />
+                      </div>
 
-                    <ul className="govuk-list">
-                      {publication && (
+                      <ul className="govuk-list">
+                        {publication && (
+                          <li>
+                            <a href={publication.slug}>Go to publication</a>
+                          </li>
+                        )}
                         <li>
-                          <a href={publication.slug}>Go to publication</a>
+                          <a href="#download">Download data (.csv)</a>
                         </li>
-                      )}
-                      <li>
-                        <a href="#download">Download data (.csv)</a>
-                      </li>
-                      <li>
-                        <a href="#api">Access developer API</a>
-                      </li>
-                      <li>
-                        <a href="#methodology">Methodology</a>
-                      </li>
-                      <li>
-                        <a href="#contact">Contact</a>
-                      </li>
-                    </ul>
-                  </>
-                )}
-              </>
-            )}
-          </WizardStep>
-        </Wizard>
+                        <li>
+                          <a href="#api">Access developer API</a>
+                        </li>
+                        <li>
+                          <a href="#methodology">Methodology</a>
+                        </li>
+                        <li>
+                          <a href="#contact">Contact</a>
+                        </li>
+                      </ul>
+                    </>
+                  )}
+                </>
+              )}
+            </WizardStep>
+          </Wizard>
+
+          <ModalConfirm title="Go back to previous step">
+            <p>You will lose any changes you have made in the current step.</p>
+          </ModalConfirm>
+        </ConfirmContextProvider>
       </Page>
     );
   }

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/FiltersForm.tsx
@@ -8,6 +8,7 @@ import {
 import createErrorHelper from '@common/lib/validation/createErrorHelper';
 import Yup from '@common/lib/validation/yup';
 import { PublicationSubjectMeta } from '@common/services/tableBuilderService';
+import useResetFormOnPreviousStep from '@frontend/modules/table-tool/components/hooks/useResetFormOnPreviousStep';
 import { FormikProps } from 'formik';
 import camelCase from 'lodash/camelCase';
 import mapValues from 'lodash/mapValues';
@@ -32,25 +33,33 @@ interface Props {
 }
 
 const FiltersForm = (props: Props & InjectedWizardProps) => {
-  const { onSubmit, specification, goToNextStep } = props;
+  const {
+    onSubmit,
+    specification,
+    goToNextStep,
+    currentStep,
+    stepNumber,
+  } = props;
 
   const ref = useRef<HTMLDivElement>(null);
 
+  const formikRef = useRef<Formik<FormValues>>(null);
   const formId = 'filtersForm';
+
+  useResetFormOnPreviousStep(formikRef, currentStep, stepNumber);
 
   const stepHeading = (
     <WizardStepHeading {...props}>Choose your filters</WizardStepHeading>
   );
 
-  const initialValues = {
-    filters: mapValues(specification.filters, () => []),
-    indicators: [],
-  };
-
   return (
     <Formik<FormValues>
       enableReinitialize
-      initialValues={initialValues}
+      ref={formikRef}
+      initialValues={{
+        filters: mapValues(specification.filters, () => []),
+        indicators: [],
+      }}
       validationSchema={Yup.object<FormValues>({
         filters: Yup.object(
           mapValues(specification.filters, () =>
@@ -139,12 +148,6 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
                 formId={formId}
                 submitText="Create table"
                 submittingText="Creating table"
-                onPreviousStep={() => {
-                  form.resetForm({
-                    filters: mapValues(specification.filters, () => []),
-                    indicators: [],
-                  });
-                }}
               />
             </Form>
           </div>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/PreviousStepModalConfirm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/PreviousStepModalConfirm.tsx
@@ -1,0 +1,21 @@
+import ModalConfirm from '@common/components/ModalConfirm';
+import { useConfirmContext } from '@common/context/ConfirmContext';
+import React from 'react';
+
+const PreviousStepModalConfirm = () => {
+  const { isConfirming, confirm, cancel } = useConfirmContext();
+
+  return (
+    <ModalConfirm
+      title="Go back to previous step"
+      onExit={cancel}
+      onConfirm={confirm}
+      onCancel={cancel}
+      mounted={isConfirming}
+    >
+      <p>You will lose any changes you have made in the current step.</p>
+    </ModalConfirm>
+  );
+};
+
+export default PreviousStepModalConfirm;

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationSubjectForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationSubjectForm.tsx
@@ -3,8 +3,9 @@ import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import Yup from '@common/lib/validation/yup';
 import { PublicationSubject } from '@common/services/tableBuilderService';
+import useResetFormOnPreviousStep from '@frontend/modules/table-tool/components/hooks/useResetFormOnPreviousStep';
 import { FormikProps } from 'formik';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 import WizardStepHeading from './WizardStepHeading';
@@ -24,10 +25,22 @@ interface Props {
 }
 
 const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
-  const { isActive, onSubmit, options, goToNextStep } = props;
+  const {
+    isActive,
+    onSubmit,
+    options,
+    goToNextStep,
+    currentStep,
+    stepNumber,
+  } = props;
   const [subjectName, setSubjectName] = useState('');
 
+  const formikRef = useRef<Formik<FormValues>>(null);
   const formId = 'publicationSubjectForm';
+
+  useResetFormOnPreviousStep(formikRef, currentStep, stepNumber, () => {
+    setSubjectName('');
+  });
 
   const stepHeading = (
     <WizardStepHeading {...props} fieldsetHeading>
@@ -40,8 +53,9 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
   };
 
   return (
-    <Formik
+    <Formik<FormValues>
       enableReinitialize
+      ref={formikRef}
       onSubmit={async ({ subjectId }) => {
         await onSubmit({
           subjectId,
@@ -69,15 +83,7 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
               }}
             />
 
-            <WizardStepFormActions
-              {...props}
-              form={form}
-              formId={formId}
-              onPreviousStep={() => {
-                form.resetForm(initialValues);
-                setSubjectName('');
-              }}
-            />
+            <WizardStepFormActions {...props} form={form} formId={formId} />
           </Form>
         ) : (
           <>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TimePeriodForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TimePeriodForm.tsx
@@ -11,8 +11,9 @@ import Yup from '@common/lib/validation/yup';
 import { PublicationSubjectMeta } from '@common/services/tableBuilderService';
 import TimePeriod from '@common/services/types/TimePeriod';
 import { Comparison } from '@common/types/util';
+import useResetFormOnPreviousStep from '@frontend/modules/table-tool/components/hooks/useResetFormOnPreviousStep';
 import { FormikProps } from 'formik';
-import React from 'react';
+import React, { useRef } from 'react';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 import WizardStepHeading from './WizardStepHeading';
@@ -28,9 +29,19 @@ interface Props {
 }
 
 const TimePeriodForm = (props: Props & InjectedWizardProps) => {
-  const { options, onSubmit, isActive, goToNextStep } = props;
+  const {
+    options,
+    onSubmit,
+    isActive,
+    goToNextStep,
+    currentStep,
+    stepNumber,
+  } = props;
 
+  const formikRef = useRef<Formik<FormValues>>(null);
   const formId = 'timePeriodForm';
+
+  useResetFormOnPreviousStep(formikRef, currentStep, stepNumber);
 
   const timePeriodOptions: SelectOption[] = [
     {
@@ -51,18 +62,18 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
     </WizardStepHeading>
   );
 
-  const initialValues = {
-    start: '',
-    end: '',
-  };
-
   return (
     <Formik<FormValues>
+      enableReinitialize
+      ref={formikRef}
       onSubmit={async values => {
         await onSubmit(values);
         goToNextStep();
       }}
-      initialValues={initialValues}
+      initialValues={{
+        start: '',
+        end: '',
+      }}
       validationSchema={Yup.object<FormValues>({
         end: Yup.string()
           .required('End date is required')
@@ -137,14 +148,7 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
               />
             </FormFieldset>
 
-            <WizardStepFormActions
-              {...props}
-              form={form}
-              formId={formId}
-              onPreviousStep={() => {
-                form.resetForm(initialValues);
-              }}
-            />
+            <WizardStepFormActions {...props} form={form} formId={formId} />
           </Form>
         ) : (
           <>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/Wizard.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/Wizard.module.scss
@@ -1,8 +1,3 @@
-@import '~explore-education-statistics-common/src/styles/govuk-base';
-
-//.container {
-//}
-
 .stepNav {
   list-style: none;
   padding-left: 0;

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/Wizard.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/Wizard.tsx
@@ -16,10 +16,14 @@ interface Props {
   children: ReactElement | ReactElement[];
   initialStep?: number;
   id: string;
+  onStepChange?: (
+    nextStep: number,
+    previousStep: number,
+  ) => void | number | Promise<number> | Promise<void>;
 }
 
-const Wizard = ({ children, initialStep = 1, id }: Props) => {
-  const [currentStep, setCurrentStep] = useState(initialStep);
+const Wizard = ({ children, initialStep = 1, id, onStepChange }: Props) => {
+  const [currentStep, setCurrentStepState] = useState(initialStep);
 
   const filteredChildren = Children.toArray(children).filter(child =>
     isComponentType(child, WizardStep),
@@ -27,34 +31,42 @@ const Wizard = ({ children, initialStep = 1, id }: Props) => {
 
   const lastStep = filteredChildren.length;
 
-  return (
-    <>
-      <ol className={styles.stepNav}>
-        {filteredChildren.map((child, index) => {
-          const stepNumber = index + 1;
+  const setCurrentStep = async (nextStep: number) => {
+    if (onStepChange) {
+      const next = await onStepChange(nextStep, currentStep);
 
-          return cloneElement<WizardStepProps | InjectedWizardProps>(child, {
-            stepNumber,
-            currentStep,
-            setCurrentStep(nextStep: number) {
-              if (nextStep <= lastStep && nextStep >= 1) {
-                setCurrentStep(nextStep);
-              }
-            },
-            id: child.props.id || `${id}-step-${stepNumber}`,
-            isActive: stepNumber === currentStep,
-            goToPreviousStep() {
-              setCurrentStep(stepNumber - 1 < 1 ? 1 : stepNumber - 1);
-            },
-            goToNextStep() {
-              setCurrentStep(
-                stepNumber + 1 > lastStep ? lastStep : stepNumber + 1,
-              );
-            },
-          });
-        })}
-      </ol>
-    </>
+      setCurrentStepState(next || nextStep);
+    } else {
+      setCurrentStepState(nextStep);
+    }
+  };
+
+  return (
+    <ol className={styles.stepNav}>
+      {filteredChildren.map((child, index) => {
+        const stepNumber = index + 1;
+
+        return cloneElement<WizardStepProps | InjectedWizardProps>(child, {
+          stepNumber,
+          currentStep,
+          async setCurrentStep(nextStep: number) {
+            if (nextStep <= lastStep && nextStep >= 1) {
+              await setCurrentStep(nextStep);
+            }
+          },
+          id: child.props.id || `${id}-step-${stepNumber}`,
+          isActive: stepNumber === currentStep,
+          async goToPreviousStep() {
+            await setCurrentStep(stepNumber - 1 < 1 ? 1 : stepNumber - 1);
+          },
+          async goToNextStep() {
+            await setCurrentStep(
+              stepNumber + 1 > lastStep ? lastStep : stepNumber + 1,
+            );
+          },
+        });
+      })}
+    </ol>
   );
 };
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/Wizard.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/Wizard.tsx
@@ -28,33 +28,33 @@ const Wizard = ({ children, initialStep = 1, id }: Props) => {
   const lastStep = filteredChildren.length;
 
   return (
-    <ol className={styles.stepNav}>
-      {filteredChildren.map((child, index) => {
-        const stepNumber = index + 1;
+    <>
+      <ol className={styles.stepNav}>
+        {filteredChildren.map((child, index) => {
+          const stepNumber = index + 1;
 
-        return cloneElement<WizardStepProps | InjectedWizardProps>(child, {
-          stepNumber,
-          currentStep,
-          setCurrentStep(nextStep: number) {
-            if (nextStep <= lastStep && nextStep >= 1) {
-              setCurrentStep(nextStep);
-            }
-          },
-          id: child.props.id || `${id}-step-${stepNumber}`,
-          isActive: stepNumber === currentStep,
-          goToPreviousStep() {
-            setCurrentStep(stepNumber - 1 < 1 ? 1 : stepNumber - 1);
-          },
-          goToNextStep() {
-            setCurrentStep(
-              stepNumber + 1 > filteredChildren.length
-                ? filteredChildren.length
-                : stepNumber + 1,
-            );
-          },
-        });
-      })}
-    </ol>
+          return cloneElement<WizardStepProps | InjectedWizardProps>(child, {
+            stepNumber,
+            currentStep,
+            setCurrentStep(nextStep: number) {
+              if (nextStep <= lastStep && nextStep >= 1) {
+                setCurrentStep(nextStep);
+              }
+            },
+            id: child.props.id || `${id}-step-${stepNumber}`,
+            isActive: stepNumber === currentStep,
+            goToPreviousStep() {
+              setCurrentStep(stepNumber - 1 < 1 ? 1 : stepNumber - 1);
+            },
+            goToNextStep() {
+              setCurrentStep(
+                stepNumber + 1 > lastStep ? lastStep : stepNumber + 1,
+              );
+            },
+          });
+        })}
+      </ol>
+    </>
   );
 };
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/Wizard.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/Wizard.tsx
@@ -6,10 +6,10 @@ import WizardStep, { WizardStepProps } from './WizardStep';
 export interface InjectedWizardProps {
   stepNumber: number;
   currentStep: number;
-  setCurrentStep: (step: number) => void;
+  setCurrentStep(step: number): void;
   isActive: boolean;
-  goToNextStep: () => void;
-  goToPreviousStep: () => void;
+  goToNextStep(): void;
+  goToPreviousStep(): void;
 }
 
 interface Props {
@@ -25,34 +25,36 @@ const Wizard = ({ children, initialStep = 1, id }: Props) => {
     isComponentType(child, WizardStep),
   );
 
-  return (
-    <div className={styles.container}>
-      <div>
-        <ol className={styles.stepNav}>
-          {filteredChildren.map((child, index) => {
-            const stepNumber = index + 1;
+  const lastStep = filteredChildren.length;
 
-            return cloneElement<WizardStepProps | InjectedWizardProps>(child, {
-              stepNumber,
-              currentStep,
-              setCurrentStep,
-              id: child.props.id || `${id}-${stepNumber}`,
-              isActive: stepNumber === currentStep,
-              goToPreviousStep: () => {
-                setCurrentStep(stepNumber - 1 < 1 ? 1 : stepNumber - 1);
-              },
-              goToNextStep: () => {
-                setCurrentStep(
-                  stepNumber + 1 > filteredChildren.length
-                    ? filteredChildren.length
-                    : stepNumber + 1,
-                );
-              },
-            });
-          })}
-        </ol>
-      </div>
-    </div>
+  return (
+    <ol className={styles.stepNav}>
+      {filteredChildren.map((child, index) => {
+        const stepNumber = index + 1;
+
+        return cloneElement<WizardStepProps | InjectedWizardProps>(child, {
+          stepNumber,
+          currentStep,
+          setCurrentStep(nextStep: number) {
+            if (nextStep <= lastStep && nextStep >= 1) {
+              setCurrentStep(nextStep);
+            }
+          },
+          id: child.props.id || `${id}-step-${stepNumber}`,
+          isActive: stepNumber === currentStep,
+          goToPreviousStep() {
+            setCurrentStep(stepNumber - 1 < 1 ? 1 : stepNumber - 1);
+          },
+          goToNextStep() {
+            setCurrentStep(
+              stepNumber + 1 > filteredChildren.length
+                ? filteredChildren.length
+                : stepNumber + 1,
+            );
+          },
+        });
+      })}
+    </ol>
   );
 };
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStep.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStep.module.scss
@@ -6,13 +6,12 @@ $step-padding-top: govuk-spacing(6);
 
 .step {
   align-items: flex-start;
-  display: none;
+  display: flex;
   padding-left: govuk-spacing(8);
   position: relative;
 
-  &.stepActive,
-  &.stepEnabled {
-    display: flex;
+  &.stepHidden {
+    display: none;
   }
 
   &::before {

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStep.tsx
@@ -30,11 +30,12 @@ const WizardStep = ({ children, id, ...restProps }: WizardStepProps) => {
     <li
       className={classNames(styles.step, {
         [styles.stepActive]: isActive,
-        [styles.stepEnabled]: currentStep > stepNumber,
+        [styles.stepHidden]: stepNumber > currentStep,
       })}
       id={id}
       ref={ref}
       tabIndex={-1}
+      hidden={stepNumber > currentStep}
     >
       <div className={styles.content}>
         <span className={styles.number} aria-hidden>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStepFormActions.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStepFormActions.tsx
@@ -1,6 +1,5 @@
 import Button from '@common/components/Button';
 import { FormGroup } from '@common/components/form';
-import { useConfirmContext } from '@common/context/ConfirmContext';
 import { FormikState } from 'formik';
 import React, { MouseEventHandler } from 'react';
 import { InjectedWizardProps } from './Wizard';
@@ -24,8 +23,6 @@ const WizardStepFormActions = ({
   submitText = 'Next step',
   submittingText = 'Submitting',
 }: Props) => {
-  const { askConfirm } = useConfirmContext();
-
   return (
     <FormGroup>
       <Button
@@ -40,17 +37,15 @@ const WizardStepFormActions = ({
         <Button
           type="button"
           variant="secondary"
-          onClick={event =>
-            askConfirm(() => {
-              if (onPreviousStep) {
-                onPreviousStep(event);
-              }
+          onClick={event => {
+            if (onPreviousStep) {
+              onPreviousStep(event);
+            }
 
-              if (!event.isDefaultPrevented()) {
-                goToPreviousStep();
-              }
-            })
-          }
+            if (!event.isDefaultPrevented()) {
+              goToPreviousStep();
+            }
+          }}
         >
           Previous step
         </Button>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStepFormActions.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStepFormActions.tsx
@@ -1,5 +1,6 @@
 import Button from '@common/components/Button';
 import { FormGroup } from '@common/components/form';
+import { useConfirmContext } from '@common/context/ConfirmContext';
 import { FormikState } from 'formik';
 import React, { MouseEventHandler } from 'react';
 import { InjectedWizardProps } from './Wizard';
@@ -23,6 +24,8 @@ const WizardStepFormActions = ({
   submitText = 'Next step',
   submittingText = 'Submitting',
 }: Props) => {
+  const { askConfirm } = useConfirmContext();
+
   return (
     <FormGroup>
       <Button
@@ -37,15 +40,17 @@ const WizardStepFormActions = ({
         <Button
           type="button"
           variant="secondary"
-          onClick={event => {
-            if (onPreviousStep) {
-              onPreviousStep(event);
-            }
+          onClick={event =>
+            askConfirm(() => {
+              if (onPreviousStep) {
+                onPreviousStep(event);
+              }
 
-            if (!event.isDefaultPrevented()) {
-              goToPreviousStep();
-            }
-          }}
+              if (!event.isDefaultPrevented()) {
+                goToPreviousStep();
+              }
+            })
+          }
         >
           Previous step
         </Button>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStepHeading.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStepHeading.tsx
@@ -1,3 +1,4 @@
+import { useConfirmContext } from '@common/context/ConfirmContext';
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
 import { InjectedWizardProps } from './Wizard';
@@ -20,6 +21,8 @@ const WizardStepHeading = ({
 }: Props & InjectedWizardProps) => {
   const stepEnabled = currentStep > stepNumber;
 
+  const { askConfirm } = useConfirmContext();
+
   return (
     <>
       {isActive ? (
@@ -40,9 +43,9 @@ const WizardStepHeading = ({
           <button
             type="button"
             onClick={() => {
-              if (stepEnabled) {
+              askConfirm(() => {
                 setCurrentStep(stepNumber);
-              }
+              });
             }}
             className={styles.stepButton}
           >
@@ -50,13 +53,7 @@ const WizardStepHeading = ({
             {children}
 
             {stepEnabled && (
-              <span
-                className={styles.toggleText}
-                aria-hidden
-                onClick={() => {
-                  setCurrentStep(stepNumber);
-                }}
-              >
+              <span className={styles.toggleText} aria-hidden>
                 Go to this step
               </span>
             )}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStepHeading.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/WizardStepHeading.tsx
@@ -1,4 +1,3 @@
-import { useConfirmContext } from '@common/context/ConfirmContext';
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
 import { InjectedWizardProps } from './Wizard';
@@ -21,8 +20,6 @@ const WizardStepHeading = ({
 }: Props & InjectedWizardProps) => {
   const stepEnabled = currentStep > stepNumber;
 
-  const { askConfirm } = useConfirmContext();
-
   return (
     <>
       {isActive ? (
@@ -42,11 +39,7 @@ const WizardStepHeading = ({
         >
           <button
             type="button"
-            onClick={() => {
-              askConfirm(() => {
-                setCurrentStep(stepNumber);
-              });
-            }}
+            onClick={() => setCurrentStep(stepNumber)}
             className={styles.stepButton}
           >
             <span className="govuk-visually-hidden">{`Step ${stepNumber}:`}</span>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/Wizard.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/Wizard.test.tsx
@@ -1,0 +1,356 @@
+import React from 'react';
+import { fireEvent, render } from 'react-testing-library';
+import Wizard from '../Wizard';
+import WizardStep from '../WizardStep';
+
+describe('Wizard', () => {
+  test('does not render children that are not WizardSteps', () => {
+    const { queryByText } = render(
+      <Wizard id="test-wizard">
+        <WizardStep>Step 1</WizardStep>
+        <p>Not a wizard step</p>
+        <WizardStep>Step 2</WizardStep>
+      </Wizard>,
+    );
+
+    expect(queryByText('Step 1')).not.toBeNull();
+    expect(queryByText('Step 2')).not.toBeNull();
+    expect(queryByText('Not a wizard step')).toBeNull();
+  });
+
+  test('renders correctly with default `initialStep of Step 1`', () => {
+    const { container } = render(
+      <Wizard id="test-wizard">
+        <WizardStep>Step 1</WizardStep>
+        <WizardStep>Step 2</WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    const step1 = container.querySelector('#test-wizard-step-1') as HTMLElement;
+    const step2 = container.querySelector('#test-wizard-step-2') as HTMLElement;
+    const step3 = container.querySelector('#test-wizard-step-3') as HTMLElement;
+
+    expect(step1).toBeVisible();
+    expect(step1).toHaveClass('stepActive');
+
+    expect(step2).not.toBeVisible();
+    expect(step3).not.toBeVisible();
+  });
+
+  test('renders correctly with `initialStep` set to Step 2', () => {
+    const { container } = render(
+      <Wizard id="test-wizard" initialStep={2}>
+        <WizardStep>Step 1</WizardStep>
+        <WizardStep>Step 2</WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    const step1 = container.querySelector('#test-wizard-step-1') as HTMLElement;
+    const step2 = container.querySelector('#test-wizard-step-2') as HTMLElement;
+    const step3 = container.querySelector('#test-wizard-step-3') as HTMLElement;
+
+    expect(step1).toBeVisible();
+    expect(step2).toBeVisible();
+    expect(step2).toHaveClass('stepActive');
+    expect(step3).not.toBeVisible();
+  });
+
+  test('calling `setCurrentStep` render prop moves wizard to that step', () => {
+    const { container, getByText } = render(
+      <Wizard id="test-wizard">
+        <WizardStep>
+          {({ setCurrentStep }) => (
+            <button type="button" onClick={() => setCurrentStep(3)}>
+              Go to step 3
+            </button>
+          )}
+        </WizardStep>
+        <WizardStep>Step 2</WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    const step1 = container.querySelector('#test-wizard-step-1') as HTMLElement;
+    const step2 = container.querySelector('#test-wizard-step-2') as HTMLElement;
+    const step3 = container.querySelector('#test-wizard-step-3') as HTMLElement;
+
+    expect(step1).toBeVisible();
+    expect(step1).toHaveClass('stepActive');
+    expect(step2).not.toBeVisible();
+    expect(step3).not.toBeVisible();
+
+    fireEvent.click(getByText('Go to step 3'));
+
+    expect(step1).toBeVisible();
+    expect(step2).toBeVisible();
+    expect(step3).toBeVisible();
+    expect(step3).toHaveClass('stepActive');
+  });
+
+  test('calling `setCurrentStep` with a step greater than the last step will not change the wizard', () => {
+    const { container, getByText } = render(
+      <Wizard id="test-wizard">
+        <WizardStep>
+          {({ setCurrentStep }) => {
+            return (
+              <button type="button" onClick={() => setCurrentStep(4)}>
+                Go to step 4
+              </button>
+            );
+          }}
+        </WizardStep>
+        <WizardStep>Step 2</WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    const step1 = container.querySelector('#test-wizard-step-1') as HTMLElement;
+    const step2 = container.querySelector('#test-wizard-step-2') as HTMLElement;
+    const step3 = container.querySelector('#test-wizard-step-3') as HTMLElement;
+
+    expect(step1).toBeVisible();
+    expect(step1).toHaveClass('stepActive');
+    expect(step2).not.toBeVisible();
+    expect(step3).not.toBeVisible();
+
+    fireEvent.click(getByText('Go to step 4'));
+
+    expect(step1).toBeVisible();
+    expect(step1).toHaveClass('stepActive');
+    expect(step2).not.toBeVisible();
+    expect(step3).not.toBeVisible();
+  });
+
+  test('calling `setCurrentStep` with a step less than the first step will not change the wizard', () => {
+    const { container, getByText } = render(
+      <Wizard id="test-wizard">
+        <WizardStep>
+          {({ setCurrentStep }) => {
+            return (
+              <button type="button" onClick={() => setCurrentStep(-1)}>
+                Go to step -1
+              </button>
+            );
+          }}
+        </WizardStep>
+        <WizardStep>Step 2</WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    const step1 = container.querySelector('#test-wizard-step-1') as HTMLElement;
+    const step2 = container.querySelector('#test-wizard-step-2') as HTMLElement;
+    const step3 = container.querySelector('#test-wizard-step-3') as HTMLElement;
+
+    expect(step1).toBeVisible();
+    expect(step1).toHaveClass('stepActive');
+    expect(step2).not.toBeVisible();
+    expect(step3).not.toBeVisible();
+
+    fireEvent.click(getByText('Go to step -1'));
+
+    expect(step1).toBeVisible();
+    expect(step1).toHaveClass('stepActive');
+    expect(step2).not.toBeVisible();
+    expect(step3).not.toBeVisible();
+  });
+
+  test('calling `goToPreviousStep` render prop moves wizard to previous step', () => {
+    const { container, getByText } = render(
+      <Wizard id="test-wizard" initialStep={2}>
+        <WizardStep>Step 1</WizardStep>
+        <WizardStep>
+          {({ goToPreviousStep }) => (
+            <button type="button" onClick={goToPreviousStep}>
+              Go to previous step
+            </button>
+          )}
+        </WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    const step1 = container.querySelector('#test-wizard-step-1') as HTMLElement;
+    const step2 = container.querySelector('#test-wizard-step-2') as HTMLElement;
+    const step3 = container.querySelector('#test-wizard-step-3') as HTMLElement;
+
+    expect(step1).toBeVisible();
+    expect(step2).toBeVisible();
+    expect(step2).toHaveClass('stepActive');
+    expect(step3).not.toBeVisible();
+
+    fireEvent.click(getByText('Go to previous step'));
+
+    expect(step1).toBeVisible();
+    expect(step1).toHaveClass('stepActive');
+    expect(step2).not.toBeVisible();
+    expect(step3).not.toBeVisible();
+  });
+
+  test('calling `goToPreviousStep` on first step does not change wizard', () => {
+    const { container, getByText } = render(
+      <Wizard id="test-wizard">
+        <WizardStep>
+          {({ goToPreviousStep }) => (
+            <button type="button" onClick={goToPreviousStep}>
+              Go to previous step
+            </button>
+          )}
+        </WizardStep>
+        <WizardStep>Step 2</WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    const step1 = container.querySelector('#test-wizard-step-1') as HTMLElement;
+    const step2 = container.querySelector('#test-wizard-step-2') as HTMLElement;
+    const step3 = container.querySelector('#test-wizard-step-3') as HTMLElement;
+
+    expect(step1).toBeVisible();
+    expect(step1).toHaveClass('stepActive');
+    expect(step2).not.toBeVisible();
+    expect(step3).not.toBeVisible();
+
+    fireEvent.click(getByText('Go to previous step'));
+
+    expect(step1).toBeVisible();
+    expect(step1).toHaveClass('stepActive');
+    expect(step2).not.toBeVisible();
+    expect(step3).not.toBeVisible();
+  });
+
+  test('calling `goToNextStep` render prop moves wizard to next step', () => {
+    const { container, getByText } = render(
+      <Wizard id="test-wizard" initialStep={2}>
+        <WizardStep>Step 1</WizardStep>
+        <WizardStep>
+          {({ goToNextStep }) => (
+            <button type="button" onClick={goToNextStep}>
+              Go to next step
+            </button>
+          )}
+        </WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    const step1 = container.querySelector('#test-wizard-step-1') as HTMLElement;
+    const step2 = container.querySelector('#test-wizard-step-2') as HTMLElement;
+    const step3 = container.querySelector('#test-wizard-step-3') as HTMLElement;
+
+    expect(step1).toBeVisible();
+    expect(step2).toBeVisible();
+    expect(step2).toHaveClass('stepActive');
+    expect(step3).not.toBeVisible();
+
+    fireEvent.click(getByText('Go to next step'));
+
+    expect(step1).toBeVisible();
+    expect(step2).toBeVisible();
+    expect(step3).toBeVisible();
+    expect(step3).toHaveClass('stepActive');
+  });
+
+  test('calling `goToNextStep` on last step does not change wizard', () => {
+    const { container, getByText } = render(
+      <Wizard id="test-wizard" initialStep={3}>
+        <WizardStep>Step 1</WizardStep>
+        <WizardStep>Step 2</WizardStep>
+        <WizardStep>
+          {({ goToNextStep }) => (
+            <button type="button" onClick={goToNextStep}>
+              Go to next step
+            </button>
+          )}
+        </WizardStep>
+      </Wizard>,
+    );
+
+    const step1 = container.querySelector('#test-wizard-step-1') as HTMLElement;
+    const step2 = container.querySelector('#test-wizard-step-2') as HTMLElement;
+    const step3 = container.querySelector('#test-wizard-step-3') as HTMLElement;
+
+    expect(step1).toBeVisible();
+    expect(step2).toBeVisible();
+    expect(step3).toBeVisible();
+    expect(step3).toHaveClass('stepActive');
+
+    fireEvent.click(getByText('Go to next step'));
+
+    expect(step1).toBeVisible();
+    expect(step2).toBeVisible();
+    expect(step3).toBeVisible();
+    expect(step3).toHaveClass('stepActive');
+  });
+
+  test('scrolls to and focuses first step when mounted', () => {
+    const { container } = render(
+      <Wizard id="test-wizard">
+        <WizardStep>
+          {({ setCurrentStep }) => (
+            <button type="button" onClick={() => setCurrentStep(3)}>
+              Go to step 3
+            </button>
+          )}
+        </WizardStep>
+        <WizardStep>Step 2</WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    const step1 = container.querySelector('#test-wizard-step-1') as HTMLElement;
+    const step2 = container.querySelector('#test-wizard-step-2') as HTMLElement;
+    const step3 = container.querySelector('#test-wizard-step-3') as HTMLElement;
+
+    expect(step1).toHaveFocus();
+    expect(step1).toHaveScrolledIntoView();
+
+    expect(step2).not.toHaveScrolledIntoView();
+    expect(step2).not.toHaveFocus();
+
+    expect(step3).not.toHaveScrolledIntoView();
+    expect(step3).not.toHaveFocus();
+  });
+
+  test('scrolls to and focuses step when step changes', () => {
+    const { container, getByText } = render(
+      <Wizard id="test-wizard">
+        <WizardStep>
+          {({ setCurrentStep }) => (
+            <button type="button" onClick={() => setCurrentStep(3)}>
+              Go to step 3
+            </button>
+          )}
+        </WizardStep>
+        <WizardStep>Step 2</WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    const step1 = container.querySelector('#test-wizard-step-1') as HTMLElement;
+    const step2 = container.querySelector('#test-wizard-step-2') as HTMLElement;
+    const step3 = container.querySelector('#test-wizard-step-3') as HTMLElement;
+
+    expect(step1).toHaveFocus();
+    expect(step1).toHaveScrolledIntoView();
+
+    expect(step2).not.toHaveFocus();
+    expect(step2).not.toHaveScrolledIntoView();
+
+    expect(step3).not.toHaveFocus();
+    expect(step3).not.toHaveScrolledIntoView();
+
+    fireEvent.click(getByText('Go to step 3'));
+
+    expect(step1).not.toHaveFocus();
+    expect(step1).toHaveScrolledIntoView();
+
+    expect(step2).not.toHaveFocus();
+    expect(step2).not.toHaveScrolledIntoView();
+
+    expect(step3).toHaveFocus();
+    expect(step3).toHaveScrolledIntoView();
+  });
+});

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/Wizard.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/Wizard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from 'react-testing-library';
+import { fireEvent, render, wait } from 'react-testing-library';
 import Wizard from '../Wizard';
 import WizardStep from '../WizardStep';
 
@@ -352,5 +352,63 @@ describe('Wizard', () => {
 
     expect(step3).toHaveFocus();
     expect(step3).toHaveScrolledIntoView();
+  });
+
+  test('calls `onStepChange` handler when step changes', () => {
+    const onStepChange = jest.fn();
+
+    const { getByText } = render(
+      <Wizard id="test-wizard" onStepChange={onStepChange}>
+        <WizardStep>
+          {({ setCurrentStep }) => (
+            <button type="button" onClick={() => setCurrentStep(3)}>
+              Go to step 3
+            </button>
+          )}
+        </WizardStep>
+        <WizardStep>Step 2</WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    expect(onStepChange).not.toHaveBeenCalled();
+
+    fireEvent.click(getByText('Go to step 3'));
+
+    expect(onStepChange).toHaveBeenCalledWith(3, 1);
+  });
+
+  test('can change to a different step by returning a number from `onStepChange` handler', async () => {
+    const { container, getByText } = render(
+      <Wizard id="test-wizard" onStepChange={() => 2}>
+        <WizardStep>
+          {({ setCurrentStep }) => (
+            <button type="button" onClick={() => setCurrentStep(3)}>
+              Go to step 3
+            </button>
+          )}
+        </WizardStep>
+        <WizardStep>Step 2</WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    const step1 = container.querySelector('#test-wizard-step-1') as HTMLElement;
+    const step2 = container.querySelector('#test-wizard-step-2') as HTMLElement;
+    const step3 = container.querySelector('#test-wizard-step-3') as HTMLElement;
+
+    expect(step1).toBeVisible();
+    expect(step1).toHaveClass('stepActive');
+    expect(step2).not.toBeVisible();
+    expect(step3).not.toBeVisible();
+
+    fireEvent.click(getByText('Go to step 3'));
+
+    await wait();
+
+    expect(step1).toBeVisible();
+    expect(step2).toBeVisible();
+    expect(step2).toHaveClass('stepActive');
+    expect(step3).not.toBeVisible();
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/hooks/useResetFormOnPreviousStep.ts
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/hooks/useResetFormOnPreviousStep.ts
@@ -1,0 +1,29 @@
+import { Formik } from '@common/components/form';
+import { FormikValues } from 'formik';
+import { RefObject, useEffect } from 'react';
+
+/**
+ * Reset the form state for this current step if
+ * the user moves back to a previous step.
+ */
+export default function useResetFormOnPreviousStep<
+  FormValues extends FormikValues
+>(
+  formikRef: RefObject<Formik<FormValues>>,
+  currentStep: number,
+  stepNumber: number,
+  callback?: () => void,
+) {
+  useEffect(() => {
+    if (currentStep < stepNumber) {
+      if (formikRef.current) {
+        formikRef.current.resetForm();
+      }
+
+      if (callback) {
+        callback();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [formikRef, currentStep, stepNumber]);
+}

--- a/src/explore-education-statistics-frontend/src/pages/_app.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/_app.tsx
@@ -1,10 +1,12 @@
 import { logPageView } from '@frontend/services/googleAnalyticsService';
+import { initHotJar } from '@frontend/services/hotjarService';
 import BaseApp, { Container, NextAppContext } from 'next/app';
 import Router from 'next/router';
 import React from 'react';
 import Helmet from 'react-helmet';
 import './_app.scss';
-import { initHotJar } from '@frontend/services/hotjarService';
+
+process.env.APP_ROOT_ID = '__next';
 
 class App extends BaseApp {
   public static async getInitialProps({ Component, ctx }: NextAppContext) {

--- a/src/explore-education-statistics-frontend/test/setupTests.js
+++ b/src/explore-education-statistics-frontend/test/setupTests.js
@@ -2,6 +2,7 @@ import 'react-testing-library/cleanup-after-each';
 import 'jest-dom/extend-expect';
 import 'core-js/fn/array/virtual/flat-map';
 import '@common-test/setupGlobals';
+import '@common-test/extend-expect';
 
 if (typeof window !== 'undefined') {
   // fetch polyfill for making API calls.

--- a/src/explore-education-statistics-frontend/test/types.d.ts
+++ b/src/explore-education-statistics-frontend/test/types.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="jest-dom/extend-expect" />
+
+import '@common-test/types';


### PR DESCRIPTION
This PR:

- Adds `Modal` implementation based on `react-aria-modal`. This has been built with accessibility in mind and should work well with our accessibility requirements. 
- Adds `ConfirmContext` which is useful for instances where we require the user to confirm their action. This is particularly useful when used in combination with the `ModalConfirm` component.
- State is flushed more consistently whenever the user moves between steps in the Table Tool wizard (DFE-665).

Other changes:
- Add `toHaveScrolledIntoView` test assertion that can be used to check if an element's `scrollIntoView` method has been called.