### PR TITLE
DFE-583: Add methodology link on table tool

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -341,7 +341,14 @@ class TableToolPage extends Component<Props, State> {
                                   <a href="#api">Access developer API</a>
                                 </li>
                                 <li>
-                                  <a href="#methodology">Methodology</a>
+                                  <Link
+                                    as={`/methodologies/${publication.slug}`}
+                                    to={`/methodologies/methodology?methodology=${
+                                      publication.slug
+                                    }`}
+                                  >
+                                    Go to methodology
+                                  </Link>
                                 </li>
                                 <li>
                                   <a href="#contact">Contact</a>


### PR DESCRIPTION
This PR adds in the link to a publications methodology from table tool