### PR TITLE
Feature/ees 1262 methodology link

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="10.0.3" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200206143045_AddPublicationMethodologyLink.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200206143045_AddPublicationMethodologyLink.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200206143045_AddPublicationMethodologyLink")]
+    partial class AddPublicationMethodologyLink
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200206143045_AddPublicationMethodologyLink.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200206143045_AddPublicationMethodologyLink.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class AddPublicationMethodologyLink : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MethodologyUrl",
+                table: "Publications",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MethodologyUrl",
+                table: "Publications");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200206165325_AddPublicationMethodologyModel.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200206165325_AddPublicationMethodologyModel.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200206165325_AddPublicationMethodologyModel")]
+    partial class AddPublicationMethodologyModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200206165325_AddPublicationMethodologyModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200206165325_AddPublicationMethodologyModel.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class AddPublicationMethodologyModel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MethodologyUrl",
+                table: "Publications");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalMethodology_Title",
+                table: "Publications",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ExternalMethodology_Url",
+                table: "Publications",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExternalMethodology_Title",
+                table: "Publications");
+
+            migrationBuilder.DropColumn(
+                name: "ExternalMethodology_Url",
+                table: "Publications");
+
+            migrationBuilder.AddColumn<string>(
+                name: "MethodologyUrl",
+                table: "Publications",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/MyPublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/MyPublicationViewModel.cs
@@ -16,6 +16,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models.Api
         
         public MethodologyViewModel Methodology { get; set; }
         
+        public Uri MethodologyUrl { get; set; }
+        
         public Guid TopicId { get; set; }
         
         public Guid ThemeId { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/MyPublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/MyPublicationViewModel.cs
@@ -15,8 +15,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models.Api
         public List<MyReleaseViewModel> Releases { get; set; }
         
         public MethodologyViewModel Methodology { get; set; }
-        
-        public Uri MethodologyUrl { get; set; }
+
+        private ExternalMethodology ExternalMethodology { get; set; }
         
         public Guid TopicId { get; set; }
         

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/MyPublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/MyPublicationViewModel.cs
@@ -16,7 +16,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models.Api
         
         public MethodologyViewModel Methodology { get; set; }
 
-        private ExternalMethodology ExternalMethodology { get; set; }
+        public ExternalMethodology ExternalMethodology { get; set; }
         
         public Guid TopicId { get; set; }
         

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -253,6 +253,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     p => p.ToString(),
                     p => new Uri(p));
 
+            modelBuilder.Entity<Publication>()
+                .OwnsOne(p => p.ExternalMethodology);
+
             modelBuilder.Entity<Release>()
                 .Property(r => r.TimePeriodCoverage)
                 .HasConversion(new EnumToEnumValueConverter<TimeIdentifier>())

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ExternalMethodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ExternalMethodology.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model
+{
+    public class ExternalMethodology
+    {
+        public string Title { get; set; }
+        public Uri Url { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -27,7 +27,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         
         public Methodology Methodology { get; set; }
 
-        public Uri MethodologyUrl { get; set; }
+        public ExternalMethodology ExternalMethodology {
+            get;
+            set;
+        }
 
         public Uri LegacyPublicationUrl { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -26,7 +26,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public Guid? MethodologyId { get; set; }
         
         public Methodology Methodology { get; set; }
-        
+
+        public Uri MethodologyUrl { get; set; }
+
         public Uri LegacyPublicationUrl { get; set; }
 
         public List<Link> LegacyReleases { get; set; }

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
@@ -23,16 +23,16 @@ const PublicationSummary = ({ publication }: Props) => {
               {publication.methodology.title}
             </Link>
           )}
-          {publication.methodologyUrl && (
+          {publication.ExternalMethodology && (
             <a
-              href={publication.methodologyUrl}
+              href={publication.ExternalMethodology}
               target="_blank"
               rel="noopener noreferrer"
             >
-              {publication.methodologyUrl}
+              {publication.ExternalMethodology}
             </a>
           )}
-          {!publication.methodology && !publication.methodologyUrl && (
+          {!publication.methodology && !publication.ExternalMethodology && (
             <>No methodology assigned</>
           )}
         </SummaryListItem>

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
@@ -19,17 +19,18 @@ const PublicationSummary = ({ publication }: Props) => {
       <SummaryList>
         <SummaryListItem term="Methodology" smallKey>
           {publication.methodology && (
-            <Link
-              to={`/methodology/${publication.methodology.id}`}
-              target="_blank"
-            >
+            <Link to={`/methodology/${publication.methodology.id}`}>
               {publication.methodology.title}
             </Link>
           )}
           {publication.methodologyUrl && (
-            <Link to={publication.methodologyUrl}>
+            <a
+              href={publication.methodologyUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               {publication.methodologyUrl}
-            </Link>
+            </a>
           )}
           {!publication.methodology && !publication.methodologyUrl && (
             <>No methodology assigned</>

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
@@ -19,11 +19,21 @@ const PublicationSummary = ({ publication }: Props) => {
       <SummaryList>
         <SummaryListItem term="Methodology" smallKey>
           {publication.methodology && (
-            <Link to={`/methodology/${publication.methodology.id}`}>
+            <Link
+              to={`/methodology/${publication.methodology.id}`}
+              target="_blank"
+            >
               {publication.methodology.title}
             </Link>
           )}
-          {!publication.methodology && <>No methodology available</>}
+          {publication.methodologyUrl && (
+            <Link to={publication.methodologyUrl}>
+              {publication.methodologyUrl}
+            </Link>
+          )}
+          {!publication.methodology && !publication.methodologyUrl && (
+            <>No methodology assigned</>
+          )}
         </SummaryListItem>
         <SummaryListItem term="Releases" smallKey>
           <ul className="govuk-list dfe-admin">

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
@@ -23,16 +23,16 @@ const PublicationSummary = ({ publication }: Props) => {
               {publication.methodology.title}
             </Link>
           )}
-          {publication.ExternalMethodology && (
+          {publication.externalMethodology && (
             <a
-              href={publication.ExternalMethodology}
+              href={publication.externalMethodology.url}
               target="_blank"
               rel="noopener noreferrer"
             >
-              {publication.ExternalMethodology}
+              {publication.externalMethodology.url}
             </a>
           )}
-          {!publication.methodology && !publication.ExternalMethodology && (
+          {!publication.methodology && !publication.externalMethodology && (
             <>No methodology assigned</>
           )}
         </SummaryListItem>

--- a/src/explore-education-statistics-admin/src/services/dashboard/types.ts
+++ b/src/explore-education-statistics-admin/src/services/dashboard/types.ts
@@ -51,6 +51,7 @@ export interface AdminDashboardPublication {
   id: string;
   title: string;
   methodology?: IdTitlePair;
+  methodologyUrl: string;
   releases: AdminDashboardRelease[];
   contact: ContactDetails;
   permissions: {

--- a/src/explore-education-statistics-admin/src/services/dashboard/types.ts
+++ b/src/explore-education-statistics-admin/src/services/dashboard/types.ts
@@ -51,7 +51,7 @@ export interface AdminDashboardPublication {
   id: string;
   title: string;
   methodology?: IdTitlePair;
-  methodologyUrl: string;
+  ExternalMethodology: string;
   releases: AdminDashboardRelease[];
   contact: ContactDetails;
   permissions: {

--- a/src/explore-education-statistics-admin/src/services/dashboard/types.ts
+++ b/src/explore-education-statistics-admin/src/services/dashboard/types.ts
@@ -24,6 +24,11 @@ export interface Comment {
   createdDate: string;
 }
 
+export interface ExternalMethodology {
+  title: string;
+  url: string;
+}
+
 export interface AdminDashboardRelease {
   id: string;
   status: ReleaseStatus;
@@ -51,7 +56,7 @@ export interface AdminDashboardPublication {
   id: string;
   title: string;
   methodology?: IdTitlePair;
-  ExternalMethodology: string;
+  externalMethodology: ExternalMethodology;
   releases: AdminDashboardRelease[];
   contact: ContactDetails;
   permissions: {


### PR DESCRIPTION
This PR adds the new External Methodology Link and Title property to publications and the required migration to add this to the DB.

The Admin dashboard has also been updated to display this status. Of note I've deliberatly displayed the external methodology with just its url rather than title to make a clear distinction between a methodology within the service and a link.