### PR TITLE
BAU-294 Permalink print page styling

### DIFF
--- a/src/explore-education-statistics-common/src/components/CollapsibleList.module.scss
+++ b/src/explore-education-statistics-common/src/components/CollapsibleList.module.scss
@@ -11,6 +11,9 @@
   @include govuk-media-query($from: desktop) {
     :global(.dfe-width-container--wide) & {
       max-width: 66.6%;
+      @media print {
+        max-width: 100%;
+      }
     }
   }
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.module.scss
@@ -12,6 +12,9 @@
   :global(.dfe-width-container--wide) {
     figcaption {
       max-width: 66.6%;
+      @media print {
+        max-width: 100%;
+      }
     }
   }
 }

--- a/src/explore-education-statistics-common/src/styles/_layout.scss
+++ b/src/explore-education-statistics-common/src/styles/_layout.scss
@@ -2,6 +2,10 @@
 
 .dfe-width-container--wide {
   max-width: $dfe-page-width-wide;
+  @media print {
+    max-width: none;
+    width: 100%;
+  }
 }
 
 .dfe-content-overflow {

--- a/src/explore-education-statistics-common/src/styles/patterns/_dfe-modifiers.scss
+++ b/src/explore-education-statistics-common/src/styles/patterns/_dfe-modifiers.scss
@@ -19,6 +19,18 @@
   }
 }
 
+.dfe-align--centre {
+  text-align: center;
+}
+
+.dfe-align--left {
+  text-align: left;
+}
+
+.dfe-align--right {
+  text-align: right;
+}
+
 .govuk-grid-column-one-quarter {
   .fixed {
     position: relative;

--- a/src/explore-education-statistics-frontend/src/components/CookieBanner.module.scss
+++ b/src/explore-education-statistics-frontend/src/components/CookieBanner.module.scss
@@ -8,4 +8,8 @@
   > div > p {
     margin: 0;
   }
+
+  @media print {
+    display: none;
+  }
 }

--- a/src/explore-education-statistics-frontend/src/components/PrintThisPage.module.scss
+++ b/src/explore-education-statistics-frontend/src/components/PrintThisPage.module.scss
@@ -1,3 +1,5 @@
+@import '~explore-education-statistics-common/src/styles/govuk-base';
+
 .mobileHidden {
   @media (pointer: coarse) {
     // Hide if touch device
@@ -15,6 +17,13 @@
 
 :global(.js-enabled) .printContainer {
   display: block;
+  margin-top: govuk-spacing(6);
+}
+
+:global(.js-enabled .dfe-align--centre) {
+  &.printContainer {
+    margin-top: govuk-spacing(0);
+  }
 }
 
 .alignCentre {

--- a/src/explore-education-statistics-frontend/src/components/PrintThisPage.module.scss
+++ b/src/explore-education-statistics-frontend/src/components/PrintThisPage.module.scss
@@ -25,7 +25,3 @@
     margin-top: govuk-spacing(0);
   }
 }
-
-.alignCentre {
-  text-align: center;
-}

--- a/src/explore-education-statistics-frontend/src/components/PrintThisPage.module.scss
+++ b/src/explore-education-statistics-frontend/src/components/PrintThisPage.module.scss
@@ -16,3 +16,7 @@
 :global(.js-enabled) .printContainer {
   display: block;
 }
+
+.alignCentre {
+  text-align: center;
+}

--- a/src/explore-education-statistics-frontend/src/components/PrintThisPage.module.scss
+++ b/src/explore-education-statistics-frontend/src/components/PrintThisPage.module.scss
@@ -19,9 +19,3 @@
   display: block;
   margin-top: govuk-spacing(6);
 }
-
-:global(.js-enabled .dfe-align--centre) {
-  &.printContainer {
-    margin-top: govuk-spacing(0);
-  }
-}

--- a/src/explore-education-statistics-frontend/src/components/PrintThisPage.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PrintThisPage.tsx
@@ -7,14 +7,12 @@ import {
 import styles from './PrintThisPage.module.scss';
 
 interface Props {
-  noMargin?: boolean;
-  alignCentre?: boolean;
+  className?: string;
 }
 
 const PrintThisPage = ({
   analytics,
-  noMargin,
-  alignCentre,
+  className,
   ...props
 }: AnalyticProps & Props) => {
   const openPrint = () => {
@@ -28,10 +26,7 @@ const PrintThisPage = ({
   return (
     <div
       className={classNames(
-        {
-          'govuk-!-margin-top-6': !noMargin,
-          [styles.alignCentre]: alignCentre,
-        },
+        className,
         'dfe-print-hidden',
         styles.printContainer,
         styles.mobileHidden,

--- a/src/explore-education-statistics-frontend/src/components/PrintThisPage.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PrintThisPage.tsx
@@ -6,7 +6,17 @@ import {
 } from '@frontend/services/googleAnalyticsService';
 import styles from './PrintThisPage.module.scss';
 
-const PrintThisPage = ({ analytics, ...props }: AnalyticProps) => {
+interface Props {
+  noMargin?: boolean;
+  alignCentre?: boolean;
+}
+
+const PrintThisPage = ({
+  analytics,
+  noMargin,
+  alignCentre,
+  ...props
+}: AnalyticProps & Props) => {
   const openPrint = () => {
     if (analytics) {
       logEvent(analytics.category, analytics.action, window.location.pathname);
@@ -18,7 +28,10 @@ const PrintThisPage = ({ analytics, ...props }: AnalyticProps) => {
   return (
     <div
       className={classNames(
-        'govuk-!-margin-top-6',
+        {
+          'govuk-!-margin-top-6': !noMargin,
+          [styles.alignCentre]: alignCentre,
+        },
         'dfe-print-hidden',
         styles.printContainer,
         styles.mobileHidden,

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.module.scss
@@ -1,0 +1,15 @@
+@media print {
+  :global(.govuk-breadcrumbs) {
+    display: none;
+  }
+  :global(.govuk-footer__inline-list) {
+    display: none;
+  }
+}
+
+.hidePrint {
+  display: block;
+  @media print {
+    display: none;
+  }
+}

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -8,8 +8,10 @@ import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHead
 import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/tableHeaders';
 import ButtonLink from '@frontend/components/ButtonLink';
 import Page from '@frontend/components/Page';
+import PrintThisPage from '@frontend/components/PrintThisPage';
 import { NextPageContext } from 'next';
 import React, { Component } from 'react';
+import styles from './PermalinkPage.module.scss';
 
 interface Props {
   permalink: string;
@@ -58,6 +60,14 @@ class PermalinkPage extends Component<Props> {
             </dl>
           </div>
           <div className="govuk-grid-column-one-third">
+            <PrintThisPage
+              alignCentre
+              noMargin
+              analytics={{
+                category: 'Page print',
+                action: 'Print this page link selected',
+              }}
+            />
             {/* <RelatedAside>
               <h3>Related content</h3>
             </RelatedAside> */}
@@ -74,21 +84,25 @@ class PermalinkPage extends Component<Props> {
               : getDefaultTableHeaderConfig(fullTable.subjectMeta)
           }
         />
-        <DownloadCsvButton
-          publicationSlug={`permalink-${data.created}-${data.title}`}
-          fullTable={fullTable}
-        />
-        <p className="govuk-body-s">Source: DfE prototype example statistics</p>
-        <h2 className="govuk-heading-m govuk-!-margin-top-9">
-          Create your own tables online
-        </h2>
-        <p>
-          Use our tool to build tables using our range of national and regional
-          data.
-        </p>
-        <ButtonLink as="/data-tables/" href="/data-tables">
-          Create tables
-        </ButtonLink>
+        <div className={styles.hidePrint}>
+          <DownloadCsvButton
+            publicationSlug={`permalink-${data.created}-${data.title}`}
+            fullTable={fullTable}
+          />
+          <p className="govuk-body-s">
+            Source: DfE prototype example statistics
+          </p>
+          <h2 className="govuk-heading-m govuk-!-margin-top-9">
+            Create your own tables online
+          </h2>
+          <p>
+            Use our tool to build tables using our range of national and
+            regional data.
+          </p>
+          <ButtonLink as="/data-tables/" href="/data-tables">
+            Create tables
+          </ButtonLink>
+        </div>
       </Page>
     );
   }

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -61,7 +61,7 @@ class PermalinkPage extends Component<Props> {
           </div>
           <div className="govuk-grid-column-one-third">
             <PrintThisPage
-              className="dfe-align--centre"
+              className="dfe-align--centre govuk-!-margin-top-0"
               analytics={{
                 category: 'Page print',
                 action: 'Print this page link selected',

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -61,8 +61,7 @@ class PermalinkPage extends Component<Props> {
           </div>
           <div className="govuk-grid-column-one-third">
             <PrintThisPage
-              alignCentre
-              noMargin
+              className="dfe-align--centre"
               analytics={{
                 category: 'Page print',
                 action: 'Print this page link selected',


### PR DESCRIPTION
Added 'Print this page' CTA to permalink page. 
Added some extra props to the print button component to allow for better alignment within the permalink page.
Updated print styles to make better use of space for text, and also hidden unnecessary elements on the printed page. 

