### PR TITLE
EES-1238 - fix for null PublishScheduled date

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseService.cs
@@ -16,7 +16,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public PreReleaseWindowStatus GetPreReleaseWindowStatus(Release release, DateTime referenceTime)
         {
-            var publishDate = release.PublishScheduled.GetValueOrDefault();
+            if (!release.PublishScheduled.HasValue)
+            {
+                return new PreReleaseWindowStatus
+                {
+                    PreReleaseAccess = PreReleaseAccess.NoneSet
+                };
+            }
+            
+            var publishDate = release.PublishScheduled.Value;
             var accessWindowStart = publishDate.AddMinutes(-_preReleaseOptions.MinutesBeforeReleaseTimeStart);
             var accessWindowEnd = publishDate.AddMinutes(-_preReleaseOptions.MinutesBeforeReleaseTimeEnd);
 


### PR DESCRIPTION
This PR:
- dummies out the Methodology link on the RHS of the Pre Release page (links within content aren't affected)
- dummies out Other Releases links that aren't legacy links