### PR TITLE
EES-403 Page Title 'ERROR: ' prefixing

### DIFF
--- a/src/explore-education-statistics-common/src/components/ErrorPrefixPageTitle.tsx
+++ b/src/explore-education-statistics-common/src/components/ErrorPrefixPageTitle.tsx
@@ -1,0 +1,19 @@
+import React, { Component } from 'react';
+import Head from 'next/head';
+
+class ErrorPrefixPageTitle extends Component {
+  public componentWillUnmount() {
+    document.title = document.title.replace(/ERROR: /g, '');
+  }
+
+  public render() {
+    document.title = `ERROR: ${document.title.replace(/ERROR: /g, '')}`;
+    return (
+      <Head>
+        <title>ERROR: {document.title.replace(/ERROR: /g, '')}</title>
+      </Head>
+    );
+  }
+}
+
+export default ErrorPrefixPageTitle;

--- a/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
+++ b/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import ErrorPrefixPageTitle from './ErrorPrefixPageTitle';
 
 export interface ErrorSummaryMessage {
   id: string;
@@ -59,6 +60,8 @@ const ErrorSummary = ({
       <h2 className="govuk-error-summary__title" id={idTitle}>
         {title}
       </h2>
+
+      <ErrorPrefixPageTitle />
 
       <div className="govuk-error-summary__body">
         <ul className="govuk-list govuk-error-summary__list">


### PR DESCRIPTION
Ticket: https://alpha-dfe-data.atlassian.net/browse/EES-403
> Ensure that when an error occurs, the page title is prefixed with the text ‘Error:’ to enableusers to determine that there are errors on the page, immediately.Example of how to achieve this can be found at:https://design-system.service.gov.uk/components/error-summary/

-----

Added a `ErrorPrefixPageTitle` component which when rendered will always prefix the page title with `"ERROR: "`. 

The component attempts to removed the prefix when unMounting, however the prefix remains if there are other ErrorPrefixPageTitle's present