### PR TITLE
EES-825 Slug reverted back to graduate-labour-markets

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200430093743_EES760UpdatePublicationsTopicsAndThemes.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200430093743_EES760UpdatePublicationsTopicsAndThemes.cs
@@ -7,6 +7,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Note: this update was manually written, spot the copy/paste mistake in the slug which was intended to be graduate-labour-market-statistics!
+            // In EES-825 it was requested that the slug isn't changed so it should be reverted back to graduate-labour-markets
+            // This is done in a later migration, see 20200507100229_EES825RevertSlug.
             migrationBuilder.UpdateData(
                 table: "Publications",
                 keyColumn: "Id",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200507100229_EES825RevertSlug.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200507100229_EES825RevertSlug.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200507100229_EES825RevertSlug")]
+    partial class EES825RevertSlug
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200507100229_EES825RevertSlug.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200507100229_EES825RevertSlug.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES825RevertSlug : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Publications",
+                keyColumn: "Id",
+                keyValue: new Guid("42a888c4-9ee7-40fd-9128-f5de546780b3"),
+                column: "Slug",
+                value: "graduate-labour-markets");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Publications",
+                keyColumn: "Id",
+                keyValue: new Guid("42a888c4-9ee7-40fd-9128-f5de546780b3"),
+                column: "Slug",
+                value: "graduate-labour-market-statistics");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -1275,7 +1275,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     Title = "Graduate labour market statistics",
                     Summary = "",
                     TopicId = new Guid("53a1fbb7-5234-435f-892b-9baad4c82535"),
-                    Slug = "graduate-labour-market-statistics",
+                    Slug = "graduate-labour-markets",
                     LegacyPublicationUrl =
                         new Uri(
                             "https://www.gov.uk/government/collections/graduate-labour-market-quarterly-statistics#documents")


### PR DESCRIPTION
In https://github.com/dfe-analytical-services/explore-education-statistics/pull/1621 it was spotted that the Publication slug doesn’t match the title and this was corrected in advance of the first Release of this publication going live on the platform.

In https://github.com/dfe-analytical-services/explore-education-statistics/pull/1621 there was a mistake and it was going to be updated to `graduate-outcomes-leo-postgraduate-outcomes`.

Before this change was deployed to production, the first release for it was published.

This means we are now too late to correct `-markets` for `-market-statistics` without a redirect, and the slug should remain for now as `graduate-labour-markets`.

This change was required to prevent the slug being altered to `graduate-outcomes-leo-postgraduate-outcomes` and set it back to `graduate-labour-markets`.
