### PR TITLE
DFE-846 Allow clicking away from search form to close it

### DIFF
--- a/src/explore-education-statistics-common/src/components/PageSearchForm.tsx
+++ b/src/explore-education-statistics-common/src/components/PageSearchForm.tsx
@@ -87,11 +87,18 @@ class PageSearchForm extends Component<Props, State> {
   private search = (value: string) => {
     const { elementSelectors, minInput } = this.props;
 
-    if (value.length < minInput) {
+    const isAcronym = value === value.toUpperCase() && value.length > 1;
+
+    if (!isAcronym && value.length < minInput) {
+      this.resetSearch();
       return;
     }
 
-    const elements = findAllByText(value, elementSelectors.join(', '));
+    const elements = findAllByText(
+      isAcronym ? value : value.toLocaleLowerCase(),
+      elementSelectors.join(', '),
+      !isAcronym,
+    );
 
     const searchResults = elements.map(element => {
       const location = PageSearchForm.getLocationText(element);

--- a/src/explore-education-statistics-common/src/components/PageSearchForm.tsx
+++ b/src/explore-education-statistics-common/src/components/PageSearchForm.tsx
@@ -25,6 +25,7 @@ interface Props {
   className?: string;
   elementSelectors: string[];
   id: string;
+  minInput: number;
 }
 
 interface State {
@@ -41,6 +42,7 @@ class PageSearchForm extends Component<Props, State> {
   public static defaultProps = {
     elementSelectors: ['p', 'li > strong', 'h2', 'h3', 'h4'],
     id: 'pageSearchForm',
+    minInput: 3,
   };
 
   private static getLocationText(element: HTMLElement): string {
@@ -83,9 +85,9 @@ class PageSearchForm extends Component<Props, State> {
   }
 
   private search = (value: string) => {
-    const { elementSelectors } = this.props;
+    const { elementSelectors, minInput } = this.props;
 
-    if (value.length <= 3) {
+    if (value.length < minInput) {
       return;
     }
 

--- a/src/explore-education-statistics-common/src/components/__tests__/PageSearchForm.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/PageSearchForm.test.tsx
@@ -8,6 +8,108 @@ import { fireEvent, render, wait } from 'react-testing-library';
 import PageSearchForm from '../PageSearchForm';
 
 describe('PageSearchForm', () => {
+  test('does not render results if input is less than default 3 characters', () => {
+    jest.useFakeTimers();
+
+    const { container, getByLabelText } = render(
+      <div>
+        <PageSearchForm />
+
+        <div>
+          <p>Not me</p>
+          <p>To 1</p>
+        </div>
+
+        <div>
+          <h2>Not me</h2>
+          <h2>To 2</h2>
+        </div>
+
+        <div>
+          <h3>Not me</h3>
+          <h3>To 3</h3>
+        </div>
+
+        <div>
+          <h4>Not me</h4>
+          <h4>To 4</h4>
+        </div>
+
+        <ul>
+          <li>Not me</li>
+          <li>
+            <strong>To 5</strong>
+          </li>
+        </ul>
+      </div>,
+    );
+
+    fireEvent.change(getByLabelText('Find on this page'), {
+      target: {
+        value: 'To',
+      },
+    });
+
+    jest.runOnlyPendingTimers();
+
+    expect(container.querySelector('#pageSearchForm-resultsLabel')).toBeNull();
+
+    const options = container.querySelectorAll('[role="option"]');
+
+    expect(options).toHaveLength(0);
+  });
+
+  test('does not render results if input is less the custom `minInput` prop', () => {
+    jest.useFakeTimers();
+
+    const { container, getByLabelText } = render(
+      <div>
+        <PageSearchForm minInput={5} />
+
+        <div>
+          <p>Not me</p>
+          <p>Testing 1</p>
+        </div>
+
+        <div>
+          <h2>Not me</h2>
+          <h2>Testing 2</h2>
+        </div>
+
+        <div>
+          <h3>Not me</h3>
+          <h3>Testing 3</h3>
+        </div>
+
+        <div>
+          <h4>Not me</h4>
+          <h4>Testing 4</h4>
+        </div>
+
+        <ul>
+          <li>Testing me</li>
+          <li>
+            <strong>Testing 5</strong>
+          </li>
+        </ul>
+      </div>,
+    );
+
+    fireEvent.change(getByLabelText('Find on this page'), {
+      target: {
+        value: 'Test',
+      },
+    });
+
+    jest.runOnlyPendingTimers();
+
+    expect(container.querySelector('#pageSearchForm-resultsLabel')).toBeNull();
+
+    const options = container.querySelectorAll('[role="option"]');
+
+    expect(options).toHaveLength(0);
+  });
+
   test('renders results found in default elements', async () => {
     jest.useFakeTimers();
 

--- a/src/explore-education-statistics-common/src/components/__tests__/PageSearchForm.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/PageSearchForm.test.tsx
@@ -110,6 +110,116 @@ describe('PageSearchForm', () => {
     expect(options).toHaveLength(0);
   });
 
+  test('renders correct results when input is an acronym', () => {
+    jest.useFakeTimers();
+
+    const { container, getByLabelText } = render(
+      <div>
+        <PageSearchForm />
+
+        <div>
+          <p>Not me</p>
+          <p>Testing 1</p>
+        </div>
+
+        <div>
+          <h2>Not me</h2>
+          <h2>TESTING 2</h2>
+        </div>
+
+        <div>
+          <h3>Not me</h3>
+          <h3>TEST 3</h3>
+        </div>
+
+        <div>
+          <h4>Not me</h4>
+          <h4>Testing 4</h4>
+        </div>
+
+        <ul>
+          <li>Testing me</li>
+          <li>
+            <strong>Testing 5</strong>
+          </li>
+        </ul>
+      </div>,
+    );
+
+    fireEvent.change(getByLabelText('Find on this page'), {
+      target: {
+        value: 'TEST',
+      },
+    });
+
+    jest.runOnlyPendingTimers();
+
+    expect(
+      container.querySelector('#pageSearchForm-resultsLabel'),
+    ).toHaveTextContent('Found 2 results');
+
+    const options = container.querySelectorAll('[role="option"]');
+
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent('TESTING 2');
+    expect(options[1]).toHaveTextContent('TEST 3');
+  });
+
+  test('renders correct results when input is an acronym and is below `minInput`', () => {
+    jest.useFakeTimers();
+
+    const { container, getByLabelText } = render(
+      <div>
+        <PageSearchForm minInput={5} />
+
+        <div>
+          <p>Not me</p>
+          <p>Testing 1</p>
+        </div>
+
+        <div>
+          <h2>Not me</h2>
+          <h2>TESTING 2</h2>
+        </div>
+
+        <div>
+          <h3>Not me</h3>
+          <h3>TEST 3</h3>
+        </div>
+
+        <div>
+          <h4>Not me</h4>
+          <h4>Testing 4</h4>
+        </div>
+
+        <ul>
+          <li>Testing me</li>
+          <li>
+            <strong>Testing 5</strong>
+          </li>
+        </ul>
+      </div>,
+    );
+
+    fireEvent.change(getByLabelText('Find on this page'), {
+      target: {
+        value: 'TE',
+      },
+    });
+
+    jest.runOnlyPendingTimers();
+
+    expect(
+      container.querySelector('#pageSearchForm-resultsLabel'),
+    ).toHaveTextContent('Found 2 results');
+
+    const options = container.querySelectorAll('[role="option"]');
+
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent('TESTING 2');
+    expect(options[1]).toHaveTextContent('TEST 3');
+  });
+
   test('renders results found in default elements', async () => {
     jest.useFakeTimers();
 

--- a/src/explore-education-statistics-common/src/components/form/FormComboBox.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormComboBox.tsx
@@ -1,3 +1,4 @@
+import useClickAway from '@common/hooks/useClickAway';
 import useToggle from '@common/hooks/useToggle';
 import { Dictionary } from '@common/types';
 import classNames from 'classnames';
@@ -43,6 +44,7 @@ const FormComboBox = ({
   onInputChange,
   onSelect,
 }: Props) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const listBoxRef = useRef<HTMLUListElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const optionRefs = useRef<Dictionary<HTMLLIElement>>({});
@@ -50,6 +52,10 @@ const FormComboBox = ({
   const [value, setValue] = useState('');
   const [selectedOption, setSelectedOption] = useState(initialOption);
   const [showOptions, toggleShowOptions] = useToggle(false);
+
+  useClickAway(containerRef, () => {
+    toggleShowOptions(false);
+  });
 
   const renderedOptions =
     typeof options === 'function'
@@ -124,8 +130,26 @@ const FormComboBox = ({
     return nextSelectedOption;
   };
 
+  const handleContainerInteraction = () => {
+    if (showOptions) {
+      return;
+    }
+
+    // Re-show options if they have been hidden
+    // e.g. when the user clicks away from the combobox
+    if (renderedOptions) {
+      toggleShowOptions(true);
+    }
+  };
+
   return (
-    <div className={styles.container}>
+    <div
+      className={styles.container}
+      role="none"
+      onClick={handleContainerInteraction}
+      onKeyDown={handleContainerInteraction}
+      ref={containerRef}
+    >
       <div
         aria-expanded={renderedOptions ? renderedOptions.length > 0 : false}
         aria-owns={`${id}-options`}

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormComboBox.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormComboBox.test.tsx
@@ -739,4 +739,66 @@ describe('FormComboBox', () => {
       expect(container.querySelectorAll('[role="option"]')).toHaveLength(0);
     });
   });
+
+  test('clicking outside of combobox hides options', () => {
+    const { container, getByText, getByLabelText } = render(
+      <div>
+        <p id="outside">Target</p>
+
+        <FormComboBox
+          id="test-combobox"
+          inputLabel="Choose option"
+          onInputChange={() => {}}
+          onSelect={() => {}}
+          options={['Option 1', 'Option 2', 'Option 3']}
+        />
+      </div>,
+    );
+
+    const input = getByLabelText('Choose option') as HTMLInputElement;
+
+    fireEvent.change(input, {
+      target: {
+        value: 'Test',
+      },
+    });
+
+    expect(container.querySelectorAll('[role="option"]')).toHaveLength(3);
+
+    fireEvent.click(getByText('Target'));
+
+    expect(container.querySelectorAll('[role="option"]')).toHaveLength(0);
+  });
+
+  test('re-clicking combobox re-renders options', () => {
+    const { container, getByText, getByLabelText } = render(
+      <div>
+        <p id="outside">Target</p>
+
+        <FormComboBox
+          id="test-combobox"
+          inputLabel="Choose option"
+          onInputChange={() => {}}
+          onSelect={() => {}}
+          options={['Option 1', 'Option 2', 'Option 3']}
+        />
+      </div>,
+    );
+
+    const input = getByLabelText('Choose option') as HTMLInputElement;
+
+    fireEvent.change(input, {
+      target: {
+        value: 'Test',
+      },
+    });
+
+    fireEvent.click(getByText('Target'));
+
+    expect(container.querySelectorAll('[role="option"]')).toHaveLength(0);
+
+    fireEvent.click(getByLabelText('Choose option'));
+
+    expect(container.querySelectorAll('[role="option"]')).toHaveLength(3);
+  });
 });

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormComboBox.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormComboBox.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`FormComboBox renders with no options by default 1`] = `
 
-<div class="container">
+<div class="container"
+     role="none"
+>
   <div aria-expanded="true"
        aria-owns="test-combobox-options"
        aria-haspopup="listbox"
@@ -28,7 +30,9 @@ exports[`FormComboBox renders with no options by default 1`] = `
 
 exports[`FormComboBox renders with options in correct order when input changes 1`] = `
 
-<div class="container">
+<div class="container"
+     role="none"
+>
   <div aria-expanded="true"
        aria-owns="test-combobox-options"
        aria-haspopup="listbox"

--- a/src/explore-education-statistics-common/src/hooks/useClickAway.ts
+++ b/src/explore-education-statistics-common/src/hooks/useClickAway.ts
@@ -1,0 +1,34 @@
+import { RefObject, useEffect } from 'react';
+
+/**
+ * Hook detecting if the user interacts away
+ * from the specific element in {@param ref}.
+ * A callback {@param onClickAway} will be called
+ * when this occurs.
+ *
+ * Optionally, specific {@param events} to listen
+ * for outside of the element can also be specified.
+ */
+export default function useClickAway<
+  K extends keyof DocumentEventMap = 'click'
+>(
+  ref: RefObject<HTMLElement | null>,
+  onClickAway: (event: DocumentEventMap[K]) => void,
+  events: (keyof DocumentEventMap)[] = ['click'],
+) {
+  useEffect(() => {
+    const handler: EventListenerOrEventListenerObject = event => {
+      const { current: element } = ref;
+
+      if (element && event.target && !element.contains(event.target as Node)) {
+        onClickAway(event as DocumentEventMap[K]);
+      }
+    };
+
+    events.forEach(event => document.addEventListener(event, handler));
+
+    return () => {
+      events.forEach(event => document.removeEventListener(event, handler));
+    };
+  });
+}

--- a/src/explore-education-statistics-common/src/lib/dom/__tests__/findAllByText.test.tsx
+++ b/src/explore-education-statistics-common/src/lib/dom/__tests__/findAllByText.test.tsx
@@ -58,4 +58,16 @@ describe('findAllByText', () => {
 
     expect(elements).toHaveLength(0);
   });
+
+  test('optionally matches lowercase text', () => {
+    render(
+      <div>
+        <p className="test-1">Test</p>
+        <p className="test-2">Test</p>
+      </div>,
+    );
+
+    expect(findAllByText('test', 'p', false)).toHaveLength(0);
+    expect(findAllByText('test', 'p', true)).toHaveLength(2);
+  });
 });

--- a/src/explore-education-statistics-common/src/lib/dom/findAllByText.ts
+++ b/src/explore-education-statistics-common/src/lib/dom/findAllByText.ts
@@ -1,14 +1,19 @@
 /**
  * Find elements that match the given
  * {@param text} and a {@param selector}.
+ * Elements can also be matched by lower cased
+ * text content if {@param useLowerCase} is true.
  */
 export default function findAllByText<T extends HTMLElement = HTMLElement>(
   text: string,
   selector: string,
+  useLowerCase = false,
 ): T[] {
-  return Array.from(document.querySelectorAll(selector)).filter(element =>
-    (element.textContent || '')
-      .toLocaleLowerCase()
-      .includes(text.toLocaleLowerCase()),
-  ) as T[];
+  return Array.from(document.querySelectorAll(selector)).filter(element => {
+    const searchText = useLowerCase
+      ? (element.textContent || '').toLocaleLowerCase()
+      : element.textContent || '';
+
+    return searchText.includes(text);
+  }) as T[];
 }


### PR DESCRIPTION
This PR adds functionality to allow the user to close `PageSearchForm`s results list when the user clicks away. This behaviour is actually abstracted into `FormComboBox`.

Additionally, the search input now requires 3 characters to be entered (rather than 4), which should be a little more flexible to search on. To alleviate issues with acronyms (e.g. LA) with only 2 characters, search will still be performed if the input seems to be an acronym.