### PR TITLE
DFE-882 Fix excessive screen jumping due to form validation and ErrorSummary

### DIFF
--- a/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
+++ b/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
@@ -17,6 +17,14 @@ const ErrorSummary = ({ id, errors, title = 'There is a problem' }: Props) => {
   const [prevErrors, setPrevErrors] = useState<ErrorSummaryMessage[]>([]);
 
   useEffect(() => {
+    import('govuk-frontend/components/error-summary/error-summary').then(
+      ({ default: GovUkErrorSummary }) => {
+        new GovUkErrorSummary(ref.current).init();
+      },
+    );
+  }, [ref]);
+
+  useEffect(() => {
     if (errors.length > 0 && !prevErrors.length && ref.current) {
       ref.current.scrollIntoView({
         behavior: 'smooth',
@@ -27,14 +35,6 @@ const ErrorSummary = ({ id, errors, title = 'There is a problem' }: Props) => {
 
     setPrevErrors(errors);
   }, [errors, prevErrors]);
-
-  useEffect(() => {
-    import('govuk-frontend/components/error-summary/error-summary').then(
-      ({ default: GovUkErrorSummary }) => {
-        new GovUkErrorSummary(ref.current).init();
-      },
-    );
-  }, [ref]);
 
   const idTitle = `${id}-title`;
 

--- a/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
+++ b/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
@@ -8,13 +8,20 @@ export interface ErrorSummaryMessage {
 interface Props {
   errors: ErrorSummaryMessage[];
   id: string;
+  focusOnError?: boolean;
   title?: string;
 }
 
-const ErrorSummary = ({ id, errors, title = 'There is a problem' }: Props) => {
+const ErrorSummary = ({
+  id,
+  errors,
+  focusOnError = false,
+  title = 'There is a problem',
+}: Props) => {
   const ref = useRef<HTMLDivElement>(null);
 
-  const [prevErrors, setPrevErrors] = useState<ErrorSummaryMessage[]>([]);
+  // Only
+  const [prevErrors, setPrevErrors] = useState(0);
 
   useEffect(() => {
     import('govuk-frontend/components/error-summary/error-summary').then(
@@ -25,16 +32,19 @@ const ErrorSummary = ({ id, errors, title = 'There is a problem' }: Props) => {
   }, [ref]);
 
   useEffect(() => {
-    if (errors.length > 0 && !prevErrors.length && ref.current) {
-      ref.current.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      });
-      ref.current.focus();
+    if (errors.length > 0 && !prevErrors && ref.current) {
+      if (focusOnError) {
+        ref.current.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+
+        ref.current.focus();
+      }
     }
 
-    setPrevErrors(errors);
-  }, [errors, prevErrors]);
+    setPrevErrors(errors.length);
+  }, [errors, prevErrors, focusOnError]);
 
   const idTitle = `${id}-title`;
 

--- a/src/explore-education-statistics-common/src/components/__tests__/ErrorSummary.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ErrorSummary.test.tsx
@@ -20,7 +20,7 @@ describe('ErrorSummary', () => {
     expect(container.innerHTML).toMatchSnapshot();
   });
 
-  test('gains focus and scrolls into view when there are errors', () => {
+  test('does not gain focus or scroll into view when there are errors by default', () => {
     const { container } = render(
       <ErrorSummary
         id="test-errors"
@@ -35,14 +35,35 @@ describe('ErrorSummary', () => {
       '.govuk-error-summary',
     ) as HTMLElement;
 
+    expect(summary).not.toHaveFocus();
+    expect(summary).not.toHaveScrolledIntoView();
+  });
+
+  test('gains focus and scrolls into view when there are errors and `focusOnError` is true', () => {
+    const { container } = render(
+      <ErrorSummary
+        id="test-errors"
+        focusOnError
+        errors={[
+          { id: 'test-error-1', message: 'Something went wrong 1' },
+          { id: 'test-error-2', message: 'Something went wrong 2' },
+        ]}
+      />,
+    );
+
+    const summary = container.querySelector(
+      '.govuk-error-summary',
+    ) as HTMLElement;
+
     expect(summary).toHaveFocus();
-    expect(summary.scrollIntoView).toHaveBeenCalled();
+    expect(summary).toHaveScrolledIntoView();
   });
 
   test('re-rendering with new errors does not gain focus or scroll into view', () => {
     const { container, getByText, rerender } = render(
       <ErrorSummary
         id="test-errors"
+        focusOnError
         errors={[
           { id: 'test-error-1', message: 'Something went wrong 1' },
           { id: 'test-error-2', message: 'Something went wrong 2' },

--- a/src/explore-education-statistics-common/src/components/form/FieldCheckboxArray.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FieldCheckboxArray.tsx
@@ -1,5 +1,10 @@
 import createErrorHelper from '@common/lib/validation/createErrorHelper';
-import { FieldArray, FieldArrayRenderProps } from 'formik';
+import {
+  connect,
+  FieldArray,
+  FieldArrayRenderProps,
+  FormikContext,
+} from 'formik';
 import get from 'lodash/get';
 import React, { ReactNode } from 'react';
 
@@ -13,16 +18,22 @@ interface FieldCheckboxArrayProps<FormValues> {
   error?: string;
   name: string;
   showError?: boolean;
+  validateOnChange?: boolean;
 }
 
 const FieldCheckboxArray = <T extends {}>({
   children,
   error,
   name,
+  formik,
   showError = true,
-}: FieldCheckboxArrayProps<T>) => {
+  validateOnChange = false,
+}: FieldCheckboxArrayProps<T> & { formik: FormikContext<T> }) => {
   return (
-    <FieldArray name={name}>
+    <FieldArray
+      name={name}
+      validateOnChange={validateOnChange || formik.validateOnChange}
+    >
       {({ form, ...arrayHelpers }) => {
         const { getError } = createErrorHelper(form);
 
@@ -46,4 +57,4 @@ const FieldCheckboxArray = <T extends {}>({
   );
 };
 
-export default FieldCheckboxArray;
+export default connect<FieldCheckboxArrayProps<{}>>(FieldCheckboxArray);

--- a/src/explore-education-statistics-common/src/components/form/Form.tsx
+++ b/src/explore-education-statistics-common/src/components/form/Form.tsx
@@ -43,6 +43,7 @@ const Form = ({
     touched,
   });
 
+  const [submitted, setSubmitted] = useState(false);
   const [submitError, setSubmitError] = useState<ErrorSummaryMessage>();
 
   const summaryErrors: ErrorSummaryMessage[] = Object.entries(getAllErrors())
@@ -61,6 +62,7 @@ const Form = ({
       id={id}
       onReset={formik.handleReset}
       onSubmit={async event => {
+        setSubmitted(true);
         setSubmitError(undefined);
         event.preventDefault();
 
@@ -76,7 +78,11 @@ const Form = ({
         }
       }}
     >
-      <ErrorSummary errors={allErrors} id={`${id}-summary`} />
+      <ErrorSummary
+        errors={allErrors}
+        id={`${id}-summary`}
+        focusOnError={submitted}
+      />
 
       {children}
     </form>

--- a/src/explore-education-statistics-common/src/components/form/Form.tsx
+++ b/src/explore-education-statistics-common/src/components/form/Form.tsx
@@ -5,7 +5,7 @@ import createErrorHelper from '@common/lib/validation/createErrorHelper';
 import { connect, FormikContext } from 'formik';
 import camelCase from 'lodash/camelCase';
 import get from 'lodash/get';
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 
 interface Props {
   children: ReactNode;
@@ -46,6 +46,12 @@ const Form = ({
   const [submitted, setSubmitted] = useState(false);
   const [submitError, setSubmitError] = useState<ErrorSummaryMessage>();
 
+  useEffect(() => {
+    if (!formik.submitCount) {
+      setSubmitError(undefined);
+    }
+  }, [submitError, formik.submitCount]);
+
   const summaryErrors: ErrorSummaryMessage[] = Object.entries(getAllErrors())
     .filter(([errorName]) => get(touched, errorName))
     .map(([errorName, message]) => ({
@@ -60,7 +66,6 @@ const Form = ({
   return (
     <form
       id={id}
-      onReset={formik.handleReset}
       onSubmit={async event => {
         setSubmitted(true);
         setSubmitError(undefined);

--- a/src/explore-education-statistics-common/src/components/form/__tests__/Form.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/Form.test.tsx
@@ -247,4 +247,50 @@ describe('Form', () => {
 
     expect(queryByText('Something went wrong')).toBeNull();
   });
+
+  test('removes submit error when form is reset', async () => {
+    const onSubmit = jest.fn(() => {
+      throw new Error('Something went wrong');
+    });
+
+    const { container, queryByText, getByText } = render(
+      <Formik
+        initialValues={{
+          firstName: 'Firstname',
+        }}
+        validationSchema={Yup.object({
+          firstName: Yup.string().required(),
+        })}
+        onSubmit={onSubmit}
+      >
+        {formik => (
+          <Form id="test-form">
+            The form
+            <button type="button" onClick={formik.handleReset}>
+              Reset form
+            </button>
+          </Form>
+        )}
+      </Formik>,
+    );
+
+    const form = container.querySelector('#test-form') as HTMLFormElement;
+
+    fireEvent.submit(form, {
+      current: form,
+      target: form,
+    });
+
+    await wait();
+
+    expect(queryByText('Something went wrong')).not.toBeNull();
+
+    onSubmit.mockImplementation();
+
+    fireEvent.click(getByText('Reset form'));
+
+    await wait();
+
+    expect(queryByText('Something went wrong')).toBeNull();
+  });
 });


### PR DESCRIPTION
This PR fixes the excessive screen jumping that would occur due to the `ErrorSummary` grabbing the user's focus when there is a validation error. 

To fix this, we have introduced a `focusOnError` prop that toggles `ErrorSummary`s focusing behaviour and combined this with our `Form` implementation so that `focusOnError` is not true until the form has been submitted at least once.

## Other changes

- When the form is reset e.g. from moving back steps in table tool's wizard, all errors are now cleared. This includes submission errors that result from things like API calls failing.