### PR TITLE
BAU-343 Full width permalink page

### DIFF
--- a/src/explore-education-statistics-common/src/components/CollapsibleList.module.scss
+++ b/src/explore-education-statistics-common/src/components/CollapsibleList.module.scss
@@ -1,3 +1,5 @@
+@import '../styles/govuk-base';
+
 .hidePrint {
   display: block;
   @media print {
@@ -6,6 +8,12 @@
 }
 
 .listContainer {
+  @include govuk-media-query($from: desktop) {
+    :global(.dfe-width-container--wide) & {
+      max-width: 66.6%;
+    }
+  }
+
   :global(.govuk-visually-hidden) {
     @media print {
       clip: unset !important;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.module.scss
@@ -8,6 +8,14 @@
   }
 }
 
+@include govuk-media-query($from: desktop) {
+  :global(.dfe-width-container--wide) {
+    figcaption {
+      max-width: 66.6%;
+    }
+  }
+}
+
 .container {
   display: inline-block;
   max-height: 80vh;

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -39,6 +39,7 @@ class PermalinkPage extends Component<Props> {
       <Page
         title={`'${fullTable.subjectMeta.subjectName}' from '${fullTable.subjectMeta.publicationName}'`}
         caption="Permanent data table"
+        wide
         breadcrumbs={[
           { name: 'Data tables', link: '/data-tables' },
           { name: 'Permanent link', link: '/data-tables' },


### PR DESCRIPTION
Set permalink page to be full page with to better facilitate large tables.

Restricted the width of the surrounding text - table titles, and footnotes,  following GDS guidelines for text legibility