### PR TITLE
EES-633 Fix migration SQL files not being found

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
@@ -10,16 +10,6 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="Migrations" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Migrations\*.sql">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
@@ -11,6 +11,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Migrations" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Migrations\*.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  
+  <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
   </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20190819131048_InitialCreate.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20190819131048_InitialCreate.Designer.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
     [Migration("20190819131048_InitialCreate")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20190819131048_InitialCreate.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20190819131048_InitialCreate.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [ExcludeFromCodeCoverage]
     public partial class InitialCreate : Migration

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20190819131247_IntialCreate_Custom.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20190819131247_IntialCreate_Custom.Designer.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
     [Migration("20190819131247_IntialCreate_Custom")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20190819131247_IntialCreate_Custom.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20190819131247_IntialCreate_Custom.cs
@@ -1,32 +1,33 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [ExcludeFromCodeCoverage]
     public partial class IntialCreate_Custom : Migration
     {
-        private const string _migrationsPath = "Migrations";
-        private const string _migrationId = "20190819131247";
+        private const string MigrationsPath = "Migrations";
+        private const string MigrationId = "20190819131247";
 
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             // Geometry
-            ExecuteFile(migrationBuilder, $"{_migrationId}_Geometry.sql");
+            ExecuteFile(migrationBuilder, $"{MigrationId}_Geometry.sql");
             // Types
-            ExecuteFile(migrationBuilder, $"{_migrationId}_TableTypes.sql");
+            ExecuteFile(migrationBuilder, $"{MigrationId}_TableTypes.sql");
             // Routines
-            ExecuteFile(migrationBuilder, $"{_migrationId}_Routine_FilteredObservations.sql");
-            ExecuteFile(migrationBuilder, $"{_migrationId}_Routine_FilteredFootnotes.sql");
-            ExecuteFile(migrationBuilder, $"{_migrationId}_Routine_geometry2json.sql");
+            ExecuteFile(migrationBuilder, $"{MigrationId}_Routine_FilteredObservations.sql");
+            ExecuteFile(migrationBuilder, $"{MigrationId}_Routine_FilteredFootnotes.sql");
+            ExecuteFile(migrationBuilder, $"{MigrationId}_Routine_geometry2json.sql");
             // Views
-            ExecuteFile(migrationBuilder, $"{_migrationId}_Views.sql");
+            ExecuteFile(migrationBuilder, $"{MigrationId}_Views.sql");
             // Indexes
-            ExecuteFile(migrationBuilder, $"{_migrationId}_Indexes.sql");
+            ExecuteFile(migrationBuilder, $"{MigrationId}_Indexes.sql");
             // Data
-            ExecuteFile(migrationBuilder, $"{_migrationId}_BoundaryLevelData.sql");
-            ExecuteLines(migrationBuilder, $"{_migrationId}_GeometryData.sql");
+            ExecuteFile(migrationBuilder, $"{MigrationId}_BoundaryLevelData.sql");
+            ExecuteLines(migrationBuilder, $"{MigrationId}_GeometryData.sql");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -54,13 +55,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
 
         private static void ExecuteFile(MigrationBuilder migrationBuilder, string filename)
         {
-            var file = Path.Combine(Directory.GetCurrentDirectory(), $"{_migrationsPath}/{filename}");
+            var file = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                $"{MigrationsPath}{Path.DirectorySeparatorChar}{filename}");
+            
             migrationBuilder.Sql(File.ReadAllText(file));
         }
 
         private static void ExecuteLines(MigrationBuilder migrationBuilder, string filename)
         {
-            var file = Path.Combine(Directory.GetCurrentDirectory(), $"{_migrationsPath}/{filename}");
+            var file = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                $"{MigrationsPath}{Path.DirectorySeparatorChar}{filename}");
+            
             var lines = File.ReadAllLines(file);
             foreach (var line in lines)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20190830082721_AddCsvRowFieldToObservation.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20190830082721_AddCsvRowFieldToObservation.Designer.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
     [Migration("20190830082721_AddCsvRowFieldToObservation")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20190830082721_AddCsvRowFieldToObservation.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20190830082721_AddCsvRowFieldToObservation.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     public partial class AddCsvRowFieldToObservation : Migration
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20191008162516_UpdateFilteredObservationsStoredProc.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20191008162516_UpdateFilteredObservationsStoredProc.Designer.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
     [Migration("20191008162516_UpdateFilteredObservationsStoredProc")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20191008162516_UpdateFilteredObservationsStoredProc.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20191008162516_UpdateFilteredObservationsStoredProc.cs
@@ -1,8 +1,9 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [ExcludeFromCodeCoverage]
     public partial class UpdateFilteredObservationsStoredProc : Migration
@@ -23,7 +24,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
 
         private static void ExecuteFile(MigrationBuilder migrationBuilder, string filename)
         {
-            var file = Path.Combine(Directory.GetCurrentDirectory(), $"{MigrationsPath}/{filename}");
+            var file = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                $"{MigrationsPath}{Path.DirectorySeparatorChar}{filename}");
+            
             migrationBuilder.Sql(File.ReadAllText(file));
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20191101153547_Ees263UpdateFilteredObservationsStoredProc.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20191101153547_Ees263UpdateFilteredObservationsStoredProc.Designer.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
     [Migration("20191101153547_Ees263UpdateFilteredObservationsStoredProc")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20191101153547_Ees263UpdateFilteredObservationsStoredProc.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20191101153547_Ees263UpdateFilteredObservationsStoredProc.cs
@@ -1,8 +1,9 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Reflection;
 using Microsoft.EntityFrameworkCore.Migrations;
 
-namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [ExcludeFromCodeCoverage]
     public partial class Ees263UpdateFilteredObservationsStoredProc : Migration
@@ -23,7 +24,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
 
         private static void ExecuteFile(MigrationBuilder migrationBuilder, string filename)
         {
-            var file = Path.Combine(Directory.GetCurrentDirectory(), $"{MigrationsPath}/{filename}");
+            var file = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                $"{MigrationsPath}{Path.DirectorySeparatorChar}{filename}");
+            
             migrationBuilder.Sql(File.ReadAllText(file));
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/StatisticsDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/StatisticsDbContextModelSnapshot.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Migrations
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
     partial class StatisticsDbContextModelSnapshot : ModelSnapshot


### PR DESCRIPTION
The migrations directory wasn't being found after the migrations were moved to the Data.Model library project. Also updating the namespace of the migrations classes.