### PR TITLE
Feature/dfe 1398 add basic header information to manage content page

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
@@ -1,16 +1,22 @@
-import {LoginContext} from '@admin/components/Login';
+import { LoginContext } from '@admin/components/Login';
 import {
   getReleaseStatusLabel,
   getTimePeriodCoverageDateRangeStringLong,
-} from "@admin/pages/release/util/releaseSummaryUtil";
-import {dayMonthYearIsComplete, dayMonthYearToDate,} from '@admin/services/common/types';
-import {AdminDashboardRelease, Comment,} from '@admin/services/dashboard/types';
+} from '@admin/pages/release/util/releaseSummaryUtil';
+import {
+  dayMonthYearIsComplete,
+  dayMonthYearToDate,
+} from '@admin/services/common/types';
+import {
+  AdminDashboardRelease,
+  Comment,
+} from '@admin/services/dashboard/types';
 import Details from '@common/components/Details';
 import FormattedDate from '@common/components/FormattedDate';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
-import {format} from 'date-fns';
-import React, {ReactNode, useContext} from 'react';
+import { format } from 'date-fns';
+import React, { ReactNode, useContext } from 'react';
 
 const getLiveLatestLabel = (isLive: boolean, isLatest: boolean) => {
   if (isLive && isLatest) {
@@ -36,9 +42,9 @@ const ReleaseSummary = ({ release, actions, children }: Props) => {
       ? 'me'
       : release.lastEditedUser.name;
 
-  const releaseSummaryLabel = `${release.timePeriodCoverage.label}, ${
-    getTimePeriodCoverageDateRangeStringLong(release.releaseName)
-  } 
+  const releaseSummaryLabel = `${
+    release.timePeriodCoverage.label
+  }, ${getTimePeriodCoverageDateRangeStringLong(release.releaseName)} 
      ${getLiveLatestLabel(release.live, release.latestRelease)}`;
 
   return (

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
@@ -1,20 +1,16 @@
-import { LoginContext } from '@admin/components/Login';
-import {getReleaseStatusLabel} from "@admin/pages/release/util/releaseSummaryUtil";
+import {LoginContext} from '@admin/components/Login';
 import {
-  dayMonthYearIsComplete,
-  dayMonthYearToDate,
-} from '@admin/services/common/types';
-import {
-  AdminDashboardRelease,
-  Comment,
-  ReleaseStatus,
-} from '@admin/services/dashboard/types';
+  getReleaseStatusLabel,
+  getTimePeriodCoverageDateRangeStringLong,
+} from "@admin/pages/release/util/releaseSummaryUtil";
+import {dayMonthYearIsComplete, dayMonthYearToDate,} from '@admin/services/common/types';
+import {AdminDashboardRelease, Comment,} from '@admin/services/dashboard/types';
 import Details from '@common/components/Details';
 import FormattedDate from '@common/components/FormattedDate';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
-import { format } from 'date-fns';
-import React, { ReactNode, useContext } from 'react';
+import {format} from 'date-fns';
+import React, {ReactNode, useContext} from 'react';
 
 const getLiveLatestLabel = (isLive: boolean, isLatest: boolean) => {
   if (isLive && isLatest) {
@@ -41,7 +37,7 @@ const ReleaseSummary = ({ release, actions, children }: Props) => {
       : release.lastEditedUser.name;
 
   const releaseSummaryLabel = `${release.timePeriodCoverage.label}, ${
-    release.releaseName
+    getTimePeriodCoverageDateRangeStringLong(release.releaseName)
   } 
      ${getLiveLatestLabel(release.live, release.latestRelease)}`;
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
@@ -1,4 +1,5 @@
 import { LoginContext } from '@admin/components/Login';
+import {getReleaseStatusLabel} from "@admin/pages/release/util/releaseSummaryUtil";
 import {
   dayMonthYearIsComplete,
   dayMonthYearToDate,
@@ -25,19 +26,6 @@ const getLiveLatestLabel = (isLive: boolean, isLatest: boolean) => {
   return '(not Live)';
 };
 
-const getStatusLabel = (approvalStatus: ReleaseStatus) => {
-  switch (approvalStatus) {
-    case 'Draft':
-      return 'Draft';
-    case 'HigherLevelReview':
-      return 'In Review';
-    case 'Approved':
-      return 'Approved for Publication';
-    default:
-      return undefined;
-  }
-};
-
 interface Props {
   release: AdminDashboardRelease;
   actions: ReactNode;
@@ -61,7 +49,7 @@ const ReleaseSummary = ({ release, actions, children }: Props) => {
     <Details
       className="govuk-!-margin-bottom-0"
       summary={releaseSummaryLabel}
-      tag={getStatusLabel(release.status)}
+      tag={getReleaseStatusLabel(release.status)}
     >
       <SummaryList additionalClassName="govuk-!-margin-bottom-3">
         <SummaryListItem term="Publish date">

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/ReleaseContentPage.tsx
@@ -1,7 +1,79 @@
-import React from 'react';
+import {Comment} from "@admin/services/dashboard/types";
+import FormFieldset from "@common/components/form/FormFieldset";
+import FormRadio from "@common/components/form/FormRadio";
+import FormRadioGroup from "@common/components/form/FormRadioGroup";
+import React, {useEffect, useState} from 'react';
+
+interface Model {
+  unresolvedComments: Comment[];
+  pageMode: 'edit' | 'preview';
+}
 
 const ReleaseContentPage = () => {
-  return <h2 className="govuk-heading-m">Add / edit content</h2>;
+
+  const [model, setModel] = useState();
+
+  useEffect(() => {
+    const unresolvedComments: Comment[] = [{
+      message: 'Please resolve this.\nThank you.',
+      authorName: 'Amy Newton',
+      createdDate: new Date('2019-08-10 10:15').toISOString(),
+    }, {
+      message: 'And this too.\nThank you.',
+      authorName: 'Dave Matthews',
+      createdDate: new Date('2019-08-10 10:15').toISOString(),
+    }];
+
+    setModel({
+      unresolvedComments,
+      pageView: 'edit',
+    })
+  }, []);
+
+  return (
+    <>
+      {model && (
+        <div className="govuk-form-group">
+          {model.unresolvedComments.length > 0 && (
+            <div className="govuk-warning-text">
+              <span className="govuk-warning-text__icon" aria-hidden="true">
+                !
+              </span>
+              <strong className="govuk-warning-text__text">
+                <span className="govuk-warning-text__assistive">Warning</span>
+                There are {model.unresolvedComments.length} unresolved comments
+              </strong>
+            </div>
+          )}
+
+          <FormFieldset
+            id='pageModelFieldSet'
+            legend=''
+            className='dfe-toggle-edit'
+            legendHidden
+          >
+            <FormRadioGroup
+              id='pageMode'
+              name='pageMode'
+              value={model.pageMode}
+              legend='Set page view'
+              options={[
+                {
+                  label: 'Add / view comments and edit content',
+                  value: 'edit',
+                },
+                {
+                  label: 'Preview content',
+                  value: 'preview',
+                },
+              ]}
+              inline
+            />
+          </FormFieldset>
+        </div>
+      )}
+    </>
+  )
 };
 
 export default ReleaseContentPage;

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/ReleaseContentPage.tsx
@@ -1,83 +1,173 @@
+import ManageReleaseContext, {ManageRelease} from "@admin/pages/release/ManageReleaseContext";
+import {getReleaseStatusLabel} from "@admin/pages/release/util/releaseSummaryUtil";
+import commonService from '@admin/services/common/service';
+import {dayMonthYearIsComplete, dayMonthYearToDate} from "@admin/services/common/types";
 import {Comment} from "@admin/services/dashboard/types";
+import releaseService from '@admin/services/release/edit-release/summary/service';
+import {ReleaseSummaryDetails} from "@admin/services/release/types";
 import FormFieldset from "@common/components/form/FormFieldset";
 import FormRadioGroup from "@common/components/form/FormRadioGroup";
-import React, {useEffect, useState} from 'react';
+import FormattedDate from "@common/components/FormattedDate";
+import classNames from "classnames";
+import React, {useContext, useEffect, useState} from 'react';
 
 type PageMode = 'edit' | 'preview';
+
+interface ReleaseTypeIcon {
+  url: string;
+  altText: string;
+}
+
+const nationalStatisticsLogo: ReleaseTypeIcon = {
+  url: '/static/images/UKSA-quality-mark.jpg',
+  altText: 'UK statistics authority quality mark',
+};
 
 interface Model {
   unresolvedComments: Comment[];
   pageMode: PageMode;
+  releaseSummary: ReleaseSummaryDetails;
+  releaseTypeIcon?: ReleaseTypeIcon;
 }
 
 const ReleaseContentPage = () => {
 
   const [model, setModel] = useState<Model>();
 
-  useEffect(() => {
-    const unresolvedComments: Comment[] = [{
-      message: 'Please resolve this.\nThank you.',
-      authorName: 'Amy Newton',
-      createdDate: new Date('2019-08-10 10:15').toISOString(),
-    }, {
-      message: 'And this too.\nThank you.',
-      authorName: 'Dave Matthews',
-      createdDate: new Date('2019-06-13 10:15').toISOString(),
-    }];
+  const { releaseId, publication } = useContext(ManageReleaseContext) as ManageRelease;
 
-    setModel({
-      unresolvedComments,
-      pageMode: 'edit',
-    })
-  }, []);
+  useEffect(() => {
+
+    Promise.all([
+      commonService.getReleaseTypes(),
+      releaseService.getReleaseSummaryDetails(releaseId),
+    ]).then(([releaseTypes, releaseSummary]) => {
+
+      const unresolvedComments: Comment[] = [{
+        message: 'Please resolve this.\nThank you.',
+        authorName: 'Amy Newton',
+        createdDate: new Date('2019-08-10 10:15').toISOString(),
+      }, {
+        message: 'And this too.\nThank you.',
+        authorName: 'Dave Matthews',
+        createdDate: new Date('2019-06-13 10:15').toISOString(),
+      }];
+
+      const nationalStatisticsType = releaseTypes.find(type => type.title === 'National Statistics');
+
+      setModel({
+        unresolvedComments,
+        pageMode: 'edit',
+        releaseSummary,
+        releaseTypeIcon: nationalStatisticsType && releaseSummary.typeId === nationalStatisticsType.id ? nationalStatisticsLogo : undefined,
+      });
+
+    });
+  }, [releaseId]);
 
   return (
     <>
       {model && (
-        <div className="govuk-form-group">
-          {model.unresolvedComments.length > 0 && (
-            <div className="govuk-warning-text">
-              <span className="govuk-warning-text__icon" aria-hidden="true">
-                !
-              </span>
-              <strong className="govuk-warning-text__text">
-                <span className="govuk-warning-text__assistive">Warning</span>
-                There are {model.unresolvedComments.length} unresolved comments
-              </strong>
-            </div>
-          )}
+        <>
+          <div className="govuk-form-group">
+            {model.unresolvedComments.length > 0 && (
+              <div className="govuk-warning-text">
+                <span className="govuk-warning-text__icon" aria-hidden="true">
+                  !
+                </span>
+                <strong className="govuk-warning-text__text">
+                  <span className="govuk-warning-text__assistive">Warning</span>
+                  There are {model.unresolvedComments.length} unresolved comments
+                </strong>
+              </div>
+            )}
 
-          <FormFieldset
-            id='pageModelFieldset'
-            legend=''
-            className='dfe-toggle-edit'
-            legendHidden
+            <FormFieldset
+              id='pageModelFieldset'
+              legend=''
+              className='dfe-toggle-edit'
+              legendHidden
+            >
+              <FormRadioGroup
+                id='pageMode'
+                name='pageMode'
+                value={model.pageMode}
+                legend='Set page view'
+                options={[
+                  {
+                    label: 'Add / view comments and edit content',
+                    value: 'edit',
+                  },
+                  {
+                    label: 'Preview content',
+                    value: 'preview',
+                  },
+                ]}
+                inline
+                onChange={event => {
+                  setModel({
+                    ...model,
+                    pageMode: event.target.value as PageMode,
+                  });
+                }}
+              />
+            </FormFieldset>
+          </div>
+          <div
+            className={classNames('govuk-width-container', {
+              'dfe-align--comments': model.pageMode === 'edit',
+              'dfe-hide-comments': model.pageMode === 'preview',
+            })}
           >
-            <FormRadioGroup
-              id='pageMode'
-              name='pageMode'
-              value={model.pageMode}
-              legend='Set page view'
-              options={[
-                {
-                  label: 'Add / view comments and edit content',
-                  value: 'edit',
-                },
-                {
-                  label: 'Preview content',
-                  value: 'preview',
-                },
-              ]}
-              inline
-              onChange={event => {
-                setModel({
-                  ...model,
-                  pageMode: event.target.value as PageMode,
-                });
-              }}
-            />
-          </FormFieldset>
-        </div>
+            <div className={model.pageMode === 'edit' ? 'page-editing' : ''}>
+              <h1 className="govuk-heading-l">
+                <span className="govuk-caption-l">{model.releaseSummary.timePeriodCoverage.label} {model.releaseSummary.releaseName}</span>
+                {publication.title}
+              </h1>
+              <div className="govuk-grid-row">
+                <div className="govuk-grid-column-two-thirds">
+                  <div className="govuk-grid-row">
+                    <div className="govuk-grid-column-three-quarters">
+                      <span className="govuk-tag">
+                        {getReleaseStatusLabel(model.releaseSummary.status)}
+                      </span>
+
+                      <dl className="dfe-meta-content">
+                        <dt className="govuk-caption-m">Publish date: </dt>
+                        <dd>
+                          <strong><FormattedDate>{model.releaseSummary.publishScheduled}</FormattedDate></strong>
+                        </dd>
+                        <div>
+                          <dt className="govuk-caption-m">Next update: </dt>
+                          <dd>
+                            {dayMonthYearIsComplete(model.releaseSummary.nextReleaseDate) && (
+                              <strong>
+                                <FormattedDate>
+                                  {dayMonthYearToDate(model.releaseSummary.nextReleaseDate)}
+                                </FormattedDate>
+                              </strong>
+                            )}
+                          </dd>
+                        </div>
+                      </dl>
+                    </div>
+
+                    {model.releaseTypeIcon && (
+                      <div className="govuk-grid-column-one-quarter">
+                        <img
+                          src={model.releaseTypeIcon.url}
+                          alt={model.releaseTypeIcon.altText}
+                          height="120"
+                          width="120"
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </>
       )}
     </>
   )

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/ReleaseContentPage.tsx
@@ -1,17 +1,18 @@
 import {Comment} from "@admin/services/dashboard/types";
 import FormFieldset from "@common/components/form/FormFieldset";
-import FormRadio from "@common/components/form/FormRadio";
 import FormRadioGroup from "@common/components/form/FormRadioGroup";
 import React, {useEffect, useState} from 'react';
 
+type PageMode = 'edit' | 'preview';
+
 interface Model {
   unresolvedComments: Comment[];
-  pageMode: 'edit' | 'preview';
+  pageMode: PageMode;
 }
 
 const ReleaseContentPage = () => {
 
-  const [model, setModel] = useState();
+  const [model, setModel] = useState<Model>();
 
   useEffect(() => {
     const unresolvedComments: Comment[] = [{
@@ -21,12 +22,12 @@ const ReleaseContentPage = () => {
     }, {
       message: 'And this too.\nThank you.',
       authorName: 'Dave Matthews',
-      createdDate: new Date('2019-08-10 10:15').toISOString(),
+      createdDate: new Date('2019-06-13 10:15').toISOString(),
     }];
 
     setModel({
       unresolvedComments,
-      pageView: 'edit',
+      pageMode: 'edit',
     })
   }, []);
 
@@ -47,7 +48,7 @@ const ReleaseContentPage = () => {
           )}
 
           <FormFieldset
-            id='pageModelFieldSet'
+            id='pageModelFieldset'
             legend=''
             className='dfe-toggle-edit'
             legendHidden
@@ -68,6 +69,12 @@ const ReleaseContentPage = () => {
                 },
               ]}
               inline
+              onChange={event => {
+                setModel({
+                  ...model,
+                  pageMode: event.target.value as PageMode,
+                });
+              }}
             />
           </FormFieldset>
         </div>

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/content/ReleaseContentPage.tsx
@@ -1,16 +1,16 @@
-import BasicReleaseSummary from "@admin/pages/release/edit-release/content/components/BasicReleaseSummary";
-import ManageReleaseContext, {ManageRelease} from "@admin/pages/release/ManageReleaseContext";
-import {
-  getTimePeriodCoverageDateRangeStringShort,
-} from "@admin/pages/release/util/releaseSummaryUtil";
-import {Comment} from "@admin/services/dashboard/types";
+import BasicReleaseSummary from '@admin/pages/release/edit-release/content/components/BasicReleaseSummary';
+import ManageReleaseContext, {
+  ManageRelease,
+} from '@admin/pages/release/ManageReleaseContext';
+import { getTimePeriodCoverageDateRangeStringShort } from '@admin/pages/release/util/releaseSummaryUtil';
+import { Comment } from '@admin/services/dashboard/types';
 import releaseService from '@admin/services/release/edit-release/summary/service';
-import {ReleaseSummaryDetails} from "@admin/services/release/types";
-import FormFieldset from "@common/components/form/FormFieldset";
-import FormRadioGroup from "@common/components/form/FormRadioGroup";
-import WarningMessage from "@common/components/WarningMessage";
-import classNames from "classnames";
-import React, {useContext, useEffect, useState} from 'react';
+import { ReleaseSummaryDetails } from '@admin/services/release/types';
+import FormFieldset from '@common/components/form/FormFieldset';
+import FormRadioGroup from '@common/components/form/FormRadioGroup';
+import WarningMessage from '@common/components/WarningMessage';
+import classNames from 'classnames';
+import React, { useContext, useEffect, useState } from 'react';
 
 type PageMode = 'edit' | 'preview';
 
@@ -21,24 +21,26 @@ interface Model {
 }
 
 const ReleaseContentPage = () => {
-
   const [model, setModel] = useState<Model>();
 
-  const { releaseId, publication } = useContext(ManageReleaseContext) as ManageRelease;
+  const { releaseId, publication } = useContext(
+    ManageReleaseContext,
+  ) as ManageRelease;
 
   useEffect(() => {
-
     releaseService.getReleaseSummaryDetails(releaseId).then(releaseSummary => {
-
-      const unresolvedComments: Comment[] = [{
-        message: 'Please resolve this.\nThank you.',
-        authorName: 'Amy Newton',
-        createdDate: new Date('2019-08-10 10:15').toISOString(),
-      }, {
-        message: 'And this too.\nThank you.',
-        authorName: 'Dave Matthews',
-        createdDate: new Date('2019-06-13 10:15').toISOString(),
-      }];
+      const unresolvedComments: Comment[] = [
+        {
+          message: 'Please resolve this.\nThank you.',
+          authorName: 'Amy Newton',
+          createdDate: new Date('2019-08-10 10:15').toISOString(),
+        },
+        {
+          message: 'And this too.\nThank you.',
+          authorName: 'Dave Matthews',
+          createdDate: new Date('2019-06-13 10:15').toISOString(),
+        },
+      ];
 
       setModel({
         unresolvedComments,
@@ -60,16 +62,16 @@ const ReleaseContentPage = () => {
             )}
 
             <FormFieldset
-              id='pageModelFieldset'
-              legend=''
-              className='dfe-toggle-edit'
+              id="pageModelFieldset"
+              legend=""
+              className="dfe-toggle-edit"
               legendHidden
             >
               <FormRadioGroup
-                id='pageMode'
-                name='pageMode'
+                id="pageMode"
+                name="pageMode"
                 value={model.pageMode}
-                legend='Set page view'
+                legend="Set page view"
                 options={[
                   {
                     label: 'Add / view comments and edit content',
@@ -100,7 +102,10 @@ const ReleaseContentPage = () => {
               <h1 className="govuk-heading-l">
                 <span className="govuk-caption-l">
                   {model.releaseSummary.timePeriodCoverage.label}{' '}
-                  {getTimePeriodCoverageDateRangeStringShort(model.releaseSummary.releaseName, '/')}
+                  {getTimePeriodCoverageDateRangeStringShort(
+                    model.releaseSummary.releaseName,
+                    '/',
+                  )}
                 </span>
                 {publication.title}
               </h1>
@@ -116,7 +121,7 @@ const ReleaseContentPage = () => {
         </>
       )}
     </>
-  )
+  );
 };
 
 export default ReleaseContentPage;

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/content/ReleaseContentPage.tsx
@@ -1,5 +1,8 @@
 import BasicReleaseSummary from "@admin/pages/release/edit-release/content/components/BasicReleaseSummary";
 import ManageReleaseContext, {ManageRelease} from "@admin/pages/release/ManageReleaseContext";
+import {
+  getTimePeriodCoverageDateRangeStringShort,
+} from "@admin/pages/release/util/releaseSummaryUtil";
 import {Comment} from "@admin/services/dashboard/types";
 import releaseService from '@admin/services/release/edit-release/summary/service';
 import {ReleaseSummaryDetails} from "@admin/services/release/types";
@@ -95,7 +98,10 @@ const ReleaseContentPage = () => {
           >
             <div className={model.pageMode === 'edit' ? 'page-editing' : ''}>
               <h1 className="govuk-heading-l">
-                <span className="govuk-caption-l">{model.releaseSummary.timePeriodCoverage.label} {model.releaseSummary.releaseName}</span>
+                <span className="govuk-caption-l">
+                  {model.releaseSummary.timePeriodCoverage.label}{' '}
+                  {getTimePeriodCoverageDateRangeStringShort(model.releaseSummary.releaseName, '/')}
+                </span>
                 {publication.title}
               </h1>
               <div className="govuk-grid-row">

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/content/ReleaseContentPage.tsx
@@ -1,33 +1,20 @@
+import BasicReleaseSummary from "@admin/pages/release/edit-release/content/components/BasicReleaseSummary";
 import ManageReleaseContext, {ManageRelease} from "@admin/pages/release/ManageReleaseContext";
-import {getReleaseStatusLabel} from "@admin/pages/release/util/releaseSummaryUtil";
-import commonService from '@admin/services/common/service';
-import {dayMonthYearIsComplete, dayMonthYearToDate} from "@admin/services/common/types";
 import {Comment} from "@admin/services/dashboard/types";
 import releaseService from '@admin/services/release/edit-release/summary/service';
 import {ReleaseSummaryDetails} from "@admin/services/release/types";
 import FormFieldset from "@common/components/form/FormFieldset";
 import FormRadioGroup from "@common/components/form/FormRadioGroup";
-import FormattedDate from "@common/components/FormattedDate";
+import WarningMessage from "@common/components/WarningMessage";
 import classNames from "classnames";
 import React, {useContext, useEffect, useState} from 'react';
 
 type PageMode = 'edit' | 'preview';
 
-interface ReleaseTypeIcon {
-  url: string;
-  altText: string;
-}
-
-const nationalStatisticsLogo: ReleaseTypeIcon = {
-  url: '/static/images/UKSA-quality-mark.jpg',
-  altText: 'UK statistics authority quality mark',
-};
-
 interface Model {
   unresolvedComments: Comment[];
   pageMode: PageMode;
   releaseSummary: ReleaseSummaryDetails;
-  releaseTypeIcon?: ReleaseTypeIcon;
 }
 
 const ReleaseContentPage = () => {
@@ -38,10 +25,7 @@ const ReleaseContentPage = () => {
 
   useEffect(() => {
 
-    Promise.all([
-      commonService.getReleaseTypes(),
-      releaseService.getReleaseSummaryDetails(releaseId),
-    ]).then(([releaseTypes, releaseSummary]) => {
+    releaseService.getReleaseSummaryDetails(releaseId).then(releaseSummary => {
 
       const unresolvedComments: Comment[] = [{
         message: 'Please resolve this.\nThank you.',
@@ -53,15 +37,11 @@ const ReleaseContentPage = () => {
         createdDate: new Date('2019-06-13 10:15').toISOString(),
       }];
 
-      const nationalStatisticsType = releaseTypes.find(type => type.title === 'National Statistics');
-
       setModel({
         unresolvedComments,
         pageMode: 'edit',
         releaseSummary,
-        releaseTypeIcon: nationalStatisticsType && releaseSummary.typeId === nationalStatisticsType.id ? nationalStatisticsLogo : undefined,
       });
-
     });
   }, [releaseId]);
 
@@ -71,15 +51,9 @@ const ReleaseContentPage = () => {
         <>
           <div className="govuk-form-group">
             {model.unresolvedComments.length > 0 && (
-              <div className="govuk-warning-text">
-                <span className="govuk-warning-text__icon" aria-hidden="true">
-                  !
-                </span>
-                <strong className="govuk-warning-text__text">
-                  <span className="govuk-warning-text__assistive">Warning</span>
-                  There are {model.unresolvedComments.length} unresolved comments
-                </strong>
-              </div>
+              <WarningMessage>
+                There are {model.unresolvedComments.length} unresolved comments
+              </WarningMessage>
             )}
 
             <FormFieldset
@@ -127,41 +101,7 @@ const ReleaseContentPage = () => {
               <div className="govuk-grid-row">
                 <div className="govuk-grid-column-two-thirds">
                   <div className="govuk-grid-row">
-                    <div className="govuk-grid-column-three-quarters">
-                      <span className="govuk-tag">
-                        {getReleaseStatusLabel(model.releaseSummary.status)}
-                      </span>
-
-                      <dl className="dfe-meta-content">
-                        <dt className="govuk-caption-m">Publish date: </dt>
-                        <dd>
-                          <strong><FormattedDate>{model.releaseSummary.publishScheduled}</FormattedDate></strong>
-                        </dd>
-                        <div>
-                          <dt className="govuk-caption-m">Next update: </dt>
-                          <dd>
-                            {dayMonthYearIsComplete(model.releaseSummary.nextReleaseDate) && (
-                              <strong>
-                                <FormattedDate>
-                                  {dayMonthYearToDate(model.releaseSummary.nextReleaseDate)}
-                                </FormattedDate>
-                              </strong>
-                            )}
-                          </dd>
-                        </div>
-                      </dl>
-                    </div>
-
-                    {model.releaseTypeIcon && (
-                      <div className="govuk-grid-column-one-quarter">
-                        <img
-                          src={model.releaseTypeIcon.url}
-                          alt={model.releaseTypeIcon.altText}
-                          height="120"
-                          width="120"
-                        />
-                      </div>
-                    )}
+                    <BasicReleaseSummary release={model.releaseSummary} />
                   </div>
                 </div>
               </div>

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/content/components/BasicReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/content/components/BasicReleaseSummary.tsx
@@ -1,0 +1,91 @@
+import {getReleaseStatusLabel} from "@admin/pages/release/util/releaseSummaryUtil";
+import commonService from "@admin/services/common/service";
+import {dayMonthYearIsComplete, dayMonthYearToDate} from "@admin/services/common/types";
+import {ReleaseSummaryDetails} from "@admin/services/release/types";
+import FormattedDate from "@common/components/FormattedDate";
+import {Dictionary} from "@common/types";
+import React, {useEffect, useState} from "react";
+
+interface ReleaseTypeIcon {
+  url: string;
+  altText: string;
+}
+
+const nationalStatisticsLogo: ReleaseTypeIcon = {
+  url: '/static/images/UKSA-quality-mark.jpg',
+  altText: 'UK statistics authority quality mark',
+};
+
+interface Props {
+  release: ReleaseSummaryDetails;
+}
+
+const BasicReleaseSummary = ({release} : Props) => {
+
+  const [releaseTypeIdsToIcons, setReleaseTypeIdsToIcons] = useState<Dictionary<ReleaseTypeIcon>>();
+
+  useEffect(() => {
+
+    commonService.getReleaseTypes().then(types => {
+
+      const icons: Dictionary<ReleaseTypeIcon> = {};
+
+      // TODO would be nicer to control this via some metadata from the back end rather than
+      // trust this matching on title
+      const nationalStatisticsType = types.find(type => type.title === 'National Statistics');
+
+      if (nationalStatisticsType) {
+        icons[nationalStatisticsType.id] = nationalStatisticsLogo;
+      }
+
+      setReleaseTypeIdsToIcons(icons);
+    });
+
+  }, []);
+
+  return (
+    <>
+      {releaseTypeIdsToIcons && (
+        <>
+          <div className="govuk-grid-column-three-quarters">
+            <span className="govuk-tag">
+              {getReleaseStatusLabel(release.status)}
+            </span>
+
+            <dl className="dfe-meta-content">
+              <dt className="govuk-caption-m">Publish date: </dt>
+              <dd>
+                <strong><FormattedDate>{release.publishScheduled}</FormattedDate></strong>
+              </dd>
+              <div>
+                <dt className="govuk-caption-m">Next update: </dt>
+                <dd>
+                  {dayMonthYearIsComplete(release.nextReleaseDate) && (
+                    <strong>
+                      <FormattedDate>
+                        {dayMonthYearToDate(release.nextReleaseDate)}
+                      </FormattedDate>
+                    </strong>
+                  )}
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          {releaseTypeIdsToIcons[release.typeId] && (
+            <div className="govuk-grid-column-one-quarter">
+              <img
+                src={releaseTypeIdsToIcons[release.typeId].url}
+                alt={releaseTypeIdsToIcons[release.typeId].altText}
+                height="120"
+                width="120"
+              />
+            </div>
+          )}
+        </>
+      )}
+    </>
+  );
+};
+
+export default BasicReleaseSummary;

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/content/components/BasicReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/content/components/BasicReleaseSummary.tsx
@@ -1,10 +1,13 @@
-import {getReleaseStatusLabel} from "@admin/pages/release/util/releaseSummaryUtil";
-import commonService from "@admin/services/common/service";
-import {dayMonthYearIsComplete, dayMonthYearToDate} from "@admin/services/common/types";
-import {ReleaseSummaryDetails} from "@admin/services/release/types";
-import FormattedDate from "@common/components/FormattedDate";
-import {Dictionary} from "@common/types";
-import React, {useEffect, useState} from "react";
+import { getReleaseStatusLabel } from '@admin/pages/release/util/releaseSummaryUtil';
+import commonService from '@admin/services/common/service';
+import {
+  dayMonthYearIsComplete,
+  dayMonthYearToDate,
+} from '@admin/services/common/types';
+import { ReleaseSummaryDetails } from '@admin/services/release/types';
+import FormattedDate from '@common/components/FormattedDate';
+import { Dictionary } from '@common/types';
+import React, { useEffect, useState } from 'react';
 
 interface ReleaseTypeIcon {
   url: string;
@@ -20,19 +23,20 @@ interface Props {
   release: ReleaseSummaryDetails;
 }
 
-const BasicReleaseSummary = ({release} : Props) => {
-
-  const [releaseTypeIdsToIcons, setReleaseTypeIdsToIcons] = useState<Dictionary<ReleaseTypeIcon>>();
+const BasicReleaseSummary = ({ release }: Props) => {
+  const [releaseTypeIdsToIcons, setReleaseTypeIdsToIcons] = useState<
+    Dictionary<ReleaseTypeIcon>
+  >();
 
   useEffect(() => {
-
     commonService.getReleaseTypes().then(types => {
-
       const icons: Dictionary<ReleaseTypeIcon> = {};
 
       // TODO would be nicer to control this via some metadata from the back end rather than
       // trust this matching on title
-      const nationalStatisticsType = types.find(type => type.title === 'National Statistics');
+      const nationalStatisticsType = types.find(
+        type => type.title === 'National Statistics',
+      );
 
       if (nationalStatisticsType) {
         icons[nationalStatisticsType.id] = nationalStatisticsLogo;
@@ -40,7 +44,6 @@ const BasicReleaseSummary = ({release} : Props) => {
 
       setReleaseTypeIdsToIcons(icons);
     });
-
   }, []);
 
   return (
@@ -55,7 +58,9 @@ const BasicReleaseSummary = ({release} : Props) => {
             <dl className="dfe-meta-content">
               <dt className="govuk-caption-m">Publish date: </dt>
               <dd>
-                <strong><FormattedDate>{release.publishScheduled}</FormattedDate></strong>
+                <strong>
+                  <FormattedDate>{release.publishScheduled}</FormattedDate>
+                </strong>
               </dd>
               <div>
                 <dt className="govuk-caption-m">Next update: </dt>

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/summary/ReleaseSummaryPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/summary/ReleaseSummaryPage.tsx
@@ -4,7 +4,7 @@ import ManageReleaseContext, {
 } from '@admin/pages/release/ManageReleaseContext';
 import {
   getSelectedReleaseType,
-  getSelectedTimePeriodCoverageLabel,
+  getSelectedTimePeriodCoverageLabel, getTimePeriodCoverageDateRangeStringLong,
 } from '@admin/pages/release/util/releaseSummaryUtil';
 import { summaryEditRoute } from '@admin/routes/edit-release/routes';
 import commonService from '@admin/services/common/service';
@@ -67,10 +67,7 @@ const ReleaseSummaryPage = () => {
               )}
             </SummaryListItem>
             <SummaryListItem term="Release period">
-              <time>{model.releaseSummaryDetails.releaseName}</time> to{' '}
-              <time>
-                {parseInt(model.releaseSummaryDetails.releaseName, 10) + 1}
-              </time>
+              <time>{getTimePeriodCoverageDateRangeStringLong(model.releaseSummaryDetails.releaseName)}</time>
             </SummaryListItem>
             <SummaryListItem term="Lead statistician">
               {publication.contact && publication.contact.contactName}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/summary/ReleaseSummaryPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/summary/ReleaseSummaryPage.tsx
@@ -4,7 +4,8 @@ import ManageReleaseContext, {
 } from '@admin/pages/release/ManageReleaseContext';
 import {
   getSelectedReleaseType,
-  getSelectedTimePeriodCoverageLabel, getTimePeriodCoverageDateRangeStringLong,
+  getSelectedTimePeriodCoverageLabel,
+  getTimePeriodCoverageDateRangeStringLong,
 } from '@admin/pages/release/util/releaseSummaryUtil';
 import { summaryEditRoute } from '@admin/routes/edit-release/routes';
 import commonService from '@admin/services/common/service';
@@ -67,7 +68,11 @@ const ReleaseSummaryPage = () => {
               )}
             </SummaryListItem>
             <SummaryListItem term="Release period">
-              <time>{getTimePeriodCoverageDateRangeStringLong(model.releaseSummaryDetails.releaseName)}</time>
+              <time>
+                {getTimePeriodCoverageDateRangeStringLong(
+                  model.releaseSummaryDetails.releaseName,
+                )}
+              </time>
             </SummaryListItem>
             <SummaryListItem term="Lead statistician">
               {publication.contact && publication.contact.contactName}

--- a/src/explore-education-statistics-admin/src/pages/release/util/releaseSummaryUtil.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/util/releaseSummaryUtil.ts
@@ -96,4 +96,16 @@ export const getReleaseStatusLabel = (approvalStatus: ReleaseStatus) => {
   }
 };
 
+export const getTimePeriodCoverageDateRangeStringLong = (releaseName: string, separatorString: string = ' to ') => {
+  const numberRegex = /[0-9]+/;
+  const results = numberRegex.exec(releaseName);
+  return results ? `${releaseName}${separatorString}${parseInt(results[0], 10) + 1}` : releaseName;
+};
+
+export const getTimePeriodCoverageDateRangeStringShort = (releaseName: string, separatorString: string = '/') => {
+  const fourYearRegex = /[0-9]*([0-9]{2})/;
+  const results = fourYearRegex.exec(releaseName);
+  return results ? `${releaseName}${separatorString}${parseInt(results[1], 10) + 1}` : releaseName;
+};
+
 export default {};

--- a/src/explore-education-statistics-admin/src/pages/release/util/releaseSummaryUtil.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/util/releaseSummaryUtil.ts
@@ -4,7 +4,7 @@ import {
   IdTitlePair,
   TimePeriodCoverageGroup,
 } from '@admin/services/common/types';
-import {ReleaseStatus} from "@admin/services/dashboard/types";
+import { ReleaseStatus } from '@admin/services/dashboard/types';
 import { CreateReleaseRequest } from '@admin/services/release/create-release/types';
 import { UpdateReleaseSummaryDetailsRequest } from '@admin/services/release/edit-release/summary/types';
 import { BaseReleaseSummaryDetailsRequest } from '@admin/services/release/types';
@@ -96,16 +96,26 @@ export const getReleaseStatusLabel = (approvalStatus: ReleaseStatus) => {
   }
 };
 
-export const getTimePeriodCoverageDateRangeStringLong = (releaseName: string, separatorString: string = ' to ') => {
+export const getTimePeriodCoverageDateRangeStringLong = (
+  releaseName: string,
+  separatorString: string = ' to ',
+) => {
   const numberRegex = /[0-9]+/;
   const results = numberRegex.exec(releaseName);
-  return results ? `${releaseName}${separatorString}${parseInt(results[0], 10) + 1}` : releaseName;
+  return results
+    ? `${releaseName}${separatorString}${parseInt(results[0], 10) + 1}`
+    : releaseName;
 };
 
-export const getTimePeriodCoverageDateRangeStringShort = (releaseName: string, separatorString: string = '/') => {
+export const getTimePeriodCoverageDateRangeStringShort = (
+  releaseName: string,
+  separatorString: string = '/',
+) => {
   const fourYearRegex = /[0-9]*([0-9]{2})/;
   const results = fourYearRegex.exec(releaseName);
-  return results ? `${releaseName}${separatorString}${parseInt(results[1], 10) + 1}` : releaseName;
+  return results
+    ? `${releaseName}${separatorString}${parseInt(results[1], 10) + 1}`
+    : releaseName;
 };
 
 export default {};

--- a/src/explore-education-statistics-admin/src/pages/release/util/releaseSummaryUtil.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/util/releaseSummaryUtil.ts
@@ -4,6 +4,7 @@ import {
   IdTitlePair,
   TimePeriodCoverageGroup,
 } from '@admin/services/common/types';
+import {ReleaseStatus} from "@admin/services/dashboard/types";
 import { CreateReleaseRequest } from '@admin/services/release/create-release/types';
 import { UpdateReleaseSummaryDetailsRequest } from '@admin/services/release/edit-release/summary/types';
 import { BaseReleaseSummaryDetailsRequest } from '@admin/services/release/types';
@@ -81,5 +82,18 @@ export const getSelectedReleaseType = (
 ) =>
   availableReleaseTypes.find(type => type.id === releaseTypeId) ||
   availableReleaseTypes[0];
+
+export const getReleaseStatusLabel = (approvalStatus: ReleaseStatus) => {
+  switch (approvalStatus) {
+    case 'Draft':
+      return 'Draft';
+    case 'HigherLevelReview':
+      return 'In Review';
+    case 'Approved':
+      return 'Approved for Publication';
+    default:
+      return undefined;
+  }
+};
 
 export default {};

--- a/src/explore-education-statistics-admin/src/routes/edit-release/routes.ts
+++ b/src/explore-education-statistics-admin/src/routes/edit-release/routes.ts
@@ -1,5 +1,5 @@
 import ReleaseDataPage from '@admin/pages/release/edit-release/data/ReleaseDataPage';
-import ReleaseContentPage from '@admin/pages/release/edit-release/ReleaseContentPage';
+import ReleaseContentPage from '@admin/pages/release/edit-release/content/ReleaseContentPage';
 import ReleasePublishStatusPage from '@admin/pages/release/edit-release/ReleaseStatusPage';
 import ReleaseSummaryEditPage from '@admin/pages/release/edit-release/summary/ReleaseSummaryEditPage';
 import ReleaseSummaryPage from '@admin/pages/release/edit-release/summary/ReleaseSummaryPage';

--- a/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
@@ -28,12 +28,9 @@ const FormFieldset = ({
   return (
     <FormGroup hasError={!!error}>
       <fieldset
-        className={classNames(
-          'govuk-fieldset',
-          {
-            [className || '']: className,
-          }
-        )}
+        className={classNames('govuk-fieldset', {
+          [className || '']: className,
+        })}
         id={id}
         aria-describedby={createDescribedBy({
           id,

--- a/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
@@ -12,6 +12,7 @@ export interface FormFieldsetProps {
   legend: ReactNode | string;
   legendSize?: 'xl' | 'l' | 'm' | 's';
   legendHidden?: boolean;
+  className?: string;
 }
 
 const FormFieldset = ({
@@ -22,11 +23,17 @@ const FormFieldset = ({
   legend,
   legendSize = 'm',
   legendHidden = false,
+  className,
 }: FormFieldsetProps) => {
   return (
     <FormGroup hasError={!!error}>
       <fieldset
-        className="govuk-fieldset"
+        className={classNames(
+          'govuk-fieldset',
+          {
+            [className || '']: className,
+          }
+        )}
         id={id}
         aria-describedby={createDescribedBy({
           id,


### PR DESCRIPTION
![DFE-1398](https://user-images.githubusercontent.com/12444316/64118135-eb67a880-cd8e-11e9-9a96-193804a52831.png)

This PR:
- renders the above portion of the Manage Content page using real API calls
- includes some helper utilities to better format the start / end dates in different formats