### PR TITLE
moved the previous fix (reasonable tick override) to a more appropriate place

### DIFF
--- a/src/explore-education-statistics-admin/src/modules/chart-builder/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/modules/chart-builder/ChartAxisConfiguration.tsx
@@ -12,7 +12,6 @@ import {
   ChartDataB,
   ChartMetaData,
   createSortedAndMappedDataForAxis,
-  getNiceMaxValue,
 } from '@common/modules/find-statistics/components/charts/ChartFunctions';
 import { DataBlockData } from '@common/services/dataBlockService';
 import {
@@ -147,24 +146,11 @@ const ChartAxisConfiguration = ({
     });
   };
 
-  const getReasonableMinTickSpacing = (): number => {
-    if (axisConfiguration) {
-      const { min, max } = axisConfiguration;
-      return getNiceMaxValue(Math.floor((Number(max) - Number(min)) / 100));
-    }
-    return 1;
-  };
-
   const getTickSpacing = (): number => {
-    // to avoid rendering a ridiculous amount of ticks
-    // we conditionally return a reasonableTickSpacing
     if (axisConfiguration) {
       const { tickSpacing } = axisConfiguration;
-      const reasonableTickSpacing = getReasonableMinTickSpacing();
       if (tickSpacing) {
-        return Number(tickSpacing) > reasonableTickSpacing
-          ? Number(tickSpacing)
-          : reasonableTickSpacing;
+        return Number(tickSpacing);
       }
     }
     return 1;
@@ -376,17 +362,8 @@ const ChartAxisConfiguration = ({
                           onChange={e => {
                             const theValue = parseInt(e.target.value, 10);
                             if (theValue > 0 && e.target.value !== '') {
-                              const reasonableMinTickSpacing = getReasonableMinTickSpacing();
                               updateAxisConfiguration({
-                                tickSpacing: `${
-                                  theValue > reasonableMinTickSpacing
-                                    ? theValue
-                                    : reasonableMinTickSpacing
-                                }`,
-                              });
-                            } else {
-                              updateAxisConfiguration({
-                                tickSpacing: `${getTickSpacing()}`,
+                                tickSpacing: `${theValue}`,
                               });
                             }
                           }}

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/charts/ChartFunctions.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/charts/ChartFunctions.tsx
@@ -598,6 +598,30 @@ const parseNumberOrDefault = (
   return parsed;
 };
 
+export function getNiceMaxValue(maxValue: number) {
+  if (maxValue === 0) {
+    return 0;
+  }
+
+  const maxIsLessThanOne = Math.abs(maxValue) < 1;
+  let max = maxValue;
+  if (maxIsLessThanOne) {
+    max = maxValue * 100;
+  }
+
+  const numberOf0s = 10 ** Math.floor(Math.log10(Math.abs(max)));
+  const maxReducedToLessThan10 = Math.ceil(max / numberOf0s);
+
+  if (maxReducedToLessThan10 % 2 && maxReducedToLessThan10 % 5) {
+    return maxIsLessThanOne
+      ? ((maxReducedToLessThan10 + 1) * numberOf0s) / 100
+      : (maxReducedToLessThan10 + 1) * numberOf0s;
+  }
+  return maxIsLessThanOne
+    ? (maxReducedToLessThan10 * numberOf0s) / 100
+    : maxReducedToLessThan10 * numberOf0s;
+}
+
 function calculateMinorTicks(
   config: string | undefined,
   min: number,
@@ -616,6 +640,13 @@ function calculateMinorTicks(
     return undefined;
 
   if (config === 'custom') {
+    const minimumSpacingValue = getNiceMaxValue(
+      Math.floor((Number(max) - Number(min)) / 100),
+    );
+    if (spacingValue < minimumSpacingValue) {
+      spacingValue = minimumSpacingValue;
+    }
+
     const result = [];
 
     let [start, end] = [min, max];
@@ -673,30 +704,6 @@ function calculateMajorTicks(
     return [categories[min], categories[max]];
   }
   return undefined;
-}
-
-export function getNiceMaxValue(maxValue: number) {
-  if (maxValue === 0) {
-    return 0;
-  }
-
-  const maxIsLessThanOne = Math.abs(maxValue) < 1;
-  let max = maxValue;
-  if (maxIsLessThanOne) {
-    max = maxValue * 100;
-  }
-
-  const numberOf0s = 10 ** Math.floor(Math.log10(Math.abs(max)));
-  const maxReducedToLessThan10 = Math.ceil(max / numberOf0s);
-
-  if (maxReducedToLessThan10 % 2 && maxReducedToLessThan10 % 5) {
-    return maxIsLessThanOne
-      ? ((maxReducedToLessThan10 + 1) * numberOf0s) / 100
-      : (maxReducedToLessThan10 + 1) * numberOf0s;
-  }
-  return maxIsLessThanOne
-    ? (maxReducedToLessThan10 * numberOf0s) / 100
-    : maxReducedToLessThan10 * numberOf0s;
 }
 
 export function generateMinorAxis(


### PR DESCRIPTION
Should now just work, as the override steps in before rendering, whereas before it was stepping in on input change, which meant it was being missed on initial render (causing the crash)