### PR TITLE
EES-706 Prevent querying orphaned footnotes with no matching criteria

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FootnoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FootnoteService.cs
@@ -143,6 +143,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .CheckEntityExists<Release>(releaseId)
                 .OnSuccess(release => DbSet()
                     .Where(footnote =>
+                        footnote.ReleaseId == releaseId &&
                         (!footnote.Subjects.Any() ||
                          footnote.Subjects.Any(subjectFootnote => subjectFootnote.Subject.ReleaseId == releaseId))
                         && (!footnote.Filters.Any() || footnote.Filters.Any(filterFootnote =>


### PR DESCRIPTION
This can be reproduced by engineering a footnote to be orphaned, i.e. with no matching criteria which is what appears to have happened in the Test environment where there is bad data. No matching criteria means:

- No subject links
- No filter links
- No filter group links
- No filter item links
- No indicator links

This should never happen but can be setup as follows in any environment:

In the Admin set up two Releases with at least one file uploaded to both.

On one of the Releases create a footnote with some dummy text for the Subject and make it applicable to all filters and indicators (i.e. it has a just a Subject link).

Switch to the Footnotes tab on the other Release and observe that no footnotes are visible.

Now delete the Subject link directly from the database.

Observe that the footnote is now on the original Release with no matching criteria but is also showing on the other Release which it wasn’t created for.

This should be impossible because of the foreign key between the Footnote and the Release, but in the Admin query it wasn't included in the query.