### PR TITLE
Correct the names of two filter items when building content

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ApplicationDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ApplicationDbContext.cs
@@ -26,8 +26,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
         {
             Characteristic__Total,
             School_Type__Total,
-            Year_of_admission__Primary_Total,
-            Year_of_admission__Secondary_Total
+            Year_of_admission__Primary_All_primary,
+            Year_of_admission__Secondary_All_secondary
         }
 
         private enum IndicatorName
@@ -80,10 +80,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     17, new Dictionary<FilterItemName, int>
                     {
                         {
-                            FilterItemName.Year_of_admission__Primary_Total, 575
+                            FilterItemName.Year_of_admission__Primary_All_primary, 575
                         },
                         {
-                            FilterItemName.Year_of_admission__Secondary_Total, 577
+                            FilterItemName.Year_of_admission__Secondary_All_secondary, 577
                         }
                     }
                 }
@@ -2701,7 +2701,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                             },
                             Filters = new List<string>
                             {
-                                FItem(17, FilterItemName.Year_of_admission__Primary_Total)
+                                FItem(17, FilterItemName.Year_of_admission__Primary_All_primary)
                             },
                             Indicators = new List<string>
                             {
@@ -2812,7 +2812,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
 
                                         Filters = new List<string>
                                         {
-                                            FItem(17, FilterItemName.Year_of_admission__Secondary_Total)
+                                            FItem(17, FilterItemName.Year_of_admission__Secondary_All_secondary)
                                         },
                                         Indicators = new List<string>
                                         {
@@ -2923,7 +2923,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
 
                                         Filters = new List<string>
                                         {
-                                            FItem(17, FilterItemName.Year_of_admission__Primary_Total)
+                                            FItem(17, FilterItemName.Year_of_admission__Primary_All_primary)
                                         },
                                         Indicators = new List<string>
                                         {


### PR DESCRIPTION
There are no changes to content. No migrations need to run. This just cleans up the names of two enum values to match the new filter item names.