### PR TITLE
Feature/ees 677 api for adding html blocks

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/AddContentBlockRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/AddContentBlockRequest.cs
@@ -1,9 +1,11 @@
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.ManageContent
 {
     public class AddContentBlockRequest
     {
-        public string Type { get; set; }
+        public ContentBlockType Type { get; set; }
         
-        public int Order { get; set; }
+        public int? Order { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/AddContentBlockRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/AddContentBlockRequest.cs
@@ -1,0 +1,9 @@
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.ManageContent
+{
+    public class AddContentBlockRequest
+    {
+        public string Type { get; set; }
+        
+        public int Order { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/AddContentSectionRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/AddContentSectionRequest.cs
@@ -1,0 +1,7 @@
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.ManageContent
+{
+    public class AddContentSectionRequest
+    {
+        public int Order { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/ContentController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/ContentController.cs
@@ -40,7 +40,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Manag
         }
 
         [HttpPost("release/{releaseId}/content/sections/add")]
-        public Task<ActionResult<ContentSectionViewModel>> AddContentSection(Guid releaseId, AddContentSectionRequest request)
+        public Task<ActionResult<ContentSectionViewModel>> AddContentSection(
+            Guid releaseId, AddContentSectionRequest? request = null)
         {
             return this.HandlingValidationErrorsAsync(
                 () => _contentService.AddContentSectionAsync(releaseId, request),
@@ -83,7 +84,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Manag
         }
 
         [HttpPost("release/{releaseId}/content/section/{contentSectionId}/blocks/add")]
-        public Task<ActionResult<IContentBlock>> AddContentBlock(Guid releaseId, Guid contentSectionId, AddContentBlockRequest request)
+        public Task<ActionResult<IContentBlock>> AddContentBlock(
+            Guid releaseId, Guid contentSectionId, AddContentBlockRequest request)
         {
             return this.HandlingValidationErrorsAsync(
                 () => _contentService.AddContentBlockAsync(releaseId, contentSectionId, request),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/ContentController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/ContentController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.ExtensionMethods;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.ManageContent;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -30,7 +31,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Manag
         }
         
         [HttpPut("release/{releaseId}/content/sections/order")]
-        public Task<ActionResult<List<ContentSectionViewModel>>> ReorderSections(Guid releaseId, Dictionary<Guid, int> newSectionOrder)
+        public Task<ActionResult<List<ContentSectionViewModel>>> ReorderSections(
+            Guid releaseId, Dictionary<Guid, int> newSectionOrder)
         {
             return this.HandlingValidationErrorsAsync(
                 () => _contentService.ReorderContentSectionsAsync(releaseId, newSectionOrder),
@@ -46,7 +48,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Manag
         }
 
         [HttpPut("release/{releaseId}/content/section/{contentSectionId}/heading")]
-        public Task<ActionResult<ContentSectionViewModel>> UpdateContentSectionHeading(Guid releaseId, Guid contentSectionId, UpdateContentSectionHeadingRequest request)
+        public Task<ActionResult<ContentSectionViewModel>> UpdateContentSectionHeading(
+            Guid releaseId, Guid contentSectionId, UpdateContentSectionHeadingRequest request)
         {
             return this.HandlingValidationErrorsAsync(
                 () => _contentService.UpdateContentSectionHeadingAsync(releaseId, contentSectionId, request.Heading),
@@ -54,10 +57,45 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Manag
         }
 
         [HttpDelete("release/{releaseId}/content/section/{contentSectionId}")]
-        public Task<ActionResult<List<ContentSectionViewModel>>> RemoveContentSection(Guid releaseId, Guid contentSectionId)
+        public Task<ActionResult<List<ContentSectionViewModel>>> RemoveContentSection(
+            Guid releaseId, Guid contentSectionId)
         {
             return this.HandlingValidationErrorsAsync(
                 () => _contentService.RemoveContentSectionAsync(releaseId, contentSectionId),
+                Ok);
+        }
+
+        [HttpGet("release/{releaseId}/content/section/{contentSectionId}")]
+        public Task<ActionResult<ContentSectionViewModel>> GetContentSection(Guid releaseId, Guid contentSectionId)
+        {
+            return this.HandlingValidationErrorsAsync(
+                () => _contentService.GetContentSectionAsync(releaseId, contentSectionId),
+                Ok);
+        }
+        
+        [HttpPut("release/{releaseId}/content/section/{contentSectionId}/blocks/order")]
+        public Task<ActionResult<List<IContentBlock>>> ReorderContentBlocks(
+            Guid releaseId, Guid contentSectionId, Dictionary<Guid, int> newBlocksOrder)
+        {
+            return this.HandlingValidationErrorsAsync(
+                () => _contentService.ReorderContentBlocksAsync(releaseId, contentSectionId, newBlocksOrder),
+                Ok);
+        }
+
+        [HttpPost("release/{releaseId}/content/section/{contentSectionId}/add")]
+        public Task<ActionResult<IContentBlock>> AddContentBlock(Guid releaseId, Guid contentSectionId)
+        {
+            return this.HandlingValidationErrorsAsync(
+                () => _contentService.AddContentBlockAsync(releaseId, contentSectionId),
+                Ok);
+        }
+
+        [HttpDelete("release/{releaseId}/content/section/{contentSectionId}/block/{contentBlockId}")]
+        public Task<ActionResult<List<IContentBlock>>> RemoveContentBlock(
+            Guid releaseId, Guid contentSectionId, Guid contentBlockId)
+        {
+            return this.HandlingValidationErrorsAsync(
+                () => _contentService.RemoveContentBlockAsync(releaseId, contentSectionId, contentBlockId),
                 Ok);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/ContentController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/ContentController.cs
@@ -40,10 +40,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Manag
         }
 
         [HttpPost("release/{releaseId}/content/sections/add")]
-        public Task<ActionResult<ContentSectionViewModel>> AddContentSection(Guid releaseId)
+        public Task<ActionResult<ContentSectionViewModel>> AddContentSection(Guid releaseId, AddContentSectionRequest request)
         {
             return this.HandlingValidationErrorsAsync(
-                () => _contentService.AddContentSectionAsync(releaseId),
+                () => _contentService.AddContentSectionAsync(releaseId, request),
                 Ok);
         }
 
@@ -83,10 +83,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Manag
         }
 
         [HttpPost("release/{releaseId}/content/section/{contentSectionId}/blocks/add")]
-        public Task<ActionResult<IContentBlock>> AddContentBlock(Guid releaseId, Guid contentSectionId)
+        public Task<ActionResult<IContentBlock>> AddContentBlock(Guid releaseId, Guid contentSectionId, AddContentBlockRequest request)
         {
             return this.HandlingValidationErrorsAsync(
-                () => _contentService.AddContentBlockAsync(releaseId, contentSectionId),
+                () => _contentService.AddContentBlockAsync(releaseId, contentSectionId, request),
                 Ok);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/ContentController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/ContentController.cs
@@ -82,7 +82,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Manag
                 Ok);
         }
 
-        [HttpPost("release/{releaseId}/content/section/{contentSectionId}/add")]
+        [HttpPost("release/{releaseId}/content/section/{contentSectionId}/blocks/add")]
         public Task<ActionResult<IContentBlock>> AddContentBlock(Guid releaseId, Guid contentSectionId)
         {
             return this.HandlingValidationErrorsAsync(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Utils/PersistenceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Utils/PersistenceHelper.cs
@@ -45,10 +45,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Utils
                         .FirstOrDefaultAsync();
 
                     return entity == null
-                        ? ValidationResult(ValidationErrorMessages.EntityNotFound)
+                        ? ValidationResult(_notFoundErrorMessage)
                         : new Either<ValidationResult, TEntity>(entity);
                 },
                 successAction.Invoke);
+        } 
+        
+        public Task<Either<ValidationResult, T>> CheckEntityExists<T>(
+            TEntityId id, 
+            Func<TEntity, Either<ValidationResult, T>> successAction,
+            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null)
+        {
+            Task<Either<ValidationResult, T>> Success(TEntity entity)
+            {
+                return Task.FromResult(successAction.Invoke(entity));
+            }
+            
+            return CheckEntityExists(
+                id,
+                Success,
+                hydrateEntityFn);
         } 
         
         public Task<Either<ValidationResult, T>> CheckEntityExists<T>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20191120145056_AddOrderToContentBlocks.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20191120145056_AddOrderToContentBlocks.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Migrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20191120145056_AddOrderToContentBlocks")]
+    partial class AddOrderToContentBlocks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -558,8 +560,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         new
                         {
                             Id = new Guid("caa8e56f-41d2-4129-a5c3-53b051134bd7"),
-                            Annexes = "[{\"Id\":\"0522bb29-1e0d-455a-88ef-5887f76fb069\",\"Order\":1,\"Heading\":\"Annex A - Calculations\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"8b90b3b2-f63d-4499-91aa-41ccae74e1c7\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"f1aac714-665d-436e-a488-1ca409d618bf\",\"Order\":2,\"Heading\":\"Annex B - School attendance codes\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"47f3e500-ec9f-4a00-96f8-c488f76b06e6\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"0b888133-215a-4b28-8c24-e0ee9a32df6e\",\"Order\":3,\"Heading\":\"Annex C - Links to pupil absence national statistics and data\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"a00a7765-aa81-43f2-afe1-fead7f070291\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"4c4c71e2-24e1-4b57-8a23-ce54fae9b329\",\"Order\":4,\"Heading\":\"Annex D - Standard breakdowns\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"7cc516d4-fc79-4e22-b35b-a042d5b14d35\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"97a138bf-4ebb-4b17-86ab-ed78584608e3\",\"Order\":5,\"Heading\":\"Annex E - Timeline\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"8ddc6877-acd2-479d-a86f-1139c1bd429f\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"dc00e749-0893-47f7-8440-5a4da47ceed7\",\"Order\":6,\"Heading\":\"Annex F - Absence rates over time\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"0fd71cfd-cfdd-42c5-86e7-9e311beee646\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"}]",
-                            Content = "[{\"Id\":\"5a7fd947-d131-475d-afcd-11ab2b1ece67\",\"Order\":1,\"Heading\":\"1. Overview of absence statistics\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"4d5ae97d-fa1c-4a09-a0a3-b28307fcfb09\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"dabb7562-0433-42fc-96e4-64a68f399dac\",\"Order\":2,\"Heading\":\"2. National Statistics badging\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"6bf20dd4-a7d6-4bc6-a13a-9f574935c9af\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"50b5031a-93e4-4756-843e-21f88f52ba68\",\"Order\":3,\"Heading\":\"3. Methodology\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"63a318d9-05fa-40eb-9808-b825a6deb54a\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"e4ca520f-b609-4abb-a38c-c2d610a18e9f\",\"Order\":4,\"Heading\":\"4. Data collection\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"7714efb9-cc82-4895-ba27-bf5464541e38\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"da91d355-b878-4135-a0a9-fb538c601246\",\"Order\":5,\"Heading\":\"5. Data processing\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"6f81ab70-5730-4cf1-a513-669f5c4bef09\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"8df45966-5444-4487-be49-763c5009eea6\",\"Order\":6,\"Heading\":\"6. Data quality\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"a40d6c9e-fe61-48c0-b907-9757148beb0d\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"bf6870de-07d3-4e65-a877-373a63dbcc5d\",\"Order\":7,\"Heading\":\"7. Contacts\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"f620a229-21b7-4c6e-afd4-e9feb111f09a\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"}]",
+                            Annexes = "[{\"Id\":\"0522bb29-1e0d-455a-88ef-5887f76fb069\",\"Order\":1,\"Heading\":\"Annex A - Calculations\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"8b90b3b2-f63d-4499-91aa-41ccae74e1c7\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"f1aac714-665d-436e-a488-1ca409d618bf\",\"Order\":2,\"Heading\":\"Annex B - School attendance codes\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"47f3e500-ec9f-4a00-96f8-c488f76b06e6\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"0b888133-215a-4b28-8c24-e0ee9a32df6e\",\"Order\":3,\"Heading\":\"Annex C - Links to pupil absence national statistics and data\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"a00a7765-aa81-43f2-afe1-fead7f070291\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"4c4c71e2-24e1-4b57-8a23-ce54fae9b329\",\"Order\":4,\"Heading\":\"Annex D - Standard breakdowns\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"7cc516d4-fc79-4e22-b35b-a042d5b14d35\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"97a138bf-4ebb-4b17-86ab-ed78584608e3\",\"Order\":5,\"Heading\":\"Annex E - Timeline\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"8ddc6877-acd2-479d-a86f-1139c1bd429f\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"dc00e749-0893-47f7-8440-5a4da47ceed7\",\"Order\":6,\"Heading\":\"Annex F - Absence rates over time\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"0fd71cfd-cfdd-42c5-86e7-9e311beee646\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"}]",
+                            Content = "[{\"Id\":\"5a7fd947-d131-475d-afcd-11ab2b1ece67\",\"Order\":1,\"Heading\":\"1. Overview of absence statistics\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"4d5ae97d-fa1c-4a09-a0a3-b28307fcfb09\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"dabb7562-0433-42fc-96e4-64a68f399dac\",\"Order\":2,\"Heading\":\"2. National Statistics badging\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"6bf20dd4-a7d6-4bc6-a13a-9f574935c9af\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"50b5031a-93e4-4756-843e-21f88f52ba68\",\"Order\":3,\"Heading\":\"3. Methodology\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"63a318d9-05fa-40eb-9808-b825a6deb54a\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"e4ca520f-b609-4abb-a38c-c2d610a18e9f\",\"Order\":4,\"Heading\":\"4. Data collection\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"7714efb9-cc82-4895-ba27-bf5464541e38\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"da91d355-b878-4135-a0a9-fb538c601246\",\"Order\":5,\"Heading\":\"5. Data processing\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"6f81ab70-5730-4cf1-a513-669f5c4bef09\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"8df45966-5444-4487-be49-763c5009eea6\",\"Order\":6,\"Heading\":\"6. Data quality\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"a40d6c9e-fe61-48c0-b907-9757148beb0d\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"bf6870de-07d3-4e65-a877-373a63dbcc5d\",\"Order\":7,\"Heading\":\"7. Contacts\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"f620a229-21b7-4c6e-afd4-e9feb111f09a\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"}]",
                             LastUpdated = new DateTime(2019, 6, 26, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             Published = new DateTime(2018, 3, 22, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             Slug = "pupil-absence-in-schools-in-england",
@@ -569,7 +571,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         new
                         {
                             Id = new Guid("8ab41234-cc9d-4b3d-a42c-c9fce7762719"),
-                            Content = "[{\"Id\":\"d82b2a2c-b117-4f96-b812-80de5304ae21\",\"Order\":1,\"Heading\":\"1. Overview of applications and offers statistics\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"ff7b34e3-58ba-4578-849a-e5044fc14b8d\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"f0814433-92d4-4ce5-b63b-2f2cb1b6f48a\",\"Order\":2,\"Heading\":\"2. The admissions process\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"d7f310d7-e917-47e2-9e05-065c8bcab891\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"1d7a492b-3e59-4624-9a2a-076635d1f780\",\"Order\":3,\"Heading\":\"3. Methodology\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"a89226ef-1d6a-48ba-a795-0dbc334a9198\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"f129939b-803f-461b-8838-e7a3d8c6eca2\",\"Order\":4,\"Heading\":\"4. Contacts\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"16898320-cf69-45c4-8dbb-2486901759b1\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"}]",
+                            Content = "[{\"Id\":\"d82b2a2c-b117-4f96-b812-80de5304ae21\",\"Order\":1,\"Heading\":\"1. Overview of applications and offers statistics\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"ff7b34e3-58ba-4578-849a-e5044fc14b8d\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"f0814433-92d4-4ce5-b63b-2f2cb1b6f48a\",\"Order\":2,\"Heading\":\"2. The admissions process\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"d7f310d7-e917-47e2-9e05-065c8bcab891\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"1d7a492b-3e59-4624-9a2a-076635d1f780\",\"Order\":3,\"Heading\":\"3. Methodology\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"a89226ef-1d6a-48ba-a795-0dbc334a9198\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"f129939b-803f-461b-8838-e7a3d8c6eca2\",\"Order\":4,\"Heading\":\"4. Contacts\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"16898320-cf69-45c4-8dbb-2486901759b1\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"}]",
                             Published = new DateTime(2018, 6, 14, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             Slug = "secondary-and-primary-schools-applications-and-offers",
                             Summary = "",
@@ -578,8 +580,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         new
                         {
                             Id = new Guid("c8c911e3-39c1-452b-801f-25bb79d1deb7"),
-                            Annexes = "[{\"Id\":\"2bb1ce6d-8b54-4a77-bf7d-466c5f7f6bc3\",\"Order\":1,\"Heading\":\"Annex A - Calculations\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"c2d4d345-59b6-443b-bcb0-67c1f1dd9732\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"01e9feb8-8ca0-4d98-8a17-78672e4641a7\",\"Order\":2,\"Heading\":\"Annex B - Exclusion by reason codes\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"e4e4f98b-cbeb-451f-bd17-8e2d572b83f4\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"39576875-4a54-4028-bdb0-fecc67041f82\",\"Order\":3,\"Heading\":\"Annex C - Links to pupil exclusions statistics and data\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"94246f85-e43a-4b6c-97a0-b045701dc077\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"e3bfcc04-7d91-45b7-b0ee-19713de4b433\",\"Order\":4,\"Heading\":\"Annex D - Standard breakdowns\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"b05ae1f7-b2d1-4ae3-9db6-28fb0edf98ae\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"}]",
-                            Content = "[{\"Id\":\"bceaafc1-9548-4a03-98d5-d3476c8b9d99\",\"Order\":1,\"Heading\":\"1. Overview of exclusion statistics\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"9a034a5f-7cdb-4895-b205-864e7f834ebf\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"66b15928-46c6-48d5-90e6-12cf354b4e04\",\"Order\":2,\"Heading\":\"2. National Statistics badging\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"f745893e-68a6-4813-ba8b-35d44c0935aa\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"863f2b02-67b1-41bd-b1c9-f998f4581297\",\"Order\":3,\"Heading\":\"3. Methodology\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"4c88cbdd-e0e2-4019-a656-31e4b97d19d5\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"fc66f72e-0176-4c75-b15f-2f35c7329563\",\"Order\":4,\"Heading\":\"4. Data collection\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"085ba061-918b-4e6e-9a02-3a8b12671587\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"0c44636a-9a31-4e05-8db7-331ed5eae366\",\"Order\":5,\"Heading\":\"5. Data processing\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"29f138eb-070e-41fe-95c6-e271cdf4eaf4\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"69df08b6-dcda-449e-828e-5666c8e6d533\",\"Order\":6,\"Heading\":\"6. Data quality\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"8263cdc1-a2e8-4db6-a581-44043a6add64\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"fa315759-a51b-4860-8ae5-7b9505873108\",\"Order\":7,\"Heading\":\"7. Contacts\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"e1eb03d9-25e4-4247-b3de-49805cce7889\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":1}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"}]",
+                            Annexes = "[{\"Id\":\"2bb1ce6d-8b54-4a77-bf7d-466c5f7f6bc3\",\"Order\":1,\"Heading\":\"Annex A - Calculations\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"c2d4d345-59b6-443b-bcb0-67c1f1dd9732\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"01e9feb8-8ca0-4d98-8a17-78672e4641a7\",\"Order\":2,\"Heading\":\"Annex B - Exclusion by reason codes\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"e4e4f98b-cbeb-451f-bd17-8e2d572b83f4\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"39576875-4a54-4028-bdb0-fecc67041f82\",\"Order\":3,\"Heading\":\"Annex C - Links to pupil exclusions statistics and data\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"94246f85-e43a-4b6c-97a0-b045701dc077\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"e3bfcc04-7d91-45b7-b0ee-19713de4b433\",\"Order\":4,\"Heading\":\"Annex D - Standard breakdowns\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"b05ae1f7-b2d1-4ae3-9db6-28fb0edf98ae\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"}]",
+                            Content = "[{\"Id\":\"bceaafc1-9548-4a03-98d5-d3476c8b9d99\",\"Order\":1,\"Heading\":\"1. Overview of exclusion statistics\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"9a034a5f-7cdb-4895-b205-864e7f834ebf\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"66b15928-46c6-48d5-90e6-12cf354b4e04\",\"Order\":2,\"Heading\":\"2. National Statistics badging\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"f745893e-68a6-4813-ba8b-35d44c0935aa\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"863f2b02-67b1-41bd-b1c9-f998f4581297\",\"Order\":3,\"Heading\":\"3. Methodology\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"4c88cbdd-e0e2-4019-a656-31e4b97d19d5\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"fc66f72e-0176-4c75-b15f-2f35c7329563\",\"Order\":4,\"Heading\":\"4. Data collection\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"085ba061-918b-4e6e-9a02-3a8b12671587\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"0c44636a-9a31-4e05-8db7-331ed5eae366\",\"Order\":5,\"Heading\":\"5. Data processing\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"29f138eb-070e-41fe-95c6-e271cdf4eaf4\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"69df08b6-dcda-449e-828e-5666c8e6d533\",\"Order\":6,\"Heading\":\"6. Data quality\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"8263cdc1-a2e8-4db6-a581-44043a6add64\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"},{\"Id\":\"fa315759-a51b-4860-8ae5-7b9505873108\",\"Order\":7,\"Heading\":\"7. Contacts\",\"Caption\":\"\",\"Content\":[{\"Body\":\"\",\"Type\":\"HtmlBlock\",\"Id\":\"e1eb03d9-25e4-4247-b3de-49805cce7889\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}],\"Release\":null,\"ReleaseId\":\"00000000-0000-0000-0000-000000000000\"}]",
                             Published = new DateTime(2018, 8, 25, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             Slug = "permanent-and-fixed-period-exclusions-in-england",
                             Summary = "",
@@ -2099,7 +2101,7 @@ Find out how and why these statistics are collected and published - [Secondary a
                         new
                         {
                             Id = new Guid("5d1e6b67-26d7-4440-9e77-c0de71a9fc21"),
-                            Order = 1,
+                            Order = 0,
                             Type = "DataBlock",
                             Charts = "[{\"Legend\":\"top\",\"Labels\":{\"23_1_58_____\":{\"Label\":\"Unauthorised absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"},\"26_1_58_____\":{\"Label\":\"Overall absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#f5a450\",\"symbol\":\"cross\",\"LineStyle\":\"solid\"},\"28_1_58_____\":{\"Label\":\"Authorised absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#005ea5\",\"symbol\":\"diamond\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriod\",\"DataSets\":[{\"Indicator\":\"23\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"26\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"28\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriod\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":0,\"Max\":null,\"Size\":null}},\"Type\":\"line\",\"Title\":null,\"Width\":0,\"Height\":0}]",
                             DataBlockRequest = "{\"SubjectId\":1,\"GeographicLevel\":\"Country\",\"TimePeriod\":{\"StartYear\":\"2012\",\"StartCode\":\"AY\",\"EndYear\":\"2016\",\"EndCode\":\"AY\"},\"Filters\":[\"1\",\"58\"],\"Indicators\":[\"23\",\"26\",\"28\"],\"Country\":null,\"Institution\":null,\"LocalAuthority\":null,\"LocalAuthorityDistrict\":null,\"LocalEnterprisePartnership\":null,\"MultiAcademyTrust\":null,\"MayoralCombinedAuthority\":null,\"OpportunityArea\":null,\"ParliamentaryConstituency\":null,\"Region\":null,\"RscRegion\":null,\"Sponsor\":null,\"Ward\":null}",
@@ -2110,7 +2112,7 @@ Find out how and why these statistics are collected and published - [Secondary a
                         {
                             Id = new Guid("5d3058f2-459e-426a-b0b3-9f60d8629fef"),
                             ContentSectionId = new Guid("8965ef44-5ad7-4ab0-a142-78453d6f40af"),
-                            Order = 1,
+                            Order = 0,
                             Type = "DataBlock",
                             Charts = "[{\"Legend\":\"top\",\"Labels\":{\"23_1_58_____\":{\"Label\":\"Unauthorised absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"},\"26_1_58_____\":{\"Label\":\"Overall absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#f5a450\",\"symbol\":\"cross\",\"LineStyle\":\"solid\"},\"28_1_58_____\":{\"Label\":\"Authorised absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#005ea5\",\"symbol\":\"diamond\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriod\",\"DataSets\":[{\"Indicator\":\"23\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"26\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"28\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriod\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":0,\"Max\":null,\"Size\":null}},\"Type\":\"line\",\"Title\":null,\"Width\":0,\"Height\":0}]",
                             DataBlockRequest = "{\"SubjectId\":1,\"GeographicLevel\":\"Country\",\"TimePeriod\":{\"StartYear\":\"2012\",\"StartCode\":\"AY\",\"EndYear\":\"2016\",\"EndCode\":\"AY\"},\"Filters\":[\"1\",\"58\"],\"Indicators\":[\"23\",\"26\",\"28\"],\"Country\":null,\"Institution\":null,\"LocalAuthority\":null,\"LocalAuthorityDistrict\":null,\"LocalEnterprisePartnership\":null,\"MultiAcademyTrust\":null,\"MayoralCombinedAuthority\":null,\"OpportunityArea\":null,\"ParliamentaryConstituency\":null,\"Region\":null,\"RscRegion\":null,\"Sponsor\":null,\"Ward\":null}",
@@ -2120,7 +2122,7 @@ Find out how and why these statistics are collected and published - [Secondary a
                         {
                             Id = new Guid("4a1af98a-ed8a-438e-92d4-d21cca0429f9"),
                             ContentSectionId = new Guid("68e3028c-1291-42b3-9e7c-9be285dac9a1"),
-                            Order = 1,
+                            Order = 0,
                             Type = "DataBlock",
                             Charts = "[{\"Labels\":{\"23_1_58_____\":{\"Label\":\"Unauthorised absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"},\"26_1_58_____\":{\"Label\":\"Overall absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#f5a450\",\"symbol\":\"cross\",\"LineStyle\":\"solid\"},\"28_1_58_____\":{\"Label\":\"Authorised absence rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#005ea5\",\"symbol\":\"diamond\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriod\",\"DataSets\":[{\"Indicator\":\"23\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"26\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"28\",\"Filters\":[\"1\",\"58\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriod\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null}},\"Type\":\"map\",\"Title\":null,\"Width\":0,\"Height\":0}]",
                             DataBlockRequest = "{\"SubjectId\":1,\"GeographicLevel\":\"LocalAuthorityDistrict\",\"TimePeriod\":{\"StartYear\":\"2016\",\"StartCode\":\"AY\",\"EndYear\":\"2017\",\"EndCode\":\"AY\"},\"Filters\":[\"1\",\"58\"],\"Indicators\":[\"23\",\"26\",\"28\"],\"Country\":null,\"Institution\":null,\"LocalAuthority\":null,\"LocalAuthorityDistrict\":null,\"LocalEnterprisePartnership\":null,\"MultiAcademyTrust\":null,\"MayoralCombinedAuthority\":null,\"OpportunityArea\":null,\"ParliamentaryConstituency\":null,\"Region\":null,\"RscRegion\":null,\"Sponsor\":null,\"Ward\":null}"
@@ -2128,7 +2130,7 @@ Find out how and why these statistics are collected and published - [Secondary a
                         new
                         {
                             Id = new Guid("17a0272b-318d-41f6-bda9-3bd88f78cd3d"),
-                            Order = 1,
+                            Order = 0,
                             Type = "DataBlock",
                             Charts = "[{\"Legend\":\"top\",\"Labels\":{\"181_461_____\":{\"Label\":\"Fixed period exclusion rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"},\"183_461_____\":{\"Label\":\"Pupils with one or more exclusion\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#f5a450\",\"symbol\":\"cross\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriod\",\"DataSets\":[{\"Indicator\":\"181\",\"Filters\":[\"461\"],\"Location\":null,\"TimePeriod\":null},{\"Indicator\":\"183\",\"Filters\":[\"461\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriod\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":0,\"Max\":null,\"Size\":null}},\"Type\":\"line\",\"Title\":null,\"Width\":0,\"Height\":0}]",
                             DataBlockRequest = "{\"SubjectId\":12,\"GeographicLevel\":\"Country\",\"TimePeriod\":{\"StartYear\":\"2012\",\"StartCode\":\"AY\",\"EndYear\":\"2016\",\"EndCode\":\"AY\"},\"Filters\":[\"461\"],\"Indicators\":[\"176\",\"177\",\"178\",\"179\",\"180\",\"181\",\"183\"],\"Country\":null,\"Institution\":null,\"LocalAuthority\":null,\"LocalAuthorityDistrict\":null,\"LocalEnterprisePartnership\":null,\"MultiAcademyTrust\":null,\"MayoralCombinedAuthority\":null,\"OpportunityArea\":null,\"ParliamentaryConstituency\":null,\"Region\":null,\"RscRegion\":null,\"Sponsor\":null,\"Ward\":null}",
@@ -2139,7 +2141,7 @@ Find out how and why these statistics are collected and published - [Secondary a
                         {
                             Id = new Guid("dd572e49-87e3-46f5-bb04-e9008573fc91"),
                             ContentSectionId = new Guid("6ed87fd1-81a5-46dc-8841-4598bdae7fee"),
-                            Order = 1,
+                            Order = 0,
                             Type = "DataBlock",
                             Charts = "[{\"Legend\":\"top\",\"Labels\":{\"179_461_____\":{\"Label\":\"Fixed period exclusion rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriod\",\"DataSets\":[{\"Indicator\":\"179\",\"Filters\":[\"461\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriod\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Exclusion Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":0,\"Max\":null,\"Size\":null}},\"Type\":\"line\",\"Title\":null,\"Width\":0,\"Height\":0}]",
                             DataBlockRequest = "{\"SubjectId\":12,\"GeographicLevel\":\"Country\",\"TimePeriod\":{\"StartYear\":\"2012\",\"StartCode\":\"AY\",\"EndYear\":\"2016\",\"EndCode\":\"AY\"},\"Filters\":[\"461\"],\"Indicators\":[\"179\",\"177\",\"178\"],\"Country\":null,\"Institution\":null,\"LocalAuthority\":null,\"LocalAuthorityDistrict\":null,\"LocalEnterprisePartnership\":null,\"MultiAcademyTrust\":null,\"MayoralCombinedAuthority\":null,\"OpportunityArea\":null,\"ParliamentaryConstituency\":null,\"Region\":null,\"RscRegion\":null,\"Sponsor\":null,\"Ward\":null}",
@@ -2150,7 +2152,7 @@ Find out how and why these statistics are collected and published - [Secondary a
                         {
                             Id = new Guid("038093a2-0be3-440b-8b22-8116e34aa616"),
                             ContentSectionId = new Guid("7981db34-afdb-4f84-99e8-bfd43e58f16d"),
-                            Order = 1,
+                            Order = 0,
                             Type = "DataBlock",
                             Charts = "[{\"Legend\":\"top\",\"Labels\":{\"181_461_____\":{\"Label\":\"Fixed period exclusion rate\",\"Value\":null,\"Name\":null,\"Unit\":\"%\",\"Colour\":\"#4763a5\",\"symbol\":\"circle\",\"LineStyle\":\"solid\"}},\"Axes\":{\"major\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriod\",\"DataSets\":[{\"Indicator\":\"181\",\"Filters\":[\"461\"],\"Location\":null,\"TimePeriod\":null}],\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"School Year\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":null,\"Max\":null,\"Size\":null},\"minor\":{\"Name\":null,\"Type\":\"major\",\"GroupBy\":\"timePeriod\",\"DataSets\":null,\"ReferenceLines\":null,\"Visible\":true,\"Title\":\"Absence Rate\",\"ShowGrid\":true,\"LabelPosition\":\"axis\",\"Min\":0,\"Max\":null,\"Size\":null}},\"Type\":\"line\",\"Title\":null,\"Width\":0,\"Height\":0}]",
                             DataBlockRequest = "{\"SubjectId\":12,\"GeographicLevel\":\"Country\",\"TimePeriod\":{\"StartYear\":\"2012\",\"StartCode\":\"AY\",\"EndYear\":\"2016\",\"EndCode\":\"AY\"},\"Filters\":[\"461\"],\"Indicators\":[\"181\",\"177\",\"180\"],\"Country\":null,\"Institution\":null,\"LocalAuthority\":null,\"LocalAuthorityDistrict\":null,\"LocalEnterprisePartnership\":null,\"MultiAcademyTrust\":null,\"MayoralCombinedAuthority\":null,\"OpportunityArea\":null,\"ParliamentaryConstituency\":null,\"Region\":null,\"RscRegion\":null,\"Sponsor\":null,\"Ward\":null}",
@@ -2160,7 +2162,7 @@ Find out how and why these statistics are collected and published - [Secondary a
                         new
                         {
                             Id = new Guid("475738b4-ba10-4c29-a50d-6ca82c10de6e"),
-                            Order = 1,
+                            Order = 0,
                             Type = "DataBlock",
                             DataBlockRequest = "{\"SubjectId\":17,\"GeographicLevel\":\"Country\",\"TimePeriod\":{\"StartYear\":\"2014\",\"StartCode\":\"CY\",\"EndYear\":\"2018\",\"EndCode\":\"CY\"},\"Filters\":[\"575\"],\"Indicators\":[\"211\",\"212\",\"216\",\"217\",\"218\",\"219\",\"220\",\"221\",\"222\"],\"Country\":null,\"Institution\":null,\"LocalAuthority\":null,\"LocalAuthorityDistrict\":null,\"LocalEnterprisePartnership\":null,\"MultiAcademyTrust\":null,\"MayoralCombinedAuthority\":null,\"OpportunityArea\":null,\"ParliamentaryConstituency\":null,\"Region\":null,\"RscRegion\":null,\"Sponsor\":null,\"Ward\":null}",
                             Summary = "{\"dataKeys\":[\"212\",\"216\",\"217\"],\"dataSummary\":[\"Down from 620,330 in 2017\",\"Down from 558,411 in 2017\",\"Down from 34,792 in 2017\"],\"dataDefinition\":[\"Total number of applications received for places at primary and secondary schools.\",\"Total number of first preferences offered to applicants by schools.\",\"Total number of second preferences offered to applicants by schools.\"],\"description\":{\"Body\":\"* majority of applicants received a preferred offer\\n* percentage of applicants receiving secondary first choice offers decreases as applications increase\\n* slight proportional increase in applicants receiving primary first choice offer as applications decrease\\n\",\"Type\":\"MarkDownBlock\",\"Id\":\"fdcac9d3-dab5-445d-9802-a8af0990efb2\",\"ContentSection\":null,\"ContentSectionId\":null,\"Order\":0}}",
@@ -2170,7 +2172,7 @@ Find out how and why these statistics are collected and published - [Secondary a
                         {
                             Id = new Guid("52916052-81e3-4b66-80b8-24f8666d9cbf"),
                             ContentSectionId = new Guid("6bfa9b19-25d6-4d45-8008-9447db541795"),
-                            Order = 1,
+                            Order = 0,
                             Type = "DataBlock",
                             DataBlockRequest = "{\"SubjectId\":17,\"GeographicLevel\":\"Country\",\"TimePeriod\":{\"StartYear\":\"2014\",\"StartCode\":\"CY\",\"EndYear\":\"2018\",\"EndCode\":\"CY\"},\"Filters\":[\"577\"],\"Indicators\":[\"220\",\"221\",\"222\",\"223\"],\"Country\":null,\"Institution\":null,\"LocalAuthority\":null,\"LocalAuthorityDistrict\":null,\"LocalEnterprisePartnership\":null,\"MultiAcademyTrust\":null,\"MayoralCombinedAuthority\":null,\"OpportunityArea\":null,\"ParliamentaryConstituency\":null,\"Region\":null,\"RscRegion\":null,\"Sponsor\":null,\"Ward\":null}",
                             Heading = "Table of Timeseries of key secondary preference rates, England",
@@ -2180,7 +2182,7 @@ Find out how and why these statistics are collected and published - [Secondary a
                         {
                             Id = new Guid("a8c408ed-45d8-4690-a9f3-2fb0e86377bf"),
                             ContentSectionId = new Guid("c3eb66d0-ce13-4e68-861d-98bb914d0814"),
-                            Order = 1,
+                            Order = 0,
                             Type = "DataBlock",
                             DataBlockRequest = "{\"SubjectId\":17,\"GeographicLevel\":\"Country\",\"TimePeriod\":{\"StartYear\":\"2014\",\"StartCode\":\"CY\",\"EndYear\":\"2018\",\"EndCode\":\"CY\"},\"Filters\":[\"575\"],\"Indicators\":[\"220\",\"221\",\"222\",\"223\"],\"Country\":null,\"Institution\":null,\"LocalAuthority\":null,\"LocalAuthorityDistrict\":null,\"LocalEnterprisePartnership\":null,\"MultiAcademyTrust\":null,\"MayoralCombinedAuthority\":null,\"OpportunityArea\":null,\"ParliamentaryConstituency\":null,\"Region\":null,\"RscRegion\":null,\"Sponsor\":null,\"Ward\":null}",
                             Heading = "Table showing Timeseries of key primary preference rates, England Entry into academic year",
@@ -2229,7 +2231,7 @@ Find out how and why these statistics are collected and published - [Secondary a
                         {
                             Id = new Guid("7eeb1478-ab26-4b70-9128-b976429efa2f"),
                             ContentSectionId = new Guid("24c6e9a3-1415-4ca5-9f21-b6b51cb7ba94"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"The statistics and data cover the absence of pupils of compulsory school age during the 2016/17 academic year in the following state-funded school types:
 
@@ -2249,7 +2251,7 @@ They're also used for policy development as key indicators in behaviour and scho
                         {
                             Id = new Guid("2c369594-3bbc-40b4-ad19-196c923f5c7f"),
                             ContentSectionId = new Guid("8965ef44-5ad7-4ab0-a142-78453d6f40af"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"**Overall absence**
 
@@ -2265,7 +2267,7 @@ The overall and [authorised absence](../glossary#authorised-absence) rates have 
                         {
                             Id = new Guid("3913a0af-9455-4802-a037-c4cfd4719b18"),
                             ContentSectionId = new Guid("8965ef44-5ad7-4ab0-a142-78453d6f40af"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"**Unauthorised absence**
 
@@ -2289,7 +2291,7 @@ In 2016/17, 91.8% of primary, secondary and special school pupils missed at leas
                         {
                             Id = new Guid("8a8add13-368c-4067-9210-166bb19a00c1"),
                             ContentSectionId = new Guid("6f493eee-443a-4403-9069-fef82e2f5788"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"The [persistent absence](../glossary#persistent-absence) rate increased to and accounted for 37.6% of all absence - up from 36.6% in 2015 to 16 but still down from 43.3% in 2011 to 12.
 
@@ -2301,7 +2303,7 @@ Overall, it's increased across primary and secondary schools to 10.8% - up from 
                         {
                             Id = new Guid("4aa06200-406b-4f5a-bee4-19e3b83eb1d2"),
                             ContentSectionId = new Guid("6f493eee-443a-4403-9069-fef82e2f5788"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"**Persistent absentees**
 
@@ -2315,7 +2317,7 @@ The illness absence rate is almost 4 times higher for persistent absentees at 7.
                         {
                             Id = new Guid("33c3a82e-7d8d-47fc-9019-2fe5344ec32d"),
                             ContentSectionId = new Guid("fbf99442-3b72-46bc-836d-8866c552c53d"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"These have been broken down into the following:
 
@@ -2329,7 +2331,7 @@ The illness absence rate is almost 4 times higher for persistent absentees at 7.
                         {
                             Id = new Guid("2ef5f84f-e151-425d-8906-2921712f9157"),
                             ContentSectionId = new Guid("fbf99442-3b72-46bc-836d-8866c552c53d"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"**Illness**
 
@@ -2361,7 +2363,7 @@ They also partially relate to the period after the April 2017 Supreme Court judg
                         {
                             Id = new Guid("cf01208f-cbab-41d1-9fa5-4793d2a0bc13"),
                             ContentSectionId = new Guid("6898538c-3f8d-488d-9e50-12ca7a9fd70c"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"Nearly half of all pupils (48.9%) were absent for 5 days or less across primary, secondary and special schools - down from 49.1% in 2015/16.
 
@@ -2385,7 +2387,7 @@ Across all schools:
                         {
                             Id = new Guid("eb4318f9-11e0-46ea-9796-c36a9dc25014"),
                             ContentSectionId = new Guid("08b204a2-0eeb-4797-9e0b-a1274e7f6a38"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"The [overall absence](../glossary#overall-absence) and [persistent absence](../glossary#persistent-absence) patterns for pupils with different characteristics have been consistent over recent years.
 **Ethnic groups**
@@ -2446,7 +2448,7 @@ Persistent absence rate:
                         {
                             Id = new Guid("97c54e5f-2406-4333-851d-b6c9cc4bf612"),
                             ContentSectionId = new Guid("60f8c7ca-faff-4f0d-937d-17fe376461cf"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"The [overall absence](../glossary#overall-absence) rate decreased to 5.1% - down from 5.2% for the previous 2 years.
 
@@ -2456,7 +2458,7 @@ Absence recorded for 4-year-olds is not treated as authorised or unauthorised an
                         {
                             Id = new Guid("3aaafa20-bc32-4523-bb23-dd55c458f928"),
                             ContentSectionId = new Guid("d5d604af-6b63-4a51-b106-0c09b8dbedfa"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"The [overall absence](../glossary#overall-absence) rate increased to 33.9% - up from 32.6% in 2015/16.
 
@@ -2466,7 +2468,7 @@ The [persistent absence](../glossary#persistent-absence) rate increased to 73.9%
                         {
                             Id = new Guid("7d97f8ed-e1d0-4244-bec3-3432af356f57"),
                             ContentSectionId = new Guid("68e3028c-1291-42b3-9e7c-9be285dac9a1"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"[Overall absence](../glossary#overall-absence) and [persistent absence](../glossary#persistent-absence) rates vary across primary, secondary and special schools by region and local authority (LA).
 
@@ -2490,7 +2492,7 @@ The region with the highest persistent absence rate was Yorkshire and the Humber
                         {
                             Id = new Guid("97d414f4-1a27-4ed7-85ea-c4c903e1d8cb"),
                             ContentSectionId = new Guid("b7a968ab-eb49-4100-b133-3d9d94f23d60"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"The statistics and data cover permanent and fixed period exclusions and school-level exclusions during the 2016/17 academic year in the following state-funded school types as reported in the school census:
 
@@ -2508,7 +2510,7 @@ All figures are based on unrounded data so constituent parts may not add up due 
                         {
                             Id = new Guid("70546a7d-5edd-4b8f-b096-cfd50153f4cb"),
                             ContentSectionId = new Guid("6ed87fd1-81a5-46dc-8841-4598bdae7fee"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"The number of [permanent exclusions](../glossary#permanent-exclusion) has increased across all state-funded primary, secondary and special schools to 7,720 - up from 6,685 in 2015/16.
 
@@ -2520,7 +2522,7 @@ The permanent exclusion rate has also increased to 0.10% of pupils - up from fro
                         {
                             Id = new Guid("81d8eba2-9cba-4b04-bb02-e00ace5c4418"),
                             ContentSectionId = new Guid("6ed87fd1-81a5-46dc-8841-4598bdae7fee"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"Most occurred in secondary schools which accounted for 83% of all permanent exclusions.
 
@@ -2536,7 +2538,7 @@ However, since 2012/13 it has been on the rise although rates are still lower no
                         {
                             Id = new Guid("7971329a-9e16-468b-9eb3-62bfc384b5a3"),
                             ContentSectionId = new Guid("7981db34-afdb-4f84-99e8-bfd43e58f16d"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"The number of fixed-period exclusionshas increased across all state-funded primary, secondary and special schools to 381,865 - up from 339,360 in 2015/16.
 
@@ -2546,7 +2548,7 @@ This works out to around 2,010 fixed-period exclusions per day - up from an 1,78
                         {
                             Id = new Guid("e9462ed0-10dc-4ff5-8cda-f8c3b66f2714"),
                             ContentSectionId = new Guid("7981db34-afdb-4f84-99e8-bfd43e58f16d"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"**Primary schools**
 
@@ -2570,7 +2572,7 @@ This works out to around 2,010 fixed-period exclusions per day - up from an 1,78
                         {
                             Id = new Guid("4e05bbb3-bd4e-4602-8424-069e59034c87"),
                             ContentSectionId = new Guid("50e7ca4c-e6c7-4ccd-afc1-93ee4298f358"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"**Pupils with one or more fixed-period exclusion definition**
 
@@ -2590,7 +2592,7 @@ Only 2.0% of fixed-period exclusions lasted for longer than 1 week and longer fi
                         {
                             Id = new Guid("99d75d39-7ea5-456e-979d-1215fa673a83"),
                             ContentSectionId = new Guid("015d0cdd-6630-4b57-9ef3-7341fc3d573e"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"All reasons (except bullying and theft) saw an increase in [permanent exclusions](../glossary#permanent-exclusion) since 2015/16.
 
@@ -2616,7 +2618,7 @@ All reasons saw an increase in fixed-period exclusions since 2015/16. Persistent
                         {
                             Id = new Guid("c73382ce-73ff-465f-8f1b-7a08cb6af089"),
                             ContentSectionId = new Guid("5600ca55-6800-418a-94a5-2f3c3310304e"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"There was a similar pattern to previous years where the following groups (where higher exclusion rates are expected) showed an increase in exclusions since 2015/16:
 
@@ -2664,7 +2666,7 @@ All reasons saw an increase in fixed-period exclusions since 2015/16. Persistent
                         {
                             Id = new Guid("d988a5e8-4e3c-4c1d-b5a9-bf0e1d947085"),
                             ContentSectionId = new Guid("68f8b290-4b7c-4cac-b0d9-0263609c341b"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = "There were 560 reviews lodged with [independent review panels](../glossary#independent-review-panel) in maintained primary, secondary and special schools and academies of which 525 (93.4%) were determined and 45 (8.0%) resulted in an offer of reinstatement."
                         },
@@ -2672,7 +2674,7 @@ All reasons saw an increase in fixed-period exclusions since 2015/16. Persistent
                         {
                             Id = new Guid("d3288340-2689-4346-91a6-c070e7b0799d"),
                             ContentSectionId = new Guid("5708d443-7669-47d8-b6a3-6ad851090710"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"**Permanent exclusion**
 
@@ -2690,7 +2692,7 @@ The percentage of pupils in pupil referral units who 1 or more fixed-period excl
                         {
                             Id = new Guid("1a1d29f6-c4d5-41a9-9a06-b2ce84043edd"),
                             ContentSectionId = new Guid("3960ab94-0fad-442c-8aaa-6233eff3bc32"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"There's considerable variation in the [permanent exclusion](../glossary#permanent-exclusion) and [fixed-period exclusion](../glossary#fixed-period-exclusion) rate at the LA level.
 
@@ -2716,7 +2718,7 @@ Similar to 2015/16, the region with the highest rates across all school types wa
                         {
                             Id = new Guid("49aa2ac2-1b65-4c25-9828-fec65a5ed7e8"),
                             ContentSectionId = new Guid("def347bd-0b29-405f-a11f-cd03c853a6ed"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"The statistics and data cover the number of offers made to applicants for primary and secondary school places and the proportion which have received their preferred offers.
 
@@ -2728,7 +2730,7 @@ The offers were made, and data collected, based on the National Offer Days of 1 
                         {
                             Id = new Guid("13e4577a-2291-4ce4-a8c9-6c76baa06092"),
                             ContentSectionId = new Guid("6bfa9b19-25d6-4d45-8008-9447db541795"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"**Secondary applications**
 
@@ -2754,7 +2756,7 @@ The secondary figures have been collected since 2008 and can be viewed as a time
                         {
                             Id = new Guid("8510640f-d8b6-4fe2-a161-d025e14930a4"),
                             ContentSectionId = new Guid("c1f17b4e-f576-40bc-80e1-63767998d080"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"**First preference rates**
 
@@ -2790,7 +2792,7 @@ The secondary figures have been collected since 2008 and can be viewed as a time
                         {
                             Id = new Guid("87f5343b-b7a5-4775-b483-d1668fac03fb"),
                             ContentSectionId = new Guid("c1f17b4e-f576-40bc-80e1-63767998d080"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"An applicant can apply for any school, including those situated in another local authority (LA).
 
@@ -2814,7 +2816,7 @@ However, the main tables provide more information including:
                         {
                             Id = new Guid("5f194c52-0ffb-4205-8c03-068ff4d1384b"),
                             ContentSectionId = new Guid("c3eb66d0-ce13-4e68-861d-98bb914d0814"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"**Primary applications**
 
@@ -2840,7 +2842,7 @@ The primary figures have been collected and published since 2014 and can be view
                         {
                             Id = new Guid("e4497a91-3e3b-460a-8965-42eab5e06ce5"),
                             ContentSectionId = new Guid("b87f2e62-e3e7-4492-9d68-18df8dc29041"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"**First preference rates**
 
@@ -2874,7 +2876,7 @@ Although overall results are better at primary level than at secondary, for Lond
                         {
                             Id = new Guid("8e10ad6c-9a68-4162-84f9-81fb6dc93ae3"),
                             ContentSectionId = new Guid("b87f2e62-e3e7-4492-9d68-18df8dc29041"),
-                            Order = 1,
+                            Order = 0,
                             Type = "MarkDownBlock",
                             Body = @"**Primary offers**
 In 2018, 97.1% of primary offers made were from schools inside the home authority. This figure has been stable since 2014 when this data was first collected and published.

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20191120145056_AddOrderToContentBlocks.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20191120145056_AddOrderToContentBlocks.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Migrations
+{
+    public partial class AddOrderToContentBlocks : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Order",
+                table: "ContentBlock",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("13e4577a-2291-4ce4-a8c9-6c76baa06092"),
+                column: "Order",
+                value: 2);
+            
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("87f5343b-b7a5-4775-b483-d1668fac03fb"),
+                column: "Order",
+                value: 2);
+            
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("a8c408ed-45d8-4690-a9f3-2fb0e86377bf"),
+                column: "Order",
+                value: 2);
+            
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("8e10ad6c-9a68-4162-84f9-81fb6dc93ae3"),
+                column: "Order",
+                value: 2);
+            
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("5d3058f2-459e-426a-b0b3-9f60d8629fef"),
+                column: "Order",
+                value: 2);
+            
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("3913a0af-9455-4802-a037-c4cfd4719b18"),
+                column: "Order",
+                value: 3);
+            
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("4aa06200-406b-4f5a-bee4-19e3b83eb1d2"),
+                column: "Order",
+                value: 2);
+            
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("33c3a82e-7d8d-47fc-9019-2fe5344ec32d"),
+                column: "Order",
+                value: 2);
+            
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("4a1af98a-ed8a-438e-92d4-d21cca0429f9"),
+                column: "Order",
+                value: 2);
+
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("81d8eba2-9cba-4b04-bb02-e00ace5c4418"),
+                column: "Order",
+                value: 2);
+            
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("dd572e49-87e3-46f5-bb04-e9008573fc91"),
+                column: "Order",
+                value: 3);
+            
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("038093a2-0be3-440b-8b22-8116e34aa616"),
+                column: "Order",
+                value: 2);
+            
+            migrationBuilder.UpdateData(
+                table: "ContentBlock",
+                keyColumn: "Id",
+                keyValue: new Guid("e9462ed0-10dc-4ff5-8cda-f8c3b66f2714"),
+                column: "Order",
+                value: 3);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IContentService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.ManageContent;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -14,7 +15,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 
         Task<Either<ValidationResult, List<ContentSectionViewModel>>> ReorderContentSectionsAsync(Guid releaseId, Dictionary<Guid, int> newSectionOrder);
         
-        Task<Either<ValidationResult, ContentSectionViewModel>> AddContentSectionAsync(Guid releaseId);
+        Task<Either<ValidationResult, ContentSectionViewModel>> AddContentSectionAsync(Guid releaseId,
+            AddContentSectionRequest request);
 
         Task<Either<ValidationResult, ContentSectionViewModel>> UpdateContentSectionHeadingAsync(
             Guid releaseId, Guid contentSectionId, string newHeading);
@@ -26,7 +28,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
         
         Task<Either<ValidationResult, List<IContentBlock>>> ReorderContentBlocksAsync(Guid releaseId, Guid contentSectionId, Dictionary<Guid,int> newBlocksOrder);
         
-        Task<Either<ValidationResult, IContentBlock>> AddContentBlockAsync(Guid releaseId, Guid contentSectionId);
+        Task<Either<ValidationResult, IContentBlock>> AddContentBlockAsync(Guid releaseId, Guid contentSectionId,
+            AddContentBlockRequest request);
         
         Task<Either<ValidationResult, List<IContentBlock>>> RemoveContentBlockAsync(Guid releaseId, Guid contentSectionId, Guid contentBlockId);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IContentService.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.ManageContent
 {
@@ -20,5 +21,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 
         Task<Either<ValidationResult, List<ContentSectionViewModel>>> RemoveContentSectionAsync(Guid releaseId,
             Guid contentSectionId);
+
+        Task<Either<ValidationResult, ContentSectionViewModel>> GetContentSectionAsync(Guid releaseId, Guid contentSectionId);
+        
+        Task<Either<ValidationResult, List<IContentBlock>>> ReorderContentBlocksAsync(Guid releaseId, Guid contentSectionId, Dictionary<Guid,int> newBlocksOrder);
+        
+        Task<Either<ValidationResult, IContentBlock>> AddContentBlockAsync(Guid releaseId, Guid contentSectionId);
+        
+        Task<Either<ValidationResult, List<IContentBlock>>> RemoveContentBlockAsync(Guid releaseId, Guid contentSectionId, Guid contentBlockId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IContentService.cs
@@ -16,7 +16,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
         Task<Either<ValidationResult, List<ContentSectionViewModel>>> ReorderContentSectionsAsync(Guid releaseId, Dictionary<Guid, int> newSectionOrder);
         
         Task<Either<ValidationResult, ContentSectionViewModel>> AddContentSectionAsync(Guid releaseId,
-            AddContentSectionRequest request);
+            AddContentSectionRequest? request);
 
         Task<Either<ValidationResult, ContentSectionViewModel>> UpdateContentSectionHeadingAsync(
             Guid releaseId, Guid contentSectionId, string newHeading);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ContentService.cs
@@ -269,7 +269,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                 }
 
                 return await contentSectionFn.Invoke(new Tuple<Release, ContentSection>(release, section));
-            });
+            }, HydrateContentSectionsAndBlocks);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ContentService.cs
@@ -192,6 +192,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                     .FindAll(contentBlock => contentBlock.Order > removedBlockOrder)
                     .ForEach(contentBlock => contentBlock.Order--);
                 
+                _context.ContentBlocks.Remove(blockToRemove);
                 _context.ContentSections.Update(section);
                 await _context.SaveChangesAsync();
                 return OrderedContentBlocks(section);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/RelatedInformationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/RelatedInformationService.cs
@@ -36,6 +36,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
         {
             return _releaseHelper.CheckEntityExists(releaseId, async release =>
             {
+                if (release.RelatedInformation == null)
+                {
+                    release.RelatedInformation = new List<BasicLink>();
+                }
+                
                 release.RelatedInformation.Add(new BasicLink
                 {
                     Id = Guid.NewGuid(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -166,6 +166,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                         .Build();
                     options.Filters.Add(new AuthorizeFilter(policy));
                     options.EnableEndpointRouting = false;
+                    options.AllowEmptyInputInBodyModelBinding = true;
                 })
                 .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddNewtonsoftJson(options =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -116,6 +116,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
                     return new ValidationResult("RELATED_INFORMATION_ITEM_NOT_FOUND");
                 case EntityNotFound:
                     return new ValidationResult("NOT_FOUND");
+                case ContentSectionNotFound:
+                    return new ValidationResult("CONTENT_SECTION_NOT_FOUND");
+                case ContentBlockNotFound:
+                    return new ValidationResult("CONTENT_BLOCK_NOT_FOUND");
                 default:
                     throw new ArgumentOutOfRangeException(nameof(message), message, null);
             }
@@ -144,5 +148,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         ReleaseNotFound,
         RelatedInformationItemNotFound,
         ContentSectionNotFound,
+        ContentBlockNotFound,
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ManageContent/ManageContentPageViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ManageContent/ManageContentPageViewModel.cs
@@ -77,24 +77,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageCont
             {
                 Id = section.Id,
                 Caption = section.Caption,
-                Content = section.Content,
+                Content = section.Content?.OrderBy(contentBlock => contentBlock.Order).ToList(),
                 Heading = section.Heading,
                 Order = section.Order
             };
             
-            UnsetUnwantedFields(model);
-
             return model;
-        }
-
-        // remove unwanted fields from the ContentBlock JSON structure
-        private static void UnsetUnwantedFields(ContentSectionViewModel model)
-        {
-            model.Content?.ForEach(contentBlock =>
-            {
-                contentBlock.ContentSection = null;
-                contentBlock.ContentSectionId = null;
-            });
         }
 
         public Guid Id { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentSection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentSection.cs
@@ -35,6 +35,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public ContentSection ContentSection { get; set; }
 
         public Guid? ContentSectionId { get; set; }
+        
+        public int Order { get; set; }
 
         public abstract string Type { get; set; }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentSection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentSection.cs
@@ -32,8 +32,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
     {
         public Guid Id { get; set; }
 
+        [JsonIgnore]
         public ContentSection ContentSection { get; set; }
 
+        [JsonIgnore]
         public Guid? ContentSectionId { get; set; }
         
         public int Order { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentSection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentSection.cs
@@ -23,6 +23,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public Guid ReleaseId { get; set; }
     }
 
+    public enum ContentBlockType
+    {
+        MarkDownBlock,
+        HtmlBlock,
+        InsetTextBlock,
+        DataBlock,
+    }
+
     [JsonConverter(typeof(ContentBlockConverter))]
     [KnownType(typeof(MarkDownBlock))]
     [KnownType(typeof(InsetTextBlock))]
@@ -45,29 +53,49 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
     public class MarkDownBlock : IContentBlock
     {
+        public MarkDownBlock()
+        {
+            
+        }
+        
         public string Body { get; set; }
 
-        public override string Type { get; set; } = "MarkDownBlock";
+        public override string Type { get; set; } = ContentBlockType.MarkDownBlock.ToString();
     }
 
     public class HtmlBlock : IContentBlock
     {
+        public HtmlBlock()
+        {
+            
+        }
+        
         public string Body { get; set; }
 
-        public override string Type { get; set; } = "HtmlBlock";
+        public override string Type { get; set; } = ContentBlockType.HtmlBlock.ToString();
     }
 
     public class InsetTextBlock : IContentBlock
     {
+        public InsetTextBlock()
+        {
+            
+        }
+        
         public string Heading { get; set; }
 
         public string Body { get; set; }
 
-        public override string Type { get; set; } = "InsetTextBlock";
+        public override string Type { get; set; } = ContentBlockType.InsetTextBlock.ToString();
     }
 
     public class DataBlock : IContentBlock
     {
+        public DataBlock()
+        {
+            
+        }
+        
         public string Heading { get; set; }
         
         public string CustomFootnotes { get; set; }
@@ -84,7 +112,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<Table> Tables { get; set; }
 
-        public override string Type { get; set; } = "DataBlock";
+        public override string Type { get; set; } = ContentBlockType.DataBlock.ToString();
     }
 
     public class Summary

--- a/tests/newman/tests/admin-api.json
+++ b/tests/newman/tests/admin-api.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "42cebec7-4835-4df8-8bde-72029b0ffcdf",
+		"_postman_id": "12115576-7694-4505-a41a-540189aa6281",
 		"name": "DfE Admin API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -2227,11 +2227,6 @@
 											"",
 											"pm.test(\"Related Information array should no longer contain the deleted item\", function () { ",
 											"    pm.expect(respJson.some(item => item.id === pm.environment.get(\"latest_related_information_id\"))).to.be.false;",
-											"});",
-											"",
-											"pm.test(\"Unset variables\", function () {",
-											"    pm.environment.unset(\"latest_related_information_id\");",
-											"    pm.environment.unset(\"number_of_related_information_items\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -2260,6 +2255,62 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Verify Related Information entry deleted",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+										"exec": [
+											"var respJson = pm.response.json();",
+											"",
+											"pm.test(\"Status code is 200\", function () { ",
+											"    pm.response.to.have.status(200); ",
+											"});",
+											"",
+											"pm.test(\"Related Information array contains one less value than before\", function () {",
+											"    pm.expect(respJson.length).to.equal(pm.environment.get(\"number_of_related_information_items\") - 1);",
+											"});",
+											"",
+											"pm.test(\"Related Information array should no longer contain the deleted item\", function () { ",
+											"    pm.expect(respJson.some(item => item.id === pm.environment.get(\"latest_related_information_id\"))).to.be.false;",
+											"});",
+											"",
+											"pm.test(\"Unset variables\", function () {",
+											"    pm.environment.unset(\"latest_related_information_id\");",
+											"    pm.environment.unset(\"number_of_related_information_items\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/related-information",
+									"host": [
+										"{{admin_api_url}}"
+									],
+									"path": [
+										"release",
+										"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+										"content",
+										"related-information"
+									]
+								}
+							},
+							"response": []
 						}
 					],
 					"protocolProfileBehavior": {},
@@ -2269,595 +2320,784 @@
 					"name": "Content",
 					"item": [
 						{
-							"name": "Get Content Sections",
-							"event": [
+							"name": "Content Sections",
+							"item": [
 								{
-									"listen": "test",
-									"script": {
-										"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
-										"exec": [
-											"pm.test(\"Status code is 200\", function () { ",
-											"    pm.response.to.have.status(200); ",
-											"});",
-											"",
-											"pm.test(\"Content Sections should contain the correct information\", function () { ",
-											"",
-											"    var respJson = pm.response.json();",
-											"",
-											"    pm.expect(respJson.length).to.equal(9);",
-											"",
-											"    // assert that all of our content sections are coming back with details ",
-											"    respJson.forEach(section => {",
-											"        pm.expect(section.id).to.not.be.null;",
-											"        pm.expect(section.heading).to.not.be.null;",
-											"        pm.expect(section.caption).to.not.be.null;",
-											"        pm.expect(section.content.length).to.be.above(0);",
-											"    });",
-											"    ",
-											"    // assert that all of our sections are coming back in correct order",
-											"    respJson.forEach((section, index) => {",
-											"        pm.expect(section.order).to.equal(index + 1);",
-											"    });",
-											"    ",
-											"    // assert that the content sections' content blocks are coming back with details",
-											"    respJson.forEach(section => {",
-											"        section.content.forEach(contentBlock => {",
-											"            pm.expect(contentBlock.id).to.not.be.null;",
-											"            pm.expect(contentBlock.type).to.not.be.null;",
-											"        }); ",
-											"    });",
-											"    ",
-											"    // assert that the deliberately blanked out fields are undefined",
-											"    respJson.forEach(section => {",
-											"        section.content.forEach(contentBlock => {",
-											"            pm.expect(contentBlock.contentSection).to.be.undefined;",
-											"            pm.expect(contentBlock.contentSectionId).to.be.undefined;",
-											"       }); ",
-											"    });",
-											"    ",
-											"    // test a specific content section's content",
-											"    pm.expect(respJson[0].id).to.equal(\"b7a968ab-eb49-4100-b133-3d9d94f23d60\");",
-											"    pm.expect(respJson[0].order).to.equal(1);",
-											"    pm.expect(respJson[0].heading).to.equal(\"About this release\");",
-											"    pm.expect(respJson[0].caption).to.equal(\"\");",
-											"    ",
-											"    // test a MarkDownBlock's content",
-											"    pm.expect(respJson[0].content.length).to.equal(1);",
-											"    pm.expect(respJson[0].content[0].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
-											"    pm.expect(respJson[0].content[0].type).to.equal(\"MarkDownBlock\");",
-											"    pm.expect(respJson[0].content[0].body.startsWith(\"The statistics and data cover permanent and fixed period exclusions\")).to.be.true;",
-											"",
-											"    // test a DataBlock's content",
-											"    pm.expect(respJson[1].content[2].id).to.equal(\"dd572e49-87e3-46f5-bb04-e9008573fc91\");",
-											"    pm.expect(respJson[1].content[2].type).to.equal(\"DataBlock\");",
-											"    pm.expect(respJson[1].content[2].heading).to.equal(\"Chart showing permanent exclusions in England\");",
-											"    pm.expect(respJson[1].content[2].dataBlockRequest).to.not.be.null;",
-											"    pm.expect(respJson[1].content[2].charts).to.not.be.null;",
-											"    pm.expect(respJson[1].content[2].tables).to.not.be.null;",
-											"});"
+									"name": "Get Content Sections",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () { ",
+													"    pm.response.to.have.status(200); ",
+													"});",
+													"",
+													"pm.test(\"Content Sections should contain the correct information\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.length).to.equal(9);",
+													"",
+													"    // assert that all of our content sections are coming back with details ",
+													"    respJson.forEach(section => {",
+													"        pm.expect(section.id).to.not.be.null;",
+													"        pm.expect(section.heading).to.not.be.null;",
+													"        pm.expect(section.caption).to.not.be.null;",
+													"        pm.expect(section.content.length).to.be.above(0);",
+													"    });",
+													"    ",
+													"    // assert that all of our sections are coming back in correct order",
+													"    respJson.forEach((section, index) => {",
+													"        pm.expect(section.order).to.equal(index + 1);",
+													"    });",
+													"    ",
+													"    // assert that the content sections' content blocks are coming back with details",
+													"    respJson.forEach(section => {",
+													"        section.content.forEach(contentBlock => {",
+													"            pm.expect(contentBlock.id).to.not.be.null;",
+													"            pm.expect(contentBlock.type).to.not.be.null;",
+													"        }); ",
+													"    });",
+													"    ",
+													"    // assert that the deliberately blanked out fields are undefined",
+													"    respJson.forEach(section => {",
+													"        section.content.forEach(contentBlock => {",
+													"            pm.expect(contentBlock.contentSection).to.be.undefined;",
+													"            pm.expect(contentBlock.contentSectionId).to.be.undefined;",
+													"       }); ",
+													"    });",
+													"    ",
+													"    // test a specific content section's content",
+													"    pm.expect(respJson[0].id).to.equal(\"b7a968ab-eb49-4100-b133-3d9d94f23d60\");",
+													"    pm.expect(respJson[0].order).to.equal(1);",
+													"    pm.expect(respJson[0].heading).to.equal(\"About this release\");",
+													"    pm.expect(respJson[0].caption).to.equal(\"\");",
+													"    ",
+													"    // test a MarkDownBlock's content",
+													"    pm.expect(respJson[0].content.length).to.equal(1);",
+													"    pm.expect(respJson[0].content[0].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson[0].content[0].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson[0].content[0].body.startsWith(\"The statistics and data cover permanent and fixed period exclusions\")).to.be.true;",
+													"",
+													"    // test a DataBlock's content",
+													"    pm.expect(respJson[1].content[2].id).to.equal(\"dd572e49-87e3-46f5-bb04-e9008573fc91\");",
+													"    pm.expect(respJson[1].content[2].type).to.equal(\"DataBlock\");",
+													"    pm.expect(respJson[1].content[2].heading).to.equal(\"Chart showing permanent exclusions in England\");",
+													"    pm.expect(respJson[1].content[2].dataBlockRequest).to.not.be.null;",
+													"    pm.expect(respJson[1].content[2].charts).to.not.be.null;",
+													"    pm.expect(respJson[1].content[2].tables).to.not.be.null;",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"sections"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Add Content Section",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"New Content Section should be present\", function () { ",
+													"",
+													"    const respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.id).to.not.be.null;",
+													"    pm.expect(respJson.heading).to.equal('New section');",
+													"    pm.expect(respJson.order).to.equal(10);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections/add",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"sections",
+												"add"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Verify new Content Section added",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"New Content Section should be in the last position of the Content Section list\", function () { ",
+													"",
+													"    const expectedOrder = [",
+													"        'About this release',",
+													"        'Permanent exclusions',",
+													"        'Fixed-period exclusions',",
+													"        'Number and length of fixed-period exclusions',",
+													"        'Reasons for exclusions',",
+													"        'Exclusions by pupil characteristics',",
+													"        'Independent exclusion reviews',",
+													"        'Pupil referral units exclusions',",
+													"        'Regional and local authority (LA) breakdown',",
+													"        'New section'",
+													"    ];",
+													"    ",
+													"    const respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
+													"",
+													"    pm.environment.set(\"added_content_section_id\", respJson[respJson.length - 1].id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"sections"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Verify Content Section Order",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Content Sections should be in the expected updated order\", function () { ",
+													"",
+													"    const expectedOrder = [",
+													"        'About this release',",
+													"        'Permanent exclusions',",
+													"        'Fixed-period exclusions',",
+													"        'Number and length of fixed-period exclusions',",
+													"        'Reasons for exclusions',",
+													"        'Exclusions by pupil characteristics',",
+													"        'Independent exclusion reviews',",
+													"        'Pupil referral units exclusions',",
+													"        'Regional and local authority (LA) breakdown',",
+													"        'New section',",
+													"    ];",
+													"    ",
+													"    const respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"sections"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update Content Section heading",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Content Section should have an updated heading\", function () { ",
+													"    const respJson = pm.response.json();",
+													"    pm.expect(respJson.heading).to.equal('Updated heading');",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
 										],
-										"type": "text/javascript"
-									}
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\theading: 'Updated heading'\n}"
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/{{added_content_section_id}}/heading",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"{{added_content_section_id}}",
+												"heading"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Reorder Content Sections",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Content Sections should be in the expected starting order\", function () { ",
+													"",
+													"    const expectedOrder = [",
+													"        'Permanent exclusions',",
+													"        'Fixed-period exclusions',",
+													"        'Number and length of fixed-period exclusions',",
+													"        'About this release',",
+													"        'Exclusions by pupil characteristics',",
+													"        'Independent exclusion reviews',",
+													"        'Reasons for exclusions',",
+													"        'Updated heading',",
+													"        'Pupil referral units exclusions',",
+													"        'Regional and local authority (LA) breakdown',",
+													"    ];",
+													"    ",
+													"    const respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{    \n\t'b7a968ab-eb49-4100-b133-3d9d94f23d60': 4,\n    '6ed87fd1-81a5-46dc-8841-4598bdae7fee': 1,\n    '7981db34-afdb-4f84-99e8-bfd43e58f16d': 2,\n    '50e7ca4c-e6c7-4ccd-afc1-93ee4298f358': 3,\n    '015d0cdd-6630-4b57-9ef3-7341fc3d573e': 7,\n    '5600ca55-6800-418a-94a5-2f3c3310304e': 5,\n    '68f8b290-4b7c-4cac-b0d9-0263609c341b': 6,\n    '5708d443-7669-47d8-b6a3-6ad851090710': 9,\n    '3960ab94-0fad-442c-8aaa-6233eff3bc32': 10,\n    '{{added_content_section_id}}': 8,\n}"
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections/order",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"sections",
+												"order"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Verify Content Sections Order updated",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Content Sections should be in the expected updated order\", function () { ",
+													"",
+													"    const expectedOrder = [",
+													"        'Permanent exclusions',",
+													"        'Fixed-period exclusions',",
+													"        'Number and length of fixed-period exclusions',",
+													"        'About this release',",
+													"        'Exclusions by pupil characteristics',",
+													"        'Independent exclusion reviews',",
+													"        'Reasons for exclusions',",
+													"        'Updated heading',",
+													"        'Pupil referral units exclusions',",
+													"        'Regional and local authority (LA) breakdown',",
+													"    ];",
+													"    ",
+													"    const respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"sections"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Restore Content Sections order",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Content Sections should be in the expected starting order\", function () { ",
+													"",
+													"    const expectedOrder = [",
+													"        'About this release',",
+													"        'Permanent exclusions',",
+													"        'Fixed-period exclusions',",
+													"        'Number and length of fixed-period exclusions',",
+													"        'Reasons for exclusions',",
+													"        'Exclusions by pupil characteristics',",
+													"        'Independent exclusion reviews',",
+													"        'Updated heading',",
+													"        'Pupil referral units exclusions',",
+													"        'Regional and local authority (LA) breakdown',",
+													"    ];",
+													"    ",
+													"    const respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{    \n\t'b7a968ab-eb49-4100-b133-3d9d94f23d60': 1,\n    '6ed87fd1-81a5-46dc-8841-4598bdae7fee': 2,\n    '7981db34-afdb-4f84-99e8-bfd43e58f16d': 3,\n    '50e7ca4c-e6c7-4ccd-afc1-93ee4298f358': 4,\n    '015d0cdd-6630-4b57-9ef3-7341fc3d573e': 5,\n    '5600ca55-6800-418a-94a5-2f3c3310304e': 6,\n    '68f8b290-4b7c-4cac-b0d9-0263609c341b': 7,\n    '{{added_content_section_id}}': 8, \n    '5708d443-7669-47d8-b6a3-6ad851090710': 9,\n    '3960ab94-0fad-442c-8aaa-6233eff3bc32': 10,\n}"
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections/order",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"sections",
+												"order"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Remove Content Section",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"New Content Section should be removed\", function () { ",
+													"",
+													"    const expectedOrder = [",
+													"        'About this release',",
+													"        'Permanent exclusions',",
+													"        'Fixed-period exclusions',",
+													"        'Number and length of fixed-period exclusions',",
+													"        'Reasons for exclusions',",
+													"        'Exclusions by pupil characteristics',",
+													"        'Independent exclusion reviews',",
+													"        'Pupil referral units exclusions',",
+													"        'Regional and local authority (LA) breakdown',",
+													"    ];",
+													"    ",
+													"    const respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/{{added_content_section_id}}",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"{{added_content_section_id}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Verify Content Section removed",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Content Sections should be in the expected updated order\", function () { ",
+													"",
+													"    const expectedOrder = [",
+													"        'About this release',",
+													"        'Permanent exclusions',",
+													"        'Fixed-period exclusions',",
+													"        'Number and length of fixed-period exclusions',",
+													"        'Reasons for exclusions',",
+													"        'Exclusions by pupil characteristics',",
+													"        'Independent exclusion reviews',",
+													"        'Pupil referral units exclusions',",
+													"        'Regional and local authority (LA) breakdown',",
+													"    ];",
+													"    ",
+													"    const respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
+													"    pm.expect(respJson.map(section => section.order)).to.eql([1, 2, 3, 4, 5, 6, 7, 8, 9]);",
+													"});",
+													"",
+													"pm.test(\"Unset variables\", function () {",
+													"    pm.environment.unset(\"added_content_section_id\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"sections"
+											]
+										}
+									},
+									"response": []
 								}
 							],
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							},
-							"request": {
-								"method": "GET",
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections",
-									"host": [
-										"{{admin_api_url}}"
-									],
-									"path": [
-										"release",
-										"e7774a74-1f62-4b76-b9b5-84f14dac7278",
-										"content",
-										"sections"
-									]
-								}
-							},
-							"response": []
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
 						},
 						{
-							"name": "Add Content Section",
-							"event": [
+							"name": "Content Blocks",
+							"item": [
 								{
-									"listen": "test",
-									"script": {
-										"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
-										"exec": [
-											"pm.test(\"New Content Section should be present\", function () { ",
-											"",
-											"    const respJson = pm.response.json();",
-											"",
-											"    pm.expect(respJson.id).to.not.be.null;",
-											"    pm.expect(respJson.heading).to.equal('New section');",
-											"    pm.expect(respJson.order).to.equal(10);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
+									"name": "Get Content Section",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () { ",
+													"    pm.response.to.have.status(200); ",
+													"});",
+													"",
+													"pm.test(\"Content Section should contain the correct information\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.id).to.equal(\"b7a968ab-eb49-4100-b133-3d9d94f23d60\");",
+													"    pm.expect(respJson.order).to.equal(1);",
+													"    pm.expect(respJson.heading).to.equal(\"About this release\");",
+													"    pm.expect(respJson.caption).to.equal(\"\");",
+													"    ",
+													"    // test a MarkDownBlock's content",
+													"    pm.expect(respJson.content.length).to.equal(1);",
+													"    pm.expect(respJson.content[0].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson.content[0].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson.content[0].body.startsWith(\"The statistics and data cover permanent and fixed period exclusions\")).to.be.true;",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Add HTML Block",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"New HTMLBlock should be present\", function () { ",
+													"",
+													"    const respJson = pm.response.json();",
+													"",
+													"    // assert new block details",
+													"    pm.expect(respJson.id).to.not.be.null;",
+													"    pm.expect(respJson.order).to.equal(2);",
+													"    pm.expect(respJson.type).to.equal(\"HtmlBlock\");",
+													"    pm.expect(respJson.content).to.be.undefined;",
+													"    ",
+													"    // assert that deliberately excluded fields are not present",
+													"    pm.expect(respJson.contentSection).to.be.undefined;",
+													"    pm.expect(respJson.contentSectionId).to.be.undefined;",
+													"});",
+													"",
+													"pm.test(\"Store variables for upcoming tests\", function () {",
+													"    ",
+													"    pm.environment.set(\"added_html_block_id\", pm.response.json().id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/blocks/add",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"blocks",
+												"add"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Verify HTML Block added",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Content Section should contain the newly added HtmlBlock\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    // test a MarkDownBlock's content",
+													"    pm.expect(respJson.content.length).to.equal(2);",
+													"    pm.expect(respJson.content[0].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson.content[0].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson.content[0].order).to.equal(1);",
+													"    ",
+													"    pm.expect(respJson.content[1].id).to.equal(pm.environment.get(\"added_html_block_id\"));",
+													"    pm.expect(respJson.content[1].type).to.equal(\"HtmlBlock\");",
+													"    pm.expect(respJson.content[1].order).to.equal(2);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60"
+											]
+										}
+									},
+									"response": []
 								}
 							],
-							"request": {
-								"method": "POST",
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections/add",
-									"host": [
-										"{{admin_api_url}}"
-									],
-									"path": [
-										"release",
-										"e7774a74-1f62-4b76-b9b5-84f14dac7278",
-										"content",
-										"sections",
-										"add"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Verify new Content Section added",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
-										"exec": [
-											"pm.test(\"New Content Section should be in the last position of the Content Section list\", function () { ",
-											"",
-											"    const expectedOrder = [",
-											"        'About this release',",
-											"        'Permanent exclusions',",
-											"        'Fixed-period exclusions',",
-											"        'Number and length of fixed-period exclusions',",
-											"        'Reasons for exclusions',",
-											"        'Exclusions by pupil characteristics',",
-											"        'Independent exclusion reviews',",
-											"        'Pupil referral units exclusions',",
-											"        'Regional and local authority (LA) breakdown',",
-											"        'New section'",
-											"    ];",
-											"    ",
-											"    const respJson = pm.response.json();",
-											"",
-											"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
-											"",
-											"    pm.environment.set(\"added_content_section_id\", respJson[respJson.length - 1].id);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							},
-							"request": {
-								"method": "GET",
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections",
-									"host": [
-										"{{admin_api_url}}"
-									],
-									"path": [
-										"release",
-										"e7774a74-1f62-4b76-b9b5-84f14dac7278",
-										"content",
-										"sections"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Verify Content Section Order",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
-										"exec": [
-											"pm.test(\"Content Sections should be in the expected updated order\", function () { ",
-											"",
-											"    const expectedOrder = [",
-											"        'About this release',",
-											"        'Permanent exclusions',",
-											"        'Fixed-period exclusions',",
-											"        'Number and length of fixed-period exclusions',",
-											"        'Reasons for exclusions',",
-											"        'Exclusions by pupil characteristics',",
-											"        'Independent exclusion reviews',",
-											"        'Pupil referral units exclusions',",
-											"        'Regional and local authority (LA) breakdown',",
-											"        'New section',",
-											"    ];",
-											"    ",
-											"    const respJson = pm.response.json();",
-											"",
-											"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							},
-							"request": {
-								"method": "GET",
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections",
-									"host": [
-										"{{admin_api_url}}"
-									],
-									"path": [
-										"release",
-										"e7774a74-1f62-4b76-b9b5-84f14dac7278",
-										"content",
-										"sections"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Update Content Section heading",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
-										"exec": [
-											"pm.test(\"Content Section should have an updated heading\", function () { ",
-											"    const respJson = pm.response.json();",
-											"    pm.expect(respJson.heading).to.equal('Updated heading');",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n\theading: 'Updated heading'\n}"
-								},
-								"url": {
-									"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/{{added_content_section_id}}/heading",
-									"host": [
-										"{{admin_api_url}}"
-									],
-									"path": [
-										"release",
-										"e7774a74-1f62-4b76-b9b5-84f14dac7278",
-										"content",
-										"section",
-										"{{added_content_section_id}}",
-										"heading"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Reorder Content Sections",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
-										"exec": [
-											"pm.test(\"Content Sections should be in the expected starting order\", function () { ",
-											"",
-											"    const expectedOrder = [",
-											"        'Permanent exclusions',",
-											"        'Fixed-period exclusions',",
-											"        'Number and length of fixed-period exclusions',",
-											"        'About this release',",
-											"        'Exclusions by pupil characteristics',",
-											"        'Independent exclusion reviews',",
-											"        'Reasons for exclusions',",
-											"        'Updated heading',",
-											"        'Pupil referral units exclusions',",
-											"        'Regional and local authority (LA) breakdown',",
-											"    ];",
-											"    ",
-											"    const respJson = pm.response.json();",
-											"",
-											"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json",
-										"type": "text"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{    \n\t'b7a968ab-eb49-4100-b133-3d9d94f23d60': 4,\n    '6ed87fd1-81a5-46dc-8841-4598bdae7fee': 1,\n    '7981db34-afdb-4f84-99e8-bfd43e58f16d': 2,\n    '50e7ca4c-e6c7-4ccd-afc1-93ee4298f358': 3,\n    '015d0cdd-6630-4b57-9ef3-7341fc3d573e': 7,\n    '5600ca55-6800-418a-94a5-2f3c3310304e': 5,\n    '68f8b290-4b7c-4cac-b0d9-0263609c341b': 6,\n    '5708d443-7669-47d8-b6a3-6ad851090710': 9,\n    '3960ab94-0fad-442c-8aaa-6233eff3bc32': 10,\n    '{{added_content_section_id}}': 8,\n}"
-								},
-								"url": {
-									"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections/order",
-									"host": [
-										"{{admin_api_url}}"
-									],
-									"path": [
-										"release",
-										"e7774a74-1f62-4b76-b9b5-84f14dac7278",
-										"content",
-										"sections",
-										"order"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Verify Content Sections Order updated",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
-										"exec": [
-											"pm.test(\"Content Sections should be in the expected updated order\", function () { ",
-											"",
-											"    const expectedOrder = [",
-											"        'Permanent exclusions',",
-											"        'Fixed-period exclusions',",
-											"        'Number and length of fixed-period exclusions',",
-											"        'About this release',",
-											"        'Exclusions by pupil characteristics',",
-											"        'Independent exclusion reviews',",
-											"        'Reasons for exclusions',",
-											"        'Updated heading',",
-											"        'Pupil referral units exclusions',",
-											"        'Regional and local authority (LA) breakdown',",
-											"    ];",
-											"    ",
-											"    const respJson = pm.response.json();",
-											"",
-											"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							},
-							"request": {
-								"method": "GET",
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections",
-									"host": [
-										"{{admin_api_url}}"
-									],
-									"path": [
-										"release",
-										"e7774a74-1f62-4b76-b9b5-84f14dac7278",
-										"content",
-										"sections"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Restore Content Sections order",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
-										"exec": [
-											"pm.test(\"Content Sections should be in the expected starting order\", function () { ",
-											"",
-											"    const expectedOrder = [",
-											"        'About this release',",
-											"        'Permanent exclusions',",
-											"        'Fixed-period exclusions',",
-											"        'Number and length of fixed-period exclusions',",
-											"        'Reasons for exclusions',",
-											"        'Exclusions by pupil characteristics',",
-											"        'Independent exclusion reviews',",
-											"        'Updated heading',",
-											"        'Pupil referral units exclusions',",
-											"        'Regional and local authority (LA) breakdown',",
-											"    ];",
-											"    ",
-											"    const respJson = pm.response.json();",
-											"",
-											"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{    \n\t'b7a968ab-eb49-4100-b133-3d9d94f23d60': 1,\n    '6ed87fd1-81a5-46dc-8841-4598bdae7fee': 2,\n    '7981db34-afdb-4f84-99e8-bfd43e58f16d': 3,\n    '50e7ca4c-e6c7-4ccd-afc1-93ee4298f358': 4,\n    '015d0cdd-6630-4b57-9ef3-7341fc3d573e': 5,\n    '5600ca55-6800-418a-94a5-2f3c3310304e': 6,\n    '68f8b290-4b7c-4cac-b0d9-0263609c341b': 7,\n    '{{added_content_section_id}}': 8, \n    '5708d443-7669-47d8-b6a3-6ad851090710': 9,\n    '3960ab94-0fad-442c-8aaa-6233eff3bc32': 10,\n}"
-								},
-								"url": {
-									"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections/order",
-									"host": [
-										"{{admin_api_url}}"
-									],
-									"path": [
-										"release",
-										"e7774a74-1f62-4b76-b9b5-84f14dac7278",
-										"content",
-										"sections",
-										"order"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Remove Content Section",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
-										"exec": [
-											"pm.test(\"New Content Section should be removed\", function () { ",
-											"",
-											"    const expectedOrder = [",
-											"        'About this release',",
-											"        'Permanent exclusions',",
-											"        'Fixed-period exclusions',",
-											"        'Number and length of fixed-period exclusions',",
-											"        'Reasons for exclusions',",
-											"        'Exclusions by pupil characteristics',",
-											"        'Independent exclusion reviews',",
-											"        'Pupil referral units exclusions',",
-											"        'Regional and local authority (LA) breakdown',",
-											"    ];",
-											"    ",
-											"    const respJson = pm.response.json();",
-											"",
-											"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "DELETE",
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/{{added_content_section_id}}",
-									"host": [
-										"{{admin_api_url}}"
-									],
-									"path": [
-										"release",
-										"e7774a74-1f62-4b76-b9b5-84f14dac7278",
-										"content",
-										"section",
-										"{{added_content_section_id}}"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Verify Content Section removed",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
-										"exec": [
-											"pm.test(\"Content Sections should be in the expected updated order\", function () { ",
-											"",
-											"    const expectedOrder = [",
-											"        'About this release',",
-											"        'Permanent exclusions',",
-											"        'Fixed-period exclusions',",
-											"        'Number and length of fixed-period exclusions',",
-											"        'Reasons for exclusions',",
-											"        'Exclusions by pupil characteristics',",
-											"        'Independent exclusion reviews',",
-											"        'Pupil referral units exclusions',",
-											"        'Regional and local authority (LA) breakdown',",
-											"    ];",
-											"    ",
-											"    const respJson = pm.response.json();",
-											"",
-											"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
-											"    pm.expect(respJson.map(section => section.order)).to.eql([1, 2, 3, 4, 5, 6, 7, 8, 9]);",
-											"});",
-											"",
-											"pm.test(\"Unset variables\", function () {",
-											"    pm.environment.unset(\"added_content_section_id\");",
-											"});"
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							},
-							"request": {
-								"method": "GET",
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections",
-									"host": [
-										"{{admin_api_url}}"
-									],
-									"path": [
-										"release",
-										"e7774a74-1f62-4b76-b9b5-84f14dac7278",
-										"content",
-										"sections"
-									]
-								}
-							},
-							"response": []
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
 						}
 					],
 					"protocolProfileBehavior": {},

--- a/tests/newman/tests/admin-api.json
+++ b/tests/newman/tests/admin-api.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "12115576-7694-4505-a41a-540189aa6281",
+		"_postman_id": "7f5ac04a-ba58-4b33-8a4f-533834aa47e6",
 		"name": "DfE Admin API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -2433,7 +2433,11 @@
 													"",
 													"    pm.expect(respJson.id).to.not.be.null;",
 													"    pm.expect(respJson.heading).to.equal('New section');",
-													"    pm.expect(respJson.order).to.equal(10);",
+													"    pm.expect(respJson.order).to.equal(2);",
+													"});",
+													"",
+													"pm.test(\"Store environment variables\", function() {",
+													"    pm.environment.set(\"added_content_section_id\", pm.response.json().id);",
 													"});"
 												],
 												"type": "text/javascript"
@@ -2442,10 +2446,16 @@
 									],
 									"request": {
 										"method": "POST",
-										"header": [],
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
 										"body": {
 											"mode": "raw",
-											"raw": ""
+											"raw": "{\n\torder: 2\n}"
 										},
 										"url": {
 											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections/add",
@@ -2475,6 +2485,7 @@
 													"",
 													"    const expectedOrder = [",
 													"        'About this release',",
+													"        'New section',",
 													"        'Permanent exclusions',",
 													"        'Fixed-period exclusions',",
 													"        'Number and length of fixed-period exclusions',",
@@ -2482,15 +2493,12 @@
 													"        'Exclusions by pupil characteristics',",
 													"        'Independent exclusion reviews',",
 													"        'Pupil referral units exclusions',",
-													"        'Regional and local authority (LA) breakdown',",
-													"        'New section'",
+													"        'Regional and local authority (LA) breakdown'",
 													"    ];",
 													"    ",
 													"    const respJson = pm.response.json();",
 													"",
 													"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
-													"",
-													"    pm.environment.set(\"added_content_section_id\", respJson[respJson.length - 1].id);",
 													"});"
 												],
 												"type": "text/javascript"
@@ -2534,6 +2542,7 @@
 													"",
 													"    const expectedOrder = [",
 													"        'About this release',",
+													"        'New section',",
 													"        'Permanent exclusions',",
 													"        'Fixed-period exclusions',",
 													"        'Number and length of fixed-period exclusions',",
@@ -2541,8 +2550,7 @@
 													"        'Exclusions by pupil characteristics',",
 													"        'Independent exclusion reviews',",
 													"        'Pupil referral units exclusions',",
-													"        'Regional and local authority (LA) breakdown',",
-													"        'New section',",
+													"        'Regional and local authority (LA) breakdown'",
 													"    ];",
 													"    ",
 													"    const respJson = pm.response.json();",
@@ -2919,6 +2927,118 @@
 										}
 									},
 									"response": []
+								},
+								{
+									"name": "Add Content Section without specifying order",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"New Content Section should be present\", function () { ",
+													"",
+													"    const respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.id).to.not.be.null;",
+													"    pm.expect(respJson.heading).to.equal('New section');",
+													"    pm.expect(respJson.order).to.equal(10);",
+													"});",
+													"",
+													"pm.test(\"Store environment variables for following tests\", function() {",
+													"   pm.environment.set(\"added_content_section_without_order_id\", pm.response.json().id); ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/sections/add",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"sections",
+												"add"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Remove Content Section added without order specified",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"New Content Section should be removed\", function () { ",
+													"",
+													"    const expectedOrder = [",
+													"        'About this release',",
+													"        'Permanent exclusions',",
+													"        'Fixed-period exclusions',",
+													"        'Number and length of fixed-period exclusions',",
+													"        'Reasons for exclusions',",
+													"        'Exclusions by pupil characteristics',",
+													"        'Independent exclusion reviews',",
+													"        'Pupil referral units exclusions',",
+													"        'Regional and local authority (LA) breakdown'",
+													"    ];",
+													"    ",
+													"    const respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.map(section => section.heading)).to.eql(expectedOrder);",
+													"});",
+													"",
+													"pm.test(\"Remove temporary environment variables\", function() {",
+													"   pm.environment.unset(\"added_content_section_without_order_id\"); ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/{{added_content_section_without_order_id}}",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"{{added_content_section_without_order_id}}"
+											]
+										}
+									},
+									"response": []
 								}
 							],
 							"protocolProfileBehavior": {},
@@ -2999,7 +3119,7 @@
 													"",
 													"    // assert new block details",
 													"    pm.expect(respJson.id).to.not.be.null;",
-													"    pm.expect(respJson.order).to.equal(2);",
+													"    pm.expect(respJson.order).to.equal(1);",
 													"    pm.expect(respJson.type).to.equal(\"HtmlBlock\");",
 													"    pm.expect(respJson.content).to.be.undefined;",
 													"    ",
@@ -3019,10 +3139,16 @@
 									],
 									"request": {
 										"method": "POST",
-										"header": [],
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
 										"body": {
 											"mode": "raw",
-											"raw": ""
+											"raw": "{ \n\torder: 1,\n\ttype: 'HtmlBlock'\n}"
 										},
 										"url": {
 											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/blocks/add",
@@ -3043,26 +3169,227 @@
 									"response": []
 								},
 								{
-									"name": "Verify HTML Block added",
+									"name": "Add MarkDown Block",
 									"event": [
 										{
 											"listen": "test",
 											"script": {
 												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
 												"exec": [
-													"pm.test(\"Content Section should contain the newly added HtmlBlock\", function () { ",
+													"pm.test(\"New MarkDownBlock should be present\", function () { ",
+													"",
+													"    const respJson = pm.response.json();",
+													"",
+													"    // assert new block details",
+													"    pm.expect(respJson.id).to.not.be.null;",
+													"    pm.expect(respJson.order).to.equal(1);",
+													"    pm.expect(respJson.type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson.content).to.be.undefined;",
+													"    ",
+													"    // assert that deliberately excluded fields are not present",
+													"    pm.expect(respJson.contentSection).to.be.undefined;",
+													"    pm.expect(respJson.contentSectionId).to.be.undefined;",
+													"});",
+													"",
+													"pm.test(\"Store variables for upcoming tests\", function () {",
+													"    ",
+													"    pm.environment.set(\"added_markdown_block_id\", pm.response.json().id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{ \n\torder: 1,\n\ttype: 'MarkDownBlock'\n}"
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/blocks/add",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"blocks",
+												"add"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Add InsetText Block (in the middle)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"New MarkDownBlock should be present\", function () { ",
+													"",
+													"    const respJson = pm.response.json();",
+													"",
+													"    // assert new block details",
+													"    pm.expect(respJson.id).to.not.be.null;",
+													"    pm.expect(respJson.order).to.equal(2);",
+													"    pm.expect(respJson.type).to.equal(\"InsetTextBlock\");",
+													"    pm.expect(respJson.content).to.be.undefined;",
+													"    ",
+													"    // assert that deliberately excluded fields are not present",
+													"    pm.expect(respJson.contentSection).to.be.undefined;",
+													"    pm.expect(respJson.contentSectionId).to.be.undefined;",
+													"});",
+													"",
+													"pm.test(\"Store variables for upcoming tests\", function () {",
+													"    ",
+													"    pm.environment.set(\"added_inset_text_block_id\", pm.response.json().id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{ \n\torder: 2,\n\ttype: 'InsetTextBlock'\n}"
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/blocks/add",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"blocks",
+												"add"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Add Data Block (without specifying order)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"New DataBlock should be present\", function () { ",
+													"",
+													"    const respJson = pm.response.json();",
+													"",
+													"    // assert new block details",
+													"    pm.expect(respJson.id).to.not.be.null;",
+													"    pm.expect(respJson.order).to.equal(5);",
+													"    pm.expect(respJson.type).to.equal(\"DataBlock\");",
+													"    pm.expect(respJson.content).to.be.undefined;",
+													"    ",
+													"    // assert that deliberately excluded fields are not present",
+													"    pm.expect(respJson.contentSection).to.be.undefined;",
+													"    pm.expect(respJson.contentSectionId).to.be.undefined;",
+													"});",
+													"",
+													"pm.test(\"Store variables for upcoming tests\", function () {",
+													"    ",
+													"    pm.environment.set(\"added_data_block_id\", pm.response.json().id);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{ \n\ttype: 'DataBlock'\n}"
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/blocks/add",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"blocks",
+												"add"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Verify Content Blocks added",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Content Section should contain the 4 newly added Content Blocks\", function () { ",
 													"",
 													"    var respJson = pm.response.json();",
 													"",
-													"    // test a MarkDownBlock's content",
-													"    pm.expect(respJson.content.length).to.equal(2);",
-													"    pm.expect(respJson.content[0].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson.content.length).to.equal(5);",
+													"    ",
+													"    pm.expect(respJson.content[0].id).to.equal(pm.environment.get(\"added_markdown_block_id\"));",
 													"    pm.expect(respJson.content[0].type).to.equal(\"MarkDownBlock\");",
 													"    pm.expect(respJson.content[0].order).to.equal(1);",
-													"    ",
-													"    pm.expect(respJson.content[1].id).to.equal(pm.environment.get(\"added_html_block_id\"));",
-													"    pm.expect(respJson.content[1].type).to.equal(\"HtmlBlock\");",
+													"",
+													"    pm.expect(respJson.content[1].id).to.equal(pm.environment.get(\"added_inset_text_block_id\"));",
+													"    pm.expect(respJson.content[1].type).to.equal(\"InsetTextBlock\");",
 													"    pm.expect(respJson.content[1].order).to.equal(2);",
+													"    ",
+													"    pm.expect(respJson.content[2].id).to.equal(pm.environment.get(\"added_html_block_id\"));",
+													"    pm.expect(respJson.content[2].type).to.equal(\"HtmlBlock\");",
+													"    pm.expect(respJson.content[2].order).to.equal(3);",
+													"    ",
+													"    pm.expect(respJson.content[3].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson.content[3].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson.content[3].order).to.equal(4);",
+													"    ",
+													"    pm.expect(respJson.content[4].id).to.equal(pm.environment.get(\"added_data_block_id\"));",
+													"    pm.expect(respJson.content[4].type).to.equal(\"DataBlock\");",
+													"    pm.expect(respJson.content[4].order).to.equal(5);",
 													"});"
 												],
 												"type": "text/javascript"
@@ -3090,6 +3417,290 @@
 												"content",
 												"section",
 												"b7a968ab-eb49-4100-b133-3d9d94f23d60"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete InsetText Block",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"InsetText Block should be deleted\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.length).to.equal(4);",
+													"    ",
+													"    pm.expect(respJson[0].id).to.equal(pm.environment.get(\"added_markdown_block_id\"));",
+													"    pm.expect(respJson[0].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson[0].order).to.equal(1);",
+													"",
+													"    pm.expect(respJson[1].id).to.equal(pm.environment.get(\"added_html_block_id\"));",
+													"    pm.expect(respJson[1].type).to.equal(\"HtmlBlock\");",
+													"    pm.expect(respJson[1].order).to.equal(2);",
+													"    ",
+													"    pm.expect(respJson[2].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson[2].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson[2].order).to.equal(3);",
+													"    ",
+													"    pm.expect(respJson[3].id).to.equal(pm.environment.get(\"added_data_block_id\"));",
+													"    pm.expect(respJson[3].type).to.equal(\"DataBlock\");",
+													"    pm.expect(respJson[3].order).to.equal(4);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/block/{{added_inset_text_block_id}}",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"block",
+												"{{added_inset_text_block_id}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Verify InsetText Block deleted",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"InsetText Block should be deleted\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.content.length).to.equal(4);",
+													"    ",
+													"    pm.expect(respJson.content[0].id).to.equal(pm.environment.get(\"added_markdown_block_id\"));",
+													"    pm.expect(respJson.content[0].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson.content[0].order).to.equal(1);",
+													"",
+													"    pm.expect(respJson.content[1].id).to.equal(pm.environment.get(\"added_html_block_id\"));",
+													"    pm.expect(respJson.content[1].type).to.equal(\"HtmlBlock\");",
+													"    pm.expect(respJson.content[1].order).to.equal(2);",
+													"    ",
+													"    pm.expect(respJson.content[2].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson.content[2].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson.content[2].order).to.equal(3);",
+													"    ",
+													"    pm.expect(respJson.content[3].id).to.equal(pm.environment.get(\"added_data_block_id\"));",
+													"    pm.expect(respJson.content[3].type).to.equal(\"DataBlock\");",
+													"    pm.expect(respJson.content[3].order).to.equal(4);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete MarkDown Block",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"MarkDown Block should be deleted\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.length).to.equal(3);",
+													"    ",
+													"    pm.expect(respJson[0].id).to.equal(pm.environment.get(\"added_html_block_id\"));",
+													"    pm.expect(respJson[0].type).to.equal(\"HtmlBlock\");",
+													"    pm.expect(respJson[0].order).to.equal(1);",
+													"    ",
+													"    pm.expect(respJson[1].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson[1].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson[1].order).to.equal(2);",
+													"    ",
+													"    pm.expect(respJson[2].id).to.equal(pm.environment.get(\"added_data_block_id\"));",
+													"    pm.expect(respJson[2].type).to.equal(\"DataBlock\");",
+													"    pm.expect(respJson[2].order).to.equal(3);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/block/{{added_markdown_block_id}}",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"block",
+												"{{added_markdown_block_id}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete Data Block",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Data Block should be deleted\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.length).to.equal(2);",
+													"    ",
+													"    pm.expect(respJson[0].id).to.equal(pm.environment.get(\"added_html_block_id\"));",
+													"    pm.expect(respJson[0].type).to.equal(\"HtmlBlock\");",
+													"    pm.expect(respJson[0].order).to.equal(1);",
+													"    ",
+													"    pm.expect(respJson[1].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson[1].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson[1].order).to.equal(2);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/block/{{added_data_block_id}}",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"block",
+												"{{added_data_block_id}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete HTML Block",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"HTML Block should be deleted\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.length).to.equal(1);",
+													"    ",
+													"    pm.expect(respJson[0].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson[0].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson[0].order).to.equal(1);",
+													"});",
+													"",
+													"pm.test(\"Remove temporary environment variables\", function() {",
+													"   pm.environment.unset(\"added_html_block_id\"); ",
+													"   pm.environment.unset(\"added_markdown_block_id\"); ",
+													"   pm.environment.unset(\"added_inset_text_block_id\"); ",
+													"   pm.environment.unset(\"added_data_block_id\"); ",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "DELETE",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/block/{{added_html_block_id}}",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"block",
+												"{{added_html_block_id}}"
 											]
 										}
 									},

--- a/tests/newman/tests/admin-api.json
+++ b/tests/newman/tests/admin-api.json
@@ -2868,6 +2868,64 @@
 									"response": []
 								},
 								{
+									"name": "Get Content Section Copy",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Status code is 200\", function () { ",
+													"    pm.response.to.have.status(200); ",
+													"});",
+													"",
+													"pm.test(\"Content Section should contain the correct information\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.id).to.equal(\"b7a968ab-eb49-4100-b133-3d9d94f23d60\");",
+													"    pm.expect(respJson.order).to.equal(1);",
+													"    pm.expect(respJson.heading).to.equal(\"About this release\");",
+													"    pm.expect(respJson.caption).to.equal(\"\");",
+													"    ",
+													"    // test a MarkDownBlock's content",
+													"    pm.expect(respJson.content.length).to.equal(1);",
+													"    pm.expect(respJson.content[0].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson.content[0].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson.content[0].body.startsWith(\"The statistics and data cover permanent and fixed period exclusions\")).to.be.true;",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "Verify Content Section removed",
 									"event": [
 										{
@@ -3417,6 +3475,217 @@
 												"content",
 												"section",
 												"b7a968ab-eb49-4100-b133-3d9d94f23d60"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Reorder Content Blocks",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Content Blocks should be in the newly specified order\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.length).to.equal(5);",
+													"    ",
+													"    pm.expect(respJson[0].id).to.equal(pm.environment.get(\"added_html_block_id\"));",
+													"    pm.expect(respJson[0].type).to.equal(\"HtmlBlock\");",
+													"    pm.expect(respJson[0].order).to.equal(1);",
+													"    ",
+													"    pm.expect(respJson[1].id).to.equal(pm.environment.get(\"added_markdown_block_id\"));",
+													"    pm.expect(respJson[1].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson[1].order).to.equal(2);",
+													"",
+													"    pm.expect(respJson[2].id).to.equal(pm.environment.get(\"added_inset_text_block_id\"));",
+													"    pm.expect(respJson[2].type).to.equal(\"InsetTextBlock\");",
+													"    pm.expect(respJson[2].order).to.equal(3);",
+													"    ",
+													"    pm.expect(respJson[3].id).to.equal(pm.environment.get(\"added_data_block_id\"));",
+													"    pm.expect(respJson[3].type).to.equal(\"DataBlock\");",
+													"    pm.expect(respJson[3].order).to.equal(4);",
+													"    ",
+													"    pm.expect(respJson[4].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson[4].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson[4].order).to.equal(5);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{    \n\t'{{added_html_block_id}}': 1,\n\t'{{added_markdown_block_id}}': 2,\n\t'{{added_inset_text_block_id}}': 3,\n\t'{{added_data_block_id}}': 4,\n\t'97d414f4-1a27-4ed7-85ea-c4c903e1d8cb': 5,\n}"
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/blocks/order",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"blocks",
+												"order"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Verify Content Blocks order updated",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Content Blocks should be in the newly specified order\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.content.length).to.equal(5);",
+													"    ",
+													"    pm.expect(respJson.content[0].id).to.equal(pm.environment.get(\"added_html_block_id\"));",
+													"    pm.expect(respJson.content[0].type).to.equal(\"HtmlBlock\");",
+													"    pm.expect(respJson.content[0].order).to.equal(1);",
+													"    ",
+													"    pm.expect(respJson.content[1].id).to.equal(pm.environment.get(\"added_markdown_block_id\"));",
+													"    pm.expect(respJson.content[1].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson.content[1].order).to.equal(2);",
+													"",
+													"    pm.expect(respJson.content[2].id).to.equal(pm.environment.get(\"added_inset_text_block_id\"));",
+													"    pm.expect(respJson.content[2].type).to.equal(\"InsetTextBlock\");",
+													"    pm.expect(respJson.content[2].order).to.equal(3);",
+													"    ",
+													"    pm.expect(respJson.content[3].id).to.equal(pm.environment.get(\"added_data_block_id\"));",
+													"    pm.expect(respJson.content[3].type).to.equal(\"DataBlock\");",
+													"    pm.expect(respJson.content[3].order).to.equal(4);",
+													"    ",
+													"    pm.expect(respJson.content[4].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson.content[4].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson.content[4].order).to.equal(5);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{    \n\t'{{added_html_block_id}}': 1,\n\t'{{added_html_block_id}}': 2,\n\t'{{added_html_block_id}}': 3,\n\t'{{added_html_block_id}}': 4,\n\t'97d414f4-1a27-4ed7-85ea-c4c903e1d8cb': 5,\n}"
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Restore Content Blocks order",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Content Blocks should be in previous order again\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.length).to.equal(5);",
+													"    ",
+													"    pm.expect(respJson[0].id).to.equal(pm.environment.get(\"added_markdown_block_id\"));",
+													"    pm.expect(respJson[0].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson[0].order).to.equal(1);",
+													"",
+													"    pm.expect(respJson[1].id).to.equal(pm.environment.get(\"added_inset_text_block_id\"));",
+													"    pm.expect(respJson[1].type).to.equal(\"InsetTextBlock\");",
+													"    pm.expect(respJson[1].order).to.equal(2);",
+													"    ",
+													"    pm.expect(respJson[2].id).to.equal(pm.environment.get(\"added_html_block_id\"));",
+													"    pm.expect(respJson[2].type).to.equal(\"HtmlBlock\");",
+													"    pm.expect(respJson[2].order).to.equal(3);",
+													"    ",
+													"    pm.expect(respJson[3].id).to.equal(\"97d414f4-1a27-4ed7-85ea-c4c903e1d8cb\");",
+													"    pm.expect(respJson[3].type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson[3].order).to.equal(4);",
+													"    ",
+													"    pm.expect(respJson[4].id).to.equal(pm.environment.get(\"added_data_block_id\"));",
+													"    pm.expect(respJson[4].type).to.equal(\"DataBlock\");",
+													"    pm.expect(respJson[4].order).to.equal(5);",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{    \n\t'{{added_markdown_block_id}}': 1,\n\t'{{added_inset_text_block_id}}': 2,\n\t'{{added_html_block_id}}': 3,\n\t'97d414f4-1a27-4ed7-85ea-c4c903e1d8cb': 4,\n\t'{{added_data_block_id}}': 5,\n}"
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/blocks/order",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"blocks",
+												"order"
 											]
 										}
 									},


### PR DESCRIPTION
This PR:
- adds an endpoint to add *new* DataBlocks, HtmlBlocks, InsetTextBlocks and MarkDownBlocks to a ContentSection within a certain Order position (optional)
- improves upon the previous "add Content *Section* to a Release" endpoint to allow the API client to specify an Order position for those too (optional again)
- adds an endpoint to reorder ContentBlocks within a ContentSection
- adds an endpoint to remove ContentBlocks from a ContentSection
- includes Postman tests for all of the above functionality
