### PR TITLE
Bugfix/dfe 1317

### DIFF
--- a/armTemplates/ees-service/template.json
+++ b/armTemplates/ees-service/template.json
@@ -1223,7 +1223,8 @@
           "connectionStrings": [
             {
               "name": "TableStorageConnString",
-              "connectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('notificationsstorageAccountName'), ';AccountKey=', listKeys(variables('notificationsstorageAccountId'),'2015-05-01-preview').key1)]"
+              "connectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('notificationsstorageAccountName'), ';AccountKey=', listKeys(variables('notificationsstorageAccountId'),'2015-05-01-preview').key1)]",
+              "type": "Custom"
             }
           ]
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -131,6 +131,7 @@
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model\GovUk.Education.ExploreEducationStatistics.Content.Model.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Processor.Model\GovUk.Education.ExploreEducationStatistics.Data.Processor.Model.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Services\GovUk.Education.ExploreEducationStatistics.Data.Services.csproj" />
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Notifier.Model\GovUk.Education.ExploreEducationStatistics.Notifier.Model.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Publisher.Model\GovUk.Education.ExploreEducationStatistics.Publisher.Model.csproj" />
   </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/NotifySubscribersMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/NotifySubscribersMessage.cs
@@ -1,9 +1,0 @@
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
-{
-    public class NotifySubscribersMessage
-    {
-        public string Name { get; set; }
-        public string PublicationId { get; set; }
-        public string Slug { get; set; }
-    }
-}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/NotificationsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/NotificationsService.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Linq;
-using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.WindowsAzure.Storage;
@@ -56,11 +56,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             var message = _context.Publications
                 .Where(p => p.Id.Equals(publicationId))
-                .Select(p => new NotifySubscribersMessage
+                .Select(p => new PublicationNotificationMessage
                 {
                     Name = p.Title,
                     Slug = p.Slug,
-                    PublicationId = p.Id.ToString()
+                    PublicationId = p.Id
                 }).FirstOrDefault();
 
             return new CloudQueueMessage(JsonConvert.SerializeObject(message));

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/GovUk.Education.ExploreEducationStatistics.Notifier.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/GovUk.Education.ExploreEducationStatistics.Notifier.Model.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+
+</Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/PublicationNotificationMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/PublicationNotificationMessage.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model
+{
+    public class PublicationNotificationMessage
+    {
+        public Guid PublicationId { get; set; }
+        public string Name { get; set; }
+        public string Slug { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
@@ -12,6 +12,9 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Notifier.Model\GovUk.Education.ExploreEducationStatistics.Notifier.Model.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/PublicationNotification.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/PublicationNotification.cs
@@ -1,9 +1,0 @@
-namespace GovUk.Education.ExploreEducationStatistics.Notifier
-{
-    public class PublicationNotification
-    {
-        public string PublicationId { get; set; }
-        public string Name { get; set; }
-        public string Slug { get; set; }
-    }
-}

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/PublicationNotifier.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/PublicationNotifier.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
 using GovUk.Education.ExploreEducationStatistics.Notifier.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -64,7 +65,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier
             var table = GetCloudTable(_storageTableService, config, SubscriptionsTblName);
             var query = new TableQuery<SubscriptionEntity>()
                 .Where(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal,
-                    publicationNotification.PublicationId));
+                    publicationNotification.PublicationId.ToString()));
 
             TableContinuationToken token = null;
             do
@@ -82,7 +83,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier
                     {
                         // Use values from the queue just in case the name or slug of the publication changes
                         {"publication_name", publicationNotification.Name},
-                        {"publication_link", webApplicationBaseUrl + "statistics/" + publicationNotification.Slug},
+                        {"publication_link", webApplicationBaseUrl + "find-statistics/" + publicationNotification.Slug},
                         {"unsubscribe_link", baseUrl + entity.PartitionKey + "/unsubscribe/" + unsubscribeToken}
                     };
 
@@ -333,9 +334,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier
             return storageTableService.GetTable(connectionStr, tableName).Result;
         }
 
-        private static PublicationNotification ExtractNotification(JObject publicationNotification)
+        private static PublicationNotificationMessage ExtractNotification(JObject publicationNotification)
         {
-            return publicationNotification.ToObject<PublicationNotification>();
+            return publicationNotification.ToObject<PublicationNotificationMessage>();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.sln
+++ b/src/GovUk.Education.ExploreEducationStatistics.sln
@@ -43,6 +43,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEduc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEducationStatistics.Data.Services.Tests", "GovUk.Education.ExploreEducationStatistics.Data.Services.Tests\GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.csproj", "{1FBC2FB0-1DCA-4E53-818A-B30977D96376}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEducationStatistics.Notifier.Model", "GovUk.Education.ExploreEducationStatistics.Notifier.Model\GovUk.Education.ExploreEducationStatistics.Notifier.Model.csproj", "{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -293,6 +295,18 @@ Global
 		{1FBC2FB0-1DCA-4E53-818A-B30977D96376}.Release|x64.Build.0 = Release|Any CPU
 		{1FBC2FB0-1DCA-4E53-818A-B30977D96376}.Release|x86.ActiveCfg = Release|Any CPU
 		{1FBC2FB0-1DCA-4E53-818A-B30977D96376}.Release|x86.Build.0 = Release|Any CPU
+		{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}.Debug|x64.Build.0 = Debug|Any CPU
+		{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}.Debug|x86.Build.0 = Debug|Any CPU
+		{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}.Release|x64.ActiveCfg = Release|Any CPU
+		{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}.Release|x64.Build.0 = Release|Any CPU
+		{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}.Release|x86.ActiveCfg = Release|Any CPU
+		{BEBD1809-3E17-4FC1-8A74-A1DFB03D7CBA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Query to table storage to find Subscriptions by Publication Id wasn't finding any results due to a mismatch in case of the Publication Guid stored in the Partition key column. I'm changing the Function trigger message to use Guid rather than String to communicate the Publication Id by, and also using a common class for the message to clean things up.

This also fixes a link in the email.