### PR TITLE
EES-751 - Another stab at the expired token handling of the client

### DIFF
--- a/src/explore-education-statistics-admin/src/components/ProtectedRoute.tsx
+++ b/src/explore-education-statistics-admin/src/components/ProtectedRoute.tsx
@@ -18,15 +18,11 @@ const AuthenticationCheckingComponent = ({
     return null;
   }
 
-  if (redirectIfNotLoggedIn && !user) {
+  if (redirectIfNotLoggedIn && (!user || user.validToken === false)) {
     return <Redirect to={signInService.getSignInLink()} />;
   }
 
-  return (
-    <LoginContext.Provider value={{ user }}>
-      {React.createElement(component, props)}
-    </LoginContext.Provider>
-  );
+  return React.createElement(component, props);
 };
 
 /**

--- a/src/explore-education-statistics-admin/src/components/ProtectedRoutes.tsx
+++ b/src/explore-education-statistics-admin/src/components/ProtectedRoutes.tsx
@@ -31,12 +31,14 @@ const ProtectedRoutes = ({ children }: Props) => {
       await authService
         .getUser()
         .then(userProfile => {
+          const { profile } = userProfile;
           const user: User = {
-            id: userProfile.sub,
-            name: userProfile.given_name,
-            permissions: userProfile.role
-              ? (userProfile.role as string).split(',')
+            id: profile.sub,
+            name: profile.given_name,
+            permissions: profile.role
+              ? (profile.role as string).split(',')
               : [],
+            validToken: new Date() < new Date(userProfile.expires_at * 1000),
           };
 
           setAuthState({

--- a/src/explore-education-statistics-admin/src/components/api-authorization/AuthorizeService.js
+++ b/src/explore-education-statistics-admin/src/components/api-authorization/AuthorizeService.js
@@ -29,13 +29,13 @@ export class AuthorizeService {
   }
 
   async getUser() {
-    if (this._user && this._user.profile) {
-      return this._user.profile;
+    if (this._user) {
+      return this._user;
     }
 
     await this.ensureUserManagerInitialized();
     const user = await this.userManager.getUser();
-    return user && user.profile;
+    return user;
   }
 
   async getAccessToken() {

--- a/src/explore-education-statistics-admin/src/components/api-authorization/LoginMenu.js
+++ b/src/explore-education-statistics-admin/src/components/api-authorization/LoginMenu.js
@@ -28,13 +28,13 @@ export class LoginMenu extends Component {
   }
 
   async populateState() {
-    const [isAuthenticated, user] = await Promise.all([
+    const [isAuthenticated, { profile }] = await Promise.all([
       authService.isAuthenticated(),
       authService.getUser(),
     ]);
     this.setState({
       isAuthenticated,
-      userName: user && user.name,
+      userName: profile && profile.name,
     });
   }
 

--- a/src/explore-education-statistics-admin/src/services/sign-in/types.ts
+++ b/src/explore-education-statistics-admin/src/services/sign-in/types.ts
@@ -2,6 +2,7 @@ export interface User {
   id: string;
   name: string;
   permissions: string[];
+  validToken?: boolean;
 }
 
 export interface Authentication {


### PR DESCRIPTION
AuthenticationService now returns full user details, not just profile and we now store a "validToken" prop on the user state of the LoginContext.

~On a side note:~
> ~The user's refreshToken coming back from the AuthenticationService is undefined - could the be causing the the silentRefresh of the token to fail?~ (see futher comment below)

If the user navigates to a ProtectedRoute with an expired token, it will redirect in the same way as if the user is not logged in.