### PR TITLE
DFE-1135 Meta data is calculated from matching observations. The obse…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Models/Query/SubjectMetaQueryContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Models/Query/SubjectMetaQueryContext.cs
@@ -34,7 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Models.Query
         {
             var predicate = PredicateBuilder.True<Observation>()
                 .And(observation => observation.SubjectId == SubjectId);
-            
+
             if (TimePeriod != null)
             {
                 // Don't use the observation.GetTimePeriod() extension in the expression here as it can't be translated
@@ -47,87 +47,196 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Models.Query
                 predicate = predicate.And(observation => observation.GeographicLevel == GeographicLevel);
             }
 
-            if (Country != null && Country.Any())
+            if (ObservationalUnitExists())
             {
-                predicate = predicate.And(observation =>
-                    Country.Contains(observation.Location.Country.Code));
-            }
-
-            if (Institution != null && Institution.Any())
-            {
-                predicate = predicate.And(observation =>
-                    Institution.Contains(observation.Location.Institution.Code));
-            }
-
-            if (LocalAuthority != null && LocalAuthority.Any())
-            {
-                predicate = predicate.And(observation =>
-                    LocalAuthority.Contains(observation.Location.LocalAuthority.Code));
-            }
-
-            if (LocalAuthorityDistrict != null && LocalAuthorityDistrict.Any())
-            {
-                predicate = predicate.And(observation =>
-                    LocalAuthorityDistrict.Contains(observation.Location.LocalAuthorityDistrict.Code));
-            }
-
-            if (LocalEnterprisePartnership != null && LocalEnterprisePartnership.Any())
-            {
-                predicate = predicate.And(observation =>
-                    LocalEnterprisePartnership.Contains(observation.Location.LocalEnterprisePartnership.Code));
-            }
-
-            if (MultiAcademyTrust != null && MultiAcademyTrust.Any())
-            {
-                predicate = predicate.And(observation =>
-                    MultiAcademyTrust.Contains(observation.Location.MultiAcademyTrust.Code));
-            }
-
-            if (MayoralCombinedAuthority != null && MayoralCombinedAuthority.Any())
-            {
-                predicate = predicate.And(observation =>
-                    MayoralCombinedAuthority.Contains(observation.Location.MayoralCombinedAuthority.Code));
-            }
-
-            if (OpportunityArea != null && OpportunityArea.Any())
-            {
-                predicate = predicate.And(observation =>
-                    OpportunityArea.Contains(observation.Location.OpportunityArea.Code));
-            }
-
-            if (ParliamentaryConstituency != null && ParliamentaryConstituency.Any())
-            {
-                predicate = predicate.And(observation =>
-                    ParliamentaryConstituency.Contains(observation.Location.ParliamentaryConstituency.Code));
-            }
-
-            if (Region != null && Region.Any())
-            {
-                predicate = predicate.And(observation =>
-                    Region.Contains(observation.Location.Region.Code));
-            }
-
-            if (RscRegion != null && RscRegion.Any())
-            {
-                predicate = predicate.And(observation =>
-                    RscRegion.Contains(observation.Location.RscRegion.Code));
-            }
-
-            if (Sponsor != null && Sponsor.Any())
-            {
-                predicate = predicate.And(observation =>
-                    Sponsor.Contains(observation.Location.Sponsor.Code));
-            }
-
-            if (Ward != null && Ward.Any())
-            {
-                predicate = predicate.And(observation =>
-                    Ward.Contains(observation.Location.Ward.Code));
+                predicate = predicate.And(ObservationalUnitsPredicate());
             }
 
             return predicate;
         }
-        
+
+        private Expression<Func<Observation, bool>> ObservationalUnitsPredicate()
+        {
+            var predicate = PredicateBuilder.False<Observation>();
+
+            if (Country != null)
+            {
+                predicate = predicate.Or(CountryPredicate());
+            }
+
+            if (Institution != null)
+            {
+                predicate = predicate.Or(InstitutionPredicate());
+            }
+
+            if (LocalAuthority != null)
+            {
+                predicate = predicate.Or(LocalAuthorityPredicate());
+            }
+
+            if (LocalAuthorityDistrict != null)
+            {
+                predicate = predicate.Or(LocalAuthorityDistrictPredicate());
+            }
+
+            if (LocalEnterprisePartnership != null)
+            {
+                predicate = predicate.Or(LocalEnterprisePartnershipPredicate());
+            }
+
+            if (MayoralCombinedAuthority != null)
+            {
+                predicate = predicate.Or(MayoralCombinedAuthorityPredicate());
+            }
+
+            if (MultiAcademyTrust != null)
+            {
+                predicate = predicate.Or(MultiAcademyTrustPredicate());
+            }
+
+            if (OpportunityArea != null)
+            {
+                predicate = predicate.Or(OpportunityAreaPredicate());
+            }
+
+            if (ParliamentaryConstituency != null)
+            {
+                predicate = predicate.Or(ParliamentaryConstituencyPredicate());
+            }
+
+            if (Region != null)
+            {
+                predicate = predicate.Or(RegionPredicate());
+            }
+
+            if (RscRegion != null)
+            {
+                predicate = predicate.Or(RscRegionPredicate());
+            }
+
+            if (Sponsor != null)
+            {
+                predicate = predicate.Or(SponsorPredicate());
+            }
+
+            if (Ward != null)
+            {
+                predicate = predicate.Or(WardPredicate());
+            }
+
+            return predicate;
+        }
+
+        private bool ObservationalUnitExists()
+        {
+            return !(Country == null &&
+                     Institution == null &&
+                     LocalAuthority == null &&
+                     LocalAuthorityDistrict == null &&
+                     LocalEnterprisePartnership == null &&
+                     MultiAcademyTrust == null &&
+                     MayoralCombinedAuthority == null &&
+                     OpportunityArea == null &&
+                     ParliamentaryConstituency == null &&
+                     Region == null &&
+                     RscRegion == null &&
+                     Sponsor == null &&
+                     Ward == null);
+        }
+
+        private Expression<Func<Observation, bool>> CountryPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.Country,
+                observation => Country.Contains(observation.Location.Country.Code));
+        }
+
+        private Expression<Func<Observation, bool>> InstitutionPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.Institution,
+                observation => Institution.Contains(observation.Location.Institution.Code));
+        }
+
+        private Expression<Func<Observation, bool>> LocalAuthorityPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.Local_Authority,
+                observation => LocalAuthority.Contains(observation.Location.LocalAuthority.Code));
+        }
+
+        private Expression<Func<Observation, bool>> LocalAuthorityDistrictPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.Local_Authority_District,
+                observation => LocalAuthorityDistrict.Contains(observation.Location.LocalAuthorityDistrict.Code));
+        }
+
+        private Expression<Func<Observation, bool>> LocalEnterprisePartnershipPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.Local_Enterprise_Partnership,
+                observation =>
+                    LocalEnterprisePartnership.Contains(observation.Location.LocalEnterprisePartnership.Code));
+        }
+
+        private Expression<Func<Observation, bool>> MayoralCombinedAuthorityPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.Mayoral_Combined_Authority,
+                observation => MayoralCombinedAuthority.Contains(observation.Location.MayoralCombinedAuthority.Code));
+        }
+
+        private Expression<Func<Observation, bool>> MultiAcademyTrustPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.Multi_Academy_Trust,
+                observation => MultiAcademyTrust.Contains(observation.Location.MultiAcademyTrust.Code));
+        }
+
+        private Expression<Func<Observation, bool>> OpportunityAreaPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.Opportunity_Area,
+                observation => OpportunityArea.Contains(observation.Location.OpportunityArea.Code));
+        }
+
+        private Expression<Func<Observation, bool>> ParliamentaryConstituencyPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.Parliamentary_Constituency,
+                observation => ParliamentaryConstituency.Contains(observation.Location.ParliamentaryConstituency.Code));
+        }
+
+        private Expression<Func<Observation, bool>> RegionPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.Region,
+                observation => Region.Contains(observation.Location.Region.Code));
+        }
+
+        private Expression<Func<Observation, bool>> RscRegionPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.RSC_Region,
+                observation => RscRegion.Contains(observation.Location.RscRegion.Code));
+        }
+
+        private Expression<Func<Observation, bool>> SponsorPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.Sponsor,
+                observation => Sponsor.Contains(observation.Location.Sponsor.Code));
+        }
+
+        private Expression<Func<Observation, bool>> WardPredicate()
+        {
+            return ObservationalUnitPredicate(Model.GeographicLevel.Ward,
+                observation => Ward.Contains(observation.Location.Ward.Code));
+        }
+
+        private Expression<Func<Observation, bool>> ObservationalUnitPredicate(
+            GeographicLevel geographicLevel, Expression<Func<Observation, bool>> expression)
+        {
+            var predicate = PredicateBuilder.True<Observation>()
+                .And(expression);
+
+            if (GeographicLevel == null)
+            {
+                predicate = predicate.And(observation => observation.GeographicLevel.Equals(geographicLevel));
+            }
+
+            return predicate;
+        }
+
         private static IEnumerable<string> GetTimePeriodRange(TimePeriodQuery timePeriod)
         {
             if (timePeriod.StartCode.IsNumberOfTerms() || timePeriod.EndCode.IsNumberOfTerms())

--- a/tests/newman/tests/data-api.json
+++ b/tests/newman/tests/data-api.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "37cd712d-51f6-4bfd-ac63-ae39bb18e25c",
+		"_postman_id": "1931315c-617e-4071-bc24-64c0d944c6a8",
 		"name": "DfE Data API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -2018,7 +2018,6 @@
 													"    pm.expect(pm.response.to.have.jsonBody(\"locations\"));",
 													"    pm.expect(pm.response.to.have.jsonBody(\"locations.country\"));",
 													"    pm.expect(pm.response.to.have.jsonBody(\"locations.region\"));",
-													"    pm.expect(pm.response.to.have.jsonBody(\"locations.localAuthority\"));",
 													"    pm.expect(pm.response.to.have.jsonBody(\"timePeriod\"));",
 													"    pm.expect(pm.response.to.have.jsonBody(\"timePeriod.hint\"));",
 													"    pm.expect(pm.response.to.have.jsonBody(\"timePeriod.legend\"));",
@@ -2026,8 +2025,8 @@
 													"});",
 													"",
 													"pm.test(\"Number of YearOfAdmission options should be correct\", function () { ",
-													"    pm.expect(pm.response.json().filters.YearOfAdmission.options.Primary.options.length).to.equal(2);",
-													"    pm.expect(pm.response.json().filters.YearOfAdmission.options.Secondary.options.length).to.equal(2);",
+													"    pm.expect(pm.response.json().filters.YearOfAdmission.options.Primary.options.length).to.equal(1);",
+													"    pm.expect(pm.response.json().filters.YearOfAdmission.options.Secondary.options.length).to.equal(1);",
 													"});",
 													"",
 													"pm.test(\"Time periods options should be correct\", function() {",
@@ -2037,7 +2036,6 @@
 													"pm.test(\"Number of location options should be correct\", function() {",
 													"    pm.expect(pm.response.json().locations.country.options.length).to.equal(1);",
 													"    pm.expect(pm.response.json().locations.region.options.length).to.equal(2);",
-													"    pm.expect(pm.response.json().locations.localAuthority.options.length).to.equal(34);",
 													"});",
 													"",
 													"pm.test(\"Expect correct number of indicator categories\", function () {",


### PR DESCRIPTION
…rvation predicate used for this has been updated so that any of the observational units supplied can match but where they do they must be matched by GeographicLevel. For example, an observation is matched by region code if the GeographicLevel is regional unless the GeographicLevel is overriden.