### PR TITLE
BAU-553: Improve user management - Part 1

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/BAU/BauUsersController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/BAU/BauUsersController.cs
@@ -101,5 +101,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.BAU
             
             return ValidationProblem(new ValidationProblemDetails(ModelState));
         }
+        
+        [HttpDelete("bau/users/invite/{email}")]
+        public async Task<ActionResult> InviteUser(string email)
+        {
+            var invite = await _userManagementService.CancelInviteAsync(email);
+
+            if (invite)
+            {
+                return Ok();
+            }
+
+            AddErrors(ModelState, ValidationResult(UnableToCancelInvite));
+            
+            return ValidationProblem(new ValidationProblemDetails(ModelState));
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/BAU/BauUsersController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/BAU/BauUsersController.cs
@@ -22,10 +22,49 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.BAU
             _userManagementService = userManagementService;
         }
 
+        [HttpGet("bau/users/{userId}")]
+        public async Task<ActionResult<UserViewModel>> GetUser(string userId)
+        {
+            var user = await _userManagementService.GetAsync(userId);
+
+            if (user != null)
+            {
+                return Ok(user);
+            }
+
+            return NotFound();
+        }
+        
         [HttpGet("bau/users")]
         public async Task<ActionResult<List<UserViewModel>>> GetUserList()
         {
             var users = await _userManagementService.ListAsync();
+
+            if (users.Any())
+            {
+                return Ok(users);
+            }
+
+            return NotFound();
+        }
+        
+        [HttpGet("bau/users/roles")]
+        public async Task<ActionResult<List<RoleViewModel>>> GetRoleList()
+        {
+            var users = await _userManagementService.ListRolesAsync();
+
+            if (users.Any())
+            {
+                return Ok(users);
+            }
+
+            return NotFound();
+        }
+        
+        [HttpGet("bau/users/pre-release")]
+        public async Task<ActionResult<List<UserViewModel>>> GetPreReleaseUserList()
+        {
+            var users = await _userManagementService.ListPreReleaseUsersAsync();
 
             if (users.Any())
             {
@@ -51,7 +90,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.BAU
         [HttpPost("bau/users/invite")]
         public async Task<ActionResult> GetUserList(UserInviteViewModel userInviteViewModel)
         {
-            var invite = await _userManagementService.InviteAsync(userInviteViewModel.Email, User.Identity.Name);
+            var invite = await _userManagementService.InviteAsync(userInviteViewModel.Email, User.Identity.Name, userInviteViewModel.RoleId);
 
             if (invite)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/BAU/BauUsersController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/BAU/BauUsersController.cs
@@ -88,7 +88,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.BAU
         }
         
         [HttpPost("bau/users/invite")]
-        public async Task<ActionResult> GetUserList(UserInviteViewModel userInviteViewModel)
+        public async Task<ActionResult> InviteUser(UserInviteViewModel userInviteViewModel)
         {
             var invite = await _userManagementService.InviteAsync(userInviteViewModel.Email, User.Identity.Name, userInviteViewModel.RoleId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserManagementService.cs
@@ -17,5 +17,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<List<UserViewModel>> ListPendingAsync();
 
         Task<bool> InviteAsync(string email, string user, string roleId);
+        
+        Task<bool> CancelInviteAsync(string email);
+
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IUserManagementService.cs
@@ -6,10 +6,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IUserManagementService
     {
+        Task<UserViewModel> GetAsync(string userId);
+        
         Task<List<UserViewModel>> ListAsync();
+        
+        Task<List<RoleViewModel>> ListRolesAsync();
+        
+        Task<List<UserViewModel>> ListPreReleaseUsersAsync();
+        
+        Task<List<UserViewModel>> ListPendingAsync();
 
-        Task<List<string>> ListPendingAsync();
-
-        Task<bool> InviteAsync(string email, string user);
+        Task<bool> InviteAsync(string email, string user, string roleId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -67,6 +67,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 }).OrderBy(x => x.Name)
                 .ToListAsync();
 
+            // Potentially user role could be null in the above result in an empty array so assign role afterwards
             foreach (var user in users)
             {
                 user.Role = GetUserRole(user.Id);
@@ -95,7 +96,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<List<UserViewModel>> ListPendingAsync()
         {
-            // Bit of a hack to get the role of the user.
             var pendingUsers = await _context.UserInvites.Where(u => u.Accepted == false)
                 .OrderBy(x => x.Email).Select(u => new UserViewModel
                 {
@@ -106,6 +106,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return pendingUsers;
         }
 
+        // TODO: Part 2: Switch this to and Either result with validation errors
+        // TODO: Part 2: Verify the role exists
+        // TODO: Part 2: Verify valid email address
         public async Task<bool> InviteAsync(string email, string user, string roleId)
         {
             if (_context.Users.Any(u => u.Email == email) || string.IsNullOrWhiteSpace(email)) return false;
@@ -117,7 +120,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     // TODO add role selection to Invite Users UI
                     var analystRole = await _context
                         .Roles
-                        // TODO represent roles with an enum
                         .Where(r => r.Id == roleId)
                         .FirstAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -36,18 +36,77 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 }).OrderBy(x => x.Name)
                 .ToListAsync();
 
-            return users;
+            foreach (var user in users)
+            {
+                user.Role = GetUserRole(user.Id);
+            }
+
+            return users.Where(u => u.Role != "Prerelease User").ToList();
         }
 
-        public async Task<List<string>> ListPendingAsync()
+        public async Task<List<RoleViewModel>> ListRolesAsync()
         {
-            var pendingUsers = await _context.UserInvites.Where(u => u.Accepted == false).Select(u => u.Email)
-                .OrderBy(x => x).ToListAsync();
+            var roles = await _context.Roles.Select(r => new RoleViewModel()
+                {
+                    Id = r.Id,
+                    Name = r.Name,
+                    NormalizedName = r.NormalizedName
+                }).OrderBy(x => x.Name)
+                .ToListAsync();
+
+            return roles.Where(r => r.NormalizedName != "PRERELEASE USER").ToList();
+        }
+
+        public async Task<List<UserViewModel>> ListPreReleaseUsersAsync()
+        {
+            var users = await _context.Users.Select(u => new UserViewModel
+                {
+                    Id = u.Id,
+                    Name = u.FirstName + " " + u.LastName,
+                    Email = u.Email
+                }).OrderBy(x => x.Name)
+                .ToListAsync();
+
+            foreach (var user in users)
+            {
+                user.Role = GetUserRole(user.Id);
+            }
+
+            return users.Where(u => u.Role == "Prerelease User").ToList();
+        }
+
+        public async Task<UserViewModel> GetAsync(string userId)
+        {
+            var user = await _context.Users.FirstOrDefaultAsync(u => u.Id == userId);
+
+            if (user != null)
+            {
+                return new UserViewModel
+                {
+                    Id = user.Id,
+                    Name = user.FirstName + " " + user.LastName,
+                    Email = user.Email,
+                    Role = GetUserRole(user.Id)
+                };
+            }
+
+            return null;
+        }
+
+        public async Task<List<UserViewModel>> ListPendingAsync()
+        {
+            // Bit of a hack to get the role of the user.
+            var pendingUsers = await _context.UserInvites.Where(u => u.Accepted == false)
+                .OrderBy(x => x.Email).Select(u => new UserViewModel
+                {
+                    Email = u.Email,
+                    Role = u.Role.Name
+                }).ToListAsync();
 
             return pendingUsers;
         }
 
-        public async Task<bool> InviteAsync(string email, string user)
+        public async Task<bool> InviteAsync(string email, string user, string roleId)
         {
             if (_context.Users.Any(u => u.Email == email) || string.IsNullOrWhiteSpace(email)) return false;
 
@@ -59,9 +118,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     var analystRole = await _context
                         .Roles
                         // TODO represent roles with an enum
-                        .Where(r => r.Name == "Analyst")
+                        .Where(r => r.Id == roleId)
                         .FirstAsync();
-                    
+
                     var invite = new UserInvite
                     {
                         Email = email,
@@ -85,6 +144,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             {
                 return false;
             }
+        }
+
+        private string GetUserRole(string userId)
+        {
+            var userRole = _context.UserRoles.FirstOrDefault(r => r.UserId == userId);
+
+            return _context.Roles.FirstOrDefault(r => r.Id == userRole.RoleId)?.Name;
         }
 
         private void SendInviteEmail(string email)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -148,6 +148,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             }
         }
 
+        public async Task<bool> CancelInviteAsync(string email)
+        {
+            var invite = _context.UserInvites.FirstOrDefault(i => i.Email == email);
+            _context.UserInvites.Remove(invite);
+
+            await _context.SaveChangesAsync();
+
+            return true;
+        }
+
         private string GetUserRole(string userId)
         {
             var userRole = _context.UserRoles.FirstOrDefault(r => r.UserId == userId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -414,11 +414,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             using (var serviceScope = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>()
                 .CreateScope())
             {
-//                using (var context = serviceScope.ServiceProvider.GetService<StatisticsDbContext>())
-//                {
-//                    context.Database.SetCommandTimeout(int.MaxValue);
-//                    context.Database.Migrate();
-//                }
+                using (var context = serviceScope.ServiceProvider.GetService<StatisticsDbContext>())
+                {
+                    context.Database.SetCommandTimeout(int.MaxValue);
+                    context.Database.Migrate();
+                }
 
                 using (var context = serviceScope.ServiceProvider.GetService<UsersAndRolesDbContext>())
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -414,11 +414,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             using (var serviceScope = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>()
                 .CreateScope())
             {
-                using (var context = serviceScope.ServiceProvider.GetService<StatisticsDbContext>())
-                {
-                    context.Database.SetCommandTimeout(int.MaxValue);
-                    context.Database.Migrate();
-                }
+//                using (var context = serviceScope.ServiceProvider.GetService<StatisticsDbContext>())
+//                {
+//                    context.Database.SetCommandTimeout(int.MaxValue);
+//                    context.Database.Migrate();
+//                }
 
                 using (var context = serviceScope.ServiceProvider.GetService<UsersAndRolesDbContext>())
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -81,6 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         ContentBlockNotAttachedToThisContentSection,
         CommentNotFound,
         UserAlreadyExists,
+        UnableToCancelInvite,
         InvalidEmailAddress,
         ApprovedReleaseMustHavePublishScheduledDate,
         PublicationDoesNotExist,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/RoleViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/RoleViewModel.cs
@@ -1,15 +1,11 @@
-using System;
-
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
-    public class UserViewModel
+    public class RoleViewModel
     {
         public string Id { get; set; }
         
         public string Name { get; set; }
         
-        public string Email { get; set; }
-        
-        public string Role { get; set; }
+        public string NormalizedName { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/UserInviteViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/UserInviteViewModel.cs
@@ -3,5 +3,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
     public class UserInviteViewModel
     {
         public string Email { get; set; }
+        
+        public string RoleId { get; set; }
+
     }
 }

--- a/src/explore-education-statistics-admin/src/components/PageFooter.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageFooter.tsx
@@ -26,11 +26,6 @@ const PageFooter = ({ wide }: Props) => {
                   user.permissions.canAccessMethodologyAdministrationPages) && (
                   <>
                     <li className="govuk-footer__inline-list-item">
-                      <Link className="govuk-footer__link" to="/administration">
-                        Platform administration
-                      </Link>
-                    </li>
-                    <li className="govuk-footer__inline-list-item">
                       <a className="govuk-footer__link" href="/docs">
                         API Documentation
                       </a>

--- a/src/explore-education-statistics-admin/src/components/PageHeader.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageHeader.tsx
@@ -89,6 +89,16 @@ const LoggedInLinks = ({ user }: Authentication) => (
         </a>
       </li>
     )}
+
+    {user &&
+      (user.permissions.canAccessUserAdministrationPages ||
+        user.permissions.canAccessMethodologyAdministrationPages) && (
+        <li className="govuk-header__navigation-item">
+          <a className="govuk-header__link" href="/administration">
+            Platform administration
+          </a>
+        </li>
+      )}
     <li className="govuk-header__navigation-item">
       <Link className="govuk-header__link" to={loginService.getSignOutLink()}>
         Sign out

--- a/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
@@ -14,22 +14,53 @@ const BauDashboardPage = () => {
     : false;
 
   return (
-    <Page wide>
+    <Page wide breadcrumbs={[{ name: 'Platform administration' }]}>
       <h1 className="govuk-heading-xl">Platform administration</h1>
-      <ul>
+
+      <h2 className="govuk-heading-m govuk-!-margin-top-9">Content and data</h2>
+
+      <div className="govuk-grid-row govuk-!-margin-bottom-9">
         {canManageMethodologies && (
-          <li>
-            <Link to="/administration/methodology">
-              View methodology status
-            </Link>
-          </li>
+          <div className="govuk-grid-column-one-third">
+            <h3 className="govuk-heading-s govuk-!-margin-bottom-0">
+              <Link to="/administration/methodology">Manage methodology</Link>
+            </h3>
+            <p className="govuk-caption-m govuk-!-margin-top-1">
+              View a list of all methodologies and their status.
+            </p>
+          </div>
         )}
+      </div>
+
+      <hr className="govuk-!-margin-top-9" />
+
+      <h2 className="govuk-heading-m govuk-!-margin-top-9">Platform</h2>
+      <div className="govuk-grid-row govuk-!-margin-bottom-9">
         {canManageUsers && (
-          <li>
-            <Link to="/administration/users">View service users</Link>
-          </li>
+          <>
+            <div className="govuk-grid-column-one-third">
+              <h3 className="govuk-heading-s govuk-!-margin-bottom-0">
+                <Link to="/administration/users">
+                  Manage access to the service
+                </Link>
+              </h3>
+              <p className="govuk-caption-m govuk-!-margin-top-1">
+                Invite users to the service, manage permissions and access.
+              </p>
+            </div>
+            <div className="govuk-grid-column-one-third">
+              <h3 className="govuk-heading-s govuk-!-margin-bottom-0">
+                <Link to="/administration/users/pre-release">
+                  Pre-release users
+                </Link>
+              </h3>
+              <p className="govuk-caption-m govuk-!-margin-top-1">
+                Manage pre-release users and their access to the service.
+              </p>
+            </div>
+          </>
         )}
-      </ul>
+      </div>
     </Page>
   );
 };

--- a/src/explore-education-statistics-admin/src/pages/bau/BauUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauUsersPage.tsx
@@ -1,23 +1,16 @@
 import Link from '@admin/components/Link';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 import Page from '@admin/components/Page';
+import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import userService from '@admin/services/users/service';
 import { UserStatus } from '@admin/services/users/types';
 import React, { useEffect, useState } from 'react';
 
-interface Model {
-  users: UserStatus[];
-}
-
 const BauUsersPage = () => {
-  const [model, setModel] = useState<Model>();
+  const { value, isLoading, error } = useAsyncRetry(() =>
+    userService.getUsers(),
+  );
 
-  useEffect(() => {
-    userService.getUsers().then(users => {
-      setModel({
-        users,
-      });
-    });
-  }, []);
   return (
     <Page
       wide
@@ -44,22 +37,24 @@ const BauUsersPage = () => {
             <th>Actions</th>
           </tr>
         </thead>
-        {model && (
-          <tbody className="govuk-table__body">
-            {model.users.map(user => (
-              <tr className="govuk-table__row" key={user.id}>
-                <th scope="row" className="govuk-table__header">
-                  {user.name}
-                </th>
-                <td className="govuk-table__cell">{user.email}</td>
-                <td className="govuk-table__cell">{user.role}</td>
-                <td className="govuk-table__cell">
-                  {/* <Link to={`/administration/users/${user.id}`}>Manage</Link> */}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        )}
+        <LoadingSpinner loading={isLoading} text="Loading users">
+          {value && (
+            <tbody className="govuk-table__body">
+              {value.map(user => (
+                <tr className="govuk-table__row" key={user.id}>
+                  <th scope="row" className="govuk-table__header">
+                    {user.name}
+                  </th>
+                  <td className="govuk-table__cell">{user.email}</td>
+                  <td className="govuk-table__cell">{user.role}</td>
+                  <td className="govuk-table__cell">
+                    {/* <Link to={`/administration/users/${user.id}`}>Manage</Link> */}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          )}
+        </LoadingSpinner>
       </table>
       <Link
         to="/administration/users/pending"

--- a/src/explore-education-statistics-admin/src/pages/bau/BauUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauUsersPage.tsx
@@ -54,7 +54,7 @@ const BauUsersPage = () => {
                 <td className="govuk-table__cell">{user.email}</td>
                 <td className="govuk-table__cell">{user.role}</td>
                 <td className="govuk-table__cell">
-                  <Link to={`/administration/users/${user.id}`}>Manage</Link>
+                  {/* <Link to={`/administration/users/${user.id}`}>Manage</Link> */}
                 </td>
               </tr>
             ))}

--- a/src/explore-education-statistics-admin/src/pages/users/ManageUserPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/ManageUserPage.tsx
@@ -59,12 +59,6 @@ const ManageUserPage = ({
   const cancelHandler = () => history.push('/administration/users');
 
   const handleSubmit = useFormSubmit<FormValues>(async values => {
-    // const submission: UserInvite = {
-    //   email: values.userEmail,
-    // };
-
-    // await userService.inviteUser(submission);
-
     history.push(`/administration/users`);
   }, errorCodeMappings);
 

--- a/src/explore-education-statistics-admin/src/pages/users/ManageUserPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/ManageUserPage.tsx
@@ -21,6 +21,8 @@ import Yup from '@common/validation/yup';
 import React, { useEffect, useState } from 'react';
 import { Route, RouteComponentProps, Switch } from 'react-router';
 import { IdLabelPair } from 'src/services/common/types';
+import SummaryList from '@common/components/SummaryList';
+import SummaryListItem from '@common/components/SummaryListItem';
 
 const errorCodeMappings = [
   errorCodeToFieldError(
@@ -94,42 +96,16 @@ const ManageUserPage = ({
                 legend="Detals"
                 legendSize="m"
               >
-                <dl className="govuk-summary-list">
-                  <div className="govuk-summary-list__row">
-                    <dt className="govuk-summary-list__key">Name</dt>
-                    <dd className="govuk-summary-list__value">
-                      {model?.user.name}
-                    </dd>
-                    <dd className="govuk-summary-list__actions">
-                      {/* <a className="govuk-link" href="#">
-                        Change
-                        <span className="govuk-visually-hidden"> name</span>
-                      </a> */}
-                    </dd>
-                  </div>
-                  <div className="govuk-summary-list__row">
-                    <dt className="govuk-summary-list__key">Email</dt>
-                    <dd className="govuk-summary-list__value">
-                      {model?.user.email}
-                    </dd>
-                    <dd className="govuk-summary-list__actions">
-                      {/* <a className="govuk-link" href="#">
-                        Change
-                        <span className="govuk-visually-hidden"> email</span>
-                      </a> */}
-                    </dd>
-                  </div>
-                  <div className="govuk-summary-list__row">
-                    <dt className="govuk-summary-list__key">Phone</dt>
-                    <dd className="govuk-summary-list__value">-</dd>
-                    <dd className="govuk-summary-list__actions">
-                      {/* <a className="govuk-link" href="#">
-                        Change
-                        <span className="govuk-visually-hidden"> phone</span>
-                      </a> */}
-                    </dd>
-                  </div>
-                </dl>
+                <SummaryList>
+                  <SummaryListItem term="Name">
+                    {model?.user.name}
+                  </SummaryListItem>
+                  <SummaryListItem term="Email">
+                    {' '}
+                    {model?.user.email}
+                  </SummaryListItem>
+                  <SummaryListItem term="Phone">-</SummaryListItem>
+                </SummaryList>
               </FormFieldset>
               <FormFieldset
                 id={`${formId}-role`}

--- a/src/explore-education-statistics-admin/src/pages/users/ManageUserPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/ManageUserPage.tsx
@@ -1,0 +1,174 @@
+import Link from '@admin/components/Link';
+import Button from '@common/components/Button';
+import ButtonText from '@common/components/ButtonText';
+import { errorCodeToFieldError } from '@common/components/form/util/serverValidationHandler';
+import {
+  FormFieldset,
+  FormFieldSelect,
+  FormFieldCheckboxGroup,
+  FormFieldTextInput,
+  FormGroup,
+  Formik,
+} from '@common/components/form';
+import Form from '@common/components/form/Form';
+import Page from '@admin/components/Page';
+import useFormSubmit from '@admin/hooks/useFormSubmit';
+import userService from '@admin/services/users/service';
+import { UserStatus } from '@admin/services/users/types';
+import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import Yup from '@common/validation/yup';
+
+import React, { useEffect, useState } from 'react';
+import { Route, RouteComponentProps, Switch } from 'react-router';
+import { IdLabelPair } from 'src/services/common/types';
+
+const errorCodeMappings = [
+  errorCodeToFieldError(
+    'USER_ALREADY_EXISTS',
+    'userEmail',
+    'User already exists',
+  ),
+];
+
+interface Model {
+  user: UserStatus;
+}
+
+interface FormValues {
+  userEmail: string;
+}
+
+const ManageUserPage = ({
+  match,
+  history,
+}: RouteComponentProps<{ userId: string }>) => {
+  const { userId } = match.params;
+  const [model, setModel] = useState<Model>();
+  const formId = userId;
+
+  useEffect(() => {
+    userService.getUser(userId).then(user => {
+      setModel({
+        user,
+      });
+    });
+  }, []);
+
+  const cancelHandler = () => history.push('/administration/users');
+
+  const handleSubmit = useFormSubmit<FormValues>(async values => {
+    // const submission: UserInvite = {
+    //   email: values.userEmail,
+    // };
+
+    // await userService.inviteUser(submission);
+
+    history.push(`/administration/users`);
+  }, errorCodeMappings);
+
+  return (
+    <Page
+      wide
+      breadcrumbs={[
+        { name: 'Platform administration', link: '/administration' },
+        { name: 'Users', link: '/administration/users' },
+        { name: 'Manage user' },
+      ]}
+    >
+      <h1 className="govuk-heading-xl">
+        <span className="govuk-caption-xl">Manage user</span>
+        {model?.user.name}
+      </h1>
+
+      <Formik<FormValues>
+        enableReinitialize
+        initialValues={{
+          userEmail: '',
+        }}
+        onSubmit={handleSubmit}
+        render={_ => {
+          return (
+            <Form id={formId}>
+              <FormFieldset
+                id={`${formId}-details`}
+                legend="Detals"
+                legendSize="m"
+              >
+                <dl className="govuk-summary-list">
+                  <div className="govuk-summary-list__row">
+                    <dt className="govuk-summary-list__key">Name</dt>
+                    <dd className="govuk-summary-list__value">
+                      {model?.user.name}
+                    </dd>
+                    <dd className="govuk-summary-list__actions">
+                      {/* <a className="govuk-link" href="#">
+                        Change
+                        <span className="govuk-visually-hidden"> name</span>
+                      </a> */}
+                    </dd>
+                  </div>
+                  <div className="govuk-summary-list__row">
+                    <dt className="govuk-summary-list__key">Email</dt>
+                    <dd className="govuk-summary-list__value">
+                      {model?.user.email}
+                    </dd>
+                    <dd className="govuk-summary-list__actions">
+                      {/* <a className="govuk-link" href="#">
+                        Change
+                        <span className="govuk-visually-hidden"> email</span>
+                      </a> */}
+                    </dd>
+                  </div>
+                  <div className="govuk-summary-list__row">
+                    <dt className="govuk-summary-list__key">Phone</dt>
+                    <dd className="govuk-summary-list__value">-</dd>
+                    <dd className="govuk-summary-list__actions">
+                      {/* <a className="govuk-link" href="#">
+                        Change
+                        <span className="govuk-visually-hidden"> phone</span>
+                      </a> */}
+                    </dd>
+                  </div>
+                </dl>
+              </FormFieldset>
+              <FormFieldset
+                id={`${formId}-role`}
+                legend="Role"
+                legendSize="m"
+                hint="The users role within the service."
+              >
+                <FormFieldSelect
+                  id={`${formId}-role`}
+                  label="Role"
+                  name="userRole"
+                  // options={model.roles.map(role => ({
+                  //   label: role.name,
+                  //   value: role.id,
+                  // }))}
+                />
+              </FormFieldset>
+
+              <FormFieldCheckboxGroup
+                id={`${formId}-releaseaccess`}
+                legend="Release access"
+                legendSize="m"
+                hint="The releases a user has access to (BAU Users have access to all releases)."
+                name="releaseAccess"
+                options={[]}
+              />
+
+              <Button type="submit" className="govuk-!-margin-top-6">
+                Save
+              </Button>
+              <div className="govuk-!-margin-top-6">
+                <ButtonText onClick={cancelHandler}>Cancel</ButtonText>
+              </div>
+            </Form>
+          );
+        }}
+      />
+    </Page>
+  );
+};
+
+export default ManageUserPage;

--- a/src/explore-education-statistics-admin/src/pages/users/PendingInvitesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/PendingInvitesPage.tsx
@@ -1,10 +1,12 @@
+import ButtonText from '@common/components/ButtonText';
 import Link from '@admin/components/Link';
 import Page from '@admin/components/Page';
 import userService from '@admin/services/users/service';
+import { UserStatus } from '@admin/services/users/types';
 import React, { useEffect, useState } from 'react';
 
 interface Model {
-  users: string[];
+  users: UserStatus[];
 }
 
 const PendingInvitesPage = () => {
@@ -17,6 +19,9 @@ const PendingInvitesPage = () => {
       });
     });
   }, []);
+
+  const cancelInviteHandler = () => {};
+
   return (
     <Page
       wide
@@ -38,13 +43,25 @@ const PendingInvitesPage = () => {
             <th scope="col" className="govuk-table__header">
               Email
             </th>
+            <th scope="col" className="govuk-table__header">
+              Role
+            </th>
+            <th scope="col" className="govuk-table__header">
+              Actions
+            </th>
           </tr>
         </thead>
         {model && (
           <tbody className="govuk-table__body">
             {model.users.map(user => (
-              <tr className="govuk-table__row" key={user}>
-                <td className="govuk-table__cell">{user}</td>
+              <tr className="govuk-table__row" key={user.email}>
+                <td className="govuk-table__cell">{user.email}</td>
+                <td className="govuk-table__cell">{user.role}</td>
+                <td className="govuk-table__cell">
+                  {/* <ButtonText onClick={cancelInviteHandler}>
+                    Cancel invite
+                  </ButtonText> */}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/explore-education-statistics-admin/src/pages/users/PendingInvitesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/PendingInvitesPage.tsx
@@ -58,9 +58,19 @@ const PendingInvitesPage = () => {
                 <td className="govuk-table__cell">{user.email}</td>
                 <td className="govuk-table__cell">{user.role}</td>
                 <td className="govuk-table__cell">
-                  {/* <ButtonText onClick={cancelInviteHandler}>
+                  <ButtonText
+                    onClick={() => {
+                      userService.cancelInvite(user.email).then(() => {
+                        userService.getPendingInvites().then(updatedInvites =>
+                          setModel({
+                            users: updatedInvites,
+                          }),
+                        );
+                      });
+                    }}
+                  >
                     Cancel invite
-                  </ButtonText> */}
+                  </ButtonText>
                 </td>
               </tr>
             ))}

--- a/src/explore-education-statistics-admin/src/pages/users/PreReleaseUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/PreReleaseUsersPage.tsx
@@ -1,3 +1,4 @@
+import ButtonText from '@common/components/ButtonText';
 import Link from '@admin/components/Link';
 import Page from '@admin/components/Page';
 import userService from '@admin/services/users/service';
@@ -8,30 +9,35 @@ interface Model {
   users: UserStatus[];
 }
 
-const BauUsersPage = () => {
+const PreReleaseUsersPage = () => {
   const [model, setModel] = useState<Model>();
 
   useEffect(() => {
-    userService.getUsers().then(users => {
+    userService.getPreReleaseUsers().then(users => {
       setModel({
         users,
       });
     });
   }, []);
+
+  const removeAccessHander = () => {};
+
   return (
     <Page
       wide
       breadcrumbs={[
         { name: 'Platform administration', link: '/administration' },
-        { name: 'Users' },
+        { name: 'Pre-release users' },
       ]}
     >
       <h1 className="govuk-heading-xl">
-        <span className="govuk-caption-xl">Manage access to the service</span>
-        Users
+        <span className="govuk-caption-xl">Manage pre-release users</span>
+        Pre-release users
       </h1>
       <table className="govuk-table">
-        <caption className="govuk-table__caption">Active user accounts</caption>
+        <caption className="govuk-table__caption">
+          Users with pre-release access
+        </caption>
         <thead className="govuk-table__head">
           <tr className="govuk-table__row">
             <th scope="col" className="govuk-table__header">
@@ -40,8 +46,9 @@ const BauUsersPage = () => {
             <th scope="col" className="govuk-table__header">
               Email
             </th>
-            <th>Role</th>
-            <th>Actions</th>
+            <th scope="col" className="govuk-table__header">
+              Actions
+            </th>
           </tr>
         </thead>
         {model && (
@@ -52,24 +59,14 @@ const BauUsersPage = () => {
                   {user.name}
                 </th>
                 <td className="govuk-table__cell">{user.email}</td>
-                <td className="govuk-table__cell">{user.role}</td>
                 <td className="govuk-table__cell">
-                  <Link to={`/administration/users/${user.id}`}>Manage</Link>
+                  {/* <ButtonText onClick={removeAccessHander}>Remove</ButtonText> */}
                 </td>
               </tr>
             ))}
           </tbody>
         )}
       </table>
-      <Link
-        to="/administration/users/pending"
-        className="govuk-button govuk-button--secondary"
-      >
-        View pending invites
-      </Link>{' '}
-      <Link to="/administration/users/invite" className="govuk-button">
-        Invite a new user
-      </Link>
       <p>
         <Link to="/administration/" className="govuk-back-link">
           Back
@@ -79,4 +76,4 @@ const BauUsersPage = () => {
   );
 };
 
-export default BauUsersPage;
+export default PreReleaseUsersPage;

--- a/src/explore-education-statistics-admin/src/pages/users/PreReleaseUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/PreReleaseUsersPage.tsx
@@ -1,24 +1,16 @@
 import ButtonText from '@common/components/ButtonText';
 import Link from '@admin/components/Link';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 import Page from '@admin/components/Page';
 import userService from '@admin/services/users/service';
+import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import { UserStatus } from '@admin/services/users/types';
 import React, { useEffect, useState } from 'react';
 
-interface Model {
-  users: UserStatus[];
-}
-
 const PreReleaseUsersPage = () => {
-  const [model, setModel] = useState<Model>();
-
-  useEffect(() => {
-    userService.getPreReleaseUsers().then(users => {
-      setModel({
-        users,
-      });
-    });
-  }, []);
+  const { value, isLoading, error } = useAsyncRetry(() =>
+    userService.getPreReleaseUsers(),
+  );
 
   const removeAccessHander = () => {};
 
@@ -51,21 +43,23 @@ const PreReleaseUsersPage = () => {
             </th>
           </tr>
         </thead>
-        {model && (
-          <tbody className="govuk-table__body">
-            {model.users.map(user => (
-              <tr className="govuk-table__row" key={user.id}>
-                <th scope="row" className="govuk-table__header">
-                  {user.name}
-                </th>
-                <td className="govuk-table__cell">{user.email}</td>
-                <td className="govuk-table__cell">
-                  {/* <ButtonText onClick={removeAccessHander}>Remove</ButtonText> */}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        )}
+        <LoadingSpinner loading={isLoading} text="Loading pre-release users">
+          {value && (
+            <tbody className="govuk-table__body">
+              {value.map(user => (
+                <tr className="govuk-table__row" key={user.id}>
+                  <th scope="row" className="govuk-table__header">
+                    {user.name}
+                  </th>
+                  <td className="govuk-table__cell">{user.email}</td>
+                  <td className="govuk-table__cell">
+                    {/* <ButtonText onClick={removeAccessHander}>Remove</ButtonText> */}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          )}
+        </LoadingSpinner>
       </table>
       <p>
         <Link to="/administration/" className="govuk-back-link">

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -98,7 +98,8 @@ const UserInvitePage = ({
               enableReinitialize
               initialValues={{
                 userEmail: '',
-                selectedRoleId: orderBy(model.roles, role => role.name)[0].id,
+                selectedRoleId:
+                  orderBy(model.roles, role => role.name)?.[0]?.id ?? '',
               }}
               validationSchema={Yup.object({
                 userEmail: Yup.string()

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -2,17 +2,19 @@ import Link from '@admin/components/Link';
 import Page from '@admin/components/Page';
 import useFormSubmit from '@admin/hooks/useFormSubmit';
 import userService from '@admin/services/users/service';
-import { UserInvite } from '@admin/services/users/types';
+import { UserInvite, Role } from '@admin/services/users/types';
 import Button from '@common/components/Button';
 import ButtonText from '@common/components/ButtonText';
 import { FormFieldset, Formik } from '@common/components/form';
 import Form from '@common/components/form/Form';
+import FormFieldSelect from '@common/components/form/FormFieldSelect';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
 import { errorCodeToFieldError } from '@common/components/form/util/serverValidationHandler';
 import RelatedInformation from '@common/components/RelatedInformation';
 import { ErrorControlState } from '@common/contexts/ErrorControlContext';
 import Yup from '@common/validation/yup';
-import React from 'react';
+import orderBy from 'lodash/orderBy';
+import React, { useEffect, useState } from 'react';
 import { RouteComponentProps } from 'react-router';
 
 const errorCodeMappings = [
@@ -25,23 +27,38 @@ const errorCodeMappings = [
 
 interface FormValues {
   userEmail: string;
+  selectedRoleId: string;
+}
+
+interface InviteUserModel {
+  roles: Role[];
 }
 
 const UserInvitePage = ({
   history,
 }: RouteComponentProps & ErrorControlState) => {
+  const [model, setModel] = useState<InviteUserModel>();
   const formId = 'inviteUserForm';
 
-  const cancelHandler = () => history.push('/administration/users');
+  useEffect(() => {
+    userService.getRoles().then(roles => {
+      setModel({
+        roles,
+      });
+    });
+  }, []);
+
+  const cancelHandler = () => history.push('/administration/users/');
 
   const handleSubmit = useFormSubmit<FormValues>(async values => {
     const submission: UserInvite = {
       email: values.userEmail,
+      roleId: values.selectedRoleId,
     };
 
     await userService.inviteUser(submission);
 
-    history.push(`/administration/users`);
+    history.push(`/administration/users/pending`);
   }, errorCodeMappings);
 
   return (
@@ -76,42 +93,66 @@ const UserInvitePage = ({
       </div>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <Formik<FormValues>
-            enableReinitialize
-            initialValues={{
-              userEmail: '',
-            }}
-            validationSchema={Yup.object({
-              userEmail: Yup.string()
-                .required('Provide the users email')
-                .email('Provide a valid email address'),
-            })}
-            onSubmit={handleSubmit}
-            render={_ => {
-              return (
-                <Form id={formId}>
-                  <FormFieldset
-                    id={`${formId}-selectedContactIdFieldset`}
-                    legend="Provide the email address for the user"
-                    legendSize="m"
-                    hint="The invited user must have a @education.gov.uk email address"
-                  >
-                    <FormFieldTextInput
-                      id={`${formId}-userEmail`}
-                      label="User email"
-                      name="userEmail"
-                    />
-                  </FormFieldset>
-                  <Button type="submit" className="govuk-!-margin-top-6">
-                    Send invite
-                  </Button>
-                  <div className="govuk-!-margin-top-6">
-                    <ButtonText onClick={cancelHandler}>Cancel</ButtonText>
-                  </div>
-                </Form>
-              );
-            }}
-          />
+          {model && (
+            <Formik<FormValues>
+              enableReinitialize
+              initialValues={{
+                userEmail: '',
+                selectedRoleId: orderBy(model.roles, role => role.name)[0].id,
+              }}
+              validationSchema={Yup.object({
+                userEmail: Yup.string()
+                  .required('Provide the users email')
+                  .email('Provide a valid email address'),
+                selectedRoleId: Yup.string().required(
+                  'Choose role for the user',
+                ),
+              })}
+              onSubmit={handleSubmit}
+              render={_ => {
+                return (
+                  <Form id={formId}>
+                    <FormFieldset
+                      id={`${formId}-userEmailFieldset`}
+                      legend="Provide the email address for the user"
+                      legendSize="m"
+                      hint="The invited user must have a @education.gov.uk email address"
+                    >
+                      <FormFieldTextInput
+                        id={`${formId}-userEmail`}
+                        label="User email"
+                        name="userEmail"
+                      />
+                    </FormFieldset>
+
+                    <FormFieldset
+                      id={`${formId}-selectedRoleIdFieldset`}
+                      legend="Select the role of the user within the service"
+                      legendSize="m"
+                      hint="Most users should be added with the analyst role"
+                    >
+                      <FormFieldSelect
+                        id={`${formId}-selectedRoleId`}
+                        label="Role"
+                        name="selectedRoleId"
+                        options={model?.roles.map(role => ({
+                          label: role.name,
+                          value: role.id,
+                        }))}
+                      />
+                    </FormFieldset>
+
+                    <Button type="submit" className="govuk-!-margin-top-6">
+                      Send invite
+                    </Button>
+                    <div className="govuk-!-margin-top-6">
+                      <ButtonText onClick={cancelHandler}>Cancel</ButtonText>
+                    </div>
+                  </Form>
+                );
+              }}
+            />
+          )}
         </div>
       </div>
     </Page>

--- a/src/explore-education-statistics-admin/src/routes/dashboard/routes.ts
+++ b/src/explore-education-statistics-admin/src/routes/dashboard/routes.ts
@@ -25,6 +25,8 @@ import ThemeTopicWrapper, {
 } from '@admin/pages/theme/ThemeTopicWrapper';
 import PendingInvitesPage from '@admin/pages/users/PendingInvitesPage';
 import UserInvitePage from '@admin/pages/users/UserInvitePage';
+import ManageUserPage from '@admin/pages/users/ManageUserPage';
+import PreReleaseUsersPage from '@admin/pages/users/PreReleaseUsersPage';
 import { User } from '@admin/services/sign-in/types';
 import { Dictionary } from '@admin/types';
 import { generatePath, RouteProps } from 'react-router';
@@ -96,6 +98,17 @@ const appRouteList: Dictionary<ProtectedRouteProps> = {
     component: PendingInvitesPage,
     protectedAction: user => user.permissions.canAccessUserAdministrationPages,
     exact: true,
+  },
+  administrationPreReleaseUsers: {
+    path: '/administration/users/pre-release',
+    component: PreReleaseUsersPage,
+    protectedAction: user => user.permissions.canAccessUserAdministrationPages,
+    exact: true,
+  },
+  administrationUserManage: {
+    path: '/administration/users/:userId',
+    component: ManageUserPage,
+    protectedAction: user => user.permissions.canAccessUserAdministrationPages,
   },
   methodologies: {
     path: '/methodologies',

--- a/src/explore-education-statistics-admin/src/services/users/service.ts
+++ b/src/explore-education-statistics-admin/src/services/users/service.ts
@@ -8,6 +8,7 @@ export interface UsersService {
   getPreReleaseUsers(): Promise<UserStatus[]>;
   getPendingInvites(): Promise<UserStatus[]>;
   inviteUser: (invite: UserInvite) => Promise<boolean>;
+  cancelInvite: (email: string) => Promise<boolean>;
 }
 
 const service: UsersService = {
@@ -28,6 +29,9 @@ const service: UsersService = {
   },
   inviteUser(invite: UserInvite): Promise<boolean> {
     return client.post(`/bau/users/invite`, invite);
+  },
+  cancelInvite(email: string): Promise<boolean> {
+    return client.delete(`/bau/users/invite/${email}`);
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/users/service.ts
+++ b/src/explore-education-statistics-admin/src/services/users/service.ts
@@ -1,18 +1,30 @@
 import client from '@admin/services/util/service';
-import { UserStatus, UserInvite } from '@admin/services/users/types';
+import { UserStatus, UserInvite, Role } from '@admin/services/users/types';
 
 export interface UsersService {
+  getRoles(): Promise<Role[]>;
+  getUser(userId: string): Promise<UserStatus>;
   getUsers(): Promise<UserStatus[]>;
-  getPendingInvites(): Promise<string[]>;
+  getPreReleaseUsers(): Promise<UserStatus[]>;
+  getPendingInvites(): Promise<UserStatus[]>;
   inviteUser: (invite: UserInvite) => Promise<boolean>;
 }
 
 const service: UsersService = {
+  getRoles(): Promise<Role[]> {
+    return client.get<Role[]>('/bau/users/roles');
+  },
+  getUser(userId: string): Promise<UserStatus> {
+    return client.get<UserStatus>(`/bau/users/${userId}`);
+  },
   getUsers(): Promise<UserStatus[]> {
     return client.get<UserStatus[]>('/bau/users');
   },
-  getPendingInvites(): Promise<string[]> {
-    return client.get<string[]>('/bau/users/pending');
+  getPreReleaseUsers(): Promise<UserStatus[]> {
+    return client.get<UserStatus[]>('/bau/users/pre-release');
+  },
+  getPendingInvites(): Promise<UserStatus[]> {
+    return client.get<UserStatus[]>('/bau/users/pending');
   },
   inviteUser(invite: UserInvite): Promise<boolean> {
     return client.post(`/bau/users/invite`, invite);

--- a/src/explore-education-statistics-admin/src/services/users/types.ts
+++ b/src/explore-education-statistics-admin/src/services/users/types.ts
@@ -2,9 +2,18 @@ export interface UserStatus {
   id: string;
   name: string;
   email: string;
+  role: string;
 }
 
 export interface UserInvite {
   email: string;
+  roleId: string;
 }
+
+export interface Role {
+  id: string;
+  name: string;
+  normalizedName: string;
+}
+
 export default {};


### PR DESCRIPTION
This PR updates the Platform administration functions to better support the BAU team in the management of users.

This specific PR does the following:
- BAU-549 - Improves user invites with ability to assign role
- BAU-550 -Moves "Platform administration" from the footer to the main menu with associated permissions check
- BAU-551 - Adds a"Pre-release" users section in platform administration for display of pre-release users (and thus removing this from the main user management page)
- BAU-552 - Displays a users role on the user management page-
- Updates the Platform administration page to be a bit more user friendly than a text list of links.
- BAU-554 - Add the ability to cancel a user invite

⚠️ Contains some WIP
This PR Also contains a small amount of UI WIP for Part 2 which will add the ability to edit an existing users role.