### PR TITLE
Feature/dfe 837 implement latest prototype updates

### DIFF
--- a/src/explore-education-statistics-admin/src/components/AdminDashboardPublicationsTab.tsx
+++ b/src/explore-education-statistics-admin/src/components/AdminDashboardPublicationsTab.tsx
@@ -1,8 +1,9 @@
+import FormSelect from '@common/components/form/FormSelect';
 import React from 'react';
 import { Dictionary } from '@common/types';
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
-import { Publication } from '@admin/services/types/types';
+import { IdLabelPair, Publication } from '@admin/services/types/types';
 import groupBy from 'lodash/groupBy';
 import AdminDashboardPublications from './AdminDashboardPublications';
 import Link from './Link';
@@ -10,11 +11,23 @@ import Link from './Link';
 interface AdminDashboardPublicationsTabProps {
   publications: Publication[];
   noResultsMessage: string;
+  themes: IdLabelPair[];
+  topics: IdLabelPair[];
+  selectedThemeId: string;
+  selectedTopicId: string;
+  onThemeChange: (selectedThemeId: string) => void;
+  onTopicChange: (selectedTopicId: string) => void;
 }
 
 const AdminDashboardPublicationsTab = ({
   publications,
   noResultsMessage,
+  themes,
+  topics,
+  selectedThemeId,
+  selectedTopicId,
+  onThemeChange,
+  onTopicChange,
 }: AdminDashboardPublicationsTabProps) => {
   const createThemeTopicTitleLabel = (publication: Publication) =>
     `${publication.topic.theme.label}, ${publication.topic.title}`;
@@ -37,6 +50,38 @@ const AdminDashboardPublicationsTab = ({
         Edit an existing release or create a new release for current
         publications.
       </p>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-one-half">
+          <FormSelect
+            id="selectTheme"
+            label="Select theme"
+            name="selectTheme"
+            options={themes.map(theme => ({
+              label: theme.label,
+              value: theme.id,
+            }))}
+            value={selectedThemeId}
+            onChange={event => {
+              onThemeChange(event.target.value);
+            }}
+          />
+        </div>
+        <div className="govuk-grid-column-one-half">
+          <FormSelect
+            id="selectTopic"
+            label="Select topic"
+            name="selectTopic"
+            options={topics.map(topic => ({
+              label: topic.label,
+              value: topic.id,
+            }))}
+            value={selectedTopicId}
+            onChange={event => {
+              onTopicChange(event.target.value);
+            }}
+          />
+        </div>
+      </div>
       <Link to="/prototypes/publication-create-new" className="govuk-button">
         Create a new publication
       </Link>

--- a/src/explore-education-statistics-admin/src/components/AdminDashboardPublicationsTab.tsx
+++ b/src/explore-education-statistics-admin/src/components/AdminDashboardPublicationsTab.tsx
@@ -1,10 +1,8 @@
 import FormSelect from '@common/components/form/FormSelect';
 import React from 'react';
-import { Dictionary } from '@common/types';
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
 import { IdLabelPair, Publication } from '@admin/services/types/types';
-import groupBy from 'lodash/groupBy';
 import AdminDashboardPublications from './AdminDashboardPublications';
 import Link from './Link';
 

--- a/src/explore-education-statistics-admin/src/components/AdminDashboardPublicationsTab.tsx
+++ b/src/explore-education-statistics-admin/src/components/AdminDashboardPublicationsTab.tsx
@@ -29,10 +29,6 @@ const AdminDashboardPublicationsTab = ({
   onThemeChange,
   onTopicChange,
 }: AdminDashboardPublicationsTabProps) => {
-  if (publications.length === 0) {
-    return <div className="govuk-inset-text">{noResultsMessage}</div>;
-  }
-
   const selectedTheme =
     themes.find(theme => theme.id === selectedThemeId) || themes[0];
   const selectedTopic =
@@ -79,20 +75,25 @@ const AdminDashboardPublicationsTab = ({
           />
         </div>
       </div>
+      {publications.length > 0 && (
+        <Accordion id="publications">
+          {publications.map(publication => (
+            <AccordionSection
+              key={publication.id}
+              heading={publication.title}
+              headingTag="h3"
+            >
+              <AdminDashboardPublications publication={publication} />
+            </AccordionSection>
+          ))}
+        </Accordion>
+      )}
+      {publications.length === 0 && (
+        <div className="govuk-inset-text">{noResultsMessage}</div>
+      )}
       <Link to="/prototypes/publication-create-new" className="govuk-button">
         Create a new publication
       </Link>
-      <Accordion id="publications">
-        {publications.map(publication => (
-          <AccordionSection
-            key={publication.id}
-            heading={publication.title}
-            headingTag="h3"
-          >
-            <AdminDashboardPublications publication={publication} />
-          </AccordionSection>
-        ))}
-      </Accordion>
     </section>
   );
 };

--- a/src/explore-education-statistics-admin/src/components/AdminDashboardPublicationsTab.tsx
+++ b/src/explore-education-statistics-admin/src/components/AdminDashboardPublicationsTab.tsx
@@ -29,23 +29,20 @@ const AdminDashboardPublicationsTab = ({
   onThemeChange,
   onTopicChange,
 }: AdminDashboardPublicationsTabProps) => {
-  const createThemeTopicTitleLabel = (publication: Publication) =>
-    `${publication.topic.theme.label}, ${publication.topic.title}`;
-
-  const publicationsByThemeAndTopic: Dictionary<Publication[]> = groupBy(
-    publications,
-    createThemeTopicTitleLabel,
-  );
-
-  const themesAndTopics = Object.keys(publicationsByThemeAndTopic);
-
-  if (themesAndTopics.length === 0) {
+  if (publications.length === 0) {
     return <div className="govuk-inset-text">{noResultsMessage}</div>;
   }
 
-  const themesAndTopicsSections = themesAndTopics.map(themeTopic => (
-    <React.Fragment key={themeTopic}>
-      <h2 className="govuk-heading-l govuk-!-margin-bottom-0">{themeTopic}</h2>
+  const selectedTheme =
+    themes.find(theme => theme.id === selectedThemeId) || themes[0];
+  const selectedTopic =
+    topics.find(topic => topic.id === selectedTopicId) || topics[0];
+
+  return (
+    <section>
+      <h2 className="govuk-heading-l govuk-!-margin-bottom-0">
+        {`${selectedTheme.label}, ${selectedTopic.label}`}
+      </h2>
       <p className="govuk-body">
         Edit an existing release or create a new release for current
         publications.
@@ -85,8 +82,8 @@ const AdminDashboardPublicationsTab = ({
       <Link to="/prototypes/publication-create-new" className="govuk-button">
         Create a new publication
       </Link>
-      <Accordion id={themeTopic} key={themeTopic}>
-        {publicationsByThemeAndTopic[themeTopic].map(publication => (
+      <Accordion id="publications">
+        {publications.map(publication => (
           <AccordionSection
             key={publication.id}
             heading={publication.title}
@@ -96,10 +93,8 @@ const AdminDashboardPublicationsTab = ({
           </AccordionSection>
         ))}
       </Accordion>
-    </React.Fragment>
-  ));
-
-  return <section>{themesAndTopicsSections}</section>;
+    </section>
+  );
 };
 
 export default AdminDashboardPublicationsTab;

--- a/src/explore-education-statistics-admin/src/pages/AdminDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/AdminDashboardPage.tsx
@@ -99,7 +99,7 @@ const AdminDashboardPage = () => {
               selectedThemeId={selectedThemeId}
               selectedTopicId={selectedTopicId}
               onThemeChange={themeId => setSelectedThemeId(themeId)}
-              onTopicChange={topicId => setSelectedThemeId(topicId)}
+              onTopicChange={topicId => setSelectedTopicId(topicId)}
             />
           )}
         </TabsSection>

--- a/src/explore-education-statistics-admin/src/pages/AdminDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/AdminDashboardPage.tsx
@@ -54,7 +54,9 @@ const AdminDashboardPage = () => {
 
       if (selectedTopicId) {
         const fetchedMyPublications = DummyPublicationsData.allPublications.filter(
-          publication => publication.owner.id === loggedInUserId,
+          publication =>
+            publication.owner.id === loggedInUserId &&
+            publication.topic.id === selectedTopicId,
         );
 
         const fetchedInProgressPublications = DummyPublicationsData.allPublications.filter(

--- a/src/explore-education-statistics-admin/src/pages/AdminDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/AdminDashboardPage.tsx
@@ -4,7 +4,7 @@ import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
 import { LoginContext } from '@admin/components/Login';
 import DummyPublicationsData from '@admin/pages/DummyPublicationsData';
-import { Publication } from '@admin/services/types/types';
+import { IdLabelPair, Publication } from '@admin/services/types/types';
 import AdminDashboardPublicationsTab from '@admin/components/AdminDashboardPublicationsTab';
 import Link from '../components/Link';
 import Page from '../components/Page';
@@ -16,6 +16,14 @@ const AdminDashboardPage = () => {
     Publication[]
   >([]);
 
+  const [themes, setThemes] = useState<IdLabelPair[]>();
+
+  const [topics, setTopics] = useState<IdLabelPair[]>();
+
+  const [selectedThemeId, setSelectedThemeId] = useState<string>();
+
+  const [selectedTopicId, setSelectedTopicId] = useState<string>();
+
   const authentication = useContext(LoginContext);
 
   useEffect(() => {
@@ -23,21 +31,44 @@ const AdminDashboardPage = () => {
     const loggedInUserId = user ? user.id : null;
 
     if (loggedInUserId) {
-      const fetchedMyPublications = DummyPublicationsData.allPublications.filter(
-        publication => publication.owner.id === loggedInUserId,
-      );
+      if (!themes) {
+        const { themesAndTopics } = DummyPublicationsData;
+        const listOfJustTheThemes = themesAndTopics.map(
+          themeTopicsPair => themeTopicsPair.theme,
+        );
 
-      const fetchedInProgressPublications = DummyPublicationsData.allPublications.filter(
-        publication => publication.owner.id !== loggedInUserId,
-      );
+        setThemes(listOfJustTheThemes);
+        setSelectedThemeId(listOfJustTheThemes[0].id);
+      }
 
-      setMyPublications(fetchedMyPublications);
-      setInProgressPublications(fetchedInProgressPublications);
+      if (selectedThemeId) {
+        const { themesAndTopics } = DummyPublicationsData;
+        const matchingThemeTopicsPair =
+          themesAndTopics.find(
+            themeTopicsPair => themeTopicsPair.theme.id === selectedThemeId,
+          ) || themesAndTopics[0];
+        const justThisThemesTopics = matchingThemeTopicsPair.topics;
+        setTopics(justThisThemesTopics);
+        setSelectedTopicId(justThisThemesTopics[0].id);
+      }
+
+      if (selectedTopicId) {
+        const fetchedMyPublications = DummyPublicationsData.allPublications.filter(
+          publication => publication.owner.id === loggedInUserId,
+        );
+
+        const fetchedInProgressPublications = DummyPublicationsData.allPublications.filter(
+          publication => publication.owner.id !== loggedInUserId,
+        );
+
+        setMyPublications(fetchedMyPublications);
+        setInProgressPublications(fetchedInProgressPublications);
+      }
     } else {
       setMyPublications([]);
       setInProgressPublications([]);
     }
-  }, [authentication]);
+  }, [authentication, selectedThemeId, selectedTopicId, themes, topics]);
 
   return (
     <Page wide breadcrumbs={[{ name: 'Administrator dashboard' }]}>
@@ -59,16 +90,21 @@ const AdminDashboardPage = () => {
       </div>
       <Tabs id="publicationTabs">
         <TabsSection id="my-publications" title="Publications">
-          <AdminDashboardPublicationsTab
-            publications={myPublications}
-            noResultsMessage="You have not yet created any publications"
-          />
+          {themes && topics && selectedThemeId && selectedTopicId && (
+            <AdminDashboardPublicationsTab
+              publications={myPublications}
+              noResultsMessage="You have not yet created any publications"
+              themes={themes}
+              topics={topics}
+              selectedThemeId={selectedThemeId}
+              selectedTopicId={selectedTopicId}
+              onThemeChange={themeId => setSelectedThemeId(themeId)}
+              onTopicChange={topicId => setSelectedThemeId(topicId)}
+            />
+          )}
         </TabsSection>
         <TabsSection id="in-progress-publications" title="In progress">
-          <AdminDashboardPublicationsTab
-            publications={inProgressPublications}
-            noResultsMessage="There are currently no releases in progress"
-          />
+          Hi
         </TabsSection>
       </Tabs>
     </Page>

--- a/src/explore-education-statistics-admin/src/pages/AdminDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/AdminDashboardPage.tsx
@@ -43,7 +43,7 @@ const AdminDashboardPage = () => {
         const firstTopic = topicsList[0];
 
         setSelectedThemeAndTopicIds({
-          themeId: firstTheme.theme.id,
+          themeId: firstTheme.id,
           topicId: firstTopic.id,
         });
       }
@@ -69,8 +69,7 @@ const AdminDashboardPage = () => {
   }, [authentication, selectedThemeAndTopicIds]);
 
   const findThemeById = (themeId: string, availableThemes: ThemeAndTopics[]) =>
-    availableThemes.find(theme => theme.theme.id === themeId) ||
-    availableThemes[0];
+    availableThemes.find(theme => theme.id === themeId) || availableThemes[0];
 
   return (
     <Page wide breadcrumbs={[{ name: 'Administrator dashboard' }]}>
@@ -96,10 +95,14 @@ const AdminDashboardPage = () => {
             <AdminDashboardPublicationsTab
               publications={myPublications}
               noResultsMessage="You have not yet created any publications"
-              themes={themes.map(theme => theme.theme)}
-              topics={
-                findThemeById(selectedThemeAndTopicIds.themeId, themes).topics
-              }
+              themes={themes.map(theme => ({
+                id: theme.id,
+                label: theme.title,
+              }))}
+              topics={findThemeById(
+                selectedThemeAndTopicIds.themeId,
+                themes,
+              ).topics.map(topic => ({ id: topic.id, label: topic.title }))}
               selectedThemeId={selectedThemeAndTopicIds.themeId}
               selectedTopicId={selectedThemeAndTopicIds.topicId}
               onThemeChange={themeId =>

--- a/src/explore-education-statistics-admin/src/pages/DummyPublicationsData.ts
+++ b/src/explore-education-statistics-admin/src/pages/DummyPublicationsData.ts
@@ -21,11 +21,6 @@ const theme1: IdLabelPair = {
   label: 'Pupils and schools',
 };
 
-const theme2: IdLabelPair = {
-  id: 'theme-2',
-  label: 'Theme 2',
-};
-
 const theme1Topic1: Topic = {
   id: '67c249de-1cca-446e-8ccb-dcdac542f460',
   title: 'Pupil absence',
@@ -36,18 +31,6 @@ const theme1Topic2: Topic = {
   id: '77941b7d-bbd6-4069-9107-565af89e2dec',
   title: 'Exclusions',
   theme: theme1,
-};
-
-const theme2Topic1: Topic = {
-  id: 'theme-2-topic-1',
-  title: 'Theme 2 topic 1',
-  theme: theme2,
-};
-
-const theme2Topic2: Topic = {
-  id: 'theme-2-topic-2',
-  title: 'Theme 2 topic 2',
-  theme: theme2,
 };
 
 const dataTypeRevised: ReleaseDataType = {

--- a/src/explore-education-statistics-admin/src/pages/DummyPublicationsData.ts
+++ b/src/explore-education-statistics-admin/src/pages/DummyPublicationsData.ts
@@ -300,9 +300,50 @@ const getReleaseSetupDetails = (releaseId: string): ReleaseSetupDetails => {
   };
 };
 
+interface ThemeAndTopics {
+  theme: IdLabelPair;
+  topics: IdLabelPair[];
+}
+
+const themesAndTopics: ThemeAndTopics[] = [
+  {
+    theme: {
+      id: 'pupil-schools',
+      label: 'Pupils and schools',
+    },
+    topics: [
+      {
+        id: 'pupil-absence',
+        label: 'Pupil absence',
+      },
+      {
+        id: 'exclusions',
+        label: 'Exclusions',
+      },
+    ],
+  },
+  {
+    theme: {
+      id: 'theme-2',
+      label: 'Theme 2',
+    },
+    topics: [
+      {
+        id: 'theme-2-topic-1',
+        label: 'Topic 1',
+      },
+      {
+        id: 'theme-2-topic-2',
+        label: 'Topic 2',
+      },
+    ],
+  },
+];
+
 export default {
   allPublications,
   getReleaseById,
   getOwningPublicationForRelease,
   getReleaseSetupDetails,
+  themesAndTopics,
 };

--- a/src/explore-education-statistics-admin/src/pages/DummyPublicationsData.ts
+++ b/src/explore-education-statistics-admin/src/pages/DummyPublicationsData.ts
@@ -21,16 +21,33 @@ const theme1: IdLabelPair = {
   label: 'Pupils and schools',
 };
 
+const theme2: IdLabelPair = {
+  id: 'theme-2',
+  label: 'Theme 2',
+};
+
 const theme1Topic1: Topic = {
   id: 'topic-1',
-  title: 'pupil absence',
+  title: 'Pupil absence',
   theme: theme1,
 };
 
 const theme1Topic2: Topic = {
   id: 'topic-2',
-  title: 'exclusions',
+  title: 'Exclusions',
   theme: theme1,
+};
+
+const theme2Topic1: Topic = {
+  id: 'theme-2-topic-1',
+  title: 'Theme 2 topic 1',
+  theme: theme2,
+};
+
+const theme2Topic2: Topic = {
+  id: 'theme-2-topic-2',
+  title: 'Theme 2 topic 2',
+  theme: theme2,
 };
 
 const dataTypeRevised: ReleaseDataType = {
@@ -307,34 +324,28 @@ interface ThemeAndTopics {
 
 const themesAndTopics: ThemeAndTopics[] = [
   {
-    theme: {
-      id: 'pupil-schools',
-      label: 'Pupils and schools',
-    },
+    theme: theme1,
     topics: [
       {
-        id: 'pupil-absence',
-        label: 'Pupil absence',
+        id: theme1Topic1.id,
+        label: theme1Topic1.title,
       },
       {
-        id: 'exclusions',
-        label: 'Exclusions',
+        id: theme1Topic2.id,
+        label: theme1Topic2.title,
       },
     ],
   },
   {
-    theme: {
-      id: 'theme-2',
-      label: 'Theme 2',
-    },
+    theme: theme2,
     topics: [
       {
-        id: 'theme-2-topic-1',
-        label: 'Topic 1',
+        id: theme2Topic1.id,
+        label: theme2Topic1.title,
       },
       {
-        id: 'theme-2-topic-2',
-        label: 'Topic 2',
+        id: theme2Topic2.id,
+        label: theme2Topic2.title,
       },
     ],
   },

--- a/src/explore-education-statistics-admin/src/pages/DummyPublicationsData.ts
+++ b/src/explore-education-statistics-admin/src/pages/DummyPublicationsData.ts
@@ -27,13 +27,13 @@ const theme2: IdLabelPair = {
 };
 
 const theme1Topic1: Topic = {
-  id: 'topic-1',
+  id: '67c249de-1cca-446e-8ccb-dcdac542f460',
   title: 'Pupil absence',
   theme: theme1,
 };
 
 const theme1Topic2: Topic = {
-  id: 'topic-2',
+  id: '77941b7d-bbd6-4069-9107-565af89e2dec',
   title: 'Exclusions',
   theme: theme1,
 };
@@ -318,34 +318,222 @@ const getReleaseSetupDetails = (releaseId: string): ReleaseSetupDetails => {
 };
 
 export interface ThemeAndTopics {
-  theme: IdLabelPair;
-  topics: IdLabelPair[];
+  title: string;
+  id: string;
+  topics: {
+    title: string;
+    id: string;
+  }[];
 }
 
 const themesAndTopics: ThemeAndTopics[] = [
   {
-    theme: theme1,
+    title: 'Children, early years and social care',
+    id: 'cc8e02fd-5599-41aa-940d-26bca68eab53',
     topics: [
       {
-        id: theme1Topic1.id,
-        label: theme1Topic1.title,
+        title: 'Childcare and early years',
+        id: '1003fa5c-b60a-4036-a178-e3a69a81b852',
       },
       {
-        id: theme1Topic2.id,
-        label: theme1Topic2.title,
+        title: 'Children in need and child protection',
+        id: '22c52d89-88c0-44b5-96c4-042f1bde6ddd',
+      },
+      {
+        title: "Children's social work workforce",
+        id: '734820b7-f80e-45c3-bb92-960edcc6faa5',
+      },
+      {
+        title: 'Early years foundation stage profile',
+        id: '17b2e32c-ed2f-4896-852b-513cdf466769',
+      },
+      {
+        title: 'Looked-after children',
+        id: '66ff5e67-36cf-4210-9ad2-632baeb4eca7',
+      },
+      {
+        title: "Secure children's homes",
+        id: 'd5288137-e703-43a1-b634-d50fc9785cb9',
       },
     ],
   },
   {
-    theme: theme2,
+    title: 'Destination of pupils and students',
+    id: '6412a76c-cf15-424f-8ebc-3a530132b1b3',
     topics: [
       {
-        id: theme2Topic1.id,
-        label: theme2Topic1.title,
+        title: 'Destinations of key stage 4 and key stage 5 pupils',
+        id: '0b920c62-ff67-4cf1-89ec-0c74a364e6b4',
       },
       {
-        id: theme2Topic2.id,
-        label: theme2Topic2.title,
+        title: 'Graduate labour market',
+        id: '3bef5b2b-76a1-4be1-83b1-a3269245c610',
+      },
+      {
+        title: 'NEET and participation',
+        id: '6a0f4dce-ae62-4429-834e-dd67cee32860',
+      },
+    ],
+  },
+  {
+    title: 'Finance and funding',
+    id: 'bc08839f-2970-4f34-af2d-29608a48082f',
+    topics: [
+      {
+        title: 'Local authority and school finance',
+        id: '4c658598-450b-4493-b972-8812acd154a7',
+      },
+      {
+        title: 'Student loan forecasts',
+        id: '5c5bc908-f813-46e2-aae8-494804a57aa1',
+      },
+    ],
+  },
+  {
+    title: 'Further education',
+    id: '92c5df93-c4da-4629-ab25-51bd2920cdca',
+    topics: [
+      {
+        title: 'Advanced learner loans',
+        id: 'ba0e4a29-92ef-450c-97c5-80a0a6144fb5',
+      },
+      {
+        title: 'FE choices',
+        id: 'dd4a5d02-fcc9-4b7f-8c20-c153754ba1e4',
+      },
+      {
+        title: 'Further education and skills',
+        id: '88d08425-fcfd-4c87-89da-70b2062a7367',
+      },
+      {
+        title: 'Further education for benefits claimants',
+        id: 'cf1f1dc5-27c2-4d15-a55a-9363b7757ff3',
+      },
+      {
+        title: 'National achievement rates tables',
+        id: 'dc7b7a89-e968-4a7e-af5f-bd7d19c346a5',
+      },
+    ],
+  },
+  {
+    title: 'Higher education',
+    id: '2ca22e34-b87a-4281-a0eb-b80f4f8dd374',
+    topics: [
+      {
+        title: 'Higher education graduate employment and earnings',
+        id: '53a1fbb7-5234-435f-892b-9baad4c82535',
+      },
+      {
+        title: 'Higher education statistics',
+        id: '2458a916-df6e-4845-9658-a81eace42ffd',
+      },
+      {
+        title: 'Participation rates in higher education',
+        id: '04d95654-9fe0-4f78-9dfd-cf396661ebe9',
+      },
+      {
+        title: 'Widening participation in higher education',
+        id: '7871f559-0cfe-47c0-b48d-25b2bc8a0418',
+      },
+    ],
+  },
+  {
+    title: 'Pupils and schools',
+    id: 'ee1855ca-d1e1-4f04-a795-cbd61d326a1f',
+    topics: [
+      {
+        title: 'Admission appeals',
+        id: 'c9f0b897-d58a-42b0-9d12-ca874cc7c810',
+      },
+      {
+        title: 'Exclusions',
+        id: '77941b7d-bbd6-4069-9107-565af89e2dec',
+      },
+      {
+        title: 'Parental responsibility measures',
+        id: '6b8c0242-68e2-420c-910c-e19524e09cd2',
+      },
+      {
+        title: 'Pupil absence',
+        id: '67c249de-1cca-446e-8ccb-dcdac542f460',
+      },
+      {
+        title: 'Pupil projections',
+        id: '5e196d11-8ac4-4c82-8c46-a10a67c1118e',
+      },
+      {
+        title: 'School and pupils numbers',
+        id: 'e50ba9fd-9f19-458c-aceb-4422f0c7d1ba',
+      },
+      {
+        title: 'School applications',
+        id: '1a9636e4-29d5-4c90-8c07-f41db8dd019c',
+      },
+      {
+        title: 'School capacity',
+        id: '87c27c5e-ae49-4932-aedd-4405177d9367',
+      },
+      {
+        title: 'Special educational needs (SEN)',
+        id: '85349b0a-19c7-4089-a56b-ad8dbe85449a',
+      },
+    ],
+  },
+  {
+    title: 'School and college outcomes and performance',
+    id: '74648781-85a9-4233-8be3-fe6f137165f4',
+    topics: [
+      {
+        title: '16 to 19 attainment',
+        id: '85b5454b-3761-43b1-8e84-bd056a8efcd3',
+      },
+      {
+        title: 'GCSEs (key stage 4)',
+        id: '1e763f55-bf09-4497-b838-7c5b054ba87b',
+      },
+      {
+        title: 'Key stage 1',
+        id: '504446c2-ddb1-4d52-bdbc-4148c2c4c460',
+      },
+      {
+        title: 'Key stage 2',
+        id: 'eac38700-b968-4029-b8ac-0eb8e1356480',
+      },
+      {
+        title: 'Outcome based success measures',
+        id: 'a7ce9542-20e6-401d-91f4-f832c9e58b12',
+      },
+      {
+        title: 'Performance tables',
+        id: '1318eb73-02a8-4e50-82a9-7e271176c4d1',
+      },
+    ],
+  },
+  {
+    title: 'Teachers and school workforce',
+    id: 'b601b9ea-b1c7-4970-b354-d1f695c446f1',
+    topics: [
+      {
+        title: 'Initial teacher training (ITT)',
+        id: '0f8792d2-28b1-4537-a1b4-3e139fcf0ca7',
+      },
+      {
+        title: 'School workforce',
+        id: '28cfa002-83cb-4011-9ddd-859ec99e0aa0',
+      },
+      {
+        title: 'Teacher workforce statistics and analysis',
+        id: '6d434e17-7b76-425d-897d-c7b369b42e35',
+      },
+    ],
+  },
+  {
+    title: 'UK education and training statistics',
+    id: 'a95d2ca2-a969-4320-b1e9-e4781112574a',
+    topics: [
+      {
+        title: 'UK education and training statistics',
+        id: '692050da-9ac9-435a-80d5-a6be4915f0f7',
       },
     ],
   },

--- a/src/explore-education-statistics-admin/src/pages/DummyPublicationsData.ts
+++ b/src/explore-education-statistics-admin/src/pages/DummyPublicationsData.ts
@@ -317,7 +317,7 @@ const getReleaseSetupDetails = (releaseId: string): ReleaseSetupDetails => {
   };
 };
 
-interface ThemeAndTopics {
+export interface ThemeAndTopics {
   theme: IdLabelPair;
   topics: IdLabelPair[];
 }


### PR DESCRIPTION
This PR deals with amending the Admin Dashboard to, instead of showing all publications that a user can see, instead introduces 2 dropdowns, one for theme and one for topic.  When the user selects a theme and topic, they will see just publications for that theme-topic pair.

Main changes:
- 2 dropdowns added to Admin Dashboard page
- When theme / topic choice is changed, a new set of publications is requested
- a new set of dummy publications data that mirrors the response from an API call that Rich has created in a separate PR