### PR TITLE
Feature/ees 687 related information

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
@@ -61,12 +61,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                             new HtmlBlock()
                             {
                                 Id = new Guid("65187a0b-eb17-4481-b234-949dc85f1efa"),
-                                Type = "HtmlBlock",
-                                Body = "<p>Read national statistical summaries and definitions, view charts and " +
+                                Type = "MarkDownBlock",
+                                Body = "Read national statistical summaries and definitions, view charts and " +
                                        "tables and download data files across a range of pupil absence subject " +
-                                       "areas.</p>" + 
-                                       "<p>You can also view a regional breakdown of statistics and data within the " +
-                                       "<a href=\"#\">local authorities section</a></p>",
+                                       "areas.\n" + 
+                                       "You can also view a regional breakdown of statistics and data within the " +
+                                       "[local authorities section](#)",
                             }
                         }
                     },

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
@@ -8,7 +8,6 @@ import PrintThisPage from '@admin/modules/find-statistics/components/PrintThisPa
 import ReleaseContentAccordion from '@admin/modules/find-statistics/components/ReleaseContentAccordion';
 import { getTimePeriodCoverageDateRangeStringShort } from '@admin/pages/release/util/releaseSummaryUtil';
 import { BasicPublicationDetails } from '@admin/services/common/types';
-import { EditableContentBlock } from '@admin/services/publicationService';
 import { ManageContentPageViewModel } from '@admin/services/release/edit-release/content/types';
 import { generateIdList } from '@common/components/Accordion';
 import Details from '@common/components/Details';
@@ -17,10 +16,7 @@ import PageSearchForm from '@common/components/PageSearchForm';
 import RelatedAside from '@common/components/RelatedAside';
 import { EditingContext } from '@common/modules/find-statistics/util/wrapEditableComponent';
 import { baseUrl } from '@common/services/api';
-import {
-  AbstractRelease,
-  ReleaseType,
-} from '@common/services/publicationService';
+import { ReleaseType } from '@common/services/publicationService';
 import { Dictionary } from '@common/types';
 import classNames from 'classnames';
 import React from 'react';

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
@@ -9,6 +9,7 @@ import ReleaseContentAccordion from '@admin/modules/find-statistics/components/R
 import { getTimePeriodCoverageDateRangeStringShort } from '@admin/pages/release/util/releaseSummaryUtil';
 import { BasicPublicationDetails } from '@admin/services/common/types';
 import { EditableContentBlock } from '@admin/services/publicationService';
+import { ManageContentPageViewModel } from '@admin/services/release/edit-release/content/types';
 import { generateIdList } from '@common/components/Accordion';
 import Details from '@common/components/Details';
 import FormattedDate from '@common/components/FormattedDate';
@@ -23,6 +24,7 @@ import {
 import { Dictionary } from '@common/types';
 import classNames from 'classnames';
 import React from 'react';
+import RelatedInformationSection from './components/RelatedInformationSection';
 
 export interface RendererProps {
   contentId?: string;
@@ -32,7 +34,8 @@ export interface RendererProps {
 interface Props {
   editing: boolean;
   basicPublication: BasicPublicationDetails;
-  release: AbstractRelease<EditableContentBlock>;
+  release: ManageContentPageViewModel['release'];
+  relatedInformation: ManageContentPageViewModel['relatedInformation'];
   styles: Dictionary<string>;
 
   logEvent?: (...params: string[]) => void;
@@ -44,6 +47,7 @@ const PublicationReleaseContent = ({
   editing = true,
   basicPublication,
   release,
+  relatedInformation,
   styles,
   logEvent = nullLogEvent,
 }: Props) => {
@@ -200,21 +204,10 @@ const PublicationReleaseContent = ({
                 </Details>
               </dd>
             </dl>
-            <h2
-              className="govuk-heading-m govuk-!-margin-top-6"
-              id="related-content"
-            >
-              Related guidance
-            </h2>
-            <nav role="navigation" aria-labelledby="related-content">
-              <ul className="govuk-list">
-                <li>
-                  <Link to={`/methodology/${release.publication.slug}`}>
-                    {`${release.publication.title}: methodology`}
-                  </Link>
-                </li>
-              </ul>
-            </nav>
+            <RelatedInformationSection
+              release={release}
+              relatedInformation={relatedInformation}
+            />
           </RelatedAside>
         </div>
       </div>

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/EditableLink.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/EditableLink.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Link, { LinkProps } from '@admin/components/Link';
+import wrapEditableComponent from '@common/modules/find-statistics/util/wrapEditableComponent';
+import Button from '@common/components/Button';
+
+interface Props extends LinkProps {
+  removeOnClick: () => void;
+}
+
+const EditableLink = ({ removeOnClick, ...props }: Props) => {
+  return (
+    <div>
+      <div>
+        <Link {...props} />
+      </div>
+      <Button
+        className="govuk-!-margin-bottom-1"
+        variant="secondary"
+        onClick={() => removeOnClick()}
+      >
+        Remove link
+      </Button>
+    </div>
+  );
+};
+
+export default wrapEditableComponent(EditableLink, Link);

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/EditableLink.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/EditableLink.tsx
@@ -1,6 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import Link, { LinkProps } from '@admin/components/Link';
-import wrapEditableComponent from '@common/modules/find-statistics/util/wrapEditableComponent';
+import wrapEditableComponent, {
+  EditingContext,
+} from '@common/modules/find-statistics/util/wrapEditableComponent';
 import Button from '@common/components/Button';
 
 interface Props extends LinkProps {
@@ -8,7 +10,11 @@ interface Props extends LinkProps {
 }
 
 const EditableLink = ({ removeOnClick, ...props }: Props) => {
-  return (
+  const { isEditing } = useContext(EditingContext);
+
+  return !isEditing ? (
+    <Link {...props} />
+  ) : (
     <div>
       <div>
         <Link {...props} />
@@ -24,4 +30,4 @@ const EditableLink = ({ removeOnClick, ...props }: Props) => {
   );
 };
 
-export default wrapEditableComponent(EditableLink, Link);
+export default EditableLink;

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/RelatedInformationSection.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/RelatedInformationSection.tsx
@@ -114,7 +114,7 @@ const RelatedInformationSection = ({ relatedInformation, release }: Props) => {
           </li>
           {isEditing && <hr />}
 
-          {relatedInformation.map(({ id, description, url }) => (
+          {links.map(({ id, description, url }) => (
             <li key={id}>
               <EditableLink removeOnClick={() => removeLink(id)} to={url}>
                 {description}

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/RelatedInformationSection.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/RelatedInformationSection.tsx
@@ -1,0 +1,131 @@
+import React, { useState, useContext } from 'react';
+import { FormikProps } from 'formik';
+import {
+  ManageContentPageViewModel,
+  BasicLink,
+} from '@admin/services/release/edit-release/content/types';
+import Link from '@admin/components/Link';
+import releaseContentService from '@admin/services/release/edit-release/content/service';
+import { EditingContext } from '@common/modules/find-statistics/util/wrapEditableComponent';
+import Button from '@common/components/Button';
+import {
+  Formik,
+  FormFieldset,
+  Form,
+  FormFieldTextInput,
+} from '@common/components/form';
+import Yup from '@common/lib/validation/yup';
+import EditableLink from './EditableLink';
+
+interface Props {
+  release: ManageContentPageViewModel['release'];
+  relatedInformation: ManageContentPageViewModel['relatedInformation'];
+}
+
+const RelatedInformationSection = ({ relatedInformation, release }: Props) => {
+  const [links, setLinks] = useState<BasicLink[]>(relatedInformation);
+  const [formOpen, setFormOpen] = useState<boolean>(false);
+
+  const { isEditing } = useContext(EditingContext);
+
+  const addLink = (link: Omit<BasicLink, 'id'>) => {
+    return new Promise(resolve => {
+      releaseContentService.relatedInfo
+        .create(release.id, link)
+        .then((createdLink: BasicLink) => {
+          setLinks([...links, createdLink]);
+          resolve();
+        });
+    });
+  };
+
+  const removeLink = (linkId: string) => {
+    releaseContentService.relatedInfo
+      .delete(release.id, linkId)
+      .then(() => setLinks(links.filter(({ id }) => id !== linkId)));
+  };
+
+  const renderLinkForm = () => {
+    return !formOpen ? (
+      <Button onClick={() => setFormOpen(true)}>Add related information</Button>
+    ) : (
+      <Formik<Omit<BasicLink, 'id'>>
+        initialValues={{ description: '', url: '' }}
+        validationSchema={Yup.object({
+          description: Yup.string().required('Link title must be provided'),
+          url: Yup.string()
+            .url()
+            .required('Link url must be provided'),
+        })}
+        onSubmit={link =>
+          addLink(link).then(() => {
+            setFormOpen(false);
+          })
+        }
+        render={(form: FormikProps<Omit<BasicLink, 'id'>>) => {
+          return (
+            <Form {...form} id="create-new-link-form">
+              <FormFieldset
+                id="allFieldsFieldset"
+                legend="Add related information"
+                legendSize="m"
+              >
+                <FormFieldTextInput
+                  id="title"
+                  label="Title"
+                  name="description"
+                />
+                <FormFieldTextInput id="link-url" label="Link url" name="url" />
+              </FormFieldset>
+              <Button
+                type="submit"
+                className="govuk-button govuk-!-margin-right-1"
+              >
+                Create link
+              </Button>
+              <Link
+                to="#"
+                className="govuk-button govuk-button--secondary"
+                onClick={() => {
+                  form.resetForm();
+                  setFormOpen(false);
+                }}
+              >
+                Cancel
+              </Link>
+            </Form>
+          );
+        }}
+      />
+    );
+  };
+
+  return (
+    <>
+      <h2 className="govuk-heading-m govuk-!-margin-top-6" id="related-content">
+        Related guidance
+      </h2>
+      <nav role="navigation" aria-labelledby="related-content">
+        <ul className="govuk-list">
+          <li>
+            <Link to={`/methodology/${release.publication.slug}`}>
+              {`${release.publication.title}: methodology`}
+            </Link>
+          </li>
+          {isEditing && <hr />}
+
+          {relatedInformation.map(({ id, description, url }) => (
+            <li key={id}>
+              <EditableLink removeOnClick={() => removeLink(id)} to={url}>
+                {description}
+              </EditableLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      {isEditing && renderLinkForm()}
+    </>
+  );
+};
+
+export default RelatedInformationSection;

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/RelatedInformationSection.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/RelatedInformationSection.tsx
@@ -32,17 +32,15 @@ const RelatedInformationSection = ({ relatedInformation, release }: Props) => {
     return new Promise(resolve => {
       releaseContentService.relatedInfo
         .create(release.id, link)
-        .then((createdLink: BasicLink) => {
-          setLinks([...links, createdLink]);
+        .then(newLinks => {
+          setLinks(newLinks);
           resolve();
         });
     });
   };
 
   const removeLink = (linkId: string) => {
-    releaseContentService.relatedInfo
-      .delete(release.id, linkId)
-      .then(() => setLinks(links.filter(({ id }) => id !== linkId)));
+    releaseContentService.relatedInfo.delete(release.id, linkId).then(setLinks);
   };
 
   const renderLinkForm = () => {

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/__tests__/EditableContentSubBlockRenderer.test.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/__tests__/EditableContentSubBlockRenderer.test.tsx
@@ -1,21 +1,23 @@
 import React from 'react';
 import { render } from 'react-testing-library';
-
+import { EditingContext } from '@common/modules/find-statistics/util/wrapEditableComponent';
 import EditableContentSubBlockRenderer from '../EditableContentSubBlockRenderer';
 
 describe('EditableContentSubBlockRenderer', () => {
   test('Renders non-editable Markdown block correctly', () => {
     const { container } = render(
-      <EditableContentSubBlockRenderer
-        id="test"
-        index={1}
-        block={{
-          id: 'block-000',
-          comments: [],
-          type: 'MarkDownBlock',
-          body: 'test',
-        }}
-      />,
+      <EditingContext.Provider value={{ isEditing: true, releaseId: '' }}>
+        <EditableContentSubBlockRenderer
+          id="test"
+          index={1}
+          block={{
+            id: 'block-000',
+            comments: [],
+            type: 'MarkDownBlock',
+            body: 'test',
+          }}
+        />
+      </EditingContext.Provider>,
     );
 
     expect(container.innerHTML).toMatchSnapshot();
@@ -23,17 +25,19 @@ describe('EditableContentSubBlockRenderer', () => {
 
   test('Renders editable Markdown block correctly', () => {
     const { container } = render(
-      <EditableContentSubBlockRenderer
-        id="test"
-        index={1}
-        editable
-        block={{
-          id: 'block-000',
-          comments: [],
-          type: 'MarkDownBlock',
-          body: 'test',
-        }}
-      />,
+      <EditingContext.Provider value={{ isEditing: true, releaseId: '' }}>
+        <EditableContentSubBlockRenderer
+          id="test"
+          index={1}
+          editable
+          block={{
+            id: 'block-000',
+            comments: [],
+            type: 'MarkDownBlock',
+            body: 'test',
+          }}
+        />
+      </EditingContext.Provider>,
     );
 
     expect(container.innerHTML).toMatchSnapshot();

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/content/ReleaseContentPage.tsx
@@ -6,6 +6,7 @@ import ManageReleaseContext, {
 import { Comment } from '@admin/services/dashboard/types';
 import { EditableContentBlock } from '@admin/services/publicationService';
 import releaseContentService from '@admin/services/release/edit-release/content/service';
+import { ManageContentPageViewModel } from '@admin/services/release/edit-release/content/types';
 import FormFieldset from '@common/components/form/FormFieldset';
 import FormRadioGroup from '@common/components/form/FormRadioGroup';
 import WarningMessage from '@common/components/WarningMessage';
@@ -15,10 +16,9 @@ import React, { useContext, useEffect, useState } from 'react';
 
 type PageMode = 'edit' | 'preview';
 
-interface Model {
+interface Model extends ManageContentPageViewModel {
   unresolvedComments: Comment[];
   pageMode: PageMode;
-  release: AbstractRelease<EditableContentBlock>;
 }
 
 const ReleaseContentPage = () => {
@@ -29,30 +29,35 @@ const ReleaseContentPage = () => {
   ) as ManageRelease;
 
   useEffect(() => {
-    releaseContentService.getContent(releaseId).then(content => {
-      // <editor-fold desc="TODO - content population">
+    releaseContentService
+      .getContent(releaseId)
+      .then(({ introductionSection, relatedInformation, release }) => {
+        // <editor-fold desc="TODO - content population">
 
-      const unresolvedComments: Comment[] = [
-        {
-          message: 'Please resolve this.\nThank you.',
-          authorName: 'Amy Newton',
-          createdDate: new Date('2019-08-10 10:15').toISOString(),
-        },
-        {
-          message: 'And this too.\nThank you.',
-          authorName: 'Dave Matthews',
-          createdDate: new Date('2019-06-13 10:15').toISOString(),
-        },
-      ];
+        const unresolvedComments: Comment[] = [
+          {
+            message: 'Please resolve this.\nThank you.',
+            authorName: 'Amy Newton',
+            createdDate: new Date('2019-08-10 10:15').toISOString(),
+          },
+          {
+            message: 'And this too.\nThank you.',
+            authorName: 'Dave Matthews',
+            createdDate: new Date('2019-06-13 10:15').toISOString(),
+          },
+        ];
 
-      // </editor-fold>
+        // </editor-fold>
 
-      setModel({
-        unresolvedComments,
-        pageMode: 'edit',
-        release: content.release,
+        setModel({
+          unresolvedComments,
+          pageMode: 'edit',
+          introductionSection,
+          relatedInformation,
+          release,
+          contentSections: [],
+        });
       });
-    });
   }, [releaseId, publication.themeId, publication]);
 
   return (
@@ -108,6 +113,7 @@ const ReleaseContentPage = () => {
                 editing={model.pageMode === 'edit'}
                 basicPublication={publication}
                 release={model.release}
+                relatedInformation={model.relatedInformation}
                 styles={{}}
               />
             </div>

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/content/ReleaseContentPage.tsx
@@ -4,13 +4,11 @@ import ManageReleaseContext, {
   ManageRelease,
 } from '@admin/pages/release/ManageReleaseContext';
 import { Comment } from '@admin/services/dashboard/types';
-import { EditableContentBlock } from '@admin/services/publicationService';
 import releaseContentService from '@admin/services/release/edit-release/content/service';
 import { ManageContentPageViewModel } from '@admin/services/release/edit-release/content/types';
 import FormFieldset from '@common/components/form/FormFieldset';
 import FormRadioGroup from '@common/components/form/FormRadioGroup';
 import WarningMessage from '@common/components/WarningMessage';
-import { AbstractRelease } from '@common/services/publicationService';
 import classNames from 'classnames';
 import React, { useContext, useEffect, useState } from 'react';
 

--- a/src/explore-education-statistics-admin/src/services/release/edit-release/content/service.ts
+++ b/src/explore-education-statistics-admin/src/services/release/edit-release/content/service.ts
@@ -5,6 +5,7 @@ import {
   ContentBlockViewModel,
   ContentSectionViewModel,
   ManageContentPageViewModel,
+  BasicLink,
 } from './types';
 
 export interface ReleaseContentService {
@@ -56,4 +57,35 @@ const service: ReleaseContentService = {
   },
 };
 
-export default service;
+const relatedInformationService = {
+  getAll: (
+    releaseId: string,
+  ): Promise<ManageContentPageViewModel['relatedInformation']> => {
+    return client.get(`/release/${releaseId}/content/related-information`);
+  },
+  create: (
+    releaseId: string,
+    link: Omit<BasicLink, 'id'>,
+  ): Promise<BasicLink> => {
+    return client.post(
+      `/release/${releaseId}/content/related-information`,
+      link,
+    );
+  },
+  update: (
+    releaseId: string,
+    link: { id: string; description: string; url: string },
+  ): Promise<BasicLink> => {
+    return client.put(
+      `/release/${releaseId}/content/related-information/${link.id}`,
+      link,
+    );
+  },
+  delete: (releaseId: string, linkId: string): Promise<void> => {
+    return client.delete(
+      `/release/${releaseId}/content/related-information/${linkId}`,
+    );
+  },
+};
+
+export default { ...service, relatedInfo: relatedInformationService };

--- a/src/explore-education-statistics-admin/src/services/release/edit-release/content/service.ts
+++ b/src/explore-education-statistics-admin/src/services/release/edit-release/content/service.ts
@@ -66,7 +66,7 @@ const relatedInformationService = {
   create: (
     releaseId: string,
     link: Omit<BasicLink, 'id'>,
-  ): Promise<BasicLink> => {
+  ): Promise<BasicLink[]> => {
     return client.post(
       `/release/${releaseId}/content/related-information`,
       link,
@@ -75,13 +75,13 @@ const relatedInformationService = {
   update: (
     releaseId: string,
     link: { id: string; description: string; url: string },
-  ): Promise<BasicLink> => {
+  ): Promise<BasicLink[]> => {
     return client.put(
       `/release/${releaseId}/content/related-information/${link.id}`,
       link,
     );
   },
-  delete: (releaseId: string, linkId: string): Promise<void> => {
+  delete: (releaseId: string, linkId: string): Promise<BasicLink[]> => {
     return client.delete(
       `/release/${releaseId}/content/related-information/${linkId}`,
     );

--- a/src/explore-education-statistics-admin/src/services/release/edit-release/content/types.ts
+++ b/src/explore-education-statistics-admin/src/services/release/edit-release/content/types.ts
@@ -6,7 +6,7 @@ import {
 
 export interface BasicLink {
   id: string;
-  title: string;
+  description: string;
   url: string;
 }
 

--- a/src/explore-education-statistics-common/src/modules/find-statistics/util/wrapEditableComponent.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/util/wrapEditableComponent.tsx
@@ -6,7 +6,7 @@ export interface ReleaseContentContext {
 }
 
 export const EditingContext = React.createContext<ReleaseContentContext>({
-  isEditing: true,
+  isEditing: false,
   releaseId: undefined,
 });
 


### PR DESCRIPTION
Adds the relatedInformation link section (right column) to release..
Toggle with editing context..
can create and remove links only.

There is an outstanding bug with the API ([ees-749](https://alpha-dfe-data.atlassian.net/browse/EES-749))