### PR TITLE
EES-1571 Fix server validation errors not being correctly handled by useFormSubmit

### DIFF
--- a/src/explore-education-statistics-admin/src/components/ErrorBoundary.tsx
+++ b/src/explore-education-statistics-admin/src/components/ErrorBoundary.tsx
@@ -70,7 +70,7 @@ class ErrorBoundary extends React.Component<RouteComponentProps, State> {
     this.isHandlingErrors = false;
 
     try {
-      return callback();
+      return await callback();
     } finally {
       this.isHandlingErrors = true;
     }

--- a/src/explore-education-statistics-admin/src/hooks/useFormSubmit.ts
+++ b/src/explore-education-statistics-admin/src/hooks/useFormSubmit.ts
@@ -45,15 +45,14 @@ function useFormSubmit<FormValues>(
         if (!isServerValidationError(typedError)) {
           handleApiErrors(typedError);
         } else {
-          const validationHandler = handleServerSideValidation(...errorMappers);
-
-          const errorHandled = validationHandler(
+          const isErrorHandled = handleServerSideValidation(
+            errorMappers,
             typedError.response?.data,
             actions.setFieldError,
             actions.setError,
           );
 
-          if (!errorHandled) {
+          if (!isErrorHandled) {
             handleApiErrors(typedError);
           }
         }

--- a/src/explore-education-statistics-common/src/components/form/util/serverValidationHandler.ts
+++ b/src/explore-education-statistics-common/src/components/form/util/serverValidationHandler.ts
@@ -213,16 +213,19 @@ export const errorCodeToGlobalError = (errorCode: string, message: string) =>
  * Create a validation handler that, given a set of message mappers, will link server-side validation errors to
  * field and global error messages on the UI.
  *
- * @param messageMappers - a set of message mappers that can handle the validaiton messages expected from the back end.
+ * @param messageMappers - a set of message mappers that can handle the validation messages expected from the back end.
+ * @param errors
+ * @param setFieldError
+ * @param setGlobalError
  */
 const handleServerSideValidation = <T extends {}>(
-  ...messageMappers: ServerValidationMessageMapper[]
-) => (
+  messageMappers: ServerValidationMessageMapper[],
   errors: ServerValidationErrors,
   setFieldError: FieldErrorSetter,
   setGlobalError: GlobalErrorSetter,
-): boolean => {
+) => {
   const serverValidationHandler = new ServerValidationHandler(messageMappers);
+
   return serverValidationHandler.handleServerValidationErrors(
     errors,
     setFieldError,


### PR DESCRIPTION
This PR fixes the regression that was caused by a missing `await` in the `withoutErrorHandling` method.

We also improve the `handleServerSideValidation` function by removing its use of currying as it just makes the function slightly awkward to use.