### PR TITLE
EES-162 table tool header clarification

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
@@ -21,7 +21,7 @@ const FormFieldset = ({
   hint,
   id,
   legend,
-  legendSize = 'm',
+  legendSize = 'l',
   legendHidden = false,
   className,
 }: FormFieldsetProps) => {

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`FormCheckboxGroup generates option IDs from id and value if none specif
   <fieldset class="govuk-fieldset"
             id="test-checkboxes"
   >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       Test checkboxes
     </legend>
     <div class="govuk-checkboxes">
@@ -58,7 +58,7 @@ exports[`FormCheckboxGroup renders \`Select all 3 options\` button when \`select
   <fieldset class="govuk-fieldset"
             id="test-checkboxes"
   >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       Test checkboxes
     </legend>
     <div class="govuk-checkboxes">
@@ -117,7 +117,7 @@ exports[`FormCheckboxGroup renders checkboxes with some pre-checked 1`] = `
   <fieldset class="govuk-fieldset"
             id="test-checkboxes"
   >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       Test checkboxes
     </legend>
     <div class="govuk-checkboxes">
@@ -171,7 +171,7 @@ exports[`FormCheckboxGroup renders correctly with legend 1`] = `
   <fieldset class="govuk-fieldset"
             id="test-checkboxes"
   >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       Choose some checkboxes
     </legend>
     <div class="govuk-checkboxes">
@@ -203,7 +203,7 @@ exports[`FormCheckboxGroup renders correctly with small size variants 1`] = `
       id="test-checkboxes"
     >
       <legend
-        class="govuk-fieldset__legend govuk-fieldset__legend--m"
+        class="govuk-fieldset__legend govuk-fieldset__legend--l"
       >
         Test checkboxes
       </legend>
@@ -238,7 +238,7 @@ exports[`FormCheckboxGroup renders list of checkboxes in correct order 1`] = `
   <fieldset class="govuk-fieldset"
             id="test-checkboxes"
   >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       Test checkboxes
     </legend>
     <div class="govuk-checkboxes">
@@ -291,7 +291,7 @@ exports[`FormCheckboxGroup renders option with conditional contents 1`] = `
   <fieldset class="govuk-fieldset"
             id="test-checkboxes"
   >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       Test checkboxes
     </legend>
     <div class="govuk-checkboxes">

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`FormCheckboxSearchGroup renders list of checkboxes in correct order 1`]
   <fieldset class="govuk-fieldset"
             id="test-checkboxes"
   >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       Choose options
     </legend>
     <label class="govuk-label"

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchSubGroups.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchSubGroups.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`FormCheckboxSearchSubGroups renders groups of checkboxes in correct ord
   <fieldset class="govuk-fieldset"
             id="test-checkboxes"
   >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       Choose options
     </legend>
     <label class="govuk-label"

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldset.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldset.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FormFieldset renders correctly with error 1`] = `
             id="test-fieldset"
             aria-describedby="test-fieldset-error"
   >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       Fill the form
     </legend>
     <span class="govuk-error-message"
@@ -30,7 +30,7 @@ exports[`FormFieldset renders correctly with hint 1`] = `
             id="test-fieldset"
             aria-describedby="test-fieldset-hint"
   >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       Fill the form
     </legend>
     <span class="govuk-hint"
@@ -53,7 +53,7 @@ exports[`FormFieldset renders correctly with required props 1`] = `
   <fieldset class="govuk-fieldset"
             id="test-fieldset"
   >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
       Fill the form
     </legend>
     <input type="text"

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -107,7 +107,7 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
                       name="indicators"
                       id={`${formId}-indicators`}
                       legend="Indicators"
-                      legendSize="s"
+                      legendSize="m"
                       hint="Select at least one indicator"
                       error={getError('indicators')}
                       selectAll

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationSubjectForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationSubjectForm.tsx
@@ -77,6 +77,7 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
             <FormFieldRadioGroup<FormValues>
               name="subjectId"
               legend={stepHeading}
+              legendSize="l"
               options={options.map(option => ({
                 label: option.label,
                 value: `${option.id}`,

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.tsx
@@ -14,7 +14,7 @@ const WizardStepHeading = ({
   currentStep,
   fieldsetHeading = false,
   isActive,
-  size = 'm',
+  size = 'l',
   stepNumber,
   setCurrentStep,
 }: Props & InjectedWizardProps) => {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FormFieldCheckboxGroupsMenu.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FormFieldCheckboxGroupsMenu.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
   id="test"
 >
   <legend
-    class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden"
+    class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-visually-hidden"
   >
     Choose options
   </legend>
@@ -140,7 +140,7 @@ exports[`FormFieldCheckboxGroupsMenu renders single checkbox group with search i
   id="test"
 >
   <legend
-    class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden"
+    class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-visually-hidden"
   >
     Choose options
   </legend>
@@ -215,7 +215,7 @@ exports[`FormFieldCheckboxGroupsMenu renders single checkbox group with single c
   id="test"
 >
   <legend
-    class="govuk-fieldset__legend govuk-fieldset__legend--m"
+    class="govuk-fieldset__legend govuk-fieldset__legend--l"
   >
     Choose options
   </legend>


### PR DESCRIPTION
Altered default sizing of table-tool header components to give a more hierarchical structure for clarity

https://alpha-dfe-data.atlassian.net/browse/EES-162

![image](https://user-images.githubusercontent.com/17567430/66491585-e6db9180-eaaa-11e9-90dd-d8567f5aff09.png)
