### PR TITLE
EES-774 Prevent incorrect saving of data block when reordering table headers

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/DataBlockSourceWizard.tsx
@@ -189,18 +189,6 @@ const DataBlockSourceWizard = ({
                       onSubmit={async nextTableHeaders => {
                         setTableHeaders(nextTableHeaders);
 
-                        if (dataBlock) {
-                          await onDataBlockSave({
-                            ...dataBlock,
-                            tables: [
-                              {
-                                tableHeaders: nextTableHeaders,
-                                indicators: [],
-                              },
-                            ],
-                          });
-                        }
-
                         if (dataTableRef.current) {
                           dataTableRef.current.scrollIntoView({
                             behavior: 'smooth',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -60,7 +60,7 @@ interface Props {
   source?: string;
 }
 
-const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
+const TimePeriodDataTableInternal = forwardRef<HTMLElement, Props>(
   (
     { fullTable, tableHeadersConfig, captionTitle, source }: Props,
     dataTableRef,
@@ -264,32 +264,40 @@ const TimePeriodDataTable = forwardRef<HTMLElement, Props>(
     const rows = filteredCartesian.map(row => row.map(cell => cell.text));
 
     return (
-      <ErrorBoundary
-        fallback={
-          <WarningMessage>
-            There was a problem rendering your table.
-          </WarningMessage>
+      <FixedMultiHeaderDataTable
+        caption={
+          <DataTableCaption
+            {...subjectMeta}
+            title={captionTitle}
+            id="dataTableCaption"
+          />
         }
-      >
-        <FixedMultiHeaderDataTable
-          caption={
-            <DataTableCaption
-              {...subjectMeta}
-              title={captionTitle}
-              id="dataTableCaption"
-            />
-          }
-          columnHeaders={columnHeaders}
-          rowHeaders={rowHeaders}
-          rows={rows}
-          ref={dataTableRef}
-          footnotes={subjectMeta.footnotes}
-          source={source}
-        />
-      </ErrorBoundary>
+        columnHeaders={columnHeaders}
+        rowHeaders={rowHeaders}
+        rows={rows}
+        ref={dataTableRef}
+        footnotes={subjectMeta.footnotes}
+        source={source}
+      />
     );
   },
 );
+
+TimePeriodDataTableInternal.displayName = 'TimePeriodDataTableInternal';
+
+const TimePeriodDataTable = forwardRef<HTMLElement, Props>((props, ref) => {
+  return (
+    <ErrorBoundary
+      fallback={
+        <WarningMessage>
+          There was a problem rendering the table.
+        </WarningMessage>
+      }
+    >
+      <TimePeriodDataTableInternal {...props} ref={ref} />
+    </ErrorBoundary>
+  );
+});
 
 TimePeriodDataTable.displayName = 'TimePeriodDataTable';
 


### PR DESCRIPTION
This PR addresses potential issues wherein a user might attempt to reorder the table headers **after** they have changed part of the data block's table query e.g. changed some indicators, filters, etc. The current implementation will cause the previous table query to be persisted alongside the new table header config (which has the new filters/indicators/whatever).

As the table header config and table query no longer match, this will cause `TimePeriodDataTable` to throw an error as it cannot correctly construct the headers for the table.

## Solution

- Simply don't update the data block when re-ordering table headers. This didn't really make sense anyway in the UI as there is the 'Save data block' button further down the page that should be used instead.
- Wrap `TimePeriodDataTable` with an `ErrorBoundary` to prevent the table crashing the entire app. This way, at least the user can continue viewing pages that might have this bug.