### PR TITLE
BAU-289 Key stats help and guidance dialog position

### DIFF
--- a/src/explore-education-statistics-common/src/components/TabsSection.tsx
+++ b/src/explore-education-statistics-common/src/components/TabsSection.tsx
@@ -51,15 +51,10 @@ const TabsSection = forwardRef<HTMLElement, TabsSectionProps>(
     return (
       <section
         aria-labelledby={onMedia(tabProps['aria-labelledby'])}
-        className={classNames(
-          classes.panel,
-          'dfe-content-overflow',
-          styles.panel,
-          {
-            [classes.panelHidden]: tabProps.hidden,
-            [styles.forceFullWidth]: tabProps.hidden,
-          },
-        )}
+        className={classNames(classes.panel, styles.panel, {
+          [classes.panelHidden]: tabProps.hidden,
+          [styles.forceFullWidth]: tabProps.hidden,
+        })}
         id={id}
         ref={ref}
         role={onMedia('tabpanel')}

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Tabs renders multiple tabs correctly with titles 1`] = `
       </a>
     </li>
   </ul>
-  <section class="govuk-tabs__panel dfe-content-overflow panel"
+  <section class="govuk-tabs__panel panel"
            id="test-tabs-1"
            aria-labelledby="test-tabs-1-tab"
            role="tabpanel"
@@ -46,7 +46,7 @@ exports[`Tabs renders multiple tabs correctly with titles 1`] = `
       Test section 1 content
     </p>
   </section>
-  <section class="govuk-tabs__panel dfe-content-overflow panel govuk-visually-hidden forceFullWidth"
+  <section class="govuk-tabs__panel panel govuk-visually-hidden forceFullWidth"
            id="test-tabs-2"
            aria-labelledby="test-tabs-2-tab"
            role="tabpanel"
@@ -95,7 +95,7 @@ exports[`Tabs renders multiple tabs correctly without titles 1`] = `
       </a>
     </li>
   </ul>
-  <section class="govuk-tabs__panel dfe-content-overflow panel"
+  <section class="govuk-tabs__panel panel"
            id="test-tabs-1"
            aria-labelledby="test-tabs-1-tab"
            role="tabpanel"
@@ -105,7 +105,7 @@ exports[`Tabs renders multiple tabs correctly without titles 1`] = `
       Test section 1 content
     </p>
   </section>
-  <section class="govuk-tabs__panel dfe-content-overflow panel govuk-visually-hidden forceFullWidth"
+  <section class="govuk-tabs__panel panel govuk-visually-hidden forceFullWidth"
            id="test-tabs-2"
            aria-labelledby="test-tabs-2-tab"
            role="tabpanel"
@@ -137,7 +137,7 @@ exports[`Tabs renders single tab correctly 1`] = `
       </a>
     </li>
   </ul>
-  <section class="govuk-tabs__panel dfe-content-overflow panel"
+  <section class="govuk-tabs__panel panel"
            id="test-tabs-1"
            aria-labelledby="test-tabs-1-tab"
            role="tabpanel"

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/SummaryRenderer.module.scss
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/SummaryRenderer.module.scss
@@ -87,12 +87,14 @@
 
   details {
     background: govuk-colour('white');
+    bottom: -2rem;
     font-size: 1rem;
     margin: 0;
     min-height: 2rem;
     order: 2;
     padding: 0.2rem 0 0.2rem 0.5rem;
-    text-align: right;
+    position: absolute;
+    width: 100%;
 
     @include govuk-media-query($until: tablet) {
       order: 2;
@@ -100,41 +102,41 @@
     }
   }
 
-  /* stylelint-disable */
-  details[open] {
-    order: 1;
-    @include govuk-media-query($until: tablet) {
-      order: 2;
-    }
+  :global(.dfe-page-editing) & details {
+    order: 2;
+    position: static;
   }
-  /* stylelint-enable */
 
   :global(.govuk-details__summary) {
     margin-bottom: 0;
+    max-width: calc(100% - 1rem);
+    overflow: hidden;
     padding-left: 16px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 
-:global(.page-editing) .keyStatTile {
-  margin-bottom: 10%;
-}
-
-:global(.page-editing) .keyStat {
+:global(.dfe-page-editing) .keyStat {
   flex: 0 0 auto;
 }
 
 .keyStatTile :global(.govuk-details__text) {
   background: govuk-colour('white');
   box-sizing: border-box;
-  height: calc(100% - 1rem);
   margin-left: -8px;
+  max-height: 40vh;
   overflow: auto;
   position: absolute;
   text-align: left;
   width: 100%;
-  z-index: 1;
+  z-index: 2;
 
   @include govuk-media-query($until: tablet) {
+    position: static;
+  }
+
+  :global(.dfe-page-editing) & {
     position: static;
   }
 }
@@ -144,6 +146,6 @@
 }
 
 .keyStatEdit {
-  margin-top: 3rem;
+  margin-top: 1rem;
   order: 3;
 }

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/__snapshots__/DataBlock.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/__snapshots__/DataBlock.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`DataBlock renders map instead of chart 1`] = `
 <section
   aria-labelledby="test-datablock-charts-tab"
-  class="govuk-tabs__panel dfe-content-overflow panel"
+  class="govuk-tabs__panel panel"
   id="test-datablock-charts"
   role="tabpanel"
   tabindex="-1"


### PR DESCRIPTION
Updated key stats panel styling:

- Help details now appear below the indicator
- Restricted the help text title to one line, to prevent use of overly long titles and wrapping issues.