### PR TITLE
DFE-1145: add workaround for admin sign-in to react dashboard

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/SigninController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/SigninController.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers
+{
+    [Authorize]
+    [ApiExplorerSettings(IgnoreApi=true)]
+    public class SigninController : Controller
+    {
+        // GET
+        public IActionResult Index()
+        {
+            return Redirect("/admin-dashboard");
+        }
+    }
+}

--- a/src/explore-education-statistics-admin/src/pages/sign-in/SignInPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/sign-in/SignInPage.tsx
@@ -13,12 +13,9 @@ const SignInPage = () => {
         Use this service to publish official Department for Education (DfE)
         statistics and data for state-funded schools in England.
       </p>
-      <ButtonLink
-        to="/tools/azuread/account/signin"
-        className="govuk-button--start"
-      >
+      <a href="/api/signin" className="govuk-button govuk-button--start">
         Sign-in
-      </ButtonLink>
+      </a>
     </Page>
   );
 };

--- a/src/explore-education-statistics-admin/src/pages/sign-in/SignInPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/sign-in/SignInPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Page from '@admin/components/Page';
-import ButtonLink from '@admin/components/ButtonLink';
 
 const SignInPage = () => {
   return (


### PR DESCRIPTION
This PR adds a temp workaround to sign-in and redirect back to the react application.

This can be used until the full authentication process is implemented as a means of returning to the react app as the current sign-in process is built around as server side model.