### PR TITLE
EES-849 Add correct table source to PermalinkPage

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadCsvButton.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadCsvButton.tsx
@@ -75,11 +75,11 @@ export const getCsvData = (fullTable: FullTable): string[][] => {
 };
 
 interface Props {
-  publicationSlug: string;
+  fileName: string;
   fullTable: FullTable;
 }
 
-const DownloadCsvButton = ({ publicationSlug, fullTable }: Props) => {
+const DownloadCsvButton = ({ fileName, fullTable }: Props) => {
   return (
     <ButtonText
       onClick={() => {
@@ -87,7 +87,7 @@ const DownloadCsvButton = ({ publicationSlug, fullTable }: Props) => {
         workBook.Sheets.Sheet1 = utils.aoa_to_sheet(getCsvData(fullTable));
         workBook.SheetNames[0] = 'Sheet1';
 
-        writeFile(workBook, `data-${publicationSlug}.csv`, {
+        writeFile(workBook, `${fileName}.csv`, {
           type: 'binary',
         });
       }}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadExcelButton.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadExcelButton.tsx
@@ -8,7 +8,7 @@ import React, { RefObject } from 'react';
 import { CellObject, utils, WorkSheet, writeFile } from 'xlsx';
 
 interface Props {
-  publicationSlug: string;
+  fileName: string;
   subjectMeta: FullTableMeta;
   tableRef: RefObject<HTMLElement>;
 }
@@ -140,11 +140,7 @@ export function appendFootnotes(
   return sheet;
 }
 
-const DownloadExcelButton = ({
-  publicationSlug,
-  subjectMeta,
-  tableRef,
-}: Props) => {
+const DownloadExcelButton = ({ fileName, subjectMeta, tableRef }: Props) => {
   const { footnotes } = subjectMeta;
   return (
     <ButtonText
@@ -173,7 +169,7 @@ const DownloadExcelButton = ({
         appendTitle(sheet, generateTableTitle(subjectMeta));
         appendFootnotes(sheet, footnotes);
 
-        writeFile(workBook, `data-${publicationSlug}.xlsx`, {
+        writeFile(workBook, `${fileName}.xlsx`, {
           type: 'binary',
         });
       }}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -29,7 +29,7 @@ import tableBuilderService, {
   TableDataQuery,
   ThemeMeta,
 } from '@common/services/tableBuilderService';
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { useImmer } from 'use-immer';
 
 const getDefaultSubjectMeta = (): PublicationSubjectMeta => ({

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DownloadCsvButton.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DownloadCsvButton.test.tsx
@@ -73,7 +73,7 @@ describe('DownloadCsvButton', () => {
   test('calls `writeFile` when button is pressed', () => {
     const { getByText } = render(
       <DownloadCsvButton
-        publicationSlug="pupil-absence"
+        fileName="pupil-absence"
         fullTable={{
           subjectMeta: {
             ...basicSubjectMeta,
@@ -140,7 +140,7 @@ describe('DownloadCsvButton', () => {
 
     expect(mockedWriteFile).toHaveBeenCalledTimes(1);
     expect(mockedWriteFile.mock.calls[0][0]).toMatchSnapshot();
-    expect(mockedWriteFile.mock.calls[0][1]).toBe('data-pupil-absence.csv');
+    expect(mockedWriteFile.mock.calls[0][1]).toBe('pupil-absence.csv');
   });
 
   describe('getCsvData', () => {

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -24,8 +24,6 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
     fullTable.subjectMeta,
   );
 
-  const publicationSlug = `permalink-${data.created}-${data.title}`;
-
   const { subjectName, publicationName } = fullTable.subjectMeta;
 
   return (
@@ -76,14 +74,14 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
         <ul className="govuk-list">
           <li>
             <DownloadCsvButton
-              publicationSlug={publicationSlug}
+              fileName={`permalink-${data.id}`}
               fullTable={fullTable}
             />
           </li>
           <li>
             <DownloadExcelButton
               tableRef={tableRef}
-              publicationSlug={publicationSlug}
+              fileName={`permalink-${data.id}`}
               subjectMeta={fullTable.subjectMeta}
             />
           </li>

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -26,9 +26,11 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
 
   const publicationSlug = `permalink-${data.created}-${data.title}`;
 
+  const { subjectName, publicationName } = fullTable.subjectMeta;
+
   return (
     <Page
-      title={`'${fullTable.subjectMeta.subjectName}' from '${fullTable.subjectMeta.publicationName}'`}
+      title={`'${subjectName}' from '${publicationName}'`}
       caption="Permanent data table"
       className={styles.permalinkPage}
       wide
@@ -65,7 +67,7 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
       <div ref={tableRef}>
         <TimePeriodDataTable
           fullTable={fullTable}
-          source="DfE prototype example statistics"
+          source={`${publicationName}, ${subjectName}`}
           tableHeadersConfig={tableHeadersConfig}
         />
       </div>

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -40,11 +40,10 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
           <dl className="dfe-meta-content govuk-!-margin-bottom-9">
-            <dt className="govuk-caption-m">Created:</dt>
+            <dt className="govuk-caption-m">Created: </dt>
             <dd data-testid="created-date">
               <strong>
-                {' '}
-                <FormattedDate>{data.created}</FormattedDate>{' '}
+                <FormattedDate>{data.created}</FormattedDate>
               </strong>
             </dd>
           </dl>
@@ -57,9 +56,6 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
               action: 'Print this page link selected',
             }}
           />
-          {/* <RelatedAside>
-              <h3>Related content</h3>
-            </RelatedAside> */}
         </div>
       </div>
       <div ref={tableRef}>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableTool.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableTool.tsx
@@ -145,13 +145,13 @@ const TableToolFinalStep = ({
           </li>
           <li>
             <DownloadCsvButton
-              publicationSlug={publication.slug}
+              fileName={`data-${publication.slug}`}
               fullTable={table}
             />
           </li>
           <li>
             <DownloadExcelButton
-              publicationSlug={publication.slug}
+              fileName={`data-${publication.slug}`}
               tableRef={dataTableRef}
               subjectMeta={table.subjectMeta}
             />


### PR DESCRIPTION
This PR also changes the permalink's CSV/Excel filenames to use the permalink ID. Previously the filenames would have `undefined` in them, which looked quite ugly.