### PR TITLE
ees-914, n/a values in datablock tables...

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/CreateDataBlocks.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/CreateDataBlocks.tsx
@@ -1,6 +1,9 @@
 import DataBlockDetailsForm, {
   DataBlockDetailsFormValues,
 } from '@admin/pages/release/edit-release/manage-datablocks/DataBlockDetailsForm';
+import { mapDataBlockResponseToFullTable } from '@common/modules/find-statistics/components/util/tableUtil';
+import { TableDataQuery } from '@common/modules/full-table/services/tableBuilderService';
+import { FullTable } from '@common/modules/full-table/types/fullTable';
 import getDefaultTableHeaderConfig from '@common/modules/full-table/utils/tableHeaders';
 import { generateTableTitle } from '@common/modules/table-tool/components/DataTableCaption';
 import { TableHeadersFormValues } from '@common/modules/table-tool/components/TableHeadersForm';
@@ -14,10 +17,7 @@ import {
   DataBlock,
   DataBlockResponse,
 } from '@common/services/dataBlockService';
-import React, { createRef, useState, useEffect } from 'react';
-import { TableDataQuery } from '@common/modules/full-table/services/tableBuilderService';
-import { FullTable } from '@common/modules/full-table/types/fullTable';
-import { mapDataBlockResponseToFullTable } from '@common/modules/find-statistics/components/util/tableUtil';
+import React, { createRef, useEffect, useState } from 'react';
 
 interface CreateDataBlockProps {
   releaseId: string;
@@ -129,7 +129,7 @@ const CreateDataBlocks = ({
                   <DataBlockDetailsForm
                     initialValues={initialValues}
                     query={query}
-                    tableHeaders={tableHeaders || tableHeaders}
+                    tableHeaders={tableHeaders}
                     initialDataBlock={dataBlock}
                     releaseId={releaseId}
                     onDataBlockSave={db => onDataBlockSave(db)}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -18,6 +18,7 @@ import {
   SortableOptionWithGroup,
   TableHeadersFormValues,
 } from './TableHeadersForm';
+import { reverseMapTableHeadersConfig } from './utils/tableToolHelpers';
 
 interface Props {
   fullTable: FullTable;
@@ -85,8 +86,13 @@ export const createHeaderIgnoreFromGroups = (
 
 const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
   (props: Props, dataTableRef) => {
-    const { fullTable, tableHeadersConfig } = props;
+    const { fullTable, tableHeadersConfig: unmappedHeaderConfig } = props;
     const { subjectMeta, results } = fullTable;
+
+    const tableHeadersConfig = reverseMapTableHeadersConfig(
+      unmappedHeaderConfig,
+      fullTable.subjectMeta,
+    ) as TableHeadersFormValues;
 
     if (results.length === 0) {
       return (


### PR DESCRIPTION
Fixed it by mapping tableHeader config with subject meta that casts filters to their type. so we can map results to their associated cell( as we know which filters are locations/indicators/etc.)