### PR TITLE
DFE-785-National-Stats

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -252,10 +252,9 @@ class PublicationReleasePage extends Component<Props> {
           <AccordionSection heading="National statistics" headingTag="h3">
             <p className="govuk-body">
               The United Kingdom Statistics Authority designated these
-              statistics as National Statistics in <a href="#">Month Year</a> in
-              accordance with the Statistics and Registration Service Act 2007
-              and signifying compliance with the Code of Practice for
-              Statistics.
+              statistics as National Statistics in 2011 in accordance with the
+              Statistics and Registration Service Act 2007 and signifying
+              compliance with the Code of Practice for Statistics.
             </p>
             <p className="govuk-body">
               Designation can be broadly interpreted to mean that the

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -249,31 +249,46 @@ class PublicationReleasePage extends Component<Props> {
               </li>
             </ul>
           </AccordionSection>
-          <AccordionSection heading="National statistics" headingTag="h3">
+          <AccordionSection heading="National Statistics" headingTag="h3">
             <p className="govuk-body">
-              The United Kingdom Statistics Authority designated these
-              statistics as National Statistics in 2011 in accordance with the
-              Statistics and Registration Service Act 2007 and signifying
-              compliance with the Code of Practice for Statistics.
+              The{' '}
+              <a href="https://www.statisticsauthority.gov.uk/">
+                UK Statistics Authority
+              </a>{' '}
+              designated these statistics as National Statistics in [INSERT
+              MONTH YEAR] in accordance with the{' '}
+              <a href="https://www.legislation.gov.uk/ukpga/2007/18/contents">
+                Statistics and Registration Service Act 2007
+              </a>
+              .
             </p>
             <p className="govuk-body">
-              Designation can be broadly interpreted to mean that the
-              statistics:
+              Designation signifying their compliance with the authority's{' '}
+              <a href="https://www.statisticsauthority.gov.uk/code-of-practice/the-code/">
+                Code of Practice for Statistics
+              </a>{' '}
+              which broadly means these statistics are:
             </p>
             <ul className="govuk-list govuk-list--bullet">
-              <li>meet identified user needs;</li>
-              <li>are well explained and readily accessible;</li>
-              <li>are produced according to sound methods, and</li>
               <li>
-                are managed impartially and objectively in the public interest
+                managed impartially and objectively in the public interest
               </li>
+              <li>meet identified user needs</li>
+              <li>produced according to sound methods</li>
+              <li>well explained and readily accessible</li>
             </ul>
             <p className="govuk-body">
-              Once statistics have been designated as National Statistics it is
-              a statutory requirement that the Code of Practice shall continue
-              to be observed. Information on improvements made to these
-              statistics to continue their compliance with the Code of Practice
-              are provided in this <a href="#">accompanying document</a>
+              Once designated as National Statistics it's a statutory
+              requirement for statistics to follow and comply with the Code of
+              Practice for Statistics. to be observed.
+            </p>
+            <p className="govuk-body">
+              Find out more about the standards we follow to produce these
+              statistics through our{' '}
+              <a href="https://www.gov.uk/government/publications/standards-for-official-statistics-published-by-the-department-for-education">
+                Standards for official statistics published by DfE
+              </a>{' '}
+              guidance.
             </p>
           </AccordionSection>
           <AccordionSection heading="Feedback and questions" headingTag="h3">

--- a/src/explore-education-statistics-frontend/src/prototypes/publication/PrototypePublicationPageAbsence.tsx
+++ b/src/explore-education-statistics-frontend/src/prototypes/publication/PrototypePublicationPageAbsence.tsx
@@ -731,9 +731,9 @@ const PublicationPage = () => {
         <AccordionSection heading="National Statistics" headingTag="h3">
           <p className="govuk-body">
             The United Kingdom Statistics Authority designated these statistics
-            as National Statistics in <a href="#">Month Year</a> in accordance
-            with the Statistics and Registration Service Act 2007 and signifying
-            compliance with the Code of Practice for Statistics.
+            as National Statistics in 2011 in accordance with the Statistics and
+            Registration Service Act 2007 and signifying compliance with the
+            Code of Practice for Statistics.
           </p>
           <p className="govuk-body">
             Designation can be broadly interpreted to mean that the statistics:

--- a/src/explore-education-statistics-frontend/src/prototypes/publication/PrototypePublicationPageExclusions.tsx
+++ b/src/explore-education-statistics-frontend/src/prototypes/publication/PrototypePublicationPageExclusions.tsx
@@ -680,9 +680,9 @@ const PublicationPageExclusions = () => {
         <AccordionSection heading="National Statistics" headingTag="h3">
           <p className="govuk-body">
             The United Kingdom Statistics Authority designated these statistics
-            as National Statistics in <a href="#">Month Year</a> in accordance
-            with the Statistics and Registration Service Act 2007 and signifying
-            compliance with the Code of Practice for Statistics.
+            as National Statistics in 2011 in accordance with the Statistics and
+            Registration Service Act 2007 and signifying compliance with the
+            Code of Practice for Statistics.
           </p>
           <p className="govuk-body">
             Designation can be broadly interpreted to mean that the statistics:

--- a/src/explore-education-statistics-frontend/src/prototypes/publication/PrototypePublicationPageGCSE.tsx
+++ b/src/explore-education-statistics-frontend/src/prototypes/publication/PrototypePublicationPageGCSE.tsx
@@ -599,9 +599,9 @@ const PublicationPage = () => {
         <AccordionSection heading="National Statistics" headingTag="h3">
           <p className="govuk-body">
             The United Kingdom Statistics Authority designated these statistics
-            as National Statistics in <a href="#">Month Year</a> in accordance
-            with the Statistics and Registration Service Act 2007 and signifying
-            compliance with the Code of Practice for Statistics.
+            as National Statistics in 2011 in accordance with the Statistics and
+            Registration Service Act 2007 and signifying compliance with the
+            Code of Practice for Statistics.
           </p>
           <p className="govuk-body">
             Designation can be broadly interpreted to mean that the statistics:


### PR DESCRIPTION
replaced text with requested alternate text on 4 of the hardcoded publication pages

From 
```
The United Kingdom Statistics Authority designated these
statistics as National Statistics in <a href="#">Month Year</a> in
accordance with the Statistics and Registration Service Act 2007
and signifying compliance with the Code of Practice for
Statistics.
```
To
```
The United Kingdom Statistics Authority designated these
statistics as National Statistics in 2011 in accordance with the
Statistics and Registration Service Act 2007 and signifying
compliance with the Code of Practice for Statistics.
```