### PR TITLE
Refactor Accordion and Tabs components

### DIFF
--- a/azure-pipelines.dfe.yml
+++ b/azure-pipelines.dfe.yml
@@ -145,6 +145,13 @@ jobs:
         continueOnError: true
         enabled: false
       - task: 'Npm@1'
+        displayName: 'npm run tsc'
+        inputs:
+          command: 'custom'
+          workingDir: '.'
+          verbose: false
+          customCommand: 'run tsc'
+      - task: 'Npm@1'
         displayName: 'npm run lint'
         inputs:
           command: 'custom'
@@ -272,7 +279,7 @@ jobs:
         displayName: 'Publish Pipeline Artifact'
         inputs:
           artifactName: 'frontend-dev02'
-          targetPath: '$(Build.ArtifactStagingDirectory)'          
+          targetPath: '$(Build.ArtifactStagingDirectory)'
   - job: 'FrontendArtifactDev03'
     dependsOn: 'Frontend'
     pool:

--- a/azure-pipelines.pr.yml
+++ b/azure-pipelines.pr.yml
@@ -144,6 +144,13 @@ jobs:
         continueOnError: true
         enabled: false
       - task: 'Npm@1'
+        displayName: 'npm run tsc'
+        inputs:
+          command: 'custom'
+          workingDir: '.'
+          verbose: false
+          customCommand: 'run tsc'
+      - task: 'Npm@1'
         displayName: 'npm run lint'
         inputs:
           command: 'custom'

--- a/src/explore-education-statistics-admin/src/pages/prototypes/PrototypeAdminDashboard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/prototypes/PrototypeAdminDashboard.tsx
@@ -35,7 +35,7 @@ const BrowseReleasesPage = ({ location }: RouteChildrenProps) => {
           </RelatedInformation>
         </div>
       </div>
-      <Tabs>
+      <Tabs id="dashboard-tabs">
         <TabsSection id="publications" title="Publications">
           <AdminDashboardPublications />
         </TabsSection>

--- a/src/explore-education-statistics-admin/src/pages/prototypes/publication/components/PrototypeDataSample.tsx
+++ b/src/explore-education-statistics-admin/src/pages/prototypes/publication/components/PrototypeDataSample.tsx
@@ -25,7 +25,7 @@ const PrototypeDataSample = ({
 }: Props) => {
   return (
     <>
-      <Tabs>
+      <Tabs id="data-sample-tabs">
         {sectionId === 'headlines' && (
           <TabsSection id={`${sectionId}SummaryData`} title="Summary">
             <PrototypeDataTilesHighlights />

--- a/src/explore-education-statistics-common/package-lock.json
+++ b/src/explore-education-statistics-common/package-lock.json
@@ -5691,12 +5691,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5711,17 +5713,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5838,7 +5843,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5850,6 +5856,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5864,6 +5871,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5871,12 +5879,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5895,6 +5905,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5975,7 +5986,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5987,6 +5999,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6108,6 +6121,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10297,6 +10311,18 @@
       "dev": true,
       "requires": {
         "object-is": "^1.0.1"
+      }
+    },
+    "react-test-renderer": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
+      "integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.8.6",
+        "scheduler": "^0.13.6"
       }
     },
     "react-testing-library": {

--- a/src/explore-education-statistics-common/package-lock.json
+++ b/src/explore-education-statistics-common/package-lock.json
@@ -1584,12 +1584,6 @@
         "@types/d3-path": "*"
       }
     },
-    "@types/element-resize-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/element-resize-event/-/element-resize-event-2.0.0.tgz",
-      "integrity": "sha1-G67UXvgWvqj+nh0u3jUML16pYw8=",
-      "dev": true
-    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -5676,8 +5670,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5698,14 +5691,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5720,20 +5711,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5850,8 +5838,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5863,7 +5850,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5878,7 +5864,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5886,14 +5871,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5912,7 +5895,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5993,8 +5975,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6006,7 +5987,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6092,8 +6072,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6129,7 +6108,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6149,7 +6127,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6193,14 +6170,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6677,6 +6652,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
       "integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+      "dev": true
+    },
+    "immer": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-3.1.3.tgz",
+      "integrity": "sha512-HG5SXTXTTVy9lGNwS075cNhQoV375jHsIJO3UtMjuUWJOuwlMr0u42FlsKTJcppt5AzsFAsmj9r4kHvsSHh3hQ==",
       "dev": true
     },
     "import-fresh": {
@@ -10318,18 +10299,6 @@
         "object-is": "^1.0.1"
       }
     },
-    "react-test-renderer": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
-      "integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.13.6"
-      }
-    },
     "react-testing-library": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/react-testing-library/-/react-testing-library-7.0.1.tgz",
@@ -12602,6 +12571,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "use-immer": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.3.2.tgz",
+      "integrity": "sha512-jwNyjTyPTe0vwQ07uIz1x2D/Y6P4WWeaEHyWkuV5+1HtN3+FFxPxOjBKYnIulc0d8khCIYDyiZO56lthkIFHqA==",
       "dev": true
     },
     "util": {

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -36,6 +36,7 @@
     "geojson": "^0.5.0",
     "govuk-frontend": "^2.12.0",
     "identity-obj-proxy": "^3.0.0",
+    "immer": "^3.1.3",
     "jest": "^24.8.0",
     "jest-dom": "^3.4.0",
     "jest-junit": "^6.4.0",
@@ -59,6 +60,7 @@
     "recharts": "^1.6.2",
     "stylelint": "^10.0.1",
     "typescript": "^3.5.1",
+    "use-immer": "^0.3.2",
     "yup": "^0.27.0"
   },
   "scripts": {

--- a/src/explore-education-statistics-common/src/components/AccordionSection.tsx
+++ b/src/explore-education-statistics-common/src/components/AccordionSection.tsx
@@ -1,7 +1,10 @@
+import useMounted from '@common/hooks/useMounted';
 import findAllParents from '@common/lib/dom/findAllParents';
 import classNames from 'classnames';
 import React, { createElement, ReactNode } from 'react';
 import GoToTopLink from './GoToTopLink';
+
+export type ToggleHandler = (open: boolean) => void;
 
 export interface AccordionSectionProps {
   caption?: string;
@@ -11,18 +14,21 @@ export interface AccordionSectionProps {
   goToTop?: boolean;
   heading: string;
   headingId?: string;
-  // Only for accessibility/semantic markup,
-  // does not change the actual styling
+  /**
+   * Only for accessibility/semantic markup,
+   * does not change the actual styling
+   */
   headingTag?: 'h2' | 'h3' | 'h4';
   id?: string;
   open?: boolean;
-  onToggle?: (open: boolean) => void;
+  onToggle?: ToggleHandler;
 }
 
 const classes = {
   section: 'govuk-accordion__section',
   sectionButton: 'govuk-accordion__section-button',
   sectionContent: 'govuk-accordion__section-content',
+  sectionHeading: 'govuk-accordion__section-heading',
   expanded: 'govuk-accordion__section--expanded',
 };
 
@@ -40,13 +46,10 @@ const AccordionSection = ({
   open = false,
   onToggle,
 }: AccordionSectionProps) => {
+  const { isMounted } = useMounted();
+
   return (
     <div
-      onClick={event => {
-        if (onToggle) {
-          onToggle(event.currentTarget.classList.contains(classes.expanded));
-        }
-      }}
       className={classNames(classes.section, className, {
         [classes.expanded]: open,
       })}
@@ -59,11 +62,28 @@ const AccordionSection = ({
         {createElement(
           headingTag,
           {
-            className: 'govuk-accordion__section-heading',
+            className: classes.sectionHeading,
           },
-          <span className={classes.sectionButton} id={headingId}>
-            {heading}
-          </span>,
+          isMounted ? (
+            <>
+              <button
+                aria-expanded={open}
+                className={classes.sectionButton}
+                id={headingId}
+                type="button"
+                onClick={() => {
+                  if (onToggle) {
+                    onToggle(!open);
+                  }
+                }}
+              >
+                {heading}
+              </button>
+              <span aria-hidden className="govuk-accordion__icon" />
+            </>
+          ) : (
+            heading
+          ),
         )}
         {caption && (
           <span className="govuk-accordion__section-summary">{caption}</span>

--- a/src/explore-education-statistics-common/src/components/TabsSection.tsx
+++ b/src/explore-education-statistics-common/src/components/TabsSection.tsx
@@ -16,7 +16,7 @@ export const classes = {
 
 export interface TabsSectionProps {
   children: ReactNode;
-  id: string;
+  id?: string;
   /**
    * Set to true if children should not be
    * rendered until tab has been selected.

--- a/src/explore-education-statistics-common/src/components/__tests__/Accordion.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Accordion.test.tsx
@@ -18,7 +18,7 @@ describe('Accordion', () => {
     expect(
       container.querySelector('govuk-accordion__section--expanded'),
     ).toBeNull();
-    expect(container.querySelector('#test-sections-heading-1')).toHaveAttribute(
+    expect(container.querySelector('#test-sections-1-heading')).toHaveAttribute(
       'aria-expanded',
       'false',
     );
@@ -40,7 +40,7 @@ describe('Accordion', () => {
     expect(
       container.querySelector('govuk-accordion__section--expanded'),
     ).toBeDefined();
-    expect(container.querySelector('#test-sections-heading-1')).toHaveAttribute(
+    expect(container.querySelector('#test-sections-1-heading')).toHaveAttribute(
       'aria-expanded',
       'true',
     );
@@ -81,15 +81,39 @@ describe('Accordion', () => {
     const headings = getAllByText('Test heading');
     const contents = getAllByText('Test content');
 
-    expect(headings[0]).toHaveAttribute('id', 'test-sections-heading-1');
-    expect(contents[0]).toHaveAttribute('id', 'test-sections-content-1');
+    expect(headings[0]).toHaveAttribute('id', 'test-sections-1-heading');
+    expect(contents[0]).toHaveAttribute('id', 'test-sections-1-content');
 
-    expect(headings[1]).toHaveAttribute('id', 'test-sections-heading-2');
-    expect(contents[1]).toHaveAttribute('id', 'test-sections-content-2');
+    expect(headings[1]).toHaveAttribute('id', 'test-sections-2-heading');
+    expect(contents[1]).toHaveAttribute('id', 'test-sections-2-content');
+  });
+
+  test('can use custom heading or content IDs for sections', async () => {
+    const { getAllByText } = render(
+      <Accordion id="test-sections">
+        <AccordionSection heading="Test heading" contentId="custom-content">
+          Test content
+        </AccordionSection>
+        <AccordionSection heading="Test heading" headingId="custom-heading">
+          Test content
+        </AccordionSection>
+      </Accordion>,
+    );
+
+    await wait();
+
+    const headings = getAllByText('Test heading');
+    const contents = getAllByText('Test content');
+
+    expect(headings[0]).toHaveAttribute('id', 'test-sections-1-heading');
+    expect(contents[0]).toHaveAttribute('id', 'custom-content');
+
+    expect(headings[1]).toHaveAttribute('id', 'custom-heading');
+    expect(contents[1]).toHaveAttribute('id', 'test-sections-2-content');
   });
 
   test('scrolls to and opens section if location hash matches section heading ID', async () => {
-    window.location.hash = '#test-sections-heading-1';
+    window.location.hash = '#test-sections-1-heading';
 
     const { getByText } = render(
       <Accordion id="test-sections">
@@ -111,7 +135,7 @@ describe('Accordion', () => {
   });
 
   test('scrolls to and opens section if location hash matches section content ID', async () => {
-    window.location.hash = '#test-sections-heading-1';
+    window.location.hash = '#test-sections-1-heading';
 
     const { container, getByText } = render(
       <Accordion id="test-sections">
@@ -132,7 +156,7 @@ describe('Accordion', () => {
     );
 
     const content = container.querySelector(
-      '#test-sections-content-1',
+      '#test-sections-1-content',
     ) as HTMLElement;
 
     expect(content.scrollIntoView).toHaveBeenCalled();
@@ -164,7 +188,35 @@ describe('Accordion', () => {
     expect(element.scrollIntoView).toHaveBeenCalled();
   });
 
-  test('open all click causes toggleall to fire', async () => {
+  test('clicking on `Open all` reveals all sections', async () => {
+    const { getByText, getAllByText } = render(
+      <Accordion id="test-sections">
+        <AccordionSection heading="Test heading 1">
+          <p>Test content 1</p>
+        </AccordionSection>
+        <AccordionSection heading="Test heading 2" open>
+          <p>Test content 2</p>
+        </AccordionSection>
+      </Accordion>,
+    );
+
+    await wait();
+
+    const button = getByText('Open all');
+    const sections = getAllByText(/Test heading/);
+
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(sections[0]).toHaveAttribute('aria-expanded', 'false');
+    expect(sections[1]).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(sections[0]).toHaveAttribute('aria-expanded', 'true');
+    expect(sections[1]).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('clicking on `Open all` causes `onToggleAll` handler to be called with new state', async () => {
     const toggleAll = jest.fn();
 
     const { getByText } = render(
@@ -177,14 +229,58 @@ describe('Accordion', () => {
 
     await wait();
 
-    const button = getByText('Open all');
+    expect(toggleAll).not.toHaveBeenCalled();
 
-    expect(button).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(getByText('Open all'));
+
+    expect(toggleAll).toHaveBeenCalledWith(true);
+  });
+
+  test('clicking on `Close all` closes all sections', async () => {
+    const { getByText, getAllByText } = render(
+      <Accordion id="test-sections">
+        <AccordionSection heading="Test heading 1" open>
+          <p>Test content 1</p>
+        </AccordionSection>
+        <AccordionSection heading="Test heading 2" open>
+          <p>Test content 2</p>
+        </AccordionSection>
+      </Accordion>,
+    );
+
+    await wait();
+
+    const button = getByText('Close all');
+    const sections = getAllByText(/Test heading/);
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(sections[0]).toHaveAttribute('aria-expanded', 'true');
+    expect(sections[1]).toHaveAttribute('aria-expanded', 'true');
 
     fireEvent.click(button);
 
-    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(sections[0]).toHaveAttribute('aria-expanded', 'false');
+    expect(sections[1]).toHaveAttribute('aria-expanded', 'false');
+  });
 
-    expect(toggleAll).toHaveBeenCalledWith(true);
+  test('clicking on `Close all` causes `onToggleAll` handler to be called with new state', async () => {
+    const toggleAll = jest.fn();
+
+    const { getByText } = render(
+      <Accordion id="test-sections" onToggleAll={toggleAll}>
+        <AccordionSection heading="Test heading" open>
+          <p>Test content</p>
+        </AccordionSection>
+      </Accordion>,
+    );
+
+    await wait();
+
+    expect(toggleAll).not.toHaveBeenCalled();
+
+    fireEvent.click(getByText('Close all'));
+
+    expect(toggleAll).toHaveBeenCalledWith(false);
   });
 });

--- a/src/explore-education-statistics-common/src/components/__tests__/PageSearchForm.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/PageSearchForm.test.tsx
@@ -618,11 +618,11 @@ describe('PageSearchForm', () => {
 
     const { container, getByLabelText } = render(
       <div>
-        <Tabs>
-          <TabsSection title="Tab 1" id="section-1">
+        <Tabs id="test-tabs">
+          <TabsSection title="Tab 1">
             <p>Something</p>
           </TabsSection>
-          <TabsSection title="Tab 2" id="section-2">
+          <TabsSection title="Tab 2">
             <p id="target">Test</p>
           </TabsSection>
         </Tabs>
@@ -664,11 +664,11 @@ describe('PageSearchForm', () => {
       <div>
         <Accordion id="test-accordion">
           <AccordionSection heading="Section 1">
-            <Tabs>
-              <TabsSection title="Tab 1" id="section-1">
+            <Tabs id="test-tabs">
+              <TabsSection title="Tab 1">
                 <p>Something</p>
               </TabsSection>
-              <TabsSection title="Tab 2" id="section-2">
+              <TabsSection title="Tab 2">
                 <Details summary="Details 1">
                   <p id="target">Test</p>
                 </Details>

--- a/src/explore-education-statistics-common/src/components/__tests__/PageSearchForm.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/PageSearchForm.test.tsx
@@ -567,7 +567,7 @@ describe('PageSearchForm', () => {
     jest.runOnlyPendingTimers();
 
     const accordionSection = container.querySelector(
-      '#test-accordion-heading-1',
+      '#test-accordion-1-heading',
     );
 
     expect(accordionSection).toHaveAttribute('aria-expanded', 'false');
@@ -692,7 +692,7 @@ describe('PageSearchForm', () => {
     jest.runOnlyPendingTimers();
 
     const accordionSection = container.querySelector(
-      '#test-accordion-heading-1',
+      '#test-accordion-1-heading',
     );
     const tabs = container.querySelectorAll('[role="tab"]');
     const summary = container.querySelector('summary');

--- a/src/explore-education-statistics-common/src/components/__tests__/Tabs.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Tabs.test.tsx
@@ -7,39 +7,74 @@ const hiddenSectionClass = 'govuk-tabs__panel--hidden';
 
 describe('Tabs', () => {
   test('renders single tab correctly', () => {
-    const { container } = render(
-      <Tabs>
-        <TabsSection id="section-1" title="Tab 1">
+    const { container, getAllByText } = render(
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
         </TabsSection>
       </Tabs>,
     );
+
+    expect(getAllByText('Tab 1')[0]).toHaveAttribute('aria-selected', 'true');
 
     expect(container.innerHTML).toMatchSnapshot();
   });
 
   test('renders multiple tabs correctly', () => {
-    const { container } = render(
-      <Tabs>
-        <TabsSection id="section-1" title="Tab 1">
+    const { container, getAllByText } = render(
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
         </TabsSection>
-        <TabsSection id="section-2" title="Tab 2">
+        <TabsSection title="Tab 2">
           <p>Test section 2 content</p>
         </TabsSection>
       </Tabs>,
     );
 
+    expect(getAllByText('Tab 1')[0]).toHaveAttribute('aria-selected', 'true');
+    expect(getAllByText('Tab 2')[0]).toHaveAttribute('aria-selected', 'false');
+
     expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('can use custom section IDs', () => {
+    const { container } = render(
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1" id="custom-section">
+          <p>Test section 1 content</p>
+        </TabsSection>
+        <TabsSection title="Tab 2">
+          <p>Test section 2 content</p>
+        </TabsSection>
+      </Tabs>,
+    );
+
+    expect(container.querySelector('#test-tabs-1-tab')).toBeNull();
+    expect(container.querySelector('#test-tabs-1')).toBeNull();
+
+    expect(container.querySelector('#custom-section-tab')).toHaveTextContent(
+      'Tab 1',
+    );
+    expect(container.querySelector('#custom-section')).toHaveTextContent(
+      'Test section 1 content',
+    );
+
+    expect(container.querySelector('#test-tabs-2-tab')).toHaveTextContent(
+      'Tab 2',
+    );
+    expect(container.querySelector('#test-tabs-2')).toHaveTextContent(
+      'Test section 2 content',
+    );
   });
 
   test('setting `headingTag` changes section heading size', () => {
     const { container } = render(
-      <Tabs>
-        <TabsSection id="section-1" title="Tab 1">
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
         </TabsSection>
-        <TabsSection id="section-2" title="Tab 2" headingTag="h2">
+        <TabsSection title="Tab 2" headingTag="h2">
           <p>Test section 2 content</p>
         </TabsSection>
       </Tabs>,
@@ -54,11 +89,11 @@ describe('Tabs', () => {
 
   test('does not immediately render lazy tab section', () => {
     const { queryByText } = render(
-      <Tabs>
-        <TabsSection id="section-1" title="Tab 1">
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
         </TabsSection>
-        <TabsSection id="section-2" title="Tab 2" lazy>
+        <TabsSection title="Tab 2" lazy>
           <p>Test section 2 content</p>
         </TabsSection>
       </Tabs>,
@@ -70,34 +105,34 @@ describe('Tabs', () => {
 
   test('tab links match section ids', () => {
     const { getAllByText } = render(
-      <Tabs>
-        <TabsSection id="section-1" title="Tab 1">
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
         </TabsSection>
-        <TabsSection id="section-2" title="Tab 2">
+        <TabsSection title="Tab 2">
           <p>Test section 2 content</p>
         </TabsSection>
       </Tabs>,
     );
 
-    expect(getAllByText('Tab 1')[0]).toHaveAttribute('href', '#section-1');
-    expect(getAllByText('Tab 2')[0]).toHaveAttribute('href', '#section-2');
+    expect(getAllByText('Tab 1')[0]).toHaveAttribute('href', '#test-tabs-1');
+    expect(getAllByText('Tab 2')[0]).toHaveAttribute('href', '#test-tabs-2');
   });
 
   test('clicking tab reveals correct section', () => {
     const { getAllByText, container } = render(
-      <Tabs>
-        <TabsSection id="section-1" title="Tab 1">
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
         </TabsSection>
-        <TabsSection id="section-2" title="Tab 2">
+        <TabsSection title="Tab 2">
           <p>Test section 2 content</p>
         </TabsSection>
       </Tabs>,
     );
 
-    const tabSection1 = container.querySelector('#section-1') as HTMLElement;
-    const tabSection2 = container.querySelector('#section-2') as HTMLElement;
+    const tabSection1 = container.querySelector('#test-tabs-1') as HTMLElement;
+    const tabSection2 = container.querySelector('#test-tabs-2') as HTMLElement;
 
     expect(tabSection1).not.toHaveClass(hiddenSectionClass);
     expect(tabSection2).toHaveClass(hiddenSectionClass);
@@ -110,11 +145,11 @@ describe('Tabs', () => {
 
   test('clicking tab changes location hash', () => {
     const { getAllByText } = render(
-      <Tabs>
-        <TabsSection id="section-1" title="Tab 1">
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
         </TabsSection>
-        <TabsSection id="section-2" title="Tab 2">
+        <TabsSection title="Tab 2">
           <p>Test section 2 content</p>
         </TabsSection>
       </Tabs>,
@@ -124,16 +159,16 @@ describe('Tabs', () => {
 
     fireEvent.click(getAllByText('Tab 2')[0]);
 
-    expect(window.location.hash).toBe('#section-2');
+    expect(window.location.hash).toBe('#test-tabs-2');
   });
 
   test('clicking tab renders lazy section', () => {
     const { getAllByText, queryByText } = render(
-      <Tabs>
-        <TabsSection id="section-1" title="Tab 1">
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
         </TabsSection>
-        <TabsSection id="section-2" title="Tab 2" lazy>
+        <TabsSection title="Tab 2" lazy>
           <p>Test section 2 content</p>
         </TabsSection>
       </Tabs>,
@@ -156,14 +191,14 @@ describe('Tabs', () => {
 
     beforeEach(() => {
       const { getAllByText, container } = render(
-        <Tabs>
-          <TabsSection id="section-1" title="Tab 1">
+        <Tabs id="test-tabs">
+          <TabsSection title="Tab 1">
             <p>Test section 1 content</p>
           </TabsSection>
-          <TabsSection id="section-2" title="Tab 2">
+          <TabsSection title="Tab 2">
             <p>Test section 2 content</p>
           </TabsSection>
-          <TabsSection id="section-3" title="Tab 3">
+          <TabsSection title="Tab 3">
             <p>Test section 2 content</p>
           </TabsSection>
         </Tabs>,
@@ -173,9 +208,9 @@ describe('Tabs', () => {
       tab2 = getAllByText('Tab 2')[0] as HTMLAnchorElement;
       tab3 = getAllByText('Tab 3')[0] as HTMLAnchorElement;
 
-      tabSection1 = container.querySelector('#section-1') as HTMLElement;
-      tabSection2 = container.querySelector('#section-2') as HTMLElement;
-      tabSection3 = container.querySelector('#section-3') as HTMLElement;
+      tabSection1 = container.querySelector('#test-tabs-1') as HTMLElement;
+      tabSection2 = container.querySelector('#test-tabs-2') as HTMLElement;
+      tabSection3 = container.querySelector('#test-tabs-3') as HTMLElement;
     });
 
     test('pressing left arrow key moves to previous tab', () => {
@@ -187,7 +222,7 @@ describe('Tabs', () => {
       expect(tabSection1).toHaveClass(hiddenSectionClass);
       expect(tabSection2).not.toHaveClass(hiddenSectionClass);
 
-      expect(window.location.hash).toBe('#section-2');
+      expect(window.location.hash).toBe('#test-tabs-2');
 
       fireEvent.keyDown(tab2, { key: 'ArrowLeft' });
 
@@ -198,7 +233,7 @@ describe('Tabs', () => {
       expect(tabSection1).not.toHaveClass(hiddenSectionClass);
       expect(tabSection2).toHaveClass(hiddenSectionClass);
 
-      expect(window.location.hash).toBe('#section-1');
+      expect(window.location.hash).toBe('#test-tabs-1');
     });
 
     test('pressing left arrow key cycles to end of tabs', () => {
@@ -210,7 +245,7 @@ describe('Tabs', () => {
       expect(tabSection1).not.toHaveClass(hiddenSectionClass);
       expect(tabSection3).toHaveClass(hiddenSectionClass);
 
-      expect(window.location.hash).toBe('#section-1');
+      expect(window.location.hash).toBe('#test-tabs-1');
 
       fireEvent.keyDown(tab1, { key: 'ArrowLeft' });
 
@@ -221,7 +256,7 @@ describe('Tabs', () => {
       expect(tabSection1).toHaveClass(hiddenSectionClass);
       expect(tabSection3).not.toHaveClass(hiddenSectionClass);
 
-      expect(window.location.hash).toBe('#section-3');
+      expect(window.location.hash).toBe('#test-tabs-3');
     });
 
     test('pressing right arrow key moves to next tab', () => {
@@ -233,7 +268,7 @@ describe('Tabs', () => {
       expect(tabSection2).not.toHaveClass(hiddenSectionClass);
       expect(tabSection3).toHaveClass(hiddenSectionClass);
 
-      expect(window.location.hash).toBe('#section-2');
+      expect(window.location.hash).toBe('#test-tabs-2');
 
       fireEvent.keyDown(tab2, { key: 'ArrowRight' });
 
@@ -244,7 +279,7 @@ describe('Tabs', () => {
       expect(tabSection2).toHaveClass(hiddenSectionClass);
       expect(tabSection3).not.toHaveClass(hiddenSectionClass);
 
-      expect(window.location.hash).toBe('#section-3');
+      expect(window.location.hash).toBe('#test-tabs-3');
     });
 
     test('pressing right arrow key cycles to beginning of tabs', () => {
@@ -256,7 +291,7 @@ describe('Tabs', () => {
       expect(tabSection1).toHaveClass(hiddenSectionClass);
       expect(tabSection3).not.toHaveClass(hiddenSectionClass);
 
-      expect(window.location.hash).toBe('#section-3');
+      expect(window.location.hash).toBe('#test-tabs-3');
 
       fireEvent.keyDown(tab3, { key: 'ArrowRight' });
 
@@ -267,7 +302,7 @@ describe('Tabs', () => {
       expect(tabSection1).not.toHaveClass(hiddenSectionClass);
       expect(tabSection3).toHaveClass(hiddenSectionClass);
 
-      expect(window.location.hash).toBe('#section-1');
+      expect(window.location.hash).toBe('#test-tabs-1');
     });
 
     test('pressing down arrow key focuses the tab section', async () => {

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -15,11 +15,11 @@ exports[`Accordion renders with hidden content by default 1`] = `
         class="govuk-accordion__open-all"
         type="button"
       >
-        Open all
+        Open all 
         <span
           class="govuk-visually-hidden"
         >
-           sections
+          sections
         </span>
       </button>
     </div>
@@ -35,10 +35,9 @@ exports[`Accordion renders with hidden content by default 1`] = `
           class="govuk-accordion__section-heading"
         >
           <button
-            aria-controls="test-sections-content-1"
             aria-expanded="false"
             class="govuk-accordion__section-button"
-            id="test-sections-heading-1"
+            id="test-sections-1-heading"
             type="button"
           >
             Test heading
@@ -50,9 +49,9 @@ exports[`Accordion renders with hidden content by default 1`] = `
         </h2>
       </div>
       <div
-        aria-labelledby="test-sections-heading-1"
+        aria-labelledby="test-sections-1-heading"
         class="govuk-accordion__section-content"
-        id="test-sections-content-1"
+        id="test-sections-1-content"
       >
         <p>
           Test content
@@ -86,11 +85,11 @@ exports[`Accordion renders with visible content when \`open\` is true 1`] = `
         class="govuk-accordion__open-all"
         type="button"
       >
-        Close all
+        Close all 
         <span
           class="govuk-visually-hidden"
         >
-           sections
+          sections
         </span>
       </button>
     </div>
@@ -106,10 +105,9 @@ exports[`Accordion renders with visible content when \`open\` is true 1`] = `
           class="govuk-accordion__section-heading"
         >
           <button
-            aria-controls="test-sections-content-1"
             aria-expanded="true"
             class="govuk-accordion__section-button"
-            id="test-sections-heading-1"
+            id="test-sections-1-heading"
             type="button"
           >
             Test heading
@@ -121,9 +119,9 @@ exports[`Accordion renders with visible content when \`open\` is true 1`] = `
         </h2>
       </div>
       <div
-        aria-labelledby="test-sections-heading-1"
+        aria-labelledby="test-sections-1-heading"
         class="govuk-accordion__section-content"
-        id="test-sections-content-1"
+        id="test-sections-1-content"
       >
         <p>
           Test content

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
@@ -9,8 +9,15 @@ exports[`AccordionSection renders correctly with required props 1`] = `
        data-testid="SectionHeader Test heading"
   >
     <h2 class="govuk-accordion__section-heading">
-      <span class="govuk-accordion__section-button">
+      <button aria-expanded="false"
+              class="govuk-accordion__section-button"
+              type="button"
+      >
         Test heading
+      </button>
+      <span aria-hidden="true"
+            class="govuk-accordion__icon"
+      >
       </span>
     </h2>
   </div>
@@ -39,8 +46,15 @@ exports[`AccordionSection renders with caption 1`] = `
        data-testid="SectionHeader Test heading"
   >
     <h2 class="govuk-accordion__section-heading">
-      <span class="govuk-accordion__section-button">
+      <button aria-expanded="false"
+              class="govuk-accordion__section-button"
+              type="button"
+      >
         Test heading
+      </button>
+      <span aria-hidden="true"
+            class="govuk-accordion__icon"
+      >
       </span>
     </h2>
     <span class="govuk-accordion__section-summary">
@@ -72,8 +86,15 @@ exports[`AccordionSection renders with different heading size 1`] = `
        data-testid="SectionHeader Test heading"
   >
     <h3 class="govuk-accordion__section-heading">
-      <span class="govuk-accordion__section-button">
+      <button aria-expanded="false"
+              class="govuk-accordion__section-button"
+              type="button"
+      >
         Test heading
+      </button>
+      <span aria-hidden="true"
+            class="govuk-accordion__icon"
+      >
       </span>
     </h3>
   </div>

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -10,9 +10,9 @@ exports[`Tabs renders multiple tabs correctly 1`] = `
         role="presentation"
     >
       <a class="govuk-tabs__tab govuk-tabs__tab--selected"
-         href="#section-1"
-         id="section-1-tab"
-         aria-controls="section-1"
+         href="#test-tabs-1"
+         id="test-tabs-1-tab"
+         aria-controls="test-tabs-1"
          aria-selected="true"
          role="tab"
       >
@@ -23,10 +23,10 @@ exports[`Tabs renders multiple tabs correctly 1`] = `
         role="presentation"
     >
       <a class="govuk-tabs__tab"
-         href="#section-2"
-         id="section-2-tab"
+         href="#test-tabs-2"
+         id="test-tabs-2-tab"
          tabindex="-1"
-         aria-controls="section-2"
+         aria-controls="test-tabs-2"
          aria-selected="false"
          role="tab"
       >
@@ -35,9 +35,9 @@ exports[`Tabs renders multiple tabs correctly 1`] = `
     </li>
   </ul>
   <section class="govuk-tabs__panel dfe-content-overflow panel"
-           id="section-1"
+           id="test-tabs-1"
            data-testid="Tab 1"
-           aria-labelledby="section-1-tab"
+           aria-labelledby="test-tabs-1-tab"
            role="tabpanel"
            tabindex="-1"
   >
@@ -49,9 +49,9 @@ exports[`Tabs renders multiple tabs correctly 1`] = `
     </p>
   </section>
   <section class="govuk-tabs__panel dfe-content-overflow panel govuk-tabs__panel--hidden"
-           id="section-2"
+           id="test-tabs-2"
            data-testid="Tab 2"
-           aria-labelledby="section-2-tab"
+           aria-labelledby="test-tabs-2-tab"
            role="tabpanel"
            tabindex="-1"
   >
@@ -76,9 +76,9 @@ exports[`Tabs renders single tab correctly 1`] = `
         role="presentation"
     >
       <a class="govuk-tabs__tab govuk-tabs__tab--selected"
-         href="#section-1"
-         id="section-1-tab"
-         aria-controls="section-1"
+         href="#test-tabs-1"
+         id="test-tabs-1-tab"
+         aria-controls="test-tabs-1"
          aria-selected="true"
          role="tab"
       >
@@ -87,9 +87,9 @@ exports[`Tabs renders single tab correctly 1`] = `
     </li>
   </ul>
   <section class="govuk-tabs__panel dfe-content-overflow panel"
-           id="section-1"
+           id="test-tabs-1"
            data-testid="Tab 1"
-           aria-labelledby="section-1-tab"
+           aria-labelledby="test-tabs-1-tab"
            role="tabpanel"
            tabindex="-1"
   >

--- a/src/explore-education-statistics-common/src/hooks/useMounted.ts
+++ b/src/explore-education-statistics-common/src/hooks/useMounted.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { EffectCallback, useEffect, useState } from 'react';
 
 /**
  * Simple hook that returns true once a component
@@ -8,11 +8,16 @@ import { useEffect, useState } from 'react';
  * enhancing components in SSR where not all attributes
  * should be set until the client-side JS loads.
  */
-function useMounted() {
+function useMounted(effect?: EffectCallback) {
   const [isMounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
+
+    if (effect) {
+      effect();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return {

--- a/src/explore-education-statistics-common/src/lib/type-guards/components/isComponentType.ts
+++ b/src/explore-education-statistics-common/src/lib/type-guards/components/isComponentType.ts
@@ -1,15 +1,9 @@
-import {
-  Component,
-  ComponentElement,
-  ComponentState,
-  ComponentType,
-  ReactElement,
-} from 'react';
+import { ComponentType, ReactComponentElement, ReactElement } from 'react';
 
-export default function isComponentType<P>(
+export default function isComponentType<P = {}>(
   value: unknown,
   componentType: ComponentType<P>,
-): value is ComponentElement<P, Component<P, ComponentState>> {
+): value is ReactComponentElement<ComponentType<P>, P> {
   if (!value) {
     return false;
   }

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlock.tsx
@@ -4,6 +4,8 @@ import TabsSection from '@common/components/TabsSection';
 import ChartRenderer, {
   ChartRendererProps,
 } from '@common/modules/find-statistics/components/ChartRenderer';
+
+import DataSource from '@common/modules/find-statistics/components/DataSource';
 import SummaryRenderer, {
   SummaryRendererProps,
 } from '@common/modules/find-statistics/components/SummaryRenderer';
@@ -22,8 +24,6 @@ import {
   Table,
 } from '@common/services/publicationService';
 import React, { Component, ReactNode } from 'react';
-
-import DataSource from '@common/modules/find-statistics/components/DataSource';
 import DownloadDetails from './DownloadDetails';
 
 export interface DataBlockProps {
@@ -140,15 +140,15 @@ class DataBlock extends Component<DataBlockProps, DataBlockState> {
         {isLoading ? (
           <LoadingSpinner text="Loading content..." />
         ) : (
-          <Tabs>
+          <Tabs id={id}>
             {summary && (
-              <TabsSection id={`datablock_${id}_summary`} title="Summary">
+              <TabsSection id={`${id}-summary`} title="Summary">
                 <SummaryRenderer {...summary} />
               </TabsSection>
             )}
 
             {tables && showTables && (
-              <TabsSection id={`datablock_${id}_tables`} title="Data tables">
+              <TabsSection id={`${id}-tables`} title="Data tables">
                 {tables.map((table, idx) => {
                   const key = `${id}0_table_${idx}`;
 
@@ -166,11 +166,7 @@ class DataBlock extends Component<DataBlockProps, DataBlockState> {
             )}
 
             {charts && (
-              <TabsSection
-                id={`datablock_${id}_charts`}
-                title="Charts"
-                lazy={false}
-              >
+              <TabsSection id={`${id}-charts`} title="Charts" lazy={false}>
                 {charts.map((chart, idx) => {
                   const key = `${id}_chart_${idx}`;
 

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/DataBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/DataBlock.test.tsx
@@ -128,7 +128,7 @@ describe('DataBlock', () => {
 
     expect(getDataBlockForSubject).toBeCalledWith(dataBlockRequest);
 
-    expect(container.querySelector('table')).toMatchSnapshot();
+    expect(container.querySelector('#test-datablock-table')).toMatchSnapshot();
   });
 
   test('renders summary', async () => {
@@ -140,7 +140,7 @@ describe('DataBlock', () => {
 
     const { container } = render(
       <DataBlock
-        id="test"
+        id="test-datablock"
         type="databock"
         dataBlockRequest={dataBlockRequest}
         showTables={false}
@@ -160,11 +160,11 @@ describe('DataBlock', () => {
     expect(getDataBlockForSubject).toBeCalledWith(dataBlockRequest);
 
     expect(
-      container.querySelector('#datablock_test_summary'),
+      container.querySelector('#test-datablock-summary'),
     ).toMatchSnapshot();
   });
 
-  test('datablock renders map', async () => {
+  test('renders map instead of chart', async () => {
     const getDataBlockForSubject = dataBlockService.getDataBlockForSubject.mockImplementation(
       (_: DataBlockRequest) => {
         return Promise.resolve(testData.response);
@@ -173,7 +173,7 @@ describe('DataBlock', () => {
 
     const { container } = render(
       <DataBlock
-        id="test"
+        id="test-datablock"
         type="datablock"
         dataBlockRequest={dataBlockRequest}
         showTables={false}
@@ -194,6 +194,6 @@ describe('DataBlock', () => {
 
     expect(getDataBlockForSubject).toBeCalledWith(dataBlockRequest);
 
-    expect(container.innerHTML).toMatchSnapshot();
+    expect(container.querySelector('#test-datablock-charts')).toMatchSnapshot();
   });
 });

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/__snapshots__/DataBlock.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/__snapshots__/DataBlock.test.tsx.snap
@@ -1,228 +1,312 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DataBlock datablock renders map 1`] = `
-
-<div data-testid="DataBlock ">
-  <div class="govuk-tabs">
-    <ul class="govuk-tabs__list"
-        role="tablist"
+exports[`DataBlock renders map instead of chart 1`] = `
+<section
+  aria-labelledby="test-datablock-charts-tab"
+  class="govuk-tabs__panel dfe-content-overflow panel"
+  data-testid="Charts"
+  id="test-datablock-charts"
+  role="tabpanel"
+  tabindex="-1"
+>
+  <h3>
+    Charts
+  </h3>
+  <div
+    class="govuk-grid-row"
+  >
+    <div
+      aria-live="assertive"
+      class="govuk-grid-column-one-third"
     >
-      <li class="govuk-tabs__list-item"
-          role="presentation"
-      >
-        <a class="govuk-tabs__tab govuk-tabs__tab--selected"
-           href="#datablock_test_charts"
-           id="datablock_test_charts-tab"
-           aria-controls="datablock_test_charts"
-           aria-selected="true"
-           role="tab"
+      <form>
+        <div
+          class="govuk-form-group govuk-!-margin-bottom-6"
         >
-          Charts
-        </a>
-      </li>
-    </ul>
-    <section class="govuk-tabs__panel dfe-content-overflow panel"
-             id="datablock_test_charts"
-             data-testid="Charts"
-             aria-labelledby="datablock_test_charts-tab"
-             role="tabpanel"
-             tabindex="-1"
-    >
-      <h3>
-        Charts
-      </h3>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-third"
-             aria-live="assertive"
-        >
-          <form>
-            <div class="govuk-form-group govuk-!-margin-bottom-6">
-              <label class="govuk-label"
-                     for="selectedIndicator"
-              >
-                Select data to view
-              </label>
-              <select class="govuk-select select"
-                      id="selectedIndicator"
-                      name="selectedIndicator"
-              >
-                <option value="23">
-                  Unauthorised absence rate
-                </option>
-                <option value="26">
-                  Overall absence rate
-                </option>
-                <option value="28">
-                  Authorised absence rate
-                </option>
-              </select>
-            </div>
-            <div class="govuk-form-group govuk-!-margin-bottom-6">
-              <label class="govuk-label"
-                     for="selectedLocation"
-              >
-                Select a location
-              </label>
-              <select class="govuk-select select"
-                      id="selectedLocation"
-                      name="selectedLocation"
-              >
-                <option value>
-                  select...
-                </option>
-                <option value="E92000001">
-                  England
-                </option>
-              </select>
-            </div>
-          </form>
-          <div>
-            <h3 class="govuk-heading-s">
-              Key to Authorised absence rate
-            </h3>
-            <dl class="govuk-list">
-              <dd class="legend">
-                <span class="rate0">
-                  &nbsp;
-                </span>
-                5.0%&nbsp; to 5.0%
-              </dd>
-              <dd class="legend">
-                <span class="rate1">
-                  &nbsp;
-                </span>
-                5.0%&nbsp; to 5.0%
-              </dd>
-              <dd class="legend">
-                <span class="rate2">
-                  &nbsp;
-                </span>
-                5.0%&nbsp; to 5.0%
-              </dd>
-              <dd class="legend">
-                <span class="rate3">
-                  &nbsp;
-                </span>
-                5.0%&nbsp; to 5.0%
-              </dd>
-              <dd class="legend">
-                <span class="rate4">
-                  &nbsp;
-                </span>
-                5.0%&nbsp; to 5.0%
-              </dd>
-            </dl>
-          </div>
-        </div>
-        <div class="govuk-grid-column-two-thirds">
-          <div class="map leaflet-container leaflet-grab leaflet-touch-drag"
-               style="width: 800px; height: 600px; position: relative;"
-               tabindex="0"
+          <label
+            class="govuk-label"
+            for="selectedIndicator"
           >
-            <div class="leaflet-pane leaflet-map-pane"
-                 style="left: 0px; top: 0px;"
+            Select data to view
+          </label>
+          <select
+            class="govuk-select select"
+            id="selectedIndicator"
+            name="selectedIndicator"
+          >
+            <option
+              value="23"
             >
-              <div class="leaflet-pane leaflet-tile-pane">
-              </div>
-              <div class="leaflet-pane leaflet-shadow-pane">
-              </div>
-              <div class="leaflet-pane leaflet-overlay-pane">
-                <svg pointer-events="none"
-                     width="0"
-                     height="0"
-                     style="left: 0px; top: 0px;"
-                     viewbox="0 0 0 0"
-                >
-                  <g>
-                    <path class="uk leaflet-interactive"
-                          stroke="#3388ff"
-                          stroke-opacity="1"
-                          stroke-width="3"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          fill="#3388ff"
-                          fill-opacity="0.2"
-                          fill-rule="evenodd"
-                          d="M-3 3L-3 -3L3 -3L3 3z"
-                    >
-                    </path>
-                    <path class="rateNaN leaflet-interactive"
-                          stroke="#3388ff"
-                          stroke-opacity="1"
-                          stroke-width="3"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          fill="#3388ff"
-                          fill-opacity="0.2"
-                          fill-rule="evenodd"
-                          d="M0 0"
-                    >
-                    </path>
-                  </g>
-                </svg>
-              </div>
-              <div class="leaflet-pane leaflet-marker-pane">
-              </div>
-              <div class="leaflet-pane leaflet-tooltip-pane">
-              </div>
-              <div class="leaflet-pane leaflet-popup-pane">
-              </div>
+              Unauthorised absence rate
+            </option>
+            <option
+              value="26"
+            >
+              Overall absence rate
+            </option>
+            <option
+              value="28"
+            >
+              Authorised absence rate
+            </option>
+          </select>
+        </div>
+        <div
+          class="govuk-form-group govuk-!-margin-bottom-6"
+        >
+          <label
+            class="govuk-label"
+            for="selectedLocation"
+          >
+            Select a location
+          </label>
+          <select
+            class="govuk-select select"
+            id="selectedLocation"
+            name="selectedLocation"
+          >
+            <option
+              value=""
+            >
+              select...
+            </option>
+            <option
+              value="E92000001"
+            >
+              England
+            </option>
+          </select>
+        </div>
+      </form>
+      
+      <div>
+        <h3
+          class="govuk-heading-s"
+        >
+          Key to 
+          Authorised absence rate
+        </h3>
+        <dl
+          class="govuk-list"
+        >
+          <dd
+            class="legend"
+          >
+            <span
+              class="rate0"
+            >
+               
+            </span>
+             
+            5.0
+            %
+              to 
+            5.0
+            %
+             
+          </dd>
+          <dd
+            class="legend"
+          >
+            <span
+              class="rate1"
+            >
+               
+            </span>
+             
+            5.0
+            %
+              to 
+            5.0
+            %
+             
+          </dd>
+          <dd
+            class="legend"
+          >
+            <span
+              class="rate2"
+            >
+               
+            </span>
+             
+            5.0
+            %
+              to 
+            5.0
+            %
+             
+          </dd>
+          <dd
+            class="legend"
+          >
+            <span
+              class="rate3"
+            >
+               
+            </span>
+             
+            5.0
+            %
+              to 
+            5.0
+            %
+             
+          </dd>
+          <dd
+            class="legend"
+          >
+            <span
+              class="rate4"
+            >
+               
+            </span>
+             
+            5.0
+            %
+              to 
+            5.0
+            %
+             
+          </dd>
+        </dl>
+      </div>
+    </div>
+    <div
+      class="govuk-grid-column-two-thirds"
+    >
+      <div
+        class="map leaflet-container leaflet-grab leaflet-touch-drag"
+        style="width: 800px; height: 600px; position: relative;"
+        tabindex="0"
+      >
+        <div
+          class="leaflet-pane leaflet-map-pane"
+          style="left: 0px; top: 0px;"
+        >
+          <div
+            class="leaflet-pane leaflet-tile-pane"
+          />
+          <div
+            class="leaflet-pane leaflet-shadow-pane"
+          />
+          <div
+            class="leaflet-pane leaflet-overlay-pane"
+          >
+            <svg
+              height="0"
+              pointer-events="none"
+              style="left: 0px; top: 0px;"
+              viewBox="0 0 0 0"
+              width="0"
+            >
+              <g>
+                <path
+                  class="uk leaflet-interactive"
+                  d="M-3 3L-3 -3L3 -3L3 3z"
+                  fill="#3388ff"
+                  fill-opacity="0.2"
+                  fill-rule="evenodd"
+                  stroke="#3388ff"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-opacity="1"
+                  stroke-width="3"
+                />
+                <path
+                  class="rateNaN leaflet-interactive"
+                  d="M0 0"
+                  fill="#3388ff"
+                  fill-opacity="0.2"
+                  fill-rule="evenodd"
+                  stroke="#3388ff"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-opacity="1"
+                  stroke-width="3"
+                />
+              </g>
+            </svg>
+          </div>
+          <div
+            class="leaflet-pane leaflet-marker-pane"
+          />
+          <div
+            class="leaflet-pane leaflet-tooltip-pane"
+          />
+          <div
+            class="leaflet-pane leaflet-popup-pane"
+          />
+        </div>
+        <div
+          class="leaflet-control-container"
+        >
+          <div
+            class="leaflet-top leaflet-left"
+          >
+            <div
+              class="leaflet-control-zoom leaflet-bar leaflet-control"
+            >
+              <a
+                aria-label="Zoom in"
+                class="leaflet-control-zoom-in"
+                href="#"
+                role="button"
+                title="Zoom in"
+              >
+                +
+              </a>
+              <a
+                aria-label="Zoom out"
+                class="leaflet-control-zoom-out"
+                href="#"
+                role="button"
+                title="Zoom out"
+              >
+                −
+              </a>
             </div>
-            <div class="leaflet-control-container">
-              <div class="leaflet-top leaflet-left">
-                <div class="leaflet-control-zoom leaflet-bar leaflet-control">
-                  <a class="leaflet-control-zoom-in"
-                     href="#"
-                     title="Zoom in"
-                     role="button"
-                     aria-label="Zoom in"
-                  >
-                    +
-                  </a>
-                  <a class="leaflet-control-zoom-out"
-                     href="#"
-                     title="Zoom out"
-                     role="button"
-                     aria-label="Zoom out"
-                  >
-                    −
-                  </a>
-                </div>
-              </div>
-              <div class="leaflet-top leaflet-right">
-              </div>
-              <div class="leaflet-bottom leaflet-left">
-              </div>
-              <div class="leaflet-bottom leaflet-right">
-                <div class="leaflet-control-attribution leaflet-control">
-                  <a href="https://leafletjs.com"
-                     title="A JS library for interactive maps"
-                  >
-                    Leaflet
-                  </a>
-                </div>
-              </div>
+          </div>
+          <div
+            class="leaflet-top leaflet-right"
+          />
+          <div
+            class="leaflet-bottom leaflet-left"
+          />
+          <div
+            class="leaflet-bottom leaflet-right"
+          >
+            <div
+              class="leaflet-control-attribution leaflet-control"
+            >
+              <a
+                href="https://leafletjs.com"
+                title="A JS library for interactive maps"
+              >
+                Leaflet
+              </a>
             </div>
           </div>
         </div>
       </div>
-      <div>
-        <p class="govuk-body-s">
-          Source: Department for Education
-        </p>
-      </div>
-    </section>
+    </div>
   </div>
-</div>
-
+  <div>
+    <p
+      class="govuk-body-s"
+    >
+      Source: Department for Education
+    </p>
+  </div>
+</section>
 `;
 
 exports[`DataBlock renders summary 1`] = `
 <section
-  aria-labelledby="datablock_test_summary-tab"
+  aria-labelledby="test-datablock-summary-tab"
   class="govuk-tabs__panel dfe-content-overflow panel"
   data-testid="Summary"
-  id="datablock_test_summary"
+  id="test-datablock-summary"
   role="tabpanel"
   tabindex="-1"
 >

--- a/src/explore-education-statistics-frontend/src/prototypes/publication/components/PrototypeDataSample.tsx
+++ b/src/explore-education-statistics-frontend/src/prototypes/publication/components/PrototypeDataSample.tsx
@@ -24,7 +24,7 @@ const PrototypeDataSample = ({
 }: Props) => {
   return (
     <>
-      <Tabs>
+      <Tabs id="data-sample">
         {sectionId === 'headlines' && (
           <TabsSection id={`${sectionId}SummaryData`} title="Summary">
             <PrototypeDataTilesHighlights />

--- a/src/explore-education-statistics-frontend/src/prototypes/publication/components/PrototypeDataSampleApplications.tsx
+++ b/src/explore-education-statistics-frontend/src/prototypes/publication/components/PrototypeDataSampleApplications.tsx
@@ -24,7 +24,7 @@ const PrototypeDataSample = ({
 }: Props) => {
   return (
     <>
-      <Tabs>
+      <Tabs id="data-sample-applications">
         {sectionId === 'headlines' && (
           <TabsSection id={`${sectionId}SummaryData`} title="Summary">
             <PrototypeDataTilesHighlights />

--- a/src/explore-education-statistics-frontend/src/prototypes/publication/components/PrototypeDataSampleExclusions.tsx
+++ b/src/explore-education-statistics-frontend/src/prototypes/publication/components/PrototypeDataSampleExclusions.tsx
@@ -24,7 +24,7 @@ const PrototypeDataSample = ({
 }: Props) => {
   return (
     <>
-      <Tabs>
+      <Tabs id="data-sample-exclusions">
         {sectionId === 'headlines' && (
           <TabsSection id={`${sectionId}SummaryData`} title="Summary">
             <PrototypeDataTilesHighlights />

--- a/src/explore-education-statistics-frontend/src/prototypes/publication/components/PrototypeDataSampleGCSE.tsx
+++ b/src/explore-education-statistics-frontend/src/prototypes/publication/components/PrototypeDataSampleGCSE.tsx
@@ -24,7 +24,7 @@ const PrototypeDataSample = ({
 }: Props) => {
   return (
     <>
-      <Tabs>
+      <Tabs id="data-sample-gcse">
         {sectionId === 'headlines' && (
           <TabsSection id={`${sectionId}SummaryData`} title="Summary">
             <PrototypeDataTilesHighlightsGCSE />


### PR DESCRIPTION
This PR refactors the Accordion component so that the implementation is completely in React (rather than layering the GOVUK module on top). This should have the benefit of allowing us more flexibility in how we build on top of the Accordion in the future.

Following on from the Accordion, the Tabs component has also been changed so that `id`s for TabsSection components are auto-generated from an `id` provided to the parent Tabs component. This allows for easier use without having to add IDs to every TabsSection. This makes the behaviour more consistent with the Accordion when it comes to generation of IDs for child components.