### PR TITLE
DFE-1054 Fix meta query request not having correct location shape

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -155,11 +155,13 @@ class TableToolPage extends Component<Props, State> {
     });
   };
 
-  private handleLocationFiltersFormSubmit: LocationFiltersFormSubmitHandler = async values => {
+  private handleLocationFiltersFormSubmit: LocationFiltersFormSubmitHandler = async ({
+    locations,
+  }) => {
     const { subjectId } = this.state;
 
     const subjectMeta = await tableBuilderService.filterPublicationSubjectMeta({
-      ...values,
+      ...locations,
       subjectId,
     });
 
@@ -169,11 +171,11 @@ class TableToolPage extends Component<Props, State> {
         timePeriod: subjectMeta.timePeriod,
       },
       locations: mapValuesWithKeys(
-        values.locations,
-        (locationLevel, locations) =>
-          locations
+        locations,
+        (locationLevel, locationOptions) =>
+          locationOptions
             .map(location =>
-              subjectMeta.locations[locationLevel].options.find(
+              prevState.subjectMeta.locations[locationLevel].options.find(
                 option => option.value === location,
               ),
             )


### PR DESCRIPTION
This PR fixes the `filterPublicationSubjectMeta` query not having the correct structure due to the chosen location options not being spread correctly into the query parameter.