### PR TITLE
EES-760 Change publication topic, remove unused topic, correct publication slug, change theme text

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200430093743_EES760UpdatePublicationsTopicsAndThemes.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200430093743_EES760UpdatePublicationsTopicsAndThemes.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200430093743_EES760UpdatePublicationsTopicsAndThemes")]
+    partial class EES760UpdatePublicationsTopicsAndThemes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200430093743_EES760UpdatePublicationsTopicsAndThemes.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200430093743_EES760UpdatePublicationsTopicsAndThemes.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES760UpdatePublicationsTopicsAndThemes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Publications",
+                keyColumn: "Id",
+                keyValue: new Guid("42a888c4-9ee7-40fd-9128-f5de546780b3"),
+                columns: new[] {"Slug", "TopicId"},
+                values: new object[] { "graduate-outcomes-leo-postgraduate-outcomes", new Guid("53a1fbb7-5234-435f-892b-9baad4c82535") });
+
+            migrationBuilder.DeleteData(
+                table: "Topics",
+                keyColumn: "Id",
+                keyValue: new Guid("3bef5b2b-76a1-4be1-83b1-a3269245c610"));
+
+            migrationBuilder.UpdateData(
+                table: "Themes",
+                keyColumn: "Id",
+                keyValue: new Guid("2ca22e34-b87a-4281-a0eb-b80f4f8dd374"),
+                column: "Summary",
+                value: "Including university graduate employment, graduate labour market and participation statistics");
+
+            migrationBuilder.UpdateData(
+                table: "Themes",
+                keyColumn: "Id",
+                keyValue: new Guid("6412a76c-cf15-424f-8ebc-3a530132b1b3"),
+                column: "Summary",
+                value: "Including not in education, employment or training (NEET) statistics");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Themes",
+                keyColumn: "Id",
+                keyValue: new Guid("2ca22e34-b87a-4281-a0eb-b80f4f8dd374"),
+                column: "Summary",
+                value: "Including university graduate employment and participation statistics");
+
+            migrationBuilder.UpdateData(
+                table: "Themes",
+                keyColumn: "Id",
+                keyValue: new Guid("6412a76c-cf15-424f-8ebc-3a530132b1b3"),
+                column: "Summary",
+                value: "Including graduate labour market and not in education, employment or training (NEET) statistics");
+
+            migrationBuilder.InsertData(
+                table: "Topics",
+                columns: new[] { "Id", "Description", "Slug", "Summary", "ThemeId", "Title" },
+                values: new object[] { new Guid("3bef5b2b-76a1-4be1-83b1-a3269245c610"), null, "graduate-labour-market", "", new Guid("6412a76c-cf15-424f-8ebc-3a530132b1b3"), "Graduate labour market" });
+
+            migrationBuilder.UpdateData(
+                table: "Publications",
+                keyColumn: "Id",
+                keyValue: new Guid("42a888c4-9ee7-40fd-9128-f5de546780b3"),
+                columns: new[] { "Slug", "TopicId" },
+                values: new object[] { "graduate-labour-markets", new Guid("3bef5b2b-76a1-4be1-83b1-a3269245c610") });
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -416,7 +416,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     Id = new Guid("6412a76c-cf15-424f-8ebc-3a530132b1b3"),
                     Title = "Destination of pupils and students",
                     Summary =
-                        "Including graduate labour market and not in education, employment or training (NEET) statistics",
+                        "Including not in education, employment or training (NEET) statistics",
                     Slug = "destination-of-pupils-and-students"
                 },
                 new Theme
@@ -438,7 +438,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 {
                     Id = new Guid("2ca22e34-b87a-4281-a0eb-b80f4f8dd374"),
                     Title = "Higher education",
-                    Summary = "Including university graduate employment and participation statistics",
+                    Summary = "Including university graduate employment, graduate labour market and participation statistics",
                     Slug = "higher-education"
                 },
                 new Theme
@@ -529,14 +529,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     Summary = "",
                     ThemeId = new Guid("6412a76c-cf15-424f-8ebc-3a530132b1b3"),
                     Slug = "destinations-of-ks4-and-ks5-pupils"
-                },
-                new Topic
-                {
-                    Id = new Guid("3bef5b2b-76a1-4be1-83b1-a3269245c610"),
-                    Title = "Graduate labour market",
-                    Summary = "",
-                    ThemeId = new Guid("6412a76c-cf15-424f-8ebc-3a530132b1b3"),
-                    Slug = "graduate-labour-market"
                 },
                 new Topic
                 {
@@ -1267,8 +1259,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     Id = new Guid("42a888c4-9ee7-40fd-9128-f5de546780b3"),
                     Title = "Graduate labour market statistics",
                     Summary = "",
-                    TopicId = new Guid("3bef5b2b-76a1-4be1-83b1-a3269245c610"),
-                    Slug = "graduate-labour-markets",
+                    TopicId = new Guid("53a1fbb7-5234-435f-892b-9baad4c82535"),
+                    Slug = "graduate-labour-market-statistics",
                     LegacyPublicationUrl =
                         new Uri(
                             "https://www.gov.uk/government/collections/graduate-labour-market-quarterly-statistics#documents")


### PR DESCRIPTION

- Moved Publication `Graduate labour market statistics` to topic `Higher education graduate employment and earnings`.
- Removed the (now) unused topic `Graduate labour market`.
- Changed the Publication slug from `graduate-labour-markets` to `graduate-labour-market-statistics`.
- Change two theme summaries.

By default EF migration tool wanted to delete the Publication and recreate it which would have deleted any draft Releases. This is a custom migration to avoid that.