### PR TITLE
DFE-1094 Additional Print Page functionality

### DIFF
--- a/src/explore-education-statistics-common/src/components/ContentSectionIndex.tsx
+++ b/src/explore-education-statistics-common/src/components/ContentSectionIndex.tsx
@@ -57,8 +57,10 @@ class ContentSectionIndex extends Component<Props> {
       <>
         {indexComplete && indexResults.length > 0 && (
           <>
-            <h3 className="govuk-heading-s">In this section</h3>
-            <ul className="govuk-body-s">
+            <h3 className="govuk-heading-s dfe-print-hidden">
+              In this section
+            </h3>
+            <ul className="govuk-body-s dfe-print-hidden">
               {indexResults.map(item => {
                 return (
                   <>

--- a/src/explore-education-statistics-common/src/styles/_print.scss
+++ b/src/explore-education-statistics-common/src/styles/_print.scss
@@ -35,3 +35,10 @@
     @include print-hide();
   }
 }
+
+.recharts-wrapper,
+.recharts-surface {
+  @media print {
+    width: calc(100%) !important;
+  }
+}


### PR DESCRIPTION
Does: 
- added some SCSS that will override the recharts CSS when we print, making it to have a `max-width: 100%`
- “In this section” section contents menu no longer is shown in print preview

Does *not*:
- Default headers and footers to off
- fix _"Altering the scale will still change to desktop view and then hides the tab information"_

