### PR TITLE
DFE-1359: Only show methodologies for publications with a live release

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
@@ -35,7 +35,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
                     Id = x.Id,
                     Title = x.Title,
                     Summary = x.Summary,
-                    Publications = x.Publications.Where(p => p.Methodology != null)
+                    Publications = x.Publications.Where(p => p.Methodology != null && p.Releases.Any(r => r.Published != null))
                         .Select(p => new PublicationTree
                         {
                             Id = p.Methodology.Id,


### PR DESCRIPTION
The set of logic for generating the tree is flawed but given the changes to the structure this should be a quick fix to the issue seen on dev, we only show the list of methodology if there is a valid release in the service.

I'm having a few docker db issues locally so if this could be checked on branch that would be awesome.