### PR TITLE
EES-801 Replace `withoutErrorHandling` in favour of `unhandledrejection` listener

### DIFF
--- a/src/explore-education-statistics-admin/src/App.tsx
+++ b/src/explore-education-statistics-admin/src/App.tsx
@@ -1,5 +1,5 @@
 import apiAuthorizationRouteList from '@admin/components/api-authorization/ApiAuthorizationRoutes';
-import ErrorBoundary from '@admin/components/ErrorBoundary';
+import PageErrorBoundary from '@admin/components/PageErrorBoundary';
 import ProtectedRoute from '@admin/components/ProtectedRoute';
 import ThemeAndTopic from '@admin/components/ThemeAndTopic';
 import { AuthContextProvider } from '@admin/contexts/AuthContext';
@@ -31,7 +31,7 @@ function App() {
     <ThemeAndTopic>
       <BrowserRouter>
         <AuthContextProvider>
-          <ErrorBoundary>
+          <PageErrorBoundary>
             <Switch>
               {authRoutes}
               {appRoutes}
@@ -40,7 +40,7 @@ function App() {
                 component={PageNotFoundPage}
               />
             </Switch>
-          </ErrorBoundary>
+          </PageErrorBoundary>
         </AuthContextProvider>
       </BrowserRouter>
     </ThemeAndTopic>

--- a/src/explore-education-statistics-admin/src/components/PageErrorBoundary.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageErrorBoundary.tsx
@@ -61,6 +61,8 @@ class PageErrorBoundary extends Component<RouteComponentProps, State> {
   };
 
   private handleApiErrors = (error: AxiosError) => {
+    logger.error(error);
+
     this.setState({
       errorCode: error.response?.status || 500,
     });

--- a/src/explore-education-statistics-admin/src/components/PageErrorBoundary.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageErrorBoundary.tsx
@@ -6,7 +6,7 @@ import { ErrorControlContextProvider } from '@common/contexts/ErrorControlContex
 import logger from '@common/services/logger';
 import { AxiosError } from 'axios';
 import * as H from 'history';
-import React from 'react';
+import React, { Component } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 
 interface State {
@@ -18,7 +18,7 @@ interface State {
  * specific types, or a fallback "Service problems" page
  * dependant on the type of error encountered.
  */
-class ErrorBoundary extends React.Component<RouteComponentProps, State> {
+class PageErrorBoundary extends Component<RouteComponentProps, State> {
   public state: State = {};
 
   private unregisterCallback?: H.UnregisterCallback;
@@ -116,4 +116,4 @@ class ErrorBoundary extends React.Component<RouteComponentProps, State> {
   }
 }
 
-export default withRouter(ErrorBoundary);
+export default withRouter(PageErrorBoundary);

--- a/src/explore-education-statistics-admin/src/components/__tests__/PageErrorBoundary.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/__tests__/PageErrorBoundary.test.tsx
@@ -1,0 +1,127 @@
+import PageErrorBoundary from '@admin/components/PageErrorBoundary';
+import { useErrorControl } from '@common/contexts/ErrorControlContext';
+import { render, waitFor } from '@testing-library/react';
+import { AxiosError } from 'axios';
+import React, { useEffect } from 'react';
+import { MemoryRouter } from 'react-router';
+
+describe('PageErrorBoundary', () => {
+  test('calling `handleApiErrors` renders generic error page', async () => {
+    const error = new Error('Something went wrong');
+
+    const TestComponent = () => {
+      const { handleApiErrors } = useErrorControl();
+
+      useEffect(() => {
+        Promise.reject(error).catch(err => {
+          handleApiErrors(err);
+        });
+      }, [handleApiErrors]);
+
+      return null;
+    };
+
+    const { queryByText } = render(
+      <MemoryRouter>
+        <PageErrorBoundary>
+          <TestComponent />
+        </PageErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        queryByText('Sorry, there is a problem with the service'),
+      ).not.toBeNull();
+      expect(queryByText('Try again later.')).not.toBeNull();
+    });
+  });
+
+  test('calling `handleApiErrors` with 401 error renders Forbidden page', async () => {
+    const error: Partial<AxiosError> = {
+      name: '',
+      message: 'Forbidden',
+      isAxiosError: true,
+      request: {},
+      response: {
+        config: {},
+        data: {},
+        headers: {},
+        status: 401,
+        statusText: 'Forbidden',
+        request: {},
+      },
+    };
+
+    const TestComponent = () => {
+      const { handleApiErrors } = useErrorControl();
+
+      useEffect(() => {
+        Promise.reject(error).catch(err => {
+          handleApiErrors(err);
+        });
+      }, [handleApiErrors]);
+
+      return null;
+    };
+
+    const { queryByText } = render(
+      <MemoryRouter>
+        <PageErrorBoundary>
+          <TestComponent />
+        </PageErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(queryByText('Forbidden')).not.toBeNull();
+      expect(
+        queryByText('You do not have permission to access this page.'),
+      ).not.toBeNull();
+    });
+  });
+
+  test('calling `handleApiErrors` with 404 error renders Not Found page', async () => {
+    const error: Partial<AxiosError> = {
+      name: '',
+      message: 'Not Found',
+      isAxiosError: true,
+      request: {},
+      response: {
+        config: {},
+        data: {},
+        headers: {},
+        status: 404,
+        statusText: 'Not Found',
+        request: {},
+      },
+    };
+
+    const TestComponent = () => {
+      const { handleApiErrors } = useErrorControl();
+
+      useEffect(() => {
+        Promise.reject(error).catch(err => {
+          handleApiErrors(err);
+        });
+      }, [handleApiErrors]);
+
+      return null;
+    };
+
+    const { queryByText } = render(
+      <MemoryRouter>
+        <PageErrorBoundary>
+          <TestComponent />
+        </PageErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(queryByText('Resource not found')).not.toBeNull();
+      expect(
+        queryByText('There was a problem accessing a resource.'),
+      ).not.toBeNull();
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/hooks/useFormSubmit.ts
+++ b/src/explore-education-statistics-admin/src/hooks/useFormSubmit.ts
@@ -26,19 +26,16 @@ const isServerValidationError = (error: AxiosError) => {
     errorDataAsValidationError.title !== undefined
   );
 };
-
 function useFormSubmit<FormValues>(
   onSubmit: UseFormSubmit<FormValues>,
   errorMappers: ServerValidationMessageMapper[] = [],
 ) {
-  const { handleApiErrors, withoutErrorHandling } = useErrorControl();
+  const { handleApiErrors } = useErrorControl();
 
   return useMemo(
     () => async (values: FormValues, actions: FormikActions<FormValues>) => {
       try {
-        await withoutErrorHandling(async () => {
-          await onSubmit(values, actions);
-        });
+        await onSubmit(values, actions);
       } catch (error) {
         const typedError: AxiosError = error;
 
@@ -58,7 +55,7 @@ function useFormSubmit<FormValues>(
         }
       }
     },
-    [withoutErrorHandling, onSubmit, handleApiErrors, errorMappers],
+    [onSubmit, handleApiErrors, errorMappers],
   );
 }
 

--- a/src/explore-education-statistics-admin/src/pages/users/InvitedUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/InvitedUsersPage.tsx
@@ -1,11 +1,10 @@
-import ButtonText from '@common/components/ButtonText';
 import Link from '@admin/components/Link';
-import LoadingSpinner from '@common/components/LoadingSpinner';
 import Page from '@admin/components/Page';
 import userService from '@admin/services/users/service';
 import { UserStatus } from '@admin/services/users/types';
+import ButtonText from '@common/components/ButtonText';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 import React, { useCallback, useEffect, useState } from 'react';
-import { useErrorControl } from '@common/contexts/ErrorControlContext';
 
 interface Model {
   users: UserStatus[];
@@ -15,24 +14,21 @@ const InvitedUsersPage = () => {
   const [model, setModel] = useState<Model>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [errorStatus, setErrorStatus] = useState<number>();
-  const { withoutErrorHandling } = useErrorControl();
 
   const getPendingInvites = useCallback(() => {
     setIsLoading(true);
-    withoutErrorHandling(() =>
-      userService
-        .getInvitedUsers()
-        .then(updatedInvites => {
-          setModel({
-            users: updatedInvites,
-          });
-        })
-        .catch(error => {
-          setErrorStatus(error.response.status);
-        })
-        .then(() => setIsLoading(false)),
-    );
-  }, [withoutErrorHandling]);
+    userService
+      .getInvitedUsers()
+      .then(updatedInvites => {
+        setModel({
+          users: updatedInvites,
+        });
+      })
+      .catch(error => {
+        setErrorStatus(error.response.status);
+      })
+      .then(() => setIsLoading(false));
+  }, []);
 
   useEffect(() => {
     getPendingInvites();

--- a/src/explore-education-statistics-admin/src/services/release/edit-release/data/editReleaseDataService.ts
+++ b/src/explore-education-statistics-admin/src/services/release/edit-release/data/editReleaseDataService.ts
@@ -226,7 +226,6 @@ const editReleaseDataService = {
   downloadChartFile(releaseId: string, fileName: string): Promise<Blob> {
     return client.get<Blob>(`/release/${releaseId}/chart/${fileName}`, {
       responseType: 'blob',
-      onError: error => error,
     });
   },
 };

--- a/src/explore-education-statistics-common/src/contexts/ErrorControlContext.tsx
+++ b/src/explore-education-statistics-common/src/contexts/ErrorControlContext.tsx
@@ -9,23 +9,12 @@ export interface ManualErrorHandler {
 export interface ErrorControlState {
   handleApiErrors: AxiosErrorHandler;
   handleManualErrors: ManualErrorHandler;
-  /**
-   * Run a {@param callback} in a context where
-   * the context's error handling is disabled and
-   * errors are automatically re-thrown.
-   * This is useful in situations where we want to
-   * handle errors in a different way to the default.
-   */
-  withoutErrorHandling: <T>(callback: () => Promise<T>) => Promise<T>;
 }
 
 export const ErrorControlContext = createContext<ErrorControlState>({
   handleApiErrors: noop,
   handleManualErrors: {
     forbidden: noop,
-  },
-  withoutErrorHandling: async callback => {
-    return callback();
   },
 });
 

--- a/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useDataBlockQuery.ts
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useDataBlockQuery.ts
@@ -1,4 +1,3 @@
-import { useErrorControl } from '@common/contexts/ErrorControlContext';
 import useAsyncRetry, { AsyncRetryState } from '@common/hooks/useAsyncRetry';
 import tableBuilderService, {
   TableDataResponse,
@@ -12,8 +11,6 @@ interface DataBlockWithOptionalResponse extends DataBlock {
 export default function useDataBlockQuery(
   dataBlock: DataBlockWithOptionalResponse | undefined,
 ): AsyncRetryState<TableDataResponse | undefined> {
-  const { withoutErrorHandling } = useErrorControl();
-
   return useAsyncRetry<TableDataResponse | undefined>(async () => {
     if (!dataBlock) {
       return undefined;
@@ -22,9 +19,7 @@ export default function useDataBlockQuery(
     const { dataBlockRequest, dataBlockResponse } = dataBlock;
 
     if (!dataBlockResponse) {
-      return withoutErrorHandling(() =>
-        tableBuilderService.getTableData(dataBlockRequest),
-      );
+      return tableBuilderService.getTableData(dataBlockRequest);
     }
 
     return dataBlockResponse;

--- a/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useTableQuery.ts
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useTableQuery.ts
@@ -1,4 +1,3 @@
-import { useErrorControl } from '@common/contexts/ErrorControlContext';
 import useAsyncRetry, { AsyncRetryState } from '@common/hooks/useAsyncRetry';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
@@ -20,30 +19,26 @@ export default function useTableQuery(
 
   optionsRef.current = options;
 
-  const { withoutErrorHandling } = useErrorControl();
-
   return useAsyncRetry(async () => {
     if (!query) {
       return undefined;
     }
 
-    return withoutErrorHandling(async () => {
-      try {
-        const response = await tableBuilderService.getTableData(query);
-        const fullTable = mapFullTable(response);
+    try {
+      const response = await tableBuilderService.getTableData(query);
+      const fullTable = mapFullTable(response);
 
-        if (optionsRef.current?.onSuccess) {
-          await optionsRef.current.onSuccess(fullTable, query);
-        }
-
-        return fullTable;
-      } catch (error) {
-        if (optionsRef.current?.onError) {
-          await optionsRef.current.onError(error);
-        }
-
-        throw error;
+      if (optionsRef.current?.onSuccess) {
+        await optionsRef.current.onSuccess(fullTable, query);
       }
-    });
+
+      return fullTable;
+    } catch (error) {
+      if (optionsRef.current?.onError) {
+        await optionsRef.current.onError(error);
+      }
+
+      throw error;
+    }
   }, [JSON.stringify(query)]);
 }

--- a/src/explore-education-statistics-common/src/polyfill.js
+++ b/src/explore-education-statistics-common/src/polyfill.js
@@ -1,3 +1,4 @@
+import 'core-js/features/promise';
 import 'core-js/features/array/flat';
 import 'core-js/features/array/flat-map';
 import 'cross-fetch/polyfill';

--- a/src/explore-education-statistics-common/src/services/api/Client.ts
+++ b/src/explore-education-statistics-common/src/services/api/Client.ts
@@ -7,14 +7,8 @@ import {
 
 export type AxiosErrorHandler = (error: AxiosError) => void;
 
-export interface ClientRequestConfig extends AxiosRequestConfig {
-  onError?: AxiosErrorHandler;
-}
-
 class Client {
   public readonly axios: AxiosInstance;
-
-  public errorHandler?: AxiosErrorHandler;
 
   public constructor(axios: AxiosInstance) {
     this.axios = axios;
@@ -22,55 +16,44 @@ class Client {
 
   public get<T = unknown>(
     url: string,
-    config?: ClientRequestConfig,
+    config?: AxiosRequestConfig,
   ): Promise<T> {
-    return this.unboxResponse(this.axios.get(url, config), config);
+    return Client.unboxResponse(this.axios.get(url, config));
   }
 
   public post<T = unknown>(
     url: string,
     data?: unknown,
-    config?: ClientRequestConfig,
+    config?: AxiosRequestConfig,
   ): Promise<T> {
-    return this.unboxResponse(this.axios.post(url, data, config), config);
+    return Client.unboxResponse(this.axios.post(url, data, config));
   }
 
   public put<T = unknown>(
     url: string,
     data?: unknown,
-    config?: ClientRequestConfig,
+    config?: AxiosRequestConfig,
   ): Promise<T> {
-    return this.unboxResponse(this.axios.put(url, data, config), config);
+    return Client.unboxResponse(this.axios.put(url, data, config));
   }
 
   public patch<T = unknown>(
     url: string,
     data?: unknown,
-    config?: ClientRequestConfig,
+    config?: AxiosRequestConfig,
   ): Promise<T> {
-    return this.unboxResponse(this.axios.patch(url, data, config), config);
+    return Client.unboxResponse(this.axios.patch(url, data, config));
   }
 
   public delete<T = unknown>(
     url: string,
-    config?: ClientRequestConfig,
+    config?: AxiosRequestConfig,
   ): Promise<T> {
-    return this.unboxResponse(this.axios.delete(url, config), config);
+    return Client.unboxResponse(this.axios.delete(url, config));
   }
 
-  private unboxResponse<T>(
-    promise: AxiosPromise<T>,
-    config?: ClientRequestConfig,
-  ) {
-    const response = promise.then(({ data }) => data);
-
-    if (config?.onError) {
-      response.catch(config.onError);
-    } else if (this.errorHandler) {
-      response.catch(this.errorHandler);
-    }
-
-    return response;
+  private static unboxResponse<T>(promise: AxiosPromise<T>) {
+    return promise.then(({ data }) => data);
   }
 }
 


### PR DESCRIPTION
Currently `withoutErrorHandling` is unreliable as it can create race conditions where multiple invocations can reset the default error handling behaviour once the associated task has completed. It's consequently possible for the user to still see the error page(s) when using `withoutErrorHandling` in multiple places.

The previous solution was to use `catch` everywhere, and this can robustly solve the problem, but is quite verbose.

Our new solution is to attach the default error handling to the `unhandledrejection` window event instead of the `Client` error handler. This means that most API requests no longer have a default `catch` that cannot be easily overridden.

A very nice benefit is that we can now idiomatically add custom error handling in our code as we no longer need to wrap the request with something like `withoutErrorHandling`. If no `catch` is added, it falls through to the `unhandledrejection` event handler which shows the relevant error page.