### PR TITLE
EES-802 Fix 'open datareader' error migrating datablocks

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockMigrationService.cs
@@ -41,12 +41,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<Either<ActionResult, bool>> MigrateAll()
         {
-            var dbSet = _context.DataBlocks;
+            var dataBlocks = _context.DataBlocks.ToList();
             var errors = new List<string>();
             
-            foreach (var dataBlock in dbSet)
+            foreach (var dataBlock in dataBlocks)
             {
-                dbSet.Update(dataBlock);
+                _context.DataBlocks.Update(dataBlock);
 
                 var result = await Transform(dataBlock);
                 if (result.IsLeft)
@@ -66,10 +66,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return true;
         }
 
-        private async Task<Either<string, bool>> Transform(DataBlock dataBlock)
+        private Task<Either<string, bool>> Transform(DataBlock dataBlock)
         {
             dataBlock.DataBlockRequest = _mapper.Map<ObservationQueryContext>(dataBlock.EES17DataBlockRequest);
-            return await GetSubjectMeta(dataBlock.DataBlockRequest)
+            return GetSubjectMeta(dataBlock.DataBlockRequest)
                 .OnSuccess(subjectMeta =>
                 {
                     var filters = GetFilterItemIds(subjectMeta);


### PR DESCRIPTION
While transforming each datablock we execute a query to get the metadata and this has a security check which was failing when trying to query the latest release from the linked releases for the subject.

This failure was because the datablocks query was still in progress when we began the query for the latest linked release. Each open connection can only support one query at a time.

The solution here is to resolve the datablocks DbSet into a List before we start transforming them, which is where the inner queries are made by the security check.

This solution wouldn't be ideal if there are a lot of datablocks since they are now loaded into memory up front.