### PR TITLE
EES-1170 - second time lucky - removing breadcrumbs and dashboard lin…

### DIFF
--- a/src/explore-education-statistics-admin/src/components/Breadcrumbs.tsx
+++ b/src/explore-education-statistics-admin/src/components/Breadcrumbs.tsx
@@ -6,19 +6,25 @@ export interface BreadcrumbsProps {
     link?: string;
     name: string;
   }[];
+  includeHomeBreadcrumb?: boolean;
 }
 
-const Breadcrumbs = ({ breadcrumbs = [] }: BreadcrumbsProps) => {
+const Breadcrumbs = ({
+  breadcrumbs = [],
+  includeHomeBreadcrumb = true,
+}: BreadcrumbsProps) => {
   const currentBreadcrumbIndex = breadcrumbs.length - 1;
 
   return (
     <div className="govuk-breadcrumbs">
       <ol className="govuk-breadcrumbs__list" data-testid="breadcrumbs--list">
-        <li className="govuk-breadcrumbs__list-item">
-          <Link className="govuk-breadcrumbs__link" to="/">
-            Home
-          </Link>
-        </li>
+        {includeHomeBreadcrumb && (
+          <li className="govuk-breadcrumbs__list-item">
+            <Link className="govuk-breadcrumbs__link" to="/">
+              Home
+            </Link>
+          </li>
+        )}
         {breadcrumbs.map((breadcrumb, index) => {
           return (
             <li

--- a/src/explore-education-statistics-admin/src/components/Page.tsx
+++ b/src/explore-education-statistics-admin/src/components/Page.tsx
@@ -12,7 +12,7 @@ type Props = {
   pageTitle?: string;
 } & BreadcrumbsProps;
 
-const Page = ({ breadcrumbs = [], children, wide, pageTitle }: Props) => {
+const Page = ({ children, wide, pageTitle, ...breadcrumbProps }: Props) => {
   return (
     <>
       <Helmet>
@@ -32,7 +32,7 @@ const Page = ({ breadcrumbs = [], children, wide, pageTitle }: Props) => {
       >
         <PageBanner />
 
-        <Breadcrumbs breadcrumbs={breadcrumbs} />
+        <Breadcrumbs {...breadcrumbProps} />
 
         <main
           className="app-main-class govuk-main-wrapper"

--- a/src/explore-education-statistics-admin/src/components/PageHeader.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageHeader.tsx
@@ -46,7 +46,7 @@ const PageHeader = ({ wide }: Props) => {
           </div>
           <div className="govuk-header__content">
             <a
-              href="/"
+              href={user && user.permissions.canAccessAnalystPages ? '/' : '#'}
               className="govuk-header__link govuk-header__link--service-name"
             >
               Explore education statistics

--- a/src/explore-education-statistics-admin/src/components/__tests__/Breadcrumbs.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/__tests__/Breadcrumbs.test.tsx
@@ -104,4 +104,27 @@ describe('Breadcrumbs', () => {
     expect(lastBreadcrumb).toBeDefined();
     expect(lastBreadcrumb.querySelector('a')).toBeNull();
   });
+
+  test('does not render Home breadcrumb if explicitly asked to exclude', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Breadcrumbs
+          breadcrumbs={[
+            {
+              link: '/publications',
+              name: 'Publications',
+            },
+          ]}
+          includeHomeBreadcrumb={false}
+        />
+        ,
+      </MemoryRouter>,
+    );
+
+    const breadcrumbs = container.querySelectorAll('li');
+
+    expect(breadcrumbs).toHaveLength(1);
+    expect(breadcrumbs[0].textContent).toBe('Publications');
+    expect(breadcrumbs[0].querySelector('a')).toBe(null);
+  });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/prerelease/PreReleasePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/prerelease/PreReleasePage.tsx
@@ -75,6 +75,7 @@ const PreReleasePage = ({
               ? [{ name: 'Pre Release access' }]
               : []
           }
+          includeHomeBreadcrumb={user && user.permissions.canAccessAnalystPages}
         >
           {model.preReleaseWindowStatus.preReleaseAccess === 'Within' &&
             model.content && (


### PR DESCRIPTION
This PR:
- removes non-working breadcrumbs from Pre Release page, until at some point where they have a dashboard in future development
- amends the EES link to go nowhere
- updated tests to check for new behaviour