### PR TITLE
DFE-875 Fix 'Select all' button not working for all checkbox sub-groups

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormCheckbox.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckbox.tsx
@@ -1,7 +1,12 @@
 import classNames from 'classnames';
-import React, { ChangeEventHandler, memo, ReactNode } from 'react';
+import React, { ChangeEvent, memo, ReactNode } from 'react';
 
-export type CheckboxChangeEventHandler = ChangeEventHandler<HTMLInputElement>;
+export type OtherCheckboxChangeProps = Pick<FormCheckboxProps, 'label'>;
+
+export type CheckboxChangeEventHandler = (
+  event: ChangeEvent<HTMLInputElement>,
+  otherCheckboxProps: OtherCheckboxChangeProps,
+) => void;
 
 export interface FormCheckboxProps {
   checked?: boolean;
@@ -38,7 +43,11 @@ const FormCheckbox = ({
           defaultChecked={defaultChecked}
           id={id}
           name={name}
-          onChange={onChange}
+          onChange={event => {
+            if (onChange) {
+              onChange(event, { label });
+            }
+          }}
           type="checkbox"
           value={value}
         />

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -3,9 +3,7 @@ import { OmitStrict, PartialBy } from '@common/types/util';
 import classNames from 'classnames';
 import kebabCase from 'lodash/kebabCase';
 import orderBy from 'lodash/orderBy';
-import memoize from 'memoizee';
 import React, {
-  ChangeEvent,
   createRef,
   MouseEvent,
   MouseEventHandler,
@@ -24,21 +22,17 @@ export type CheckboxOption = PartialBy<
 >;
 
 export type CheckboxGroupAllChangeEvent = MouseEvent<HTMLButtonElement>;
+
 export type CheckboxGroupAllChangeEventHandler = (
   event: CheckboxGroupAllChangeEvent,
   options: CheckboxOption[],
-) => void;
-
-export type CheckboxGroupChangeEventHandler = (
-  event: ChangeEvent<HTMLInputElement>,
-  option: CheckboxOption,
 ) => void;
 
 interface BaseFormCheckboxGroupProps {
   id: string;
   name: string;
   onAllChange?: CheckboxGroupAllChangeEventHandler;
-  onChange?: CheckboxGroupChangeEventHandler;
+  onChange?: CheckboxChangeEventHandler;
   options: CheckboxOption[];
   selectAll?: boolean;
   small?: boolean;
@@ -52,20 +46,13 @@ interface BaseFormCheckboxGroupProps {
 export type FormCheckboxGroupProps = BaseFormCheckboxGroupProps &
   FormFieldsetProps;
 
-interface State {
-  checkedCount: number;
-}
-
 /**
  * Basic checkbox group that should be used as a controlled component.
- * When using Formik, use {@see FormFieldRadioGroup} instead.
  */
 export class BaseFormCheckboxGroup extends PureComponent<
-  BaseFormCheckboxGroupProps,
-  State
+  BaseFormCheckboxGroupProps
 > {
   public static defaultProps = {
-    legendSize: 'm',
     selectAll: false,
     small: false,
     order: ['label'],
@@ -95,20 +82,13 @@ export class BaseFormCheckboxGroup extends PureComponent<
     }
   };
 
-  // eslint-disable-next-line react/sort-comp
-  private handleChange = memoize(
-    (option: CheckboxOption): CheckboxChangeEventHandler => event => {
-      const { onChange } = this.props;
+  private handleChange: CheckboxChangeEventHandler = (event, option) => {
+    const { onChange } = this.props;
 
-      if (onChange) {
-        onChange(event, option);
-      }
-    },
-    {
-      normalizer: ([option]: [CheckboxOption]) =>
-        `${option.value}-${option.label}-${option.id}`,
-    },
-  );
+    if (onChange) {
+      onChange(event, option);
+    }
+  };
 
   public render() {
     const {
@@ -151,7 +131,7 @@ export class BaseFormCheckboxGroup extends PureComponent<
             name={name}
             key={option.value}
             checked={value.indexOf(option.value) > -1}
-            onChange={this.handleChange(option)}
+            onChange={this.handleChange}
           />
         ))}
 

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -25,7 +25,7 @@ export type CheckboxGroupAllChangeEvent = MouseEvent<HTMLButtonElement>;
 
 export type CheckboxGroupAllChangeEventHandler = (
   event: CheckboxGroupAllChangeEvent,
-  options: CheckboxOption[],
+  checked: boolean,
 ) => void;
 
 interface BaseFormCheckboxGroupProps {
@@ -75,10 +75,10 @@ export class BaseFormCheckboxGroup extends PureComponent<
   }
 
   private handleAllChange: MouseEventHandler<HTMLButtonElement> = event => {
-    const { onAllChange, options } = this.props;
+    const { onAllChange } = this.props;
 
     if (onAllChange) {
-      onAllChange(event, options);
+      onAllChange(event, this.isAllChecked());
     }
   };
 
@@ -88,6 +88,12 @@ export class BaseFormCheckboxGroup extends PureComponent<
     if (onChange) {
       onChange(event, option);
     }
+  };
+
+  private isAllChecked = () => {
+    const { options, value } = this.props;
+
+    return options.every(option => value.indexOf(option.value) > -1);
   };
 
   public render() {
@@ -101,10 +107,6 @@ export class BaseFormCheckboxGroup extends PureComponent<
       orderDirection,
       small,
     } = this.props;
-
-    const isAllChecked = options.every(
-      option => value.indexOf(option.value) > -1,
-    );
 
     return (
       <div
@@ -120,7 +122,9 @@ export class BaseFormCheckboxGroup extends PureComponent<
             className={styles.selectAll}
             underline={false}
           >
-            {isAllChecked ? 'Unselect' : 'Select'} all {options.length} options
+            {`${this.isAllChecked() ? 'Unselect' : 'Select'} all ${
+              options.length
+            } options`}
           </ButtonText>
         )}
 

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.tsx
@@ -107,9 +107,9 @@ const FormCheckboxSearchSubGroups = ({
                 legend={optionGroup.legend}
                 legendSize="s"
                 options={optionGroup.options}
-                onAllChange={event => {
+                onAllChange={(event, checked) => {
                   if (onAllChange) {
-                    onAllChange(event, optionGroup.options);
+                    onAllChange(event, checked, optionGroup.options);
                   }
                 }}
               />

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSubGroups.tsx
@@ -18,6 +18,7 @@ export type FormCheckboxSubGroupsProps = Overwrite<
     }[];
     onAllChange?: (
       event: CheckboxGroupAllChangeEvent,
+      checked: boolean,
       options: CheckboxOption[],
     ) => void;
   }
@@ -56,9 +57,9 @@ const FormCheckboxSubGroups = ({
             legend={optionGroup.legend}
             legendSize="s"
             options={optionGroup.options}
-            onAllChange={event => {
+            onAllChange={(event, checked) => {
               if (onAllChange) {
-                onAllChange(event, optionGroup.options);
+                onAllChange(event, checked, optionGroup.options);
               }
             }}
           />

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxGroup.tsx
@@ -19,12 +19,12 @@ const FormFieldCheckboxGroup = <T extends {}>(props: Props<T>) => {
           {...props}
           {...fieldArrayProps}
           options={options}
-          onAllChange={event => {
+          onAllChange={(event, checked) => {
             if (props.onAllChange) {
-              props.onAllChange(event, options);
+              props.onAllChange(event, checked);
             }
 
-            onAllChange(fieldArrayProps, options)(event);
+            onAllChange(fieldArrayProps, options)(event, checked);
           }}
           onChange={(event, option) => {
             if (props.onChange) {

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxGroup.tsx
@@ -2,7 +2,10 @@ import { OmitStrict } from '@common/types/util';
 import React from 'react';
 import FieldCheckboxArray from './FieldCheckboxArray';
 import FormCheckboxGroup, { FormCheckboxGroupProps } from './FormCheckboxGroup';
-import { onAllChange, onChange } from './util/checkboxGroupFieldHelpers';
+import {
+  handleAllChange,
+  handleChange,
+} from './util/checkboxGroupFieldHelpers';
 
 type Props<FormValues> = {
   name: keyof FormValues | string;
@@ -24,14 +27,14 @@ const FormFieldCheckboxGroup = <T extends {}>(props: Props<T>) => {
               props.onAllChange(event, checked);
             }
 
-            onAllChange(fieldArrayProps, options)(event, checked);
+            handleAllChange(fieldArrayProps, options)(event, checked);
           }}
           onChange={(event, option) => {
             if (props.onChange) {
               props.onChange(event, option);
             }
 
-            onChange(fieldArrayProps)(event);
+            handleChange(fieldArrayProps)(event);
           }}
         />
       )}

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchGroup.tsx
@@ -4,7 +4,10 @@ import FieldCheckboxArray from './FieldCheckboxArray';
 import FormCheckboxSearchGroup, {
   FormCheckboxSearchGroupProps,
 } from './FormCheckboxSearchGroup';
-import { onAllChange, onChange } from './util/checkboxGroupFieldHelpers';
+import {
+  handleAllChange,
+  handleChange,
+} from './util/checkboxGroupFieldHelpers';
 
 export type FormFieldCheckboxSearchGroupProps<FormValues> = {
   name: keyof FormValues | string;
@@ -29,14 +32,14 @@ const FormFieldCheckboxSearchGroup = <T extends {}>(
                 props.onAllChange(event, checked);
               }
 
-              onAllChange(fieldArrayProps, options)(event, checked);
+              handleAllChange(fieldArrayProps, options)(event, checked);
             }}
             onChange={(event, option) => {
               if (props.onChange) {
                 props.onChange(event, option);
               }
 
-              onChange(fieldArrayProps)(event);
+              handleChange(fieldArrayProps)(event);
             }}
           />
         );

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchGroup.tsx
@@ -24,12 +24,12 @@ const FormFieldCheckboxSearchGroup = <T extends {}>(
             {...props}
             {...fieldArrayProps}
             options={options}
-            onAllChange={event => {
+            onAllChange={(event, checked) => {
               if (props.onAllChange) {
-                props.onAllChange(event, options);
+                props.onAllChange(event, checked);
               }
 
-              onAllChange(fieldArrayProps, options)(event);
+              onAllChange(fieldArrayProps, options)(event, checked);
             }}
             onChange={(event, option) => {
               if (props.onChange) {

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchSubGroups.tsx
@@ -26,12 +26,12 @@ const FormFieldCheckboxSearchSubGroups = <T extends {}>(
                 {...props}
                 {...fieldArrayProps}
                 small
-                onAllChange={(event, allOptions) => {
+                onAllChange={(event, checked, groupOptions) => {
                   if (props.onAllChange) {
-                    props.onAllChange(event, allOptions);
+                    props.onAllChange(event, checked, groupOptions);
                   }
 
-                  onAllChange(fieldArrayProps, allOptions)(event);
+                  onAllChange(fieldArrayProps, groupOptions)(event, checked);
                 }}
                 onChange={(event, option) => {
                   if (props.onChange) {
@@ -47,7 +47,15 @@ const FormFieldCheckboxSearchSubGroups = <T extends {}>(
       )}
 
       {options.length === 1 && (
-        <FormFieldCheckboxSearchGroup {...props} options={options[0].options} />
+        <FormFieldCheckboxSearchGroup
+          {...props}
+          onAllChange={(event, checked) => {
+            if (props.onAllChange) {
+              props.onAllChange(event, checked, options[0].options);
+            }
+          }}
+          options={options[0].options}
+        />
       )}
     </>
   );

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchSubGroups.tsx
@@ -5,7 +5,10 @@ import FormCheckboxSearchSubGroups, {
   FormCheckboxSearchSubGroupsProps,
 } from './FormCheckboxSearchSubGroups';
 import FormFieldCheckboxSearchGroup from './FormFieldCheckboxSearchGroup';
-import { onAllChange, onChange } from './util/checkboxGroupFieldHelpers';
+import {
+  handleAllChange,
+  handleChange,
+} from './util/checkboxGroupFieldHelpers';
 
 export type FormFieldCheckboxSearchSubGroupsProps<FormValues> = {
   showError?: boolean;
@@ -31,14 +34,17 @@ const FormFieldCheckboxSearchSubGroups = <T extends {}>(
                     props.onAllChange(event, checked, groupOptions);
                   }
 
-                  onAllChange(fieldArrayProps, groupOptions)(event, checked);
+                  handleAllChange(fieldArrayProps, groupOptions)(
+                    event,
+                    checked,
+                  );
                 }}
                 onChange={(event, option) => {
                   if (props.onChange) {
                     props.onChange(event, option);
                   }
 
-                  onChange(fieldArrayProps)(event);
+                  handleChange(fieldArrayProps)(event);
                 }}
               />
             );

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSubGroups.tsx
@@ -4,7 +4,10 @@ import FieldCheckboxArray from './FieldCheckboxArray';
 import FormCheckboxSubGroups, {
   FormCheckboxSubGroupsProps,
 } from './FormCheckboxSubGroups';
-import { onAllChange, onChange } from './util/checkboxGroupFieldHelpers';
+import {
+  handleAllChange,
+  handleChange,
+} from './util/checkboxGroupFieldHelpers';
 
 export type FormFieldCheckboxSearchSubGroupsProps<FormValues> = {
   showError?: boolean;
@@ -25,14 +28,14 @@ const FormFieldCheckboxSubGroups = <T extends {}>(
               props.onAllChange(event, checked, groupOptions);
             }
 
-            onAllChange(fieldArrayProps, groupOptions)(event, checked);
+            handleAllChange(fieldArrayProps, groupOptions)(event, checked);
           }}
           onChange={(event, option) => {
             if (props.onChange) {
               props.onChange(event, option);
             }
 
-            onChange(fieldArrayProps)(event);
+            handleChange(fieldArrayProps)(event);
           }}
         />
       )}

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSubGroups.tsx
@@ -20,12 +20,12 @@ const FormFieldCheckboxSubGroups = <T extends {}>(
           {...props}
           {...fieldArrayProps}
           small
-          onAllChange={(event, options) => {
+          onAllChange={(event, checked, groupOptions) => {
             if (props.onAllChange) {
-              props.onAllChange(event, options);
+              props.onAllChange(event, checked, groupOptions);
             }
 
-            onAllChange(fieldArrayProps, options)(event);
+            onAllChange(fieldArrayProps, groupOptions)(event, checked);
           }}
           onChange={(event, option) => {
             if (props.onChange) {

--- a/src/explore-education-statistics-common/src/components/form/FormRadio.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormRadio.tsx
@@ -1,7 +1,12 @@
 import classNames from 'classnames';
-import React, { ChangeEventHandler, memo, ReactNode } from 'react';
+import React, { ChangeEvent, memo, ReactNode } from 'react';
 
-export type RadioChangeEventHandler = ChangeEventHandler<HTMLInputElement>;
+export type OtherRadioChangeProps = Pick<FormRadioProps, 'label'>;
+
+export type RadioChangeEventHandler = (
+  event: ChangeEvent<HTMLInputElement>,
+  radioProps: OtherRadioChangeProps,
+) => void;
 
 export interface FormRadioProps {
   checked?: boolean;
@@ -37,7 +42,11 @@ const FormRadio = ({
           defaultChecked={defaultChecked}
           id={id}
           name={name}
-          onChange={onChange}
+          onChange={event => {
+            if (onChange) {
+              onChange(event, { label });
+            }
+          }}
           type="radio"
           value={value}
           data-testid={label}

--- a/src/explore-education-statistics-common/src/components/form/FormRadioGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormRadioGroup.tsx
@@ -2,8 +2,7 @@ import { OmitStrict, PartialBy } from '@common/types/util';
 import classNames from 'classnames';
 import kebabCase from 'lodash/kebabCase';
 import orderBy from 'lodash/orderBy';
-import memoize from 'memoizee';
-import React, { ChangeEvent, createRef, PureComponent } from 'react';
+import React, { createRef, PureComponent } from 'react';
 import FormFieldset, { FormFieldsetProps } from './FormFieldset';
 import FormRadio, {
   FormRadioProps,
@@ -15,15 +14,10 @@ type RadioOption = PartialBy<
   'id'
 >;
 
-export type RadioGroupChangeEventHandler = (
-  event: ChangeEvent<HTMLInputElement>,
-  option: RadioOption,
-) => void;
-
 export type FormRadioGroupProps = {
   inline?: boolean;
   name: string;
-  onChange?: RadioGroupChangeEventHandler;
+  onChange?: RadioChangeEventHandler;
   options: RadioOption[];
   small?: boolean;
   order?:
@@ -45,20 +39,6 @@ class FormRadioGroup extends PureComponent<FormRadioGroupProps> {
 
   private ref = createRef<HTMLInputElement>();
 
-  private handleChange = memoize(
-    (option: RadioOption): RadioChangeEventHandler => event => {
-      const { onChange } = this.props;
-
-      if (onChange) {
-        onChange(event, option);
-      }
-    },
-    {
-      normalizer: ([option]: [RadioOption]) =>
-        `${option.value}-${option.label}-${option.id}`,
-    },
-  );
-
   public componentDidMount(): void {
     if (this.ref.current) {
       import('govuk-frontend/components/radios/radios').then(
@@ -68,6 +48,14 @@ class FormRadioGroup extends PureComponent<FormRadioGroupProps> {
       );
     }
   }
+
+  private handleChange: RadioChangeEventHandler = (event, option) => {
+    const { onChange } = this.props;
+
+    if (onChange) {
+      onChange(event, option);
+    }
+  };
 
   public render() {
     const {
@@ -97,7 +85,7 @@ class FormRadioGroup extends PureComponent<FormRadioGroupProps> {
               checked={value === option.value}
               key={option.value}
               name={name}
-              onChange={this.handleChange(option)}
+              onChange={this.handleChange}
             />
           ))}
         </div>

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSearchSubGroups.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSearchSubGroups.test.tsx
@@ -136,11 +136,13 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
     const checkbox3 = getByLabelText('Checkbox 3') as HTMLInputElement;
     const checkbox4 = getByLabelText('Checkbox 4') as HTMLInputElement;
+    const checkbox5 = getByLabelText('Checkbox 5') as HTMLInputElement;
 
     expect(checkbox1.checked).toBe(false);
     expect(checkbox2.checked).toBe(false);
     expect(checkbox3.checked).toBe(false);
     expect(checkbox4.checked).toBe(false);
+    expect(checkbox5.checked).toBe(false);
 
     fireEvent.click(getByText('Select all 2 options'));
 
@@ -148,6 +150,64 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(false);
     expect(checkbox4.checked).toBe(false);
+    expect(checkbox5.checked).toBe(false);
+  });
+
+  test('clicking all `Select all` buttons checks all values for every group', () => {
+    const { getByLabelText, getByText } = render(
+      <Formik
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={() => null}
+        render={() => (
+          <FormFieldCheckboxSearchSubGroups<FormValues>
+            name="test"
+            id="checkboxes"
+            legend="Test checkboxes"
+            options={[
+              {
+                legend: 'Group A',
+                options: [
+                  { value: '1', label: 'Checkbox 1' },
+                  { value: '2', label: 'Checkbox 2' },
+                  { value: '3', label: 'Checkbox 3' },
+                ],
+              },
+              {
+                legend: 'Group B',
+                options: [
+                  { value: '4', label: 'Checkbox 4' },
+                  { value: '5', label: 'Checkbox 5' },
+                ],
+              },
+            ]}
+            selectAll
+          />
+        )}
+      />,
+    );
+
+    const checkbox1 = getByLabelText('Checkbox 1') as HTMLInputElement;
+    const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
+    const checkbox3 = getByLabelText('Checkbox 3') as HTMLInputElement;
+    const checkbox4 = getByLabelText('Checkbox 4') as HTMLInputElement;
+    const checkbox5 = getByLabelText('Checkbox 5') as HTMLInputElement;
+
+    expect(checkbox1.checked).toBe(false);
+    expect(checkbox2.checked).toBe(false);
+    expect(checkbox3.checked).toBe(false);
+    expect(checkbox4.checked).toBe(false);
+    expect(checkbox5.checked).toBe(false);
+
+    fireEvent.click(getByText('Select all 3 options'));
+    fireEvent.click(getByText('Select all 2 options'));
+
+    expect(checkbox1.checked).toBe(true);
+    expect(checkbox2.checked).toBe(true);
+    expect(checkbox3.checked).toBe(true);
+    expect(checkbox4.checked).toBe(true);
+    expect(checkbox5.checked).toBe(true);
   });
 
   test('clicking `Unselect all` option un-checks all values for that group', () => {

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSubGroups.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSubGroups.test.tsx
@@ -153,6 +153,63 @@ describe('FormFieldCheckboxSubGroups', () => {
     expect(checkbox5.checked).toBe(false);
   });
 
+  test('clicking all `Select all` buttons checks all values for every group', () => {
+    const { getByLabelText, getByText } = render(
+      <Formik
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={() => null}
+        render={() => (
+          <FormFieldCheckboxSubGroups<FormValues>
+            name="test"
+            id="checkboxes"
+            legend="Test checkboxes"
+            options={[
+              {
+                legend: 'Group A',
+                options: [
+                  { value: '1', label: 'Checkbox 1' },
+                  { value: '2', label: 'Checkbox 2' },
+                  { value: '3', label: 'Checkbox 3' },
+                ],
+              },
+              {
+                legend: 'Group B',
+                options: [
+                  { value: '4', label: 'Checkbox 4' },
+                  { value: '5', label: 'Checkbox 5' },
+                ],
+              },
+            ]}
+            selectAll
+          />
+        )}
+      />,
+    );
+
+    const checkbox1 = getByLabelText('Checkbox 1') as HTMLInputElement;
+    const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
+    const checkbox3 = getByLabelText('Checkbox 3') as HTMLInputElement;
+    const checkbox4 = getByLabelText('Checkbox 4') as HTMLInputElement;
+    const checkbox5 = getByLabelText('Checkbox 5') as HTMLInputElement;
+
+    expect(checkbox1.checked).toBe(false);
+    expect(checkbox2.checked).toBe(false);
+    expect(checkbox3.checked).toBe(false);
+    expect(checkbox4.checked).toBe(false);
+    expect(checkbox5.checked).toBe(false);
+
+    fireEvent.click(getByText('Select all 3 options'));
+    fireEvent.click(getByText('Select all 2 options'));
+
+    expect(checkbox1.checked).toBe(true);
+    expect(checkbox2.checked).toBe(true);
+    expect(checkbox3.checked).toBe(true);
+    expect(checkbox4.checked).toBe(true);
+    expect(checkbox5.checked).toBe(true);
+  });
+
   test('clicking `Unselect all 2 options` button un-checks all values for that group', () => {
     const { getByLabelText, getByText } = render(
       <Formik

--- a/src/explore-education-statistics-common/src/components/form/util/checkboxGroupFieldHelpers.ts
+++ b/src/explore-education-statistics-common/src/components/form/util/checkboxGroupFieldHelpers.ts
@@ -3,15 +3,15 @@ import difference from 'lodash/difference';
 import get from 'lodash/get';
 import { ChangeEvent } from 'react';
 import {
-  CheckboxGroupAllChangeEvent,
+  CheckboxGroupAllChangeEventHandler,
   CheckboxOption,
 } from '../FormCheckboxGroup';
 
 export const onAllChange = (
   { form, name }: FieldArrayRenderProps,
   options: CheckboxOption[],
-) => {
-  return (event: CheckboxGroupAllChangeEvent) => {
+): CheckboxGroupAllChangeEventHandler => {
+  return (event, checked) => {
     if (event.isDefaultPrevented()) {
       return;
     }
@@ -21,7 +21,7 @@ export const onAllChange = (
     const allOptionValues = options.map(option => option.value);
     const restValues = difference(currentValues, allOptionValues);
 
-    if (currentValues.length < allOptionValues.length) {
+    if (!checked) {
       form.setFieldValue(name, [...restValues, ...allOptionValues]);
     } else {
       form.setFieldValue(name, restValues);

--- a/src/explore-education-statistics-common/src/components/form/util/checkboxGroupFieldHelpers.ts
+++ b/src/explore-education-statistics-common/src/components/form/util/checkboxGroupFieldHelpers.ts
@@ -7,7 +7,7 @@ import {
   CheckboxOption,
 } from '../FormCheckboxGroup';
 
-export const onAllChange = (
+export const handleAllChange = (
   { form, name }: FieldArrayRenderProps,
   options: CheckboxOption[],
 ): CheckboxGroupAllChangeEventHandler => {
@@ -29,7 +29,11 @@ export const onAllChange = (
   };
 };
 
-export const onChange = ({ form, name, ...helpers }: FieldArrayRenderProps) => {
+export const handleChange = ({
+  form,
+  name,
+  ...helpers
+}: FieldArrayRenderProps) => {
   return (event: ChangeEvent<HTMLInputElement>) => {
     if (event.isDefaultPrevented()) {
       return;

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/FormFieldCheckboxGroupsMenu.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/FormFieldCheckboxGroupsMenu.tsx
@@ -27,9 +27,9 @@ const FormFieldCheckboxGroupsMenu = <T extends {}>(
         legendHidden
         selectAll
         options={options[0].options}
-        onAllChange={event => {
+        onAllChange={(event, checked) => {
           if (onAllChange) {
-            onAllChange(event, options[0].options);
+            onAllChange(event, checked, options[0].options);
           }
         }}
       />
@@ -40,6 +40,11 @@ const FormFieldCheckboxGroupsMenu = <T extends {}>(
         small
         name={name}
         options={options[0].options}
+        onAllChange={(event, checked) => {
+          if (onAllChange) {
+            onAllChange(event, checked, options[0].options);
+          }
+        }}
       />
     );
   };

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -133,17 +133,21 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
                               draft[levelKey] = [];
                             }
 
+                            const { value } = event.target;
+
                             const matchingOption = draft[levelKey].find(
-                              levelOption => levelOption.value === option.value,
+                              levelOption => levelOption.value === value,
                             );
 
                             if (matchingOption) {
                               draft[levelKey] = draft[levelKey].filter(
-                                levelOption =>
-                                  levelOption.value !== option.value,
+                                levelOption => levelOption.value !== value,
                               );
                             } else {
-                              draft[levelKey].push(option);
+                              draft[levelKey].push({
+                                value,
+                                label: option.label,
+                              });
                             }
                           });
                         }}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__snapshots__/FormFieldCheckboxGroupsMenu.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__snapshots__/FormFieldCheckboxGroupsMenu.test.tsx.snap
@@ -168,10 +168,7 @@ exports[`FormFieldCheckboxGroupsMenu renders single checkbox group with search i
         id="test-all"
         type="button"
       >
-        Select
-         all 
-        2
-         options
+        Select all 2 options
       </button>
       <div
         class="govuk-checkboxes__item"


### PR DESCRIPTION
This PR fixes the 'Select all' button for checkbox sub-groups in `FormCheckboxSubGroups` not working when another sub-group with more options has already had all of their options selected.

As part of these changes, this has involved:

- Passing a `checked` parameter through to the `FormCheckboxGroup.onAllChange` handler. This fixes the bulk of the issue.
- Refactoring `FormCheckbox.onChange` to avoid having to memoize the parent's `onChange` handler (see `FormCheckboxGroup`). As part of this, we no longer provide the original `CheckboxOption` as a parameter, but this shouldn't be an issue as we weren't really using it anyway.