### PR TITLE
EES-735 Fix updating of table query causing desynchronization of table tool state

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
@@ -30,7 +30,7 @@ const ReleaseManageDataBlocksPageTabs = ({
 }: Props) => {
   const [isSaving, setIsSaving] = useState(false);
 
-  const [tableToolState, setInitialTableToolState] = useState<TableToolState>();
+  const [tableToolState, setTableToolState] = useState<TableToolState>();
 
   const { error, isLoading } = useTableQuery(
     selectedDataBlock
@@ -47,7 +47,7 @@ const ReleaseManageDataBlocksPageTabs = ({
           query,
         );
 
-        setInitialTableToolState({
+        setTableToolState({
           initialStep: 5,
           query,
           subjectMeta,

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
@@ -16,7 +16,7 @@ import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/getDef
 import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
 import tableBuilderService from '@common/services/tableBuilderService';
 import minDelay from '@common/utils/minDelay';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 interface Props {
   releaseId: string;
@@ -28,41 +28,25 @@ const ReleaseManageDataBlocksPageTabs = ({
   selectedDataBlock,
   onDataBlockSave,
 }: Props) => {
-  const [isLoading, setLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
 
   const [tableToolState, setInitialTableToolState] = useState<TableToolState>();
 
-  const query = useMemo(
-    () =>
-      selectedDataBlock
-        ? {
-            ...selectedDataBlock.dataBlockRequest,
-            includeGeoJson: selectedDataBlock.charts.some(
-              chart => chart.type === 'map',
-            ),
-          }
-        : undefined,
-    [selectedDataBlock],
-  );
+  const { error, isLoading } = useTableQuery(
+    selectedDataBlock
+      ? {
+          ...selectedDataBlock.dataBlockRequest,
+          includeGeoJson: selectedDataBlock.charts.some(
+            chart => chart.type === 'map',
+          ),
+        }
+      : undefined,
+    {
+      onSuccess: async (table, query) => {
+        const subjectMeta = await tableBuilderService.filterPublicationSubjectMeta(
+          query,
+        );
 
-  const { value: table, error } = useTableQuery(query);
-
-  useEffect(() => {
-    if (!query) {
-      setLoading(false);
-      return;
-    }
-
-    setLoading(true);
-
-    if (!table) {
-      return;
-    }
-
-    tableBuilderService
-      .filterPublicationSubjectMeta(query)
-      .then(subjectMeta => {
         setInitialTableToolState({
           initialStep: 5,
           query,
@@ -77,10 +61,9 @@ const ReleaseManageDataBlocksPageTabs = ({
               : getDefaultTableHeaderConfig(table.subjectMeta),
           },
         });
-
-        setLoading(false);
-      });
-  }, [query, selectedDataBlock, table]);
+      },
+    },
+  );
 
   const handleDataBlockSave = useCallback(
     async (dataBlock: SavedDataBlock) => {

--- a/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useTableQuery.ts
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useTableQuery.ts
@@ -5,10 +5,21 @@ import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import tableBuilderService, {
   TableDataQuery,
 } from '@common/services/tableBuilderService';
+import { useRef } from 'react';
+
+interface TableQueryOptions {
+  onSuccess?: (table: FullTable, query: TableDataQuery) => void;
+  onError?: (error: Error) => void;
+}
 
 export default function useTableQuery(
   query: TableDataQuery | undefined,
+  options?: TableQueryOptions,
 ): AsyncRetryState<FullTable | undefined> {
+  const optionsRef = useRef<TableQueryOptions | undefined>(options);
+
+  optionsRef.current = options;
+
   const { withoutErrorHandling } = useErrorControl();
 
   return useAsyncRetry(async () => {
@@ -17,8 +28,22 @@ export default function useTableQuery(
     }
 
     return withoutErrorHandling(async () => {
-      const response = await tableBuilderService.getTableData(query);
-      return mapFullTable(response);
+      try {
+        const response = await tableBuilderService.getTableData(query);
+        const fullTable = mapFullTable(response);
+
+        if (optionsRef.current?.onSuccess) {
+          await optionsRef.current.onSuccess(fullTable, query);
+        }
+
+        return fullTable;
+      } catch (error) {
+        if (optionsRef.current?.onError) {
+          await optionsRef.current.onError(error);
+        }
+
+        throw error;
+      }
     });
   }, [JSON.stringify(query)]);
 }


### PR DESCRIPTION
This PR adds additional `onSuccess` and `onError` callback options to `useTableQuery`, allowing us to better synchronise the subject meta query (`filterPublicationSubjectMeta`) that is dependent on the table query result.

Currently, these queries can easily become de-synchronized whenever the `selectedDataBlock` prop changes (e.g. when the data block is saved). This consequently causes stale table tool state to be propagated leading to null pointer errors.