### PR TITLE
Feature/dfe 690 contact cards

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -359,31 +359,21 @@ class PublicationReleasePage extends Component<Props> {
             </p>
           </AccordionSection>
           <AccordionSection heading="Contact us" headingTag="h3">
-            <div className="govuk-warning-text">
-              <span className="govuk-warning-text__icon" aria-hidden="true">
-                !
-              </span>
-              <strong className="govuk-warning-text__text">
-                <span className="govuk-warning-text__assistive">Warning</span>
-                The following details are an example/placeholder.
-              </strong>
-            </div>
             <p>
-              If you have a specific enquiry about [[ THEME ]] statistics and
+              If you have a specific enquiry about {data.publication.topic.theme.title} statistics and
               data:
             </p>
             <h4 className="govuk-heading-s govuk-!-margin-bottom-0">
-              [[ TEAM NAME ]]
+              {data.publication.contact.teamName}
             </h4>
             <p className="govuk-!-margin-top-0">
               Email <br />
-              {/* <a href="mailto:schools.statistics@education.gov.uk"> */}
-              [[ TEAM EMAIL ADDRESS ]]
-              {/* </a> */}
+              <a href="mailto:schools.statistics@education.gov.uk">
+                {data.publication.contact.teamEmail}
+              </a>
             </p>
             <p>
-              Telephone: [[ LEAD STATISTICIAN NAME ]] <br /> [[ LEAD
-              STATISTICIAN TEL. NO.]]
+              Telephone: {data.publication.contact.contactName} <br /> {data.publication.contact.contactTelNo}
             </p>
             <h4 className="govuk-heading-s govuk-!-margin-bottom-0">
               Press office
@@ -391,7 +381,7 @@ class PublicationReleasePage extends Component<Props> {
             <p className="govuk-!-margin-top-0">If you have a media enquiry:</p>
             <p>
               Telephone <br />
-              [[ PRESS OFFICE TEL NO. ]]
+              020 7925 6789
             </p>
             <h4 className="govuk-heading-s govuk-!-margin-bottom-0">
               Public enquiries
@@ -402,7 +392,7 @@ class PublicationReleasePage extends Component<Props> {
             </p>
             <p>
               Telephone <br />
-              [[ DEPT. FOR EDUCATION TEL NO. ]]
+              037 0000 2288
             </p>
           </AccordionSection>
         </AccordionWithAnalytics>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -360,8 +360,8 @@ class PublicationReleasePage extends Component<Props> {
           </AccordionSection>
           <AccordionSection heading="Contact us" headingTag="h3">
             <p>
-              If you have a specific enquiry about {data.publication.topic.theme.title} statistics and
-              data:
+              If you have a specific enquiry about{' '}
+              {data.publication.topic.theme.title} statistics and data:
             </p>
             <h4 className="govuk-heading-s govuk-!-margin-bottom-0">
               {data.publication.contact.teamName}
@@ -373,7 +373,8 @@ class PublicationReleasePage extends Component<Props> {
               </a>
             </p>
             <p>
-              Telephone: {data.publication.contact.contactName} <br /> {data.publication.contact.contactTelNo}
+              Telephone: {data.publication.contact.contactName} <br />{' '}
+              {data.publication.contact.contactTelNo}
             </p>
             <h4 className="govuk-heading-s govuk-!-margin-bottom-0">
               Press office

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -368,7 +368,7 @@ class PublicationReleasePage extends Component<Props> {
             </h4>
             <p className="govuk-!-margin-top-0">
               Email <br />
-              <a href="mailto:schools.statistics@education.gov.uk">
+              <a href={`mailto:${data.publication.contact.teamEmail}`}>
                 {data.publication.contact.teamEmail}
               </a>
             </p>


### PR DESCRIPTION
Re-add the display of contact details on publications, still has the initial test data but DFE-1289 will add real data