### PR TITLE
Disable adding message to queue once file uploaded in admin

### DIFF
--- a/armTemplates/ees-service/template.json
+++ b/armTemplates/ees-service/template.json
@@ -270,7 +270,7 @@
             {
               "name": "StatisticsDb",
               "type": "SQLAzure",
-              "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('sqlserverName'))).fullyQualifiedDomainName, ',1433;Initial Catalog=', 'statistics', ';User Id=', parameters('sqlAdministratorLogin'), '@', reference(concat('Microsoft.Sql/servers/', variables('sqlserverName'))).fullyQualifiedDomainName, ';Password=', parameters('sqlAdministratorLoginPassword'), ';')]"
+              "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('publicSqlServerName'))).fullyQualifiedDomainName, ',1433;Initial Catalog=', 'public-statistics', ';User Id=', parameters('sqlAdministratorLogin'), '@', reference(concat('Microsoft.Sql/servers/', variables('publicSqlServerName'))).fullyQualifiedDomainName, ';Password=', parameters('sqlAdministratorLoginPassword'), ';')]"
             },
             {
               "name": "PublicStorage",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseController.cs
@@ -155,9 +155,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             return await CheckReleaseExistsAsync(releaseId, () =>
             {
                 // upload the files
-                var result = _fileStorageService.UploadDataFilesAsync(releaseId, file, metaFile, name)
+                var result = _fileStorageService.UploadDataFilesAsync(releaseId, file, metaFile, name);
                     // add message to queue to process these files
-                    .OnSuccess(() => _importService.Import(file.FileName, releaseId));
+                    // TODO: Disabled adding message to queue
+                    //.OnSuccess(() => _importService.Import(file.FileName, releaseId));
                 return result;
             });
         }


### PR DESCRIPTION
Disables file uploads adding a message to the import queue (while we sort out the import process).

Data api connection string changed to use public statistics database.