### PR TITLE
bugfixes to datablock creation

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/CreateDataBlocks.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/CreateDataBlocks.tsx
@@ -1,4 +1,6 @@
-import DataBlockDetailsForm from '@admin/pages/release/edit-release/manage-datablocks/DataBlockDetailsForm';
+import DataBlockDetailsForm, {
+  DataBlockDetailsFormValues,
+} from '@admin/pages/release/edit-release/manage-datablocks/DataBlockDetailsForm';
 import getDefaultTableHeaderConfig from '@common/modules/full-table/utils/tableHeaders';
 import { generateTableTitle } from '@common/modules/table-tool/components/DataTableCaption';
 import { TableHeadersFormValues } from '@common/modules/table-tool/components/TableHeadersForm';
@@ -48,6 +50,10 @@ const CreateDataBlocks = ({
     TableHeadersFormValues | undefined
   >();
 
+  const [initialValues, setInitialValues] = useState<
+    DataBlockDetailsFormValues
+  >();
+
   useEffect(() => {
     if (dataBlock && dataBlockResponse) {
       setQuery(dataBlock.dataBlockRequest);
@@ -71,21 +77,31 @@ const CreateDataBlocks = ({
     }
   }, [dataBlock, dataBlockResponse]);
 
-  const getInitialValues = () => {
+  useEffect(() => {
     if (!dataBlock) {
-      return {
-        title: table ? generateTableTitle(table.subjectMeta) : undefined,
-      };
+      setInitialValues({
+        title: table ? generateTableTitle(table.subjectMeta) : '',
+        name: '',
+        source: '',
+        customFootnotes: '',
+      });
+      return;
     }
 
-    const { heading: title, name, source, customFootnotes } = dataBlock;
-    return {
+    const {
+      heading: title = '',
+      name = '',
+      source = '',
+      customFootnotes = '',
+    } = dataBlock;
+
+    setInitialValues({
       title,
       name,
       source,
       customFootnotes,
-    };
-  };
+    });
+  }, [dataBlock, table]);
 
   return (
     <div>
@@ -111,7 +127,7 @@ const CreateDataBlocks = ({
 
                 {query && tableHeaders && (
                   <DataBlockDetailsForm
-                    initialValues={getInitialValues()}
+                    initialValues={initialValues}
                     query={query}
                     tableHeaders={tableHeaders || tableHeaders}
                     initialDataBlock={dataBlock}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/DataBlockDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/DataBlockDetailsForm.tsx
@@ -19,7 +19,7 @@ import { ObjectSchemaDefinition } from 'yup';
 
 interface Props {
   children?: ReactNode;
-  initialValues: { title?: string };
+  initialValues?: DataBlockDetailsFormValues;
   query: TableDataQuery;
   tableHeaders: TableHeadersFormValues;
   releaseId: string;
@@ -27,7 +27,7 @@ interface Props {
   onDataBlockSave: (dataBlock: DataBlock) => Promise<DataBlock>;
 }
 
-interface FormValues {
+export interface DataBlockDetailsFormValues {
   title: string;
   source: string;
   customFootnotes: string;
@@ -36,14 +36,14 @@ interface FormValues {
 
 const DataBlockDetailsForm = ({
   children,
-  initialValues,
+  initialValues = { title: '', name: '', source: '', customFootnotes: '' },
   query,
   tableHeaders,
   releaseId,
   initialDataBlock,
   onDataBlockSave,
 }: Props) => {
-  const formikRef = React.useRef<Formik<FormValues>>(null);
+  const formikRef = React.useRef<Formik<DataBlockDetailsFormValues>>(null);
 
   const [currentDataBlock, setCurrentDataBlock] = React.useState<
     DataBlock | undefined
@@ -73,10 +73,8 @@ const DataBlockDetailsForm = ({
     setBlockState({ saved: false, error: false });
   }, [query, tableHeaders, releaseId]);
 
-  const saveDataBlock = async (values: FormValues) => {
+  const saveDataBlock = async (values: DataBlockDetailsFormValues) => {
     const dataBlock: DataBlock = {
-      id: currentDataBlock && currentDataBlock.id,
-
       dataBlockRequest: {
         ...query,
         geographicLevel: query.geographicLevel as GeographicLevel,
@@ -109,39 +107,30 @@ const DataBlockDetailsForm = ({
     }
   };
 
-  const baseValidationRules: ObjectSchemaDefinition<FormValues> = {
+  const baseValidationRules: ObjectSchemaDefinition<
+    DataBlockDetailsFormValues
+  > = {
     title: Yup.string().required('Please enter a title'),
     name: Yup.string().required('Please supply a name'),
     source: Yup.string(),
     customFootnotes: Yup.string(),
   };
 
-  const usedInitialValues = React.useMemo(() => {
-    return {
-      title:
-        (currentDataBlock && currentDataBlock.heading) ||
-        initialValues.title ||
-        '',
-      customFootnotes:
-        (currentDataBlock && currentDataBlock.customFootnotes) || '',
-      name: (currentDataBlock && currentDataBlock.name) || '',
-      source: (currentDataBlock && currentDataBlock.source) || '',
-    };
-  }, [currentDataBlock, initialValues.title]);
-
   return (
-    <Formik<FormValues>
+    <Formik<DataBlockDetailsFormValues>
       enableReinitialize
       ref={formikRef}
-      initialValues={usedInitialValues}
-      validationSchema={Yup.object<FormValues>(baseValidationRules)}
+      initialValues={initialValues}
+      validationSchema={Yup.object<DataBlockDetailsFormValues>(
+        baseValidationRules,
+      )}
       onSubmit={saveDataBlock}
-      render={(form: FormikProps<FormValues>) => {
+      render={(form: FormikProps<DataBlockDetailsFormValues>) => {
         return (
           <div>
             <Form {...form} id="dataBlockDetails">
               <FormGroup>
-                <FormFieldTextInput<FormValues>
+                <FormFieldTextInput<DataBlockDetailsFormValues>
                   id="data-block-name"
                   name="name"
                   label="Data block name"
@@ -153,7 +142,7 @@ const DataBlockDetailsForm = ({
                 <hr />
                 {children}
 
-                <FormFieldTextArea<FormValues>
+                <FormFieldTextArea<DataBlockDetailsFormValues>
                   id="data-block-title"
                   name="title"
                   label="Table title"
@@ -161,14 +150,14 @@ const DataBlockDetailsForm = ({
                   rows={2}
                 />
 
-                <FormFieldTextInput<FormValues>
+                <FormFieldTextInput<DataBlockDetailsFormValues>
                   id="data-block-source"
                   name="source"
                   label="Source"
                   percentageWidth="two-thirds"
                 />
 
-                <FormFieldTextArea<FormValues>
+                <FormFieldTextArea<DataBlockDetailsFormValues>
                   id="data-block-footnotes"
                   name="customFootnotes"
                   label="Footnotes"

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/ReleaseManageDataBlocksPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/ReleaseManageDataBlocksPage.tsx
@@ -132,8 +132,8 @@ const ReleaseManageDataBlocksPage = ({
 
         load(dataBlocks, releaseId, selectedDataBlockId).then(
           ({ dataBlock, response: dataBlockResponse }) => {
-            if (currentlyLoadingDataBlockId.current === selectedDataBlockId) {
-              if (dataBlock && dataBlockResponse) {
+            if (dataBlock && dataBlockResponse) {
+              if (dataBlock.id === selectedDataBlockId) {
                 setDataBlockData({
                   dataBlock,
                   dataBlockResponse,


### PR DESCRIPTION
Ticket: https://alpha-dfe-data.atlassian.net/browse/EES-626

Various fixes to datablock creation/edit state handling.
The main on being that the initial Values in CreateDataBlocks.tsx are now stored in state - as opposed to being generated on each render (which was the main cause of the bug)

Some other bugs I spotted also have been squished.
notably: _Removed the ID of the currentDataBlock in DataBlockDetailsForm.tsx to avoid updating a previously edited(viewed) datablock when going back to create a new datablock_