### PR TITLE
Fix deps

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
         <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -10,6 +10,7 @@
         <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
         <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.5" />
         <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="10.0.3" />
+        <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     </ItemGroup>
 
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -10,7 +10,6 @@
         <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
         <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.5" />
         <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="10.0.3" />
-        <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     </ItemGroup>
 
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     </ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/GovUk.Education.ExploreEducationStatistics.Publisher.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/GovUk.Education.ExploreEducationStatistics.Publisher.Tests.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
- With the dependencies on older versions of `Microsoft.NET.Test.Sdk` I'm seeing two references to netcoreapp1.0 in the Filesystem view of Rider.