### PR TITLE
BAU/PP-160 - Chart width: A negative value is not valid. ("-89")

### DIFF
--- a/src/explore-education-statistics-common/src/components/TabsSection.module.scss
+++ b/src/explore-education-statistics-common/src/components/TabsSection.module.scss
@@ -8,6 +8,10 @@
   }
 }
 
+.forceFullWidth {
+  width: 100% !important;
+}
+
 @media print {
   :global(.govuk-tabs__list) {
     list-style: none;

--- a/src/explore-education-statistics-common/src/components/TabsSection.tsx
+++ b/src/explore-education-statistics-common/src/components/TabsSection.tsx
@@ -57,6 +57,7 @@ const TabsSection = forwardRef<HTMLElement, TabsSectionProps>(
           styles.panel,
           {
             [classes.panelHidden]: tabProps.hidden,
+            [styles.forceFullWidth]: tabProps.hidden,
           },
         )}
         id={id}

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Tabs renders multiple tabs correctly with titles 1`] = `
       Test section 1 content
     </p>
   </section>
-  <section class="govuk-tabs__panel dfe-content-overflow panel govuk-visually-hidden"
+  <section class="govuk-tabs__panel dfe-content-overflow panel govuk-visually-hidden forceFullWidth"
            id="test-tabs-2"
            aria-labelledby="test-tabs-2-tab"
            role="tabpanel"
@@ -105,7 +105,7 @@ exports[`Tabs renders multiple tabs correctly without titles 1`] = `
       Test section 1 content
     </p>
   </section>
-  <section class="govuk-tabs__panel dfe-content-overflow panel govuk-visually-hidden"
+  <section class="govuk-tabs__panel dfe-content-overflow panel govuk-visually-hidden forceFullWidth"
            id="test-tabs-2"
            aria-labelledby="test-tabs-2-tab"
            role="tabpanel"


### PR DESCRIPTION
The problem seemed to be that when a tab was hidden using the 'govuk-visually-hidden' class it was setting the container width to 1px which was messing up some of the math functionality on the charts.

This also fixes charts in datablocks when printing