### PR TITLE
EES-874: Prevent themes and publications endpoints returning pre-release releases

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationRepository.cs
@@ -40,7 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .UserReleaseRoles
                 .Include(r => r.Release)
                 .ThenInclude(release => release.Publication)
-                .Where(r => r.UserId == userId && r.Release.Publication.TopicId == topicId)
+                .Where(r => r.UserId == userId && r.Release.Publication.TopicId == topicId && r.Role != ReleaseRole.PrereleaseViewer)
                 .Select(r => r.Release)
                 .Distinct()
                 .ToListAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeRepository.cs
@@ -36,7 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .ThenInclude(release => release.Publication)
                 .ThenInclude(publication => publication.Topic)
                 .ThenInclude(topic => topic.Theme)
-                .Where(r => r.UserId == userId)
+                .Where(r => r.UserId == userId && r.Role != ReleaseRole.PrereleaseViewer)
                 .Select(r => r.Release.Publication.Topic)
                 .Distinct()
                 .ToListAsync();


### PR DESCRIPTION
Prevent themes and publications endpoints returning releases that a user **only** has pre-release access for.

Currently topics and publications/releases are returned on the dashboard if a user only has pre-release access, this then results in failing api calls to get the status of that releases as that is forbidden (correctly).

This modified the themes/topics response to include those that a user has access to, and excludes those that they **only** have pre-release access for (as a user may have both access and pre-release at the same time).

To be safe ive also ensured that the publications endpoint does not return publications/releases with the same conditions.
