### PR TITLE
EES-1139 - added rewrite to prevent access to any Identity pages othe…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -35,6 +35,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.AspNetCore.Rewrite;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.EntityFrameworkCore;
@@ -446,6 +447,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             app.UseAuthentication();
             app.UseIdentityServer();
             app.UseAuthorization();
+            
+            // deny access to all Identity routes other than /Identity/Account/Login and
+            // /Identity/Account/ExternalLogin
+            var options = new RewriteOptions()
+                .AddRewrite(@"^(?i)identity/(?!account/(?:external)*login)", "/", skipRemainingRules: true);
+            app.UseRewriter(options);
 
             app.UseMvc(routes =>
             {
@@ -457,7 +464,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                     name: "default",
                     template: "{controller}/{action=Index}/{id?}");
             });
-
+            
             app.UseSwagger();
             app.UseSwaggerUI(c =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -451,7 +451,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             // deny access to all Identity routes other than /Identity/Account/Login and
             // /Identity/Account/ExternalLogin
             var options = new RewriteOptions()
-                .AddRewrite(@"^(?i)identity/(?!account/(?:external)*login)", "/", skipRemainingRules: true);
+                .AddRewrite(@"^(?i)identity/(?!account/(?:external)*login$)", "/", skipRemainingRules: true);
             app.UseRewriter(options);
 
             app.UseMvc(routes =>

--- a/src/explore-education-statistics-admin/src/components/PageHeader.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageHeader.tsx
@@ -90,11 +90,6 @@ const LoggedInLinks = ({ user }: Authentication) => (
       </li>
     )}
     <li className="govuk-header__navigation-item">
-      <a className="govuk-header__link" href="/identity/account/manage">
-        {user ? user.name : ''}
-      </a>
-    </li>
-    <li className="govuk-header__navigation-item">
       <Link className="govuk-header__link" to={loginService.getSignOutLink()}>
         Sign out
       </Link>


### PR DESCRIPTION
This PR:
- disables all Identity routes other than /Identity/Account/Login and /Identity/Account/ExternalLogin
- removes the Profile link from the page header