### PR TITLE
EES-152 - rolled polyfill code back out, as this was not fixing the p…

### DIFF
--- a/src/explore-education-statistics-common/package-lock.json
+++ b/src/explore-education-statistics-common/package-lock.json
@@ -4091,11 +4091,6 @@
         "array-find-index": "^1.0.1"
       }
     },
-    "custom-event-polyfill": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
-      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
-    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -136,8 +136,5 @@
   },
   "jest-junit": {
     "ancestorSeparator": " › "
-  },
-  "dependencies": {
-    "custom-event-polyfill": "^1.0.7"
   }
 }

--- a/src/explore-education-statistics-frontend/package-lock.json
+++ b/src/explore-education-statistics-frontend/package-lock.json
@@ -1627,180 +1627,85 @@
       }
     },
     "@microsoft/applicationinsights-analytics-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.1.1.tgz",
-      "integrity": "sha512-VKIutoFKY99CyKwxLUuj6Vnq14/QwXo9/QSQDpYnHEjo+uKn7QmLsHqWw0K9uYNfNAXt4BZimX/zDg6jZtzeXg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.2.2.tgz",
+      "integrity": "sha512-69RCJPpZZhG/3FVBe0RiXPCXDBGzxtoHsty9kqlvqcS29Pzxz8B9abC/gSe8Ta1VixOcwIeUEUK/XwHYkRxL+Q==",
       "requires": {
-        "@microsoft/applicationinsights-common": "2.1.1",
-        "@microsoft/applicationinsights-core-js": "2.1.1",
+        "@microsoft/applicationinsights-common": "2.2.2",
+        "@microsoft/applicationinsights-core-js": "2.2.2",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "@microsoft/applicationinsights-common": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.1.1.tgz",
-          "integrity": "sha512-2hkS1Ia1FmAjCuYZ5JlG20/WgObqdsKtmK5YALAFGHIB4KSQ/Za1qazS+7GsG+E0F9UJivNWL1geUIcNqg5Qjg==",
-          "requires": {
-            "@microsoft/applicationinsights-core-js": "2.1.1",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@microsoft/applicationinsights-core-js": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.1.1.tgz",
-          "integrity": "sha512-4t4wf6SKqIcWEQDPg/uOhm+BxtHhu/AFreyEoYZmMfcxzAu33h1FtTQRtxBNbYH1+thiNZCh80yUpnT7d9Hrlw==",
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "@microsoft/applicationinsights-channel-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.1.1.tgz",
-      "integrity": "sha512-fYr9IAqtaEr9AmaPaL3SLQVT3t3GQzl+n74gpNKyAVakDIm0nYQ/bimjdcAhJMDf1VGNSPg/xICneyuZg7Wxlg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.2.2.tgz",
+      "integrity": "sha512-Gj4v6hoW+MA6ZHSFIfBxs7wj94nUOrteP861CPr8yzVxKSA04e15U78oYnQiJJFLQrG4wnuo/B/gMwDtj/3pyg==",
       "requires": {
-        "@microsoft/applicationinsights-common": "2.1.1",
-        "@microsoft/applicationinsights-core-js": "2.1.1",
+        "@microsoft/applicationinsights-common": "2.2.2",
+        "@microsoft/applicationinsights-core-js": "2.2.2",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "@microsoft/applicationinsights-common": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.1.1.tgz",
-          "integrity": "sha512-2hkS1Ia1FmAjCuYZ5JlG20/WgObqdsKtmK5YALAFGHIB4KSQ/Za1qazS+7GsG+E0F9UJivNWL1geUIcNqg5Qjg==",
-          "requires": {
-            "@microsoft/applicationinsights-core-js": "2.1.1",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@microsoft/applicationinsights-core-js": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.1.1.tgz",
-          "integrity": "sha512-4t4wf6SKqIcWEQDPg/uOhm+BxtHhu/AFreyEoYZmMfcxzAu33h1FtTQRtxBNbYH1+thiNZCh80yUpnT7d9Hrlw==",
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "@microsoft/applicationinsights-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.1.0.tgz",
-      "integrity": "sha512-m1OIvHm6XaqHm/CdfxuZ6xy5mcEcXkf22trCWRmAvf3IXH27+Jm3F/+6y37Nd8cd013IBLioVLMwUBQ9t2mXEg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.2.2.tgz",
+      "integrity": "sha512-jDci++srfxgqkcPPI6hUk0TPRRKpa1nhXxruBdHKlSAUezI9JSkA7s3yUp4JeUSPDOLPPRfepuHNjLcH0QhJsQ==",
       "requires": {
-        "@microsoft/applicationinsights-core-js": "2.1.0",
+        "@microsoft/applicationinsights-core-js": "2.2.2",
         "tslib": "^1.9.3"
       }
     },
     "@microsoft/applicationinsights-core-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.1.0.tgz",
-      "integrity": "sha512-gSEj51HCeKepS6Yb7kJBlaolQJtUXnFjzubZjX1ZZW/sxdRK5d1jVNPIVWK3nVU53ydcpE/9VmWhG2nf6v7kdg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.2.2.tgz",
+      "integrity": "sha512-iBFd7by50JFv7YjgmkM9B3c9AtLjyjSu+VEnWVV1QFUfA7qxBD+fJO8yNxt+qzEAnO7auE4ZvcHNi4PeaT/8+A==",
       "requires": {
         "tslib": "^1.9.3"
       }
     },
     "@microsoft/applicationinsights-dependencies-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.1.1.tgz",
-      "integrity": "sha512-yhb4EToBp+aI+qLo0h5NDNtoo3sDFV60uyIOK843YjzXqVotcXX/lRShlghTkJtYH09QhrdzDjViUHnD4sMFSQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.2.2.tgz",
+      "integrity": "sha512-ExESoscN6lrIBCpMfjlFATq02Gre7J5MG6VwdKfSNUwl0Ubkj9MEtC37IXBUiNT4SVHCMYElzVMUKXniXtPXdg==",
       "requires": {
-        "@microsoft/applicationinsights-common": "2.1.1",
-        "@microsoft/applicationinsights-core-js": "2.1.1",
+        "@microsoft/applicationinsights-common": "2.2.2",
+        "@microsoft/applicationinsights-core-js": "2.2.2",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "@microsoft/applicationinsights-common": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.1.1.tgz",
-          "integrity": "sha512-2hkS1Ia1FmAjCuYZ5JlG20/WgObqdsKtmK5YALAFGHIB4KSQ/Za1qazS+7GsG+E0F9UJivNWL1geUIcNqg5Qjg==",
-          "requires": {
-            "@microsoft/applicationinsights-core-js": "2.1.1",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@microsoft/applicationinsights-core-js": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.1.1.tgz",
-          "integrity": "sha512-4t4wf6SKqIcWEQDPg/uOhm+BxtHhu/AFreyEoYZmMfcxzAu33h1FtTQRtxBNbYH1+thiNZCh80yUpnT7d9Hrlw==",
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "@microsoft/applicationinsights-properties-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.1.1.tgz",
-      "integrity": "sha512-8l+/ppw6xKTam2RL4EHZ52Lcf217olw81j6kyBNKtIcGwSnLNHrFwEeF3vBWIteG2JKzlg1GhGjrkB3oxXsV2g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.2.2.tgz",
+      "integrity": "sha512-B6xbn9GtrdUwQvMM4EuQwztyzDO1PWod057bn0RHZU+y7MFQYEtNPVjCO+9+mfCNnSd973o80up2Gr87Fi5F6Q==",
       "requires": {
-        "@microsoft/applicationinsights-common": "2.1.1",
-        "@microsoft/applicationinsights-core-js": "2.1.1",
+        "@microsoft/applicationinsights-common": "2.2.2",
+        "@microsoft/applicationinsights-core-js": "2.2.2",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "@microsoft/applicationinsights-common": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.1.1.tgz",
-          "integrity": "sha512-2hkS1Ia1FmAjCuYZ5JlG20/WgObqdsKtmK5YALAFGHIB4KSQ/Za1qazS+7GsG+E0F9UJivNWL1geUIcNqg5Qjg==",
-          "requires": {
-            "@microsoft/applicationinsights-core-js": "2.1.1",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@microsoft/applicationinsights-core-js": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.1.1.tgz",
-          "integrity": "sha512-4t4wf6SKqIcWEQDPg/uOhm+BxtHhu/AFreyEoYZmMfcxzAu33h1FtTQRtxBNbYH1+thiNZCh80yUpnT7d9Hrlw==",
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "@microsoft/applicationinsights-react-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-react-js/-/applicationinsights-react-js-2.1.1.tgz",
-      "integrity": "sha512-iyuEFXsVc8WkSFuZ6McPYpJfw5POgympv8KsLfimbBF8gl7dEHjfdU/+cFxtRgCjsryi0RmkNU2aDPmKlsHiLA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-react-js/-/applicationinsights-react-js-2.2.2.tgz",
+      "integrity": "sha512-sIVD0SXe+ZV3LEOCZdAGNnQpMNviG+DCJH5qfZeQKk4KIGcD4ZhK3NMVfO1zxkyfxORVAJ0pz/fy1VNiX/ccHQ==",
       "requires": {
-        "@microsoft/applicationinsights-common": "2.1.0",
-        "@microsoft/applicationinsights-core-js": "2.1.0",
+        "@microsoft/applicationinsights-common": "2.2.2",
+        "@microsoft/applicationinsights-core-js": "2.2.2",
         "history": "^4.9.0",
         "react": "^16.8.6",
         "tslib": "^1.9.3"
       }
     },
     "@microsoft/applicationinsights-web": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.1.1.tgz",
-      "integrity": "sha512-crvhCkNsNxkFuPWmttyWNSAA96D5FxBtKS6UA9MV9f9XHevTfchf/E3AuU9JZcsXufWMQLwLrUQ9ZiA1QJ0EWA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.2.2.tgz",
+      "integrity": "sha512-9xaoehA1uGt02+Y9x2BJzzd9z6RYIpgzyArjp+OOLwUHs5B0Xj4SAwq5T2Gm1YADh2F3wrKTV/Y72KWIdJDfRg==",
       "requires": {
-        "@microsoft/applicationinsights-analytics-js": "2.1.1",
-        "@microsoft/applicationinsights-channel-js": "2.1.1",
-        "@microsoft/applicationinsights-common": "2.1.1",
-        "@microsoft/applicationinsights-core-js": "2.1.1",
-        "@microsoft/applicationinsights-dependencies-js": "2.1.1",
-        "@microsoft/applicationinsights-properties-js": "2.1.1"
-      },
-      "dependencies": {
-        "@microsoft/applicationinsights-common": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.1.1.tgz",
-          "integrity": "sha512-2hkS1Ia1FmAjCuYZ5JlG20/WgObqdsKtmK5YALAFGHIB4KSQ/Za1qazS+7GsG+E0F9UJivNWL1geUIcNqg5Qjg==",
-          "requires": {
-            "@microsoft/applicationinsights-core-js": "2.1.1",
-            "tslib": "^1.9.3"
-          }
-        },
-        "@microsoft/applicationinsights-core-js": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.1.1.tgz",
-          "integrity": "sha512-4t4wf6SKqIcWEQDPg/uOhm+BxtHhu/AFreyEoYZmMfcxzAu33h1FtTQRtxBNbYH1+thiNZCh80yUpnT7d9Hrlw==",
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        }
+        "@microsoft/applicationinsights-analytics-js": "2.2.2",
+        "@microsoft/applicationinsights-channel-js": "2.2.2",
+        "@microsoft/applicationinsights-common": "2.2.2",
+        "@microsoft/applicationinsights-core-js": "2.2.2",
+        "@microsoft/applicationinsights-dependencies-js": "2.2.2",
+        "@microsoft/applicationinsights-properties-js": "2.2.2"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -5326,11 +5231,6 @@
         "array-find-index": "^1.0.1"
       }
     },
-    "custom-event-polyfill": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
-      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
-    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -8081,16 +7981,16 @@
       "integrity": "sha1-SoWtZYgfYoV/xwr3F0oRhNzM4ys="
     },
     "history": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.9.0.tgz",
-      "integrity": "sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "loose-envify": "^1.2.0",
-        "resolve-pathname": "^2.2.0",
+        "resolve-pathname": "^3.0.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0",
-        "value-equal": "^0.4.0"
+        "value-equal": "^1.0.1"
       }
     },
     "hmac-drbg": {
@@ -16113,9 +16013,9 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
     },
     "resolve-pathname": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
-      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -18763,9 +18663,9 @@
       }
     },
     "value-equal": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
-      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/src/explore-education-statistics-frontend/package.json
+++ b/src/explore-education-statistics-frontend/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@microsoft/applicationinsights-react-js": "^2.1.1",
-    "@microsoft/applicationinsights-web": "^2.1.1",
+    "@microsoft/applicationinsights-react-js": "^2.2.2",
+    "@microsoft/applicationinsights-web": "^2.2.2",
     "@zeit/next-css": "^1.0.1",
     "@zeit/next-typescript": "^1.1.1",
     "applicationinsights": "^1.4.0",
@@ -13,7 +13,6 @@
     "core-js": "^2.6.5",
     "cross-env": "^5.2.0",
     "cross-fetch": "^3.0.4",
-    "custom-event-polyfill": "^1.0.7",
     "date-fns": "^2.0.0-beta.2",
     "dotenv": "^8.0.0",
     "dotenv-expand": "^5.1.0",

--- a/src/explore-education-statistics-frontend/src/pages/_app.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/_app.tsx
@@ -8,7 +8,6 @@ import Helmet from 'react-helmet';
 import './_app.scss';
 import { CookiesProvider, Cookies } from 'react-cookie';
 import { NextContext } from 'next';
-import 'custom-event-polyfill/polyfill';
 
 process.env.APP_ROOT_ID = '__next';
 
@@ -43,10 +42,6 @@ class App extends BaseApp<Props> {
   }
 
   public componentDidMount() {
-    if (typeof (window as any).Event === 'undefined') {
-      (window as any).Event = (window as any).CustomEvent;
-    }
-
     logPageView();
     initHotJar();
     initApplicationInsights();


### PR DESCRIPTION
Backed out polyfill, as its CustomEvent (and our Event) definition is overridden by something else on the dev environment.

But bumped up the versions of the application insights instrumentation libraries, which now replace "new Event" with "Util.createDomEvent" where they have POLYFILLED IT THEMSELVES!