### PR TITLE
EES-414 - Table keyboard scroll accessibility

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
@@ -65,10 +65,11 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
         <figcaption>{caption}</figcaption>
 
         <div
+          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+          tabIndex={0}
           className={styles.container}
           ref={containerRef}
           role="region"
-          tabIndex={-1}
           onScroll={event => {
             const { scrollLeft, scrollTop } = event.currentTarget;
 


### PR DESCRIPTION
Tested with Windows Narrator after the change and the screen reader still successfully reads the table header and its contents after being tabbed into.