### PR TITLE
PP-100/103 Disable onChange/Blur validations for table tool forms

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -153,6 +153,8 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
       enableReinitialize
       ref={formikRef}
       initialValues={initialFormValues}
+      validateOnBlur={false}
+      validateOnChange={false}
       validationSchema={Yup.object<FormValues>({
         indicators: Yup.array()
           .of(Yup.string())

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -10,7 +10,7 @@ import { Dictionary } from '@common/types/util';
 import useResetFormOnPreviousStep from '@common/modules/table-tool/components/hooks/useResetFormOnPreviousStep';
 import { FormikProps } from 'formik';
 import sortBy from 'lodash/sortBy';
-import React, { useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useImmer } from 'use-immer';
 import mapValuesWithKeys from '@common/lib/utils/mapValuesWithKeys';
 import FormFieldCheckboxMenu from './FormFieldCheckboxMenu';
@@ -67,14 +67,14 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
   const formikRef = useRef<Formik<FormValues>>(null);
   const formId = 'locationFiltersForm';
 
-  const formOptions = React.useMemo(() => options, [options]);
+  const formOptions = useMemo(() => options, [options]);
 
-  const formInitialValues = React.useMemo(
+  const formInitialValues = useMemo(
     () => calculateInitialValues(initialValues, options),
     [initialValues, options],
   );
 
-  const initialLocationLevels = React.useMemo(() => {
+  const initialLocationLevels = useMemo(() => {
     return mapValuesWithKeys<Dictionary<string[]>, FilterOption[]>(
       formInitialValues.locations,
       (locationKey: string, locations: string[]) => {
@@ -94,7 +94,7 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
     Dictionary<{ label: string; value: string }[]>
   >(initialLocationLevels);
 
-  React.useEffect(() => {
+  useEffect(() => {
     updateLocationLevels(() => initialLocationLevels);
   }, [initialLocationLevels, updateLocationLevels]);
 
@@ -114,6 +114,15 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
     <Formik<FormValues>
       enableReinitialize
       ref={formikRef}
+      initialValues={formInitialValues}
+      validationSchema={Yup.object<FormValues>({
+        locations: Yup.mixed().test(
+          'required',
+          'Select at least one location',
+          (value: Dictionary<string[]>) =>
+            Object.values(value).some(groupOptions => groupOptions.length > 0),
+        ),
+      })}
       onSubmit={async values => {
         const locations = Object.entries(values.locations).reduce(
           (acc, [level, levelOptions]) => {
@@ -132,15 +141,6 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
         await onSubmit({ locations });
         goToNextStep();
       }}
-      initialValues={formInitialValues}
-      validationSchema={Yup.object<FormValues>({
-        locations: Yup.mixed().test(
-          'required',
-          'Select at least one location',
-          (value: Dictionary<string[]>) =>
-            Object.values(value).some(groupOptions => groupOptions.length > 0),
-        ),
-      })}
       render={(form: FormikProps<FormValues>) => {
         return isActive ? (
           <Form {...form} id={formId} displayErrorMessageOnUncaughtErrors>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -115,6 +115,8 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
       enableReinitialize
       ref={formikRef}
       initialValues={formInitialValues}
+      validateOnBlur={false}
+      validateOnChange={false}
       validationSchema={Yup.object<FormValues>({
         locations: Yup.mixed().test(
           'required',
@@ -177,6 +179,8 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
                           });
                         }}
                         onChange={(event, option) => {
+                          event.persist();
+
                           updateLocationLevels(draft => {
                             if (!draft[levelKey]) {
                               draft[levelKey] = [];

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -58,13 +58,13 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
       initialValues={{
         publicationId,
       }}
+      validationSchema={Yup.object<FormValues>({
+        publicationId: Yup.string().required('Choose publication'),
+      })}
       onSubmit={async values => {
         await onSubmit(values);
         goToNextStep();
       }}
-      validationSchema={Yup.object<FormValues>({
-        publicationId: Yup.string().required('Choose publication'),
-      })}
       render={(form: FormikProps<FormValues>) => {
         const { values } = form;
         const { getError } = createErrorHelper(form);

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -58,6 +58,8 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
       initialValues={{
         publicationId,
       }}
+      validateOnBlur={false}
+      validateOnChange={false}
       validationSchema={Yup.object<FormValues>({
         publicationId: Yup.string().required('Choose publication'),
       })}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationSubjectForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationSubjectForm.tsx
@@ -5,7 +5,7 @@ import Yup from '@common/lib/validation/yup';
 import { PublicationSubject } from '@common/modules/full-table/services/tableBuilderService';
 import useResetFormOnPreviousStep from '@common/modules/table-tool/components/hooks/useResetFormOnPreviousStep';
 import { FormikProps } from 'formik';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 import WizardStepHeading from './WizardStepHeading';
@@ -61,7 +61,7 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
     subjectId: initialSubjectId,
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (formikRef.current) {
       formikRef.current.setValues({
         subjectId: `${initialSubjectId}`,
@@ -74,6 +74,10 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
     <Formik<FormValues>
       enableReinitialize
       ref={formikRef}
+      initialValues={initialValues}
+      validationSchema={Yup.object<FormValues>({
+        subjectId: Yup.string().required('Choose a subject'),
+      })}
       onSubmit={async ({ subjectId }) => {
         await onSubmit({
           subjectId,
@@ -81,10 +85,6 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
         });
         goToNextStep();
       }}
-      initialValues={initialValues}
-      validationSchema={Yup.object<FormValues>({
-        subjectId: Yup.string().required('Choose a subject'),
-      })}
       render={(form: FormikProps<FormValues>) => {
         return isActive ? (
           <Form {...form} id={formId} displayErrorMessageOnUncaughtErrors>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationSubjectForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationSubjectForm.tsx
@@ -75,6 +75,8 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
       enableReinitialize
       ref={formikRef}
       initialValues={initialValues}
+      validateOnBlur={false}
+      validateOnChange={false}
       validationSchema={Yup.object<FormValues>({
         subjectId: Yup.string().required('Choose a subject'),
       })}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableHeadersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableHeadersForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
 import { Form, FormikProps } from 'formik';
 import classNames from 'classnames';
@@ -38,7 +38,7 @@ const TableHeadersForm = ({
     rows: [],
   },
 }: Props) => {
-  const formInitialValues = React.useMemo(() => ({ ...initialValues }), [
+  const formInitialValues = useMemo(() => ({ ...initialValues }), [
     initialValues,
   ]);
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -149,7 +149,7 @@ const TableToolWizard = ({
         if (onInitialQueryLoaded) onInitialQueryLoaded();
       }
     });
-  }, [initialQuery, releaseId]);
+  }, [initialQuery, onInitialQueryLoaded, releaseId]);
 
   const handlePublicationFormSubmit: PublicationFormSubmitHandler = async ({
     publicationId: selectedPublicationId,

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
@@ -14,7 +14,7 @@ import {
 } from '@common/modules/full-table/services/tableBuilderService';
 import useResetFormOnPreviousStep from '@common/modules/table-tool/components/hooks/useResetFormOnPreviousStep';
 import { FormikProps } from 'formik';
-import React, { useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 import WizardStepHeading from './WizardStepHeading';
@@ -61,7 +61,7 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
     }),
   ];
 
-  const formInitialValues = React.useMemo(() => {
+  const formInitialValues = useMemo(() => {
     let start = '';
     let end = '';
 
@@ -94,10 +94,6 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
     <Formik<FormValues>
       enableReinitialize
       ref={formikRef}
-      onSubmit={async values => {
-        await onSubmit(values);
-        goToNextStep();
-      }}
       initialValues={formInitialValues}
       validationSchema={Yup.object<FormValues>({
         start: Yup.string()
@@ -153,6 +149,10 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
             },
           ),
       })}
+      onSubmit={async values => {
+        await onSubmit(values);
+        goToNextStep();
+      }}
       render={(form: FormikProps<FormValues>) => {
         return isActive ? (
           <Form id={formId} displayErrorMessageOnUncaughtErrors>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
@@ -95,6 +95,8 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
       enableReinitialize
       ref={formikRef}
       initialValues={formInitialValues}
+      validateOnBlur={false}
+      validateOnChange={false}
       validationSchema={Yup.object<FormValues>({
         start: Yup.string()
           .required('Start date required')

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -2,23 +2,9 @@ import tableBuilderService, {
   ThemeMeta,
 } from '@common/modules/full-table/services/tableBuilderService';
 import Page from '@frontend/components/Page';
-import TableTool from '@frontend/components/TableTool';
+import TableTool from '@frontend/modules/table-tool/components/TableTool';
 import { NextContext } from 'next';
 import React, { Component } from 'react';
-
-export interface PublicationOptions {
-  id: string;
-  title: string;
-  topics: {
-    id: string;
-    title: string;
-    publications: {
-      id: string;
-      title: string;
-      slug: string;
-    }[];
-  }[];
-}
 
 interface Props {
   themeMeta: ThemeMeta[];

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableTool.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableTool.tsx
@@ -3,7 +3,9 @@ import LinkContainer from '@common/components/LinkContainer';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import permalinkService from '@common/modules/full-table/services/permalinkService';
 import DownloadCsvButton from '@common/modules/table-tool/components/DownloadCsvButton';
-import TableHeadersForm, {TableHeadersFormValues,} from '@common/modules/table-tool/components/TableHeadersForm';
+import TableHeadersForm, {
+  TableHeadersFormValues,
+} from '@common/modules/table-tool/components/TableHeadersForm';
 import TableToolWizard, {
   FinalStepProps,
   TableToolWizardProps,
@@ -12,9 +14,9 @@ import TimePeriodDataTable from '@common/modules/table-tool/components/TimePerio
 import WizardStep from '@common/modules/table-tool/components/WizardStep';
 import WizardStepHeading from '@common/modules/table-tool/components/WizardStepHeading';
 import Link from '@frontend/components/Link';
-import React, {createRef, useEffect, useState} from 'react';
-import {FullTable} from '@common/modules/full-table/types/fullTable';
-import {OmitStrict} from '@common/types';
+import React, { createRef, useEffect, useState } from 'react';
+import { FullTable } from '@common/modules/full-table/types/fullTable';
+import { OmitStrict } from '@common/types';
 
 const TableToolFinalStep = ({
   table,

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableTool.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableTool.tsx
@@ -3,9 +3,7 @@ import LinkContainer from '@common/components/LinkContainer';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import permalinkService from '@common/modules/full-table/services/permalinkService';
 import DownloadCsvButton from '@common/modules/table-tool/components/DownloadCsvButton';
-import TableHeadersForm, {
-  TableHeadersFormValues,
-} from '@common/modules/table-tool/components/TableHeadersForm';
+import TableHeadersForm, {TableHeadersFormValues,} from '@common/modules/table-tool/components/TableHeadersForm';
 import TableToolWizard, {
   FinalStepProps,
   TableToolWizardProps,
@@ -14,8 +12,9 @@ import TimePeriodDataTable from '@common/modules/table-tool/components/TimePerio
 import WizardStep from '@common/modules/table-tool/components/WizardStep';
 import WizardStepHeading from '@common/modules/table-tool/components/WizardStepHeading';
 import Link from '@frontend/components/Link';
-import React, { createRef, useEffect, useState } from 'react';
-import { FullTable } from '@common/modules/full-table/types/fullTable';
+import React, {createRef, useEffect, useState} from 'react';
+import {FullTable} from '@common/modules/full-table/types/fullTable';
+import {OmitStrict} from '@common/types';
 
 const TableToolFinalStep = ({
   table,
@@ -167,10 +166,7 @@ const TableToolFinalStep = ({
   );
 };
 
-type TableToolProps = Omit<
-  TableToolWizardProps,
-  'finalStep' | 'onTableConfigurationChange'
->;
+type TableToolProps = OmitStrict<TableToolWizardProps, 'finalStep'>;
 
 const TableTool = (props: TableToolProps) => (
   <TableToolWizard {...props} finalStep={TableToolFinalStep} />


### PR DESCRIPTION
⚠️ **Depends on `run-script` branch**

This PR disables table tool form validations from occurring for `onChange` and `onBlur` events. Validation will now only occur on form submission.