### PR TITLE
EES-806 Synchronize table state across all data block tabs

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilder.tsx
@@ -170,18 +170,16 @@ const ChartBuilder = ({
       return;
     }
 
-    const saveChart = async () => {
-      if (containerRef.current) {
-        containerRef.current.scrollIntoView({
-          behavior: 'smooth',
-          block: 'start',
-        });
-      }
+    setShouldSave(false);
 
-      await onChartSave(filterChartProps(chartProps));
-    };
+    if (containerRef.current) {
+      containerRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+    }
 
-    saveChart().then(() => setShouldSave(false));
+    onChartSave(filterChartProps(chartProps));
   }, [canSaveChart, chartProps, onChartSave, shouldSave]);
 
   const handleChartDelete = useCallback(async () => {

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderTabSection.tsx
@@ -1,6 +1,7 @@
 import ChartBuilder, {
   TableQueryUpdateHandler,
 } from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilder';
+import { SavedDataBlock } from '@admin/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs';
 import editReleaseDataService from '@admin/services/release/edit-release/data/editReleaseDataService';
 import { ReleaseDataBlock } from '@admin/services/release/edit-release/datablocks/service';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
@@ -10,46 +11,45 @@ import tableBuilderService, {
 } from '@common/services/tableBuilderService';
 import { Chart } from '@common/services/types/blocks';
 import isEqual from 'lodash/isEqual';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useParams } from 'react-router';
 
 interface Props {
   dataBlock: ReleaseDataBlock;
   query: TableDataQuery;
   table: FullTable;
-  onDataBlockSave: (dataBlock: ReleaseDataBlock) => void;
+  onDataBlockSave: (dataBlock: SavedDataBlock) => void;
+  onTableUpdate: (params: { table: FullTable; query: TableDataQuery }) => void;
 }
 
 const ChartBuilderTabSection = ({
   dataBlock,
-  query: initialQuery,
+  query,
   table,
   onDataBlockSave,
+  onTableUpdate,
 }: Props) => {
   const { releaseId } = useParams<{ releaseId: string }>();
 
-  const [tableQuery, setTableQuery] = useState<TableDataQuery>(initialQuery);
-  const [fullTable, setFullTable] = useState<FullTable>(table);
-
   const meta = useMemo(
     () => ({
-      ...fullTable.subjectMeta,
+      ...table.subjectMeta,
       // Don't render footnotes as they take
       // up too much screen space.
       footnotes: [],
     }),
-    [fullTable.subjectMeta],
+    [table.subjectMeta],
   );
 
   const handleChartSave = useCallback(
     async (chart: Chart) => {
       await onDataBlockSave({
         ...dataBlock,
-        dataBlockRequest: tableQuery,
+        dataBlockRequest: query,
         charts: [chart],
       });
     },
-    [dataBlock, onDataBlockSave, tableQuery],
+    [dataBlock, onDataBlockSave, query],
   );
 
   const handleChartDelete = useCallback(
@@ -72,29 +72,31 @@ const ChartBuilderTabSection = ({
   );
 
   const handleTableQueryUpdate: TableQueryUpdateHandler = useCallback(
-    async query => {
-      const nextTableQuery: TableDataQuery = {
-        ...tableQuery,
+    async updatedQuery => {
+      const nextQuery: TableDataQuery = {
         ...query,
+        ...updatedQuery,
       };
 
       // Don't fetch table data again if queries are the same
-      if (isEqual(tableQuery, nextTableQuery)) {
+      if (isEqual(query, nextQuery)) {
         return;
       }
 
-      const tableData = await tableBuilderService.getTableData(nextTableQuery);
+      const tableData = await tableBuilderService.getTableData(nextQuery);
 
-      setTableQuery(nextTableQuery);
-      setFullTable(mapFullTable(tableData));
+      onTableUpdate({
+        table: mapFullTable(tableData),
+        query: nextQuery,
+      });
     },
-    [tableQuery],
+    [onTableUpdate, query],
   );
 
   return (
     <ChartBuilder
       releaseId={releaseId}
-      data={fullTable.results}
+      data={table.results}
       meta={meta}
       initialConfiguration={dataBlock.charts[0]}
       onChartSave={handleChartSave}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderTabSection.tsx
@@ -15,20 +15,20 @@ import { useParams } from 'react-router';
 
 interface Props {
   dataBlock: ReleaseDataBlock;
+  query: TableDataQuery;
   table: FullTable;
   onDataBlockSave: (dataBlock: ReleaseDataBlock) => void;
 }
 
 const ChartBuilderTabSection = ({
   dataBlock,
+  query: initialQuery,
   table,
   onDataBlockSave,
 }: Props) => {
   const { releaseId } = useParams<{ releaseId: string }>();
 
-  const [tableQuery, setTableQuery] = useState<TableDataQuery>(
-    dataBlock.dataBlockRequest,
-  );
+  const [tableQuery, setTableQuery] = useState<TableDataQuery>(initialQuery);
   const [fullTable, setFullTable] = useState<FullTable>(table);
 
   const meta = useMemo(

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderTabSection.tsx
@@ -45,10 +45,11 @@ const ChartBuilderTabSection = ({
     async (chart: Chart) => {
       await onDataBlockSave({
         ...dataBlock,
+        dataBlockRequest: tableQuery,
         charts: [chart],
       });
     },
-    [dataBlock, onDataBlockSave],
+    [dataBlock, onDataBlockSave, tableQuery],
   );
 
   const handleChartDelete = useCallback(

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/DataBlockSourceWizard.tsx
@@ -21,6 +21,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -135,6 +136,8 @@ const DataBlockSourceWizard = ({
   tableHeaders,
   onSave,
 }: DataBlockSourceWizardProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+
   const initialTableToolState = useMemo<TableToolState | undefined>(() => {
     if (!initialQuery || !table || !tableHeaders || !subjectMeta) {
       return undefined;
@@ -151,8 +154,22 @@ const DataBlockSourceWizard = ({
     };
   }, [initialQuery, subjectMeta, table, tableHeaders]);
 
+  const handleSave: DataBlockSourceWizardSaveHandler = useCallback(
+    state => {
+      if (ref.current) {
+        ref.current.scrollIntoView({
+          behavior: 'smooth',
+          block: 'start',
+        });
+      }
+
+      onSave(state);
+    },
+    [onSave],
+  );
+
   return (
-    <>
+    <div ref={ref}>
       <p>Configure data source for the data block</p>
 
       <TableToolWizard
@@ -173,7 +190,7 @@ const DataBlockSourceWizard = ({
                     query={query}
                     table={response.table}
                     tableHeaders={response.tableHeaders}
-                    onSave={onSave}
+                    onSave={handleSave}
                   />
                 )}
               </>
@@ -181,7 +198,7 @@ const DataBlockSourceWizard = ({
           </WizardStep>
         )}
       />
-    </>
+    </div>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
@@ -1,78 +1,113 @@
 import ChartBuilderTabSection from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilderTabSection';
 import DataBlockSourceWizard, {
-  SavedDataBlock,
+  DataBlockSourceWizardSaveHandler,
 } from '@admin/pages/release/edit-release/manage-datablocks/components/DataBlockSourceWizard';
 import TableTabSection from '@admin/pages/release/edit-release/manage-datablocks/components/TableTabSection';
 import dataBlocksService, {
+  CreateReleaseDataBlock,
   ReleaseDataBlock,
 } from '@admin/services/release/edit-release/datablocks/service';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
 import WarningMessage from '@common/components/WarningMessage';
-import useTableQuery from '@common/modules/find-statistics/hooks/useTableQuery';
-import { TableToolState } from '@common/modules/table-tool/components/TableToolWizard';
+import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import filterOrphanedDataSets from '@common/modules/charts/util/filterOrphanedDataSets';
+import { FullTable } from '@common/modules/table-tool/types/fullTable';
+import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/getDefaultTableHeadersConfig';
+import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
+import mapUnmappedTableHeaders from '@common/modules/table-tool/utils/mapUnmappedTableHeaders';
 import tableBuilderService, {
+  PublicationSubjectMeta,
   TableDataQuery,
 } from '@common/services/tableBuilderService';
 import minDelay from '@common/utils/minDelay';
-import React, { useCallback, useMemo, useState } from 'react';
+import produce from 'immer';
+import React, { useCallback, useState } from 'react';
+
+export type SavedDataBlock = CreateReleaseDataBlock & {
+  id?: string;
+};
+
+interface TableState {
+  table: FullTable;
+  tableHeaders: TableHeadersConfig;
+  query: TableDataQuery;
+}
 
 interface Props {
   releaseId: string;
   selectedDataBlock?: ReleaseDataBlock;
   onDataBlockSave: (dataBlock: ReleaseDataBlock) => void;
 }
+
 const ReleaseManageDataBlocksPageTabs = ({
   releaseId,
   selectedDataBlock,
   onDataBlockSave,
 }: Props) => {
-  const [isSaving, setIsSaving] = useState(false);
-
   // Track number of saves as we can use this to
   // force re-rendering of the tab sections.
   const [saveNumber, setSaveNumber] = useState(0);
+  const [isSaving, setIsSaving] = useState(false);
 
-  const [tableToolState, setTableToolState] = useState<TableToolState>();
+  const [subjectMeta, setSubjectMeta] = useState<PublicationSubjectMeta>();
 
-  const initialQuery = useMemo<TableDataQuery | undefined>(
-    () =>
-      selectedDataBlock
-        ? {
-            ...selectedDataBlock.dataBlockRequest,
-            includeGeoJson: selectedDataBlock.charts.some(
-              chart => chart.type === 'map',
-            ),
-          }
-        : undefined,
-    [selectedDataBlock],
-  );
+  const {
+    value: tableState,
+    setValue: setTableState,
+    error,
+    isLoading,
+  } = useAsyncRetry<TableState | undefined>(async () => {
+    if (!selectedDataBlock) {
+      return undefined;
+    }
 
-  const { error, isLoading } = useTableQuery(initialQuery, {
-    onSuccess: async (table, query) => {
-      const subjectMeta = await tableBuilderService.filterPublicationSubjectMeta(
-        query,
-      );
+    const query = {
+      ...selectedDataBlock.dataBlockRequest,
+      includeGeoJson: selectedDataBlock.charts.some(
+        chart => chart.type === 'map',
+      ),
+    };
 
-      setTableToolState({
-        initialStep: 5,
-        query,
-        subjectMeta,
-        response: {
-          table,
-          tableHeaders: selectedDataBlock
-            ? mapTableHeadersConfig(
-                selectedDataBlock.tables[0].tableHeaders,
-                table.subjectMeta,
-              )
-            : getDefaultTableHeaderConfig(table.subjectMeta),
-        },
+    const tableData = await tableBuilderService.getTableData(query);
+    const nextSubjectMeta = await tableBuilderService.filterPublicationSubjectMeta(
+      query,
+    );
+
+    const table = mapFullTable(tableData);
+
+    setSubjectMeta(nextSubjectMeta);
+
+    const tableHeaders = selectedDataBlock
+      ? mapTableHeadersConfig(
+          selectedDataBlock.tables[0].tableHeaders,
+          table.subjectMeta,
+        )
+      : getDefaultTableHeaderConfig(table.subjectMeta);
+
+    return {
+      table,
+      tableHeaders,
+      query,
+    };
+  }, []);
+
+  const updateTableState = useCallback(
+    (nextTableState: Partial<TableState>) => {
+      if (!tableState) {
+        throw new Error('Cannot update undefined table state');
+      }
+
+      setTableState({
+        ...tableState,
+        ...nextTableState,
       });
     },
-  });
+    [setTableState, tableState],
+  );
 
   const handleDataBlockSave = useCallback(
     async (dataBlock: SavedDataBlock) => {
@@ -105,6 +140,66 @@ const ReleaseManageDataBlocksPageTabs = ({
     [onDataBlockSave, releaseId, saveNumber],
   );
 
+  const handleDataBlockSourceSave: DataBlockSourceWizardSaveHandler = useCallback(
+    async ({ query, table, tableHeaders, details }) => {
+      const charts = produce(selectedDataBlock?.charts ?? [], draft => {
+        const majorAxis = draft[0]?.axes?.major;
+
+        if (majorAxis?.dataSets) {
+          majorAxis.dataSets = filterOrphanedDataSets(
+            majorAxis.dataSets,
+            table.subjectMeta,
+          );
+        }
+      });
+
+      setTableState({
+        query,
+        table,
+        tableHeaders,
+      });
+
+      await handleDataBlockSave({
+        ...(selectedDataBlock ?? {}),
+        ...details,
+        dataBlockRequest: query,
+        charts,
+        tables: [
+          {
+            tableHeaders: mapUnmappedTableHeaders(tableHeaders),
+            indicators: [],
+          },
+        ],
+      });
+    },
+    [handleDataBlockSave, selectedDataBlock, setTableState],
+  );
+
+  const handleTableHeadersSave = useCallback(
+    async (tableHeaders: TableHeadersConfig) => {
+      if (!selectedDataBlock) {
+        throw new Error(
+          'Cannot save table headers when no data block has been selected',
+        );
+      }
+
+      updateTableState({ tableHeaders });
+
+      await handleDataBlockSave({
+        ...selectedDataBlock,
+        tables: [
+          {
+            tableHeaders: mapUnmappedTableHeaders(tableHeaders),
+            indicators: [],
+          },
+        ],
+      });
+    },
+    [handleDataBlockSave, selectedDataBlock, updateTableState],
+  );
+
+  const { query, table, tableHeaders } = tableState ?? {};
+
   return (
     <div style={{ position: 'relative' }} className="govuk-!-padding-top-2">
       {(isLoading || isSaving) && (
@@ -119,33 +214,37 @@ const ReleaseManageDataBlocksPageTabs = ({
           <TabsSection title="Data source" id="manageDataBlocks-dataSource">
             {!isLoading && (
               <DataBlockSourceWizard
+                key={saveNumber}
                 releaseId={releaseId}
                 dataBlock={selectedDataBlock}
-                initialTableToolState={tableToolState}
-                onDataBlockSave={handleDataBlockSave}
+                query={query}
+                subjectMeta={subjectMeta}
+                table={table}
+                tableHeaders={tableHeaders}
+                onSave={handleDataBlockSourceSave}
               />
             )}
           </TabsSection>
 
           {selectedDataBlock && [
             <TabsSection title="Table" key="table" id="manageDataBlocks-table">
-              {tableToolState?.response && (
+              {table && tableHeaders && (
                 <TableTabSection
-                  dataBlock={selectedDataBlock}
-                  table={tableToolState.response.table}
-                  tableHeaders={tableToolState.response.tableHeaders}
-                  onDataBlockSave={handleDataBlockSave}
+                  table={table}
+                  tableHeaders={tableHeaders}
+                  onSave={handleTableHeadersSave}
                 />
               )}
             </TabsSection>,
             <TabsSection title="Chart" key="chart" id="manageDataBlocks-chart">
-              {tableToolState?.response && initialQuery && (
+              {query && table && (
                 <ChartBuilderTabSection
                   key={saveNumber}
                   dataBlock={selectedDataBlock}
-                  query={initialQuery}
-                  table={tableToolState.response.table}
+                  query={query}
+                  table={table}
                   onDataBlockSave={handleDataBlockSave}
+                  onTableUpdate={updateTableState}
                 />
               )}
             </TabsSection>,

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
@@ -30,6 +30,10 @@ const ReleaseManageDataBlocksPageTabs = ({
 }: Props) => {
   const [isSaving, setIsSaving] = useState(false);
 
+  // Track number of saves as we can use this to
+  // force re-rendering of the tab sections.
+  const [saveNumber, setSaveNumber] = useState(0);
+
   const [tableToolState, setTableToolState] = useState<TableToolState>();
 
   const { error, isLoading } = useTableQuery(
@@ -83,8 +87,9 @@ const ReleaseManageDataBlocksPageTabs = ({
       onDataBlockSave(newDataBlock);
 
       setIsSaving(false);
+      setSaveNumber(saveNumber + 1);
     },
-    [onDataBlockSave, releaseId],
+    [onDataBlockSave, releaseId, saveNumber],
   );
 
   return (
@@ -123,6 +128,7 @@ const ReleaseManageDataBlocksPageTabs = ({
             <TabsSection title="Chart" key="chart" id="manageDataBlocks-chart">
               {tableToolState?.response && (
                 <ChartBuilderTabSection
+                  key={saveNumber}
                   dataBlock={selectedDataBlock}
                   table={tableToolState.response.table}
                   onDataBlockSave={handleDataBlockSave}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
@@ -78,15 +78,23 @@ const ReleaseManageDataBlocksPageTabs = ({
     async (dataBlock: SavedDataBlock) => {
       setIsSaving(true);
 
+      const dataBlockToSave: SavedDataBlock = {
+        ...dataBlock,
+        dataBlockRequest: {
+          ...dataBlock.dataBlockRequest,
+          includeGeoJson: dataBlock.charts[0]?.type === 'map',
+        },
+      };
+
       const newDataBlock = await minDelay(() => {
-        if (dataBlock.id) {
+        if (dataBlockToSave.id) {
           return dataBlocksService.putDataBlock(
-            dataBlock.id,
-            dataBlock as ReleaseDataBlock,
+            dataBlockToSave.id,
+            dataBlockToSave as ReleaseDataBlock,
           );
         }
 
-        return dataBlocksService.postDataBlock(releaseId, dataBlock);
+        return dataBlocksService.postDataBlock(releaseId, dataBlockToSave);
       }, 500);
 
       onDataBlockSave(newDataBlock);

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/TableTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/TableTabSection.tsx
@@ -1,25 +1,16 @@
-import { SavedDataBlock } from '@admin/pages/release/edit-release/manage-datablocks/components/DataBlockSourceWizard';
-import { ReleaseDataBlock } from '@admin/services/release/edit-release/datablocks/service';
 import TableHeadersForm from '@common/modules/table-tool/components/TableHeadersForm';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
-import mapUnmappedTableHeaders from '@common/modules/table-tool/utils/mapUnmappedTableHeaders';
 import React, { useRef } from 'react';
 
 interface Props {
-  dataBlock: ReleaseDataBlock;
   table: FullTable;
   tableHeaders: TableHeadersConfig;
-  onDataBlockSave: (dataBlock: SavedDataBlock) => void;
+  onSave: (tableHeaders: TableHeadersConfig) => void;
 }
 
-const TableTabSection = ({
-  dataBlock,
-  table,
-  tableHeaders,
-  onDataBlockSave,
-}: Props) => {
+const TableTabSection = ({ table, tableHeaders, onSave }: Props) => {
   const dataTableRef = useRef<HTMLElement>(null);
 
   return (
@@ -28,15 +19,7 @@ const TableTabSection = ({
         initialValues={tableHeaders}
         id="dataBlockContentTabs-tableHeadersForm"
         onSubmit={async nextTableHeaders => {
-          await onDataBlockSave({
-            ...dataBlock,
-            tables: [
-              {
-                tableHeaders: mapUnmappedTableHeaders(nextTableHeaders),
-                indicators: [],
-              },
-            ],
-          });
+          await onSave(nextTableHeaders);
 
           if (dataTableRef.current) {
             dataTableRef.current.scrollIntoView({

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/filterOrphanedDataSets.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/filterOrphanedDataSets.test.ts
@@ -1,0 +1,281 @@
+import { DataSetConfiguration } from '@common/modules/charts/types/dataSet';
+import filterOrphanedDataSets from '@common/modules/charts/util/filterOrphanedDataSets';
+import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
+import { TableDataResponse } from '@common/services/tableBuilderService';
+
+describe('filterOrphanedDataSets', () => {
+  const testTableData: TableDataResponse = {
+    subjectMeta: {
+      filters: {
+        Characteristic: {
+          totalValue: '',
+          hint: 'Filter by pupil characteristic',
+          legend: 'Characteristic',
+          options: {
+            EthnicGroupMajor: {
+              label: 'Ethnic group major',
+              options: [
+                {
+                  label: 'Ethnicity Major Chinese',
+                  value: 'ethnicity-major-chinese',
+                },
+                {
+                  label: 'Ethnicity Major Asian Total',
+                  value: 'ethnicity-major-asian-total',
+                },
+                {
+                  label: 'Ethnicity Major Black Total',
+                  value: 'ethnicity-major-black-total',
+                },
+              ],
+            },
+          },
+          name: 'characteristic',
+        },
+        SchoolType: {
+          totalValue: '',
+          hint: 'Filter by school type',
+          legend: 'School type',
+          options: {
+            Default: {
+              label: 'Default',
+              options: [
+                {
+                  label: 'State-funded secondary',
+                  value: 'state-funded-secondary',
+                },
+                {
+                  label: 'State-funded primary',
+                  value: 'state-funded-primary',
+                },
+              ],
+            },
+          },
+          name: 'school_type',
+        },
+      },
+      footnotes: [],
+      indicators: [
+        {
+          label: 'Number of authorised absence sessions',
+          unit: '',
+          value: 'authorised-absence-sessions',
+          name: 'sess_authorised',
+        },
+        {
+          label: 'Number of overall absence sessions',
+          unit: '',
+          value: 'overall-absence-sessions',
+          name: 'sess_overall',
+        },
+        {
+          label: 'Authorised absence rate',
+          unit: '%',
+          value: 'authorised-absence-rate',
+          name: 'sess_authorised_percent',
+        },
+      ],
+      locations: [
+        { level: 'localAuthority', label: 'Barnsley', value: 'E08000016' },
+        { level: 'localAuthority', label: 'Barnet', value: 'E09000003' },
+      ],
+      boundaryLevels: [
+        {
+          id: 2,
+          label:
+            'Counties and Unitary Authorities December 2018 Boundaries EW BUC',
+        },
+      ],
+      publicationName: 'Pupil absence in schools in England',
+      subjectName: 'Absence by characteristic',
+      timePeriodRange: [
+        { code: 'AY', label: '2013/14', year: 2013 },
+        { code: 'AY', label: '2014/15', year: 2014 },
+        { code: 'AY', label: '2015/16', year: 2015 },
+      ],
+      geoJsonAvailable: true,
+    },
+    results: [],
+  };
+
+  const testFullTable = mapFullTable(testTableData);
+
+  test('returns data set that has matching location', () => {
+    const testDataSets: DataSetConfiguration[] = [
+      {
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        indicator: 'authorised-absence-sessions',
+        location: {
+          value: 'E08000016',
+          level: 'localAuthority',
+        },
+        config: {
+          label: 'Test label',
+        },
+      },
+    ];
+
+    expect(
+      filterOrphanedDataSets(testDataSets, testFullTable.subjectMeta),
+    ).toEqual(testDataSets);
+  });
+
+  test('removes data set where the location does not match on `value`', () => {
+    const testDataSets: DataSetConfiguration[] = [
+      {
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        indicator: 'authorised-absence-sessions',
+        location: {
+          value: 'does not exist',
+          level: 'localAuthority',
+        },
+        config: {
+          label: 'Test label',
+        },
+      },
+    ];
+
+    expect(
+      filterOrphanedDataSets(testDataSets, testFullTable.subjectMeta),
+    ).toEqual([]);
+  });
+
+  test('removes data set where the location does not match on `level`', () => {
+    const testDataSets: DataSetConfiguration[] = [
+      {
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        indicator: 'authorised-absence-sessions',
+        location: {
+          value: 'E08000016',
+          level: 'localAuthorityDistrict',
+        },
+        config: {
+          label: 'Test label',
+        },
+      },
+    ];
+
+    expect(
+      filterOrphanedDataSets(testDataSets, testFullTable.subjectMeta),
+    ).toEqual([]);
+  });
+
+  test('returns data sets that have matching time period', () => {
+    const testDataSets: DataSetConfiguration[] = [
+      {
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        indicator: 'authorised-absence-sessions',
+        timePeriod: '2013_AY',
+        config: {
+          label: 'Test label',
+        },
+      },
+    ];
+
+    expect(
+      filterOrphanedDataSets(testDataSets, testFullTable.subjectMeta),
+    ).toEqual(testDataSets);
+  });
+
+  test('removes data set where the time period does not match', () => {
+    const testDataSets: DataSetConfiguration[] = [
+      {
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        indicator: 'authorised-absence-sessions',
+        timePeriod: 'does not match',
+        config: {
+          label: 'Test label',
+        },
+      },
+    ];
+
+    expect(
+      filterOrphanedDataSets(testDataSets, testFullTable.subjectMeta),
+    ).toEqual([]);
+  });
+
+  test('returns data set where all filters match', () => {
+    const testDataSets: DataSetConfiguration[] = [
+      {
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        indicator: 'authorised-absence-sessions',
+        config: {
+          label: 'Test label',
+        },
+      },
+    ];
+
+    expect(
+      filterOrphanedDataSets(testDataSets, testFullTable.subjectMeta),
+    ).toEqual(testDataSets);
+  });
+
+  test('removes data set where at least one filter does not match', () => {
+    const testDataSets: DataSetConfiguration[] = [
+      {
+        filters: ['ethnicity-major-chinese', 'does not match'],
+        indicator: 'authorised-absence-sessions',
+        config: {
+          label: 'Test label',
+        },
+      },
+    ];
+
+    expect(
+      filterOrphanedDataSets(testDataSets, testFullTable.subjectMeta),
+    ).toEqual([]);
+  });
+
+  test('returns data set where indicator matches', () => {
+    const testDataSets: DataSetConfiguration[] = [
+      {
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        indicator: 'authorised-absence-sessions',
+        config: {
+          label: 'Test label',
+        },
+      },
+    ];
+
+    expect(
+      filterOrphanedDataSets(testDataSets, testFullTable.subjectMeta),
+    ).toEqual(testDataSets);
+  });
+
+  test('removes data set where indicator does not match', () => {
+    const testDataSets: DataSetConfiguration[] = [
+      {
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        indicator: 'does not match',
+        config: {
+          label: 'Test label',
+        },
+      },
+    ];
+
+    expect(
+      filterOrphanedDataSets(testDataSets, testFullTable.subjectMeta),
+    ).toEqual([]);
+  });
+
+  test('returns data set where all criteria match', () => {
+    const testDataSets: DataSetConfiguration[] = [
+      {
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        indicator: 'authorised-absence-sessions',
+        timePeriod: '2013_AY',
+        location: {
+          value: 'E08000016',
+          level: 'localAuthority',
+        },
+        config: {
+          label: 'Test label',
+        },
+      },
+    ];
+
+    expect(
+      filterOrphanedDataSets(testDataSets, testFullTable.subjectMeta),
+    ).toEqual(testDataSets);
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/charts/util/filterOrphanedDataSets.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/filterOrphanedDataSets.ts
@@ -1,0 +1,46 @@
+import { DataSet } from '@common/modules/charts/types/dataSet';
+import { LocationFilter } from '@common/modules/table-tool/types/filters';
+import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
+
+/**
+ * Remove data sets that are no longer applicable
+ * to a given table's subject meta.
+ */
+export default function filterOrphanedDataSets(
+  dataSets: DataSet[],
+  meta: FullTableMeta,
+): DataSet[] {
+  return dataSets.filter(dataSet => {
+    if (dataSet.location) {
+      const locationId = LocationFilter.createId(dataSet.location);
+
+      if (meta.locations.every(location => locationId !== location.id)) {
+        return false;
+      }
+    }
+
+    if (dataSet.timePeriod) {
+      if (
+        meta.timePeriodRange.every(
+          timePeriod => timePeriod.id !== dataSet.timePeriod,
+        )
+      ) {
+        return false;
+      }
+    }
+
+    const filterOptions = Object.values(meta.filters).flatMap(
+      filterGroup => filterGroup.options,
+    );
+
+    const hasFilters = dataSet.filters.every(
+      filter => !!filterOptions.find(option => option.id === filter),
+    );
+
+    const hasIndicator = meta.indicators.find(
+      indicator => indicator.id === dataSet.indicator,
+    );
+
+    return hasFilters && hasIndicator;
+  });
+}


### PR DESCRIPTION
This PR re-works the current state implementation the 'Manage data blocks' UI so that  `ReleaseManageDataBlocksPageTabs` is the source of truth for all of its child components.

Previously, state could still be localised in some of the child components leading to continued stale state issues. The complexity of synchronizing this UI had been unfortunately underestimated.

We've now lifted most of this state up to `ReleaseManageDataBlockPageTabs` so that it is much harder to desynchronize. We maintain this state in a `tableState` variable that is updated when any of the tabs save/update.

## How does `tableState` get changed?

- On initial render, a table query will be executed in `ReleaseManageDataBlockPageTabs` if updating an existing data block. This result is stored in `tableState`. This table query will not be executed again.
- When saving an updated data source, the `TableToolWizard` will push its state back up to `ReleaseManageDataBlocksPageTabs` and set directly into `tableState` 
- When saving table headers on the 'Table' tab, the new table headers will also be set directly into `tableState`.
- When choosing options in the 'Chart' tab, we have to potentially update `tableState` e.g. when choosing a map or changing boundary levels. This is done through the `onTableUpdate` callback for `ChartBuilderTabsSection`.