### PR TITLE
EES-115 Private beta

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Migrations/20190916133902_AlterDataBlockConfiguration.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Migrations/20190916133902_AlterDataBlockConfiguration.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190916133902_AlterDataBlockConfiguration")]
+    partial class AlterDataBlockConfiguration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Migrations/20190916133902_AlterDataBlockConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Migrations/20190916133902_AlterDataBlockConfiguration.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Migrations
+{
+    public partial class AlterDataBlockConfiguration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("038093a2-0be3-440b-8b22-8116e34aa616"),
+                column: "DataBlock_Charts",
+                value: "[{\"Width\":0,\"Height\":0,\"Legend\":\"top\",\"Labels\":{\"181_461_____\":{\"Label\":\"Fixed period exclusion rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":[{\"Indicator\":\"181\",\"Filters\":[\"461\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":0,\"Max\":null,\"Size\":null}},\"Type\":\"line\"}]");
+
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("17a0272b-318d-41f6-bda9-3bd88f78cd3d"),
+                column: "DataBlock_Charts",
+                value: "[{\"Width\":0,\"Height\":0,\"Legend\":\"top\",\"Labels\":{\"181_461_____\":{\"Label\":\"Fixed period exclusion rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"},\"183_461_____\":{\"Label\":\"Pupils with one or more exclusion\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#f5a450\",\"symbol\":\"cross\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":[{\"Indicator\":\"181\",\"Filters\":[\"461\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"183\",\"Filters\":[\"461\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":0,\"Max\":null,\"Size\":null}},\"Type\":\"line\"}]");
+
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("4a1af98a-ed8a-438e-92d4-d21cca0429f9"),
+                column: "DataBlock_Charts",
+                value: "[{\"Width\":0,\"Height\":0,\"Labels\":{\"23_1_58_____\":{\"Label\":\"Unauthorised absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"},\"26_1_58_____\":{\"Label\":\"Overall absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#f5a450\",\"symbol\":\"cross\",\"LineStyle\":\"solid\"},\"28_1_58_____\":{\"Label\":\"Authorised absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#005ea5\",\"symbol\":\"diamond\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":[{\"Indicator\":\"23\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"26\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"28\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null}},\"Type\":\"map\"}]");
+
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("5d1e6b67-26d7-4440-9e77-c0de71a9fc21"),
+                column: "DataBlock_Charts",
+                value: "[{\"Width\":0,\"Height\":0,\"Legend\":\"top\",\"Labels\":{\"23_1_58_____\":{\"Label\":\"Unauthorised absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"},\"26_1_58_____\":{\"Label\":\"Overall absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#f5a450\",\"symbol\":\"cross\",\"LineStyle\":\"solid\"},\"28_1_58_____\":{\"Label\":\"Authorised absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#005ea5\",\"symbol\":\"diamond\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":[{\"Indicator\":\"23\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"26\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"28\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":0,\"Max\":null,\"Size\":null}},\"Type\":\"line\"}]");
+
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("5d3058f2-459e-426a-b0b3-9f60d8629fef"),
+                column: "DataBlock_Charts",
+                value: "[{\"Width\":0,\"Height\":0,\"Legend\":\"top\",\"Labels\":{\"23_1_58_____\":{\"Label\":\"Unauthorised absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"},\"26_1_58_____\":{\"Label\":\"Overall absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#f5a450\",\"symbol\":\"cross\",\"LineStyle\":\"solid\"},\"28_1_58_____\":{\"Label\":\"Authorised absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#005ea5\",\"symbol\":\"diamond\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":[{\"Indicator\":\"23\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"26\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"28\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":0,\"Max\":null,\"Size\":null}},\"Type\":\"line\"}]");
+
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("dd572e49-87e3-46f5-bb04-e9008573fc91"),
+                column: "DataBlock_Charts",
+                value: "[{\"Width\":0,\"Height\":0,\"Legend\":\"top\",\"Labels\":{\"179_461_____\":{\"Label\":\"Fixed period exclusion rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":[{\"Indicator\":\"179\",\"Filters\":[\"461\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Exclusion Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":0,\"Max\":null,\"Size\":null}},\"Type\":\"line\"}]");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("038093a2-0be3-440b-8b22-8116e34aa616"),
+                column: "DataBlock_Charts",
+                value: "[{\"Width\":0,\"Height\":0,\"ShowLegend\":false,\"Labels\":{\"181_461_____\":{\"Label\":\"Fixed period exclusion Rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":[{\"Indicator\":\"181\",\"Filters\":[\"461\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Size\":null}},\"Type\":\"line\"}]");
+
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("17a0272b-318d-41f6-bda9-3bd88f78cd3d"),
+                column: "DataBlock_Charts",
+                value: "[{\"Width\":0,\"Height\":0,\"ShowLegend\":false,\"Labels\":{\"181_461_____\":{\"Label\":\"Fixed period exclusion Rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"},\"183_461_____\":{\"Label\":\"Pupils with one ore more exclusion\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#f5a450\",\"symbol\":\"cross\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":[{\"Indicator\":\"181\",\"Filters\":[\"461\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"183\",\"Filters\":[\"461\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Size\":null}},\"Type\":\"line\"}]");
+
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("4a1af98a-ed8a-438e-92d4-d21cca0429f9"),
+                column: "DataBlock_Charts",
+                value: "[{\"Width\":0,\"Height\":0,\"ShowLegend\":false,\"Labels\":{\"23_1_58_____\":{\"Label\":\"Unauthorised Absence Rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"},\"26_1_58_____\":{\"Label\":\"Overall Absence Rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#f5a450\",\"symbol\":\"cross\",\"LineStyle\":\"solid\"},\"28_1_58_____\":{\"Label\":\"Authorised Absence Rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#005ea5\",\"symbol\":\"diamond\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":[{\"Indicator\":\"23\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"26\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"28\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Size\":null}},\"Type\":\"map\"}]");
+
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("5d1e6b67-26d7-4440-9e77-c0de71a9fc21"),
+                column: "DataBlock_Charts",
+                value: "[{\"Width\":0,\"Height\":0,\"ShowLegend\":false,\"Labels\":{\"23_1_58_____\":{\"Label\":\"Unauthorised Absence Rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"},\"26_1_58_____\":{\"Label\":\"Overall Absence Rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#f5a450\",\"symbol\":\"cross\",\"LineStyle\":\"solid\"},\"28_1_58_____\":{\"Label\":\"Authorised Absence Rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#005ea5\",\"symbol\":\"diamond\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":[{\"Indicator\":\"23\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"26\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"26\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Size\":null}},\"Type\":\"line\"}]");
+
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("5d3058f2-459e-426a-b0b3-9f60d8629fef"),
+                column: "DataBlock_Charts",
+                value: "[{\"Width\":0,\"Height\":0,\"ShowLegend\":false,\"Labels\":{\"23_1_58_____\":{\"Label\":\"Unauthorised Absence Rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"},\"26_1_58_____\":{\"Label\":\"Overall Absence Rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#f5a450\",\"symbol\":\"cross\",\"LineStyle\":\"solid\"},\"28_1_58_____\":{\"Label\":\"Authorised Absence Rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#005ea5\",\"symbol\":\"diamond\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":[{\"Indicator\":\"23\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"26\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"28\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Size\":null}},\"Type\":\"line\"}]");
+
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("dd572e49-87e3-46f5-bb04-e9008573fc91"),
+                column: "DataBlock_Charts",
+                value: "[{\"Width\":0,\"Height\":0,\"ShowLegend\":false,\"Labels\":{\"179_461_____\":{\"Label\":\"Fixed period exclusion Rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":[{\"Indicator\":\"179\",\"Filters\":[\"461\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriods\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Exclusion Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Size\":null}},\"Type\":\"line\"}]");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataQuery.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataQuery.cs
@@ -99,6 +99,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         dotted
     }
 
+    public enum Legend
+    {
+        none,
+        bottom,
+        top
+    }
+
     // this enum needs these like this as they match what is used in the front end
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public enum LabelPosition
@@ -146,6 +153,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         [JsonConverter(typeof(StringEnumConverter))]
         public LabelPosition LabelPosition;
 
+        public int? Min;
+        public int? Max;
         public string Size;
     }
 
@@ -175,7 +184,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public string Type => "line";
         public int Width;
         public int Height;
-        public bool ShowLegend;
+        
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Legend Legend;
+        
         public Dictionary<string, ChartConfiguration> Labels;
         public Dictionary<string, AxisConfigurationItem> Axes;
     }
@@ -185,7 +197,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public string Type => "horizontalbar";
         public int Width;
         public int Height;
-        public bool ShowLegend;
+        
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Legend Legend;
+        
         public Dictionary<string, ChartConfiguration> Labels;
         public Dictionary<string, AxisConfigurationItem> Axes;
         public bool Stacked;
@@ -199,7 +214,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public bool Stacked;
         public int Width;
         public int Height;
-        public bool ShowLegend;
+        
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Legend Legend;
     }
 
     public class MapChart : IContentBlockChart
@@ -207,7 +224,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public string Type => "map";
         public int Width;
         public int Height;
-        public bool ShowLegend;
         public Dictionary<string, ChartConfiguration> Labels;
         public Dictionary<string, AxisConfigurationItem> Axes;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ApplicationDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ApplicationDbContext.cs
@@ -2074,7 +2074,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                         },
                                         new ChartDataSet
                                         {
-                                            Indicator = Indicator(1, IndicatorName.Overall_absence_rate),
+                                            Indicator = Indicator(1, IndicatorName.Authorised_absence_rate),
                                             Filters = new List<string>
                                             {
                                                 FItem(1, FilterItemName.Characteristic__Total),
@@ -2086,6 +2086,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 },
                                 ["minor"] = new AxisConfigurationItem
                                 {
+                                    Min = 0,
                                     Title = "Absence Rate"
                                 }
                             },
@@ -2094,7 +2095,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 [$"{Indicator(1, IndicatorName.Unauthorised_absence_rate)}_{FItem(1, FilterItemName.Characteristic__Total)}_{FItem(1, FilterItemName.School_Type__Total)}_____"]
                                     = new ChartConfiguration
                                     {
-                                        Label = "Unauthorised Absence Rate",
+                                        Label = "Unauthorised absence rate",
                                         Unit = "%",
                                         Colour = "#4763a5",
                                         symbol = ChartSymbol.circle
@@ -2102,7 +2103,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 [$"{Indicator(1, IndicatorName.Overall_absence_rate)}_{FItem(1, FilterItemName.Characteristic__Total)}_{FItem(1, FilterItemName.School_Type__Total)}_____"]
                                     = new ChartConfiguration
                                     {
-                                        Label = "Overall Absence Rate",
+                                        Label = "Overall absence rate",
                                         Unit = "%",
                                         Colour = "#f5a450",
                                         symbol = ChartSymbol.cross
@@ -2110,12 +2111,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 [$"{Indicator(1, IndicatorName.Authorised_absence_rate)}_{FItem(1, FilterItemName.Characteristic__Total)}_{FItem(1, FilterItemName.School_Type__Total)}_____"]
                                     = new ChartConfiguration
                                     {
-                                        Label = "Authorised Absence Rate",
+                                        Label = "Authorised absence rate",
                                         Unit = "%",
                                         Colour = "#005ea5",
                                         symbol = ChartSymbol.diamond
                                     }
-                            }
+                            },
+                            Legend = Legend.top
                         }
                     }
                 },
@@ -2208,6 +2210,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 },
                                 ["minor"] = new AxisConfigurationItem
                                 {
+                                    Min = 0,
                                     Title = "Absence Rate"
                                 }
                             },
@@ -2216,7 +2219,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 [$"{Indicator(1, IndicatorName.Unauthorised_absence_rate)}_{FItem(1, FilterItemName.Characteristic__Total)}_{FItem(1, FilterItemName.School_Type__Total)}_____"]
                                     = new ChartConfiguration
                                     {
-                                        Label = "Unauthorised Absence Rate",
+                                        Label = "Unauthorised absence rate",
                                         Unit = "%",
                                         Colour = "#4763a5",
                                         symbol = ChartSymbol.circle
@@ -2224,7 +2227,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 [$"{Indicator(1, IndicatorName.Overall_absence_rate)}_{FItem(1, FilterItemName.Characteristic__Total)}_{FItem(1, FilterItemName.School_Type__Total)}_____"]
                                     = new ChartConfiguration
                                     {
-                                        Label = "Overall Absence Rate",
+                                        Label = "Overall absence rate",
                                         Unit = "%",
                                         Colour = "#f5a450",
                                         symbol = ChartSymbol.cross
@@ -2232,12 +2235,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 [$"{Indicator(1, IndicatorName.Authorised_absence_rate)}_{FItem(1, FilterItemName.Characteristic__Total)}_{FItem(1, FilterItemName.School_Type__Total)}_____"]
                                     = new ChartConfiguration
                                     {
-                                        Label = "Authorised Absence Rate",
+                                        Label = "Authorised absence rate",
                                         Unit = "%",
                                         Colour = "#005ea5",
                                         symbol = ChartSymbol.diamond
                                     }
-                            }
+                            }, 
+                            Legend = Legend.top
                         }
                     }
                 },
@@ -2324,7 +2328,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 [$"{Indicator(1, IndicatorName.Unauthorised_absence_rate)}_{FItem(1, FilterItemName.Characteristic__Total)}_{FItem(1, FilterItemName.School_Type__Total)}_____"]
                                     = new ChartConfiguration
                                     {
-                                        Label = "Unauthorised Absence Rate",
+                                        Label = "Unauthorised absence rate",
                                         Unit = "%",
                                         Colour = "#4763a5",
                                         symbol = ChartSymbol.circle
@@ -2332,7 +2336,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 [$"{Indicator(1, IndicatorName.Overall_absence_rate)}_{FItem(1, FilterItemName.Characteristic__Total)}_{FItem(1, FilterItemName.School_Type__Total)}_____"]
                                     = new ChartConfiguration
                                     {
-                                        Label = "Overall Absence Rate",
+                                        Label = "Overall absence rate",
                                         Unit = "%",
                                         Colour = "#f5a450",
                                         symbol = ChartSymbol.cross
@@ -2340,7 +2344,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 [$"{Indicator(1, IndicatorName.Authorised_absence_rate)}_{FItem(1, FilterItemName.Characteristic__Total)}_{FItem(1, FilterItemName.School_Type__Total)}_____"]
                                     = new ChartConfiguration
                                     {
-                                        Label = "Authorised Absence Rate",
+                                        Label = "Authorised absence rate",
                                         Unit = "%",
                                         Colour = "#005ea5",
                                         symbol = ChartSymbol.diamond
@@ -2453,6 +2457,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 },
                                 ["minor"] = new AxisConfigurationItem
                                 {
+                                    Min = 0,
                                     Title = "Absence Rate"
                                 }
                             },
@@ -2462,7 +2467,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                     =
                                     new ChartConfiguration
                                     {
-                                        Label = "Fixed period exclusion Rate",
+                                        Label = "Fixed period exclusion rate",
                                         Unit = "%",
                                         Colour = "#4763a5",
                                         symbol = ChartSymbol.circle
@@ -2471,12 +2476,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                     =
                                     new ChartConfiguration
                                     {
-                                        Label = "Pupils with one ore more exclusion",
+                                        Label = "Pupils with one or more exclusion",
                                         Unit = "%",
                                         Colour = "#f5a450",
                                         symbol = ChartSymbol.cross
                                     }
-                            }
+                            },
+                            Legend = Legend.top
                         }
                     }
                 },
@@ -2545,6 +2551,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 },
                                 ["minor"] = new AxisConfigurationItem
                                 {
+                                    Min = 0,
                                     Title = "Exclusion Rate"
                                 }
                             },
@@ -2554,12 +2561,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                     =
                                     new ChartConfiguration
                                     {
-                                        Label = "Fixed period exclusion Rate",
+                                        Label = "Fixed period exclusion rate",
                                         Unit = "%",
                                         Colour = "#4763a5",
                                         symbol = ChartSymbol.circle
                                     }
-                            }
+                            },
+                            Legend = Legend.top
                         }
                     }
                 },
@@ -2630,6 +2638,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 },
                                 ["minor"] = new AxisConfigurationItem
                                 {
+                                    Min = 0,
                                     Title = "Absence Rate"
                                 }
                             },
@@ -2639,12 +2648,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                     =
                                     new ChartConfiguration
                                     {
-                                        Label = "Fixed period exclusion Rate",
+                                        Label = "Fixed period exclusion rate",
                                         Unit = "%",
                                         Colour = "#4763a5",
                                         symbol = ChartSymbol.circle
                                     }
-                            }
+                            },
+                            Legend = Legend.top
                         }
                     }
                 },


### PR DESCRIPTION
Changes 5 charts.

Updates the line chart configuration blocks to show legend at top of the chart.
Charts minor axis now begin at zero.
Corrects the case of some of the chart labels to be consistent.
Corrects one of the chart lines which was set for the wrong filter so it wasn't displaying.
Removes unused property `ShowLegend` from configuration block.