### PR TITLE
EES-818 Ensure prerelease window is checked before rendering PreReleasePage

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/prerelease/PreReleasePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/prerelease/PreReleasePage.tsx
@@ -54,81 +54,76 @@ const PreReleasePage = ({ match }: RouteComponentProps<MatchProps>) => {
   }, [handleManualErrors, publicationId, releaseId]);
 
   return (
-    <>
-      {model && (
-        <Page
-          wide
-          breadcrumbs={
-            user && user.permissions.canAccessAnalystPages
-              ? [{ name: 'Pre Release access' }]
-              : []
-          }
-          includeHomeBreadcrumb={user && user.permissions.canAccessAnalystPages}
-        >
-          {model.preReleaseWindowStatus.preReleaseAccess === 'Within' &&
-            model.content && (
-              <ReleaseProvider
-                value={{
-                  ...model?.content,
-                  canUpdateRelease: false,
-                  unresolvedComments: [],
-                }}
-              >
-                <PublicationReleaseContent />
-              </ReleaseProvider>
+    <Page
+      wide
+      breadcrumbs={
+        user && user.permissions.canAccessAnalystPages
+          ? [{ name: 'Pre Release access' }]
+          : []
+      }
+      includeHomeBreadcrumb={user && user.permissions.canAccessAnalystPages}
+    >
+      {model?.preReleaseWindowStatus.preReleaseAccess === 'Within' &&
+        model?.content && (
+          <ReleaseProvider
+            value={{
+              ...model?.content,
+              canUpdateRelease: false,
+              unresolvedComments: [],
+            }}
+          >
+            <PublicationReleaseContent />
+          </ReleaseProvider>
+        )}
+
+      {model?.preReleaseWindowStatus.preReleaseAccess === 'Before' && (
+        <>
+          <h1 className="govuk-heading-l">
+            Pre Release access is not yet available
+          </h1>
+          <p className="govuk-body">
+            Pre Release access for the{' '}
+            <strong>{model.content.release.title}</strong> release of{' '}
+            <strong>{model.publication.title}</strong> is not yet available.
+          </p>
+          <p className="govuk-body">
+            Pre Release access will be available from{' '}
+            {format(
+              model.preReleaseWindowStatus.preReleaseWindowStartTime,
+              'd MMMM yyyy',
             )}
-
-          {model.preReleaseWindowStatus.preReleaseAccess === 'Before' && (
-            <>
-              <h1 className="govuk-heading-l">
-                Pre Release access is not yet available
-              </h1>
-              <p className="govuk-body">
-                Pre Release access for the{' '}
-                <strong>{model.content.release.title}</strong> release of{' '}
-                <strong>{model.publication.title}</strong> is not yet available.
-              </p>
-              <p className="govuk-body">
-                Pre Release access will be available from{' '}
-                {format(
-                  model.preReleaseWindowStatus.preReleaseWindowStartTime,
-                  'd MMMM yyyy',
-                )}
-                {' at '}
-                {format(
-                  model.preReleaseWindowStatus.preReleaseWindowStartTime,
-                  'HH:mm',
-                )}{' '}
-                until{' '}
-                {format(
-                  model.preReleaseWindowStatus.preReleaseWindowEndTime,
-                  'd MMMM yyyy',
-                )}
-                {' at '}
-                {format(
-                  model.preReleaseWindowStatus.preReleaseWindowEndTime,
-                  'HH:mm',
-                )}
-                .
-              </p>
-              <p className="govuk-body">Please try again later.</p>
-            </>
-          )}
-
-          {model.preReleaseWindowStatus.preReleaseAccess === 'After' && (
-            <>
-              <h1 className="govuk-heading-l">Pre Release access has ended</h1>
-              <p className="govuk-body">
-                Pre Release access for the{' '}
-                <strong>{model.content.release.title}</strong> release of{' '}
-                <strong>{model.publication.title}</strong> is no longer
-                available.
-              </p>
-            </>
-          )}
-        </Page>
+            {' at '}
+            {format(
+              model.preReleaseWindowStatus.preReleaseWindowStartTime,
+              'HH:mm',
+            )}{' '}
+            until{' '}
+            {format(
+              model.preReleaseWindowStatus.preReleaseWindowEndTime,
+              'd MMMM yyyy',
+            )}
+            {' at '}
+            {format(
+              model.preReleaseWindowStatus.preReleaseWindowEndTime,
+              'HH:mm',
+            )}
+            .
+          </p>
+          <p className="govuk-body">Please try again later.</p>
+        </>
       )}
-    </>
+
+      {model?.preReleaseWindowStatus.preReleaseAccess === 'After' && (
+        <>
+          <h1 className="govuk-heading-l">Pre Release access has ended</h1>
+          <p className="govuk-body">
+            Pre Release access for the{' '}
+            <strong>{model.content.release.title}</strong> release of{' '}
+            <strong>{model.publication.title}</strong> is no longer available.
+          </p>
+        </>
+      )}
+    </Page>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/release/prerelease/PreReleasePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/prerelease/PreReleasePage.tsx
@@ -8,13 +8,11 @@ import permissionService, {
 } from '@admin/services/permissions/permissionService';
 import { releaseContentService } from '@admin/services/release/edit-release/content/service';
 import { ManageContentPageViewModel } from '@admin/services/release/edit-release/content/types';
-import {
-  ErrorControlState,
-  useErrorControl,
-} from '@common/contexts/ErrorControlContext';
+import { useErrorControl } from '@common/contexts/ErrorControlContext';
+import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import { format } from 'date-fns';
-import React, { useEffect, useState } from 'react';
-import { RouteComponentProps, withRouter } from 'react-router';
+import React from 'react';
+import { RouteComponentProps } from 'react-router';
 import { BasicPublicationDetails } from 'src/services/common/types';
 
 interface Model {
@@ -28,46 +26,32 @@ interface MatchProps {
   publicationId: string;
 }
 
-const PreReleasePage = ({
-  match,
-}: RouteComponentProps<MatchProps> & ErrorControlState) => {
-  const { handleManualErrors } = useErrorControl();
-  const [model, setModel] = useState<Model>();
-
-  const { user } = useAuthContext();
-
+const PreReleasePage = ({ match }: RouteComponentProps<MatchProps>) => {
   const { releaseId, publicationId } = match.params;
 
-  useEffect(() => {
-    Promise.all([
-      permissionService.getPreReleaseWindowStatus(releaseId),
+  const { handleManualErrors } = useErrorControl();
+  const { user } = useAuthContext();
+
+  const { value: model } = useAsyncRetry<Model | undefined>(async () => {
+    const preReleaseWindowStatus = await permissionService.getPreReleaseWindowStatus(
+      releaseId,
+    );
+    if (preReleaseWindowStatus.preReleaseAccess === 'NoneSet') {
+      handleManualErrors.forbidden();
+      return undefined;
+    }
+
+    const [publication, content] = await Promise.all([
       commonService.getBasicPublicationDetails(publicationId),
       releaseContentService.getContent(releaseId),
-    ]).then(([preReleaseWindowStatus, basicPublication, content]) => {
-      const newContent = {
-        ...content,
-        release: {
-          ...content.release,
-          prerelease: true,
-        },
-      };
-      if (preReleaseWindowStatus.preReleaseAccess === 'NoneSet') {
-        handleManualErrors.forbidden();
-      } else if (preReleaseWindowStatus.preReleaseAccess === 'Within') {
-        setModel({
-          publication: basicPublication,
-          preReleaseWindowStatus,
-          content: newContent,
-        });
-      } else {
-        setModel({
-          publication: basicPublication,
-          preReleaseWindowStatus,
-          content: newContent,
-        });
-      }
-    });
-  }, [releaseId, publicationId, handleManualErrors]);
+    ]);
+
+    return {
+      publication,
+      preReleaseWindowStatus,
+      content,
+    };
+  }, [handleManualErrors, publicationId, releaseId]);
 
   return (
     <>
@@ -148,4 +132,4 @@ const PreReleasePage = ({
   );
 };
 
-export default withRouter(PreReleasePage);
+export default PreReleasePage;


### PR DESCRIPTION
This PR fixes `permissionService.getPreReleaseWindowStatus` not being called before other API calls are made, causing the user to potentially see Forbidden pages.

We also clean up the page so that the user can always see the page layout. Even if there is no content, this is better than a white screen where they can't go anywhere from.