### PR TITLE
Feature/ees 676 api for wysiwyg editor

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/ContentController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/ContentController.cs
@@ -100,5 +100,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Manag
                 () => _contentService.RemoveContentBlockAsync(releaseId, contentSectionId, contentBlockId),
                 Ok);
         }
+
+        [HttpPut("release/{releaseId}/content/section/{contentSectionId}/block/{contentBlockId}")]
+        public Task<ActionResult<IContentBlock>> UpdateTextBasedContentBlock(
+            Guid releaseId, Guid contentSectionId, Guid contentBlockId, UpdateTextBasedContentBlockRequest request)
+        {
+            return this.HandlingValidationErrorsAsync(
+                () => _contentService.UpdateTextBasedContentBlockAsync(
+                    releaseId, contentSectionId, contentBlockId, request),
+                Ok);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/UpdateContentBlockRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ManageContent/UpdateContentBlockRequest.cs
@@ -1,0 +1,14 @@
+using System.Runtime.Serialization;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Converters;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.ManageContent
+{
+    public class UpdateTextBasedContentBlockRequest
+    {
+        public string? Heading { get; set; }
+
+        public string Body { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/ManageContent/IContentService.cs
@@ -11,26 +11,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 {
     public interface IContentService
     {
-        Task<Either<ValidationResult, List<ContentSectionViewModel>>> GetContentSectionsAsync(Guid releaseId);
+        Task<Either<ValidationResult, List<ContentSectionViewModel>>> GetContentSectionsAsync(
+            Guid releaseId);
 
-        Task<Either<ValidationResult, List<ContentSectionViewModel>>> ReorderContentSectionsAsync(Guid releaseId, Dictionary<Guid, int> newSectionOrder);
+        Task<Either<ValidationResult, List<ContentSectionViewModel>>> ReorderContentSectionsAsync(
+            Guid releaseId, Dictionary<Guid, int> newSectionOrder);
         
-        Task<Either<ValidationResult, ContentSectionViewModel>> AddContentSectionAsync(Guid releaseId,
-            AddContentSectionRequest? request);
+        Task<Either<ValidationResult, ContentSectionViewModel>> AddContentSectionAsync(
+            Guid releaseId, AddContentSectionRequest? request);
 
         Task<Either<ValidationResult, ContentSectionViewModel>> UpdateContentSectionHeadingAsync(
             Guid releaseId, Guid contentSectionId, string newHeading);
 
-        Task<Either<ValidationResult, List<ContentSectionViewModel>>> RemoveContentSectionAsync(Guid releaseId,
-            Guid contentSectionId);
+        Task<Either<ValidationResult, List<ContentSectionViewModel>>> RemoveContentSectionAsync(
+            Guid releaseId, Guid contentSectionId);
 
-        Task<Either<ValidationResult, ContentSectionViewModel>> GetContentSectionAsync(Guid releaseId, Guid contentSectionId);
+        Task<Either<ValidationResult, ContentSectionViewModel>> GetContentSectionAsync(
+            Guid releaseId, Guid contentSectionId);
         
-        Task<Either<ValidationResult, List<IContentBlock>>> ReorderContentBlocksAsync(Guid releaseId, Guid contentSectionId, Dictionary<Guid,int> newBlocksOrder);
+        Task<Either<ValidationResult, List<IContentBlock>>> ReorderContentBlocksAsync(
+            Guid releaseId, Guid contentSectionId, Dictionary<Guid,int> newBlocksOrder);
         
-        Task<Either<ValidationResult, IContentBlock>> AddContentBlockAsync(Guid releaseId, Guid contentSectionId,
+        Task<Either<ValidationResult, IContentBlock>> AddContentBlockAsync(
+            Guid releaseId, Guid contentSectionId,
             AddContentBlockRequest request);
         
-        Task<Either<ValidationResult, List<IContentBlock>>> RemoveContentBlockAsync(Guid releaseId, Guid contentSectionId, Guid contentBlockId);
+        Task<Either<ValidationResult, List<IContentBlock>>> RemoveContentBlockAsync(
+            Guid releaseId, Guid contentSectionId, Guid contentBlockId);
+        
+        Task<Either<ValidationResult, IContentBlock>> UpdateTextBasedContentBlockAsync(
+            Guid releaseId, Guid contentSectionId, Guid contentBlockId, UpdateTextBasedContentBlockRequest request);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
@@ -76,53 +77,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
 
         public static ValidationResult ValidationResult(ValidationErrorMessages message)
         {
-            switch (message)
-            {
-                case CannotOverwriteFile:
-                    return new ValidationResult("CANNOT_OVERWRITE_FILE");
-                case SlugNotUnique:
-                    return new ValidationResult("SLUG_NOT_UNIQUE");
-                case PartialDateNotValid:
-                    return new ValidationResult("PARTIAL_DATE_NOT_VALID");
-                case CannotUseGenericFunctionToDeleteDataFile:
-                    return new ValidationResult("CANNOT_USE_GENERIC_FUNCTION_TO_DELETE_DATA_FILE");
-                case UnableToFindMetadataFileToDelete:
-                    return new ValidationResult("UNABLE_TO_FIND_METADATA_FILE_TO_DELETE");
-                case FileNotFound:
-                    return new ValidationResult("FILE_NOT_FOUND");
-                case FileCannotBeEmpty: 
-                    return new ValidationResult("FILE_CAN_NOT_BE_EMPTY");
-                case DataFileCannotBeEmpty: 
-                    return new ValidationResult("DATA_FILE_CAN_NOT_BE_EMPTY");
-                case MetadataFileCannotBeEmpty: 
-                    return new ValidationResult("METADATA_FILE_CAN_NOT_BE_EMPTY");
-                case CannotUseGenericFunctionToAddDataFile: 
-                    return new ValidationResult("CANNOT_USE_GENERIC_FUNCTION_TO_ADD_DATA_FILE");
-                case CannotOverwriteDataFile: 
-                    return new ValidationResult("CANNOT_OVERWRITE_DATA_FILE");
-                case CannotOverwriteMetadataFile: 
-                    return new ValidationResult("CANNOT_OVERWRITE_METADATA_FILE");
-                case DataAndMetadataFilesCannotHaveTheSameName: 
-                    return new ValidationResult("DATA_AND_METADATA_FILES_CANNOT_HAVE_THE_SAME_NAME");
-                case DataFileMustBeCsvFile: 
-                    return new ValidationResult("DATA_FILE_MUST_BE_A_CSV_FILE");
-                case MetaFileMustBeCsvFile: 
-                    return new ValidationResult("META_FILE_MUST_BE_A_CSV_FILE");
-                case SubjectTitleMustBeUnique: 
-                    return new ValidationResult("SUBJECT_TITLE_MUST_BE_UNIQUE");
-                case ReleaseNotFound:
-                    return new ValidationResult("RELEASE_NOT_FOUND");
-                case RelatedInformationItemNotFound:
-                    return new ValidationResult("RELATED_INFORMATION_ITEM_NOT_FOUND");
-                case EntityNotFound:
-                    return new ValidationResult("NOT_FOUND");
-                case ContentSectionNotFound:
-                    return new ValidationResult("CONTENT_SECTION_NOT_FOUND");
-                case ContentBlockNotFound:
-                    return new ValidationResult("CONTENT_BLOCK_NOT_FOUND");
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(message), message, null);
-            }
+            return new ValidationResult(message.ToString().ScreamingSnakeCase());
         }
     }
 
@@ -149,5 +104,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         RelatedInformationItemNotFound,
         ContentSectionNotFound,
         ContentBlockNotFound,
+        IncorrectContentBlockTypeForUpdate,
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
@@ -102,16 +102,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
         }
 
         [Fact]
-        public void AcronymsAreScreamingSnakeCased()
+        public void AcronymsAreAlreadyScreamingSnakeCased()
         {
-            Assert.Equal("A_B_C", "ABC".ScreamingSnakeCase());
+            Assert.Equal("ABC", "ABC".ScreamingSnakeCase());
         }
 
         [Fact]
         public void CamelCasedStringsAreScreamingSnakeCased()
         {
             Assert.Equal("FOO", "foo".ScreamingSnakeCase());
-            Assert.Equal("CAMEL_CASE", "camelCase".ScreamingSnakeCase());
+            Assert.Equal("CAMEL_CASE_STRING", "camelCaseString".ScreamingSnakeCase());
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
         public void PascalCasedStringsAreScreamingSnakeCased()
         {
             Assert.Equal("FOO_BAR", "FooBar".ScreamingSnakeCase());
-            Assert.Equal("FOO_B_AR", "FooBAr".ScreamingSnakeCase());
+            Assert.Equal("FOO_BAR", "FooBAr".ScreamingSnakeCase());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
@@ -87,5 +87,47 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             Assert.Equal("FooBar", "Foo_Bar".PascalCase());
             Assert.Equal("FOOBar", "FOO_Bar".PascalCase());
         }
+
+        [Fact]
+        public void NullStringsCanBeScreamingSnakeCased()
+        {
+            string input = null;
+            Assert.Null(input.ScreamingSnakeCase());
+        }
+
+        [Fact]
+        public void EmptyStringCanBeScreamingSnakeCased()
+        {
+            Assert.Equal(string.Empty, string.Empty.ScreamingSnakeCase());
+        }
+
+        [Fact]
+        public void AcronymsAreScreamingSnakeCased()
+        {
+            Assert.Equal("A_B_C", "ABC".ScreamingSnakeCase());
+        }
+
+        [Fact]
+        public void CamelCasedStringsAreScreamingSnakeCased()
+        {
+            Assert.Equal("FOO", "foo".ScreamingSnakeCase());
+            Assert.Equal("CAMEL_CASE", "camelCase".ScreamingSnakeCase());
+        }
+
+        [Fact]
+        public void UnderscoreSeparatedStringsAreScreamingSnakeCased()
+        {
+            Assert.Equal("FOO_BAR", "foo_bar".ScreamingSnakeCase());
+            Assert.Equal("FOO_BAR", "foo_Bar".ScreamingSnakeCase());
+            Assert.Equal("FOO_BAR", "Foo_Bar".ScreamingSnakeCase());
+            Assert.Equal("FOO_BAR", "FOO_Bar".ScreamingSnakeCase());
+        }
+        
+        [Fact]
+        public void PascalCasedStringsAreScreamingSnakeCased()
+        {
+            Assert.Equal("FOO_BAR", "FooBar".ScreamingSnakeCase());
+            Assert.Equal("FOO_B_AR", "FooBAr".ScreamingSnakeCase());
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
@@ -30,5 +30,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             input = input.Replace(" ", "");
             return input;
         }
+
+        public static string SnakeCase(this string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return input;
+            }
+
+            input = Regex.Replace(input, "(^_([A-Z]))", "$2_$3");
+
+            return input.TrimStart('_').ToLower();
+        }
+
+        public static string ScreamingSnakeCase(this string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return input;
+            }
+
+            return SnakeCase(input).ToUpper();
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
@@ -38,7 +38,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
                 return input;
             }
 
-            input = Regex.Replace(input, "(^_([A-Z]))", "$2_$3");
+            input = Regex.Replace(input, "(([^_A-Z])([A-Z]))", "$2_$3");
 
             return input.TrimStart('_').ToLower();
         }

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/data/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/data/ReleaseDataUploadsSection.tsx
@@ -99,22 +99,22 @@ const ReleaseDataUploadsSection = ({ publicationId, releaseId }: Props) => {
       'Choose a different file name for data and metadata files',
     ),
     errorCodeToFieldError(
-      'DATA_FILE_CAN_NOT_BE_EMPTY',
+      'DATA_FILE_CANNOT_BE_EMPTY',
       'dataFile',
       'Choose a data file that is not empty',
     ),
     errorCodeToFieldError(
-      'METADATA_FILE_CAN_NOT_BE_EMPTY',
+      'METADATA_FILE_CANNOT_BE_EMPTY',
       'metadataFile',
       'Choose a metadata file that is not empty',
     ),
     errorCodeToFieldError(
-      'DATA_FILE_MUST_BE_A_CSV_FILE',
+      'DATA_FILE_MUST_BE_CSV_FILE',
       'dataFile',
       'Data file must be a csv file',
     ),
     errorCodeToFieldError(
-      'META_FILE_MUST_BE_A_CSV_FILE',
+      'META_FILE_MUST_BE_CSV_FILE',
       'metadataFile',
       'Meta file must be a csv file',
     ),

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/data/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/data/ReleaseFileUploadsSection.tsx
@@ -55,7 +55,7 @@ const ReleaseFileUploadsSection = ({ publicationId, releaseId }: Props) => {
       'Choose a unique file name',
     ),
     errorCodeToFieldError(
-      'FILE_CAN_NOT_BE_EMPTY',
+      'FILE_CANNOT_BE_EMPTY',
       'file',
       'Choose a file that is not empty',
     ),

--- a/tests/newman/tests/admin-api.json
+++ b/tests/newman/tests/admin-api.json
@@ -3481,6 +3481,221 @@
 									"response": []
 								},
 								{
+									"name": "Update HTML Block",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"The HTML Block should show the updated details\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"    ",
+													"    pm.expect(respJson.id).to.equal(pm.environment.get(\"added_html_block_id\"));",
+													"    pm.expect(respJson.type).to.equal(\"HtmlBlock\");",
+													"    pm.expect(respJson.order).to.equal(3);",
+													"    pm.expect(respJson.body).to.equal(\"<h1>Update!></h1><p>This is the new body for the HTML Block.<p>\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\tbody: '<h1>Update!></h1><p>This is the new body for the HTML Block.<p>'\n}"
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/block/{{added_html_block_id}}",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"block",
+												"{{added_html_block_id}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update MarkDown Block",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"The MarkDown Block should show the updated details\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"    ",
+													"    pm.expect(respJson.id).to.equal(pm.environment.get(\"added_markdown_block_id\"));",
+													"    pm.expect(respJson.type).to.equal(\"MarkDownBlock\");",
+													"    pm.expect(respJson.order).to.equal(1);",
+													"    pm.expect(respJson.body).to.equal(\"*Update!*\\n\\nThis is the new body for the _MarkDown Block._\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\tbody: '*Update!*\\n\\nThis is the new body for the _MarkDown Block._'\n}"
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/block/{{added_markdown_block_id}}",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"block",
+												"{{added_markdown_block_id}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Update InsetText Block",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"The Inset Text Block should show the updated details\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"    ",
+													"    pm.expect(respJson.id).to.equal(pm.environment.get(\"added_inset_text_block_id\"));",
+													"    pm.expect(respJson.type).to.equal(\"InsetTextBlock\");",
+													"    pm.expect(respJson.order).to.equal(2);",
+													"    pm.expect(respJson.heading).to.equal(\"Update!\");",
+													"    pm.expect(respJson.body).to.equal(\"This is the new body for the Inset Text Block.\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json",
+												"type": "text"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\theading: 'Update!',\n\tbody: 'This is the new body for the Inset Text Block.'\n}"
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60/block/{{added_inset_text_block_id}}",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60",
+												"block",
+												"{{added_inset_text_block_id}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Verify Content Blocks updated",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"id": "854b75f6-cbce-4351-a37f-1e73f657c407",
+												"exec": [
+													"pm.test(\"Content Section should contain the updated Content Block details\", function () { ",
+													"",
+													"    var respJson = pm.response.json();",
+													"",
+													"    pm.expect(respJson.content.length).to.equal(5);",
+													"    ",
+													"    pm.expect(respJson.content[0].id).to.equal(pm.environment.get(\"added_markdown_block_id\"));",
+													"    pm.expect(respJson.content[0].body).to.equal(\"*Update!*\\n\\nThis is the new body for the _MarkDown Block._\");",
+													"    ",
+													"    pm.expect(respJson.content[1].id).to.equal(pm.environment.get(\"added_inset_text_block_id\"));",
+													"    pm.expect(respJson.content[1].heading).to.equal(\"Update!\");",
+													"    pm.expect(respJson.content[1].body).to.equal(\"This is the new body for the Inset Text Block.\");",
+													"    ",
+													"    pm.expect(respJson.content[2].id).to.equal(pm.environment.get(\"added_html_block_id\"));",
+													"    pm.expect(respJson.content[2].body).to.equal(\"<h1>Update!></h1><p>This is the new body for the HTML Block.<p>\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "GET",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{admin_api_url}}/release/e7774a74-1f62-4b76-b9b5-84f14dac7278/content/section/b7a968ab-eb49-4100-b133-3d9d94f23d60",
+											"host": [
+												"{{admin_api_url}}"
+											],
+											"path": [
+												"release",
+												"e7774a74-1f62-4b76-b9b5-84f14dac7278",
+												"content",
+												"section",
+												"b7a968ab-eb49-4100-b133-3d9d94f23d60"
+											]
+										}
+									},
+									"response": []
+								},
+								{
 									"name": "Reorder Content Blocks",
 									"event": [
 										{


### PR DESCRIPTION
This PR:
- adds an endpoint for updating the bodies on HtmlBlocks, MarkDownBlocks and InsetTextBlocks (and the heading for InsetTestBlocks also)
- removes a lot of duplication in ValidationUtils
- contains Postman tests for the new endpoint