### PR TITLE
Feature/ees 399 poison queue handling

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/PoisonQueueHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/PoisonQueueHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
@@ -10,28 +11,42 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
 {
     public class PoisonQueueHandler
     {
-        public PoisonQueueHandler()
+        private readonly IBatchService _batchService;
+
+        public PoisonQueueHandler(IBatchService batchService)
         {
         }
 
         [FunctionName("ProcessUploadsPoisonHandler")]
-        public void ProcessUploads(
+        public void ProcessUploadsPoisonQueueHandler(
             [QueueTrigger("imports-pending-poison")]
             ImportMessage message,
             ILogger logger
         )
         {
-            // TODO: Flag these files as failed
+            var errors = new List<string>() { "File failed to import for unknown reason in upload processing stage."};
+            
+            _batchService.FailImport(
+                message.Release.Id.ToString(),
+                message.DataFileName,
+                errors
+            ).Wait();
         }
 
 
         [FunctionName("ImportObservationsPoisonHandler")]
-        public void ImportObservations(
+        public void ImportObservationsPoisonQueueHandler(
             [QueueTrigger("imports-available-poison")]
             ImportMessage message,
             ILogger logger)
         {
-            // TODO: Flag these files as failed
+            var errors = new List<string>() { "File failed to import for unknown reason in observation import stage." };
+            
+            _batchService.FailImport(
+                message.Release.Id.ToString(),
+                message.DataFileName,
+                errors
+            ).Wait();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/PoisonQueueHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/PoisonQueueHandler.cs
@@ -1,0 +1,37 @@
+using System;
+using GovUk.Education.ExploreEducationStatistics.Data.Importer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
+{
+    public class PoisonQueueHandler
+    {
+        public PoisonQueueHandler()
+        {
+        }
+
+        [FunctionName("ProcessUploadsPoisonHandler")]
+        public void ProcessUploads(
+            [QueueTrigger("imports-pending-poison")]
+            ImportMessage message,
+            ILogger logger
+        )
+        {
+            // TODO: Flag these files as failed
+        }
+
+
+        [FunctionName("ImportObservationsPoisonHandler")]
+        public void ImportObservations(
+            [QueueTrigger("imports-available-poison")]
+            ImportMessage message,
+            ILogger logger)
+        {
+            // TODO: Flag these files as failed
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/PoisonQueueHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/PoisonQueueHandler.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using GovUk.Education.ExploreEducationStatistics.Data.Importer.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
@@ -15,10 +12,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
 
         public PoisonQueueHandler(IBatchService batchService)
         {
+            _batchService = batchService;
         }
 
         [FunctionName("ProcessUploadsPoisonHandler")]
-        public void ProcessUploadsPoisonQueueHandler(
+        public async void ProcessUploadsPoisonQueueHandler(
             [QueueTrigger("imports-pending-poison")]
             ImportMessage message,
             ILogger logger
@@ -26,27 +24,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
         {
             var errors = new List<string>() { "File failed to import for unknown reason in upload processing stage."};
             
-            _batchService.FailImport(
+            await _batchService.FailImport(
                 message.Release.Id.ToString(),
                 message.DataFileName,
                 errors
-            ).Wait();
+            );
         }
 
 
         [FunctionName("ImportObservationsPoisonHandler")]
-        public void ImportObservationsPoisonQueueHandler(
+        public async void ImportObservationsPoisonQueueHandler(
             [QueueTrigger("imports-available-poison")]
             ImportMessage message,
             ILogger logger)
         {
             var errors = new List<string>() { "File failed to import for unknown reason in observation import stage." };
             
-            _batchService.FailImport(
+            await _batchService.FailImport(
                 message.Release.Id.ToString(),
                 message.DataFileName,
                 errors
-            ).Wait();
+            );
         }
     }
 }


### PR DESCRIPTION
This PR adds handling for files ending up on the poision queue.

Currently files failing with an uncaught exception in the processor will be added to the posion queue and retried 5 times (default configuration). The status of these files however is no updated so to a user this file appears as "validating" permently. 

This add two new functions that process the poison queue and update the status to failed.