### PR TITLE
EES-1177 Order by publish scheduled if the release hasn't been published yet

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -87,7 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 .Where(release => release.PublicationId == publicationId)
                 .ToList()
                 .Where(release => IsReleasePublished(release, includedReleaseIds))
-                .OrderByDescending(release => release.Published)
+                .OrderByDescending(release => release.Published ?? release.PublishScheduled)
                 .FirstOrDefault();
         }
 


### PR DESCRIPTION
The generate content task considers the latest release to be the one with the most recent published date.

A bug occurs because the release has no published date set until all stages of publishing have been completed, which is after the generate content task has been run.