### PR TITLE
EES-1263 - dummied out links

### DIFF
--- a/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
@@ -226,11 +226,7 @@ const PublicationReleaseContent = ({
                           ({ id, slug, title }) => [
                             title,
                             <li key={id} data-testid="previous-release-item">
-                              <Link
-                                to={`/find-statistics/${release.publication.slug}/${slug}`}
-                              >
-                                {title}
-                              </Link>
+                              <Link to="#">{title}</Link>
                             </li>,
                           ],
                         ),

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/RelatedInformationSection.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/RelatedInformationSection.tsx
@@ -113,14 +113,7 @@ const RelatedInformationSection = ({
       <nav role="navigation" aria-labelledby="related-content">
         <ul className="govuk-list">
           <li>
-            <Link
-              to={`/methodology/${
-                release.publication.methodology
-                  ? release.publication.methodology.id
-                  : 'no-methodology'
-              }`}
-              target="_blank"
-            >
+            <Link to="#">
               {release.publication.methodology
                 ? release.publication.methodology.title
                 : 'Methodology title'}


### PR DESCRIPTION
This PR:
- replaces methodology links and Other Releases links (that aren't legacy releases) with dummy "#" links

Note that this does not affect links embedded within content.