### PR TITLE
EES-1212 Add source to datablock charts/tables

### DIFF
--- a/src/explore-education-statistics-common/src/components/CollapsibleList.tsx
+++ b/src/explore-education-statistics-common/src/components/CollapsibleList.tsx
@@ -63,7 +63,7 @@ const CollapsibleList = ({
             {collapsed
               ? `Show ${collapsedCount} ${
                   listItems && listItems.length > collapsedCount ? 'more' : ''
-                } items`
+                } item${collapsedCount > 1 ? 's' : ''}`
               : 'Collapse list'}
           </ButtonText>
         </div>

--- a/src/explore-education-statistics-common/src/components/__tests__/CollapsibleList.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/CollapsibleList.test.tsx
@@ -1,5 +1,5 @@
-import { render, fireEvent } from '@testing-library/react';
 import CollapsibleList from '@common/components/CollapsibleList';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
 describe('CollapsibleList', () => {
@@ -21,6 +21,26 @@ describe('CollapsibleList', () => {
     expect(getByText('Item 5')).toHaveClass('govuk-visually-hidden');
 
     expect(queryByText('Show 2 more items'));
+  });
+
+  test('renders 5 items with 1 visually hidden', () => {
+    const { getByText, queryByText } = render(
+      <CollapsibleList collapseAfter={4}>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+        <li>Item 4</li>
+        <li>Item 5</li>
+      </CollapsibleList>,
+    );
+
+    expect(getByText('Item 1')).not.toHaveClass('govuk-visually-hidden');
+    expect(getByText('Item 2')).not.toHaveClass('govuk-visually-hidden');
+    expect(getByText('Item 3')).not.toHaveClass('govuk-visually-hidden');
+    expect(getByText('Item 4')).not.toHaveClass('govuk-visually-hidden');
+    expect(getByText('Item 5')).toHaveClass('govuk-visually-hidden');
+
+    expect(queryByText('Show 1 more item'));
   });
 
   test('renders no visually hidden items when `collapseAfter` is more than the list size', () => {

--- a/src/explore-education-statistics-common/src/modules/charts/components/ChartRenderer.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/ChartRenderer.tsx
@@ -25,7 +25,9 @@ const DynamicMapBlock = dynamic(
   },
 );
 
-export type ChartRendererProps =
+export type ChartRendererProps = {
+  source?: string;
+} & (
   | ({
       type: 'line';
     } & LineChartProps)
@@ -40,9 +42,10 @@ export type ChartRendererProps =
     } & MapBlockProps)
   | ({
       type: 'infographic';
-    } & InfographicChartProps);
+    } & InfographicChartProps)
+);
 
-function ChartRenderer({ title, ...props }: ChartRendererProps) {
+function ChartRenderer({ title, source, ...props }: ChartRendererProps) {
   const { data, meta } = props;
 
   const [legendProps, setLegendProps] = useState<LegendProps>();
@@ -104,6 +107,8 @@ function ChartRenderer({ title, ...props }: ChartRendererProps) {
           )}
 
         <FigureFootnotes footnotes={meta.footnotes} />
+
+        {source && <p className="govuk-body-s">Source: {source}</p>}
       </figure>
     );
   }

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockRenderer.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockRenderer.tsx
@@ -58,22 +58,20 @@ const DataBlockRenderer = ({
               );
 
               return (
-                <>
-                  <TimePeriodDataTable
-                    key={index}
-                    fullTable={fullTable}
-                    captionTitle={dataBlock?.heading}
-                    source={dataBlock?.source}
-                    tableHeadersConfig={
-                      table.tableHeaders
-                        ? mapTableHeadersConfig(
-                            table.tableHeaders,
-                            fullTable.subjectMeta,
-                          )
-                        : getDefaultTableHeaderConfig(fullTable.subjectMeta)
-                    }
-                  />
-                </>
+                <TimePeriodDataTable
+                  key={index}
+                  fullTable={fullTable}
+                  captionTitle={dataBlock?.heading}
+                  source={dataBlock?.source}
+                  tableHeadersConfig={
+                    table.tableHeaders
+                      ? mapTableHeadersConfig(
+                          table.tableHeaders,
+                          fullTable.subjectMeta,
+                        )
+                      : getDefaultTableHeaderConfig(fullTable.subjectMeta)
+                  }
+                />
               );
             })}
 

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockRenderer.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockRenderer.tsx
@@ -101,6 +101,7 @@ const DataBlockRenderer = ({
                     key={key}
                     data={dataBlockResponse}
                     meta={parseMetaData(dataBlockResponse.metaData)}
+                    source={dataBlock?.source}
                     releaseId={releaseId}
                     getInfographic={getInfographic}
                   />
@@ -113,6 +114,7 @@ const DataBlockRenderer = ({
                   key={key}
                   data={dataBlockResponse}
                   meta={parseMetaData(dataBlockResponse.metaData)}
+                  source={dataBlock?.source}
                 />
               );
             })}

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockRenderer.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockRenderer.tsx
@@ -58,19 +58,22 @@ const DataBlockRenderer = ({
               );
 
               return (
-                <TimePeriodDataTable
-                  key={index}
-                  fullTable={fullTable}
-                  captionTitle={dataBlock?.heading}
-                  tableHeadersConfig={
-                    table.tableHeaders
-                      ? mapTableHeadersConfig(
-                          table.tableHeaders,
-                          fullTable.subjectMeta,
-                        )
-                      : getDefaultTableHeaderConfig(fullTable.subjectMeta)
-                  }
-                />
+                <>
+                  <TimePeriodDataTable
+                    key={index}
+                    fullTable={fullTable}
+                    captionTitle={dataBlock?.heading}
+                    source={dataBlock?.source}
+                    tableHeadersConfig={
+                      table.tableHeaders
+                        ? mapTableHeadersConfig(
+                            table.tableHeaders,
+                            fullTable.subjectMeta,
+                          )
+                        : getDefaultTableHeaderConfig(fullTable.subjectMeta)
+                    }
+                  />
+                </>
               );
             })}
 

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/__snapshots__/DataBlockRenderer.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/__snapshots__/DataBlockRenderer.test.tsx.snap
@@ -301,6 +301,7 @@ exports[`DataBlockRenderer renders map instead of chart 1`] = `
         </div>
       </div>
     </div>
+    
   </figure>
 </section>
 `;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadExcelButton.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadExcelButton.tsx
@@ -146,26 +146,24 @@ const DownloadExcelButton = ({
   tableRef,
 }: Props) => {
   const { footnotes } = subjectMeta;
-
-  // Try to find table element within the ref
-  let tableEl: HTMLTableElement | null = null;
-
-  if (tableRef.current) {
-    if (tableRef.current.tagName.toLowerCase() === 'table') {
-      tableEl = tableRef.current as HTMLTableElement;
-    } else {
-      tableEl = tableRef.current.querySelector('table');
-    }
-
-    // Don't render anything if no table could be found
-    if (!tableEl) {
-      return null;
-    }
-  }
-
   return (
     <ButtonText
       onClick={() => {
+        // Try to find table element within the ref
+        let tableEl: HTMLTableElement | null = null;
+
+        if (tableRef.current) {
+          if (tableRef.current.tagName.toLowerCase() === 'table') {
+            tableEl = tableRef.current as HTMLTableElement;
+          } else {
+            tableEl = tableRef.current.querySelector('table');
+          }
+        }
+
+        if (!tableEl) {
+          return;
+        }
+
         const workBook = utils.table_to_book(tableEl, {
           raw: true,
         });

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
@@ -14,11 +14,17 @@ interface Props {
   rowHeaders: HeaderGroup[];
   rows: string[][];
   footnotes?: FullTableMeta['footnotes'];
+  source?: string;
 }
 
 const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
   (props, ref) => {
-    const { caption, captionId = 'dataTableCaption', footnotes = [] } = props;
+    const {
+      caption,
+      captionId = 'dataTableCaption',
+      footnotes = [],
+      source,
+    } = props;
 
     const containerRef = useRef<HTMLDivElement>(null);
     const mainTableRef = useRef<HTMLTableElement>(null);
@@ -103,6 +109,8 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
         </div>
 
         <FigureFootnotes footnotes={footnotes} />
+
+        {source && <p className="govuk-body-s">Source: {source}</p>}
       </figure>
     );
   },

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -25,6 +25,7 @@ interface Props {
   captionTitle?: string;
   fullTable: FullTable;
   tableHeadersConfig: TableHeadersConfig;
+  source?: string;
 }
 
 const createFilterGroupHeaders = (group: Filter[]): HeaderSubGroup[] =>
@@ -119,7 +120,10 @@ const createHeaders = (
 };
 
 const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
-  ({ fullTable, tableHeadersConfig, captionTitle }: Props, dataTableRef) => {
+  (
+    { fullTable, tableHeadersConfig, captionTitle, source }: Props,
+    dataTableRef,
+  ) => {
     const { subjectMeta, results } = fullTable;
 
     if (results.length === 0) {
@@ -232,6 +236,7 @@ const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
           rows={rows}
           ref={dataTableRef}
           footnotes={subjectMeta.footnotes}
+          source={source}
         />
       </ErrorBoundary>
     );

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -1,109 +1,110 @@
 import FormattedDate from '@common/components/FormattedDate';
 import DownloadCsvButton from '@common/modules/table-tool/components/DownloadCsvButton';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
-import permalinkService from '@common/modules/table-tool/services/permalinkService';
-import { Permalink } from '@common/modules/table-tool/types/permalink';
+import permalinkService, {
+  UnmappedPermalink,
+} from '@common/modules/table-tool/services/permalinkService';
 import mapPermalink from '@common/modules/table-tool/utils/mapPermalink';
 import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
 import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/tableHeaders';
 import ButtonLink from '@frontend/components/ButtonLink';
 import Page from '@frontend/components/Page';
 import PrintThisPage from '@frontend/components/PrintThisPage';
-import { NextPageContext } from 'next';
-import React, { Component } from 'react';
+import { NextPage, NextPageContext } from 'next';
+import React from 'react';
 import styles from './PermalinkPage.module.scss';
 
 interface Props {
-  permalink: string;
-  data: Permalink;
+  data: UnmappedPermalink;
 }
 
-class PermalinkPage extends Component<Props> {
-  public static async getInitialProps({ query }: NextPageContext) {
-    const { permalink } = query;
+const PermalinkPage: NextPage<Props> = ({ data }) => {
+  const { fullTable, query } = mapPermalink(data);
+  const { configuration } = query;
 
-    const request = permalinkService.getPermalink(permalink as string);
+  const publicationSlug = `permalink-${data.created}-${data.title}`;
 
-    const data = await request;
-
-    return {
-      data,
-      permalink,
-    };
-  }
-
-  public render() {
-    const { data } = this.props;
-    const { fullTable, query } = mapPermalink(data);
-    const { configuration } = query;
-
-    return (
-      <Page
-        title={`'${fullTable.subjectMeta.subjectName}' from '${fullTable.subjectMeta.publicationName}'`}
-        caption="Permanent data table"
-        wide
-        breadcrumbs={[
-          { name: 'Data tables', link: '/data-tables' },
-          { name: 'Permanent link', link: '/data-tables' },
-        ]}
-      >
-        <div className="govuk-grid-row">
-          <div className="govuk-grid-column-two-thirds">
-            <dl className="dfe-meta-content govuk-!-margin-bottom-9">
-              <dt className="govuk-caption-m">Created:</dt>
-              <dd data-testid="created-date">
-                <strong>
-                  {' '}
-                  <FormattedDate>{data.created}</FormattedDate>{' '}
-                </strong>
-              </dd>
-            </dl>
-          </div>
-          <div className="govuk-grid-column-one-third">
-            <PrintThisPage
-              className="dfe-align--centre govuk-!-margin-top-0"
-              analytics={{
-                category: 'Page print',
-                action: 'Print this page link selected',
-              }}
-            />
-            {/* <RelatedAside>
+  return (
+    <Page
+      title={`'${fullTable.subjectMeta.subjectName}' from '${fullTable.subjectMeta.publicationName}'`}
+      caption="Permanent data table"
+      wide
+      breadcrumbs={[
+        { name: 'Data tables', link: '/data-tables' },
+        { name: 'Permanent link', link: '/data-tables' },
+      ]}
+    >
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-two-thirds">
+          <dl className="dfe-meta-content govuk-!-margin-bottom-9">
+            <dt className="govuk-caption-m">Created:</dt>
+            <dd data-testid="created-date">
+              <strong>
+                {' '}
+                <FormattedDate>{data.created}</FormattedDate>{' '}
+              </strong>
+            </dd>
+          </dl>
+        </div>
+        <div className="govuk-grid-column-one-third">
+          <PrintThisPage
+            className="dfe-align--centre govuk-!-margin-top-0"
+            analytics={{
+              category: 'Page print',
+              action: 'Print this page link selected',
+            }}
+          />
+          {/* <RelatedAside>
               <h3>Related content</h3>
             </RelatedAside> */}
-          </div>
         </div>
-        <TimePeriodDataTable
-          fullTable={fullTable}
-          source="DfE prototype example statistics"
-          tableHeadersConfig={
-            configuration.tableHeadersConfig
-              ? mapTableHeadersConfig(
-                  configuration.tableHeadersConfig,
-                  fullTable.subjectMeta,
-                )
-              : getDefaultTableHeaderConfig(fullTable.subjectMeta)
-          }
-        />
-        <div className={styles.hidePrint}>
-          <DownloadCsvButton
-            publicationSlug={`permalink-${data.created}-${data.title}`}
-            fullTable={fullTable}
-          />
+      </div>
+      <TimePeriodDataTable
+        fullTable={fullTable}
+        source="DfE prototype example statistics"
+        tableHeadersConfig={
+          configuration.tableHeadersConfig
+            ? mapTableHeadersConfig(
+                configuration.tableHeadersConfig,
+                fullTable.subjectMeta,
+              )
+            : getDefaultTableHeaderConfig(fullTable.subjectMeta)
+        }
+      />
+      <div className={styles.hidePrint}>
+        <ul className="govuk-list">
+          <li>
+            <DownloadCsvButton
+              publicationSlug={publicationSlug}
+              fullTable={fullTable}
+            />
+          </li>
+        </ul>
 
-          <h2 className="govuk-heading-m govuk-!-margin-top-9">
-            Create your own tables online
-          </h2>
-          <p>
-            Use our tool to build tables using our range of national and
-            regional data.
-          </p>
-          <ButtonLink as="/data-tables/" href="/data-tables">
-            Create tables
-          </ButtonLink>
-        </div>
-      </Page>
-    );
-  }
-}
+        <h2 className="govuk-heading-m govuk-!-margin-top-9">
+          Create your own tables online
+        </h2>
+        <p>
+          Use our tool to build tables using our range of national and regional
+          data.
+        </p>
+        <ButtonLink as="/data-tables/" href="/data-tables">
+          Create tables
+        </ButtonLink>
+      </div>
+    </Page>
+  );
+};
+
+PermalinkPage.getInitialProps = async ({ query }: NextPageContext) => {
+  const { permalink } = query;
+  const request = permalinkService.getPermalink(permalink as string);
+
+  const data = await request;
+
+  return {
+    data,
+  };
+};
 
 export default PermalinkPage;

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -1,5 +1,6 @@
 import FormattedDate from '@common/components/FormattedDate';
 import DownloadCsvButton from '@common/modules/table-tool/components/DownloadCsvButton';
+import DownloadExcelButton from '@common/modules/table-tool/components/DownloadExcelButton';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
 import permalinkService, {
   UnmappedPermalink,
@@ -11,7 +12,7 @@ import ButtonLink from '@frontend/components/ButtonLink';
 import Page from '@frontend/components/Page';
 import PrintThisPage from '@frontend/components/PrintThisPage';
 import { NextPage, NextPageContext } from 'next';
-import React from 'react';
+import React, { useRef } from 'react';
 import styles from './PermalinkPage.module.scss';
 
 interface Props {
@@ -19,6 +20,7 @@ interface Props {
 }
 
 const PermalinkPage: NextPage<Props> = ({ data }) => {
+  const tableRef = useRef<HTMLDivElement>(null);
   const { fullTable, query } = mapPermalink(data);
   const { configuration } = query;
 
@@ -59,24 +61,34 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
             </RelatedAside> */}
         </div>
       </div>
-      <TimePeriodDataTable
-        fullTable={fullTable}
-        source="DfE prototype example statistics"
-        tableHeadersConfig={
-          configuration.tableHeadersConfig
-            ? mapTableHeadersConfig(
-                configuration.tableHeadersConfig,
-                fullTable.subjectMeta,
-              )
-            : getDefaultTableHeaderConfig(fullTable.subjectMeta)
-        }
-      />
+      <div ref={tableRef}>
+        <TimePeriodDataTable
+          fullTable={fullTable}
+          source="DfE prototype example statistics"
+          tableHeadersConfig={
+            configuration.tableHeadersConfig
+              ? mapTableHeadersConfig(
+                  configuration.tableHeadersConfig,
+                  fullTable.subjectMeta,
+                )
+              : getDefaultTableHeaderConfig(fullTable.subjectMeta)
+          }
+        />
+      </div>
+
       <div className={styles.hidePrint}>
         <ul className="govuk-list">
           <li>
             <DownloadCsvButton
               publicationSlug={publicationSlug}
               fullTable={fullTable}
+            />
+          </li>
+          <li>
+            <DownloadExcelButton
+              tableRef={tableRef}
+              publicationSlug={publicationSlug}
+              subjectMeta={fullTable.subjectMeta}
             />
           </li>
         </ul>

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -74,6 +74,7 @@ class PermalinkPage extends Component<Props> {
         </div>
         <TimePeriodDataTable
           fullTable={fullTable}
+          source="DfE prototype example statistics"
           tableHeadersConfig={
             configuration.tableHeadersConfig
               ? mapTableHeadersConfig(
@@ -88,9 +89,7 @@ class PermalinkPage extends Component<Props> {
             publicationSlug={`permalink-${data.created}-${data.title}`}
             fullTable={fullTable}
           />
-          <p className="govuk-body-s">
-            Source: DfE prototype example statistics
-          </p>
+
           <h2 className="govuk-heading-m govuk-!-margin-top-9">
             Create your own tables online
           </h2>


### PR DESCRIPTION
This PR adds data block `source` information to charts and tables.

## Other changes

- Fixes `PermalinkPage` not having a button for downloading the XLSX version of the table.
- De-pluralises text used for the `CollapsibleList` button if there is only 1 hidden list item.
