### PR TITLE
DFE-759 Remove unnecessary formatting from CSV

### DIFF
--- a/src/explore-education-statistics-common/src/lib/utils/number/__tests__/formatPretty.test.ts
+++ b/src/explore-education-statistics-common/src/lib/utils/number/__tests__/formatPretty.test.ts
@@ -1,0 +1,51 @@
+import formatPretty from '../formatPretty';
+
+describe('formatPretty', () => {
+  test('returns formatted string from integer', () => {
+    expect(formatPretty(150000000)).toBe('150,000,000');
+  });
+
+  test('returns formatted string rounded down from float', () => {
+    expect(formatPretty(150000000.1234)).toBe('150,000,000.123');
+    expect(formatPretty(150000000.1234, 2)).toBe('150,000,000.12');
+    expect(formatPretty(150000000.1234, 4)).toBe('150,000,000.1234');
+    expect(formatPretty(150000000.12344, 4)).toBe('150,000,000.1234');
+  });
+
+  test('returns formatted string rounded up from float', () => {
+    expect(formatPretty(150000000.2567)).toBe('150,000,000.257');
+    expect(formatPretty(150000000.2567, 2)).toBe('150,000,000.26');
+    expect(formatPretty(150000000.2567, 4)).toBe('150,000,000.2567');
+    expect(formatPretty(150000000.25678, 4)).toBe('150,000,000.2568');
+  });
+
+  test('returns formatted string from string containing integer', () => {
+    expect(formatPretty('150000000')).toBe('150,000,000');
+  });
+
+  test('returns formatted string rounded down from string containing float', () => {
+    expect(formatPretty('150000000.1234')).toBe('150,000,000.123');
+  });
+
+  test('returns formatted string rounded up from string containing float', () => {
+    expect(formatPretty('150000000.2567')).toBe('150,000,000.257');
+    expect(formatPretty('150000000.2567', 2)).toBe('150,000,000.26');
+    expect(formatPretty('150000000.2567', 4)).toBe('150,000,000.2567');
+    expect(formatPretty('150000000.25678', 4)).toBe('150,000,000.2568');
+  });
+
+  test('returns formatted string from string containing trailing zeroes', () => {
+    expect(formatPretty('150000000.0')).toBe('150,000,000.0');
+    expect(formatPretty('150000000.00')).toBe('150,000,000.00');
+    expect(formatPretty('150000000.000')).toBe('150,000,000.000');
+    expect(formatPretty('150000000.0000')).toBe('150,000,000.000');
+
+    expect(formatPretty('150000000.10')).toBe('150,000,000.10');
+    expect(formatPretty('150000000.100')).toBe('150,000,000.100');
+    expect(formatPretty('150000000.1000')).toBe('150,000,000.100');
+
+    expect(formatPretty('150000000.11')).toBe('150,000,000.11');
+    expect(formatPretty('150000000.110')).toBe('150,000,000.110');
+    expect(formatPretty('150000000.1100')).toBe('150,000,000.110');
+  });
+});

--- a/src/explore-education-statistics-common/src/lib/utils/number/formatPretty.ts
+++ b/src/explore-education-statistics-common/src/lib/utils/number/formatPretty.ts
@@ -1,0 +1,42 @@
+/**
+ * Return a formatted {@param value} in a pretty format
+ * i.e. 10,000,000.000.
+ *
+ * {@param maxDecimals} can be optionally used
+ * determine the number of decimal places that
+ * the formatted number can have.
+ *
+ * This also accepts strings and preserves their
+ * decimal places, even if there are trailing zeros.
+ */
+export default function formatPretty(
+  value: string | number,
+  maxDecimals = 3,
+): string {
+  if (typeof value === 'string') {
+    const numberValue = Number(value);
+
+    if (Number.isNaN(numberValue)) {
+      return value;
+    }
+
+    const decimals = value.split('.')[1];
+    const decimalPlaces = decimals ? decimals.length : 0;
+
+    if (decimalPlaces > 0) {
+      return numberValue.toLocaleString('en-GB', {
+        maximumFractionDigits: maxDecimals,
+        minimumFractionDigits:
+          decimalPlaces > maxDecimals ? maxDecimals : decimalPlaces,
+      });
+    }
+
+    return Number(value).toLocaleString('en-GB', {
+      maximumFractionDigits: maxDecimals,
+    });
+  }
+
+  return value.toLocaleString('en-GB', {
+    maximumFractionDigits: maxDecimals,
+  });
+}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/DownloadCsvButton.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/DownloadCsvButton.tsx
@@ -1,6 +1,5 @@
 import ButtonText from '@common/components/ButtonText';
 import cartesian from '@common/lib/utils/cartesian';
-import formatPretty from '@common/lib/utils/number/formatPretty';
 import {
   FilterOption,
   IndicatorOption,
@@ -64,13 +63,7 @@ const DownloadCsvButton = ({
           return 'n/a';
         }
 
-        const value = matchingResult.measures[indicator.value];
-
-        if (Number.isNaN(Number(value))) {
-          return value;
-        }
-
-        return formatPretty(value);
+        return matchingResult.measures[indicator.value];
       });
 
       return [...row.map(column => column.label), ...indicatorCells];

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/DownloadCsvButton.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/DownloadCsvButton.tsx
@@ -86,7 +86,7 @@ const DownloadCsvButton = ({
         });
       }}
     >
-      Download data (.csv)
+      Download underlying data (.csv)
     </ButtonText>
   );
 };

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/DownloadCsvButton.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/DownloadCsvButton.tsx
@@ -1,5 +1,6 @@
 import ButtonText from '@common/components/ButtonText';
 import cartesian from '@common/lib/utils/cartesian';
+import formatPretty from '@common/lib/utils/number/formatPretty';
 import {
   FilterOption,
   IndicatorOption,
@@ -63,20 +64,13 @@ const DownloadCsvButton = ({
           return 'n/a';
         }
 
-        const rawValue = matchingResult.measures[indicator.value];
-        const numberValue = Number(rawValue);
+        const value = matchingResult.measures[indicator.value];
 
-        if (Number.isNaN(numberValue)) {
-          return rawValue;
+        if (Number.isNaN(Number(value))) {
+          return value;
         }
 
-        const decimals = rawValue.split('.')[1];
-        const decimalPlaces = decimals ? decimals.length : 0;
-
-        return numberValue.toLocaleString('en-GB', {
-          maximumFractionDigits: decimalPlaces,
-          minimumFractionDigits: decimalPlaces,
-        });
+        return formatPretty(value);
       });
 
       return [...row.map(column => column.label), ...indicatorCells];

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -1,4 +1,5 @@
 import cartesian from '@common/lib/utils/cartesian';
+import formatPretty from '@common/lib/utils/number/formatPretty';
 import commaList from '@common/lib/utils/string/commaList';
 import {
   FilterOption,
@@ -126,20 +127,13 @@ const TimePeriodDataTable = ({
         return 'n/a';
       }
 
-      const rawValue = matchingResult.measures[indicatorOption.value];
-      const numberValue = Number(rawValue);
+      const value = matchingResult.measures[indicatorOption.value];
 
-      if (Number.isNaN(numberValue)) {
-        return rawValue;
+      if (Number.isNaN(Number(value))) {
+        return value;
       }
 
-      const decimals = rawValue.split('.')[1];
-      const decimalPlaces = decimals ? decimals.length : 0;
-
-      return `${numberValue.toLocaleString('en-GB', {
-        maximumFractionDigits: decimalPlaces,
-        minimumFractionDigits: decimalPlaces,
-      })}${indicatorOption.unit}`;
+      return `${formatPretty(value)}${indicatorOption.unit}`;
     });
   });
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/DownloadCsvButton.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/DownloadCsvButton.test.tsx
@@ -195,7 +195,7 @@ describe('DownloadCsvButton', () => {
 
     jest.spyOn(Papa, 'unparse');
 
-    fireEvent.click(getByText('Download data (.csv)'));
+    fireEvent.click(getByText('Download underlying data (.csv)'));
 
     const csv = (Papa.unparse as jest.Mock).mock.calls[0][0];
 
@@ -244,7 +244,7 @@ describe('DownloadCsvButton', () => {
 
     jest.spyOn(Papa, 'unparse');
 
-    fireEvent.click(getByText('Download data (.csv)'));
+    fireEvent.click(getByText('Download underlying data (.csv)'));
 
     const csv = (Papa.unparse as jest.Mock).mock.calls[0][0];
 
@@ -296,7 +296,7 @@ describe('DownloadCsvButton', () => {
 
     jest.spyOn(Papa, 'unparse');
 
-    fireEvent.click(getByText('Download data (.csv)'));
+    fireEvent.click(getByText('Download underlying data (.csv)'));
 
     const csv = (Papa.unparse as jest.Mock).mock.calls[0][0];
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/DownloadCsvButton.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/DownloadCsvButton.test.tsx
@@ -5,80 +5,82 @@ import { fireEvent, render } from 'react-testing-library';
 import DownloadCsvButton from '../DownloadCsvButton';
 
 describe('DownloadCsvButton', () => {
-  test('clicking generates correct CSV', async () => {
-    const { getByText } = render(
-      <DownloadCsvButton
-        publicationSlug="pupil-absence"
-        meta={{
-          filters: {
-            characteristics: {
-              legend: 'Characteristics',
-              hint: '',
-              options: {
-                gender: {
-                  label: 'Gender',
-                  options: [
-                    { label: 'Male', value: 'gender_male' },
-                    { label: 'Female', value: 'gender_female' },
-                  ],
-                },
-              },
-            },
-            schoolType: {
-              legend: 'School type',
-              hint: '',
-              options: {
-                default: {
-                  label: '',
-                  options: [
-                    {
-                      label: 'State-funded-primary',
-                      value: 'school_primary',
-                    },
-                    {
-                      label: 'State-funded secondary',
-                      value: 'school_secondary',
-                    },
-                  ],
-                },
-              },
-            },
+  const testMeta = {
+    filters: {
+      characteristics: {
+        legend: 'Characteristics',
+        hint: '',
+        options: {
+          gender: {
+            label: 'Gender',
+            options: [
+              { label: 'Male', value: 'gender_male' },
+              { label: 'Female', value: 'gender_female' },
+            ],
           },
-          indicators: {
-            absenceFields: {
-              label: 'Absence fields',
-              options: [
-                {
-                  label: 'Authorised absence rate',
-                  value: 'auth_abs_rate',
-                  unit: '%',
-                },
-                {
-                  label: 'Number of authorised absence sessions',
-                  value: 'auth_abs_sess',
-                  unit: '',
-                },
-              ],
-            },
-          },
-          locations: {},
-          timePeriod: {
-            legend: 'Academic year',
-            hint: '',
+        },
+      },
+      schoolType: {
+        legend: 'School type',
+        hint: '',
+        options: {
+          default: {
+            label: '',
             options: [
               {
-                code: 'AY',
-                label: '2014/15',
-                year: 2014,
+                label: 'State-funded-primary',
+                value: 'school_primary',
               },
               {
-                code: 'AY',
-                label: '2015/16',
-                year: 2015,
+                label: 'State-funded secondary',
+                value: 'school_secondary',
               },
             ],
           },
-        }}
+        },
+      },
+    },
+    indicators: {
+      absenceFields: {
+        label: 'Absence fields',
+        options: [
+          {
+            label: 'Authorised absence rate',
+            value: 'auth_abs_rate',
+            unit: '%',
+          },
+          {
+            label: 'Number of authorised absence sessions',
+            value: 'auth_abs_sess',
+            unit: '',
+          },
+        ],
+      },
+    },
+    locations: {},
+    timePeriod: {
+      legend: 'Academic year',
+      hint: '',
+      options: [
+        {
+          code: 'AY',
+          label: '2014/15',
+          year: 2014,
+        },
+        {
+          code: 'AY',
+          label: '2015/16',
+          year: 2015,
+        },
+      ],
+    },
+  };
+
+  test('clicking generates complete csv', async () => {
+    const { getByText } = render(
+      <DownloadCsvButton
+        publicationSlug="pupil-absence"
+        meta={testMeta}
         filters={{
           characteristics: [
             { label: 'Male', value: 'gender_male' },
@@ -200,95 +202,19 @@ describe('DownloadCsvButton', () => {
     expect(csv).toMatchSnapshot();
   });
 
-  test('csv can contain suppressed or cells with no result ', () => {
+  test('generated csv does not format values', () => {
     const { getByText } = render(
       <DownloadCsvButton
         publicationSlug="pupil-absence"
-        meta={{
-          filters: {
-            characteristics: {
-              legend: 'Characteristics',
-              hint: '',
-              options: {
-                gender: {
-                  label: 'Gender',
-                  options: [
-                    { label: 'Male', value: 'gender_male' },
-                    { label: 'Female', value: 'gender_female' },
-                  ],
-                },
-              },
-            },
-            schoolType: {
-              legend: 'School type',
-              hint: '',
-              options: {
-                default: {
-                  label: '',
-                  options: [
-                    {
-                      label: 'State-funded-primary',
-                      value: 'school_primary',
-                    },
-                    {
-                      label: 'State-funded secondary',
-                      value: 'school_secondary',
-                    },
-                  ],
-                },
-              },
-            },
-          },
-          indicators: {
-            absenceFields: {
-              label: 'Absence fields',
-              options: [
-                {
-                  label: 'Authorised absence rate',
-                  value: 'auth_abs_rate',
-                  unit: '%',
-                },
-                {
-                  label: 'Number of authorised absence sessions',
-                  value: 'auth_abs_sess',
-                  unit: '',
-                },
-              ],
-            },
-          },
-          locations: {},
-          timePeriod: {
-            legend: 'Academic year',
-            hint: '',
-            options: [
-              {
-                code: 'AY',
-                label: '2014/15',
-                year: 2014,
-              },
-              {
-                code: 'AY',
-                label: '2015/16',
-                year: 2015,
-              },
-            ],
-          },
-        }}
+        meta={testMeta}
         filters={{
-          characteristics: [
-            { label: 'Male', value: 'gender_male' },
-            { label: 'Female', value: 'gender_female' },
-          ],
+          characteristics: [{ label: 'Female', value: 'gender_female' }],
           schoolType: [
             { label: 'State-funded primary', value: 'school_primary' },
-            { label: 'State-funded secondary', value: 'school_secondary' },
           ],
         }}
         locations={{}}
-        timePeriods={[
-          TimePeriod.fromString('2014_AY'),
-          TimePeriod.fromString('2015_AY'),
-        ]}
+        timePeriods={[TimePeriod.fromString('2015_AY')]}
         indicators={[
           {
             label: 'Authorised absence rate',
@@ -303,71 +229,63 @@ describe('DownloadCsvButton', () => {
         ]}
         results={[
           {
-            filters: ['gender_male', 'school_primary'],
-            timeIdentifier: 'AY',
-            location: {},
-            measures: {
-              authAbsRate: '1.2',
-              authAbsSess: '2',
-            },
-            year: 2014,
-          },
-          {
             filters: ['gender_female', 'school_primary'],
             timeIdentifier: 'AY',
             location: {},
             measures: {
-              authAbsRate: '5.6',
-              authAbsSess: '6',
-            },
-            year: 2014,
-          },
-          {
-            filters: ['gender_female', 'school_secondary'],
-            timeIdentifier: 'AY',
-            location: {},
-            measures: {
-              authAbsRate: '7.8',
-              authAbsSess: '8',
-            },
-            year: 2014,
-          },
-          {
-            filters: ['gender_male', 'school_primary'],
-            timeIdentifier: 'AY',
-            location: {},
-            measures: {
-              authAbsRate: '9',
-              authAbsSess: '10',
+              authAbsRate: '12300000',
+              authAbsSess: '44255667.2356',
             },
             year: 2015,
           },
+        ]}
+      />,
+    );
+
+    jest.spyOn(Papa, 'unparse');
+
+    fireEvent.click(getByText('Download data (.csv)'));
+
+    const csv = (Papa.unparse as jest.Mock).mock.calls[0][0];
+
+    expect(csv).toMatchSnapshot();
+  });
+
+  test('generated csv can contain suppressed or cells with no result ', () => {
+    const { getByText } = render(
+      <DownloadCsvButton
+        publicationSlug="pupil-absence"
+        meta={testMeta}
+        filters={{
+          characteristics: [
+            { label: 'Male', value: 'gender_male' },
+            { label: 'Female', value: 'gender_female' },
+          ],
+          schoolType: [
+            { label: 'State-funded primary', value: 'school_primary' },
+          ],
+        }}
+        locations={{}}
+        timePeriods={[TimePeriod.fromString('2015_AY')]}
+        indicators={[
           {
-            filters: ['gender_male', 'school_secondary'],
-            timeIdentifier: 'AY',
-            location: {},
-            measures: {
-              authAbsRate: '11.2',
-              authAbsSess: '12',
-            },
-            year: 2015,
+            label: 'Authorised absence rate',
+            value: 'authAbsRate',
+            unit: '%',
           },
+          {
+            label: 'Number of authorised absence sessions',
+            value: 'authAbsSess',
+            unit: '',
+          },
+        ]}
+        results={[
           {
             filters: ['gender_female', 'school_primary'],
             timeIdentifier: 'AY',
             location: {},
             measures: {
               authAbsRate: '13.4',
-              authAbsSess: 'x',
-            },
-            year: 2015,
-          },
-          {
-            filters: ['gender_female', 'school_secondary'],
-            timeIdentifier: 'AY',
-            location: {},
-            measures: {
-              authAbsRate: '15.6',
               authAbsSess: 'x',
             },
             year: 2015,

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__snapshots__/DownloadCsvButton.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__snapshots__/DownloadCsvButton.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DownloadCsvButton clicking generates correct CSV 1`] = `
+exports[`DownloadCsvButton clicking generates complete csv 1`] = `
 Array [
   Array [
     "Time period",
@@ -68,7 +68,7 @@ Array [
 ]
 `;
 
-exports[`DownloadCsvButton csv can contain suppressed or cells with no result  1`] = `
+exports[`DownloadCsvButton generated csv can contain suppressed or cells with no result  1`] = `
 Array [
   Array [
     "Time period",
@@ -78,46 +78,11 @@ Array [
     "Number of authorised absence sessions",
   ],
   Array [
-    "2014/15",
-    "Male",
-    "State-funded primary",
-    "1.2",
-    "2",
-  ],
-  Array [
-    "2014/15",
-    "Male",
-    "State-funded secondary",
-    "n/a",
-    "n/a",
-  ],
-  Array [
-    "2014/15",
-    "Female",
-    "State-funded primary",
-    "5.6",
-    "6",
-  ],
-  Array [
-    "2014/15",
-    "Female",
-    "State-funded secondary",
-    "7.8",
-    "8",
-  ],
-  Array [
     "2015/16",
     "Male",
     "State-funded primary",
-    "9",
-    "10",
-  ],
-  Array [
-    "2015/16",
-    "Male",
-    "State-funded secondary",
-    "11.2",
-    "12",
+    "n/a",
+    "n/a",
   ],
   Array [
     "2015/16",
@@ -126,12 +91,24 @@ Array [
     "13.4",
     "x",
   ],
+]
+`;
+
+exports[`DownloadCsvButton generated csv does not format values 1`] = `
+Array [
+  Array [
+    "Time period",
+    "Characteristics",
+    "School type",
+    "Authorised absence rate (%)",
+    "Number of authorised absence sessions",
+  ],
   Array [
     "2015/16",
     "Female",
-    "State-funded secondary",
-    "15.6",
-    "x",
+    "State-funded primary",
+    "12300000",
+    "44255667.2356",
   ],
 ]
 `;


### PR DESCRIPTION
This PR:

- Removes the unnecessary en-GB locale number formatting from the generated CSV.
- Abstracts the formatting from the generated table, into `formatPretty` util function.
- Changes CSV button text from 'Download data (.csv)' to 'Download underlying data (.csv)' to make it clearer that the data does not necessarily align with how the generated table looks.