### PR TITLE
EES-1303 Ensure data blocks with one result will appear in list of po…

### DIFF
--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyIndicatorSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyIndicatorSelectForm.tsx
@@ -7,6 +7,7 @@ import {
   locationLevelKeys,
   TimePeriodQuery,
 } from '@common/modules/table-tool/services/tableBuilderService';
+import orderBy from 'lodash/orderBy';
 import React, { useMemo, useState } from 'react';
 
 interface Props {
@@ -80,10 +81,13 @@ const KeyIndicatorSelectForm = ({
             label: 'Select a data block',
             value: '',
           },
-          ...keyIndicatorDatablocks.map(dataBlock => ({
-            label: dataBlock.name || '',
-            value: dataBlock.id || '',
-          })),
+          ...orderBy(
+            keyIndicatorDatablocks.map(dataBlock => ({
+              label: dataBlock.name || '',
+              value: dataBlock.id || '',
+            })),
+            'label',
+          ),
         ]}
       />
       {getKeyStatPreview()}

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyIndicatorSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyIndicatorSelectForm.tsx
@@ -29,6 +29,14 @@ const KeyIndicatorSelectForm = ({
     return availableDataBlocks.filter(db => {
       const req = db.dataBlockRequest;
       const timePeriod = req.timePeriod as TimePeriodQuery;
+      if (
+        Object.keys(req).filter(key => locationLevelKeys.includes(key as any))
+          .length !== 1
+      ) {
+        console.log(
+          'WARN: Request should contain single location from locationLevelKeys!',
+        );
+      }
       return (
         req.indicators.length !== 1 ||
         timePeriod.startYear !== timePeriod.endYear ||

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyIndicatorSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyIndicatorSelectForm.tsx
@@ -5,11 +5,9 @@ import { FormSelect } from '@common/components/form';
 import KeyStatTile from '@common/modules/find-statistics/components/KeyStatTile';
 import {
   locationLevelKeys,
-  LocationLevelKeys,
   TimePeriodQuery,
 } from '@common/modules/table-tool/services/tableBuilderService';
 import React, { useMemo, useState } from 'react';
-import { DataBlockRequest } from '@common/services/dataBlockService';
 
 interface Props {
   onSelect: (selectedDataBlockId: string) => void;
@@ -68,6 +66,7 @@ const KeyIndicatorSelectForm = ({
         label={label}
         value={selectedDataBlockId}
         onChange={e => setSelectedDataBlockId(e.target.value)}
+        order={[]}
         options={[
           {
             label: 'Select a data block',

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyStatSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyStatSelectForm.tsx
@@ -34,6 +34,7 @@ const KeyStatSelectForm = ({
         key => req[key]?.length !== 1,
       );
       if (!hasSingleLocation) {
+        // eslint-disable-next-line no-console
         console.warn(
           'dataBlockRequest should contain single location from locationLevelKeys!',
         );

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyStatSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyStatSelectForm.tsx
@@ -17,16 +17,16 @@ interface Props {
   label?: string;
 }
 
-const KeyIndicatorSelectForm = ({
+const KeyStatSelectForm = ({
   onSelect,
   onCancel = () => {},
   hideCancel = false,
-  label = 'Select a key indicator',
+  label = 'Select a key statistic',
 }: Props) => {
   const { availableDataBlocks } = useReleaseState();
   const [selectedDataBlockId, setSelectedDataBlockId] = useState('');
 
-  const keyIndicatorDatablocks = useMemo(() => {
+  const keyStatDatablocks = useMemo(() => {
     return availableDataBlocks.filter(db => {
       const req = db.dataBlockRequest;
       const timePeriod = req.timePeriod as TimePeriodQuery;
@@ -82,7 +82,7 @@ const KeyIndicatorSelectForm = ({
             value: '',
           },
           ...orderBy(
-            keyIndicatorDatablocks.map(dataBlock => ({
+            keyStatDatablocks.map(dataBlock => ({
               label: dataBlock.name || '',
               value: dataBlock.id || '',
             })),
@@ -103,4 +103,4 @@ const KeyIndicatorSelectForm = ({
   );
 };
 
-export default KeyIndicatorSelectForm;
+export default KeyStatSelectForm;

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyStatSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyStatSelectForm.tsx
@@ -30,18 +30,18 @@ const KeyStatSelectForm = ({
     return availableDataBlocks.filter(db => {
       const req = db.dataBlockRequest;
       const timePeriod = req.timePeriod as TimePeriodQuery;
-      if (
-        Object.keys(req).filter(key => locationLevelKeys.includes(key as any))
-          .length !== 1
-      ) {
-        console.log(
-          'WARN: Request should contain single location from locationLevelKeys!',
+      const hasSingleLocation = !locationLevelKeys.some(
+        key => req[key]?.length !== 1,
+      );
+      if (!hasSingleLocation) {
+        console.warn(
+          'dataBlockRequest should contain single location from locationLevelKeys!',
         );
       }
       return (
         req.indicators.length !== 1 ||
         timePeriod.startYear !== timePeriod.endYear ||
-        locationLevelKeys.some(key => req[key]?.length !== 1)
+        !hasSingleLocation
         // NOTE(mark): No check for number of filters because they cannot tell us whether
         // there is a single result
       );

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/KeyStatistics.tsx
@@ -10,7 +10,7 @@ import {
   Publication,
 } from '@common/services/publicationService';
 import React, { useCallback, useEffect, useState } from 'react';
-import KeyIndicatorSelectForm from './KeyIndicatorSelectForm';
+import KeyStatSelectForm from './KeyStatSelectForm';
 
 export interface KeyStatisticsProps {
   release: AbstractRelease<EditableContentBlock, Publication>;
@@ -119,7 +119,7 @@ const AddKeyStatistics = ({ release }: KeyStatisticsProps) => {
   return (
     <>
       {isFormOpen ? (
-        <KeyIndicatorSelectForm
+        <KeyStatSelectForm
           onSelect={addKeyStatToSection}
           onCancel={() => setIsFormOpen(false)}
         />


### PR DESCRIPTION
…ssible key stats

This fixes the bug where data blocks that returned one result didn't
appear in the list of data blocks available to add as a key stat tile.
This bug occurred because in a data block request, you only have a flat
array of filter GUIDs. This doesn't tell you whether those filters
belong to the same category or not, and therefore it is not possible from
the response alone to tell whether that data block will return one or
more results.

My quick (imperfect) fix is continue to filter data blocks that contain more than
one timePeriod or indicator, but allow data blocks with any number of
filters. This means that data blocks that contain multiple results may
still appear as an option for a key stat tile if they have multiple
filters from the same filter group selected.