### PR TITLE
EES-758 Remove siblingless filters from charts

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
@@ -72,6 +72,38 @@ const ChartAxisConfiguration = ({
     return createDataSetCategories(config, data, meta);
   }, [configuration, data, meta]);
 
+  const groupByOptions = useMemo<SelectOption<AxisGroupBy>[]>(() => {
+    const options: SelectOption<AxisGroupBy>[] = [
+      {
+        label: 'Time periods',
+        value: 'timePeriod',
+      },
+      {
+        label: 'Locations',
+        value: 'locations',
+      },
+      {
+        label: 'Indicators',
+        value: 'indicators',
+      },
+    ];
+
+    // Don't show 'Filters' option if we would end up with no
+    // categories due to every filter being siblingless filters.
+    const canGroupByFilters = Object.values(meta.filters).some(
+      filterGroup => filterGroup.options.length > 1,
+    );
+
+    if (canGroupByFilters) {
+      options.push({
+        label: 'Filters',
+        value: 'filters',
+      });
+    }
+
+    return options;
+  }, [meta.filters]);
+
   // TODO: Figure out how we should sort data
   // const sortOptions = useMemo<SelectOption[]>(() => {
   //   return [
@@ -197,31 +229,15 @@ const ChartAxisConfiguration = ({
           />
 
           <FormGroup>
-            {configuration.type === 'major' && !capabilities.fixedAxisGroupBy && (
-              <FormFieldSelect<AxisConfiguration>
-                id={`${id}-groupBy`}
-                label="Group data by"
-                name="groupBy"
-                options={[
-                  {
-                    label: 'Time periods',
-                    value: 'timePeriod' as AxisGroupBy,
-                  },
-                  {
-                    label: 'Locations',
-                    value: 'locations' as AxisGroupBy,
-                  },
-                  {
-                    label: 'Indicators',
-                    value: 'indicators' as AxisGroupBy,
-                  },
-                  {
-                    label: 'Filters',
-                    value: 'filters' as AxisGroupBy,
-                  },
-                ]}
-              />
-            )}
+            {configuration.type === 'major' &&
+              !capabilities.fixedAxisGroupBy && (
+                <FormFieldSelect<AxisConfiguration>
+                  id={`${id}-groupBy`}
+                  label="Group data by"
+                  name="groupBy"
+                  options={groupByOptions}
+                />
+              )}
 
             {capabilities.hasAxes && (
               <FormFieldTextInput<AxisConfiguration>

--- a/src/explore-education-statistics-common/src/components/form/FormSelect.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormSelect.tsx
@@ -11,9 +11,9 @@ import ErrorMessage from '../ErrorMessage';
 
 export type SelectChangeEventHandler = ChangeEventHandler<HTMLSelectElement>;
 
-export interface SelectOption {
+export interface SelectOption<Value = string | number> {
   label: string;
-  value: string | number;
+  value: Value;
   selected?: boolean;
   style?: CSSProperties;
 }

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
@@ -1140,4 +1140,131 @@ describe('createDataSetCategories', () => {
       },
     });
   });
+
+  test('does not categorise by siblingless filters', () => {
+    const axisConfiguration: AxisConfiguration = {
+      type: 'major',
+      groupBy: 'filters',
+      sortBy: 'name',
+      sortAsc: true,
+      dataSets: [
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          config: {
+            label: 'Test label 1',
+          },
+        },
+      ],
+      referenceLines: [],
+      visible: true,
+      unit: '',
+      min: 0,
+    };
+
+    const fullTable = mapFullTable({
+      ...testTable,
+      subjectMeta: {
+        ...testTable.subjectMeta,
+        filters: {
+          ...testTable.subjectMeta.filters,
+          SchoolType: {
+            ...testTable.subjectMeta.filters.SchoolType,
+            options: {
+              Default: {
+                ...testTable.subjectMeta.filters.SchoolType.options.Default,
+                options: [
+                  {
+                    label: 'State-funded primary',
+                    value: 'state-funded-primary',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    } as TableDataResponse);
+
+    const dataSetCategories = createDataSetCategories(
+      axisConfiguration,
+      fullTable.results,
+      fullTable.subjectMeta,
+    );
+
+    expect(dataSetCategories).toHaveLength(1);
+
+    expect(dataSetCategories[0].filter.label).toBe('Ethnicity Major Chinese');
+  });
+
+  test('falls back to categorising by siblingless filters if there would be no categories otherwise', () => {
+    const axisConfiguration: AxisConfiguration = {
+      type: 'major',
+      groupBy: 'filters',
+      sortBy: 'name',
+      sortAsc: true,
+      dataSets: [
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          config: {
+            label: 'Test label 1',
+          },
+        },
+      ],
+      referenceLines: [],
+      visible: true,
+      unit: '',
+      min: 0,
+    };
+
+    const fullTable = mapFullTable({
+      ...testTable,
+      subjectMeta: {
+        ...testTable.subjectMeta,
+        filters: {
+          Characteristic: {
+            ...testTable.subjectMeta.filters.Characteristic,
+            options: {
+              EthnicGroupMajor: {
+                ...testTable.subjectMeta.filters.Characteristic.options
+                  .EthnicGroupMajor,
+                options: [
+                  {
+                    label: 'Ethnicity Major Chinese',
+                    value: 'ethnicity-major-chinese',
+                  },
+                ],
+              },
+            },
+          },
+          SchoolType: {
+            ...testTable.subjectMeta.filters.SchoolType,
+            options: {
+              Default: {
+                ...testTable.subjectMeta.filters.SchoolType.options.Default,
+                options: [
+                  {
+                    label: 'State-funded primary',
+                    value: 'state-funded-primary',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    } as TableDataResponse);
+
+    const dataSetCategories = createDataSetCategories(
+      axisConfiguration,
+      fullTable.results,
+      fullTable.subjectMeta,
+    );
+
+    expect(dataSetCategories).toHaveLength(2);
+
+    expect(dataSetCategories[0].filter.label).toBe('Ethnicity Major Chinese');
+    expect(dataSetCategories[1].filter.label).toBe('State-funded primary');
+  });
 });

--- a/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
@@ -144,11 +144,25 @@ function getCategoryFilters(
   let filters: Filter[] = [];
 
   switch (axisGroupBy) {
-    case 'filters':
-      filters = Object.values(meta.filters).flatMap(
-        filterGroup => filterGroup.options,
-      );
+    case 'filters': {
+      const filterGroups = Object.values(meta.filters);
+
+      // We want to try and remove any filter groups with only
+      // one filter as these don't really make sense to display
+      // on the chart (this is similar to what we do in table tool).
+      const filteredFilters = filterGroups
+        .filter(filterGroup => filterGroup.options.length > 1)
+        .flatMap(filterGroup => filterGroup.options);
+
+      // If there are no filtered filters, we need to at least
+      // try to show something otherwise the chart will just
+      // break due to the major axis having no categories.
+      filters =
+        filteredFilters.length > 0
+          ? filteredFilters
+          : filterGroups.flatMap(filterGroup => filterGroup.options);
       break;
+    }
     case 'timePeriod':
       filters = meta.timePeriodRange;
       break;


### PR DESCRIPTION
This PR removes siblingless filters from the chart when grouping by 'Filters'. 

The user will typically find it undesirable to show filters from groups where there is only one option selected. An example of this would be the following chart:

![image](https://user-images.githubusercontent.com/9917868/80362770-1ef5c680-887b-11ea-9a04-1be2f0a34d48.png)

FTE is the only option selected in it's filter group, and will end up aggregating all of the data sets from the other categories (hence why it has 5 bars). This isn't particularly useful to the user as it doesn't provide any better granularity of the data than the other filter groups. Consequently, we should just remove these.