### PR TITLE
EES-434 Correcting methodology link

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -173,7 +173,7 @@ class TableToolPage extends Component<Props, State> {
                   <li>
                     <Link
                       as={`/methodology/${finalStepProps.publication.slug}`}
-                      to={`/methodology/methodology?methodology=${finalStepProps.publication.slug}`}
+                      to={`/methodology/methodology?publication=${finalStepProps.publication.slug}`}
                     >
                       Go to methodology
                     </Link>


### PR DESCRIPTION
I debugged clicking the methodology link on the Table Tool page and found it was trying to GET
http://localhost:5010/api/Methodology/**undefined**

I.e. the publication slug segment of the service call in methodologyService.ts was undefined.

Fixed it by correcting the publication slug link parameter on the Table Tool page.