### PR TITLE
BAU-282 Publish Jest test artifacts as single test run

### DIFF
--- a/azure-pipelines.dfe.yml
+++ b/azure-pipelines.dfe.yml
@@ -254,9 +254,10 @@ jobs:
         displayName: 'Publish frontend test results'
         inputs:
           testResultsFormat: 'JUnit'
-          testResultsFiles: '**/junit.xml'
+          testResultsFiles: 'explore-education-statistics-*/junit-*.xml'
           searchFolder: './src'
-          testRunTitle: 'Frontend Jest tests'
+          testRunTitle: 'Release Jest tests'
+          mergeTestResults: true
 
   - job: 'FrontendArtifactDev01'
     dependsOn: 'Frontend'

--- a/azure-pipelines.pr.yml
+++ b/azure-pipelines.pr.yml
@@ -246,9 +246,10 @@ jobs:
         displayName: 'Publish frontend test results'
         inputs:
           testResultsFormat: 'JUnit'
-          testResultsFiles: '**/junit.xml'
+          testResultsFiles: 'explore-education-statistics-*/junit-*.xml'
           searchFolder: './src'
-          testRunTitle: 'Frontend Jest tests'
+          testRunTitle: 'PR Jest tests'
+          mergeTestResults: true
   - job: 'MiscellaneousArtifacts'
     pool:
       vmImage: 'ubuntu-16.04'

--- a/src/explore-education-statistics-admin/package.json
+++ b/src/explore-education-statistics-admin/package.json
@@ -191,6 +191,11 @@
       "<rootDir>/node_modules/jest-watch-typeahead/testname.js"
     ]
   },
+  "jest-junit": {
+    "ancestorSeparator": " › ",
+    "suiteName": "Admin Jest tests",
+    "outputName": "junit-admin.xml"
+  },
   "browserslist": [
     "ie>=11",
     "safari>=12",

--- a/src/explore-education-statistics-common/package-lock.json
+++ b/src/explore-education-statistics-common/package-lock.json
@@ -7521,6 +7521,16 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -10330,6 +10340,13 @@
         "loader-utils": "^1.2.3",
         "schema-utils": "^2.0.0"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -14988,6 +15005,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -20600,7 +20624,8 @@
     "use-immer": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.3.5.tgz",
-      "integrity": "sha512-0CNaJ/CtnF8/OmM4NBG7R0rhWMMQtgXPmWbakv8CK5z8dXeMaBYValFDXpkjBnToknjKJZuEPcoUZYd0rnQL2Q=="
+      "integrity": "sha512-0CNaJ/CtnF8/OmM4NBG7R0rhWMMQtgXPmWbakv8CK5z8dXeMaBYValFDXpkjBnToknjKJZuEPcoUZYd0rnQL2Q==",
+      "dev": true
     },
     "use-memo-one": {
       "version": "1.1.1",
@@ -20901,6 +20926,8 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
           "dependencies": {

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -145,6 +145,8 @@
     ]
   },
   "jest-junit": {
-    "ancestorSeparator": " › "
+    "ancestorSeparator": " › ",
+    "suiteName": "Common Jest tests",
+    "outputName": "junit-common.xml"
   }
 }

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -146,8 +146,5 @@
   },
   "jest-junit": {
     "ancestorSeparator": " › "
-  },
-  "dependencies": {
-    "use-immer": "^0.3.5"
   }
 }

--- a/src/explore-education-statistics-frontend/package.json
+++ b/src/explore-education-statistics-frontend/package.json
@@ -179,6 +179,8 @@
     ]
   },
   "jest-junit": {
-    "ancestorSeparator": " › "
+    "ancestorSeparator": " › ",
+    "suiteName": "Frontend Jest tests",
+    "outputName": "junit-frontend.xml"
   }
 }


### PR DESCRIPTION
This PR changes the way that Jest test artifacts for the frontend are being published. Previously we were publishing them as several test runs in Azure DevOps, but now we can merge them into a single test run for the PR and Release pipelines respectively.

This has the main advantage of Jest tests being in a single artifact, rather than multiple.