### PR TITLE
Feature/ees 1092 add permissions to files and statuses

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleaseControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleaseControllerTests.cs
@@ -106,7 +106,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var mocks = Mocks();
             SetupEntityLookupResult(mocks.PersistenceHelper, _releaseId, _releaseExistsResult);
             mocks.FileStorageService.Setup(s => s.ListFilesAsync(_releaseId, ReleaseFileTypes.Ancillary))
-                .ReturnsAsync(testFiles);
+                .ReturnsAsync(new Either<ActionResult, IEnumerable<FileInfo>>(testFiles));
             var controller = ReleasesControllerWithMocks(mocks);
             
             // Call the method under test
@@ -195,7 +195,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             SetupEntityLookupResult(mocks.PersistenceHelper, _releaseId, _releaseExistsResult);
             
             mocks.FileStorageService.Setup(s => s.ListFilesAsync(_releaseId, ReleaseFileTypes.Data))
-                .ReturnsAsync(testFiles);
+                .ReturnsAsync(new Either<ActionResult, IEnumerable<FileInfo>>(testFiles));
             var controller = ReleasesControllerWithMocks(mocks);
 
             // Call the method under test

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleaseControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleaseControllerTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
-using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Utils;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
@@ -12,8 +11,6 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -22,7 +19,6 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using FileInfo = GovUk.Education.ExploreEducationStatistics.Admin.Models.FileInfo;
-using IReleaseService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseService;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 {
@@ -40,20 +36,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         private readonly Guid _releaseId = Guid.NewGuid();
         private readonly Guid _publicationId = Guid.NewGuid();
         
-        private readonly Task<Either<ActionResult, Release>> _releaseExistsResult 
-            = Task.FromResult(new Either<ActionResult, Release>(new Release()));
-        
-        private readonly Task<Either<ActionResult, Publication>> _publicationExistsResult 
-            = Task.FromResult(new Either<ActionResult, Publication>(new Publication()));
-        
-        private readonly Task<Either<ActionResult, Release>> _releaseNotFoundResult 
-            = Task.FromResult(new Either<ActionResult, Release>(new NotFoundResult()));
-
         [Fact]
         public async void Create_Release_Returns_Ok()
         {
             var mocks = Mocks();
-            SetupEntityLookupResult(mocks.PersistenceHelper, _publicationId, _publicationExistsResult);
             
             mocks.ReleaseService.Setup(s => s.CreateReleaseAsync(It.IsAny<CreateReleaseViewModel>()))
                 .ReturnsAsync(new Either<ActionResult, ReleaseViewModel>(new ReleaseViewModel()));
@@ -68,7 +54,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         public async Task AddAncillaryFilesAsync_UploadsTheFiles_Returns_Ok()
         {
             var mocks = Mocks();
-            SetupEntityLookupResult(mocks.PersistenceHelper, _releaseId, _releaseExistsResult);
             
             var ancillaryFile = MockFile("ancillaryFile.doc");
             mocks.FileStorageService
@@ -104,7 +89,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 }
             };
             var mocks = Mocks();
-            SetupEntityLookupResult(mocks.PersistenceHelper, _releaseId, _releaseExistsResult);
             mocks.FileStorageService.Setup(s => s.ListFilesAsync(_releaseId, ReleaseFileTypes.Ancillary))
                 .ReturnsAsync(new Either<ActionResult, IEnumerable<FileInfo>>(testFiles));
             var controller = ReleasesControllerWithMocks(mocks);
@@ -115,19 +99,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             Assert.NotNull(unboxed);
         }
 
-        [Fact]
-        public async Task GetAncillaryFilesAsync_Returns_NotFound()
-        {
-            var mocks = Mocks();
-            SetupEntityLookupResult(mocks.PersistenceHelper, _releaseId, _releaseNotFoundResult);
-
-            var controller = ReleasesControllerWithMocks(mocks);
-            
-            // Call the method under test 
-            var result = await controller.GetAncillaryFilesAsync(_releaseId);
-            AssertNotFound(result);
-        }
-        
         [Fact(Skip="Needs principal setting")]
         public async Task AddDataFilesAsync_UploadsTheFiles_Returns_Ok()
         {
@@ -135,8 +106,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var dataFile = MockFile("datafile.csv");
             var metaFile = MockFile("metafile.csv");
             
-            SetupEntityLookupResult(mocks.PersistenceHelper, _releaseId, _releaseExistsResult);
-
             mocks.FileStorageService
                 .Setup(service => service.UploadDataFilesAsync(_releaseId, dataFile, metaFile, "Subject name", false, "test user"))
                 .ReturnsAsync(new List<FileInfo>());
@@ -155,8 +124,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var dataFile = MockFile("datafile.csv");
             var metaFile = MockFile("metafile.csv");
             
-            SetupEntityLookupResult(mocks.PersistenceHelper, _releaseId, _releaseExistsResult);
-
             mocks.FileStorageService
                 .Setup(service => service.UploadDataFilesAsync(_releaseId, dataFile, metaFile, "Subject name", false, 
                     "test user"))
@@ -192,8 +159,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var mocks = Mocks();
             
-            SetupEntityLookupResult(mocks.PersistenceHelper, _releaseId, _releaseExistsResult);
-            
             mocks.FileStorageService.Setup(s => s.ListFilesAsync(_releaseId, ReleaseFileTypes.Data))
                 .ReturnsAsync(new Either<ActionResult, IEnumerable<FileInfo>>(testFiles));
             var controller = ReleasesControllerWithMocks(mocks);
@@ -206,27 +171,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         }
 
         [Fact]
-        public async Task GetDataFilesAsync_Returns_NotFound()
-        {
-            var mocks = Mocks();
-            SetupEntityLookupResult(mocks.PersistenceHelper, _releaseId, _releaseNotFoundResult);
-
-            var controller = ReleasesControllerWithMocks(mocks);
-            
-            // Call the method under test
-            var result = await controller.GetDataFilesAsync(_releaseId);
-            AssertNotFound(result);
-        }
-
-        [Fact]
         public async Task DeleteDataFilesAsync_Returns_OK()
         {
             var mocks = Mocks();
             
-            SetupEntityLookupResult(mocks.PersistenceHelper, _releaseId, _releaseExistsResult);
-            
-            mocks.FileStorageService
-                .Setup(service => service.DeleteDataFileAsync(_releaseId, "datafilename"))
+            mocks.ReleaseService
+                .Setup(service => service.DeleteDataFilesAsync(_releaseId, "datafilename", "subject title"))
                 .ReturnsAsync(new List<FileInfo>());
             var controller = ReleasesControllerWithMocks(mocks);
 
@@ -241,10 +191,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         {
             var mocks = Mocks();
             
-            SetupEntityLookupResult(mocks.PersistenceHelper, _releaseId, _releaseExistsResult);
-            
-            mocks.FileStorageService
-                .Setup(service => service.DeleteDataFileAsync(_releaseId, "datafilename"))
+            mocks.ReleaseService
+                .Setup(service => service.DeleteDataFilesAsync(_releaseId, "datafilename", "subject title"))
                 .ReturnsAsync(ValidationActionResult(UnableToFindMetadataFileToDelete));
             var controller = ReleasesControllerWithMocks(mocks);
 
@@ -257,8 +205,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         public async void Edit_Release_Summary_Returns_Ok()
         {
             var mocks = Mocks();
-            
-            SetupEntityLookupResult(mocks.PersistenceHelper, _releaseId, _releaseExistsResult);
             
             mocks.ReleaseService
                 .Setup(s => s.EditReleaseSummaryAsync(
@@ -354,25 +300,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             return validationProblem;
         }
 
-        private static (Mock<IImportService> ImportService,
+        private static (
+            Mock<IImportService> ImportService,
             Mock<IReleaseService> ReleaseService,
             Mock<IFileStorageService> FileStorageService,
             Mock<IImportStatusService> ImportStatusService,
             Mock<IReleaseStatusService> ReleaseStatusService,
-            Mock<ISubjectService> SubjectService,
-            Mock<ITableStorageService> TableStorageService,
-            Mock<UserManager<ApplicationUser>> UserManager,
-            Mock<IPersistenceHelper<ContentDbContext>> PersistenceHelper) Mocks()
+            Mock<UserManager<ApplicationUser>> UserManager) Mocks()
         {
             return (new Mock<IImportService>(),
                     new Mock<IReleaseService>(),
                     new Mock<IFileStorageService>(),
                     new Mock<IImportStatusService>(),
                     new Mock<IReleaseStatusService>(),
-                    new Mock<ISubjectService>(),
-                    new Mock<ITableStorageService>(),
-                    MockUserManager(Users),
-                    new Mock<IPersistenceHelper<ContentDbContext>>()
+                    MockUserManager(Users)
                 );
         }
 
@@ -382,10 +323,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             Mock<IFileStorageService> FileStorageService,
             Mock<IImportStatusService> ImportStatusService,
             Mock<IReleaseStatusService> ReleaseStatusService,
-            Mock<ISubjectService> SubjectService,
-            Mock<ITableStorageService> TableStorageService,
-            Mock<UserManager<ApplicationUser>> UserManager,
-            Mock<IPersistenceHelper<ContentDbContext>> PersistenceHelper) mocks)
+            Mock<UserManager<ApplicationUser>> UserManager) mocks)
         {
             return new ReleasesController(
                 mocks.ImportService.Object,
@@ -393,10 +331,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 mocks.FileStorageService.Object,
                 mocks.ImportStatusService.Object,
                 mocks.ReleaseStatusService.Object,
-                mocks.SubjectService.Object,
-                mocks.TableStorageService.Object,
-                mocks.UserManager.Object,
-                mocks.PersistenceHelper.Object);
+                mocks.UserManager.Object);
         }
         
         private static Mock<UserManager<TUser>> MockUserManager<TUser>(List<TUser> ls) where TUser : class
@@ -411,16 +346,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             mgr.Setup(x => x.UpdateAsync(It.IsAny<TUser>())).ReturnsAsync(IdentityResult.Success);
 
             return mgr;
-        }
-        
-        private void SetupEntityLookupResult<TEntity>(Mock<IPersistenceHelper<ContentDbContext>> persistenceHelper, Guid id, 
-            Task<Either<ActionResult, TEntity>> result) 
-            where TEntity : class
-        {
-            persistenceHelper
-                .Setup(s => s
-                    .CheckEntityExists<TEntity>(id, null))
-                .Returns(result);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileStorageServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileStorageServicePermissionTests.cs
@@ -75,6 +75,39 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         ), 
                 CanUpdateSpecificRelease);
         }
+
+        [Fact]
+        public void ListFilesAsync()
+        {
+            AssertSecurityPoliciesChecked(service => 
+                    service.ListFilesAsync(
+                        _release.Id,
+                        ReleaseFileTypes.Ancillary
+                    ), 
+                CanViewSpecificRelease);
+        }
+        
+        [Fact]
+        public void ListPublicFilesPreview()
+        {
+            AssertSecurityPoliciesChecked(service => 
+                    service.ListPublicFilesPreview(
+                        _release.Id
+                    ), 
+                CanViewSpecificRelease);
+        }
+        
+        [Fact]
+        public void StreamFile()
+        {
+            AssertSecurityPoliciesChecked(service => 
+                    service.StreamFile(
+                        _release.Id,
+                        ReleaseFileTypes.Ancillary,
+                        ""
+                    ), 
+                CanViewSpecificRelease);
+        }
         
         private void AssertSecurityPoliciesChecked<T>(
             Func<FileStorageService, Task<Either<ActionResult, T>>> protectedAction, params SecurityPolicies[] policies)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -4,13 +4,14 @@ using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Utils;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api;
-using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
@@ -26,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void CreateReleaseNoTemplate()
         {
-            var (userService, _, publishingService, repository) = Mocks();
+            var (userService, _, publishingService, repository, subjectService, tableStorageService, fileStorageService) = Mocks();
 
             using (var context = InMemoryApplicationDbContext("CreateReleaseNoTemplate"))
             {
@@ -39,7 +40,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using (var context = InMemoryApplicationDbContext("CreateReleaseNoTemplate"))
             {
                 var releaseService = new ReleaseService(context, AdminMapper(), 
-                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object);
+                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object);
                 
                 var result = releaseService.CreateReleaseAsync(
                     new CreateReleaseViewModel
@@ -61,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void CreateReleaseWithTemplate()
         {
-            var (userService, _, publishingService, repository) = Mocks();
+            var (userService, _, publishingService, repository, subjectService, tableStorageService, fileStorageService) = Mocks();
 
             using (var context = InMemoryApplicationDbContext("Create"))
             {
@@ -132,7 +134,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using (var context = InMemoryApplicationDbContext("Create"))
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object);
+                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object);
                 
                 // Service method under test
                 var result = releaseService.CreateReleaseAsync(
@@ -176,7 +179,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void LatestReleaseCorrectlyReported()
         {
-            var (userService, persistenceHelper, publishingService, repository) = Mocks();
+            var (userService, persistenceHelper, publishingService, repository, subjectService, tableStorageService, fileStorageService) = Mocks();
 
             var latestReleaseId = new Guid("274d4621-7d21-431b-80de-77b62a4374d2");
             var notLatestReleaseId = new Guid("49b73c2f-141a-4dc7-a2d4-69316aef8bbc");
@@ -210,7 +213,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using (var context = InMemoryApplicationDbContext("LatestReleaseCorrectlyReported"))
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, persistenceHelper.Object, userService.Object, repository.Object);
+                    publishingService.Object, persistenceHelper.Object, userService.Object, repository.Object,
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object);
                 
                 // Method under test
                 var notLatest =
@@ -222,7 +226,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using (var context = InMemoryApplicationDbContext("LatestReleaseCorrectlyReported"))
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, persistenceHelper.Object, userService.Object, repository.Object);
+                    publishingService.Object, persistenceHelper.Object, userService.Object, repository.Object,
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object);
                 
                 // Method under test
                 var notLatest =
@@ -235,7 +240,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void EditReleaseSummary()
         {
-            var (userService, _, publishingService, repository) = Mocks();
+            var (userService, _, publishingService, repository, subjectService, tableStorageService, fileStorageService) = Mocks();
 
             var releaseId = new Guid("02c73027-3e06-4495-82a4-62b778c005a9");
             var addHocReleaseTypeId = new Guid("f3800c32-1e1c-4d42-8165-d1bcb3c8b47c");
@@ -292,7 +297,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using (var context = InMemoryApplicationDbContext("LatestReleaseCorrectlyReported"))
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object);
+                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object);
                 
                 // Method under test 
                 var edited = await releaseService
@@ -318,7 +324,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void GetReleaseSummaryAsync()
         {
-            var (userService, persistenceHelper, publishingService, repository) = Mocks();
+            var (userService, persistenceHelper, publishingService, repository, subjectService, tableStorageService, fileStorageService) = Mocks();
             
             var releaseId = new Guid("5cf345d4-7f7b-425c-8267-de785cfc040b");
             var adhocReleaseType = new ReleaseType
@@ -377,7 +383,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using (var context = InMemoryApplicationDbContext("GetReleaseSummaryAsync"))
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, persistenceHelper.Object, userService.Object, repository.Object);
+                    publishingService.Object, persistenceHelper.Object, userService.Object, repository.Object,
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object);
                 
                 // Method under test 
                 var summaryResult = await releaseService.GetReleaseSummaryAsync(releaseId);
@@ -394,7 +401,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void GetLatestReleaseAsync()
         {
-            var (userService, persistenceHelper, publishingService, repository) = Mocks();
+            var (userService, persistenceHelper, publishingService, repository, subjectService, tableStorageService, fileStorageService) = Mocks();
             
             var publicationId = new Guid("94af186f-5dbe-4f46-8a8e-f5480ed9f4fc");
             var firstReleaseId = new Guid("8781ebf8-790c-484b-8a34-19ea501c9c74");
@@ -433,7 +440,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using (var context = InMemoryApplicationDbContext("GetReleasesForPublicationAsync"))
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, persistenceHelper.Object, userService.Object, repository.Object);
+                    publishingService.Object, persistenceHelper.Object, userService.Object, repository.Object,
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object);
 
                 // Method under test 
                 var latest = releaseService.GetLatestReleaseAsync(publicationId).Result.Right;
@@ -446,7 +454,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             Mock<IUserService>, 
             Mock<IPersistenceHelper<ContentDbContext>>, 
             Mock<IPublishingService>,
-            Mock<IReleaseRepository>) Mocks()
+            Mock<IReleaseRepository>,
+            Mock<ISubjectService>,
+            Mock<ITableStorageService>,
+            Mock<IFileStorageService>) Mocks()
         {
             var userService = MockUtils.AlwaysTrueUserService();
 
@@ -458,7 +469,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             MockUtils.SetupCall<ContentDbContext, Release>(persistenceHelper);
             MockUtils.SetupCall<ContentDbContext, Publication>(persistenceHelper);
             
-            return (userService, persistenceHelper, new Mock<IPublishingService>(), new Mock<IReleaseRepository>());
+            return (
+                userService, 
+                persistenceHelper, 
+                new Mock<IPublishingService>(), 
+                new Mock<IReleaseRepository>(),
+                new Mock<ISubjectService>(), 
+                new Mock<ITableStorageService>(), 
+                new Mock<IFileStorageService>());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseStatusServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseStatusServicePermissionTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
+using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Utils;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
+{
+    public class ReleaseStatusServicePermissionTests
+    {
+        private readonly Release _release = new Release
+        {
+            Id = Guid.NewGuid()
+        };
+        
+        [Fact]
+        public void GetReleaseStatusesAsync()
+        {
+            AssertSecurityPoliciesChecked(service => 
+                    service.GetReleaseStatusesAsync(_release.Id),  
+                _release,
+                CanViewSpecificRelease);
+        }
+        
+        private void AssertSecurityPoliciesChecked<T, TEntity>(
+            Func<ReleaseStatusService, Task<Either<ActionResult, T>>> protectedAction, TEntity protectedEntity, params SecurityPolicies[] policies)
+            where TEntity : class
+        {
+            var (mapper, userService, persistenceHelper, tableStorageService) = Mocks();
+
+            var service = new ReleaseStatusService(mapper.Object, userService.Object, 
+                persistenceHelper.Object, tableStorageService.Object);
+            PermissionTestUtil.AssertSecurityPoliciesChecked(protectedAction, protectedEntity, userService, service, policies);
+        }
+        
+        private (
+            Mock<IMapper>,
+            Mock<IUserService>, 
+            Mock<IPersistenceHelper<ContentDbContext>>,
+            Mock<ITableStorageService>) Mocks()
+        {
+            return (
+                new Mock<IMapper>(), 
+                new Mock<IUserService>(), 
+                MockUtils.MockPersistenceHelper<ContentDbContext, Release>(_release.Id, _release),
+                new Mock<ITableStorageService>());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseController.cs
@@ -32,21 +32,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         private readonly IFileStorageService _fileStorageService;
         private readonly IImportStatusService _importStatusService;
         private readonly IReleaseStatusService _releaseStatusService;
-        private readonly ISubjectService _subjectService;
-        private readonly ITableStorageService _tableStorageService;
         private readonly UserManager<ApplicationUser> _userManager;
-        // TODO EES-918 - remove in favour of checking for release inside service calls
-        private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
 
         public ReleasesController(IImportService importService,
             IReleaseService releaseService,
             IFileStorageService fileStorageService,
             IImportStatusService importStatusService,
             IReleaseStatusService releaseStatusService,
-            ISubjectService subjectService,
-            ITableStorageService tableStorageService,
-            UserManager<ApplicationUser> userManager,
-            IPersistenceHelper<ContentDbContext> persistenceHelper
+            UserManager<ApplicationUser> userManager
             )
         {
             _importService = importService;
@@ -54,36 +47,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             _fileStorageService = fileStorageService;
             _importStatusService = importStatusService;
             _releaseStatusService = releaseStatusService;
-            _subjectService = subjectService;
-            _tableStorageService = tableStorageService;
             _userManager = userManager;
-            _persistenceHelper = persistenceHelper;
         }
 
         [HttpGet("release/{releaseId}/chart/{filename}")]
         public async Task<ActionResult> GetChartFile(Guid releaseId, string filename)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<Release>(releaseId)
-                .OnSuccess(_ => _fileStorageService.StreamFile(releaseId, ReleaseFileTypes.Chart, filename))
+            return await _fileStorageService
+                .StreamFile(releaseId, ReleaseFileTypes.Chart, filename)
                 .HandleFailures();
         }
 
         [HttpGet("release/{releaseId}/data/{filename}")]
         public async Task<ActionResult> GetDataFile(Guid releaseId, string filename)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<Release>(releaseId)
-                .OnSuccess(_ => _fileStorageService.StreamFile(releaseId, ReleaseFileTypes.Data, filename))
+            return await _fileStorageService
+                .StreamFile(releaseId, ReleaseFileTypes.Data, filename)
                 .HandleFailures();
         }
 
         [HttpGet("release/{releaseId}/ancillary/{filename}")]
         public async Task<ActionResult> GetAncillaryFile(Guid releaseId, string filename)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<Release>(releaseId)
-                .OnSuccess(_ => _fileStorageService.StreamFile(releaseId, ReleaseFileTypes.Ancillary, filename))
+            return await _fileStorageService
+                .StreamFile(releaseId, ReleaseFileTypes.Ancillary, filename)
                 .HandleFailures();
         }
 
@@ -106,9 +93,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [ProducesResponseType(404)]
         public async Task<ActionResult<IEnumerable<FileInfo>>> GetDataFilesAsync(Guid releaseId)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<Release>(releaseId)
-                .OnSuccess(_ => _fileStorageService.ListFilesAsync(releaseId, ReleaseFileTypes.Data))
+            return await _fileStorageService
+                .ListFilesAsync(releaseId, ReleaseFileTypes.Data)
                 .HandleFailuresOr(Ok);
         }
 
@@ -119,9 +105,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [ProducesResponseType(404)]
         public async Task<ActionResult<IEnumerable<FileInfo>>> GetAncillaryFilesAsync(Guid releaseId)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<Release>(releaseId)
-                .OnSuccess(_ => _fileStorageService.ListFilesAsync(releaseId, ReleaseFileTypes.Ancillary))
+            return await _fileStorageService
+                .ListFilesAsync(releaseId, ReleaseFileTypes.Ancillary)
                 .HandleFailuresOr(Ok);
         }
 
@@ -132,9 +117,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [ProducesResponseType(404)]
         public async Task<ActionResult<IEnumerable<FileInfo>>> GetChartFilesAsync(Guid releaseId)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<Release>(releaseId)
-                .OnSuccess(_ => _fileStorageService.ListFilesAsync(releaseId, ReleaseFileTypes.Chart))
+            return await _fileStorageService
+                .ListFilesAsync(releaseId, ReleaseFileTypes.Chart)
                 .HandleFailuresOr(Ok);
         }
 
@@ -249,15 +233,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [HttpDelete("release/{releaseId}/data/{fileName}/{subjectTitle}")]
         public async Task<ActionResult<IEnumerable<FileInfo>>> DeleteDataFiles(Guid releaseId, string fileName, string subjectTitle)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<Release>(releaseId)
-                .OnSuccess(async _ =>
-                {
-                    await _tableStorageService.DeleteEntityAsync("imports",
-                        new DatafileImport(releaseId.ToString(), fileName, 0,0, null));
-                    await _subjectService.DeleteAsync(releaseId, subjectTitle);
-                    return await _fileStorageService.DeleteDataFileAsync(releaseId, fileName);
-                })
+            return await _releaseService
+                .DeleteDataFilesAsync(releaseId, fileName, subjectTitle)
                 .HandleFailuresOr(Ok);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseController.cs
@@ -284,7 +284,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [HttpGet("releases/{releaseId}/status")]
         public async Task<ActionResult<IEnumerable<ReleaseStatusViewModel>>> GetReleaseStatusesAsync(Guid releaseId)
         {
-            return Ok(await _releaseStatusService.GetReleaseStatusesAsync(releaseId));
+            return await _releaseStatusService
+                .GetReleaseStatusesAsync(releaseId)
+                .HandleFailuresOr(Ok);
         }
 
         [HttpPut("releases/{releaseId}/status")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileStorageService.cs
@@ -15,9 +15,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, IEnumerable<FileInfo>>> UploadDataFilesAsync(Guid releaseId,
             IFormFile dataFile, IFormFile metaFile, string name, bool overwrite, string userName);
 
-        Task<IEnumerable<FileInfo>> ListFilesAsync(Guid releaseId, ReleaseFileTypes type);
+        Task<Either<ActionResult, IEnumerable<FileInfo>>> ListFilesAsync(Guid releaseId, ReleaseFileTypes type);
 
-        IEnumerable<Common.Model.FileInfo> ListPublicFilesPreview(Guid releaseId);
+        Task<Either<ActionResult, IEnumerable<Common.Model.FileInfo>>> ListPublicFilesPreview(Guid releaseId);
 
         Task<Either<ActionResult, IEnumerable<FileInfo>>> UploadFilesAsync(Guid releaseId, IFormFile dataFile,
             string name, ReleaseFileTypes type, bool overwrite);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Mvc;
+using FileInfo = GovUk.Education.ExploreEducationStatistics.Admin.Models.FileInfo;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
@@ -27,5 +28,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, List<ReleaseViewModel>>> GetMyReleasesForReleaseStatusesAsync(params ReleaseStatus[] releaseStatuses);
 
         Task<Either<ActionResult, ReleaseSummaryViewModel>> UpdateReleaseStatusAsync(Guid releaseId, ReleaseStatus status, string internalReleaseNote);
+        Task<Either<ActionResult, IEnumerable<FileInfo>>>  DeleteDataFilesAsync(Guid releaseId, string fileName, string subjectTitle);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseStatusService.cs
@@ -2,11 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IReleaseStatusService
     {
-        Task<IEnumerable<ReleaseStatusViewModel>> GetReleaseStatusesAsync(Guid releaseId);
+        Task<Either<ActionResult, IEnumerable<ReleaseStatusViewModel>>> GetReleaseStatusesAsync(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseStatusService.cs
@@ -2,45 +2,62 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Utils;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Cosmos.Table;
-using Microsoft.Extensions.Configuration;
+using ReleaseStatus = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 {
     public class ReleaseStatusService : IReleaseStatusService
     {
+        private const string TableName = "ReleaseStatus";
+        
         private readonly IMapper _mapper;
         private readonly ITableStorageService _tableStorageService;
-        private const string TableName = "ReleaseStatus";
+        private readonly IUserService _userService;
+        private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
 
-        public ReleaseStatusService(IConfiguration config, IMapper mapper)
+        public ReleaseStatusService(IMapper mapper, IUserService userService, 
+            IPersistenceHelper<ContentDbContext> persistenceHelper, ITableStorageService tableStorageService)
         {
             _mapper = mapper;
-            _tableStorageService = new TableStorageService(config.GetConnectionString("PublisherStorage"));
+            _userService = userService;
+            _persistenceHelper = persistenceHelper;
+            _tableStorageService = tableStorageService;
         }
 
-        public async Task<IEnumerable<ReleaseStatusViewModel>> GetReleaseStatusesAsync(Guid releaseId)
+        public async Task<Either<ActionResult, IEnumerable<ReleaseStatusViewModel>>> GetReleaseStatusesAsync(Guid releaseId)
         {
-            var query = new TableQuery<ReleaseStatus>().Where(
-                TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.PartitionKey), QueryComparisons.Equal,
-                    releaseId.ToString()));
+            return await _persistenceHelper
+                .CheckEntityExists<Release>(releaseId)
+                .OnSuccess(_userService.CheckCanViewRelease)
+                .OnSuccess(async _ =>
+                {
+                    var query = new TableQuery<ReleaseStatus>().Where(
+                        TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.PartitionKey), QueryComparisons.Equal,
+                            releaseId.ToString()));
 
-            var results = new List<ReleaseStatus>();
-            var table = await GetTableAsync();
-            TableContinuationToken token = null;
-            do
-            {
-                var queryResult = await table.ExecuteQuerySegmentedAsync(query, token);
-                results.AddRange(queryResult.Results);
-                token = queryResult.ContinuationToken;
-            } while (token != null);
+                    var results = new List<ReleaseStatus>();
+                    var table = await GetTableAsync();
+                    TableContinuationToken token = null;
+                    do
+                    {
+                        var queryResult = await table.ExecuteQuerySegmentedAsync(query, token);
+                        results.AddRange(queryResult.Results);
+                        token = queryResult.ContinuationToken;
+                    } while (token != null);
 
-            return _mapper.Map<IEnumerable<ReleaseStatusViewModel>>(results);
+                    return _mapper.Map<IEnumerable<ReleaseStatusViewModel>>(results);
+                });
         }
 
         private async Task<CloudTable> GetTableAsync()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -245,7 +245,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IFileStorageService, FileStorageService>();
             services.AddTransient<IImportService, ImportService>();
             services.AddTransient<IPublishingService, PublishingService>();
-            services.AddTransient<IReleaseStatusService, ReleaseStatusService>();
+            services.AddTransient<IReleaseStatusService, ReleaseStatusService>(s => 
+                new ReleaseStatusService(
+                    s.GetService<IMapper>(),
+                    s.GetService<IUserService>(),
+                    s.GetService<IPersistenceHelper<ContentDbContext>>(),
+                    new TableStorageService(Configuration.GetConnectionString("PublisherStorage"))));
             services.AddTransient<IThemeService, ThemeService>();
             services.AddTransient<IThemeRepository, ThemeRepository>();
             services.AddTransient<ITopicService, TopicService>();

--- a/src/explore-education-statistics-admin/src/components/ReleaseServiceStatus.tsx
+++ b/src/explore-education-statistics-admin/src/components/ReleaseServiceStatus.tsx
@@ -31,9 +31,7 @@ const ReleaseServiceStatus = ({
   const fetchReleaseServiceStatus = useCallback(() => {
     return dashboardService
       .getReleaseStatus(releaseId)
-      .then(([status]) => {
-        setCurrentStatus(status);
-      })
+      .then(setCurrentStatus)
       .catch(handleApiErrors);
   }, [releaseId, handleApiErrors]);
 

--- a/src/explore-education-statistics-admin/src/components/ReleaseServiceStatus.tsx
+++ b/src/explore-education-statistics-admin/src/components/ReleaseServiceStatus.tsx
@@ -1,8 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
+import StatusBlock, { StatusBlockProps } from '@admin/components/StatusBlock';
 import styles from '@admin/pages/release/edit-release/data/ReleaseDataUploadsSection.module.scss';
 import dashboardService from '@admin/services/dashboard/service';
+import withErrorControl, {
+  ErrorControlProps,
+} from '@admin/validation/withErrorControl';
 import Details from '@common/components/Details';
-import StatusBlock, { StatusBlockProps } from '@admin/components/StatusBlock';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 interface Props {
   releaseId: string;
@@ -18,17 +21,21 @@ const ReleaseServiceStatus = ({
   releaseId,
   refreshPeriod = 5000,
   exclude,
-}: Props) => {
+  handleApiErrors,
+}: Props & ErrorControlProps) => {
   const [currentStatus, setCurrentStatus] = useState<ReleaseServiceStatus>();
   const [statusColor, setStatusColor] = useState<StatusBlockProps['color']>(
     'blue',
   );
 
-  function fetchReleaseServiceStatus() {
-    return dashboardService.getReleaseStatus(releaseId).then(([status]) => {
-      setCurrentStatus(status);
-    });
-  }
+  const fetchReleaseServiceStatus = useCallback(() => {
+    return dashboardService
+      .getReleaseStatus(releaseId)
+      .then(([status]) => {
+        setCurrentStatus(status);
+      })
+      .catch(handleApiErrors);
+  }, [releaseId, handleApiErrors]);
 
   const intervalRef = useRef<NodeJS.Timeout>();
 
@@ -42,7 +49,7 @@ const ReleaseServiceStatus = ({
     return () => {
       cancelTimer();
     };
-  }, []);
+  }, [fetchReleaseServiceStatus, refreshPeriod]);
 
   const statusDetailColor = (text: string) => {
     if (currentStatus) {
@@ -105,4 +112,4 @@ const ReleaseServiceStatus = ({
   );
 };
 
-export default ReleaseServiceStatus;
+export default withErrorControl(ReleaseServiceStatus);

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/ReleaseStatusPage.tsx
@@ -16,8 +16,6 @@ import Yup from '@common/lib/validation/yup';
 import { ReleaseStatus } from '@common/services/publicationService';
 import { FormikProps } from 'formik';
 import React, { useContext, useEffect, useState } from 'react';
-import { RouteComponentProps } from 'react-router';
-import appRouteList from '@admin/routes/dashboard/routes';
 
 interface FormValues {
   releaseStatus: ReleaseStatus;
@@ -29,10 +27,7 @@ interface Model {
   statusOptions: RadioOption[];
 }
 
-const ReleaseStatusPage = ({
-  history,
-  handleApiErrors,
-}: RouteComponentProps & ErrorControlProps) => {
+const ReleaseStatusPage = ({ handleApiErrors }: ErrorControlProps) => {
   const [model, setModel] = useState<Model>();
 
   const { releaseId } = useContext(ManageReleaseContext) as ManageRelease;


### PR DESCRIPTION
This PR:
- adds permission checks to methods in FileStorageService and ReleaseStatusService
- moves DeleteDataFiles code from ReleasesController to ReleaseService (in order to better secure it)
- clears up warnings in the ReleaseServiceStatus.tsx component

Additionally I've raised EES-1102 to look at breaking ReleaseService into smaller components at some point in the future. 