### PR TITLE
EES-647 Add 'Delete chart' button to chart builder

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
@@ -32,12 +32,13 @@ import parseNumber from '@common/utils/number/parseNumber';
 import Yup from '@common/validation/yup';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { ReactNode, useCallback, useMemo, useState } from 'react';
 import { ObjectSchema, Schema } from 'yup';
 
 type FormValues = Partial<OmitStrict<AxisConfiguration, 'dataSets' | 'type'>>;
 
 interface Props {
+  buttons?: ReactNode;
   canSaveChart: boolean;
   id: string;
   defaultDataType?: AxisGroupBy;
@@ -52,6 +53,7 @@ interface Props {
 }
 
 const ChartAxisConfiguration = ({
+  buttons,
   canSaveChart,
   id,
   configuration,
@@ -588,6 +590,8 @@ const ChartAxisConfiguration = ({
           <Button type="submit" id={`${id}-submit`}>
             Save chart options
           </Button>
+
+          {buttons}
         </Form>
       )}
     />

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderTabSection.tsx
@@ -1,6 +1,7 @@
 import ChartBuilder, {
   TableQueryUpdateHandler,
 } from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilder';
+import editReleaseDataService from '@admin/services/release/edit-release/data/editReleaseDataService';
 import { ReleaseDataBlock } from '@admin/services/release/edit-release/datablocks/service';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
@@ -42,12 +43,27 @@ const ChartBuilderTabSection = ({
 
   const handleChartSave = useCallback(
     async (chart: Chart) => {
-      onDataBlockSave({
+      await onDataBlockSave({
         ...dataBlock,
         charts: [chart],
       });
     },
     [dataBlock, onDataBlockSave],
+  );
+
+  const handleChartDelete = useCallback(
+    async (chart: Chart) => {
+      // Cleanup potential infographic chart file if required
+      if (chart.type === 'infographic' && chart.fileId) {
+        await editReleaseDataService.deleteChartFile(releaseId, chart.fileId);
+      }
+
+      await onDataBlockSave({
+        ...dataBlock,
+        charts: [],
+      });
+    },
+    [dataBlock, onDataBlockSave, releaseId],
   );
 
   const handleTableQueryUpdate: TableQueryUpdateHandler = useCallback(
@@ -77,6 +93,7 @@ const ChartBuilderTabSection = ({
       meta={meta}
       initialConfiguration={dataBlock.charts[0]}
       onChartSave={handleChartSave}
+      onChartDelete={handleChartDelete}
       onTableQueryUpdate={handleTableQueryUpdate}
     />
   );

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartConfiguration.tsx
@@ -17,13 +17,14 @@ import parseNumber from '@common/utils/number/parseNumber';
 import Yup from '@common/validation/yup';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
-import React, { useCallback, useMemo } from 'react';
+import React, { ReactNode, useCallback, useMemo } from 'react';
 import { ObjectSchema, Schema } from 'yup';
 import InfographicChartForm from './InfographicChartForm';
 
 type FormValues = Partial<ChartOptions>;
 
 interface Props {
+  buttons?: ReactNode;
   canSaveChart: boolean;
   definition: ChartDefinition;
   chartOptions: ChartOptions;
@@ -38,6 +39,7 @@ interface Props {
 const formId = 'chartConfigurationForm';
 
 const ChartConfiguration = ({
+  buttons,
   canSaveChart,
   chartOptions,
   definition,
@@ -249,6 +251,8 @@ const ChartConfiguration = ({
             <Button type="submit" id={`${formId}-submit`}>
               Save chart options
             </Button>
+
+            {buttons}
           </Form>
         )}
       />

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
@@ -21,7 +21,7 @@ import { Dictionary } from '@common/types';
 import Yup from '@common/validation/yup';
 import difference from 'lodash/difference';
 import mapValues from 'lodash/mapValues';
-import React, { useMemo, useState } from 'react';
+import React, { ReactNode, useMemo, useState } from 'react';
 import styles from './ChartDataSelector.module.scss';
 
 interface FormValues {
@@ -32,6 +32,7 @@ interface FormValues {
 }
 
 interface Props {
+  buttons?: ReactNode;
   canSaveChart?: boolean;
   chartType: ChartDefinition;
   dataSets?: DataSetConfiguration[];
@@ -46,6 +47,7 @@ interface Props {
 const formId = 'chartDataSelectorForm';
 
 const ChartDataSelector = ({
+  buttons,
   canSaveChart,
   meta,
   capabilities,
@@ -308,6 +310,8 @@ const ChartDataSelector = ({
               >
                 Save chart options
               </Button>
+
+              {buttons}
             </>
           )}
         </>

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/reducers/__tests__/chartBuilderReducer.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/reducers/__tests__/chartBuilderReducer.test.ts
@@ -816,6 +816,58 @@ describe('chartBuilderReducer', () => {
     });
   });
 
+  describe('RESET', () => {
+    test('resets to correct initial state', () => {
+      const initialState: ChartBuilderState = {
+        axes: {
+          major: {
+            type: 'major',
+            visible: true,
+            referenceLines: [],
+            dataSets: [],
+          },
+        },
+        definition: testChartDefinition,
+        options: {
+          height: 400,
+          title: 'Something',
+        },
+        forms: {
+          options: {
+            isValid: false,
+          },
+          data: {
+            isValid: false,
+          },
+          major: {
+            isValid: false,
+          },
+        },
+      };
+
+      const nextState = produce(chartBuilderReducer)(initialState, {
+        type: 'RESET',
+      });
+
+      expect(nextState).toEqual({
+        axes: {},
+        options: {
+          height: 300,
+          title: '',
+        },
+        definition: undefined,
+        forms: {
+          options: {
+            isValid: true,
+          },
+          data: {
+            isValid: true,
+          },
+        },
+      });
+    });
+  });
+
   describe('useChartBuilderReducer', () => {
     test('has correct state when no initial configuration', () => {
       const { result } = renderHook(() => useChartBuilderReducer());

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer.ts
@@ -67,6 +67,9 @@ export type ChartBuilderActions =
         form: keyof ChartBuilderState['forms'];
         state: FormState;
       };
+    }
+  | {
+      type: 'RESET';
     };
 
 const defaultOptions: Partial<ChartOptions> = {
@@ -91,6 +94,71 @@ const updateAxis = (
     ...next,
     ...(axisDefinition.constants ?? {}),
     type: axisDefinition.type,
+  };
+};
+
+const getInitialState = (initialConfiguration?: Chart): ChartBuilderState => {
+  const definition = chartDefinitions.find(
+    ({ type }) => type === initialConfiguration?.type,
+  );
+
+  // Make sure height is never actually 0 or negative
+  // as this wouldn't make sense for any chart.
+  const height =
+    typeof initialConfiguration?.height !== 'undefined' &&
+    initialConfiguration?.height > 0
+      ? initialConfiguration.height
+      : definition?.options?.defaults?.height ?? 300;
+
+  const initialState: ChartBuilderState = {
+    axes: {},
+    definition,
+    options: {
+      ...omit(initialConfiguration ?? {}, ['axes', 'type']),
+      title: initialConfiguration?.title ?? '',
+      height,
+    },
+    forms: {
+      data: { isValid: true },
+      options: { isValid: true },
+    },
+  };
+
+  if (!initialConfiguration) {
+    return initialState;
+  }
+
+  const axes: AxesConfiguration = mapValues(
+    initialState.definition?.axes ?? {},
+    (axisDefinition: ChartDefinitionAxis, type: AxisType) => {
+      return updateAxis(
+        axisDefinition,
+        (initialConfiguration.axes[type] ?? {}) as AxisConfiguration,
+      );
+    },
+  );
+
+  if (
+    axes.major?.dataSets?.some(dataSet => !dataSet.config) &&
+    initialConfiguration.labels
+  ) {
+    axes.major.dataSets = getLabelDataSetConfigurations(
+      initialConfiguration.labels,
+      axes.major.dataSets,
+    );
+  }
+
+  const forms: ChartBuilderState['forms'] = {
+    ...initialState.forms,
+    ...(mapValues(axes, () => ({
+      isValid: true,
+    })) as Dictionary<FormState>),
+  };
+
+  return {
+    ...initialState,
+    axes,
+    forms,
   };
 };
 
@@ -207,81 +275,23 @@ export const chartBuilderReducer: Reducer<
       draft.forms[action.payload.form] = action.payload.state;
 
       break;
+    case 'RESET':
+      return getInitialState();
     default:
       break;
   }
+
+  return draft;
 };
 
 export function useChartBuilderReducer(initialConfiguration?: Chart) {
-  const definition = chartDefinitions.find(
-    ({ type }) => type === initialConfiguration?.type,
-  );
-
-  // Make sure height is never actually 0 or negative
-  // as this wouldn't make sense for any chart.
-  const height =
-    typeof initialConfiguration?.height !== 'undefined' &&
-    initialConfiguration?.height > 0
-      ? initialConfiguration.height
-      : definition?.options?.defaults?.height ?? 300;
-
   const [state, dispatch] = useLoggedImmerReducer<
     ChartBuilderState,
     ChartBuilderActions
   >(
     'Chart builder',
     chartBuilderReducer,
-    {
-      axes: {},
-      definition,
-      options: {
-        ...omit(initialConfiguration ?? {}, ['axes', 'type']),
-        title: initialConfiguration?.title ?? '',
-        height,
-      },
-      forms: {
-        data: { isValid: true },
-        options: { isValid: true },
-      },
-    },
-    (initialState: ChartBuilderState) => {
-      if (!initialConfiguration) {
-        return initialState;
-      }
-
-      const axes: AxesConfiguration = mapValues(
-        initialState.definition?.axes ?? {},
-        (axisDefinition: ChartDefinitionAxis, type: AxisType) => {
-          return updateAxis(
-            axisDefinition,
-            (initialConfiguration.axes[type] ?? {}) as AxisConfiguration,
-          );
-        },
-      );
-
-      if (
-        axes.major?.dataSets?.some(dataSet => !dataSet.config) &&
-        initialConfiguration.labels
-      ) {
-        axes.major.dataSets = getLabelDataSetConfigurations(
-          initialConfiguration.labels,
-          axes.major.dataSets,
-        );
-      }
-
-      const forms: ChartBuilderState['forms'] = {
-        ...initialState.forms,
-        ...(mapValues(axes, () => ({
-          isValid: true,
-        })) as Dictionary<FormState>),
-      };
-
-      return {
-        ...initialState,
-        axes,
-        forms,
-      };
-    },
+    getInitialState(initialConfiguration),
   );
 
   const addDataSet = useCallback(
@@ -363,6 +373,12 @@ export function useChartBuilderReducer(initialConfiguration?: Chart) {
     [dispatch],
   );
 
+  const resetState = useCallback(() => {
+    dispatch({
+      type: 'RESET',
+    });
+  }, [dispatch]);
+
   const actions = useMemo(
     () => ({
       addDataSet,
@@ -372,6 +388,7 @@ export function useChartBuilderReducer(initialConfiguration?: Chart) {
       updateChartOptions,
       updateChartAxis,
       updateFormState,
+      resetState,
     }),
     [
       addDataSet,
@@ -381,6 +398,7 @@ export function useChartBuilderReducer(initialConfiguration?: Chart) {
       updateChartOptions,
       updateDataSets,
       updateFormState,
+      resetState,
     ],
   );
 

--- a/src/explore-education-statistics-common/src/components/ModalConfirm.tsx
+++ b/src/explore-education-statistics-common/src/components/ModalConfirm.tsx
@@ -19,8 +19,8 @@ const ModalConfirm = ({
   cancelText = 'Cancel',
   mounted,
   onConfirm,
-  onCancel,
   onExit,
+  onCancel = onExit,
   title,
 }: Props) => {
   return (


### PR DESCRIPTION
This PR adds the 'Delete chart' button to bottom of each chart builder form. On clicking it, a confirmation modal will appear to make sure the user didn't accidentally click it.