### PR TITLE
EES-409 Notify users that rely on audio feedback when a page is Loading... (spinner)

### DIFF
--- a/src/explore-education-statistics-common/package-lock.json
+++ b/src/explore-education-statistics-common/package-lock.json
@@ -1876,6 +1876,15 @@
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.5.tgz",
+      "integrity": "sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/vfile": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/vfile/-/vfile-3.0.2.tgz",
@@ -10563,27 +10572,21 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.9.0.tgz",
-      "integrity": "sha512-R62stB73qZyhrJo7wmCW9jgl/07ai+YzvouvCXIJLBkRlRqLx4j9RqcLEAfNfU3OxTGucqR2Whmn3/Aad6L3hQ==",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.11.0.tgz",
+      "integrity": "sha512-nh9gDl8R4ut+ZNNb2EeKO5VMvTKxwzurbSMuGBoKtjpjbg8JK/u3eVPVNi1h1Ue+eYK9oSzJjb+K3lzLxyA4ag==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "react-is": "^16.9.0",
-        "scheduler": "^0.15.0"
+        "react-is": "^16.8.6",
+        "scheduler": "^0.17.0"
       },
       "dependencies": {
-        "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
-          "dev": true
-        },
         "scheduler": {
-          "version": "0.15.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
-          "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+          "version": "0.17.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.17.0.tgz",
+          "integrity": "sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==",
           "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",
@@ -12933,10 +12936,9 @@
       }
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -20,6 +20,7 @@
     "@types/react-leaflet": "^2.2.1",
     "@types/react-test-renderer": "^16.8.2",
     "@types/recharts": "^1.1.17",
+    "@types/uuid": "^3.4.5",
     "@types/yup": "^0.26.21",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
@@ -142,5 +143,8 @@
   },
   "jest-junit": {
     "ancestorSeparator": " › "
+  },
+  "dependencies": {
+    "uuid": "^3.3.3"
   }
 }

--- a/src/explore-education-statistics-common/src/components/AriaLiveAnnouncer.tsx
+++ b/src/explore-education-statistics-common/src/components/AriaLiveAnnouncer.tsx
@@ -1,0 +1,46 @@
+import React, { ReactNode, useState } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+export const AriaLiveContext = React.createContext({
+  announceAssertive: (message: string) => {
+    console.warn(message, "AriaLiveAnnounce hasn't wrapped the app");
+  },
+  announcePolite: (message: string) => {
+    console.warn(message, "AriaLiveAnnounce hasn't wrapped the app");
+  },
+});
+
+const AriaLiveAnnouncer = ({ children }: Props) => {
+  const [assertiveMessage, setAssertiveMessage] = useState<
+    string | undefined
+  >();
+  const [politeMessage, setPoliteMessage] = useState<string | undefined>();
+
+  return (
+    <AriaLiveContext.Provider
+      value={{
+        announceAssertive: message => {
+          alert(message);
+          setAssertiveMessage(message);
+        },
+        announcePolite: message => {
+          alert(message);
+          setPoliteMessage(message);
+        },
+      }}
+    >
+      {children}
+      <div aria-live="assertive" className="govuk-visually-hidden">
+        {assertiveMessage}
+      </div>
+      <div aria-live="polite" className="govuk-visually-hidden">
+        {politeMessage}
+      </div>
+    </AriaLiveContext.Provider>
+  );
+};
+
+export default AriaLiveAnnouncer;

--- a/src/explore-education-statistics-common/src/components/AriaLiveAnnouncer.tsx
+++ b/src/explore-education-statistics-common/src/components/AriaLiveAnnouncer.tsx
@@ -4,40 +4,69 @@ interface Props {
   children: ReactNode;
 }
 
+export interface LiveMessage {
+  id: string;
+  type: 'polite' | 'assertive';
+  message: string;
+}
+
 export const AriaLiveContext = React.createContext({
-  announceAssertive: (message: string) => {
-    console.warn(message, "AriaLiveAnnounce hasn't wrapped the app");
+  announceMessage: (liveMessage: LiveMessage) => {
+    // eslint-disable-next-line no-console
+    console.warn(
+      liveMessage.message,
+      "AriaLiveAnnounce hasn't wrapped the app",
+    );
   },
-  announcePolite: (message: string) => {
-    console.warn(message, "AriaLiveAnnounce hasn't wrapped the app");
+  removeMessage: (messageId: string) => {
+    // eslint-disable-next-line no-console
+    console.warn(messageId, "AriaLiveAnnounce hasn't wrapped the app");
   },
 });
 
 const AriaLiveAnnouncer = ({ children }: Props) => {
-  const [assertiveMessage, setAssertiveMessage] = useState<
-    string | undefined
-  >();
-  const [politeMessage, setPoliteMessage] = useState<string | undefined>();
+  const [messageList, setMessageList] = useState<LiveMessage[]>([]);
+
+  const announceMessage = (liveMessage: LiveMessage) => {
+    setMessageList([...messageList, liveMessage]);
+  };
+  const removeMessage = (messageId: string) => {
+    setMessageList([
+      ...messageList.filter(message => message.id !== messageId),
+    ]);
+  };
 
   return (
     <AriaLiveContext.Provider
       value={{
-        announceAssertive: message => {
-          alert(message);
-          setAssertiveMessage(message);
-        },
-        announcePolite: message => {
-          alert(message);
-          setPoliteMessage(message);
-        },
+        announceMessage,
+        removeMessage,
       }}
     >
       {children}
-      <div aria-live="assertive" className="govuk-visually-hidden">
-        {assertiveMessage}
+      <div
+        aria-live="assertive"
+        aria-atomic="false"
+        aria-relevant="additions"
+        className="govuk-visually-hidden"
+      >
+        {messageList
+          .filter(message => message.type === 'assertive')
+          .map(({ message, id }) => (
+            <p key={id}>{message}</p>
+          ))}
       </div>
-      <div aria-live="polite" className="govuk-visually-hidden">
-        {politeMessage}
+      <div
+        aria-live="polite"
+        aria-atomic="false"
+        aria-relevant="additions"
+        className="govuk-visually-hidden"
+      >
+        {messageList
+          .filter(message => message.type === 'polite')
+          .map(({ message, id }) => (
+            <p key={id}>{message}</p>
+          ))}
       </div>
     </AriaLiveContext.Provider>
   );

--- a/src/explore-education-statistics-common/src/components/AriaLiveMessage.tsx
+++ b/src/explore-education-statistics-common/src/components/AriaLiveMessage.tsx
@@ -1,0 +1,30 @@
+/**
+ * Consumes the AriaLiveAnnouncer context to be able to send messages that will be read to screenreaders
+ */
+
+import React from 'react';
+import { AriaLiveContext } from '@common/components/AriaLiveAnnouncer';
+
+interface Props {
+  message: string;
+  setting?: 'polite' | 'assertive';
+}
+
+const AriaLiveMessage = ({ message, setting = 'polite' }: Props) => {
+  // send message to announcer
+
+  return (
+    <AriaLiveContext.Consumer>
+      {context => {
+        if (setting === 'polite') {
+          context.announcePolite(message);
+        } else {
+          context.announceAssertive(message);
+        }
+        return null;
+      }}
+    </AriaLiveContext.Consumer>
+  );
+};
+
+export default AriaLiveMessage;

--- a/src/explore-education-statistics-common/src/components/LoadingSpinner.tsx
+++ b/src/explore-education-statistics-common/src/components/LoadingSpinner.tsx
@@ -9,7 +9,7 @@ interface Props {
   size?: number;
   inline?: boolean;
   overlay?: boolean;
-  srMessage?: string;
+  screenReaderMessage?: string;
 }
 
 const LoadingSpinner = ({
@@ -18,27 +18,30 @@ const LoadingSpinner = ({
   size = 80,
   inline = false,
   overlay = false,
-  srMessage = 'Loading',
+  screenReaderMessage = 'The page is loading.',
 }: Props) => {
   return (
-    <div
-      className={classNames({
-        [styles.container]: true,
-        [styles.inline]: inline,
-        [styles.overlay]: overlay,
-      })}
-    >
-      {text && <p className={styles.text}>{text}</p>}
+    <>
       <div
-        className={classNames(styles.spinner, className)}
-        style={{
-          height: `${size}px`,
-          width: `${size}px`,
-          borderWidth: `${size * 0.15}px`,
-        }}
-      />
-      <AriaLiveMessage message={srMessage} />
-    </div>
+        className={classNames({
+          [styles.container]: true,
+          [styles.inline]: inline,
+          [styles.overlay]: overlay,
+        })}
+      >
+        {text && <p className={styles.text}>{text}</p>}
+        <div
+          className={classNames(styles.spinner, className)}
+          style={{
+            height: `${size}px`,
+            width: `${size}px`,
+            borderWidth: `${size * 0.15}px`,
+          }}
+        />
+      </div>
+      {screenReaderMessage ||
+        (text && <AriaLiveMessage message={screenReaderMessage || text} />)}
+    </>
   );
 };
 

--- a/src/explore-education-statistics-common/src/components/LoadingSpinner.tsx
+++ b/src/explore-education-statistics-common/src/components/LoadingSpinner.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import AriaLiveMessage from './AriaLiveMessage';
 import styles from './LoadingSpinner.module.scss';
 
 interface Props {
@@ -8,6 +9,7 @@ interface Props {
   size?: number;
   inline?: boolean;
   overlay?: boolean;
+  srMessage?: string;
 }
 
 const LoadingSpinner = ({
@@ -16,6 +18,7 @@ const LoadingSpinner = ({
   size = 80,
   inline = false,
   overlay = false,
+  srMessage = 'Loading',
 }: Props) => {
   return (
     <div
@@ -34,6 +37,7 @@ const LoadingSpinner = ({
           borderWidth: `${size * 0.15}px`,
         }}
       />
+      <AriaLiveMessage message={srMessage} />
     </div>
   );
 };

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -138,8 +138,11 @@ class TableToolPage extends Component<Props, State> {
                       <>
                         {permalinkLoading ? (
                           <>
-                            Generating permanent link
-                            <LoadingSpinner inline size={19} />
+                            <LoadingSpinner
+                              inline
+                              size={19}
+                              text="Generating permanent link"
+                            />
                           </>
                         ) : (
                           <ButtonText

--- a/src/explore-education-statistics-frontend/src/pages/_app.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import AriaLiveAnnouncer from '@common/components/AriaLiveAnnouncer';
 import { logPageView } from '@frontend/services/googleAnalyticsService';
 import { initHotJar } from '@frontend/services/hotjarService';
 import { initApplicationInsights } from '@frontend/services/applicationInsightsService';
@@ -58,9 +59,11 @@ class App extends BaseApp<Props> {
 
     return (
       <Container>
-        <CookiesProvider cookies={new Cookies(cookies)}>
-          <Component {...pageProps} />
-        </CookiesProvider>
+        <AriaLiveAnnouncer>
+          <CookiesProvider cookies={new Cookies(cookies)}>
+            <Component {...pageProps} />
+          </CookiesProvider>
+        </AriaLiveAnnouncer>
       </Container>
     );
   }


### PR DESCRIPTION
Ticket: https://alpha-dfe-data.atlassian.net/browse/EES-409

The frontend app has been now been wrapped with AriaLiveAnnouncer component that provides a context that can be used by the AriaLiveMessage components to send messages into an [aria-live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) to notify users that rely on audio feedback as to why they might be waiting on a page (ie: table-tool).

LoadingSpinner component now renders an AriaLiveMessage with a default message of "The page is loading."