### PR TITLE
BAU-541 Release on demand. Also allow regenerating Release content and maintain Release Status history.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseStatusServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseStatusServicePermissionTests.cs
@@ -27,9 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void GetReleaseStatusesAsync()
         {
             AssertSecurityPoliciesChecked(service => 
-                    service.GetReleaseStatusesAsync(_release.Id),  
-                _release,
-                CanViewSpecificRelease);
+                    service.GetReleaseStatusAsync(_release.Id), _release, CanViewSpecificRelease);
         }
         
         private void AssertSecurityPoliciesChecked<T, TEntity>(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseController.cs
@@ -272,7 +272,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         public async Task<ActionResult<IEnumerable<ReleaseStatusViewModel>>> GetReleaseStatusesAsync(Guid releaseId)
         {
             return await _releaseStatusService
-                .GetReleaseStatusesAsync(releaseId)
+                .GetReleaseStatusAsync(releaseId)
                 .HandleFailuresOr(Ok);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -54,7 +54,6 @@
     <PackageReference Include="Notify" Version="2.5.1" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
-    <PackageReference Include="WindowsAzure.StorageExtensions" Version="1.2.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/ReleaseStatusViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/ReleaseStatusViewModel.cs
@@ -1,17 +1,23 @@
 ﻿using System;
-using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Models.Api
 {
     public class ReleaseStatusViewModel
     {
         public Guid ReleaseId { get; set; }
-        public string DataStage { get; set; }
-        public string ContentStage { get; set; }
-        public string FilesStage { get; set; }
-        public string PublishingStage { get; set; }
-        public string OverallStage { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ReleaseStatusDataStage DataStage { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ReleaseStatusContentStage ContentStage { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ReleaseStatusFilesStage FilesStage { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ReleaseStatusPublishingStage PublishingStage { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ReleaseStatusOverallStage OverallStage { get; set; }
         public DateTimeOffset LastUpdated { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublishingService.cs
@@ -6,6 +6,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IPublishingService
     {
-        Task<ReleaseStatusMessage> QueueReleaseStatusAsync(Guid releaseId);
+        Task QueueValidateReleaseAsync(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseStatusService.cs
@@ -8,6 +8,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IReleaseStatusService
     {
-        Task<Either<ActionResult, ReleaseStatusViewModel>> GetReleaseStatusesAsync(Guid releaseId);
+        Task<Either<ActionResult, ReleaseStatusViewModel>> GetReleaseStatusAsync(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 {
@@ -33,7 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task QueueValidateReleaseAsync(Guid releaseId)
         {
             var release = await GetRelease(releaseId);
-            var queue = await QueueUtils.GetQueueReferenceAsync(_storageConnectionString, "releases");
+            var queue = await QueueUtils.GetQueueReferenceAsync(_storageConnectionString, ValidateReleaseQueue);
             var message = BuildValidateReleaseMessage(release);
             await queue.AddMessageAsync(ToCloudQueueMessage(message));
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
@@ -52,7 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             return new ValidateReleaseMessage
             {
-                Immediate = true,
+                Immediate = false,
                 ReleaseId = release.Id
             };
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
@@ -30,16 +30,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _logger = logger;
         }
 
-        public async Task<ReleaseStatusMessage> QueueReleaseStatusAsync(Guid releaseId)
+        public async Task QueueValidateReleaseAsync(Guid releaseId)
         {
             var release = await GetRelease(releaseId);
             var queue = await QueueUtils.GetQueueReferenceAsync(_storageConnectionString, "releases");
-            var message = BuildReleaseStatusMessage(release);
+            var message = BuildValidateReleaseMessage(release);
             await queue.AddMessageAsync(ToCloudQueueMessage(message));
 
             _logger.LogTrace($"Sent release status message for release: {releaseId}");
-
-            return message;
         }
 
         private Task<Release> GetRelease(Guid releaseId)
@@ -49,10 +47,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .SingleAsync(release => release.Id == releaseId);
         }
 
-        private static ReleaseStatusMessage BuildReleaseStatusMessage(Release release)
+        private static ValidateReleaseMessage BuildValidateReleaseMessage(Release release)
         {
-            return new ReleaseStatusMessage
+            return new ValidateReleaseMessage
             {
+                Immediate = false,
                 ReleaseId = release.Id
             };
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -299,7 +299,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     _context.Releases.Update(release);
                     await _context.SaveChangesAsync();
 
-                    await _publishingService.QueueReleaseStatusAsync(releaseId);
+                    await _publishingService.QueueValidateReleaseAsync(releaseId);
 
                     return await GetReleaseSummaryAsync(releaseId);
                 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseStatusService.cs
@@ -36,7 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _tableStorageService = tableStorageService;
         }
 
-        public async Task<Either<ActionResult, ReleaseStatusViewModel>> GetReleaseStatusesAsync(Guid releaseId)
+        public async Task<Either<ActionResult, ReleaseStatusViewModel>> GetReleaseStatusAsync(Guid releaseId)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Release>(releaseId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ITableStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ITableStorageService.cs
@@ -6,6 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 {
     public interface ITableStorageService
     {
+        Task<IEnumerable<TElement>> ExecuteQueryAsync<TElement>(string tableName, TableQuery<TElement> query) where TElement : ITableEntity, new();
         Task<CloudTable> GetTableAsync(string tableName, bool createIfNotExists = true);
         Task<bool> DeleteEntityAsync(string tableName, ITableEntity entity);
         Task<TableResult> RetrieveEntity(string tableName, ITableEntity entity, List<string> columns);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/TableStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/TableStorageService.cs
@@ -51,13 +51,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         public async Task<TableResult> RetrieveEntity(string tableName, ITableEntity entity, List<string> columns)
         {
             var table = _client.GetTableReference(tableName);
-            return await table.ExecuteAsync(TableOperation.Retrieve(entity.PartitionKey,entity.RowKey, columns));
+            return await table.ExecuteAsync(TableOperation.Retrieve(entity.PartitionKey, entity.RowKey, columns));
         }
-        
+
         public async Task<TableResult> UpdateEntity(string tableName, ITableEntity entity)
         {
             var table = _client.GetTableReference(tableName);
             return await table.ExecuteAsync(TableOperation.InsertOrReplace(entity));
+        }
+
+        public async Task<IEnumerable<TElement>> ExecuteQueryAsync<TElement>(string tableName, TableQuery<TElement> query) where TElement : ITableEntity, new()
+        {
+            var results = new List<TElement>();
+            var table = await GetTableAsync(tableName);
+            TableContinuationToken token = null;
+            do
+            {
+                var queryResult = await table.ExecuteQuerySegmentedAsync(query, token);
+                results.AddRange(queryResult.Results);
+                token = queryResult.ContinuationToken;
+            } while (token != null);
+
+            return results;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -60,7 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             {
                 app.UseDeveloperExceptionPage();
                 
-                GenerateReleaseContent();
+                PublishAllContent();
             }
             else
             {
@@ -88,18 +88,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
         }
         
         /**
-         * Add a message to the queue to generate all content.
-         * TODO EES-861 This should only be used in development!
+         * Add a message to the queue to publish all content.
+         * This should only be used in development!
          */
-        private void GenerateReleaseContent()
+        private void PublishAllContent()
         {
-            const string queueName = "generate-all-content";
+            const string queueName = "publish-all-content";
             try
             {
                 var storageConnectionString = Configuration.GetConnectionString("PublisherStorage");
                 var queue = QueueUtils.GetQueueReference(storageConnectionString, queueName);
 
-                var message = new GenerateAllContentMessage();
+                var message = new PublishAllContentMessage();
                 queue.AddMessage(ToCloudQueueMessage(message));
                 
                 _logger.LogInformation($"Message added to {queueName} queue");

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api
 {
@@ -93,7 +94,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
          */
         private void PublishAllContent()
         {
-            const string queueName = "publish-all-content";
+            const string queueName = PublishAllContentQueue;
             try
             {
                 var storageConnectionString = Configuration.GetConnectionString("PublisherStorage");

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Location.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Location.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/GenerateReleaseContentMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/GenerateReleaseContentMessage.cs
@@ -6,5 +6,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
     public class GenerateReleaseContentMessage
     {
         public IEnumerable<(Guid ReleaseId, Guid ReleaseStatusId)> Releases;
+
+        public override string ToString()
+        {
+            return $"{nameof(Releases)}: {string.Join(", ", Releases)}";
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishAllContentMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishAllContentMessage.cs
@@ -1,6 +1,6 @@
 ﻿namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
 {
-    public class GenerateAllContentMessage
+    public class PublishAllContentMessage
     {
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishReleaseContentImmediateMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishReleaseContentImmediateMessage.cs
@@ -6,5 +6,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
     {
         public Guid ReleaseId { get; set; }
         public Guid ReleaseStatusId { get; set; }
+
+        public override string ToString()
+        {
+            return $"{nameof(ReleaseId)}: {ReleaseId}, {nameof(ReleaseStatusId)}: {ReleaseStatusId}";
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishReleaseContentImmediateMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishReleaseContentImmediateMessage.cs
@@ -2,8 +2,9 @@
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
 {
-    public class ReleaseStatusMessage
+    public class PublishReleaseContentImmediateMessage
     {
         public Guid ReleaseId { get; set; }
+        public Guid ReleaseStatusId { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishReleaseDataMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishReleaseDataMessage.cs
@@ -6,5 +6,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
     {
         public Guid ReleaseId { get; set; }
         public Guid ReleaseStatusId { get; set; }
+
+        public override string ToString()
+        {
+            return $"{nameof(ReleaseId)}: {ReleaseId}, {nameof(ReleaseStatusId)}: {ReleaseStatusId}";
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishReleaseFilesMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishReleaseFilesMessage.cs
@@ -6,5 +6,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
     public class PublishReleaseFilesMessage
     {
         public IEnumerable<(Guid ReleaseId, Guid ReleaseStatusId)> Releases;
+
+        public override string ToString()
+        {
+            return $"{nameof(Releases)}: {string.Join(", ", Releases)}";
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherQueues.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherQueues.cs
@@ -1,0 +1,12 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
+{
+    public static class PublisherQueues
+    {
+        public const string GenerateReleaseContentQueue = "generate-release-content";
+        public const string PublishAllContentQueue = "publish-all-content";
+        public const string PublishReleaseContentImmediateQueue = "publish-release-content-immediate";
+        public const string PublishReleaseDataQueue = "publish-release-data";
+        public const string PublishReleaseFilesQueue = "publish-release-files";
+        public const string ValidateReleaseQueue = "releases";
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatus.cs
@@ -18,6 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         public string FilesStage { get; set; }
         public string PublishingStage { get; set; }
         public string OverallStage { get; set; }
+        public bool Immediate { get; set; }
         public string Messages { get; set; }
         private ReleaseStatusState _state;
 
@@ -30,12 +31,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
             Guid releaseId,
             string releaseSlug,
             ReleaseStatusState state,
+            bool immediate,
             IEnumerable<ReleaseStatusLogMessage> logMessages = null)
         {
             Created = DateTime.UtcNow;
             PublicationSlug = publicationSlug;
             Publish = publish;
             ReleaseSlug = releaseSlug;
+            Immediate = immediate;
             Messages = logMessages == null ? null : JsonConvert.SerializeObject(logMessages);
             State = state;
             RowKey = Guid.NewGuid().ToString();

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatus.cs
@@ -63,10 +63,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
                 DataStage = value.Data.ToString();
                 FilesStage = value.Files.ToString();
                 PublishingStage = value.Publishing.ToString();
-                OverallStage = value.Overall.ToString();
+                OverallStage = value.ReleaseStatusOverall.ToString();
 
                 _state = new ReleaseStatusState(value.Content, value.Files, value.Data, value.Publishing,
-                    value.Overall);
+                    value.ReleaseStatusOverall);
                 _state.PropertyChanged += StateChangedCallback;
             }
         }
@@ -109,7 +109,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
                     break;
             }
 
-            OverallStage = _state.Overall.ToString();
+            OverallStage = _state.ReleaseStatusOverall.ToString();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusState.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusState.cs
@@ -170,8 +170,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         Failed,
         Scheduled,
         NotStarted,
-        Started,
-        // TODO BAU-541 Remove me
-        ToDo,
+        Started
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusState.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusState.cs
@@ -1,37 +1,40 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.Stage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
 {
     public class ReleaseStatusState : INotifyPropertyChanged
     {
-        private Stage _content;
-        private Stage _files;
-        private Stage _data;
-        private Stage _publishing;
-        public Stage Overall { get; private set; }
+        private ReleaseStatusContentStage _content;
+        private ReleaseStatusFilesStage _files;
+        private ReleaseStatusDataStage _data;
+        private ReleaseStatusPublishingStage _publishing;
+        public ReleaseStatusOverallStage ReleaseStatusOverall { get; private set; }
 
-        public ReleaseStatusState(Stage content, Stage files, Stage data, Stage publishing, Stage overall)
+        public ReleaseStatusState(ReleaseStatusContentStage content,
+            ReleaseStatusFilesStage files,
+            ReleaseStatusDataStage data,
+            ReleaseStatusPublishingStage publishing,
+            ReleaseStatusOverallStage releaseStatusOverall)
         {
             _content = content;
             _files = files;
             _data = data;
             _publishing = publishing;
-            Overall = overall;
+            ReleaseStatusOverall = releaseStatusOverall;
         }
 
         public ReleaseStatusState(string content, string files, string data, string publishing, string overall) : this(
-            Enum.Parse<Stage>(content),
-            Enum.Parse<Stage>(files),
-            Enum.Parse<Stage>(data),
-            Enum.Parse<Stage>(publishing),
-            Enum.Parse<Stage>(overall))
+            Enum.Parse<ReleaseStatusContentStage>(content),
+            Enum.Parse<ReleaseStatusFilesStage>(files),
+            Enum.Parse<ReleaseStatusDataStage>(data),
+            Enum.Parse<ReleaseStatusPublishingStage>(publishing),
+            Enum.Parse<ReleaseStatusOverallStage>(overall))
         {
         }
 
-        public Stage Content
+        public ReleaseStatusContentStage Content
         {
             get => _content;
             set
@@ -46,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
             }
         }
 
-        public Stage Files
+        public ReleaseStatusFilesStage Files
         {
             get => _files;
             set
@@ -61,7 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
             }
         }
 
-        public Stage Data
+        public ReleaseStatusDataStage Data
         {
             get => _data;
             set
@@ -76,7 +79,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
             }
         }
 
-        public Stage Publishing
+        public ReleaseStatusPublishingStage Publishing
         {
             get => _publishing;
             set
@@ -93,18 +96,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
 
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
-            if (Content == Complete && Data == Complete && Files == Complete && Publishing == Complete)
+            if (Content == ReleaseStatusContentStage.Complete
+                && Data == ReleaseStatusDataStage.Complete
+                && Files == ReleaseStatusFilesStage.Complete
+                && Publishing == ReleaseStatusPublishingStage.Complete)
             {
-                Overall = Complete;
+                ReleaseStatusOverall = ReleaseStatusOverallStage.Complete;
             }
 
-            if (Content == Failed || Data == Failed || Files == Failed || Publishing == Failed)
+            if (Content == ReleaseStatusContentStage.Failed
+                || Data == ReleaseStatusDataStage.Failed 
+                || Files == ReleaseStatusFilesStage.Failed
+                || Publishing == ReleaseStatusPublishingStage.Failed)
             {
-                if (Content == Failed || Data == Failed || Files == Failed)
+                if (Content == ReleaseStatusContentStage.Failed
+                    || Data == ReleaseStatusDataStage.Failed 
+                    || Files == ReleaseStatusFilesStage.Failed)
                 {
-                    Publishing = Cancelled;
+                    Publishing = ReleaseStatusPublishingStage.Cancelled;
                 }
-                Overall = Failed;
+                ReleaseStatusOverall = ReleaseStatusOverallStage.Failed;
             }
 
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
@@ -113,13 +124,50 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         public event PropertyChangedEventHandler PropertyChanged;
     }
 
-    public enum Stage
+    public enum ReleaseStatusContentStage
     {
         Cancelled,
         Complete,
         Failed,
-        Invalid,
         Queued,
+        NotStarted,
+        Started
+    }
+    
+    public enum ReleaseStatusDataStage
+    {
+        Cancelled,
+        Complete,
+        Failed,
+        Queued,
+        NotStarted,
+        Started
+    }
+    
+    public enum ReleaseStatusFilesStage
+    {
+        Cancelled,
+        Complete,
+        Failed,
+        Queued,
+        NotStarted,
+        Started
+    }
+    
+    public enum ReleaseStatusOverallStage
+    {
+        Complete,
+        Failed,
+        Invalid,
+        Scheduled,
+        Started
+    }
+    
+    public enum ReleaseStatusPublishingStage
+    {
+        Cancelled,
+        Complete,
+        Failed,
         Scheduled,
         NotStarted,
         Started

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusState.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusState.cs
@@ -105,12 +105,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
             }
 
             if (Content == ReleaseStatusContentStage.Failed
-                || Data == ReleaseStatusDataStage.Failed 
+                || Data == ReleaseStatusDataStage.Failed
                 || Files == ReleaseStatusFilesStage.Failed
                 || Publishing == ReleaseStatusPublishingStage.Failed)
             {
                 if (Content == ReleaseStatusContentStage.Failed
-                    || Data == ReleaseStatusDataStage.Failed 
+                    || Data == ReleaseStatusDataStage.Failed
                     || Files == ReleaseStatusFilesStage.Failed)
                 {
                     Publishing = ReleaseStatusPublishingStage.Cancelled;
@@ -133,7 +133,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         NotStarted,
         Started
     }
-    
+
     public enum ReleaseStatusDataStage
     {
         Cancelled,
@@ -143,7 +143,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         NotStarted,
         Started
     }
-    
+
     public enum ReleaseStatusFilesStage
     {
         Cancelled,
@@ -153,7 +153,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         NotStarted,
         Started
     }
-    
+
     public enum ReleaseStatusOverallStage
     {
         Complete,
@@ -162,7 +162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         Scheduled,
         Started
     }
-    
+
     public enum ReleaseStatusPublishingStage
     {
         Cancelled,
@@ -170,6 +170,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         Failed,
         Scheduled,
         NotStarted,
-        Started
+        Started,
+        // TODO BAU-541 Remove me
+        ToDo,
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusStates.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusStates.cs
@@ -1,0 +1,45 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
+{
+    public static class ReleaseStatusStates
+    {
+        /**
+         * State used when a Release fails validation
+         */
+        public static readonly ReleaseStatusState InvalidState =
+            new ReleaseStatusState(ReleaseStatusContentStage.Cancelled,
+                ReleaseStatusFilesStage.Cancelled,
+                ReleaseStatusDataStage.Cancelled,
+                ReleaseStatusPublishingStage.Cancelled,
+                ReleaseStatusOverallStage.Invalid);
+
+        /**
+         * State used when a Release passes validation and is scheduled
+         */
+        public static readonly ReleaseStatusState ScheduledState =
+            new ReleaseStatusState(ReleaseStatusContentStage.NotStarted,
+                ReleaseStatusFilesStage.NotStarted,
+                ReleaseStatusDataStage.NotStarted,
+                ReleaseStatusPublishingStage.NotStarted,
+                ReleaseStatusOverallStage.Scheduled);
+
+        /**
+         * State used when the process of publishing a Release has started
+         */
+        public static readonly ReleaseStatusState StartedState =
+            new ReleaseStatusState(ReleaseStatusContentStage.NotStarted,
+                ReleaseStatusFilesStage.NotStarted,
+                ReleaseStatusDataStage.NotStarted,
+                ReleaseStatusPublishingStage.Scheduled,
+                ReleaseStatusOverallStage.Started);
+        
+        /**
+         * TODO BAU-541 Combine with the above and make pubishing state notstarted?
+         */
+        public static readonly ReleaseStatusState StartedImmediateState =
+            new ReleaseStatusState(ReleaseStatusContentStage.NotStarted,
+                ReleaseStatusFilesStage.NotStarted,
+                ReleaseStatusDataStage.NotStarted,
+                ReleaseStatusPublishingStage.ToDo,
+                ReleaseStatusOverallStage.Started);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusStates.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusStates.cs
@@ -23,9 +23,9 @@
                 ReleaseStatusOverallStage.Scheduled);
 
         /**
-         * State used when the process of publishing a Release has started
+         * State used when the process of publishing a scheduled Release has started
          */
-        public static readonly ReleaseStatusState StartedState =
+        public static readonly ReleaseStatusState ScheduledReleaseStartedState =
             new ReleaseStatusState(ReleaseStatusContentStage.NotStarted,
                 ReleaseStatusFilesStage.NotStarted,
                 ReleaseStatusDataStage.NotStarted,
@@ -33,13 +33,13 @@
                 ReleaseStatusOverallStage.Started);
         
         /**
-         * TODO BAU-541 Combine with the above and make pubishing state notstarted?
+         * State used when the process of publishing an immediate Release has started
          */
-        public static readonly ReleaseStatusState StartedImmediateState =
+        public static readonly ReleaseStatusState ImmediateReleaseStartedState =
             new ReleaseStatusState(ReleaseStatusContentStage.NotStarted,
                 ReleaseStatusFilesStage.NotStarted,
                 ReleaseStatusDataStage.NotStarted,
-                ReleaseStatusPublishingStage.ToDo,
+                ReleaseStatusPublishingStage.NotStarted,
                 ReleaseStatusOverallStage.Started);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ValidateReleaseMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ValidateReleaseMessage.cs
@@ -6,5 +6,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
     {
         public bool Immediate { get; set; }
         public Guid ReleaseId { get; set; }
+
+        public override string ToString()
+        {
+            return $"{nameof(Immediate)}: {Immediate}, {nameof(ReleaseId)}: {ReleaseId}";
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ValidateReleaseMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ValidateReleaseMessage.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
+{
+    public class ValidateReleaseMessage
+    {
+        public bool Immediate { get; set; }
+        public Guid ReleaseId { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/DataFactoryPipelineStatusFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/DataFactoryPipelineStatusFunction.cs
@@ -9,7 +9,7 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.Stage;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusDataStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/GenerateAllContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/GenerateAllContentFunction.cs
@@ -10,6 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
     /**
      * Development / BAU Function which performs a full content refresh
      */
+    // ReSharper disable once UnusedType.Global
     public class GenerateAllContentFunction
     {
         private readonly IContentService _contentService;
@@ -22,6 +23,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         }
 
         [FunctionName("GenerateAllContent")]
+        // ReSharper disable once UnusedMember.Global
         public async Task GenerateAllContent(
             [QueueTrigger(QueueName)] GenerateAllContentMessage message,
             ExecutionContext executionContext,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/GenerateReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/GenerateReleaseContentFunction.cs
@@ -5,17 +5,16 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusContentStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
-    // ReSharper disable once ClassNeverInstantiated.Global
+    // ReSharper disable once UnusedType.Global
     public class GenerateReleaseContentFunction
     {
         private readonly IContentService _contentService;
         private readonly IReleaseStatusService _releaseStatusService;
-
-        public const string QueueName = "generate-release-content";
 
         public GenerateReleaseContentFunction(IContentService contentService,
             IReleaseStatusService releaseStatusService)
@@ -31,7 +30,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         [FunctionName("GenerateReleaseContent")]
         // ReSharper disable once UnusedMember.Global
         public async Task GenerateReleaseContent(
-            [QueueTrigger(QueueName)] GenerateReleaseContentMessage message,
+            [QueueTrigger(GenerateReleaseContentQueue)] GenerateReleaseContentMessage message,
             ExecutionContext executionContext,
             ILogger logger)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/GenerateReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/GenerateReleaseContentFunction.cs
@@ -9,6 +9,7 @@ using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseS
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
+    // ReSharper disable once ClassNeverInstantiated.Global
     public class GenerateReleaseContentFunction
     {
         private readonly IContentService _contentService;
@@ -23,6 +24,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             _releaseStatusService = releaseStatusService;
         }
 
+        /**
+         * Azure function which generates the content for a Release into a staging directory.
+         * Depends on the download files existing.
+         */
         [FunctionName("GenerateReleaseContent")]
         // ReSharper disable once UnusedMember.Global
         public async Task GenerateReleaseContent(

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/GenerateReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/GenerateReleaseContentFunction.cs
@@ -5,7 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.Stage;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusContentStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
@@ -24,6 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         }
 
         [FunctionName("GenerateReleaseContent")]
+        // ReSharper disable once UnusedMember.Global
         public async Task GenerateReleaseContent(
             [QueueTrigger(QueueName)] GenerateReleaseContentMessage message,
             ExecutionContext executionContext,
@@ -46,7 +47,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             logger.LogInformation($"{executionContext.FunctionName} completed");
         }
 
-        private async Task UpdateStage(GenerateReleaseContentMessage message, Stage stage,
+        private async Task UpdateStage(GenerateReleaseContentMessage message, ReleaseStatusContentStage stage,
             ReleaseStatusLogMessage logMessage = null)
         {
             foreach (var (releaseId, releaseStatusId) in message.Releases)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishAllContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishAllContentFunction.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
@@ -11,8 +12,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
     public class PublishAllContentFunction
     {
         private readonly IContentService _contentService;
-
-        private const string QueueName = "publish-all-content";
 
         public PublishAllContentFunction(IContentService contentService)
         {
@@ -26,7 +25,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         [FunctionName("PublishAllContent")]
         // ReSharper disable once UnusedMember.Global
         public async Task PublishAllContent(
-            [QueueTrigger(QueueName)] PublishAllContentMessage message,
+            [QueueTrigger(PublishAllContentQueue)] PublishAllContentMessage message,
             ExecutionContext executionContext,
             ILogger logger)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishAllContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishAllContentFunction.cs
@@ -7,25 +7,26 @@ using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
-    /**
-     * Development / BAU Function which performs a full content refresh
-     */
     // ReSharper disable once UnusedType.Global
-    public class GenerateAllContentFunction
+    public class PublishAllContentFunction
     {
         private readonly IContentService _contentService;
 
-        private const string QueueName = "generate-all-content";
+        private const string QueueName = "publish-all-content";
 
-        public GenerateAllContentFunction(IContentService contentService)
+        public PublishAllContentFunction(IContentService contentService)
         {
             _contentService = contentService;
         }
 
-        [FunctionName("GenerateAllContent")]
+        /**
+         * Development / BAU Function to generate and publish the content of all Releases immediately.
+         * Depends on the download files existing.
+         */
+        [FunctionName("PublishAllContent")]
         // ReSharper disable once UnusedMember.Global
-        public async Task GenerateAllContent(
-            [QueueTrigger(QueueName)] GenerateAllContentMessage message,
+        public async Task PublishAllContent(
+            [QueueTrigger(QueueName)] PublishAllContentMessage message,
             ExecutionContext executionContext,
             ILogger logger)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -7,10 +7,10 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.Cosmos.Table;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.Stage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
+    // ReSharper disable once UnusedType.Global
     public class PublishReleaseContentFunction
     {
         private readonly INotificationsService _notificationsService;
@@ -27,6 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         }
 
         [FunctionName("PublishReleaseContent")]
+        // ReSharper disable once UnusedMember.Global
         public async Task PublishReleaseContent([TimerTrigger("%PublishReleaseContentCronSchedule%")]
             TimerInfo timer,
             ExecutionContext executionContext,
@@ -41,7 +42,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 foreach (var releaseStatus in scheduled)
                 {
                     logger.LogInformation($"Moving content for release: {releaseStatus.ReleaseId}");
-                    await UpdateStage(releaseStatus, Started);
+                    await UpdateStage(releaseStatus, ReleaseStatusPublishingStage.Started);
                     try
                     {
                         await _publishingService.PublishReleaseContentAsync(releaseStatus.ReleaseId);
@@ -50,7 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                     catch (Exception e)
                     {
                         logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
-                        await UpdateStage(releaseStatus, Failed,
+                        await UpdateStage(releaseStatus, ReleaseStatusPublishingStage.Failed,
                             new ReleaseStatusLogMessage($"Exception in publishing stage: {e.Message}"));
                     }
                 }
@@ -60,12 +61,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 try
                 {
                     await _notificationsService.NotifySubscribersAsync(releaseIds);
-                    await UpdateStage(published, Complete);
+                    await UpdateStage(published, ReleaseStatusPublishingStage.Complete);
                 }
                 catch (Exception e)
                 {
                     logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
-                    await UpdateStage(published, Failed,
+                    await UpdateStage(published, ReleaseStatusPublishingStage.Failed,
                         new ReleaseStatusLogMessage($"Exception in publishing stage: {e.Message}"));
                 }
             }
@@ -79,9 +80,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             var dateQuery = TableQuery.GenerateFilterConditionForDate(nameof(ReleaseStatus.Publish),
                 QueryComparisons.LessThan, DateTime.Today.AddDays(1));
             var contentStageQuery = TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.ContentStage),
-                QueryComparisons.Equal, Complete.ToString());
+                QueryComparisons.Equal, ReleaseStatusContentStage.Complete.ToString());
             var publishingStageQuery = TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.PublishingStage),
-                QueryComparisons.Equal, Scheduled.ToString());
+                QueryComparisons.Equal, ReleaseStatusPublishingStage.Scheduled.ToString());
             var stageQuery = TableQuery.CombineFilters(contentStageQuery, TableOperators.And, publishingStageQuery);
             var query = new TableQuery<ReleaseStatus>().Where(TableQuery.CombineFilters(dateQuery, TableOperators.And,
                 stageQuery));
@@ -89,7 +90,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             return await _releaseStatusService.ExecuteQueryAsync(query);
         }
 
-        private async Task UpdateStage(IEnumerable<ReleaseStatus> releaseStatuses, Stage stage,
+        private async Task UpdateStage(IEnumerable<ReleaseStatus> releaseStatuses, ReleaseStatusPublishingStage stage,
             ReleaseStatusLogMessage logMessage = null)
         {
             foreach (var releaseStatus in releaseStatuses)
@@ -98,7 +99,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             }
         }
 
-        private async Task UpdateStage(ReleaseStatus releaseStatus, Stage stage,
+        private async Task UpdateStage(ReleaseStatus releaseStatus, ReleaseStatusPublishingStage stage,
             ReleaseStatusLogMessage logMessage = null)
         {
             await _releaseStatusService.UpdatePublishingStageAsync(releaseStatus.ReleaseId, releaseStatus.Id, stage,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.Cosmos.Table;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusPublishingStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
@@ -26,6 +27,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             _publishingService = publishingService;
         }
 
+        /**
+         * Azure function which publishes the content for a Release at a scheduled time by moving it from a staging directory.
+         * Sets the published time on the Release which means it's considered as 'Live'.
+         */
         [FunctionName("PublishReleaseContent")]
         // ReSharper disable once UnusedMember.Global
         public async Task PublishReleaseContent([TimerTrigger("%PublishReleaseContentCronSchedule%")]
@@ -42,16 +47,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 foreach (var releaseStatus in scheduled)
                 {
                     logger.LogInformation($"Moving content for release: {releaseStatus.ReleaseId}");
-                    await UpdateStage(releaseStatus, ReleaseStatusPublishingStage.Started);
+                    await UpdateStage(releaseStatus, Started);
                     try
                     {
-                        await _publishingService.PublishReleaseContentAsync(releaseStatus.ReleaseId);
+                        await _publishingService.PublishStagedReleaseContentAsync(releaseStatus.ReleaseId);
                         published.Add(releaseStatus);
                     }
                     catch (Exception e)
                     {
                         logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
-                        await UpdateStage(releaseStatus, ReleaseStatusPublishingStage.Failed,
+                        await UpdateStage(releaseStatus, Failed,
                             new ReleaseStatusLogMessage($"Exception in publishing stage: {e.Message}"));
                     }
                 }
@@ -61,12 +66,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 try
                 {
                     await _notificationsService.NotifySubscribersAsync(releaseIds);
-                    await UpdateStage(published, ReleaseStatusPublishingStage.Complete);
+                    await UpdateStage(published, Complete);
                 }
                 catch (Exception e)
                 {
                     logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
-                    await UpdateStage(published, ReleaseStatusPublishingStage.Failed,
+                    await UpdateStage(published, Failed,
                         new ReleaseStatusLogMessage($"Exception in publishing stage: {e.Message}"));
                 }
             }
@@ -81,13 +86,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 QueryComparisons.LessThan, DateTime.Today.AddDays(1));
             var contentStageQuery = TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.ContentStage),
                 QueryComparisons.Equal, ReleaseStatusContentStage.Complete.ToString());
+            var dataStageQuery = TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.DataStage),
+                QueryComparisons.Equal, ReleaseStatusDataStage.Complete.ToString());
             var publishingStageQuery = TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.PublishingStage),
-                QueryComparisons.Equal, ReleaseStatusPublishingStage.Scheduled.ToString());
-            var stageQuery = TableQuery.CombineFilters(contentStageQuery, TableOperators.And, publishingStageQuery);
-            var query = new TableQuery<ReleaseStatus>().Where(TableQuery.CombineFilters(dateQuery, TableOperators.And,
-                stageQuery));
+                QueryComparisons.Equal, Scheduled.ToString());
 
-            return await _releaseStatusService.ExecuteQueryAsync(query);
+            var stageQuery = TableQuery.CombineFilters(
+                TableQuery.CombineFilters(contentStageQuery, TableOperators.And, dataStageQuery),
+                TableOperators.And, publishingStageQuery);
+            var combinedQuery = TableQuery.CombineFilters(dateQuery, TableOperators.And, stageQuery);
+
+            return await _releaseStatusService.ExecuteQueryAsync(new TableQuery<ReleaseStatus>().Where(combinedQuery));
         }
 
         private async Task UpdateStage(IEnumerable<ReleaseStatus> releaseStatuses, ReleaseStatusPublishingStage stage,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentImmediateFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentImmediateFunction.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusPublishingStage;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public class PublishReleaseContentImmediateFunction
+    {
+        private readonly IContentService _contentService;
+        private readonly INotificationsService _notificationsService;
+        private readonly IReleaseService _releaseService;
+        private readonly IReleaseStatusService _releaseStatusService;
+
+        public const string QueueName = "publish-release-content-immediate";
+
+        public PublishReleaseContentImmediateFunction(IContentService contentService,
+            INotificationsService notificationsService,
+            IReleaseService releaseService,
+            IReleaseStatusService releaseStatusService)
+        {
+            _contentService = contentService;
+            _notificationsService = notificationsService;
+            _releaseService = releaseService;
+            _releaseStatusService = releaseStatusService;
+        }
+
+        /**
+         * Azure function which generates and publishes the content for a Release immediately.
+         * Depends on the download files existing.
+         * Sets the published time on the Release which means it's considered as 'Live'.
+         */
+        [FunctionName("PublishReleaseContentImmediate")]
+        // ReSharper disable once UnusedMember.Global
+        public async Task PublishReleaseContentImmediate(
+            [QueueTrigger(QueueName)] PublishReleaseContentImmediateMessage message,
+            ExecutionContext executionContext,
+            ILogger logger)
+        {
+            logger.LogInformation($"{executionContext.FunctionName} triggered at: {DateTime.Now}");
+            try
+            {
+                await _contentService.UpdateContentAsync(new[] {message.ReleaseId}, false);
+                await _releaseService.SetPublishedDateAsync(message.ReleaseId);
+                await _notificationsService.NotifySubscribersAsync(new[] {message.ReleaseId});
+                // TODO BAU-541 This isn't updating the content stage
+                await UpdateStage(message, Complete);
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
+                await UpdateStage(message, Failed,
+                    new ReleaseStatusLogMessage($"Exception publishing release immediately: {e.Message}"));
+            }
+
+            logger.LogInformation($"{executionContext.FunctionName} completed");
+        }
+
+        private async Task UpdateStage(PublishReleaseContentImmediateMessage message,
+            ReleaseStatusPublishingStage stage, ReleaseStatusLogMessage logMessage = null)
+        {
+            await _releaseStatusService.UpdatePublishingStageAsync(message.ReleaseId, message.ReleaseStatusId, stage,
+                logMessage);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentImmediateFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentImmediateFunction.cs
@@ -4,19 +4,18 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusPublishingStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
-    // ReSharper disable once ClassNeverInstantiated.Global
+    // ReSharper disable once UnusedType.Global
     public class PublishReleaseContentImmediateFunction
     {
         private readonly IContentService _contentService;
         private readonly INotificationsService _notificationsService;
         private readonly IReleaseService _releaseService;
         private readonly IReleaseStatusService _releaseStatusService;
-
-        public const string QueueName = "publish-release-content-immediate";
 
         public PublishReleaseContentImmediateFunction(IContentService contentService,
             INotificationsService notificationsService,
@@ -37,7 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         [FunctionName("PublishReleaseContentImmediate")]
         // ReSharper disable once UnusedMember.Global
         public async Task PublishReleaseContentImmediate(
-            [QueueTrigger(QueueName)] PublishReleaseContentImmediateMessage message,
+            [QueueTrigger(PublishReleaseContentImmediateQueue)] PublishReleaseContentImmediateMessage message,
             ExecutionContext executionContext,
             ILogger logger)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseDataFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseDataFunction.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
-using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.Stage;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusDataStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
@@ -28,6 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         }
 
         [FunctionName("PublishReleaseData")]
+        // ReSharper disable once UnusedMember.Global
         public async Task PublishReleaseData(
             [QueueTrigger(QueueName)] PublishReleaseDataMessage message,
             ExecutionContext executionContext,
@@ -59,7 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             logger.LogInformation($"{executionContext.FunctionName} completed");
         }
 
-        private async Task UpdateStage(PublishReleaseDataMessage message, Stage stage,
+        private async Task UpdateStage(PublishReleaseDataMessage message, ReleaseStatusDataStage stage,
             ReleaseStatusLogMessage logMessage = null)
         {
             await _releaseStatusService.UpdateDataStageAsync(message.ReleaseId, message.ReleaseStatusId, stage,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseDataFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseDataFunction.cs
@@ -10,18 +10,17 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusDataStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
-    // ReSharper disable once ClassNeverInstantiated.Global
+    // ReSharper disable once UnusedType.Global
     public class PublishReleaseDataFunction
     {
         private readonly IConfiguration _configuration;
         private readonly IQueueService _queueService;
         private readonly IReleaseStatusService _releaseStatusService;
-
-        public const string QueueName = "publish-release-data";
 
         public PublishReleaseDataFunction(IConfiguration configuration,
             IQueueService queueService,
@@ -39,7 +38,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         [FunctionName("PublishReleaseData")]
         // ReSharper disable once UnusedMember.Global
         public async Task PublishReleaseData(
-            [QueueTrigger(QueueName)] PublishReleaseDataMessage message,
+            [QueueTrigger(PublishReleaseDataQueue)] PublishReleaseDataMessage message,
             ExecutionContext executionContext,
             ILogger logger)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
@@ -9,6 +10,7 @@ using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseS
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
+    // ReSharper disable once ClassNeverInstantiated.Global
     public class PublishReleaseFilesFunction
     {
         private readonly IPublishingService _publishingService;
@@ -26,6 +28,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             _releaseStatusService = releaseStatusService;
         }
 
+        /**
+         * Azure function which publishes the files for a Release by copying them between storage accounts.
+         * Triggers publishing statistics data for the Release if publishing is immediate.
+         * Triggers generating staged content for the Release if publishing is not immediate.
+         */
         [FunctionName("PublishReleaseFiles")]
         // ReSharper disable once UnusedMember.Global
         public async Task PublishReleaseFiles(
@@ -35,10 +42,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         {
             logger.LogInformation($"{executionContext.FunctionName} triggered: {message}");
 
+            var immediate = await IsImmediate(message);
             var published = new List<(Guid ReleaseId, Guid ReleaseStatusId)>();
             foreach (var (releaseId, releaseStatusId) in message.Releases)
             {
-                await UpdateFilesStage(releaseId, releaseStatusId, Started);
+                await UpdateStage(releaseId, releaseStatusId, Started);
                 try
                 {
                     _publishingService.PublishReleaseFilesAsync(releaseId).Wait();
@@ -47,31 +55,42 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 catch (Exception e)
                 {
                     logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
-                    await UpdateFilesStage(releaseId, releaseStatusId, Failed,
+                    await UpdateStage(releaseId, releaseStatusId, Failed,
                         new ReleaseStatusLogMessage($"Exception in files stage: {e.Message}"));
                 }
             }
 
-            await _queueService.QueueGenerateReleaseContentMessageAsync(published);
+            if (immediate)
+            {
+                await _queueService.QueuePublishReleaseDataMessagesAsync(published);
+            } else {
+                await _queueService.QueueGenerateReleaseContentMessageAsync(published);
+            }
 
             foreach (var (releaseId, releaseStatusId) in published)
             {
-                await UpdateFilesStage(releaseId, releaseStatusId, Complete);
-                await UpdateContentStage(releaseId, releaseStatusId, ReleaseStatusContentStage.Queued);
+                await UpdateStage(releaseId, releaseStatusId, Complete);
             }
 
             logger.LogInformation($"{executionContext.FunctionName} completed");
         }
 
-        private async Task UpdateFilesStage(Guid releaseId, Guid releaseStatusId, ReleaseStatusFilesStage stage,
+        private async Task<bool> IsImmediate(PublishReleaseFilesMessage message)
+        {
+            if (message.Releases.Count() > 1)
+            {
+                // If there's more than one Release this invocation couldn't have been triggered for immediate publishing
+                return false;
+            }
+
+            var (releaseId, releaseStatusId) = message.Releases.Single();
+            return await _releaseStatusService.IsImmediate(releaseId, releaseStatusId);
+        }
+        
+        private async Task UpdateStage(Guid releaseId, Guid releaseStatusId, ReleaseStatusFilesStage stage,
             ReleaseStatusLogMessage logMessage = null)
         {
             await _releaseStatusService.UpdateFilesStageAsync(releaseId, releaseStatusId, stage, logMessage);
-        }
-
-        private async Task UpdateContentStage(Guid releaseId, Guid releaseStatusId, ReleaseStatusContentStage stage)
-        {
-            await _releaseStatusService.UpdateContentStageAsync(releaseId, releaseStatusId, stage);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
@@ -5,7 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.Stage;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusFilesStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
@@ -27,6 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         }
 
         [FunctionName("PublishReleaseFiles")]
+        // ReSharper disable once UnusedMember.Global
         public async Task PublishReleaseFiles(
             [QueueTrigger(QueueName)] PublishReleaseFilesMessage message,
             ExecutionContext executionContext,
@@ -56,19 +57,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             foreach (var (releaseId, releaseStatusId) in published)
             {
                 await UpdateFilesStage(releaseId, releaseStatusId, Complete);
-                await UpdateContentStage(releaseId, releaseStatusId, Queued);
+                await UpdateContentStage(releaseId, releaseStatusId, ReleaseStatusContentStage.Queued);
             }
 
             logger.LogInformation($"{executionContext.FunctionName} completed");
         }
 
-        private async Task UpdateFilesStage(Guid releaseId, Guid releaseStatusId, Stage stage,
+        private async Task UpdateFilesStage(Guid releaseId, Guid releaseStatusId, ReleaseStatusFilesStage stage,
             ReleaseStatusLogMessage logMessage = null)
         {
             await _releaseStatusService.UpdateFilesStageAsync(releaseId, releaseStatusId, stage, logMessage);
         }
 
-        private async Task UpdateContentStage(Guid releaseId, Guid releaseStatusId, Stage stage)
+        private async Task UpdateContentStage(Guid releaseId, Guid releaseStatusId, ReleaseStatusContentStage stage)
         {
             await _releaseStatusService.UpdateContentStageAsync(releaseId, releaseStatusId, stage);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
@@ -6,18 +6,17 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusFilesStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
-    // ReSharper disable once ClassNeverInstantiated.Global
+    // ReSharper disable once UnusedType.Global
     public class PublishReleaseFilesFunction
     {
         private readonly IPublishingService _publishingService;
         private readonly IQueueService _queueService;
         private readonly IReleaseStatusService _releaseStatusService;
-
-        public const string QueueName = "publish-release-files";
 
         public PublishReleaseFilesFunction(IPublishingService publishingService,
             IQueueService queueService,
@@ -36,7 +35,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         [FunctionName("PublishReleaseFiles")]
         // ReSharper disable once UnusedMember.Global
         public async Task PublishReleaseFiles(
-            [QueueTrigger(QueueName)] PublishReleaseFilesMessage message,
+            [QueueTrigger(PublishReleaseFilesQueue)]
+            PublishReleaseFilesMessage message,
             ExecutionContext executionContext,
             ILogger logger)
         {
@@ -63,7 +63,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             if (immediate)
             {
                 await _queueService.QueuePublishReleaseDataMessagesAsync(published);
-            } else {
+            }
+            else
+            {
                 await _queueService.QueueGenerateReleaseContentMessageAsync(published);
             }
 
@@ -86,7 +88,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             var (releaseId, releaseStatusId) = message.Releases.Single();
             return await _releaseStatusService.IsImmediate(releaseId, releaseStatusId);
         }
-        
+
         private async Task UpdateStage(Guid releaseId, Guid releaseStatusId, ReleaseStatusFilesStage stage,
             ReleaseStatusLogMessage logMessage = null)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleasesFunction.cs
@@ -47,7 +47,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             {
                 foreach (var (releaseId, releaseStatusId) in scheduled)
                 {
-                    await _releaseStatusService.UpdateStateAsync(releaseId, releaseStatusId, StartedState);
+                    await _releaseStatusService.UpdateStateAsync(releaseId, releaseStatusId, ScheduledReleaseStartedState);
                 }
 
                 await _queueService.QueuePublishReleaseFilesMessageAsync(scheduled);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleasesFunction.cs
@@ -7,17 +7,22 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.Cosmos.Table;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.Stage;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusOverallStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
+    // ReSharper disable once UnusedType.Global
     public class PublishReleasesFunction
     {
         private readonly IQueueService _queueService;
         private readonly IReleaseStatusService _releaseStatusService;
-        
+
         private static readonly ReleaseStatusState StartedState =
-            new ReleaseStatusState(NotStarted, Queued, Queued, Scheduled, Started);
+            new ReleaseStatusState(ReleaseStatusContentStage.NotStarted,
+                ReleaseStatusFilesStage.Queued,
+                ReleaseStatusDataStage.Queued,
+                ReleaseStatusPublishingStage.Scheduled,
+                Started);
 
         public PublishReleasesFunction(IQueueService queueService, IReleaseStatusService releaseStatusService)
         {
@@ -29,6 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
          * Azure function which publishes all Releases that are scheduled to be published during the day.
          */
         [FunctionName("PublishReleases")]
+        // ReSharper disable once UnusedMember.Global
         public void PublishReleases([TimerTrigger("%PublishReleasesCronSchedule%")]
             TimerInfo timer,
             ExecutionContext executionContext,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/ValidateReleaseFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/ValidateReleaseFunction.cs
@@ -40,11 +40,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             logger.LogInformation($"{executionContext.FunctionName} triggered: {message}");
             await ValidateReleaseAsync(message, async () =>
             {
-                // TODO BAU-541 fail is there is already a run that is Started
-                // TODO BAU-541 cancel an existing run that is already Scheduled
+                // TODO BAU-563 fail is there is already a run that is Started
+                // TODO BAU-562 cancel an existing run that is already Scheduled
                 if (message.Immediate)
                 {
-                    // TODO BAU-541 fail if the staging directory already exists
+                    // TODO BAU-563 fail if the staging directory already exists
                     var releaseStatus = await CreateReleaseStatusAsync(message, StartedImmediateState);
                     await _queueService.QueuePublishReleaseFilesMessageAsync(releaseStatus.ReleaseId, releaseStatus.Id);
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/ValidateReleaseFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/ValidateReleaseFunction.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusStates;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
@@ -15,8 +16,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         private readonly IQueueService _queueService;
         private readonly IReleaseStatusService _releaseStatusService;
         private readonly IValidationService _validationService;
-
-        private const string QueueName = "releases";
 
         public ValidateReleaseFunction(IQueueService queueService,
             IReleaseStatusService releaseStatusService,
@@ -34,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         [FunctionName("ValidateRelease")]
         // ReSharper disable once UnusedMember.Global
         public async Task ValidateRelease(
-            [QueueTrigger(QueueName)] ValidateReleaseMessage message,
+            [QueueTrigger(ValidateReleaseQueue)] ValidateReleaseMessage message,
             ExecutionContext executionContext,
             ILogger logger)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/ValidateReleaseFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/ValidateReleaseFunction.cs
@@ -45,7 +45,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 if (message.Immediate)
                 {
                     // TODO BAU-563 fail if the staging directory already exists
-                    var releaseStatus = await CreateReleaseStatusAsync(message, StartedImmediateState);
+                    var releaseStatus = await CreateReleaseStatusAsync(message, ImmediateReleaseStartedState);
                     await _queueService.QueuePublishReleaseFilesMessageAsync(releaseStatus.ReleaseId, releaseStatus.Id);
                 }
                 else

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
@@ -7,6 +7,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
     public interface IContentService
     {
         Task UpdateAllContentAsync();
-        Task UpdateContentAsync(IEnumerable<Guid> releaseIds);
+        Task UpdateContentAsync(IEnumerable<Guid> releaseIds, bool staging = true);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublishingService.cs
@@ -5,7 +5,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 {
     public interface IPublishingService
     {
-        Task PublishReleaseContentAsync(Guid releaseId);
+        Task PublishStagedReleaseContentAsync(Guid releaseId);
 
         Task PublishReleaseFilesAsync(Guid releaseId);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IQueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IQueueService.cs
@@ -8,8 +8,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
     {
         Task QueueGenerateReleaseContentMessageAsync(IEnumerable<(Guid ReleaseId, Guid ReleaseStatusId)> releases);
 
+        Task QueuePublishReleaseContentImmediateMessageAsync(Guid releaseId, Guid releaseStatusId);
+
         Task QueuePublishReleaseDataMessagesAsync(IEnumerable<(Guid ReleaseId, Guid ReleaseStatusId)> releases);
 
+        Task QueuePublishReleaseFilesMessageAsync(Guid releaseId, Guid releaseStatusId);
+        
         Task QueuePublishReleaseFilesMessageAsync(IEnumerable<(Guid ReleaseId, Guid ReleaseStatusId)> releases);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseStatusService.cs
@@ -10,14 +10,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
     {
         Task<ReleaseStatus> CreateAsync(Guid releaseId, ReleaseStatusState state, bool immediate,
             IEnumerable<ReleaseStatusLogMessage> logMessages = null);
-        
+
         Task<IEnumerable<ReleaseStatus>> ExecuteQueryAsync(TableQuery<ReleaseStatus> query);
 
         Task<ReleaseStatus> GetAsync(Guid releaseId, Guid releaseStatusId);
 
         Task<bool> IsImmediate(Guid releaseId, Guid releaseStatusId);
-        
+
         Task UpdateStateAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusState state);
+
+        Task UpdateStagesAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusContentStage? contentStage = null,
+            ReleaseStatusDataStage? dataStage = null, ReleaseStatusFilesStage? filesStage = null,
+            ReleaseStatusPublishingStage? publishingStage = null, ReleaseStatusLogMessage logMessage = null);
 
         Task UpdateContentStageAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusContentStage stage,
             ReleaseStatusLogMessage logMessage = null);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseStatusService.cs
@@ -8,11 +8,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 {
     public interface IReleaseStatusService
     {
-        Task CreateAsync(Guid releaseId, ReleaseStatusState state,
+        Task<ReleaseStatus> CreateAsync(Guid releaseId, ReleaseStatusState state, bool immediate,
             IEnumerable<ReleaseStatusLogMessage> logMessages = null);
-
+        
         Task<IEnumerable<ReleaseStatus>> ExecuteQueryAsync(TableQuery<ReleaseStatus> query);
 
+        Task<ReleaseStatus> GetAsync(Guid releaseId, Guid releaseStatusId);
+
+        Task<bool> IsImmediate(Guid releaseId, Guid releaseStatusId);
+        
         Task UpdateStateAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusState state);
 
         Task UpdateContentStageAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusContentStage stage,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseStatusService.cs
@@ -8,23 +8,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 {
     public interface IReleaseStatusService
     {
-        Task CreateOrUpdateAsync(Guid releaseId, ReleaseStatusState state,
+        Task CreateAsync(Guid releaseId, ReleaseStatusState state,
             IEnumerable<ReleaseStatusLogMessage> logMessages = null);
 
         Task<IEnumerable<ReleaseStatus>> ExecuteQueryAsync(TableQuery<ReleaseStatus> query);
 
         Task UpdateStateAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusState state);
 
-        Task UpdateContentStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+        Task UpdateContentStageAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusContentStage stage,
             ReleaseStatusLogMessage logMessage = null);
 
-        Task UpdateDataStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+        Task UpdateDataStageAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusDataStage stage,
             ReleaseStatusLogMessage logMessage = null);
 
-        Task UpdateFilesStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+        Task UpdateFilesStageAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusFilesStage stage,
             ReleaseStatusLogMessage logMessage = null);
 
-        Task UpdatePublishingStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+        Task UpdatePublishingStageAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusPublishingStage stage,
             ReleaseStatusLogMessage logMessage = null);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IValidationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IValidationService.cs
@@ -7,6 +7,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
     public interface IValidationService
     {
         Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidateAsync(
-            ReleaseStatusMessage statusMessage);
+            ValidateReleaseMessage validateReleaseMessage);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -16,7 +16,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             _releaseService = releaseService;
         }
 
-        public async Task PublishReleaseContentAsync(Guid releaseId)
+        public async Task PublishStagedReleaseContentAsync(Guid releaseId)
         {
             await _fileStorageService.MoveStagedContentAsync();
             await _releaseService.SetPublishedDateAsync(releaseId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/QueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/QueueService.cs
@@ -79,7 +79,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             var queue = await GetQueueReferenceAsync(_storageConnectionString, PublishReleaseFilesQueue);
             var releasesList = releases.ToList();
             _logger.LogInformation(
-                $"Queuing files message for releases: {releasesList.Select(tuple => tuple.ReleaseId)}");
+                $"Queuing files message for releases: {string.Join(", ", releasesList.Select(tuple => tuple.ReleaseId))}");
             await queue.AddMessageAsync(ToCloudQueueMessage(BuildPublishReleaseFilesMessage(releasesList)));
             foreach (var (releaseId, releaseStatusId) in releasesList)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -116,7 +116,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             }
         }
 
-        private DateTime GetNextScheduledPublishingTime()
+        private static DateTime GetNextScheduledPublishingTime()
         {
             var publishReleasesCronSchedule = Environment.GetEnvironmentVariable("PublishReleaseContentCronSchedule");
             return TryParseCronSchedule(publishReleasesCronSchedule, out var cronSchedule)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseStatusService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -31,28 +30,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             _tableStorageService = tableStorageService;
         }
 
-        public async Task CreateOrUpdateAsync(Guid releaseId, ReleaseStatusState state,
+        public async Task CreateAsync(Guid releaseId, ReleaseStatusState state,
             IEnumerable<ReleaseStatusLogMessage> logMessages = null)
         {
             var release = await GetReleaseAsync(releaseId);
             var table = await GetTableAsync();
-
-            var releaseStatus = await GetReleaseStatus(releaseId);
-            if (releaseStatus == null)
-            {
-                releaseStatus = new ReleaseStatus(release.Publication.Slug, release.PublishScheduled, release.Id,
-                    release.Slug, state, logMessages);
-            }
-            else
-            {
-                releaseStatus.PublicationSlug = release.Publication.Slug;
-                releaseStatus.Publish = release.PublishScheduled;
-                releaseStatus.ReleaseSlug = release.Slug;
-                releaseStatus.State = state;
-                releaseStatus.AppendLogMessages(logMessages);
-            }
-
-            await table.ExecuteAsync(TableOperation.InsertOrReplace(releaseStatus));
+            var releaseStatus = new ReleaseStatus(release.Publication.Slug, release.PublishScheduled, release.Id,
+                release.Slug, state, logMessages);
+            await table.ExecuteAsync(TableOperation.Insert(releaseStatus));
         }
 
         public async Task<IEnumerable<ReleaseStatus>> ExecuteQueryAsync(TableQuery<ReleaseStatus> query)
@@ -79,7 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             });
         }
 
-        public async Task UpdateContentStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+        public async Task UpdateContentStageAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusContentStage stage,
             ReleaseStatusLogMessage logMessage = null)
         {
             await UpdateRowAsync(releaseId, releaseStatusId, row =>
@@ -90,7 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             });
         }
 
-        public async Task UpdateDataStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+        public async Task UpdateDataStageAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusDataStage stage,
             ReleaseStatusLogMessage logMessage = null)
         {
             await UpdateRowAsync(releaseId, releaseStatusId, row =>
@@ -101,7 +86,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             });
         }
 
-        public async Task UpdateFilesStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
+        public async Task UpdateFilesStageAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusFilesStage stage,
             ReleaseStatusLogMessage logMessage = null)
         {
             await UpdateRowAsync(releaseId, releaseStatusId, row =>
@@ -112,8 +97,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             });
         }
 
-        public async Task UpdatePublishingStageAsync(Guid releaseId, Guid releaseStatusId, Stage stage,
-            ReleaseStatusLogMessage logMessage = null)
+        public async Task UpdatePublishingStageAsync(Guid releaseId, Guid releaseStatusId,
+            ReleaseStatusPublishingStage stage, ReleaseStatusLogMessage logMessage = null)
         {
             await UpdateRowAsync(releaseId, releaseStatusId, row =>
             {
@@ -162,7 +147,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                         {
                             throw;
                         }
-                    } 
+                    }
                     else
                     {
                         throw;
@@ -171,14 +156,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             }
         }
 
-        private async Task<ReleaseStatus> GetReleaseStatus(Guid releaseId)
-        {
-            var table = await GetTableAsync();
-            var queryResults = table.ExecuteQuery(new TableQuery<ReleaseStatus>().Where(
-                TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.PartitionKey), QueryComparisons.Equal,
-                    releaseId.ToString())));
-            return queryResults.SingleOrDefault();
-        }
+        // private async Task<ReleaseStatus> GetReleaseStatus(Guid releaseId)
+        // {
+        //     var table = await GetTableAsync();
+        //     var queryResults = table.ExecuteQuery(new TableQuery<ReleaseStatus>().Where(
+        //         TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.PartitionKey), QueryComparisons.Equal,
+        //             releaseId.ToString())));
+        //     return queryResults.SingleOrDefault();
+        // }
 
         private Task<Release> GetReleaseAsync(Guid releaseId)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseStatusService.cs
@@ -84,6 +84,38 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             });
         }
 
+        public async Task UpdateStagesAsync(Guid releaseId, Guid releaseStatusId,
+            ReleaseStatusContentStage? contentStage,
+            ReleaseStatusDataStage? dataStage, ReleaseStatusFilesStage? filesStage,
+            ReleaseStatusPublishingStage? publishingStage, ReleaseStatusLogMessage logMessage = null)
+        {
+            await UpdateRowAsync(releaseId, releaseStatusId, row =>
+            {
+                if (contentStage.HasValue)
+                {
+                    row.State.Content = contentStage.Value;
+                }
+
+                if (dataStage.HasValue)
+                {
+                    row.State.Data = dataStage.Value;
+                }
+
+                if (filesStage.HasValue)
+                {
+                    row.State.Files = filesStage.Value;
+                }
+
+                if (publishingStage.HasValue)
+                {
+                    row.State.Publishing = publishingStage.Value;
+                }
+
+                row.AppendLogMessage(logMessage);
+                return row;
+            });
+        }
+
         public async Task UpdateContentStageAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusContentStage stage,
             ReleaseStatusLogMessage logMessage = null)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseStatusService.cs
@@ -40,19 +40,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             await table.ExecuteAsync(TableOperation.Insert(releaseStatus));
         }
 
-        public async Task<IEnumerable<ReleaseStatus>> ExecuteQueryAsync(TableQuery<ReleaseStatus> query)
+        public Task<IEnumerable<ReleaseStatus>> ExecuteQueryAsync(TableQuery<ReleaseStatus> query)
         {
-            var results = new List<ReleaseStatus>();
-            var table = await GetTableAsync();
-            TableContinuationToken token = null;
-            do
-            {
-                var queryResult = await table.ExecuteQuerySegmentedAsync(query, token);
-                results.AddRange(queryResult.Results);
-                token = queryResult.ContinuationToken;
-            } while (token != null);
-
-            return results;
+            return _tableStorageService.ExecuteQueryAsync(TableName, query);
         }
 
         public async Task UpdateStateAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusState state)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ValidationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ValidationService.cs
@@ -25,11 +25,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         }
 
         public async Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidateAsync(
-            ReleaseStatusMessage statusMessage)
+            ValidateReleaseMessage validateReleaseMessage)
         {
-            _logger.LogTrace($"Validating release: {statusMessage.ReleaseId}");
+            _logger.LogTrace($"Validating release: {validateReleaseMessage.ReleaseId}");
 
-            var release = await GetReleaseAsync(statusMessage.ReleaseId);
+            var release = await GetReleaseAsync(validateReleaseMessage.ReleaseId);
 
             var (approvalValid, approvalMessages) = ValidateApproval(release);
             var (scheduledPublishDateValid, scheduledPublishDateMessages) = ValidateScheduledPublishDate(release);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/host.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/host.json
@@ -3,12 +3,13 @@
   "logging": {
     "logLevel": {
       "default": "None",
-      "Function.GenerateAllContent": "Information",
+      "Function.PublishAllContent": "Information",
       "Function.GenerateReleaseContent": "Information",
       "Function.PublishReleases": "Information",
       "Function.PublishReleaseContent": "Information",
       "Function.PublishReleaseData": "Information",
       "Function.PublishReleaseFiles": "Information",
+      "Function.PublishReleaseContentImmediate": "Information",
       "Function.ValidateRelease": "Information",
       "Function.DataFactoryPipelineStatusFunction": "Information",
       "GovUk.Education.ExploreEducationStatistics.Publisher": "Information"


### PR DESCRIPTION
- Every time the Release is approved in the Admin and validated we now create a new ReleaseStatus entry so that we maintain a history if a Release is ever re-approved (for whatever reason).
- A new `PublishReleaseContentImmediate` function has been added which generates and publishes the content for a Release immediately. This has the ability to be run standalone in the future where we need to retry or rerun the content stage only without doing a full release of files and statistics data.
- `ValidateReleaseMessage` which is dropped onto the releases queue when a Release is approved now has an `Immediate` flag. This can be used in the future where we want to perform a Release on demand. It triggers all of the stages. Content is published immediately rather than being staged. This uses the new `PublishReleaseContentImmediate` function.
- Separates the `Stage` enum into five different enums so the stage each task can be in is constrained to a set only applicable to it.

There can only be one Release when _immediate_ is used. There can still be multiple releases _scheduled_ at the same time.

When running with `Immediate` there has had to a change to the order which tasks are run in.

Generating content still depends on listing the files so the files task must always run before content.
Content can't be published until the files and data tasks have completed. This wasn't a problem for scheduled releases but is if publishing content immediately especially because the ADF Pipeline can take a while to run.

**Scheduled release (order not changed):**
Files and data tasks are triggered simultaneously.
Content staging is triggered once the files task is complete.
Publishing happens at 09:30. There is now a check to make sure the content and data tasks are completed.

**Immediate (new):**
Files task is triggered.
Data task is triggered once the files task is complete.
Content is generated and published immediately once the ADF Pipeline status callback is triggered.

If running locally where there is no ADF Pipeline the content is generated and published immediately when the data task is skipped.