### PR TITLE
EES-1224 Appending messages if a stage fails

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatus.cs
@@ -75,6 +75,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
             ? new List<ReleaseStatusLogMessage>()
             : JsonConvert.DeserializeObject<IEnumerable<ReleaseStatusLogMessage>>(Messages);
 
+        public void AppendLogMessage(ReleaseStatusLogMessage logMessage)
+        {
+            if (logMessage != null)
+            {
+                Messages = JsonConvert.SerializeObject(LogMessages.Append(logMessage));
+            }
+        }
+
         public void AppendLogMessages(IEnumerable<ReleaseStatusLogMessage> logMessages)
         {
             if (logMessages != null)
@@ -100,7 +108,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
                     PublishingStage = _state.Publishing.ToString();
                     break;
             }
-            
+
             OverallStage = _state.Overall.ToString();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/GenerateReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/GenerateReleaseContentFunction.cs
@@ -39,17 +39,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             catch (Exception e)
             {
                 logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
-                await UpdateStage(message, Failed);
+                await UpdateStage(message, Failed,
+                    new ReleaseStatusLogMessage($"Exception in content stage: {e.Message}"));
             }
 
             logger.LogInformation($"{executionContext.FunctionName} completed");
         }
 
-        private async Task UpdateStage(GenerateReleaseContentMessage message, Stage stage)
+        private async Task UpdateStage(GenerateReleaseContentMessage message, Stage stage,
+            ReleaseStatusLogMessage logMessage = null)
         {
             foreach (var (releaseId, releaseStatusId) in message.Releases)
             {
-                await _releaseStatusService.UpdateContentStageAsync(releaseId, releaseStatusId, stage);
+                await _releaseStatusService.UpdateContentStageAsync(releaseId, releaseStatusId, stage, logMessage);
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -50,7 +50,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                     catch (Exception e)
                     {
                         logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
-                        await UpdateStage(releaseStatus, Failed);
+                        await UpdateStage(releaseStatus, Failed, new ReleaseStatusLogMessage(
+                            $"Exception in publishing stage: {e.Message}"));
                     }
                 }
 
@@ -64,7 +65,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 catch (Exception e)
                 {
                     logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
-                    await UpdateStage(published, Failed);
+                    await UpdateStage(published, Failed,
+                        new ReleaseStatusLogMessage($"Exception in publishing stage: {e.Message}"));
                 }
             }
 
@@ -87,17 +89,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             return await _releaseStatusService.ExecuteQueryAsync(query);
         }
 
-        private async Task UpdateStage(IEnumerable<ReleaseStatus> releaseStatuses, Stage stage)
+        private async Task UpdateStage(IEnumerable<ReleaseStatus> releaseStatuses, Stage stage,
+            ReleaseStatusLogMessage logMessage = null)
         {
             foreach (var releaseStatus in releaseStatuses)
             {
-                await UpdateStage(releaseStatus, stage);
+                await UpdateStage(releaseStatus, stage, logMessage);
             }
         }
 
-        private async Task UpdateStage(ReleaseStatus releaseStatus, Stage stage)
+        private async Task UpdateStage(ReleaseStatus releaseStatus, Stage stage,
+            ReleaseStatusLogMessage logMessage = null)
         {
-            await _releaseStatusService.UpdatePublishingStageAsync(releaseStatus.ReleaseId, releaseStatus.Id, stage);
+            await _releaseStatusService.UpdatePublishingStageAsync(releaseStatus.ReleaseId, releaseStatus.Id, stage,
+                logMessage);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -50,8 +50,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                     catch (Exception e)
                     {
                         logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
-                        await UpdateStage(releaseStatus, Failed, new ReleaseStatusLogMessage(
-                            $"Exception in publishing stage: {e.Message}"));
+                        await UpdateStage(releaseStatus, Failed,
+                            new ReleaseStatusLogMessage($"Exception in publishing stage: {e.Message}"));
                     }
                 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseDataFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseDataFunction.cs
@@ -64,8 +64,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 catch (Exception e)
                 {
                     logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
-                    await UpdateStage(message, Failed, new ReleaseStatusLogMessage(
-                        $"Exception in data stage: {e.Message}"));
+                    await UpdateStage(message, Failed,
+                        new ReleaseStatusLogMessage($"Exception in data stage: {e.Message}"));
                 }
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseDataFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseDataFunction.cs
@@ -64,16 +64,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 catch (Exception e)
                 {
                     logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
-                    await UpdateStage(message, Failed);
+                    await UpdateStage(message, Failed, new ReleaseStatusLogMessage(
+                        $"Exception in data stage: {e.Message}"));
                 }
             }
 
             logger.LogInformation($"{executionContext.FunctionName} completed");
         }
 
-        private async Task UpdateStage(PublishReleaseDataMessage message, Stage stage)
+        private async Task UpdateStage(PublishReleaseDataMessage message, Stage stage,
+            ReleaseStatusLogMessage logMessage = null)
         {
-            await _releaseStatusService.UpdateDataStageAsync(message.ReleaseId, message.ReleaseStatusId, stage);
+            await _releaseStatusService.UpdateDataStageAsync(message.ReleaseId, message.ReleaseStatusId, stage,
+                logMessage);
         }
 
         private IEnumerable<Subject> GetSubjects(Guid releaseId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseStatusService.cs
@@ -15,12 +15,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task UpdateStateAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusState state);
 
-        Task UpdateContentStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage);
+        Task UpdateContentStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+            ReleaseStatusLogMessage logMessage = null);
 
-        Task UpdateDataStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage);
+        Task UpdateDataStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+            ReleaseStatusLogMessage logMessage = null);
 
-        Task UpdateFilesStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage);
+        Task UpdateFilesStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+            ReleaseStatusLogMessage logMessage = null);
 
-        Task UpdatePublishingStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage);
+        Task UpdatePublishingStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+            ReleaseStatusLogMessage logMessage = null);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseStatusService.cs
@@ -79,38 +79,46 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             });
         }
 
-        public async Task UpdateContentStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage)
+        public async Task UpdateContentStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+            ReleaseStatusLogMessage logMessage = null)
         {
             await UpdateRowAsync(releaseId, releaseStatusId, row =>
             {
                 row.State.Content = stage;
+                row.AppendLogMessage(logMessage);
                 return row;
             });
         }
 
-        public async Task UpdateDataStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage)
+        public async Task UpdateDataStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+            ReleaseStatusLogMessage logMessage = null)
         {
             await UpdateRowAsync(releaseId, releaseStatusId, row =>
             {
                 row.State.Data = stage;
+                row.AppendLogMessage(logMessage);
                 return row;
             });
         }
 
-        public async Task UpdateFilesStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage)
+        public async Task UpdateFilesStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+            ReleaseStatusLogMessage logMessage = null)
         {
             await UpdateRowAsync(releaseId, releaseStatusId, row =>
             {
                 row.State.Files = stage;
+                row.AppendLogMessage(logMessage);
                 return row;
             });
         }
 
-        public async Task UpdatePublishingStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage)
+        public async Task UpdatePublishingStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+            ReleaseStatusLogMessage logMessage = null)
         {
             await UpdateRowAsync(releaseId, releaseStatusId, row =>
             {
                 row.State.Publishing = stage;
+                row.AppendLogMessage(logMessage);
                 return row;
             });
         }


### PR DESCRIPTION
For example, if the data factory pipeline fails it would be handy to have the message in the release status table to avoid having to backtrack to work out the release status id from the release, go to data factory and work out which is the corresponding data factory pipeline run (there could be a few), and then read the error message.

This PR appends messages if any of the stages fail, hopefully giving a quick indication of what the cause is.