### PR TITLE
EES-114 Updated header hierarchy + moved search box on methodology

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationList.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationList.tsx
@@ -18,17 +18,17 @@ function PublicationList({ publications }: Props) {
     <>
       {publications.length > 0 ? (
         publications.map(({ id, legacyPublicationUrl, slug, title }) => (
-          <li key={id} className="govuk-!-margin-bottom-6">
-            <strong>{title}</strong>
+          <li key={id} className="govuk-!-margin-bottom-0">
+            <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{title}</h3>
             {legacyPublicationUrl ? (
-              <span>
+              <div className="govuk-!-margin-bottom-3">
                 {' '}
-                - currently available via{' '}
+                Currently available via{' '}
                 <a href={legacyPublicationUrl}>Statistics at DfE</a>
-              </span>
+              </div>
             ) : (
-              <div className="govuk-grid-row govuk-!-margin-top-2 govuk-!-margin-bottom-4">
-                <div className="govuk-grid-column-one-third govuk-!-margin-bottom-2">
+              <div className="govuk-grid-row govuk-!-margin-bottom-3">
+                <div className="govuk-grid-column-one-third govuk-!-margin-bottom-1">
                   <Link
                     className="govuk-link"
                     to={`/find-statistics/publication?publication=${slug}`}

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
@@ -49,7 +49,7 @@ class MethodologyPage extends Component<Props> {
       >
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
-            <dl className="dfe-meta-content govuk-!-margin-0">
+            <dl className="dfe-meta-content govuk-!-margin-top-0">
               <div>
                 <dt className="govuk-caption-m">Published: </dt>
                 <dd data-testid="published-date">
@@ -69,8 +69,6 @@ class MethodologyPage extends Component<Props> {
                 </>
               )}
             </dl>
-          </div>
-          <div className="govuk-grid-column-one-third">
             <PageSearchFormWithAnalytics />
           </div>
         </div>


### PR DESCRIPTION
Covers lists of publications on find stats page, with h3s added to publication titles. Also methodology search position moved to be consistent with the rest of the site.