### PR TITLE
EES-778

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStorageUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStorageUtils.cs
@@ -44,10 +44,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         
         public static Task<string> DownloadTextAsync(string storageConnectionString, string containerName, string blobName)
         {
-            return GetBlob(storageConnectionString, containerName, blobName).DownloadTextAsync();
+            return GetBlockBlob(storageConnectionString, containerName, blobName).DownloadTextAsync();
         }
 
-        public static CloudBlockBlob GetBlob(string storageConnectionString, string containerName, string blobName)
+        public static CloudBlob GetBlob(string storageConnectionString, string containerName, string blobName)
+        {
+            var blobContainer = GetCloudBlobContainer(storageConnectionString, containerName);
+            return blobContainer.GetBlobReference(blobName);
+        }
+        
+        public static CloudBlockBlob GetBlockBlob(string storageConnectionString, string containerName, string blobName)
         {
             var blobContainer = GetCloudBlobContainer(storageConnectionString, containerName);
             return blobContainer.GetBlockBlobReference(blobName);
@@ -187,7 +193,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         }
 
         /**
-         * Storage Emulator doesn't support AppendBlob. This method checks if AppendBlob can be used.
+         * Storage Emulator doesn't support AppendBlob. This method checks if AppendBlob can be used by either checking
+         * for its presence or creating a new one.
          */
         public static async Task<bool> TryGetOrCreateAppendBlobAsync(string storageConnectionString, string containerName,
             string blobName)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/FileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/FileStorageService.cs
@@ -30,21 +30,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             return FileStorageUtils.ListBlobs(_storageConnectionString, containerName);
         }
 
-        public bool FileExists(string containerName, string blobName)
+        public CloudBlob GetBlob(string containerName, string blobName)
         {
-            var blob = GetBlob(_storageConnectionString, containerName, blobName);
-            return blob.Exists();
+            return FileStorageUtils.GetBlob(_storageConnectionString, containerName, blobName);
         }
 
         public bool FileExistsAndIsReleased(string containerName, string blobName)
         {
-            var blob = GetBlob(_storageConnectionString, containerName, blobName);
+            var blob = GetBlob(containerName, blobName);
             return blob.Exists() && IsFileReleased(blob);
         }
 
         public async Task<FileStreamResult> StreamFile(string containerName, string blobName, string fileName)
         {
-            var blob = GetBlob(_storageConnectionString, containerName, blobName);
+            var blob = GetBlockBlob(_storageConnectionString, containerName, blobName);
 
             if (!blob.Exists())
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/Interfaces/IFileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/Interfaces/IFileStorageService.cs
@@ -11,10 +11,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interface
         
         Task<string> DownloadTextAsync(string containerName, string blobName);
 
-        bool FileExists(string containerName, string blobName);
-
         bool FileExistsAndIsReleased(string containerName, string blobName);
 
+        public CloudBlob GetBlob(string containerName, string blobName);
+        
         IEnumerable<CloudBlockBlob> ListBlobs(string containerName);
 
         Task<bool> TryGetOrCreateAppendBlobAsync(string containerName, string blobName);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkMigrationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkMigrationService.cs
@@ -143,7 +143,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
 
         public bool IsHistoryExists()
         {
-            return _fileStorageService.FileExists(_containerName, _migrationId);
+            var blob = _fileStorageService.GetBlob(_containerName, _migrationId);
+            if (!blob.Exists())
+            {
+                return false;
+            }
+            blob.FetchAttributes();
+            return blob.Properties.Length > 0;
         }
 
         public Task WriteHistoryAsync(string message)
@@ -173,7 +179,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             return _fileStorageService.AppendFromStreamAsync(_containerName,
                 _migrationId,
                 MediaTypeNames.Text.Plain,
-                $"{now}: {message}");
+                $"{now}: {message}{Environment.NewLine}");
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -137,7 +137,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             UpdateDatabase(app);
-            MigratePermalinksAsync(app).Wait();
+            // Intentionally don't await call here. Long running operation with it's own error handling.
+            var ignoredTask = MigratePermalinksAsync(app);
 
             if (env.IsDevelopment())
             {
@@ -203,8 +204,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
             using (var serviceScope = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
             {
                 var permalinkMigrationService = serviceScope.ServiceProvider.GetRequiredService<IEES17PermalinkMigrationService>();
-                // Intentionally don't await call here
-                permalinkMigrationService.MigrateAll();
+                await permalinkMigrationService.MigrateAll();
             }
         }
     }


### PR DESCRIPTION
Fixing PermalinkMigrationService logging when using CloudAppendBlob supported in Azure rather than CloudBlockBlob in the Storage Emulator.

Checking for support for CloudAppendBlob to be used by the logging attempts to create a blob. This made the check for whether the migration should run or not always return false since it checks for the presence of the blob. It now checks for the presence of a blob with content length greater than zero.