### PR TITLE
Tools/content cache genertion on content api startup

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
@@ -39,6 +39,7 @@
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.6.1" />
         <PackageReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="10.0.3" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.3" />
         <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="10.0.3" />
         <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Converters;
@@ -9,9 +11,11 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.Storage.Queue;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.Swagger;
 
@@ -20,9 +24,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
     [ExcludeFromCodeCoverage]
     public class Startup
     {
-        public Startup(IConfiguration configuration)
+        private readonly ILogger<Startup> _logger;
+
+        public Startup(IConfiguration configuration, ILogger<Startup> logger)
         {
             Configuration = configuration;
+            _logger = logger;
         }
 
         public IConfiguration Configuration { get; }
@@ -72,6 +79,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                
+                GenerateContentCache();
             }
             else
             {
@@ -108,6 +117,40 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
                 {
                     context.Database.Migrate();
                 }
+            }
+        }
+
+        // TODO: this should only be used in development, adds the required message to the content-cache queue
+        private void GenerateContentCache()
+        {
+            CloudQueueClient cloudStorageClient = null;
+            
+            try
+            {
+                var cloudStorageAccount = CloudStorageAccount.Parse(Configuration.GetConnectionString("PublicStorage"));
+                cloudStorageClient = cloudStorageAccount.CreateCloudQueueClient();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Unable to create content-cache queue client");
+                throw;
+            }
+
+            try
+            {
+                var queue = cloudStorageClient.GetQueueReference("content-cache");
+                queue.CreateIfNotExists();
+                
+                var message = new CloudQueueMessage("Generation triggered by the Content API Startup");
+                queue.AddMessage(message);
+                
+                _logger.LogInformation("Message added to content-cache queue.");
+                _logger.LogInformation("Please ensure the publisher function is running");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError("Unable add message to content-cache queue");
+                throw;
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "PublicStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;",
+    "PublicStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;QueueEndpoint=http://data-storage:10001/devstoreaccount1;",
     "ContentDb": "Server=db;Database=content;User=SA;Password=Your_Password123;Trusted_Connection=False;"
   },
   "Logging": {


### PR DESCRIPTION
When running the content api in development mode this will add a message to the local "content-cache" queue.

If running the Published function this will then generate the content-cache locally.