### PR TITLE
EES-512 - Display the zip of all files for download

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileStorageService.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Functions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
@@ -12,6 +13,7 @@ using ICSharpCode.SharpZipLib.Zip;
 using Microsoft.Azure.Storage.Blob;
 using Microsoft.Azure.Storage.DataMovement;
 using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Common.Model.ReleaseFileTypes;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
@@ -152,17 +154,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             return cloudBlob.Uri.Segments.Last();
         }
 
-        private static string GetZipFilename(PublishReleaseDataMessage message)
+        private static string GetZipFilePath(PublishReleaseDataMessage message)
         {
-            return $"{message.PublicationSlug}_{message.ReleaseSlug}.zip";
+            return $"{Ancillary.GetEnumLabel()}/{message.PublicationSlug}_{message.ReleaseSlug}.zip";
         }
 
         private static CloudBlockBlob CreateBlobForAllFilesZip(CloudBlobDirectory directory,
             PublishReleaseDataMessage message)
         {
-            var blob = directory.GetBlockBlobReference(GetZipFilename(message));
-            blob.Properties.ContentType = "application/zip";
-            blob.Metadata.Add("name", "All data files");
+            var blob = directory.GetBlockBlobReference(GetZipFilePath(message));
+            blob.Properties.ContentType = "application/x-zip-compressed";
+            blob.Metadata.Add("name", "All files");
             return blob;
         }
     }


### PR DESCRIPTION
We produce a zip containing all the files which are copied from the Admin to the Public site when a release happens. This will be:

- Data (i.e. the original csv files but not the meta files) that have been uploaded via the Admin.
- Ancillary files that have been uploaded via the Admin.
- Media, i.e. images and other charts that have been uploaded via the Admin.

The zip file is created in the ancillary directory in the Public site and has a label property for the UI of “All files”.

The content cache function produces the list of files which appear under the “Download data files” link. The list comprises of the following two directories:

- ancillary (which now includes the “All files” zip entry) 
- data 

The list of files is sorted alphabetically A-Z. We might want further work on controlling the order of the “All files” entry, i.e. so that it appears first or last in the list.