### PR TITLE
Bugfix: Failing data api test due to theme count

### DIFF
--- a/tests/newman/tests/data-api.json
+++ b/tests/newman/tests/data-api.json
@@ -32,7 +32,7 @@
 											"pm.test(\"Status code is 200\", function () { pm.response.to.have.status(200); });",
 											"",
 											"pm.test(\"Expect correct number of themes\", function () {",
-											"    pm.expect(pm.response.json().length).to.be.above(2);",
+											"    pm.expect(pm.response.json().length).to.be.above(1);",
 											"});",
 											"",
 											"pm.test(\"Pupils and school theme should contain correct data\", function () {",


### PR DESCRIPTION
Expectation is that it should be above 1 rather than 2 as most enviroments only have 2 themes. Resolves pass on dev but failure on test and production