### PR TITLE
EES-749 Stop basic auth from triggering on Next's static assets

### DIFF
--- a/src/explore-education-statistics-frontend/server.js
+++ b/src/explore-education-statistics-frontend/server.js
@@ -21,6 +21,7 @@ const basicAuth = require('express-basic-auth');
 const express = require('express');
 const helmet = require('helmet');
 const nextApp = require('next');
+const path = require('path');
 const referrerPolicy = require('referrer-policy');
 const url = require('url');
 const cookiesMiddleware = require('universal-cookie-express');
@@ -120,6 +121,10 @@ async function startServer(port = process.env.PORT || 3000) {
   });
 
   if (process.env.BASIC_AUTH === 'true') {
+    server.use(
+      '/_next/static',
+      express.static(path.resolve(__dirname, 'src/.next/static')),
+    );
     server.use(
       basicAuth({
         users: {


### PR DESCRIPTION
This PR prevents basic auth from triggering on Next's static assets in `/_next/static`. 

IE11 shows multiple auth prompts on initial render due to loading in multiple additional static asset chunks via XHR. Getting any of these prompts wrong will mean that the associated static asset for that prompt will proceed to return 401s. 

Any asset chunks that fail to load in can break their respective parts of the application when trying to navigate to them via page links. By de-authenticating these assets, we should no longer get multiple auth prompts and also stop the app from breaking.