### PR TITLE
EES-1424 Fix tables showing n/as in release content

### DIFF
--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/ReleaseHeadlines.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/ReleaseHeadlines.tsx
@@ -11,6 +11,7 @@ import { mapDataBlockResponseToFullTable } from '@common/modules/find-statistics
 import { EditingContext } from '@common/modules/find-statistics/util/wrapEditableComponent';
 import { TableDataQuery } from '@common/modules/table-tool/services/tableBuilderService';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
+import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
 import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/tableHeaders';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
 import DataBlockService, {
@@ -133,13 +134,15 @@ const ReleaseHeadlines = ({ release, setRelease = () => {} }: Props) => {
                 <TimePeriodDataTable
                   fullTable={secondaryStatsDatablock.data}
                   tableHeadersConfig={
-                    (secondaryStatsDatablock.datablock.tables &&
-                      secondaryStatsDatablock.datablock.tables[0] &&
-                      secondaryStatsDatablock.datablock.tables[0]
-                        .tableHeaders) ||
-                    getDefaultTableHeaderConfig(
-                      secondaryStatsDatablock.data.subjectMeta,
-                    )
+                    secondaryStatsDatablock.datablock.tables?.[0]?.tableHeaders
+                      ? mapTableHeadersConfig(
+                          secondaryStatsDatablock.datablock.tables?.[0]
+                            ?.tableHeaders,
+                          secondaryStatsDatablock.data.subjectMeta,
+                        )
+                      : getDefaultTableHeaderConfig(
+                          secondaryStatsDatablock.data.subjectMeta,
+                        )
                   }
                 />
               ) : (

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/TimePeriodDataTableRenderer.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/TimePeriodDataTableRenderer.tsx
@@ -1,4 +1,5 @@
 import { mapDataBlockResponseToFullTable } from '@common/modules/find-statistics/components/util/tableUtil';
+import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
 import getDefaultTableHeaderConfig, {
   TableHeadersConfig,
 } from '@common/modules/table-tool/utils/tableHeaders';
@@ -19,7 +20,9 @@ const TimePeriodDataTableRenderer = ({ response, tableHeaders }: Props) => {
     <TimePeriodDataTable
       fullTable={table}
       tableHeadersConfig={
-        tableHeaders ?? getDefaultTableHeaderConfig(table.subjectMeta)
+        tableHeaders
+          ? mapTableHeadersConfig(tableHeaders, table.subjectMeta)
+          : getDefaultTableHeaderConfig(table.subjectMeta)
       }
     />
   );

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -4,6 +4,7 @@ import TimePeriodDataTable from '@common/modules/table-tool/components/TimePerio
 import permalinkService from '@common/modules/table-tool/services/permalinkService';
 import { Permalink } from '@common/modules/table-tool/types/permalink';
 import mapPermalink from '@common/modules/table-tool/utils/mapPermalink';
+import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
 import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/tableHeaders';
 import ButtonLink from '@frontend/components/ButtonLink';
 import Page from '@frontend/components/Page';
@@ -69,7 +70,10 @@ class PermalinkPage extends Component<Props> {
           fullTable={fullTable}
           tableHeadersConfig={
             configuration.tableHeadersConfig
-              ? configuration.tableHeadersConfig
+              ? mapTableHeadersConfig(
+                  configuration.tableHeadersConfig,
+                  fullTable.subjectMeta,
+                )
               : getDefaultTableHeaderConfig(fullTable.subjectMeta)
           }
         />


### PR DESCRIPTION
This PR fixes a regression due to earlier refactoring which removed `mapTableHeadersConfig` from being applied in `TimePeriodDataTable` itself. We now apply this function in all the relevant call sites (particularly in release content), so that our tables are not just populated with n/a's.