### PR TITLE
EES-385: Set release live flag

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/ReleaseViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/ReleaseViewModel.cs
@@ -32,6 +32,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models.Api
 
         public DateTime? Published { get; set; }
 
+        public bool Live => Published != null && Published > DateTime.UtcNow;
+
         [JsonConverter(typeof(TimeIdentifierJsonConverter))]
         public TimeIdentifier? TimePeriodCoverage { get; set; }
 


### PR DESCRIPTION
Set release live flag to the release view model this will then correctly display the release as "live" e.g. on the public facing site within the admin application.