### PR TITLE
EES-793 Fix validation errors not being removed when table tool forms changed

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -155,7 +155,6 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
       ref={formikRef}
       initialValues={initialFormValues}
       validateOnBlur={false}
-      validateOnChange={false}
       validationSchema={Yup.object<FormValues>({
         indicators: Yup.array()
           .of(Yup.string())

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -75,7 +75,6 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
         }),
       }}
       validateOnBlur={false}
-      validateOnChange={false}
       validationSchema={Yup.object<FormValues>({
         locations: Yup.mixed().test(
           'required',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationSubjectForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationSubjectForm.tsx
@@ -60,7 +60,6 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
       ref={formikRef}
       initialValues={initialValues}
       validateOnBlur={false}
-      validateOnChange={false}
       validationSchema={Yup.object<FormValues>({
         subjectId: Yup.string().required('Choose a subject'),
       })}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
@@ -96,7 +96,6 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
       ref={formikRef}
       initialValues={formInitialValues}
       validateOnBlur={false}
-      validateOnChange={false}
       validationSchema={Yup.object<FormValues>({
         start: Yup.string()
           .required('Start date required')


### PR DESCRIPTION
This PR fixes validation errors not being removed when table tool's forms have been changed. This was due to `validateOnChange` being set to false. We've removed this in favour of using the default `validateOnChange` (which is true).