### PR TITLE
EES-765 Fix 'Total' filters being incorrectly removed from tables

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/__snapshots__/DataBlockRenderer.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/__snapshots__/DataBlockRenderer.test.tsx.snap
@@ -146,7 +146,9 @@ exports[`DataBlockRenderer renders table 1`] = `
   aria-labelledby="dataTableCaption"
   class="govuk-table table"
 >
-  <thead>
+  <thead
+    class="tableHead"
+  >
     <tr>
       <td
         class="borderBottom"
@@ -154,7 +156,6 @@ exports[`DataBlockRenderer renders table 1`] = `
         rowspan="1"
       />
       <th
-        class="govuk-table__header--numeric borderBottom"
         colspan="1"
         rowspan="1"
         scope="col"
@@ -162,7 +163,6 @@ exports[`DataBlockRenderer renders table 1`] = `
         2012/13
       </th>
       <th
-        class="govuk-table__header--numeric borderBottom"
         colspan="1"
         rowspan="1"
         scope="col"
@@ -170,7 +170,6 @@ exports[`DataBlockRenderer renders table 1`] = `
         2013/14
       </th>
       <th
-        class="govuk-table__header--numeric borderBottom"
         colspan="1"
         rowspan="1"
         scope="col"
@@ -178,7 +177,6 @@ exports[`DataBlockRenderer renders table 1`] = `
         2014/15
       </th>
       <th
-        class="govuk-table__header--numeric borderBottom"
         colspan="1"
         rowspan="1"
         scope="col"
@@ -186,7 +184,6 @@ exports[`DataBlockRenderer renders table 1`] = `
         2015/16
       </th>
       <th
-        class="govuk-table__header--numeric borderBottom borderRightNone"
         colspan="1"
         rowspan="1"
         scope="col"

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.module.scss
@@ -18,18 +18,6 @@ $border-width: 1px;
     padding-right: govuk-spacing(2);
   }
 
-  thead td {
-    background: #fff;
-    position: relative;
-    z-index: 3;
-  }
-
-  thead th {
-    background: #fff;
-    position: relative;
-    z-index: 2;
-  }
-
   tbody th {
     background: #fff;
     position: relative;
@@ -38,15 +26,30 @@ $border-width: 1px;
   }
 }
 
-:global(.govuk-table) {
-  .columnHeaderGroup {
+.tableHead {
+  td {
+    background: #fff;
+    position: relative;
+    z-index: 3;
+  }
+
+  th {
     background: govuk-colour('light-grey');
     border-bottom: 1px solid $govuk-border-colour;
     border-right: 1px solid $govuk-border-colour;
+    padding: govuk-spacing(2);
+    position: relative;
     text-align: center;
+    z-index: 2;
   }
 
-  .borderRightNone {
+  tr:first-child:last-child th {
+    background: govuk-colour('white');
+    border-right: 0;
+    text-align: right;
+  }
+
+  th:last-child {
     border-right: 0;
   }
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
@@ -134,7 +134,7 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
         className={classNames('govuk-table', styles.table, className)}
         ref={ref}
       >
-        <thead>
+        <thead className={styles.tableHead}>
           {expandedColumnHeaders.map((columns, rowIndex) => {
             return (
               // eslint-disable-next-line react/no-array-index-key
@@ -154,14 +154,6 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
 
                     return (
                       <th
-                        className={classNames({
-                          'govuk-table__header--numeric': !column.isGroup,
-                          [styles.columnHeaderGroup]:
-                            column.isGroup || column.crossSpan > 1,
-                          [styles.borderBottom]: !column.isGroup,
-                          [styles.borderRightNone]:
-                            column.start + column.span === rows[0].length,
-                        })}
                         colSpan={column.span}
                         rowSpan={column.crossSpan}
                         scope={column.isGroup ? 'colgroup' : 'col'}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
@@ -27,10 +27,10 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
     const createExpandedHeaders = (headers: Header[]): ExpandedHeader[][] => {
       const createExpandedHeader = (
         header: Header,
-        expandedHeaders?: ExpandedHeader[][],
+        expandedHeaders: ExpandedHeader[][],
       ): ExpandedHeader => {
         const { depth } = header;
-        const previousSibling = last(expandedHeaders?.[depth]);
+        const previousSibling = last(expandedHeaders[depth]);
 
         const newExpandedHeader = {
           id: header.id,
@@ -47,10 +47,10 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
         // Header and its parents appear identical
         // so we can merge them together.
         if (
-          header.text === header?.parent?.text &&
-          header.span === header?.parent?.span
+          header.text === header.parent?.text &&
+          header.span === header.parent?.span
         ) {
-          const parent = expandedHeaders?.[depth - 1]?.find(
+          const parent = expandedHeaders[depth - 1]?.find(
             expandedHeader => expandedHeader.start === newExpandedHeader.start,
           );
 
@@ -75,7 +75,7 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
           const { depth } = child;
 
           if (!acc[depth]) {
-            acc.push([createExpandedHeader(child)]);
+            acc[depth] = [createExpandedHeader(child, acc)];
           } else {
             acc[depth].push(createExpandedHeader(child, acc));
           }
@@ -92,7 +92,7 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
         const { depth } = header;
 
         if (!acc[depth]) {
-          acc.push([createExpandedHeader(header)]);
+          acc[depth] = [createExpandedHeader(header, acc)];
         } else {
           acc[depth].push(createExpandedHeader(header, acc));
         }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/MultiHeaderTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/MultiHeaderTable.test.tsx
@@ -764,7 +764,93 @@ describe('MultiHeaderTable', () => {
     expect(container.innerHTML).toMatchSnapshot();
   });
 
-  test('renders table with `row` header merged with identical subgroup', () => {
+  test('renders table with `rowgroup` header merged with identical parent', () => {
+    const { container } = render(
+      <MultiHeaderTable
+        columnHeaders={[new Header('1', '1'), new Header('2', '2')]}
+        rowHeaders={[
+          new Header('A', 'A').addChild(
+            new Header('B', 'B').addChild(new Header('C', 'C')),
+          ),
+          new Header('D', 'D').addChild(
+            new Header('D', 'D').addChild(new Header('E', 'E')),
+          ),
+          new Header('F', 'F').addChild(
+            new Header('G', 'G').addChild(new Header('H', 'H')),
+          ),
+        ]}
+        rows={[
+          ['ABC1', 'ABC2'],
+          ['DDE1', 'DDE2'],
+          ['FGH1', 'FGH2'],
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(3);
+    expect(container.querySelectorAll('tbody td')).toHaveLength(6);
+
+    // Row 2
+    const row2Headers = container.querySelectorAll('tbody tr:nth-child(2) th');
+    expect(row2Headers).toHaveLength(2);
+
+    expect(row2Headers[0]).toHaveTextContent('D');
+    expect(row2Headers[0]).toHaveAttribute('scope', 'rowgroup');
+    expect(row2Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row2Headers[0]).toHaveAttribute('colspan', '2');
+
+    expect(row2Headers[1]).toHaveTextContent('E');
+    expect(row2Headers[1]).toHaveAttribute('scope', 'row');
+    expect(row2Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row2Headers[1]).toHaveAttribute('colspan', '1');
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders table with `rowgroup` header merged with identical parent on first row', () => {
+    const { container } = render(
+      <MultiHeaderTable
+        columnHeaders={[new Header('1', '1'), new Header('2', '2')]}
+        rowHeaders={[
+          new Header('A', 'A').addChild(
+            new Header('A', 'A').addChild(new Header('B', 'B')),
+          ),
+          new Header('C', 'C').addChild(
+            new Header('D', 'D').addChild(new Header('E', 'E')),
+          ),
+          new Header('F', 'F').addChild(
+            new Header('G', 'G').addChild(new Header('H', 'H')),
+          ),
+        ]}
+        rows={[
+          ['AAB1', 'AAB2'],
+          ['CDE1', 'CDE2'],
+          ['FGH1', 'FGH2'],
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(3);
+    expect(container.querySelectorAll('tbody td')).toHaveLength(6);
+
+    // Row 1
+    const row1Headers = container.querySelectorAll('tbody tr:nth-child(1) th');
+    expect(row1Headers).toHaveLength(2);
+
+    expect(row1Headers[0]).toHaveTextContent('A');
+    expect(row1Headers[0]).toHaveAttribute('scope', 'rowgroup');
+    expect(row1Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row1Headers[0]).toHaveAttribute('colspan', '2');
+
+    expect(row1Headers[1]).toHaveTextContent('B');
+    expect(row1Headers[1]).toHaveAttribute('scope', 'row');
+    expect(row1Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row1Headers[1]).toHaveAttribute('colspan', '1');
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders table with `row` header merged with identical parent', () => {
     const { container } = render(
       <MultiHeaderTable
         columnHeaders={[new Header('1', '1'), new Header('2', '2')]}
@@ -793,6 +879,44 @@ describe('MultiHeaderTable', () => {
     expect(row2Headers[0]).toHaveAttribute('scope', 'row');
     expect(row2Headers[0]).toHaveAttribute('rowspan', '1');
     expect(row2Headers[0]).toHaveAttribute('colspan', '2');
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders table with `row` header merged with identical parent on first row', () => {
+    const { container } = render(
+      <MultiHeaderTable
+        columnHeaders={[new Header('1', '1'), new Header('2', '2')]}
+        rowHeaders={[
+          new Header('A', 'A')
+            .addChild(new Header('B', 'B').addChild(new Header('B', 'B')))
+            .addChild(new Header('C', 'C').addChild(new Header('D', 'D')))
+            .addChild(new Header('E', 'E').addChild(new Header('F', 'F'))),
+        ]}
+        rows={[
+          ['ABB1', 'ABB2'],
+          ['ACD1', 'ACD2'],
+          ['AEF1', 'AEF2'],
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(3);
+    expect(container.querySelectorAll('tbody td')).toHaveLength(6);
+
+    // Row 1
+    const row1Headers = container.querySelectorAll('tbody tr:nth-child(1) th');
+    expect(row1Headers).toHaveLength(2);
+
+    expect(row1Headers[0]).toHaveTextContent('A');
+    expect(row1Headers[0]).toHaveAttribute('scope', 'rowgroup');
+    expect(row1Headers[0]).toHaveAttribute('rowspan', '3');
+    expect(row1Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row1Headers[1]).toHaveTextContent('B');
+    expect(row1Headers[1]).toHaveAttribute('scope', 'row');
+    expect(row1Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row1Headers[1]).toHaveAttribute('colspan', '2');
 
     expect(container.innerHTML).toMatchSnapshot();
   });
@@ -1008,7 +1132,7 @@ describe('MultiHeaderTable', () => {
     expect(container.innerHTML).toMatchSnapshot();
   });
 
-  test('renders table with `colgroup` header merged with identical subgroup', () => {
+  test('renders table with `colgroup` header merged with identical parent', () => {
     const { container } = render(
       <MultiHeaderTable
         columnHeaders={[
@@ -1067,6 +1191,195 @@ describe('MultiHeaderTable', () => {
     expect(row2Headers[1]).toHaveAttribute('scope', 'colgroup');
     expect(row2Headers[1]).toHaveAttribute('rowspan', '1');
     expect(row2Headers[1]).toHaveAttribute('colspan', '1');
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders table with `colgroup` header merged with identical parent on first column', () => {
+    const { container } = render(
+      <MultiHeaderTable
+        columnHeaders={[
+          new Header('A', 'A').addChild(
+            new Header('A', 'A').addChild(new Header('F', 'F')),
+          ),
+          new Header('B', 'B').addChild(
+            new Header('C', 'C').addChild(new Header('F', 'F')),
+          ),
+          new Header('D', 'D').addChild(
+            new Header('E', 'E').addChild(new Header('F', 'F')),
+          ),
+        ]}
+        rowHeaders={[new Header('1', '1'), new Header('2', '2')]}
+        rows={[
+          ['BAF1', 'CCF1', 'DEF1'],
+          ['BAF2', 'CCF2', 'DEF2'],
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2);
+    expect(container.querySelectorAll('tbody td')).toHaveLength(6);
+
+    expect(container.querySelectorAll('thead tr')).toHaveLength(3);
+
+    // Row 1
+    const row1Headers = container.querySelectorAll('thead tr:nth-child(1) th');
+    expect(row1Headers).toHaveLength(3);
+
+    expect(row1Headers[0]).toHaveTextContent('A');
+    expect(row1Headers[0]).toHaveAttribute('scope', 'colgroup');
+    expect(row1Headers[0]).toHaveAttribute('rowspan', '2');
+    expect(row1Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row1Headers[1]).toHaveTextContent('B');
+    expect(row1Headers[1]).toHaveAttribute('scope', 'colgroup');
+    expect(row1Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row1Headers[1]).toHaveAttribute('colspan', '1');
+
+    expect(row1Headers[2]).toHaveTextContent('D');
+    expect(row1Headers[2]).toHaveAttribute('scope', 'colgroup');
+    expect(row1Headers[2]).toHaveAttribute('rowspan', '1');
+    expect(row1Headers[2]).toHaveAttribute('colspan', '1');
+
+    // Row 2
+    const row2Headers = container.querySelectorAll('thead tr:nth-child(2) th');
+    expect(row2Headers).toHaveLength(2);
+
+    expect(row2Headers[0]).toHaveTextContent('C');
+    expect(row2Headers[0]).toHaveAttribute('scope', 'colgroup');
+    expect(row2Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row2Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row2Headers[1]).toHaveTextContent('E');
+    expect(row2Headers[1]).toHaveAttribute('scope', 'colgroup');
+    expect(row2Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row2Headers[1]).toHaveAttribute('colspan', '1');
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders table with `col` header merged with identical parent', () => {
+    const { container } = render(
+      <MultiHeaderTable
+        columnHeaders={[
+          new Header('A', 'A').addChild(
+            new Header('B', 'B').addChild(new Header('C', 'C')),
+          ),
+          new Header('D', 'D').addChild(
+            new Header('E', 'E').addChild(new Header('E', 'E')),
+          ),
+          new Header('F', 'F').addChild(
+            new Header('G', 'G').addChild(new Header('H', 'H')),
+          ),
+        ]}
+        rowHeaders={[new Header('1', '1'), new Header('2', '2')]}
+        rows={[
+          ['ABC1', 'DEE1', 'FGH1'],
+          ['ABC2', 'DEE2', 'FGH2'],
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2);
+    expect(container.querySelectorAll('tbody td')).toHaveLength(6);
+
+    expect(container.querySelectorAll('thead tr')).toHaveLength(3);
+
+    // Row 2
+    const row1Headers = container.querySelectorAll('thead tr:nth-child(2) th');
+    expect(row1Headers).toHaveLength(3);
+
+    expect(row1Headers[0]).toHaveTextContent('B');
+    expect(row1Headers[0]).toHaveAttribute('scope', 'colgroup');
+    expect(row1Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row1Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row1Headers[1]).toHaveTextContent('E');
+    expect(row1Headers[1]).toHaveAttribute('scope', 'col');
+    expect(row1Headers[1]).toHaveAttribute('rowspan', '2');
+    expect(row1Headers[1]).toHaveAttribute('colspan', '1');
+
+    expect(row1Headers[2]).toHaveTextContent('G');
+    expect(row1Headers[2]).toHaveAttribute('scope', 'colgroup');
+    expect(row1Headers[2]).toHaveAttribute('rowspan', '1');
+    expect(row1Headers[2]).toHaveAttribute('colspan', '1');
+
+    // Row 3
+    const row3Headers = container.querySelectorAll('thead tr:nth-child(3) th');
+    expect(row3Headers).toHaveLength(2);
+
+    expect(row3Headers[0]).toHaveTextContent('C');
+    expect(row3Headers[0]).toHaveAttribute('scope', 'col');
+    expect(row3Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row3Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row3Headers[1]).toHaveTextContent('H');
+    expect(row3Headers[1]).toHaveAttribute('scope', 'col');
+    expect(row3Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row3Headers[1]).toHaveAttribute('colspan', '1');
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders table with `col` header merged with identical parent on first column', () => {
+    const { container } = render(
+      <MultiHeaderTable
+        columnHeaders={[
+          new Header('A', 'A').addChild(
+            new Header('B', 'B').addChild(new Header('B', 'B')),
+          ),
+          new Header('C', 'C').addChild(
+            new Header('D', 'D').addChild(new Header('E', 'E')),
+          ),
+          new Header('F', 'F').addChild(
+            new Header('G', 'G').addChild(new Header('H', 'H')),
+          ),
+        ]}
+        rowHeaders={[new Header('1', '1'), new Header('2', '2')]}
+        rows={[
+          ['ABB1', 'CDE1', 'FGH1'],
+          ['ABB2', 'CDE2', 'FGH2'],
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2);
+    expect(container.querySelectorAll('tbody td')).toHaveLength(6);
+
+    expect(container.querySelectorAll('thead tr')).toHaveLength(3);
+
+    // Row 2
+    const row1Headers = container.querySelectorAll('thead tr:nth-child(2) th');
+    expect(row1Headers).toHaveLength(3);
+
+    expect(row1Headers[0]).toHaveTextContent('B');
+    expect(row1Headers[0]).toHaveAttribute('scope', 'col');
+    expect(row1Headers[0]).toHaveAttribute('rowspan', '2');
+    expect(row1Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row1Headers[1]).toHaveTextContent('D');
+    expect(row1Headers[1]).toHaveAttribute('scope', 'colgroup');
+    expect(row1Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row1Headers[1]).toHaveAttribute('colspan', '1');
+
+    expect(row1Headers[2]).toHaveTextContent('G');
+    expect(row1Headers[2]).toHaveAttribute('scope', 'colgroup');
+    expect(row1Headers[2]).toHaveAttribute('rowspan', '1');
+    expect(row1Headers[2]).toHaveAttribute('colspan', '1');
+
+    // Row 3
+    const row3Headers = container.querySelectorAll('thead tr:nth-child(3) th');
+    expect(row3Headers).toHaveLength(2);
+
+    expect(row3Headers[0]).toHaveTextContent('E');
+    expect(row3Headers[0]).toHaveAttribute('scope', 'col');
+    expect(row3Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row3Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row3Headers[1]).toHaveTextContent('H');
+    expect(row3Headers[1]).toHaveAttribute('scope', 'col');
+    expect(row3Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row3Headers[1]).toHaveAttribute('colspan', '1');
 
     expect(container.innerHTML).toMatchSnapshot();
   });

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FixedMultiHeaderDataTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FixedMultiHeaderDataTable.test.tsx.snap
@@ -5,7 +5,9 @@ exports[`FixedMultiHeaderDataTable renders underlying table 1`] = `
   aria-labelledby="dataTableCaption"
   class="govuk-table table"
 >
-  <thead>
+  <thead
+    class="tableHead"
+  >
     <tr>
       <td
         class="borderBottom"
@@ -13,7 +15,6 @@ exports[`FixedMultiHeaderDataTable renders underlying table 1`] = `
         rowspan="2"
       />
       <th
-        class="columnHeaderGroup"
         colspan="2"
         rowspan="1"
         scope="colgroup"
@@ -21,7 +22,6 @@ exports[`FixedMultiHeaderDataTable renders underlying table 1`] = `
         Col group A
       </th>
       <th
-        class="columnHeaderGroup borderRightNone"
         colspan="2"
         rowspan="1"
         scope="colgroup"
@@ -31,7 +31,6 @@ exports[`FixedMultiHeaderDataTable renders underlying table 1`] = `
     </tr>
     <tr>
       <th
-        class="govuk-table__header--numeric borderBottom"
         colspan="1"
         rowspan="1"
         scope="col"
@@ -39,7 +38,6 @@ exports[`FixedMultiHeaderDataTable renders underlying table 1`] = `
         Col C
       </th>
       <th
-        class="govuk-table__header--numeric borderBottom"
         colspan="1"
         rowspan="1"
         scope="col"
@@ -47,7 +45,6 @@ exports[`FixedMultiHeaderDataTable renders underlying table 1`] = `
         Col D
       </th>
       <th
-        class="govuk-table__header--numeric borderBottom"
         colspan="1"
         rowspan="1"
         scope="col"
@@ -55,7 +52,6 @@ exports[`FixedMultiHeaderDataTable renders underlying table 1`] = `
         Col C
       </th>
       <th
-        class="govuk-table__header--numeric borderBottom borderRightNone"
         colspan="1"
         rowspan="1"
         scope="col"

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/MultiHeaderTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/MultiHeaderTable.test.tsx.snap
@@ -818,6 +818,454 @@ exports[`MultiHeaderTable renders 2x2x2 table correctly 1`] = `
 </table>
 `;
 
+exports[`MultiHeaderTable renders table with \`col\` header merged with identical parent 1`] = `
+<table class="govuk-table table">
+  <thead>
+    <tr>
+      <td colspan="1"
+          rowspan="3"
+          class="borderBottom"
+      >
+      </td>
+      <th class="columnHeaderGroup"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        A
+      </th>
+      <th class="columnHeaderGroup"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        D
+      </th>
+      <th class="columnHeaderGroup borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        F
+      </th>
+    </tr>
+    <tr>
+      <th class="columnHeaderGroup"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        B
+      </th>
+      <th class="govuk-table__header--numeric columnHeaderGroup borderBottom"
+          colspan="1"
+          rowspan="2"
+          scope="col"
+      >
+        E
+      </th>
+      <th class="columnHeaderGroup borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        G
+      </th>
+    </tr>
+    <tr>
+      <th class="govuk-table__header--numeric borderBottom"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        C
+      </th>
+      <th class="govuk-table__header--numeric borderBottom borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        H
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        1
+      </th>
+      <td class="govuk-table__cell--numeric">
+        ABC1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        DEE1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        FGH1
+      </td>
+    </tr>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        2
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        ABC2
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        DEE2
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        FGH2
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`MultiHeaderTable renders table with \`col\` header merged with identical parent on first column 1`] = `
+<table class="govuk-table table">
+  <thead>
+    <tr>
+      <td colspan="1"
+          rowspan="3"
+          class="borderBottom"
+      >
+      </td>
+      <th class="columnHeaderGroup"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        A
+      </th>
+      <th class="columnHeaderGroup"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        C
+      </th>
+      <th class="columnHeaderGroup borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        F
+      </th>
+    </tr>
+    <tr>
+      <th class="govuk-table__header--numeric columnHeaderGroup borderBottom"
+          colspan="1"
+          rowspan="2"
+          scope="col"
+      >
+        B
+      </th>
+      <th class="columnHeaderGroup"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        D
+      </th>
+      <th class="columnHeaderGroup borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        G
+      </th>
+    </tr>
+    <tr>
+      <th class="govuk-table__header--numeric borderBottom"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        E
+      </th>
+      <th class="govuk-table__header--numeric borderBottom borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        H
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        1
+      </th>
+      <td class="govuk-table__cell--numeric">
+        ABB1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        CDE1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        FGH1
+      </td>
+    </tr>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        2
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        ABB2
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        CDE2
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        FGH2
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`MultiHeaderTable renders table with \`colgroup\` header merged with identical parent 1`] = `
+<table class="govuk-table table">
+  <thead>
+    <tr>
+      <td colspan="1"
+          rowspan="3"
+          class="borderBottom"
+      >
+      </td>
+      <th class="columnHeaderGroup"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        B
+      </th>
+      <th class="columnHeaderGroup"
+          colspan="1"
+          rowspan="2"
+          scope="colgroup"
+      >
+        C
+      </th>
+      <th class="columnHeaderGroup borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        D
+      </th>
+    </tr>
+    <tr>
+      <th class="columnHeaderGroup"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        A
+      </th>
+      <th class="columnHeaderGroup borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        E
+      </th>
+    </tr>
+    <tr>
+      <th class="govuk-table__header--numeric borderBottom"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        F
+      </th>
+      <th class="govuk-table__header--numeric borderBottom"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        F
+      </th>
+      <th class="govuk-table__header--numeric borderBottom borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        F
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        1
+      </th>
+      <td class="govuk-table__cell--numeric">
+        BAF1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        CCF1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        DEF1
+      </td>
+    </tr>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        2
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        BAF2
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        CCF2
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        DEF2
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`MultiHeaderTable renders table with \`colgroup\` header merged with identical parent on first column 1`] = `
+<table class="govuk-table table">
+  <thead>
+    <tr>
+      <td colspan="1"
+          rowspan="3"
+          class="borderBottom"
+      >
+      </td>
+      <th class="columnHeaderGroup"
+          colspan="1"
+          rowspan="2"
+          scope="colgroup"
+      >
+        A
+      </th>
+      <th class="columnHeaderGroup"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        B
+      </th>
+      <th class="columnHeaderGroup borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        D
+      </th>
+    </tr>
+    <tr>
+      <th class="columnHeaderGroup"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        C
+      </th>
+      <th class="columnHeaderGroup borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        E
+      </th>
+    </tr>
+    <tr>
+      <th class="govuk-table__header--numeric borderBottom"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        F
+      </th>
+      <th class="govuk-table__header--numeric borderBottom"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        F
+      </th>
+      <th class="govuk-table__header--numeric borderBottom borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        F
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        1
+      </th>
+      <td class="govuk-table__cell--numeric">
+        BAF1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        CCF1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        DEF1
+      </td>
+    </tr>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        2
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        BAF2
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        CCF2
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        DEF2
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`MultiHeaderTable renders table with \`colgroup\` header merged with identical subgroup 1`] = `
 <table class="govuk-table table">
   <thead>
@@ -930,7 +1378,7 @@ exports[`MultiHeaderTable renders table with \`colgroup\` header merged with ide
 </table>
 `;
 
-exports[`MultiHeaderTable renders table with \`row\` header merged with identical subgroup 1`] = `
+exports[`MultiHeaderTable renders table with \`row\` header merged with identical parent 1`] = `
 <table class="govuk-table table">
   <thead>
     <tr>
@@ -1020,6 +1468,418 @@ exports[`MultiHeaderTable renders table with \`row\` header merged with identica
       </td>
       <td class="govuk-table__cell--numeric borderBottom">
         ADF2
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`MultiHeaderTable renders table with \`row\` header merged with identical parent on first row 1`] = `
+<table class="govuk-table table">
+  <thead>
+    <tr>
+      <td colspan="3"
+          rowspan="1"
+          class="borderBottom"
+      >
+      </td>
+      <th class="govuk-table__header--numeric borderBottom"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        1
+      </th>
+      <th class="govuk-table__header--numeric borderBottom borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        2
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class="borderBottom"
+          rowspan="3"
+          colspan="1"
+          scope="rowgroup"
+      >
+        A
+      </th>
+      <th class
+          rowspan="1"
+          colspan="2"
+          scope="row"
+      >
+        B
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        ABB1
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        ABB2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        C
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        D
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        ACD1
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        ACD2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        E
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        F
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        AEF1
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        AEF2
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`MultiHeaderTable renders table with \`row\` header merged with identical subgroup on first row 1`] = `
+<table class="govuk-table table">
+  <thead>
+    <tr>
+      <td colspan="3"
+          rowspan="1"
+          class="borderBottom"
+      >
+      </td>
+      <th class="govuk-table__header--numeric borderBottom"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        1
+      </th>
+      <th class="govuk-table__header--numeric borderBottom borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        2
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class="borderBottom"
+          rowspan="3"
+          colspan="1"
+          scope="rowgroup"
+      >
+        A
+      </th>
+      <th class
+          rowspan="1"
+          colspan="2"
+          scope="row"
+      >
+        B
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        ABB1
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        ABB2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        C
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        D
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        ACD1
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        ACD2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        E
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        F
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        AEF1
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        AEF2
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`MultiHeaderTable renders table with \`rowgroup\` header merged with identical parent 1`] = `
+<table class="govuk-table table">
+  <thead>
+    <tr>
+      <td colspan="3"
+          rowspan="1"
+          class="borderBottom"
+      >
+      </td>
+      <th class="govuk-table__header--numeric borderBottom"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        1
+      </th>
+      <th class="govuk-table__header--numeric borderBottom borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        2
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        A
+      </th>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        B
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        C
+      </th>
+      <td class="govuk-table__cell--numeric">
+        ABC1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        ABC2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="2"
+          scope="rowgroup"
+      >
+        D
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        E
+      </th>
+      <td class="govuk-table__cell--numeric">
+        DDE1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        DDE2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        F
+      </th>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        G
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        H
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        FGH1
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        FGH2
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`MultiHeaderTable renders table with \`rowgroup\` header merged with identical parent on first row 1`] = `
+<table class="govuk-table table">
+  <thead>
+    <tr>
+      <td colspan="3"
+          rowspan="1"
+          class="borderBottom"
+      >
+      </td>
+      <th class="govuk-table__header--numeric borderBottom"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        1
+      </th>
+      <th class="govuk-table__header--numeric borderBottom borderRightNone"
+          colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        2
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="2"
+          scope="rowgroup"
+      >
+        A
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        B
+      </th>
+      <td class="govuk-table__cell--numeric">
+        AAB1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        AAB2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        C
+      </th>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        D
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        E
+      </th>
+      <td class="govuk-table__cell--numeric">
+        CDE1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        CDE2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        F
+      </th>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        G
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        H
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        FGH1
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        FGH2
       </td>
     </tr>
   </tbody>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/MultiHeaderTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/MultiHeaderTable.test.tsx.snap
@@ -2,22 +2,20 @@
 
 exports[`MultiHeaderTable does not render \`colgroup\` headers with multi-span subgroup with invalid rowspans and colspans 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="1"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         B
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="3"
+      <th colspan="3"
           rowspan="1"
           scope="colgroup"
       >
@@ -25,22 +23,19 @@ exports[`MultiHeaderTable does not render \`colgroup\` headers with multi-span s
       </th>
     </tr>
     <tr>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         A
       </th>
-      <th class="columnHeaderGroup"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
         C
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -48,22 +43,19 @@ exports[`MultiHeaderTable does not render \`colgroup\` headers with multi-span s
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         E
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="col"
       >
         E
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -120,22 +112,20 @@ exports[`MultiHeaderTable does not render \`colgroup\` headers with multi-span s
 
 exports[`MultiHeaderTable does not render \`rowgroup\` headers with multi-span subgroup with invalid rowspans and colspans 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -238,22 +228,20 @@ exports[`MultiHeaderTable does not render \`rowgroup\` headers with multi-span s
 
 exports[`MultiHeaderTable renders 2x2 table correctly 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="2"
           rowspan="2"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
         A
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
@@ -261,29 +249,25 @@ exports[`MultiHeaderTable renders 2x2 table correctly 1`] = `
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         C
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         D
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         C
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -396,22 +380,20 @@ exports[`MultiHeaderTable renders 2x2 table correctly 1`] = `
 
 exports[`MultiHeaderTable renders 2x2x2 table correctly 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup"
-          colspan="4"
+      <th colspan="4"
           rowspan="1"
           scope="colgroup"
       >
         A
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="4"
+      <th colspan="4"
           rowspan="1"
           scope="colgroup"
       >
@@ -419,29 +401,25 @@ exports[`MultiHeaderTable renders 2x2x2 table correctly 1`] = `
       </th>
     </tr>
     <tr>
-      <th class="columnHeaderGroup"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
         C
       </th>
-      <th class="columnHeaderGroup"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
         D
       </th>
-      <th class="columnHeaderGroup"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
         C
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
@@ -449,57 +427,49 @@ exports[`MultiHeaderTable renders 2x2x2 table correctly 1`] = `
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         E
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         F
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         E
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         F
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         E
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         F
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         E
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -820,29 +790,26 @@ exports[`MultiHeaderTable renders 2x2x2 table correctly 1`] = `
 
 exports[`MultiHeaderTable renders table with \`col\` header merged with identical parent 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="1"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         A
       </th>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         D
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -850,22 +817,19 @@ exports[`MultiHeaderTable renders table with \`col\` header merged with identica
       </th>
     </tr>
     <tr>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         B
       </th>
-      <th class="govuk-table__header--numeric columnHeaderGroup borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="2"
           scope="col"
       >
         E
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -873,15 +837,13 @@ exports[`MultiHeaderTable renders table with \`col\` header merged with identica
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         C
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -932,29 +894,26 @@ exports[`MultiHeaderTable renders table with \`col\` header merged with identica
 
 exports[`MultiHeaderTable renders table with \`col\` header merged with identical parent on first column 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="1"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         A
       </th>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         C
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -962,22 +921,19 @@ exports[`MultiHeaderTable renders table with \`col\` header merged with identica
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric columnHeaderGroup borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="2"
           scope="col"
       >
         B
       </th>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         D
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -985,15 +941,13 @@ exports[`MultiHeaderTable renders table with \`col\` header merged with identica
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         E
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -1044,29 +998,26 @@ exports[`MultiHeaderTable renders table with \`col\` header merged with identica
 
 exports[`MultiHeaderTable renders table with \`colgroup\` header merged with identical parent 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="1"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         B
       </th>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="2"
           scope="colgroup"
       >
         C
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -1074,15 +1025,13 @@ exports[`MultiHeaderTable renders table with \`colgroup\` header merged with ide
       </th>
     </tr>
     <tr>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         A
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -1090,22 +1039,19 @@ exports[`MultiHeaderTable renders table with \`colgroup\` header merged with ide
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         F
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         F
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -1156,29 +1102,26 @@ exports[`MultiHeaderTable renders table with \`colgroup\` header merged with ide
 
 exports[`MultiHeaderTable renders table with \`colgroup\` header merged with identical parent on first column 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="1"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="2"
           scope="colgroup"
       >
         A
       </th>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         B
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -1186,15 +1129,13 @@ exports[`MultiHeaderTable renders table with \`colgroup\` header merged with ide
       </th>
     </tr>
     <tr>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         C
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -1202,134 +1143,19 @@ exports[`MultiHeaderTable renders table with \`colgroup\` header merged with ide
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         F
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         F
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
-          rowspan="1"
-          scope="col"
-      >
-        F
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th class
-          rowspan="1"
-          colspan="1"
-          scope="row"
-      >
-        1
-      </th>
-      <td class="govuk-table__cell--numeric">
-        BAF1
-      </td>
-      <td class="govuk-table__cell--numeric">
-        CCF1
-      </td>
-      <td class="govuk-table__cell--numeric">
-        DEF1
-      </td>
-    </tr>
-    <tr>
-      <th class
-          rowspan="1"
-          colspan="1"
-          scope="row"
-      >
-        2
-      </th>
-      <td class="govuk-table__cell--numeric borderBottom">
-        BAF2
-      </td>
-      <td class="govuk-table__cell--numeric borderBottom">
-        CCF2
-      </td>
-      <td class="govuk-table__cell--numeric borderBottom">
-        DEF2
-      </td>
-    </tr>
-  </tbody>
-</table>
-`;
-
-exports[`MultiHeaderTable renders table with \`colgroup\` header merged with identical subgroup 1`] = `
-<table class="govuk-table table">
-  <thead>
-    <tr>
-      <td colspan="1"
-          rowspan="3"
-          class="borderBottom"
-      >
-      </td>
-      <th class="columnHeaderGroup"
-          colspan="1"
-          rowspan="1"
-          scope="colgroup"
-      >
-        B
-      </th>
-      <th class="columnHeaderGroup"
-          colspan="1"
-          rowspan="2"
-          scope="colgroup"
-      >
-        C
-      </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
-          rowspan="1"
-          scope="colgroup"
-      >
-        D
-      </th>
-    </tr>
-    <tr>
-      <th class="columnHeaderGroup"
-          colspan="1"
-          rowspan="1"
-          scope="colgroup"
-      >
-        A
-      </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
-          rowspan="1"
-          scope="colgroup"
-      >
-        E
-      </th>
-    </tr>
-    <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
-          rowspan="1"
-          scope="col"
-      >
-        F
-      </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
-          rowspan="1"
-          scope="col"
-      >
-        F
-      </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -1380,22 +1206,20 @@ exports[`MultiHeaderTable renders table with \`colgroup\` header merged with ide
 
 exports[`MultiHeaderTable renders table with \`row\` header merged with identical parent 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -1476,118 +1300,20 @@ exports[`MultiHeaderTable renders table with \`row\` header merged with identica
 
 exports[`MultiHeaderTable renders table with \`row\` header merged with identical parent on first row 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
-          rowspan="1"
-          scope="col"
-      >
-        2
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th class="borderBottom"
-          rowspan="3"
-          colspan="1"
-          scope="rowgroup"
-      >
-        A
-      </th>
-      <th class
-          rowspan="1"
-          colspan="2"
-          scope="row"
-      >
-        B
-      </th>
-      <td class="govuk-table__cell--numeric borderBottom">
-        ABB1
-      </td>
-      <td class="govuk-table__cell--numeric borderBottom">
-        ABB2
-      </td>
-    </tr>
-    <tr>
-      <th class="borderBottom"
-          rowspan="1"
-          colspan="1"
-          scope="rowgroup"
-      >
-        C
-      </th>
-      <th class
-          rowspan="1"
-          colspan="1"
-          scope="row"
-      >
-        D
-      </th>
-      <td class="govuk-table__cell--numeric borderBottom">
-        ACD1
-      </td>
-      <td class="govuk-table__cell--numeric borderBottom">
-        ACD2
-      </td>
-    </tr>
-    <tr>
-      <th class="borderBottom"
-          rowspan="1"
-          colspan="1"
-          scope="rowgroup"
-      >
-        E
-      </th>
-      <th class
-          rowspan="1"
-          colspan="1"
-          scope="row"
-      >
-        F
-      </th>
-      <td class="govuk-table__cell--numeric borderBottom">
-        AEF1
-      </td>
-      <td class="govuk-table__cell--numeric borderBottom">
-        AEF2
-      </td>
-    </tr>
-  </tbody>
-</table>
-`;
-
-exports[`MultiHeaderTable renders table with \`row\` header merged with identical subgroup on first row 1`] = `
-<table class="govuk-table table">
-  <thead>
-    <tr>
-      <td colspan="3"
-          rowspan="1"
-          class="borderBottom"
-      >
-      </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
-          rowspan="1"
-          scope="col"
-      >
-        1
-      </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -1668,22 +1394,20 @@ exports[`MultiHeaderTable renders table with \`row\` header merged with identica
 
 exports[`MultiHeaderTable renders table with \`rowgroup\` header merged with identical parent 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -1778,22 +1502,20 @@ exports[`MultiHeaderTable renders table with \`rowgroup\` header merged with ide
 
 exports[`MultiHeaderTable renders table with \`rowgroup\` header merged with identical parent on first row 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -1888,22 +1610,20 @@ exports[`MultiHeaderTable renders table with \`rowgroup\` header merged with ide
 
 exports[`MultiHeaderTable renders table with \`rowgroup\` header merged with identical subgroup 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -1998,22 +1718,20 @@ exports[`MultiHeaderTable renders table with \`rowgroup\` header merged with ide
 
 exports[`MultiHeaderTable renders table with multi-span \`colgroup\` merged with its identical groups 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="1"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         B
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="2"
+      <th colspan="2"
           rowspan="2"
           scope="colgroup"
       >
@@ -2021,8 +1739,7 @@ exports[`MultiHeaderTable renders table with multi-span \`colgroup\` merged with
       </th>
     </tr>
     <tr>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -2030,15 +1747,13 @@ exports[`MultiHeaderTable renders table with multi-span \`colgroup\` merged with
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         F
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="col"
       >
@@ -2089,22 +1804,20 @@ exports[`MultiHeaderTable renders table with multi-span \`colgroup\` merged with
 
 exports[`MultiHeaderTable renders table with multi-span \`rowgroup\` merged with its identical groups 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -2178,15 +1891,14 @@ exports[`MultiHeaderTable renders table with multi-span \`rowgroup\` merged with
 
 exports[`MultiHeaderTable renders table with one \`col\` header subgroup 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="1"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
@@ -2194,8 +1906,7 @@ exports[`MultiHeaderTable renders table with one \`col\` header subgroup 1`] = `
       </th>
     </tr>
     <tr>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
@@ -2203,15 +1914,13 @@ exports[`MultiHeaderTable renders table with one \`col\` header subgroup 1`] = `
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         C
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -2256,15 +1965,14 @@ exports[`MultiHeaderTable renders table with one \`col\` header subgroup 1`] = `
 
 exports[`MultiHeaderTable renders table with one \`colgroup\` header subgroup 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="1"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
@@ -2272,8 +1980,7 @@ exports[`MultiHeaderTable renders table with one \`colgroup\` header subgroup 1`
       </th>
     </tr>
     <tr>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
@@ -2281,15 +1988,13 @@ exports[`MultiHeaderTable renders table with one \`colgroup\` header subgroup 1`
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         C
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -2334,22 +2039,20 @@ exports[`MultiHeaderTable renders table with one \`colgroup\` header subgroup 1`
 
 exports[`MultiHeaderTable renders table with one \`row\` header subgroup 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -2408,22 +2111,20 @@ exports[`MultiHeaderTable renders table with one \`row\` header subgroup 1`] = `
 
 exports[`MultiHeaderTable renders table with one \`rowgroup\` header subgroup 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -2482,15 +2183,14 @@ exports[`MultiHeaderTable renders table with one \`rowgroup\` header subgroup 1`
 
 exports[`MultiHeaderTable renders table with three \`col\` header subgroups 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="1"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="4"
+      <th colspan="4"
           rowspan="1"
           scope="colgroup"
       >
@@ -2498,22 +2198,19 @@ exports[`MultiHeaderTable renders table with three \`col\` header subgroups 1`] 
       </th>
     </tr>
     <tr>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         B
       </th>
-      <th class="columnHeaderGroup"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
         C
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -2521,29 +2218,25 @@ exports[`MultiHeaderTable renders table with three \`col\` header subgroups 1`] 
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         E
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         F
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         G
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -2600,29 +2293,26 @@ exports[`MultiHeaderTable renders table with three \`col\` header subgroups 1`] 
 
 exports[`MultiHeaderTable renders table with three \`colgroup\` header subgroups 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="1"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         B
       </th>
-      <th class="columnHeaderGroup"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
         C
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -2630,29 +2320,25 @@ exports[`MultiHeaderTable renders table with three \`colgroup\` header subgroups
       </th>
     </tr>
     <tr>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         A
       </th>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         D
       </th>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         F
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -2660,29 +2346,25 @@ exports[`MultiHeaderTable renders table with three \`colgroup\` header subgroups
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         H
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         H
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         H
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -2739,22 +2421,20 @@ exports[`MultiHeaderTable renders table with three \`colgroup\` header subgroups
 
 exports[`MultiHeaderTable renders table with three \`row\` header subgroups 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -2857,22 +2537,20 @@ exports[`MultiHeaderTable renders table with three \`row\` header subgroups 1`] 
 
 exports[`MultiHeaderTable renders table with three \`rowgroup\` header subgroups 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -2996,15 +2674,14 @@ exports[`MultiHeaderTable renders table with three \`rowgroup\` header subgroups
 
 exports[`MultiHeaderTable renders table with two \`col\` header subgroups 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="1"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="3"
+      <th colspan="3"
           rowspan="1"
           scope="colgroup"
       >
@@ -3012,15 +2689,13 @@ exports[`MultiHeaderTable renders table with two \`col\` header subgroups 1`] = 
       </th>
     </tr>
     <tr>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         B
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
@@ -3028,22 +2703,19 @@ exports[`MultiHeaderTable renders table with two \`col\` header subgroups 1`] = 
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         D
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         E
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -3094,22 +2766,20 @@ exports[`MultiHeaderTable renders table with two \`col\` header subgroups 1`] = 
 
 exports[`MultiHeaderTable renders table with two \`colgroup\` header subgroups 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="1"
           rowspan="3"
           class="borderBottom"
       >
       </td>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         B
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="2"
+      <th colspan="2"
           rowspan="1"
           scope="colgroup"
       >
@@ -3117,22 +2787,19 @@ exports[`MultiHeaderTable renders table with two \`colgroup\` header subgroups 1
       </th>
     </tr>
     <tr>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         A
       </th>
-      <th class="columnHeaderGroup"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
         D
       </th>
-      <th class="columnHeaderGroup borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="colgroup"
       >
@@ -3140,22 +2807,19 @@ exports[`MultiHeaderTable renders table with two \`colgroup\` header subgroups 1
       </th>
     </tr>
     <tr>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         F
       </th>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         F
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -3206,22 +2870,20 @@ exports[`MultiHeaderTable renders table with two \`colgroup\` header subgroups 1
 
 exports[`MultiHeaderTable renders table with two \`row\` header subgroups 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
@@ -3302,22 +2964,20 @@ exports[`MultiHeaderTable renders table with two \`row\` header subgroups 1`] = 
 
 exports[`MultiHeaderTable renders table with two \`rowgroup\` header subgroups 1`] = `
 <table class="govuk-table table">
-  <thead>
+  <thead class="tableHead">
     <tr>
       <td colspan="3"
           rowspan="1"
           class="borderBottom"
       >
       </td>
-      <th class="govuk-table__header--numeric borderBottom"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >
         1
       </th>
-      <th class="govuk-table__header--numeric borderBottom borderRightNone"
-          colspan="1"
+      <th colspan="1"
           rowspan="1"
           scope="col"
       >

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/TimePeriodDataTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/TimePeriodDataTable.test.tsx.snap
@@ -1,22 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TimePeriodDataTable renders table with completely empty columns removed 1`] = `
-<thead>
+<thead class="tableHead">
   <tr>
     <td colspan="3"
         rowspan="2"
         class="borderBottom"
     >
     </td>
-    <th class="columnHeaderGroup"
-        colspan="3"
+    <th colspan="3"
         rowspan="1"
         scope="colgroup"
     >
       First language Known or believed to be other than English
     </th>
-    <th class="columnHeaderGroup borderRightNone"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="colgroup"
     >
@@ -24,29 +22,25 @@ exports[`TimePeriodDataTable renders table with completely empty columns removed
     </th>
   </tr>
   <tr>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2013/14
     </th>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2014/15
     </th>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2015/16
     </th>
-    <th class="govuk-table__header--numeric borderBottom borderRightNone"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
@@ -171,15 +165,14 @@ exports[`TimePeriodDataTable renders table with completely empty columns removed
 `;
 
 exports[`TimePeriodDataTable renders table with completely empty rows removed 1`] = `
-<thead>
+<thead class="tableHead">
   <tr>
     <td colspan="3"
         rowspan="2"
         class="borderBottom"
     >
     </td>
-    <th class="columnHeaderGroup borderRightNone"
-        colspan="3"
+    <th colspan="3"
         rowspan="1"
         scope="colgroup"
     >
@@ -187,22 +180,19 @@ exports[`TimePeriodDataTable renders table with completely empty rows removed 1`
     </th>
   </tr>
   <tr>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2013/14
     </th>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2014/15
     </th>
-    <th class="govuk-table__header--numeric borderBottom borderRightNone"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
@@ -358,29 +348,26 @@ exports[`TimePeriodDataTable renders table with completely empty rows removed 1`
 `;
 
 exports[`TimePeriodDataTable renders table with no filters 1`] = `
-<thead>
+<thead class="tableHead">
   <tr>
     <td colspan="2"
         rowspan="1"
         class="borderBottom"
     >
     </td>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2014/15
     </th>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2015/16
     </th>
-    <th class="govuk-table__header--numeric borderBottom borderRightNone"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
@@ -454,15 +441,14 @@ exports[`TimePeriodDataTable renders table with no filters 1`] = `
 `;
 
 exports[`TimePeriodDataTable renders table with only one of each option 1`] = `
-<thead>
+<thead class="tableHead">
   <tr>
     <td colspan="1"
         rowspan="1"
         class="borderBottom"
     >
     </td>
-    <th class="govuk-table__header--numeric borderBottom borderRightNone"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
@@ -487,15 +473,14 @@ exports[`TimePeriodDataTable renders table with only one of each option 1`] = `
 `;
 
 exports[`TimePeriodDataTable renders table with only one of each option and no filters 1`] = `
-<thead>
+<thead class="tableHead">
   <tr>
     <td colspan="1"
         rowspan="1"
         class="borderBottom"
     >
     </td>
-    <th class="govuk-table__header--numeric borderBottom borderRightNone"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
@@ -520,15 +505,14 @@ exports[`TimePeriodDataTable renders table with only one of each option and no f
 `;
 
 exports[`TimePeriodDataTable renders table with only one of each option and no filters or locations 1`] = `
-<thead>
+<thead class="tableHead">
   <tr>
     <td colspan="1"
         rowspan="1"
         class="borderBottom"
     >
     </td>
-    <th class="govuk-table__header--numeric borderBottom borderRightNone"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
@@ -553,22 +537,20 @@ exports[`TimePeriodDataTable renders table with only one of each option and no f
 `;
 
 exports[`TimePeriodDataTable renders table with two of every option 1`] = `
-<thead>
+<thead class="tableHead">
   <tr>
     <td colspan="3"
         rowspan="2"
         class="borderBottom"
     >
     </td>
-    <th class="columnHeaderGroup"
-        colspan="2"
+    <th colspan="2"
         rowspan="1"
         scope="colgroup"
     >
       Ethnicity Major Asian Total
     </th>
-    <th class="columnHeaderGroup borderRightNone"
-        colspan="2"
+    <th colspan="2"
         rowspan="1"
         scope="colgroup"
     >
@@ -576,29 +558,25 @@ exports[`TimePeriodDataTable renders table with two of every option 1`] = `
     </th>
   </tr>
   <tr>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2013/14
     </th>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2014/15
     </th>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2013/14
     </th>
-    <th class="govuk-table__header--numeric borderBottom borderRightNone"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
@@ -821,22 +799,20 @@ exports[`TimePeriodDataTable renders table with two of every option 1`] = `
 `;
 
 exports[`TimePeriodDataTable renders table without indicators when there is only one 1`] = `
-<thead>
+<thead class="tableHead">
   <tr>
     <td colspan="2"
         rowspan="2"
         class="borderBottom"
     >
     </td>
-    <th class="columnHeaderGroup"
-        colspan="2"
+    <th colspan="2"
         rowspan="1"
         scope="colgroup"
     >
       Ethnicity Major Asian Total
     </th>
-    <th class="columnHeaderGroup borderRightNone"
-        colspan="2"
+    <th colspan="2"
         rowspan="1"
         scope="colgroup"
     >
@@ -844,29 +820,25 @@ exports[`TimePeriodDataTable renders table without indicators when there is only
     </th>
   </tr>
   <tr>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2013/14
     </th>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2014/15
     </th>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       2013/14
     </th>
-    <th class="govuk-table__header--numeric borderBottom borderRightNone"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
@@ -977,22 +949,20 @@ exports[`TimePeriodDataTable renders table without indicators when there is only
 `;
 
 exports[`TimePeriodDataTable renders table without time period when there is only one 1`] = `
-<thead>
+<thead class="tableHead">
   <tr>
     <td colspan="2"
         rowspan="1"
         class="borderBottom"
     >
     </td>
-    <th class="govuk-table__header--numeric borderBottom"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >
       Ethnicity Major Asian Total
     </th>
-    <th class="govuk-table__header--numeric borderBottom borderRightNone"
-        colspan="1"
+    <th colspan="1"
         rowspan="1"
         scope="col"
     >

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/getDefaultTableHeadersConfig.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/getDefaultTableHeadersConfig.ts
@@ -6,21 +6,19 @@ import {
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import sortBy from 'lodash/sortBy';
 
-const removeSiblinglessTotalRows = (
+const removeSiblinglessFilters = (
   filters: FullTableMeta['filters'],
 ): CategoryFilter[][] => {
   return Object.values(filters)
     .map(filterGroup => filterGroup.options)
-    .filter(filterGroup => {
-      return filterGroup.length > 1 || !filterGroup[0].isTotal;
-    });
+    .filter(filterGroup => filterGroup.length > 1);
 };
 
 const getDefaultTableHeaderConfig = (fullTableMeta: FullTableMeta) => {
   const { indicators, filters, locations, timePeriodRange } = fullTableMeta;
 
   const sortedFilters = sortBy(
-    [...removeSiblinglessTotalRows(filters), locations],
+    [...removeSiblinglessFilters(filters), locations],
     [options => options.length],
   );
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/mapTableHeadersConfig.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/mapTableHeadersConfig.ts
@@ -77,8 +77,7 @@ export default function mapTableHeadersConfig(
         optionGroup.map(
           option =>
             locationAndFilterGroups[currentIndex].find(filter => {
-              const hasMatch =
-                filter.value === option.value && filter.label === option.label;
+              const hasMatch = filter.value === option.value;
 
               // The filter might be a location so just cast
               // these as variables for convenience.


### PR DESCRIPTION
This PR fixes 'Total' filters being potentially removed from tables when they shouldn't be. This was due to:

- Aggressive filtering of filters based on them being totals.
- Incorrect merging of identical headers.

## Other changes

- Simplified `MultiHeaderTable` styling. Due to the new header merging rules that have been implemented, the styling for the column headers could easily be made to look bad.

  To avoid this, we just simplify the styling by mostly getting rid of conditional classes and default to the following:

  When more than one column header row:
  - Use `text-align: center` and grey background

  When single column header row:
  - Use `text-align: right` and white background