### PR TITLE
EES-1263 - restoring missing changes, and amending methodology link i…

### DIFF
--- a/src/explore-education-statistics-admin/src/components/Breadcrumbs.tsx
+++ b/src/explore-education-statistics-admin/src/components/Breadcrumbs.tsx
@@ -6,19 +6,25 @@ export interface BreadcrumbsProps {
     link?: string;
     name: string;
   }[];
+  includeHomeBreadcrumb?: boolean;
 }
 
-const Breadcrumbs = ({ breadcrumbs = [] }: BreadcrumbsProps) => {
+const Breadcrumbs = ({
+  breadcrumbs = [],
+  includeHomeBreadcrumb = true,
+}: BreadcrumbsProps) => {
   const currentBreadcrumbIndex = breadcrumbs.length - 1;
 
   return (
     <div className="govuk-breadcrumbs">
       <ol className="govuk-breadcrumbs__list" data-testid="breadcrumbs--list">
-        <li className="govuk-breadcrumbs__list-item">
-          <Link className="govuk-breadcrumbs__link" to="/">
-            Home
-          </Link>
-        </li>
+        {includeHomeBreadcrumb && (
+          <li className="govuk-breadcrumbs__list-item">
+            <Link className="govuk-breadcrumbs__link" to="/">
+              Home
+            </Link>
+          </li>
+        )}
         {breadcrumbs.map((breadcrumb, index) => {
           return (
             <li

--- a/src/explore-education-statistics-admin/src/components/Page.tsx
+++ b/src/explore-education-statistics-admin/src/components/Page.tsx
@@ -12,7 +12,7 @@ type Props = {
   pageTitle?: string;
 } & BreadcrumbsProps;
 
-const Page = ({ breadcrumbs = [], children, wide, pageTitle }: Props) => {
+const Page = ({ children, wide, pageTitle, ...breadcrumbProps }: Props) => {
   return (
     <>
       <Helmet>
@@ -32,7 +32,7 @@ const Page = ({ breadcrumbs = [], children, wide, pageTitle }: Props) => {
       >
         <PageBanner />
 
-        <Breadcrumbs breadcrumbs={breadcrumbs} />
+        <Breadcrumbs {...breadcrumbProps} />
 
         <main
           className="app-main-class govuk-main-wrapper"

--- a/src/explore-education-statistics-admin/src/components/PageHeader.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageHeader.tsx
@@ -46,7 +46,7 @@ const PageHeader = ({ wide }: Props) => {
           </div>
           <div className="govuk-header__content">
             <a
-              href="/"
+              href={user && user.permissions.canAccessAnalystPages ? '/' : '#'}
               className="govuk-header__link govuk-header__link--service-name"
             >
               Explore education statistics

--- a/src/explore-education-statistics-admin/src/components/__tests__/Breadcrumbs.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/__tests__/Breadcrumbs.test.tsx
@@ -104,4 +104,27 @@ describe('Breadcrumbs', () => {
     expect(lastBreadcrumb).toBeDefined();
     expect(lastBreadcrumb.querySelector('a')).toBeNull();
   });
+
+  test('does not render Home breadcrumb if explicitly asked to exclude', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Breadcrumbs
+          breadcrumbs={[
+            {
+              link: '/publications',
+              name: 'Publications',
+            },
+          ]}
+          includeHomeBreadcrumb={false}
+        />
+        ,
+      </MemoryRouter>,
+    );
+
+    const breadcrumbs = container.querySelectorAll('li');
+
+    expect(breadcrumbs).toHaveLength(1);
+    expect(breadcrumbs[0].textContent).toBe('Publications');
+    expect(breadcrumbs[0].querySelector('a')).toBe(null);
+  });
 });

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
@@ -4,6 +4,7 @@ import BasicReleaseSummary from '@admin/modules/find-statistics/components/Basic
 import PrintThisPage from '@admin/modules/find-statistics/components/PrintThisPage';
 import ReleaseContentAccordion from '@admin/modules/find-statistics/components/ReleaseContentAccordion';
 import { getTimePeriodCoverageDateRangeStringShort } from '@admin/pages/release/util/releaseSummaryUtil';
+import { releaseContentService } from '@admin/services/release/edit-release/content/service';
 import { ManageContentPageViewModel } from '@admin/services/release/edit-release/content/types';
 import service from '@admin/services/release/edit-release/data/service';
 import withErrorControl, {
@@ -15,15 +16,14 @@ import Details from '@common/components/Details';
 import PageSearchForm from '@common/components/PageSearchForm';
 import RelatedAside from '@common/components/RelatedAside';
 import { EditingContext } from '@common/modules/find-statistics/util/wrapEditableComponent';
+import { DataBlock as DataBlockModel } from '@common/services/dataBlockService';
 import { Dictionary } from '@common/types';
 import classNames from 'classnames';
 import React from 'react';
-import { DataBlock as DataBlockModel } from '@common/services/dataBlockService';
-import { releaseContentService } from '@admin/services/release/edit-release/content/service';
-import RelatedInformationSection from './components/RelatedInformationSection';
-import ReleaseNotesSection from './components/ReleaseNotesSection';
-import ReleaseHeadlines from './components/ReleaseHeadlines';
 import ContentBlocks from './components/EditableContentBlocks';
+import RelatedInformationSection from './components/RelatedInformationSection';
+import ReleaseHeadlines from './components/ReleaseHeadlines';
+import ReleaseNotesSection from './components/ReleaseNotesSection';
 
 export interface RendererProps {
   contentId?: string;
@@ -222,14 +222,12 @@ const PublicationReleaseContent = ({
                   >
                     <ul className="govuk-list">
                       {[
-                        ...release.publication.releases.map(
-                          ({ id, slug, title }) => [
-                            title,
-                            <li key={id} data-testid="previous-release-item">
-                              <Link to="#">{title}</Link>
-                            </li>,
-                          ],
-                        ),
+                        ...release.publication.releases.map(({ id, title }) => [
+                          title,
+                          <li key={id} data-testid="previous-release-item">
+                            <Link to="#">{title}</Link>
+                          </li>,
+                        ]),
                         ...release.publication.legacyReleases.map(
                           ({ id, description, url }) => [
                             description,

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/AdminPublicationReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/AdminPublicationReleaseHelpAndSupportSection.tsx
@@ -30,16 +30,7 @@ const AdminPublicationReleaseHelpAndSupportSection = ({
           headingTag="h3"
         >
           <p>
-            Read our{' '}
-            <Link
-              to={`/methodology/${
-                release.publication.methodology
-                  ? release.publication.methodology.id
-                  : 'no-methodology'
-              }`}
-            >
-              {`${publication.title}: methodology`}
-            </Link>{' '}
+            Read our <Link to="#">{`${publication.title}: methodology`}</Link>{' '}
             guidance.
           </p>
         </AccordionSection>

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/ReleaseStatusPage.tsx
@@ -39,7 +39,6 @@ const statusMap: {
 };
 
 const ReleaseStatusPage = ({
-  history,
   handleApiErrors,
 }: RouteComponentProps & ErrorControlProps) => {
   const [model, setModel] = useState<Model>();

--- a/src/explore-education-statistics-admin/src/pages/release/prerelease/PreReleasePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/prerelease/PreReleasePage.tsx
@@ -75,6 +75,7 @@ const PreReleasePage = ({
               ? [{ name: 'Pre Release access' }]
               : []
           }
+          includeHomeBreadcrumb={user && user.permissions.canAccessAnalystPages}
         >
           {model.preReleaseWindowStatus.preReleaseAccess === 'Within' &&
             model.content && (


### PR DESCRIPTION
This PR:
- removes breadcrumbs for the Pre Release user
- dummies out the "EES" header link in the page header
- fixes an undummied link spotted by Mark in the Help and Support section of the Pre Release page