### PR TITLE
EES-808 Fix existing data block source options not being correct on previous steps

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/DataBlockDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/DataBlockDetailsForm.tsx
@@ -51,9 +51,8 @@ const DataBlockDetailsForm = ({
               <FormFieldTextInput<DataBlockDetailsFormValues>
                 id="data-block-name"
                 name="name"
-                label="Data block name"
-                hint=" Name and save your data block before viewing it under the
-                    'View data blocks' tab at the top of this page."
+                label="Name"
+                hint="Name of the data block"
                 percentageWidth="one-half"
               />
 

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/DataBlockSourceWizard.tsx
@@ -169,7 +169,7 @@ const DataBlockSourceWizard = ({
   );
 
   return (
-    <div ref={ref}>
+    <div ref={ref} className="govuk-!-margin-bottom-8">
       <p>Configure data source for the data block</p>
 
       <TableToolWizard

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
@@ -73,8 +73,8 @@ const ReleaseManageDataBlocksPageTabs = ({
     };
 
     const tableData = await tableBuilderService.getTableData(query);
-    const nextSubjectMeta = await tableBuilderService.filterPublicationSubjectMeta(
-      query,
+    const nextSubjectMeta = await tableBuilderService.getPublicationSubjectMeta(
+      query.subjectId,
     );
 
     const table = mapFullTable(tableData);

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -144,6 +144,18 @@ const TableToolWizard = ({
     });
   };
 
+  const handleLocationStepBack = async () => {
+    const { subjectId } = state.query;
+
+    const nextSubjectMeta = await tableBuilderService.getPublicationSubjectMeta(
+      subjectId,
+    );
+
+    updateState(draft => {
+      draft.subjectMeta = nextSubjectMeta;
+    });
+  };
+
   const handleLocationFiltersFormSubmit: LocationFiltersFormSubmitHandler = async ({
     locations,
   }) => {
@@ -158,6 +170,21 @@ const TableToolWizard = ({
       draft.subjectMeta.timePeriod = nextSubjectMeta.timePeriod;
 
       draft.query.locations = locations;
+    });
+  };
+
+  const handleTimePeriodStepBack = async () => {
+    const { subjectId, locations } = state.query;
+
+    const nextSubjectMeta = await tableBuilderService.filterPublicationSubjectMeta(
+      {
+        subjectId,
+        locations,
+      },
+    );
+
+    updateState(draft => {
+      draft.subjectMeta.timePeriod = nextSubjectMeta.timePeriod;
     });
   };
 
@@ -188,6 +215,23 @@ const TableToolWizard = ({
         endYear,
         endCode,
       };
+    });
+  };
+
+  const handleFiltersStepBack = async () => {
+    const { subjectId, locations, timePeriod } = state.query;
+
+    const nextSubjectMeta = await tableBuilderService.filterPublicationSubjectMeta(
+      {
+        subjectId,
+        locations,
+        timePeriod,
+      },
+    );
+
+    updateState(draft => {
+      draft.subjectMeta.indicators = nextSubjectMeta.indicators;
+      draft.subjectMeta.filters = nextSubjectMeta.filters;
     });
   };
 
@@ -258,7 +302,7 @@ const TableToolWizard = ({
                 />
               )}
             </WizardStep>
-            <WizardStep>
+            <WizardStep onBack={handleLocationStepBack}>
               {stepProps => (
                 <LocationFiltersForm
                   {...stepProps}
@@ -268,7 +312,7 @@ const TableToolWizard = ({
                 />
               )}
             </WizardStep>
-            <WizardStep>
+            <WizardStep onBack={handleTimePeriodStepBack}>
               {stepProps => (
                 <TimePeriodForm
                   {...stepProps}
@@ -278,7 +322,7 @@ const TableToolWizard = ({
                 />
               )}
             </WizardStep>
-            <WizardStep>
+            <WizardStep onBack={handleFiltersStepBack}>
               {stepProps => (
                 <FiltersForm
                   {...stepProps}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.tsx
@@ -5,6 +5,7 @@ import styles from './WizardStep.module.scss';
 
 export interface WizardStepProps {
   children: ((props: InjectedWizardProps) => ReactNode) | ReactNode;
+  onBack?: () => void;
   id?: string;
 }
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/PublicationForm.test.tsx
@@ -162,6 +162,7 @@ describe('PublicationForm', () => {
     currentStep: 1,
     setCurrentStep: () => undefined,
     isActive: true,
+    isLoading: false,
     goToNextStep: () => undefined,
     goToPreviousStep: () => undefined,
   };

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/Wizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/Wizard.test.tsx
@@ -419,4 +419,52 @@ describe('Wizard', () => {
     expect(step2).toHaveClass('stepActive');
     expect(step3).not.toBeVisible();
   });
+
+  test('moving back calls the step `onBack` handler', async () => {
+    const onBack = jest.fn();
+
+    const { getByText } = render(
+      <Wizard id="test-wizard" initialStep={2}>
+        <WizardStep onBack={onBack}>Step 1</WizardStep>
+        <WizardStep>
+          {({ setCurrentStep }) => (
+            <button type="button" onClick={() => setCurrentStep(1)}>
+              Go to step 1
+            </button>
+          )}
+        </WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    fireEvent.click(getByText('Go to step 1'));
+
+    await wait();
+
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  test('moving forward does not call the step `onBack` handler', async () => {
+    const onBack = jest.fn();
+
+    const { getByText } = render(
+      <Wizard id="test-wizard">
+        <WizardStep>
+          {({ setCurrentStep }) => (
+            <button type="button" onClick={() => setCurrentStep(2)}>
+              Go to step 2
+            </button>
+          )}
+        </WizardStep>
+        <WizardStep onBack={onBack}>Step 2</WizardStep>
+        <WizardStep>Step 3</WizardStep>
+      </Wizard>,
+    );
+
+    fireEvent.click(getByText('Go to step 2'));
+
+    await wait();
+
+    expect(onBack).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
> :warning: Depends on `ees-806`

This PR fixes the `DataBlockSourceWizard` showing incorrect options when the user attempts to go to a previous step for an existing data block to update it. This was due to the subject meta being potentially incorrect as we start at the final step, instead of moving from step 1 through 5.

We consequently need to add an `onBack` callback to the relevant `TableToolWizard` steps so that we can re-filter the subject meta options for that step. This way we can ensure that the options are actually correct.

To err on the safe side, we also initialise the `DataBlockSourceWizard` will the full subject meta so that options are filtered out. This looks marginally better than flicker as options load in.