### PR TITLE
EES-646 chart axis freezing bug

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/charts/ChartFunctions.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/charts/ChartFunctions.tsx
@@ -675,7 +675,7 @@ function calculateMajorTicks(
   return undefined;
 }
 
-function getNiceMaxValue(maxValue: number) {
+export function getNiceMaxValue(maxValue: number) {
   if (maxValue === 0) {
     return 0;
   }


### PR DESCRIPTION
A conditional override value for tickSpacing to avoid rendering potentially 1000's of ticks

I believe the problem to be that the default value for tickSpacing to be set to `1`.
The problem with that is that in this particular chart, outlined in the ticket, the minimum and maximum values on the Y-axis are 0 and 300,000 respectively. As the user selects _Custom_, the chart attempts to render a tick for every `1` value between the 0 and 300,000; resulting in 299,998 ticks attempting to render - resulting in a browser crash due to insufficient memory.

The solution I've implemented is to provide a reasonable tickSpacing value whenever the tickSpacing input changes to ensure that a maximum of 100 ticks can be attempted to be rendered.