### PR TITLE
EES-571 - fully populating the subject metadata when building the ini…

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/tableToolHelpers.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/tableToolHelpers.ts
@@ -401,10 +401,6 @@ export const initialiseFromInitialQuery = async (
   let subjectMeta: PublicationSubjectMeta;
 
   if (initialQuery) {
-    subjectMeta = await tableBuilderService.filterPublicationSubjectMeta(
-      initialQuery,
-    );
-
     let buildNewQuery: TableDataQuery = {
       subjectId: '',
       filters: [],
@@ -425,6 +421,14 @@ export const initialiseFromInitialQuery = async (
     if (initialStep === 5) {
       createdTable = await queryForTable(buildNewQuery, releaseId);
     }
+
+    const queryForEntireSubject = {
+      subjectId: initialQuery.subjectId,
+    };
+
+    subjectMeta = await tableBuilderService.filterPublicationSubjectMeta(
+      queryForEntireSubject,
+    );
 
     // eslint-disable-next-line prefer-destructuring
     if (initialStep > 1) subjectId = buildNewQuery.subjectId;


### PR DESCRIPTION
…tial query to allow the form to be prepared for the user going back a step

Changed the code that populates the table from an initial query to only use the subject id and fully populate the meta data.

This is slower, but prepares the possibility of the user falling back to previous steps.

There is the potential that there is more data in the final subject meta than is required.