### PR TITLE
Prototype/bau methodologies

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/BAU/BauMethodologyController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/BAU/BauMethodologyController.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.BAU
+{
+    [Route("api")]
+    [ApiController]
+    [Authorize]
+    public class BauMethodologyController : ControllerBase
+    {
+        private readonly IMethodologyService _methodologyService;
+        
+        public BauMethodologyController(IMethodologyService methodologyService)
+        {
+            _methodologyService = methodologyService;
+        }
+        
+        [HttpGet("bau/methodology")]
+        public async Task<ActionResult<List<Methodology>>> GetMethodologyList()
+        {
+            var methodologies = await _methodologyService.ListAsync();
+
+            if (methodologies.Any())
+            {
+                return Ok(methodologies);
+            }
+
+            return NotFound();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/BAU/BauMethodologyController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/BAU/BauMethodologyController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
@@ -24,9 +25,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.BAU
         }
         
         [HttpGet("bau/methodology")]
-        public async Task<ActionResult<List<Methodology>>> GetMethodologyList()
+        public async Task<ActionResult<List<MethodologyStatusViewModel>>> GetMethodologyList()
         {
-            var methodologies = await _methodologyService.ListAsync();
+            var methodologies = await _methodologyService.ListStatusAsync();
 
             if (methodologies.Any())
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -62,7 +62,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                     m => m.MapFrom(summary => summary.Release.Status));
 
             CreateMap<Methodology, MethodologyViewModel>();
-
+            CreateMap<Methodology, MethodologyStatusViewModel>();
+            CreateMap<Publication, MethodologyStatusPublications>();
+            
             CreateMap<Publication, PublicationViewModel>()
                 .ForMember(
                     dest => dest.ThemeId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/MethodologyStatusViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/MethodologyStatusViewModel.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Models.Api
+{
+    public class MethodologyStatusViewModel
+    {
+        public Guid Id { get; set; }
+
+        public string Title { get; set; }
+        
+        // TODO: fake the status until the it is added to methodology as a concept
+        public string Status => "Live";
+
+        public List<MethodologyStatusPublications> Publications { get; set; }
+    }
+
+    public class MethodologyStatusPublications
+    {
+        public Guid Id { get; set; }
+        
+        public string Title { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IMethodologyService.cs
@@ -9,6 +9,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     {
         Task<List<MethodologyViewModel>> ListAsync();
         
+        Task<List<MethodologyStatusViewModel>> ListStatusAsync();
+        
         Task<List<MethodologyViewModel>> GetTopicMethodologiesAsync(TopicId topicId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MethodologyService.cs
@@ -4,8 +4,10 @@ using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using TopicId = System.Guid;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
@@ -27,7 +29,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return _mapper.Map<List<MethodologyViewModel>>(result);
             
         }
-        
+
+        public async Task<List<MethodologyStatusViewModel>> ListStatusAsync()
+        {
+            var result = await _context.Methodologies.Include(m => m.Publications).ToListAsync();
+
+            return _mapper.Map<List<MethodologyStatusViewModel>>(result);
+        }
         public async Task<List<MethodologyViewModel>> GetTopicMethodologiesAsync(TopicId topicId)
         {
             var methodologies = await _context.Publications

--- a/src/explore-education-statistics-admin/src/App.tsx
+++ b/src/explore-education-statistics-admin/src/App.tsx
@@ -33,8 +33,8 @@ import AdminDocumentationStyle from './pages/documentation/DocumentationStyle';
 import AdminDocumentationUsingDashboard from './pages/documentation/DocumentationUsingDashboard';
 import IndexPage from './pages/IndexPage';
 
-import BauDashboardPage from './pages/bau/BauDashboardPage'
-import BauMethodologyPage from './pages/bau/BauMethodologyPage'
+import BauDashboardPage from './pages/bau/BauDashboardPage';
+import BauMethodologyPage from './pages/bau/BauMethodologyPage';
 
 import PrototypeAdminDashboard from './pages/prototypes/PrototypeAdminDashboard';
 import PrototypeChartTest from './pages/prototypes/PrototypeChartTest';

--- a/src/explore-education-statistics-admin/src/App.tsx
+++ b/src/explore-education-statistics-admin/src/App.tsx
@@ -33,6 +33,9 @@ import AdminDocumentationStyle from './pages/documentation/DocumentationStyle';
 import AdminDocumentationUsingDashboard from './pages/documentation/DocumentationUsingDashboard';
 import IndexPage from './pages/IndexPage';
 
+import BauDashboardPage from './pages/bau/BauDashboardPage'
+import BauMethodologyPage from './pages/bau/BauMethodologyPage'
+
 import PrototypeAdminDashboard from './pages/prototypes/PrototypeAdminDashboard';
 import PrototypeChartTest from './pages/prototypes/PrototypeChartTest';
 import AdminDocumentationCreateNewPublication from './pages/prototypes/PrototypeDocumentationCreateNewPublication';
@@ -78,6 +81,18 @@ function App() {
 
             <Redirect exact strict from="/" to="/dashboard" />
           </Switch>
+
+          <ProtectedRoute
+            exact
+            path="/bau"
+            component={BauDashboardPage}
+          />
+
+          <ProtectedRoute
+            exact
+            path="/bau/methodology"
+            component={BauMethodologyPage}
+          />
 
           <ProtectedRoute
             exact

--- a/src/explore-education-statistics-admin/src/App.tsx
+++ b/src/explore-education-statistics-admin/src/App.tsx
@@ -84,13 +84,13 @@ function App() {
 
           <ProtectedRoute
             exact
-            path="/bau"
+            path="/administration"
             component={BauDashboardPage}
           />
 
           <ProtectedRoute
             exact
-            path="/bau/methodology"
+            path="/administration/methodology"
             component={BauMethodologyPage}
           />
 

--- a/src/explore-education-statistics-admin/src/components/PageFooter.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageFooter.tsx
@@ -23,8 +23,8 @@ const PageFooter = ({ wide }: Props) => (
               </Link>
             </li>
             <li className="govuk-footer__inline-list-item">
-              <a href="/tools" className="govuk-footer__link">
-                BAU Tools
+              <a href="/administration" className="govuk-footer__link">
+                Platform administration
               </a>
             </li>
             <li className="govuk-footer__inline-list-item">

--- a/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
@@ -1,11 +1,13 @@
 import React, { useContext, useEffect, useState } from 'react';
 import Page from '@admin/components/Page';
+import Link from '@admin/components/Link';
 
 function BauDashboardPage() {
   return (
-    <Page>
-      <h1>BAU</h1>
+    <Page wide>
+      <h1 className="govuk-heading-xl">Platform administration</h1>
 
+      <Link to="/administration/methodology">View methodology status</Link>
     </Page>
   );
 }

--- a/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
@@ -1,0 +1,13 @@
+import React, { useContext, useEffect, useState } from 'react';
+import Page from '@admin/components/Page';
+
+function BauDashboardPage() {
+  return (
+    <Page>
+      <h1>BAU</h1>
+
+    </Page>
+  );
+}
+
+export default BauDashboardPage;

--- a/src/explore-education-statistics-admin/src/pages/bau/BauMethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauMethodologyPage.tsx
@@ -1,0 +1,13 @@
+import React, { useContext, useEffect, useState } from 'react';
+import Page from '@admin/components/Page';
+
+function BauMethodologyPage() {
+  return (
+    <Page>
+      <h1>BAU Methodology</h1>
+
+    </Page>
+  );
+}
+
+export default BauMethodologyPage;

--- a/src/explore-education-statistics-admin/src/pages/bau/BauMethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauMethodologyPage.tsx
@@ -1,10 +1,10 @@
 import React, { useContext, useEffect, useState } from 'react';
 import methodologyService from '@admin/services/methodology/service';
 import Page from '@admin/components/Page';
-import { IdTitlePair } from '@admin/services/common/types';
+import { MethodologyStatus } from '@admin/services/methodology/types';
 
 interface Model {
-  methodologies: IdTitlePair[];
+  methodologies: MethodologyStatus[];
 }
 
 const BauMethodologyPage = () => {
@@ -19,12 +19,20 @@ const BauMethodologyPage = () => {
   }, []);
 
   return (
-    <Page>
-      <h1>BAU Methodology</h1>
+    <Page
+      wide
+      breadcrumbs={[
+        { name: 'Platform administration', link: '/administration' },
+        { name: 'Methodology' },
+      ]}
+    >
+      <h1>Methodology status</h1>
 
       {model && (
         <table className="govuk-table">
-          <caption className="govuk-table__caption">Methodologies list</caption>
+          <caption className="govuk-table__caption">
+            Current methodologies
+          </caption>
           <thead className="govuk-table__head">
             <tr className="govuk-table__row">
               <th scope="col" className="govuk-table__header">
@@ -41,16 +49,15 @@ const BauMethodologyPage = () => {
           <tbody className="govuk-table__body">
             {model.methodologies.map(methodology => (
               <tr className="govuk-table__row" key={methodology.id}>
-                <th scope="row" className="govuk-table__header">
-                  {methodology.title}
-                </th>
+                <td className="govuk-table__header">{methodology.title}</td>
                 <td className="govuk-table__cell">
-                  <strong className="govuk-tag">Draft</strong>
+                  <strong className="govuk-tag">{methodology.status}</strong>
                 </td>
                 <td className="govuk-table__cell">
                   <ul className="govuk-list">
-                    <li>Pupil absence in schools in England</li>
-                    <li>Pupil absence in schools in England (Spring)</li>
+                    {methodology.publications.map(publication => (
+                      <li key={publication.id}>{publication.title}</li>
+                    ))}
                   </ul>
                 </td>
               </tr>

--- a/src/explore-education-statistics-admin/src/pages/bau/BauMethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauMethodologyPage.tsx
@@ -1,13 +1,65 @@
 import React, { useContext, useEffect, useState } from 'react';
+import methodologyService from '@admin/services/methodology/service';
 import Page from '@admin/components/Page';
+import { IdTitlePair } from '@admin/services/common/types';
 
-function BauMethodologyPage() {
+interface Model {
+  methodologies: IdTitlePair[];
+}
+
+const BauMethodologyPage = () => {
+  const [model, setModel] = useState<Model>();
+
+  useEffect(() => {
+    methodologyService.getMethodologies().then(methodologies => {
+      setModel({
+        methodologies,
+      });
+    });
+  }, []);
+
   return (
     <Page>
       <h1>BAU Methodology</h1>
 
+      {model && (
+        <table className="govuk-table">
+          <caption className="govuk-table__caption">Methodologies list</caption>
+          <thead className="govuk-table__head">
+            <tr className="govuk-table__row">
+              <th scope="col" className="govuk-table__header">
+                Methodology
+              </th>
+              <th scope="col" className="govuk-table__header">
+                Status
+              </th>
+              <th scope="col" className="govuk-table__header">
+                Publications
+              </th>
+            </tr>
+          </thead>
+          <tbody className="govuk-table__body">
+            {model.methodologies.map(methodology => (
+              <tr className="govuk-table__row" key={methodology.id}>
+                <th scope="row" className="govuk-table__header">
+                  {methodology.title}
+                </th>
+                <td className="govuk-table__cell">
+                  <strong className="govuk-tag">Draft</strong>
+                </td>
+                <td className="govuk-table__cell">
+                  <ul className="govuk-list">
+                    <li>Pupil absence in schools in England</li>
+                    <li>Pupil absence in schools in England (Spring)</li>
+                  </ul>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </Page>
   );
-}
+};
 
 export default BauMethodologyPage;

--- a/src/explore-education-statistics-admin/src/services/methodology/service.ts
+++ b/src/explore-education-statistics-admin/src/services/methodology/service.ts
@@ -1,0 +1,14 @@
+import client from '@admin/services/util/service';
+import { IdTitlePair } from '@admin/services/common/types';
+
+export interface MethodologyService {
+  getMethodologies(): Promise<IdTitlePair[]>;
+}
+
+const service: MethodologyService = {
+  getMethodologies(): Promise<IdTitlePair[]> {
+    return client.get<IdTitlePair[]>('/bau/methodology');
+  },
+};
+
+export default service;

--- a/src/explore-education-statistics-admin/src/services/methodology/service.ts
+++ b/src/explore-education-statistics-admin/src/services/methodology/service.ts
@@ -1,13 +1,13 @@
 import client from '@admin/services/util/service';
-import { IdTitlePair } from '@admin/services/common/types';
+import { MethodologyStatus } from '@admin/services/methodology/types';
 
 export interface MethodologyService {
-  getMethodologies(): Promise<IdTitlePair[]>;
+  getMethodologies(): Promise<MethodologyStatus[]>;
 }
 
 const service: MethodologyService = {
-  getMethodologies(): Promise<IdTitlePair[]> {
-    return client.get<IdTitlePair[]>('/bau/methodology');
+  getMethodologies(): Promise<MethodologyStatus[]> {
+    return client.get<MethodologyStatus[]>('/bau/methodology');
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/methodology/types.ts
+++ b/src/explore-education-statistics-admin/src/services/methodology/types.ts
@@ -1,11 +1,11 @@
 export interface MethodologyStatus {
-    id: string;
-    title: string;
-    status: string;
-    publications: MethodologyStatusPublication[]
-  }
+  id: string;
+  title: string;
+  status: string;
+  publications: MethodologyStatusPublication[];
+}
 
 export interface MethodologyStatusPublication {
-    id: string;
-    title: string;
+  id: string;
+  title: string;
 }

--- a/src/explore-education-statistics-admin/src/services/methodology/types.ts
+++ b/src/explore-education-statistics-admin/src/services/methodology/types.ts
@@ -1,0 +1,11 @@
+export interface MethodologyStatus {
+    id: string;
+    title: string;
+    status: string;
+    publications: MethodologyStatusPublication[]
+  }
+
+export interface MethodologyStatusPublication {
+    id: string;
+    title: string;
+}


### PR DESCRIPTION
This adds in the first of the react based BAU pages.

Displays a list of methodologies in the service, a placeholder of its publication status and a list of related publications to that methodology.

The expection is that we will build out the BAU tools further from here, this also provides a basic api for methodologies that can be used to start building the methodology dashboard presented to standard admin users.