### PR TITLE
Fix for PageMeta

### DIFF
--- a/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageMeta.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Helmet } from 'react-helmet';
+import Head from 'next/head';
 
 export interface PageMetaProps {
   title?: string;
@@ -13,7 +13,7 @@ const PageMeta = ({
   imgUrl,
 }: PageMetaProps) => {
   return (
-    <Helmet>
+    <Head>
       {/* <!-- Primary Meta Tags --> */}
       <title>{title}</title>
       <meta name="title" content={title} />
@@ -30,7 +30,7 @@ const PageMeta = ({
       <meta property="twitter:title" content={title} />
       <meta property="twitter:description" content={description} />
       {imgUrl && <meta property="twitter:image" content={imgUrl} />}
-    </Helmet>
+    </Head>
   );
 };
 


### PR DESCRIPTION
Fixing: https://alpha-dfe-data.atlassian.net/browse/DFE-983

No longer using `react-helmet` and instead using `next/head`

Tested by requesting the page in postman and the appropriate <head><meta... tags are in there from the server.

This should fix the issue with page meta not appearing when sharing links etc.