### PR TITLE
DFE-682 Add dynamic publication list to 'Choose publication' step

### DIFF
--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -22,6 +22,22 @@ export interface GroupedFilterOptions {
   };
 }
 
+export interface ThemeMeta {
+  id: string;
+  title: string;
+  slug: string;
+  topics: {
+    id: string;
+    title: string;
+    slug: string;
+    publications: {
+      id: string;
+      title: string;
+      slug: string;
+    }[];
+  }[];
+}
+
 export interface PublicationSubject {
   id: string;
   label: string;
@@ -77,6 +93,9 @@ export interface TableData {
 }
 
 export default {
+  getThemes(): Promise<ThemeMeta[]> {
+    return dataApi.get(`/meta/themes`);
+  },
   getPublicationMeta(publicationUuid: string): Promise<PublicationMeta> {
     return dataApi.get(`/meta/publication/${publicationUuid}`);
   },

--- a/src/explore-education-statistics-common/src/services/types/TimePeriod.ts
+++ b/src/explore-education-statistics-common/src/services/types/TimePeriod.ts
@@ -1,8 +1,8 @@
 import { Comparison } from '@common/types/util';
 
-export type TimePeriodCode = 'AY' | 'HT6' | 'HT5';
+export type TimePeriodCode = 'AY' | 'CY' | 'HT6' | 'HT5';
 
-const allowedTimePeriodCodes: TimePeriodCode[] = ['AY', 'HT6', 'HT5'];
+const allowedTimePeriodCodes: TimePeriodCode[] = ['AY', 'CY', 'HT6', 'HT5'];
 
 class TimePeriod {
   public readonly year: number;
@@ -52,6 +52,8 @@ class TimePeriod {
         const yearString = this.year.toString();
         return `${yearString}/${Number(yearString.substring(2, 4)) + 1}`;
       }
+      case 'CY':
+        return this.year.toString();
       default:
         throw new Error('Cold not parse label');
     }
@@ -64,6 +66,7 @@ class TimePeriod {
   public previousPeriod(): TimePeriod {
     switch (this.code) {
       case 'AY':
+      case 'CY':
       case 'HT6':
       case 'HT5':
         return new TimePeriod(this.year - 1, this.code);
@@ -75,6 +78,7 @@ class TimePeriod {
   public nextPeriod(): TimePeriod {
     switch (this.code) {
       case 'AY':
+      case 'CY':
       case 'HT6':
       case 'HT5':
         return new TimePeriod(this.year + 1, this.code);

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -5,6 +5,7 @@ import tableBuilderService, {
   PublicationSubject,
   PublicationSubjectMeta,
   TableData,
+  ThemeMeta,
 } from '@common/services/tableBuilderService';
 import TimePeriod from '@common/services/types/TimePeriod';
 import { Dictionary } from '@common/types/util';
@@ -43,39 +44,9 @@ export interface PublicationOptions {
   }[];
 }
 
-const defaultPublicationOptions: PublicationOptions[] = [
-  {
-    id: 'early-years-and-schools',
-    title: 'Early years and schools',
-    topics: [
-      {
-        id: 'absence-and-exclusions',
-        title: 'Absence and exclusions',
-        publications: [
-          {
-            id: 'cbbd299f-8297-44bc-92ac-558bcf51f8ad',
-            title: 'Pupil absence',
-            slug: '/statistics/pupil-absence-in-schools-in-england',
-          },
-          // {
-          //   id: 'bf2b4284-6b84-46b0-aaaa-a2e0a23be2a9',
-          //   title: 'Exclusions',
-          // },
-        ],
-      },
-      {
-        id: 'school-and-pupil-numbers',
-        title: 'School and pupil numbers',
-        publications: [
-          // {
-          //   id: 'a91d9e05-be82-474c-85ae-4913158406d0',
-          //   title: 'Schools, pupils and their characteristics',
-          // },
-        ],
-      },
-    ],
-  },
-];
+interface Props {
+  themeMeta: ThemeMeta[];
+}
 
 interface State {
   timePeriods: TimePeriod[];
@@ -90,7 +61,7 @@ interface State {
   tableData: TableData['result'];
 }
 
-class TableToolPage extends Component<{}, State> {
+class TableToolPage extends Component<Props, State> {
   public state: State = {
     filters: {},
     timePeriods: [],
@@ -112,10 +83,16 @@ class TableToolPage extends Component<{}, State> {
     tableData: [],
   };
 
+  public static async getInitialProps() {
+    const themeMeta = await tableBuilderService.getThemes();
+    return { themeMeta };
+  }
+
   private handlePublicationFormSubmit: PublicationFormSubmitHandler = async ({
     publicationId,
   }) => {
-    const publication = defaultPublicationOptions
+    const { themeMeta } = this.props;
+    const publication = themeMeta
       .flatMap(option => option.topics)
       .flatMap(option => option.publications)
       .find(option => option.id === publicationId);
@@ -201,6 +178,7 @@ class TableToolPage extends Component<{}, State> {
   };
 
   public render() {
+    const { themeMeta } = this.props;
     const {
       filters,
       indicators,
@@ -232,7 +210,7 @@ class TableToolPage extends Component<{}, State> {
             {stepProps => (
               <PublicationForm
                 {...stepProps}
-                options={defaultPublicationOptions}
+                options={themeMeta}
                 onSubmit={this.handlePublicationFormSubmit}
               />
             )}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/PublicationForm.tsx
@@ -11,10 +11,10 @@ import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import createErrorHelper from '@common/lib/validation/createErrorHelper';
 import Yup from '@common/lib/validation/yup';
+import { ThemeMeta } from '@common/services/tableBuilderService';
 import { FormikProps } from 'formik';
 import camelCase from 'lodash';
 import React, { useState } from 'react';
-import { PublicationOptions } from '../TableToolPage';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 import WizardStepHeading from './WizardStepHeading';
@@ -27,7 +27,7 @@ export type PublicationFormSubmitHandler = (values: FormValues) => void;
 
 interface Props {
   onSubmit: PublicationFormSubmitHandler;
-  options: PublicationOptions[];
+  options: ThemeMeta[];
 }
 
 const PublicationForm = (props: Props & InjectedWizardProps) => {


### PR DESCRIPTION
This PR replaces the hard-coded publication list in the 'Choose publication' step with a call to the new `/meta/themes` endpoint which returns a tree of themes/topics/publications that can be used to display the publication options.