### PR TITLE
EES-350 Trim leading and trailing whitespace. 

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/CsvUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/CsvUtil.cs
@@ -28,7 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
 
         public static string Value(IReadOnlyList<string> line, List<string> headers, string column)
         {
-            return headers.Contains(column) ? line[headers.FindIndex(h => h.Equals(column))].NullIfWhiteSpace() : null;
+            return headers.Contains(column) ? line[headers.FindIndex(h => h.Equals(column))].Trim().NullIfWhiteSpace() : null;
         }
     }
 }


### PR DESCRIPTION
Spotted when two indicator groups were created for the same group name, one with trailing whitespace.

@shakes90 see what you think to the difference in timings.
Alternatively this could be dealt with through validation or trimming individual fields such as the group names.