### PR TITLE
Revert "EES-1117 - Regex temp solution"

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/ContentSubBlockRenderer.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/ContentSubBlockRenderer.tsx
@@ -24,19 +24,12 @@ const ContentSubBlockRenderer = ({
 }: Props) => {
   switch (block.type) {
     case 'MarkDownBlock':
-      return (
-        <ReactMarkdown
-          className="govuk-body"
-          source={block.body.replace(/ {15} +/g, '')}
-        />
-      );
+      return <ReactMarkdown className="govuk-body" source={block.body} />;
     case 'HtmlBlock':
       return (
         <div
           // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{
-            __html: block.body,
-          }}
+          dangerouslySetInnerHTML={{ __html: block.body }}
         />
       );
     case 'InsetTextBlock':

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -140,10 +140,9 @@ class PublicationReleasePage extends Component<Props> {
               className="govuk-body"
               source={
                 data.summarySection.content &&
-                data.summarySection.content[0].body.replace(/ {15} +/g, '')
+                data.summarySection.content[0].body
               }
             />
-
             {data.downloadFiles && (
               <Details
                 summary="Download data files"


### PR DESCRIPTION
This reverts commit 2e53439df219a1cbe102b3df06be6cbe8d69badf.

Reverting the temporary regex solution.

After the following PR was merged, developers who recreate their Content database should no longer have an issue as a fix to the Markdown content was applied to the IntialCreate.cs migration file.
https://github.com/dfe-analytical-services/explore-education-statistics/pull/1200

The affected Markdown blocks were also manually updated in all environments so this temporary regex solution _should_ no longer be needed.