### PR TITLE
BAU-468, BAU-195 Fix timing issue causing Details to fail to open when searching

### DIFF
--- a/src/explore-education-statistics-common/src/components/Details.tsx
+++ b/src/explore-education-statistics-common/src/components/Details.tsx
@@ -3,7 +3,13 @@ import useToggle from '@common/hooks/useToggle';
 import findAllParents from '@common/utils/dom/findAllParents';
 import { formatTestId } from '@common/utils/test-utils';
 import classNames from 'classnames';
-import React, { MouseEvent, ReactNode, useEffect, useRef } from 'react';
+import React, {
+  MouseEvent,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 let hasNativeDetails: boolean;
 let idCounter = 0;
@@ -38,13 +44,14 @@ export interface DetailsProps {
 const Details = ({
   className,
   children,
-  id = `details-content-${(idCounter += 1)}`,
+  id: propId = `details-content-${(idCounter += 1)}`,
   jsRequired = false,
   open = false,
   onToggle,
   summary,
   tag,
 }: DetailsProps) => {
+  const [id] = useState(propId);
   const ref = useRef<HTMLElement>(null);
 
   const { onMounted } = useMounted(undefined, jsRequired);

--- a/src/explore-education-statistics-common/src/components/__tests__/Details.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Details.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { fireEvent, render, wait } from '@testing-library/react';
+import React from 'react';
 import Details from '../Details';
 
 describe('Details', () => {
@@ -13,6 +13,22 @@ describe('Details', () => {
     await wait();
 
     expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('re-rendering does not change auto-generated `id`', () => {
+    const { container, rerender } = render(
+      <Details summary="Test summary">Test content</Details>,
+    );
+
+    const originalId = container.querySelector('.govuk-details__text')?.id;
+
+    expect(originalId).toBeDefined();
+
+    rerender(<Details summary="Test summary 2">Test content 2</Details>);
+
+    const currentId = container.querySelector('.govuk-details__text')?.id;
+
+    expect(currentId).toBe(originalId);
   });
 
   test('renders correctly with `open` prop set to true', async () => {

--- a/src/explore-education-statistics-common/src/components/__tests__/PageSearchForm.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/PageSearchForm.test.tsx
@@ -3,8 +3,8 @@ import AccordionSection from '@common/components/AccordionSection';
 import Details from '@common/components/Details';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
-import React from 'react';
 import { fireEvent, render, wait } from '@testing-library/react';
+import React from 'react';
 import PageSearchForm from '../PageSearchForm';
 
 const labelText = 'Find on this page';
@@ -503,17 +503,19 @@ describe('PageSearchForm', () => {
 
     jest.runOnlyPendingTimers();
 
+    jest.useRealTimers();
+
     fireEvent.click(container.querySelector('[role="option"]') as HTMLElement);
 
-    jest.runOnlyPendingTimers();
+    await wait(() => {
+      const target = container.querySelector('#target');
 
-    const target = container.querySelector('#target');
-
-    expect(target).toHaveFocus();
-    expect(target).toHaveScrolledIntoView();
+      expect(target).toHaveFocus();
+      expect(target).toHaveScrolledIntoView();
+    });
   });
 
-  test('pressing Enter on result scrolls and focuses the element', () => {
+  test('pressing Enter on result scrolls and focuses the element', async () => {
     jest.useFakeTimers();
 
     const { container, getByLabelText } = render(
@@ -533,17 +535,19 @@ describe('PageSearchForm', () => {
 
     jest.runOnlyPendingTimers();
 
+    jest.useRealTimers();
+
     const listBox = container.querySelector('[role="listbox"]') as HTMLElement;
 
     fireEvent.keyDown(listBox, { key: 'ArrowDown' });
     fireEvent.keyDown(listBox, { key: 'Enter' });
 
-    jest.runOnlyPendingTimers();
+    await wait(() => {
+      const target = container.querySelector('#target');
 
-    const target = container.querySelector('#target');
-
-    expect(target).toHaveFocus();
-    expect(target).toHaveScrolledIntoView();
+      expect(target).toHaveFocus();
+      expect(target).toHaveScrolledIntoView();
+    });
   });
 
   test('opens parent accordion of selected result', async () => {
@@ -611,11 +615,13 @@ describe('PageSearchForm', () => {
 
     expect(summary).toHaveAttribute('aria-expanded', 'false');
 
+    jest.useRealTimers();
+
     fireEvent.click(container.querySelector('[role="option"]') as HTMLElement);
 
-    jest.runOnlyPendingTimers();
-
-    expect(summary).toHaveAttribute('aria-expanded', 'true');
+    await wait(() => {
+      expect(summary).toHaveAttribute('aria-expanded', 'true');
+    });
   });
 
   test('opens parent tab section of selected result', async () => {
@@ -654,12 +660,14 @@ describe('PageSearchForm', () => {
     expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
     expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
 
+    jest.useRealTimers();
+
     fireEvent.click(container.querySelector('[role="option"]') as HTMLElement);
 
-    jest.runOnlyPendingTimers();
-
-    expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
-    expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+    await wait(() => {
+      expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
+      expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+    });
   });
 
   test('opens nested sections of selected result', async () => {
@@ -702,12 +710,14 @@ describe('PageSearchForm', () => {
     const tabs = container.querySelectorAll('[role="tab"]');
     const summary = container.querySelector('summary');
 
+    jest.useRealTimers();
+
     fireEvent.click(container.querySelector('[role="option"]') as HTMLElement);
 
-    jest.runOnlyPendingTimers();
-
-    expect(accordionSection).toHaveAttribute('aria-expanded', 'true');
-    expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
-    expect(summary).toHaveAttribute('aria-expanded', 'true');
+    await wait(() => {
+      expect(accordionSection).toHaveAttribute('aria-expanded', 'true');
+      expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+      expect(summary).toHaveAttribute('aria-expanded', 'true');
+    });
   });
 });

--- a/src/explore-education-statistics-common/src/utils/delay.ts
+++ b/src/explore-education-statistics-common/src/utils/delay.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns a promise that will not complete
+ * until a specific {@param timeout} has elapsed.
+ *
+ * This is basically just a promisified
+ * version of {@see setTimeout}.
+ */
+export default async function delay(timeout?: number): Promise<void> {
+  await new Promise(resolve => {
+    setTimeout(async () => {
+      resolve();
+    }, timeout);
+  });
+}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
@@ -3,9 +3,9 @@ import AccordionSection from '@common/components/AccordionSection';
 import Details from '@common/components/Details';
 import RelatedInformation from '@common/components/RelatedInformation';
 import { contentApi } from '@common/services/api';
-import PageSearchFormWithAnalytics from '@frontend/components/PageSearchFormWithAnalytics';
 import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
+import PageSearchFormWithAnalytics from '@frontend/components/PageSearchFormWithAnalytics';
 import React, { Component } from 'react';
 import PublicationList from './components/PublicationList';
 import { Topic } from './components/TopicList';
@@ -92,7 +92,11 @@ class FindStatisticsPage extends Component<Props> {
                 >
                   {topics.map(
                     ({ id: topicId, title: topicTitle, publications }) => (
-                      <Details key={topicId} summary={topicTitle}>
+                      <Details
+                        key={topicId}
+                        summary={topicTitle}
+                        id={`topic-${topicId}`}
+                      >
                         <div className="govuk-!-margin-top-0 govuk-!-padding-top-0">
                           <ul className="govuk-bulllet-list govuk-!-margin-bottom-3 govuk-!-margin-top-0">
                             <PublicationList publications={publications} />

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
@@ -97,11 +97,7 @@ class FindStatisticsPage extends Component<Props> {
                         summary={topicTitle}
                         id={`topic-${topicId}`}
                       >
-                        <div className="govuk-!-margin-top-0 govuk-!-padding-top-0">
-                          <ul className="govuk-bulllet-list govuk-!-margin-bottom-3 govuk-!-margin-top-0">
-                            <PublicationList publications={publications} />
-                          </ul>
-                        </div>
+                        <PublicationList publications={publications} />
                       </Details>
                     ),
                   )}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationList.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationList.tsx
@@ -14,53 +14,49 @@ interface Props {
 }
 
 function PublicationList({ publications }: Props) {
-  return (
-    <>
-      {publications.length > 0 ? (
-        publications.map(({ id, legacyPublicationUrl, slug, title }) => (
-          <li key={id} className="govuk-!-margin-bottom-0">
-            <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{title}</h3>
-            {legacyPublicationUrl ? (
-              <div className="govuk-!-margin-bottom-3">
-                {' '}
-                Currently available via{' '}
-                <a href={legacyPublicationUrl}>
-                  Statistics at DfE{' '}
+  return publications.length > 0 ? (
+    <ul className="govuk-!-margin-top-0">
+      {publications.map(({ id, legacyPublicationUrl, slug, title }) => (
+        <li key={id} className="govuk-!-margin-bottom-0">
+          <h3 className="govuk-heading-s govuk-!-margin-bottom-0">{title}</h3>
+          {legacyPublicationUrl ? (
+            <div className="govuk-!-margin-bottom-3">
+              {' '}
+              Currently available via{' '}
+              <a href={legacyPublicationUrl}>
+                Statistics at DfE{' '}
+                <span className="govuk-visually-hidden">for {title}</span>
+              </a>
+            </div>
+          ) : (
+            <div className="govuk-grid-row govuk-!-margin-bottom-3">
+              <div className="govuk-grid-column-one-third govuk-!-margin-bottom-1">
+                <Link
+                  className="govuk-link"
+                  to={`/find-statistics/publication?publication=${slug}`}
+                  as={`/find-statistics/${slug}`}
+                  data-testid={`view-stats-${slug}`}
+                >
+                  View statistics and data{' '}
                   <span className="govuk-visually-hidden">for {title}</span>
-                </a>
+                </Link>
               </div>
-            ) : (
-              <div className="govuk-grid-row govuk-!-margin-bottom-3">
-                <div className="govuk-grid-column-one-third govuk-!-margin-bottom-1">
-                  <Link
-                    className="govuk-link"
-                    to={`/find-statistics/publication?publication=${slug}`}
-                    as={`/find-statistics/${slug}`}
-                    data-testid={`view-stats-${slug}`}
-                  >
-                    View statistics and data{' '}
-                    <span className="govuk-visually-hidden">for {title}</span>
-                  </Link>
-                </div>
-                <div className="govuk-grid-column-one-third">
-                  <Link
-                    className="govuk-link"
-                    to={`/data-tables/${slug}`}
-                    data-testid={`create-table-${slug}`}
-                  >
-                    Create your own tables online{' '}
-                    <span className="govuk-visually-hidden">for {title}</span>
-                  </Link>
-                </div>
+              <div className="govuk-grid-column-one-third">
+                <Link
+                  className="govuk-link"
+                  to={`/data-tables/${slug}`}
+                  data-testid={`create-table-${slug}`}
+                >
+                  Create your own tables online{' '}
+                  <span className="govuk-visually-hidden">for {title}</span>
+                </Link>
               </div>
-            )}
-          </li>
-        ))
-      ) : (
-        <></>
-      )}
-    </>
-  );
+            </div>
+          )}
+        </li>
+      ))}
+    </ul>
+  ) : null;
 }
 
 export default PublicationList;


### PR DESCRIPTION
This PR fixes a fairly subtle timing issue that meant that the required `Details` component to open would not register the click to open it correctly when using `PageSearchForm`.

I believe the `Details` could fail to open as React could potentially be in the middle of re-rendering the component, meaning that the click event could potentially be lost.

We've added delays to simply slow down the code enough that React has time to fully update the DOM before we try and do some subsequent steps.

## Other changes

- Changed `Details` to render with a stable auto-generated default `id` prop. Previously re-rendering would cause the default `id` prop to change, changing the ids used in the DOM.
- Cleaned up markup/styling around `PublicationList`.