### PR TITLE
DFE-691: Remove Feedback and Questions from release page

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -291,19 +291,6 @@ class PublicationReleasePage extends Component<Props> {
               guidance.
             </p>
           </AccordionSection>
-          <AccordionSection heading="Feedback and questions" headingTag="h3">
-            <ul className="govuk-list">
-              <li>
-                <a href="#">Feedback on this page</a>
-              </li>
-              <li>
-                <a href="#">Make a suggestion</a>
-              </li>
-              <li>
-                <a href="#">Ask a question</a>
-              </li>
-            </ul>
-          </AccordionSection>
           <AccordionSection heading="Contact us" headingTag="h3">
             <div className="govuk-warning-text">
               <span className="govuk-warning-text__icon" aria-hidden="true">


### PR DESCRIPTION
Removes the feedback and questions section as this is no longer required