### PR TITLE
dfe-785 National Stats update 2

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -253,14 +253,15 @@ class PublicationReleasePage extends Component<Props> {
             <p className="govuk-body">
               The{' '}
               <a href="https://www.statisticsauthority.gov.uk/">
-                UK Statistics Authority
+                United Kindom Statistics Authority
               </a>{' '}
-              designated these statistics as National Statistics in [INSERT
-              MONTH YEAR] in accordance with the{' '}
+              designated these statistics as National Statistics in accordance
+              with the{' '}
               <a href="https://www.legislation.gov.uk/ukpga/2007/18/contents">
                 Statistics and Registration Service Act 2007
-              </a>
-              .
+              </a>{' '}
+              and signifying compliance with the Code of Practice for
+              Statistics.
             </p>
             <p className="govuk-body">
               Designation signifying their compliance with the authority's{' '}


### PR DESCRIPTION
As requested, updated the text to: 
> The United Kingdom Statistics Authority designated these statistics as National Statistics in accordance with the Statistics and Registration Service Act 2007 and signifying compliance with the Code of Practice for Statistics.

https://alpha-dfe-data.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=DFE&modal=detail&selectedIssue=DFE-785