### PR TITLE
EES-317: Added arm template parameters files with scaling of sku's

### DIFF
--- a/armTemplates/ees-service/dev.parameters.json
+++ b/armTemplates/ees-service/dev.parameters.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "skuPublic": {
+            "value": "B1 Basic"
+        },
+        "skuData": {
+            "value": "S1 Standard"
+        },
+        "skuContent": {
+            "value": "S1 Standard"
+        },
+        "skuAdmin": {
+            "value": "S3 Standard"
+        }
+    }
+}

--- a/armTemplates/ees-service/prod.parameters.json
+++ b/armTemplates/ees-service/prod.parameters.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "skuPublic": {
+            "value": "B1 Basic"
+        },
+        "skuData": {
+            "value": "S2 Standard"
+        },
+        "skuContent": {
+            "value": "S1 Standard"
+        },
+        "skuAdmin": {
+            "value": "S2 Standard"
+        }
+    }
+}

--- a/armTemplates/ees-service/test.parameters.json
+++ b/armTemplates/ees-service/test.parameters.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "skuPublic": {
+            "value": "B1 Basic"
+        },
+        "skuData": {
+            "value": "S1 Standard"
+        },
+        "skuContent": {
+            "value": "S1 Standard"
+        },
+        "skuAdmin": {
+            "value": "S2 Standard"
+        }
+    }
+}


### PR DESCRIPTION
This adds some of the arm template parameters into environment specific files.

Once this is merged then the pipeline can be updated to use these.

I've scaled down the admin app for now, and scaled up the data API in production.

This will be a part 1, and is just single instance scaling (scale up), once this is proven i'll raise another ticket to add more instances as a configuration option (scale out).