### PR TITLE
EES-1177 Using the PublishScheduled date/time to compare unpublished …

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -50,7 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 .Where(release => release.PublicationId == publicationId)
                 .ToList()
                 .Where(release => IsReleasePublished(release, includedReleaseIds))
-                .OrderByDescending(release => release.Published ?? release.PublishScheduled)
+                .OrderByDescending(release => release.Published ?? DateTime.UtcNow)
                 .FirstOrDefault();
         }
 


### PR DESCRIPTION
…releases with published ones is misleading because the date could be set in the past, yet the release is being published now.