### PR TITLE
EES-209 Fix for methodology page

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
@@ -113,14 +113,14 @@ class MethodologyPage extends Component<Props> {
                 >
                   <MethodologyHeader>
                     <ContentSectionIndex
-                      fromId={`contents-sections-${order}-content`}
+                      fromId={`${this.accId[0]}-${order}-content`}
                     />
                   </MethodologyHeader>
 
                   <MethodologyContent>
                     <ContentBlock
                       content={content}
-                      id={`content_${order}`}
+                      id={`${this.accId[0]}_${order}`}
                       publication={data.publication}
                     />
                   </MethodologyContent>
@@ -144,7 +144,7 @@ class MethodologyPage extends Component<Props> {
                   >
                     <ContentBlock
                       content={content}
-                      id={`content_${order}`}
+                      id={`${this.accId[1]}_${order}`}
                       publication={data.publication}
                     />
                   </AccordionSection>


### PR DESCRIPTION
This fixes an issue where the dynamic id wasn't getting passed down to the 'In this section' links on the methodology pages.