### PR TITLE
EES-778 Allow creation of charts without filters

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilder.tsx
@@ -132,25 +132,9 @@ const ChartBuilder = ({
     ChartDefinition | undefined
   >();
 
-  const indicatorIds = Object.keys(data.metaData.indicators);
   const metaData = useMemo(
     () => (data.metaData && parseMetaData(data.metaData)) || emptyMetadata,
     [data.metaData],
-  );
-
-  const filterIdCombinations = useMemo<string[][]>(
-    () =>
-      Object.values(
-        data.result.reduce((filterSet, result) => {
-          const filterIds = Array.from(result.filters);
-
-          return {
-            ...filterSet,
-            [filterIds.join('_')]: filterIds,
-          };
-        }, {}),
-      ),
-    [data.result],
   );
 
   const [chartOptions, setChartOptions] = useState<ChartOptions>({
@@ -487,8 +471,6 @@ const ChartBuilder = ({
                   setDataSetAndConfiguration([...newData]);
                 }}
                 metaData={metaData}
-                indicatorIds={indicatorIds}
-                filterIds={filterIdCombinations}
                 selectedData={dataSetAndConfiguration}
                 chartType={selectedChartType}
                 capabilities={selectedChartType.capabilities}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilder.tsx
@@ -19,6 +19,11 @@ import TabsSection from '@common/components/TabsSection';
 import ChartRenderer, {
   ChartRendererProps,
 } from '@common/modules/charts/components/ChartRenderer';
+import HorizontalBarBlock from '@common/modules/charts/components/HorizontalBarBlock';
+import Infographic from '@common/modules/charts/components/Infographic';
+import LineChartBlock from '@common/modules/charts/components/LineChartBlock';
+import MapBlock from '@common/modules/charts/components/MapBlock';
+import VerticalBarBlock from '@common/modules/charts/components/VerticalBarBlock';
 import {
   ChartDefinition,
   ChartMetaData,
@@ -27,11 +32,6 @@ import {
   generateKeyFromDataSet,
   parseMetaData,
 } from '@common/modules/charts/util/chartUtils';
-import HorizontalBarBlock from '@common/modules/charts/components/HorizontalBarBlock';
-import Infographic from '@common/modules/charts/components/Infographic';
-import LineChartBlock from '@common/modules/charts/components/LineChartBlock';
-import MapBlock from '@common/modules/charts/components/MapBlock';
-import VerticalBarBlock from '@common/modules/charts/components/VerticalBarBlock';
 import {
   DataBlockRerequest,
   DataBlockResponse,
@@ -43,7 +43,6 @@ import {
   DataSetConfiguration,
 } from '@common/services/publicationService';
 import { Dictionary } from '@common/types';
-import classnames from 'classnames';
 import React, {
   useCallback,
   useEffect,
@@ -457,19 +456,13 @@ const ChartBuilder = ({
         <Details summary="Chart preview" open>
           <div className="govuk-width-container">
             {renderedChartProps === undefined ? (
-              <div
-                className={classnames(styles.preview)}
-                style={{
-                  width: chartOptions.width && `${chartOptions.width}px`,
-                  height: chartOptions.height && `${chartOptions.height}px`,
-                }}
-              >
+              <div className={styles.previewPlaceholder}>
                 {selectedChartType.axes.length > 0 ? (
-                  <span>Add data to view a preview of the chart</span>
+                  <p>Add data to view a preview of the chart</p>
                 ) : (
-                  <span>
+                  <p>
                     Configure the {selectedChartType.name} to view a preview
-                  </span>
+                  </p>
                 )}
               </div>
             ) : (

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataConfiguration.tsx
@@ -18,7 +18,7 @@ import React, { useState } from 'react';
 interface Props {
   configuration: DataSetConfiguration;
   capabilities: ChartCapabilities;
-
+  id: string;
   onConfigurationChange?: (value: DataSetConfiguration) => void;
 }
 
@@ -50,6 +50,7 @@ const lineStyleOptions: SelectOption[] = [
 const ChartDataConfiguration = ({
   configuration,
   capabilities,
+  id,
   onConfigurationChange,
 }: Props) => {
   const [config, setConfig] = useState<DataSetConfiguration>(configuration);
@@ -70,7 +71,7 @@ const ChartDataConfiguration = ({
         <div className={styles.chartDataLabelConfiguration}>
           <div className={styles.chartDataItem}>
             <FormTextInput
-              id="label"
+              id={`${id}-label`}
               name="label"
               value={config.label}
               label="Label"
@@ -85,7 +86,7 @@ const ChartDataConfiguration = ({
 
           <div className={styles.chartDataItem}>
             <FormTextInput
-              id="colour"
+              id={`${id}-colour`}
               name="colour"
               label="Colour"
               type="color"
@@ -103,7 +104,7 @@ const ChartDataConfiguration = ({
           {capabilities.dataSymbols && (
             <div className={styles.chartDataItem}>
               <FormSelect
-                id="symbol"
+                id={`${id}-symbol`}
                 name="symbol"
                 label="Symbol"
                 value={configuration.symbol}
@@ -121,7 +122,7 @@ const ChartDataConfiguration = ({
           {capabilities.lineStyle && (
             <div className={styles.chartDataItem}>
               <FormSelect
-                id="lineStyle"
+                id={`${id}-lineStyle`}
                 name="lineStyle"
                 label="Style"
                 value={configuration.lineStyle}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.module.scss
@@ -1,0 +1,27 @@
+@import '~explore-education-statistics-common/src/styles/govuk-base';
+
+.selectedData {
+  border-bottom: 1px solid govuk-colour('mid-grey');
+  margin-bottom: govuk-spacing(2);
+
+  &:last-of-type {
+    border-bottom: 0;
+  }
+}
+
+.selectedDataRow {
+  display: flex;
+}
+
+.selectedDataFilter {
+  flex-basis: 40%;
+  flex-grow: 1;
+}
+
+.selectedDataIndicator {
+  flex-basis: 40%;
+}
+
+.selectedDataAction {
+  margin-left: auto;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
@@ -128,11 +128,13 @@ const ChartDataSelector = ({
           indicator,
         };
 
-        const name = `${
-          metaData.indicators[indicator].label
-        } (${dataSet.filters
-          .map(filter => filtersByValue[filter].label)
-          .join(', ')})`;
+        const name = `${metaData.indicators[indicator].label}${
+          dataSet.filters.length
+            ? ` (${dataSet.filters
+                .map(filter => filtersByValue[filter].label)
+                .join(', ')})`
+            : ''
+        }`;
 
         const newChartData = {
           dataSet,
@@ -210,13 +212,16 @@ const ChartDataSelector = ({
                 >
                   <div className={styles.selectedData}>
                     <div className={styles.selectedDataRow}>
-                      <div className={styles.selectedDataFilter}>
-                        <span>
-                          {selected.dataSet.filters
-                            .map(filter => filtersByValue[filter].label)
-                            .join(', ')}
-                        </span>
-                      </div>
+                      {selected.dataSet.filters.length > 0 && (
+                        <div className={styles.selectedDataFilter}>
+                          <span>
+                            {selected.dataSet.filters
+                              .map(filter => filtersByValue[filter].label)
+                              .join(', ')}
+                          </span>
+                        </div>
+                      )}
+
                       <div className={styles.selectedDataIndicator}>
                         {metaData.indicators[selected.dataSet.indicator].label}
                       </div>

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
@@ -53,6 +53,8 @@ export interface ChartDataSetAndConfiguration {
   configuration: DataSetConfiguration;
 }
 
+const formId = 'chartDataSelectorForm';
+
 const ChartDataSelector = ({
   metaData,
   onDataRemoved,
@@ -158,12 +160,12 @@ const ChartDataSelector = ({
       }}
       render={form => (
         <>
-          <Form {...form} id="chartDataSelectorForm" showSubmitError>
+          <Form {...form} id={formId} showSubmitError>
             <div className="govuk-grid-row">
               {Object.entries(metaData.filters).map(([filterKey, filter]) => (
                 <div className="govuk-grid-column-one-third" key={filterKey}>
                   <FormFieldSelect
-                    id="filters"
+                    id={`${formId}-filters-${filterKey}`}
                     name={`filters.${filterKey}`}
                     label={filter.legend}
                     className="govuk-!-width-full"
@@ -182,7 +184,7 @@ const ChartDataSelector = ({
               ))}
               <div className="govuk-grid-column-one-third">
                 <FormFieldSelect
-                  id="indicators"
+                  id={`${formId}-indicators`}
                   name="indicator"
                   label="Indicator"
                   className="govuk-!-width-full"
@@ -244,6 +246,7 @@ const ChartDataSelector = ({
                         <ChartDataConfiguration
                           configuration={selected.configuration}
                           capabilities={capabilities}
+                          id={`${formId}-chartDataConfiguration-${index}`}
                           onConfigurationChange={(
                             value: DataSetConfiguration,
                           ) => {

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
@@ -1,5 +1,4 @@
 import ChartDataConfiguration from '@admin/pages/release/edit-release/manage-datablocks/components/ChartDataConfiguration';
-import styles from '@admin/pages/release/edit-release/manage-datablocks/components/graph-builder.module.scss';
 import Button from '@common/components/Button';
 import Details from '@common/components/Details';
 import { Form, FormFieldSelect, Formik } from '@common/components/form';
@@ -24,6 +23,7 @@ import { Dictionary } from '@common/types';
 import difference from 'lodash/difference';
 import mapValues from 'lodash/mapValues';
 import React, { useMemo, useState } from 'react';
+import styles from './ChartDataSelector.module.scss';
 
 interface FormValues {
   filters: Dictionary<string>;

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/DataBlockDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/DataBlockDetailsForm.tsx
@@ -14,14 +14,7 @@ import {
 import { TableHeadersConfig } from '@common/modules/table-tool/utils/tableHeaders';
 import { DataBlock, GeographicLevel } from '@common/services/dataBlockService';
 import { FormikProps } from 'formik';
-import React, {
-  ReactNode,
-  Reducer,
-  useEffect,
-  useReducer,
-  useRef,
-  useState,
-} from 'react';
+import React, { Reducer, useEffect, useReducer, useRef, useState } from 'react';
 import { ObjectSchemaDefinition } from 'yup';
 
 type BlockState = {
@@ -50,7 +43,6 @@ const reducer: BlockStateReducer = (
 };
 
 interface Props {
-  children?: ReactNode;
   initialValues?: DataBlockDetailsFormValues;
   query: TableDataQuery;
   tableHeaders: TableHeadersConfig;
@@ -67,7 +59,6 @@ export interface DataBlockDetailsFormValues {
 }
 
 const DataBlockDetailsForm = ({
-  children,
   initialValues = { title: '', name: '', source: '', customFootnotes: '' },
   query,
   tableHeaders,
@@ -138,63 +129,59 @@ const DataBlockDetailsForm = ({
       onSubmit={saveDataBlock}
       render={(form: FormikProps<DataBlockDetailsFormValues>) => {
         return (
-          <div>
-            <Form {...form} id="dataBlockDetails">
-              <FormGroup>
-                <FormFieldTextInput<DataBlockDetailsFormValues>
-                  id="data-block-name"
-                  name="name"
-                  label="Data block name"
-                  hint=" Name and save your data block before viewing it under the
+          <Form {...form} id="dataBlockDetails">
+            <h2>Data block details</h2>
+
+            <FormGroup>
+              <FormFieldTextInput<DataBlockDetailsFormValues>
+                id="data-block-name"
+                name="name"
+                label="Data block name"
+                hint=" Name and save your data block before viewing it under the
                     'View data blocks' tab at the top of this page."
-                  percentageWidth="one-half"
-                />
+                percentageWidth="one-half"
+              />
 
-                <hr />
-                {children}
+              <FormFieldTextArea<DataBlockDetailsFormValues>
+                id="data-block-title"
+                name="title"
+                label="Table title"
+                additionalClass="govuk-!-width-two-thirds"
+                rows={2}
+              />
 
-                <FormFieldTextArea<DataBlockDetailsFormValues>
-                  id="data-block-title"
-                  name="title"
-                  label="Table title"
-                  additionalClass="govuk-!-width-two-thirds"
-                  rows={2}
-                />
+              <FormFieldTextInput<DataBlockDetailsFormValues>
+                id="data-block-source"
+                name="source"
+                label="Source"
+                percentageWidth="two-thirds"
+              />
 
-                <FormFieldTextInput<DataBlockDetailsFormValues>
-                  id="data-block-source"
-                  name="source"
-                  label="Source"
-                  percentageWidth="two-thirds"
-                />
+              <FormFieldTextArea<DataBlockDetailsFormValues>
+                id="data-block-footnotes"
+                name="customFootnotes"
+                label="Footnotes"
+                additionalClass="govuk-!-width-two-thirds"
+              />
 
-                <FormFieldTextArea<DataBlockDetailsFormValues>
-                  id="data-block-footnotes"
-                  name="customFootnotes"
-                  label="Footnotes"
-                  additionalClass="govuk-!-width-two-thirds"
-                />
+              <Button type="submit" className="govuk-!-margin-top-6">
+                {currentDataBlock ? 'Update data block' : 'Save data block'}
+              </Button>
+            </FormGroup>
 
-                <Button type="submit" className="govuk-!-margin-top-6">
-                  {currentDataBlock ? 'Update data block' : 'Save data block'}
-                </Button>
-              </FormGroup>
-
-              {blockState.error && (
-                <p>
-                  An error occurred saving the data block, please try again
-                  later.
-                </p>
-              )}
-              {blockState.saved && (
-                <p>
-                  {blockState.updated
-                    ? 'The data block has been updated.'
-                    : 'The data block has been saved.'}
-                </p>
-              )}
-            </Form>
-          </div>
+            {blockState.error && (
+              <p>
+                An error occurred saving the data block, please try again later.
+              </p>
+            )}
+            {blockState.saved && (
+              <p>
+                {blockState.updated
+                  ? 'The data block has been updated.'
+                  : 'The data block has been saved.'}
+              </p>
+            )}
+          </Form>
         );
       }}
     />

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/DataBlockSourceWizard.tsx
@@ -129,7 +129,7 @@ const DataBlockSourceWizard = ({
           {wizardStepProps => (
             <>
               <WizardStepHeading {...wizardStepProps}>
-                Data block details
+                {initialValues ? 'Update data block' : 'Create data block'}
               </WizardStepHeading>
 
               {query && tableHeaders && table && (
@@ -168,6 +168,8 @@ const DataBlockSourceWizard = ({
                       tableHeadersConfig={tableHeaders}
                     />
                   </div>
+
+                  <hr />
 
                   <DataBlockDetailsForm
                     initialValues={initialValues}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/graph-builder.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/graph-builder.module.scss
@@ -1,3 +1,5 @@
+@import '~explore-education-statistics-common/src/styles/govuk-base';
+
 .chartContainer {
   display: flex;
 }
@@ -167,16 +169,14 @@
   margin-top: 30px;
 }
 
-.preview {
+.previewPlaceholder {
   align-items: center;
-  background-color: #eee;
+  background-color: govuk-colour('light-grey');
   display: flex;
+  font-size: 1.5rem;
+  font-weight: $govuk-font-weight-bold;
+  height: 300px;
   justify-content: center;
-
-  span {
-    font-size: 1.5em;
-    font-weight: bold;
-  }
 }
 
 .chartTypeUnavailable {

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/graph-builder.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/graph-builder.module.scss
@@ -115,29 +115,6 @@
   }
 }
 
-.selectedData {
-  border-bottom: 1px solid #b1b4b6;
-  margin-bottom: 1em;
-}
-
-.selectedDataRow {
-  display: flex;
-  flex-basis: 50%;
-}
-
-.selectedDataFilter {
-  flex-shrink: 0;
-  width: 34%;
-}
-
-.selectedDataIndicator {
-  width: 30%;
-}
-
-.selectedDataAction {
-  margin-left: auto;
-}
-
 .fullWidth {
   width: 100%;
 }
@@ -158,7 +135,7 @@
 
 .axisRange {
   display: flex;
-  flex-wrap: 0;
+  flex-wrap: nowrap;
 
   .formGroup {
     width: 50%;

--- a/src/explore-education-statistics-common/src/components/form/Form.tsx
+++ b/src/explore-education-statistics-common/src/components/form/Form.tsx
@@ -11,7 +11,7 @@ interface Props {
   children: ReactNode;
   id: string;
   submitId?: string;
-  displayErrorMessageOnUncaughtErrors?: boolean;
+  showSubmitError?: boolean;
 }
 
 /**
@@ -36,7 +36,7 @@ const Form = ({
   id,
   submitId = `${id}-submit`,
   formik,
-  displayErrorMessageOnUncaughtErrors = false,
+  showSubmitError = false,
 }: Props & { formik: FormikContext<{}> }) => {
   const { errors, touched } = formik;
 
@@ -77,7 +77,7 @@ const Form = ({
           await formik.submitForm();
         } catch (error) {
           if (error) {
-            if (displayErrorMessageOnUncaughtErrors) {
+            if (showSubmitError) {
               setSubmitError({
                 id: submitId,
                 message: error.message,

--- a/src/explore-education-statistics-common/src/components/form/__tests__/Form.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/Form.test.tsx
@@ -1,7 +1,7 @@
 import Yup from '@common/lib/validation/yup';
+import { fireEvent, render, wait } from '@testing-library/react';
 import { Formik } from 'formik';
 import React from 'react';
-import { fireEvent, render, wait } from '@testing-library/react';
 import Form from '../Form';
 
 describe('Form', () => {
@@ -186,7 +186,7 @@ describe('Form', () => {
         }}
       >
         {() => (
-          <Form id="test-form" displayErrorMessageOnUncaughtErrors>
+          <Form id="test-form" showSubmitError>
             The form
           </Form>
         )}
@@ -226,7 +226,7 @@ describe('Form', () => {
         onSubmit={onSubmit}
       >
         {() => (
-          <Form id="test-form" displayErrorMessageOnUncaughtErrors>
+          <Form id="test-form" showSubmitError>
             The form
           </Form>
         )}
@@ -272,7 +272,7 @@ describe('Form', () => {
         onSubmit={onSubmit}
       >
         {formik => (
-          <Form id="test-form" displayErrorMessageOnUncaughtErrors>
+          <Form id="test-form" showSubmitError>
             The form
             <button type="button" onClick={formik.handleReset}>
               Reset form

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -1,3 +1,4 @@
+import { PublicationSubjectMeta } from '@common/modules/table-tool/services/tableBuilderService';
 import {
   BoundaryLevel,
   DataBlockData,
@@ -16,7 +17,7 @@ import { Dictionary } from '@common/types';
 import { ReactNode } from 'react';
 
 export interface ChartMetaData {
-  filters: Dictionary<LabelValueMetadata>;
+  filters: PublicationSubjectMeta['filters'];
   indicators: Dictionary<LabelValueUnitMetadata>;
   locations: Dictionary<DataBlockLocationMetadata>;
   boundaryLevels?: BoundaryLevel[];

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/chartUtils.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/chartUtils.test.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { ChartMetaData } from '@common/modules/charts/types/chart';
+
+import Data from '@common/modules/charts/util/__tests__/__data__/chartUtils.data';
 import {
   createDataForAxis,
   createSortedDataForAxis,
@@ -9,8 +11,6 @@ import {
   AxisConfiguration,
   ChartDataSet,
 } from '@common/services/publicationService';
-
-import Data from '@common/modules/charts/util/__tests__/__data__/chartUtils.data';
 
 describe('chartUtils', () => {
   const dataSet23_1_72: ChartDataSet = {
@@ -261,9 +261,5 @@ describe('chartUtils', () => {
     expect(chartMeta.indicators).not.toBeUndefined();
     expect(chartMeta.locations).not.toBeUndefined();
     expect(chartMeta.timePeriod).not.toBeUndefined();
-
-    expect(chartMeta.filters['1']).not.toBeUndefined();
-    expect(chartMeta.filters['1'].label).toEqual('All pupils');
-    expect(chartMeta.filters['1'].value).toEqual('1');
   });
 });

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -179,7 +179,7 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
 
         return isActive ? (
           <div ref={ref}>
-            <Form {...form} id={formId} displayErrorMessageOnUncaughtErrors>
+            <Form {...form} id={formId} showSubmitError>
               {stepHeading}
 
               <FormGroup>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -101,7 +101,7 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
       render={(form: FormikProps<FormValues>) => {
         if (isActive) {
           return (
-            <Form {...form} id={formId} displayErrorMessageOnUncaughtErrors>
+            <Form {...form} id={formId} showSubmitError>
               <FormFieldset
                 id={`${formId}-levels`}
                 legend={stepHeading}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -109,7 +109,7 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
         return (
           <>
             {isActive ? (
-              <Form {...form} id={formId} displayErrorMessageOnUncaughtErrors>
+              <Form {...form} id={formId} showSubmitError>
                 <FormFieldset
                   error={getError('publicationId')}
                   id={`${formId}-publicationId`}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationSubjectForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationSubjectForm.tsx
@@ -89,7 +89,7 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
       }}
       render={(form: FormikProps<FormValues>) => {
         return isActive ? (
-          <Form {...form} id={formId} displayErrorMessageOnUncaughtErrors>
+          <Form {...form} id={formId} showSubmitError>
             <FormFieldRadioGroup<FormValues>
               name="subjectId"
               legend={stepHeading}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
@@ -159,7 +159,7 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
       }}
       render={(form: FormikProps<FormValues>) => {
         return isActive ? (
-          <Form id={formId} displayErrorMessageOnUncaughtErrors>
+          <Form id={formId} showSubmitError>
             <FormFieldset id={`${formId}-timePeriod`} legend={stepHeading}>
               <FormFieldSelect
                 name="start"


### PR DESCRIPTION
This PR:

- Adds multiple selects for each filter type e.g. Characteristics, School Types, etc when building a chart. This makes it easier for a user to select the filters in a more granular way, whereas before they were represented using a single select with all of the option combinations as comma separated strings.
- Fixing the filters UI also nicely fixes this ticket's issue.

## Other changes

- Adds validation and error messages to the `ChartDataSelector` form so that the user receives feedback properly.
- Tidy up how the `DataBlockDetailsForm` is presented to make it more obvious to the user. Currently it can be a little hidden away if the data table has footnotes.
- Refactors styles for `ChartDataSelector` out of the catch-all `graph-builder.module.scss` stylesheet. This needs further refactoring to separate out individual component styles.