### PR TITLE
IE11 Frontend: Visiting anchor tag directly leads to grey screen

### DIFF
--- a/src/explore-education-statistics-common/src/polyfill.js
+++ b/src/explore-education-statistics-common/src/polyfill.js
@@ -42,13 +42,13 @@ if (!Element.prototype.matches) {
 }
 
 if (!Element.prototype.closest) {
-  Element.prototype.closest = s => {
+  Element.prototype.closest = function closest(s) {
     let el = this;
 
     do {
       if (el.matches(s)) return el;
       el = el.parentElement || el.parentNode;
-    } while (el !== null && el.nodeType === 1);
+    } while (el !== null && el !== undefined && el.nodeType === 1);
     return null;
   };
 }


### PR DESCRIPTION
I've removed an arrow function that caused 'this' to be undefined - breaking the page