### PR TITLE
EES-826 Add tweaks to chart builder submit error messages

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
@@ -269,8 +269,8 @@ const ChartAxisConfiguration = ({
     <Formik<FormValues>
       initialValues={initialValues}
       enableReinitialize
+      validateOnMount
       validationSchema={validationSchema}
-      isInitialValid={validationSchema.isValidSync(initialValues)}
       onSubmit={values => {
         onSubmit(normalizeValues(values));
       }}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
@@ -1,7 +1,7 @@
 import styles from '@admin/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.module.scss';
+import ChartBuilderSaveButton from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton';
 import Button from '@common/components/Button';
 import Effect from '@common/components/Effect';
-import ErrorSummary from '@common/components/ErrorSummary';
 import {
   Form,
   FormFieldRadioGroup,
@@ -29,11 +29,11 @@ import { TableDataResult } from '@common/services/tableBuilderService';
 import { OmitStrict } from '@common/types';
 import parseNumber from '@common/utils/number/parseNumber';
 import Yup from '@common/validation/yup';
+import { Formik } from 'formik';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
 import React, { ReactNode, useCallback, useMemo, useState } from 'react';
 import { ObjectSchema, Schema } from 'yup';
-import { Formik } from 'formik';
 
 type FormValues = Partial<OmitStrict<AxisConfiguration, 'dataSets' | 'type'>>;
 
@@ -575,22 +575,12 @@ const ChartAxisConfiguration = ({
             </table>
           )}
 
-          {form.isValid && form.submitCount > 0 && !canSaveChart && (
-            <ErrorSummary
-              title="Cannot save chart"
-              id={`${id}-errorSummary`}
-              errors={[
-                {
-                  id: `${id}-submit`,
-                  message: 'Ensure that all other tabs are valid first',
-                },
-              ]}
-            />
-          )}
-
-          <Button type="submit" id={`${id}-submit`}>
-            Save chart options
-          </Button>
+          <ChartBuilderSaveButton
+            formId={id}
+            showSubmitError={
+              form.isValid && form.submitCount > 0 && !canSaveChart
+            }
+          />
 
           {buttons}
         </Form>

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
@@ -1,5 +1,6 @@
 import styles from '@admin/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.module.scss';
 import ChartBuilderSaveButton from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton';
+import { FormState } from '@admin/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer';
 import Button from '@common/components/Button';
 import Effect from '@common/components/Effect';
 import {
@@ -34,29 +35,32 @@ import merge from 'lodash/merge';
 import pick from 'lodash/pick';
 import React, { ReactNode, useCallback, useMemo, useState } from 'react';
 import { ObjectSchema, Schema } from 'yup';
+import mapValues from 'lodash/mapValues';
 
 type FormValues = Partial<OmitStrict<AxisConfiguration, 'dataSets' | 'type'>>;
 
 interface Props {
   buttons?: ReactNode;
   canSaveChart: boolean;
-  id: string;
   defaultDataType?: AxisGroupBy;
+  hasSubmittedChart: boolean;
+  id: string;
   type: AxisType;
   configuration: AxisConfiguration;
   data: TableDataResult[];
   meta: FullTableMeta;
   capabilities: ChartCapabilities;
   onChange: (configuration: AxisConfiguration) => void;
-  onFormStateChange: (state: { form: AxisType; isValid: boolean }) => void;
+  onFormStateChange: (state: { form: AxisType } & FormState) => void;
   onSubmit: (configuration: AxisConfiguration) => void;
 }
 
 const ChartAxisConfiguration = ({
   buttons,
   canSaveChart,
-  id,
   configuration,
+  hasSubmittedChart,
+  id,
   data,
   meta,
   type,
@@ -267,8 +271,13 @@ const ChartAxisConfiguration = ({
 
   return (
     <Formik<FormValues>
-      initialValues={initialValues}
       enableReinitialize
+      initialValues={initialValues}
+      initialTouched={
+        hasSubmittedChart
+          ? mapValues(validationSchema.fields, () => true)
+          : undefined
+      }
       validateOnMount
       validationSchema={validationSchema}
       onSubmit={values => {
@@ -291,6 +300,7 @@ const ChartAxisConfiguration = ({
             value={{
               form: type,
               isValid: form.isValid,
+              submitCount: form.submitCount,
             }}
             onMount={onFormStateChange}
             onChange={onFormStateChange}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
@@ -1,4 +1,5 @@
 import styles from '@admin/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.module.scss';
+import { ChartBuilderForm } from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilder';
 import ChartBuilderSaveButton from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton';
 import { FormState } from '@admin/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer';
 import Button from '@common/components/Button';
@@ -20,22 +21,22 @@ import {
   AxisConfiguration,
   AxisGroupBy,
   AxisType,
-  ChartCapabilities,
+  ChartDefinition,
   ReferenceLine,
 } from '@common/modules/charts/types/chart';
 import { DataSetCategory } from '@common/modules/charts/types/dataSet';
 import createDataSetCategories from '@common/modules/charts/util/createDataSetCategories';
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import { TableDataResult } from '@common/services/tableBuilderService';
-import { OmitStrict } from '@common/types';
+import { Dictionary, OmitStrict } from '@common/types';
 import parseNumber from '@common/utils/number/parseNumber';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
+import mapValues from 'lodash/mapValues';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
 import React, { ReactNode, useCallback, useMemo, useState } from 'react';
 import { ObjectSchema, Schema } from 'yup';
-import mapValues from 'lodash/mapValues';
 
 type FormValues = Partial<OmitStrict<AxisConfiguration, 'dataSets' | 'type'>>;
 
@@ -43,13 +44,14 @@ interface Props {
   buttons?: ReactNode;
   canSaveChart: boolean;
   defaultDataType?: AxisGroupBy;
+  forms: Dictionary<ChartBuilderForm>;
   hasSubmittedChart: boolean;
   id: string;
   type: AxisType;
   configuration: AxisConfiguration;
+  definition: ChartDefinition;
   data: TableDataResult[];
   meta: FullTableMeta;
-  capabilities: ChartCapabilities;
   onChange: (configuration: AxisConfiguration) => void;
   onFormStateChange: (state: { form: AxisType } & FormState) => void;
   onSubmit: (configuration: AxisConfiguration) => void;
@@ -59,16 +61,19 @@ const ChartAxisConfiguration = ({
   buttons,
   canSaveChart,
   configuration,
+  definition,
+  forms,
   hasSubmittedChart,
   id,
   data,
   meta,
   type,
-  capabilities,
   onChange,
   onFormStateChange,
   onSubmit,
 }: Props) => {
+  const { capabilities } = definition;
+
   const dataSetCategories = useMemo<DataSetCategory[]>(() => {
     if (type === 'minor') {
       return [];
@@ -589,6 +594,7 @@ const ChartAxisConfiguration = ({
 
           <ChartBuilderSaveButton
             formId={id}
+            forms={forms}
             showSubmitError={
               form.isValid && form.submitCount > 0 && !canSaveChart
             }

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
@@ -272,7 +272,9 @@ const ChartAxisConfiguration = ({
       validateOnMount
       validationSchema={validationSchema}
       onSubmit={values => {
-        onSubmit(normalizeValues(values));
+        if (canSaveChart) {
+          onSubmit(normalizeValues(values));
+        }
       }}
     >
       {form => (

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilder.tsx
@@ -74,6 +74,7 @@ const filterChartProps = (props: ChartProps): Chart => {
 
 export interface ChartBuilderForm extends FormState {
   title: string;
+  id: string;
 }
 
 export type TableQueryUpdateHandler = (
@@ -114,7 +115,11 @@ const ChartBuilder = ({
 
   const getChartFile = useGetChartFile(releaseId);
 
-  const forms: Dictionary<ChartBuilderForm> = useMemo(() => {
+  const forms: {
+    options: ChartBuilderForm;
+    data: ChartBuilderForm;
+    [key: string]: ChartBuilderForm;
+  } = useMemo(() => {
     const formTitles: Dictionary<string> = {
       ...mapValues(
         (definition?.axes as Required<ChartDefinition['axes']>) ?? {},
@@ -127,6 +132,7 @@ const ChartBuilder = ({
     return mapValues(formStates, (form, formKey) => ({
       ...form,
       title: formTitles[formKey],
+      id: `chartBuilder-${formKey}`,
     }));
   }, [definition, formStates]);
 
@@ -319,6 +325,7 @@ const ChartBuilder = ({
           <TabsSection
             title="Chart configuration"
             headingTitle="Chart configuration"
+            id={forms.options.id}
           >
             <ChartConfiguration
               buttons={deleteButton}
@@ -340,6 +347,7 @@ const ChartBuilder = ({
             <TabsSection
               title="Data sets"
               headingTitle="Choose data to add to the chart"
+              id={forms.data.id}
             >
               <ChartDataSelector
                 buttons={deleteButton}
@@ -369,7 +377,7 @@ const ChartBuilder = ({
               return (
                 <TabsSection
                   key={type}
-                  id={`${type}-tab`}
+                  id={forms[type].id}
                   title={axis.title}
                   headingTitle={axis.title}
                 >

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilder.tsx
@@ -112,6 +112,11 @@ const ChartBuilder = ({
     [forms],
   );
 
+  const hasSubmittedChart = useMemo(
+    () => Object.values(forms).some(form => form.submitCount > 0),
+    [forms],
+  );
+
   const chartProps = useMemo<ChartRendererProps | undefined>(() => {
     if (!definition) {
       return undefined;
@@ -295,6 +300,7 @@ const ChartBuilder = ({
             <ChartConfiguration
               buttons={deleteButton}
               canSaveChart={canSaveChart}
+              hasSubmittedChart={hasSubmittedChart}
               definition={definition}
               chartOptions={options}
               meta={meta}
@@ -321,6 +327,7 @@ const ChartBuilder = ({
                 onDataAdded={actions.addDataSet}
                 onDataRemoved={actions.removeDataSet}
                 onDataChanged={actions.updateDataSets}
+                onFormStateChange={actions.updateFormState}
                 onSubmit={handleChartDataSubmit}
               />
             </TabsSection>
@@ -345,6 +352,7 @@ const ChartBuilder = ({
                   <ChartAxisConfiguration
                     buttons={deleteButton}
                     canSaveChart={canSaveChart}
+                    hasSubmittedChart={hasSubmittedChart}
                     id={`chartAxisConfiguration-${type}`}
                     type={type as AxisType}
                     configuration={axisConfiguration}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilder.tsx
@@ -6,6 +6,7 @@ import ChartDataSelector from '@admin/pages/release/edit-release/manage-databloc
 import ChartDefinitionSelector from '@admin/pages/release/edit-release/manage-datablocks/components/ChartDefinitionSelector';
 import {
   ChartOptions,
+  FormState,
   useChartBuilderReducer,
 } from '@admin/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer';
 import Button from '@common/components/Button';
@@ -46,7 +47,9 @@ import {
   TableDataResult,
 } from '@common/services/tableBuilderService';
 import { Chart } from '@common/services/types/blocks';
+import { Dictionary } from '@common/types';
 import parseNumber from '@common/utils/number/parseNumber';
+import mapValues from 'lodash/mapValues';
 import omit from 'lodash/omit';
 import React, {
   useCallback,
@@ -68,6 +71,10 @@ const filterChartProps = (props: ChartProps): Chart => {
   // anymore in the deprecated format.
   return omit(props, ['data', 'meta', 'labels']) as Chart;
 };
+
+export interface ChartBuilderForm extends FormState {
+  title: string;
+}
 
 export type TableQueryUpdateHandler = (
   query: Partial<TableDataQuery>,
@@ -103,9 +110,25 @@ const ChartBuilder = ({
     initialConfiguration,
   );
 
-  const { axes, definition, options, forms } = chartBuilderState;
+  const { axes, definition, options, forms: formStates } = chartBuilderState;
 
   const getChartFile = useGetChartFile(releaseId);
+
+  const forms: Dictionary<ChartBuilderForm> = useMemo(() => {
+    const formTitles: Dictionary<string> = {
+      ...mapValues(
+        (definition?.axes as Required<ChartDefinition['axes']>) ?? {},
+        axis => axis.title,
+      ),
+      data: 'Data sets',
+      options: 'Chart configuration',
+    };
+
+    return mapValues(formStates, (form, formKey) => ({
+      ...form,
+      title: formTitles[formKey],
+    }));
+  }, [definition, formStates]);
 
   const canSaveChart = useMemo(
     () => Object.values(forms).every(form => form.isValid),
@@ -301,6 +324,7 @@ const ChartBuilder = ({
               buttons={deleteButton}
               canSaveChart={canSaveChart}
               hasSubmittedChart={hasSubmittedChart}
+              forms={forms}
               definition={definition}
               chartOptions={options}
               meta={meta}
@@ -320,10 +344,10 @@ const ChartBuilder = ({
               <ChartDataSelector
                 buttons={deleteButton}
                 canSaveChart={canSaveChart}
+                forms={forms}
                 meta={meta}
                 dataSets={axes.major?.dataSets}
-                chartType={definition}
-                capabilities={definition.capabilities}
+                definition={definition}
                 onDataAdded={actions.addDataSet}
                 onDataRemoved={actions.removeDataSet}
                 onDataChanged={actions.updateDataSets}
@@ -353,10 +377,11 @@ const ChartBuilder = ({
                     buttons={deleteButton}
                     canSaveChart={canSaveChart}
                     hasSubmittedChart={hasSubmittedChart}
+                    forms={forms}
                     id={`chartAxisConfiguration-${type}`}
                     type={type as AxisType}
                     configuration={axisConfiguration}
-                    capabilities={definition.capabilities}
+                    definition={definition}
                     data={data}
                     meta={meta}
                     onChange={actions.updateChartAxis}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton.tsx
@@ -19,40 +19,42 @@ const ChartBuilderSaveButton = ({
 }: Props) => {
   return (
     <>
-      {showSubmitError && (
-        <ErrorSummary
-          title="Cannot save chart"
-          id={`${formId}-errorSummary`}
-          errors={Object.values(forms)
-            .filter(form => !form.isValid)
-            .map(form => ({
-              id: form.id,
-              message: `${form.title} tab is invalid`,
-            }))}
-          onErrorClick={event => {
-            event.preventDefault();
+      <ErrorSummary
+        title="Cannot save chart"
+        id={`${formId}-errorSummary`}
+        errors={
+          showSubmitError
+            ? Object.values(forms)
+                .filter(form => !form.isValid)
+                .map(form => ({
+                  id: form.id,
+                  message: `${form.title} tab is invalid`,
+                }))
+            : []
+        }
+        onErrorClick={event => {
+          event.preventDefault();
 
-            const tab = document.querySelector<HTMLAnchorElement>(
-              `${event.currentTarget.getAttribute('href')}-tab`,
+          const tab = document.querySelector<HTMLAnchorElement>(
+            `${event.currentTarget.getAttribute('href')}-tab`,
+          );
+
+          if (tab) {
+            tab.click();
+
+            const tabs = document.querySelector<HTMLDivElement>(
+              '#chartBuilder-tabs',
             );
 
-            if (tab) {
-              tab.click();
-
-              const tabs = document.querySelector<HTMLDivElement>(
-                '#chartBuilder-tabs',
-              );
-
-              if (tabs) {
-                tabs.scrollIntoView({
-                  behavior: 'smooth',
-                  block: 'start',
-                });
-              }
+            if (tabs) {
+              tabs.scrollIntoView({
+                behavior: 'smooth',
+                block: 'start',
+              });
             }
-          }}
-        />
-      )}
+          }
+        }}
+      />
 
       <Button type="submit" id={`${formId}-submit`} onClick={onClick}>
         Save chart options

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton.tsx
@@ -1,15 +1,19 @@
+import { ChartBuilderForm } from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilder';
 import Button from '@common/components/Button';
 import ErrorSummary from '@common/components/ErrorSummary';
+import { Dictionary } from '@common/types';
 import React, { MouseEventHandler } from 'react';
 
 interface Props {
   formId: string;
+  forms: Dictionary<ChartBuilderForm>;
   showSubmitError: boolean;
   onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
 const ChartBuilderSaveButton = ({
   formId,
+  forms,
   showSubmitError,
   onClick,
 }: Props) => {
@@ -19,12 +23,12 @@ const ChartBuilderSaveButton = ({
         <ErrorSummary
           title="Cannot save chart"
           id={`${formId}-errorSummary`}
-          errors={[
-            {
+          errors={Object.values(forms)
+            .filter(form => !form.isValid)
+            .map(form => ({
               id: `${formId}-submit`,
-              message: 'Ensure that all other tabs are valid first',
-            },
-          ]}
+              message: `${form.title} tab is invalid`,
+            }))}
         />
       )}
 

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton.tsx
@@ -1,0 +1,38 @@
+import Button from '@common/components/Button';
+import ErrorSummary from '@common/components/ErrorSummary';
+import React, { MouseEventHandler } from 'react';
+
+interface Props {
+  formId: string;
+  showSubmitError: boolean;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+}
+
+const ChartBuilderSaveButton = ({
+  formId,
+  showSubmitError,
+  onClick,
+}: Props) => {
+  return (
+    <>
+      {showSubmitError && (
+        <ErrorSummary
+          title="Cannot save chart"
+          id={`${formId}-errorSummary`}
+          errors={[
+            {
+              id: `${formId}-submit`,
+              message: 'Ensure that all other tabs are valid first',
+            },
+          ]}
+        />
+      )}
+
+      <Button type="submit" id={`${formId}-submit`} onClick={onClick}>
+        Save chart options
+      </Button>
+    </>
+  );
+};
+
+export default ChartBuilderSaveButton;

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton.tsx
@@ -26,9 +26,31 @@ const ChartBuilderSaveButton = ({
           errors={Object.values(forms)
             .filter(form => !form.isValid)
             .map(form => ({
-              id: `${formId}-submit`,
+              id: form.id,
               message: `${form.title} tab is invalid`,
             }))}
+          onErrorClick={event => {
+            event.preventDefault();
+
+            const tab = document.querySelector<HTMLAnchorElement>(
+              `${event.currentTarget.getAttribute('href')}-tab`,
+            );
+
+            if (tab) {
+              tab.click();
+
+              const tabs = document.querySelector<HTMLDivElement>(
+                '#chartBuilder-tabs',
+              );
+
+              if (tabs) {
+                tabs.scrollIntoView({
+                  behavior: 'smooth',
+                  block: 'start',
+                });
+              }
+            }
+          }}
         />
       )}
 

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartConfiguration.tsx
@@ -1,3 +1,4 @@
+import { ChartBuilderForm } from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilder';
 import ChartBuilderSaveButton from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton';
 import {
   ChartOptions,
@@ -10,6 +11,7 @@ import FormFieldNumberInput from '@common/components/form/FormFieldNumberInput';
 import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
 import { ChartDefinition } from '@common/modules/charts/types/chart';
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
+import { Dictionary } from '@common/types';
 import parseNumber from '@common/utils/number/parseNumber';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
@@ -32,6 +34,7 @@ interface Props {
   canSaveChart: boolean;
   chartOptions: ChartOptions;
   definition: ChartDefinition;
+  forms: Dictionary<ChartBuilderForm>;
   hasSubmittedChart: boolean;
   releaseId: string;
   meta: FullTableMeta;
@@ -52,6 +55,7 @@ const ChartConfiguration = ({
   canSaveChart,
   chartOptions,
   definition,
+  forms,
   hasSubmittedChart,
   meta,
   releaseId,
@@ -284,6 +288,7 @@ const ChartConfiguration = ({
 
             <ChartBuilderSaveButton
               formId={formId}
+              forms={forms}
               showSubmitError={
                 form.isValid && form.submitCount > 0 && !canSaveChart
               }

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartConfiguration.tsx
@@ -148,7 +148,7 @@ const ChartConfiguration = ({
         onSubmit={values => {
           onSubmit(normalizeValues(values));
         }}
-        isInitialValid={validationSchema.isValidSync(initialValues)}
+        validateOnMount
         validationSchema={validationSchema}
       >
         {form => (

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartConfiguration.tsx
@@ -1,5 +1,8 @@
 import ChartBuilderSaveButton from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton';
-import { ChartOptions } from '@admin/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer';
+import {
+  ChartOptions,
+  FormState,
+} from '@admin/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer';
 import Effect from '@common/components/Effect';
 import { Form, FormFieldSelect, FormGroup } from '@common/components/form';
 import FormFieldCheckbox from '@common/components/form/FormFieldCheckbox';
@@ -10,6 +13,7 @@ import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import parseNumber from '@common/utils/number/parseNumber';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
+import mapValues from 'lodash/mapValues';
 import merge from 'lodash/merge';
 import pick from 'lodash/pick';
 import React, { ChangeEvent, ReactNode, useCallback, useMemo } from 'react';
@@ -26,13 +30,18 @@ type FormValues = Partial<ChartOptions>;
 interface Props {
   buttons?: ReactNode;
   canSaveChart: boolean;
-  definition: ChartDefinition;
   chartOptions: ChartOptions;
+  definition: ChartDefinition;
+  hasSubmittedChart: boolean;
   releaseId: string;
   meta: FullTableMeta;
   onBoundaryLevelChange?: (boundaryLevel: string) => void;
   onChange: (chartOptions: ChartOptions) => void;
-  onFormStateChange: (state: { form: 'options'; isValid: boolean }) => void;
+  onFormStateChange: (
+    state: {
+      form: 'options';
+    } & FormState,
+  ) => void;
   onSubmit: (chartOptions: ChartOptions) => void;
 }
 
@@ -43,6 +52,7 @@ const ChartConfiguration = ({
   canSaveChart,
   chartOptions,
   definition,
+  hasSubmittedChart,
   meta,
   releaseId,
   onBoundaryLevelChange,
@@ -143,15 +153,20 @@ const ChartConfiguration = ({
       )}
 
       <Formik<FormValues>
-        initialValues={initialValues}
         enableReinitialize
+        initialValues={initialValues}
+        initialTouched={
+          hasSubmittedChart
+            ? mapValues(validationSchema.fields, () => true)
+            : undefined
+        }
+        validateOnMount
+        validationSchema={validationSchema}
         onSubmit={values => {
           if (canSaveChart) {
             onSubmit(normalizeValues(values));
           }
         }}
-        validateOnMount
-        validationSchema={validationSchema}
       >
         {form => (
           <Form id={formId}>
@@ -167,6 +182,7 @@ const ChartConfiguration = ({
               value={{
                 form: 'options',
                 isValid: form.isValid,
+                submitCount: form.submitCount,
               }}
               onChange={onFormStateChange}
               onMount={onFormStateChange}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartConfiguration.tsx
@@ -1,7 +1,6 @@
+import ChartBuilderSaveButton from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton';
 import { ChartOptions } from '@admin/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer';
-import Button from '@common/components/Button';
 import Effect from '@common/components/Effect';
-import ErrorSummary from '@common/components/ErrorSummary';
 import { Form, FormFieldSelect, FormGroup } from '@common/components/form';
 import FormFieldCheckbox from '@common/components/form/FormFieldCheckbox';
 import FormFieldNumberInput from '@common/components/form/FormFieldNumberInput';
@@ -265,22 +264,12 @@ const ChartConfiguration = ({
               </>
             )}
 
-            {form.isValid && form.submitCount > 0 && !canSaveChart && (
-              <ErrorSummary
-                title="Cannot save chart"
-                id={`${formId}-errorSummary`}
-                errors={[
-                  {
-                    id: `${formId}-submit`,
-                    message: 'Ensure that all other tabs are valid first',
-                  },
-                ]}
-              />
-            )}
-
-            <Button type="submit" id={`${formId}-submit`}>
-              Save chart options
-            </Button>
+            <ChartBuilderSaveButton
+              formId={formId}
+              showSubmitError={
+                form.isValid && form.submitCount > 0 && !canSaveChart
+              }
+            />
 
             {buttons}
           </Form>

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartConfiguration.tsx
@@ -146,7 +146,9 @@ const ChartConfiguration = ({
         initialValues={initialValues}
         enableReinitialize
         onSubmit={values => {
-          onSubmit(normalizeValues(values));
+          if (canSaveChart) {
+            onSubmit(normalizeValues(values));
+          }
         }}
         validateOnMount
         validationSchema={validationSchema}

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
@@ -1,7 +1,7 @@
+import ChartBuilderSaveButton from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton';
 import ChartDataConfiguration from '@admin/pages/release/edit-release/manage-datablocks/components/ChartDataConfiguration';
 import Button from '@common/components/Button';
 import Details from '@common/components/Details';
-import ErrorSummary from '@common/components/ErrorSummary';
 import { Form, FormFieldSelect } from '@common/components/form';
 import {
   ChartCapabilities,
@@ -290,28 +290,14 @@ const ChartDataSelector = ({
                 })}
               </ul>
 
-              {isChartSubmitted && !canSaveChart && (
-                <ErrorSummary
-                  title="Cannot save chart"
-                  id={`${formId}-errorSummary`}
-                  errors={[
-                    {
-                      id: `${formId}-submit`,
-                      message: 'Ensure that all other tabs are valid first',
-                    },
-                  ]}
-                />
-              )}
-
-              <Button
-                id={`${formId}-submit`}
+              <ChartBuilderSaveButton
+                formId={formId}
+                showSubmitError={isChartSubmitted && !canSaveChart}
                 onClick={() => {
                   setChartSubmitted(true);
                   onSubmit(dataSetConfigs);
                 }}
-              >
-                Save chart options
-              </Button>
+              />
 
               {buttons}
             </>

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
@@ -295,7 +295,10 @@ const ChartDataSelector = ({
                 showSubmitError={isChartSubmitted && !canSaveChart}
                 onClick={() => {
                   setChartSubmitted(true);
-                  onSubmit(dataSetConfigs);
+
+                  if (canSaveChart) {
+                    onSubmit(dataSetConfigs);
+                  }
                 }}
               />
 

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartDataSelector.tsx
@@ -1,13 +1,11 @@
+import { ChartBuilderForm } from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilder';
 import ChartBuilderSaveButton from '@admin/pages/release/edit-release/manage-datablocks/components/ChartBuilderSaveButton';
 import ChartDataConfiguration from '@admin/pages/release/edit-release/manage-datablocks/components/ChartDataConfiguration';
 import { FormState } from '@admin/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer';
 import Button from '@common/components/Button';
 import Details from '@common/components/Details';
 import { Form, FormFieldSelect } from '@common/components/form';
-import {
-  ChartCapabilities,
-  ChartDefinition,
-} from '@common/modules/charts/types/chart';
+import { ChartDefinition } from '@common/modules/charts/types/chart';
 import {
   DataSet,
   DataSetConfiguration,
@@ -36,10 +34,10 @@ interface FormValues {
 interface Props {
   buttons?: ReactNode;
   canSaveChart: boolean;
-  chartType: ChartDefinition;
   dataSets?: DataSetConfiguration[];
+  definition: ChartDefinition;
+  forms: Dictionary<ChartBuilderForm>;
   meta: FullTableMeta;
-  capabilities: ChartCapabilities;
   onDataAdded?: (data: DataSetConfiguration) => void;
   onDataRemoved?: (data: DataSetConfiguration, index: number) => void;
   onDataChanged?: (data: DataSetConfiguration[]) => void;
@@ -56,15 +54,18 @@ const formId = 'chartDataSelectorForm';
 const ChartDataSelector = ({
   buttons,
   canSaveChart,
+  forms,
   meta,
-  capabilities,
   dataSets = [],
+  definition,
   onDataRemoved,
   onDataAdded,
   onDataChanged,
   onFormStateChange,
   onSubmit,
 }: Props) => {
+  const { capabilities } = definition;
+
   const indicatorOptions = useMemo(() => Object.values(meta.indicators), [
     meta.indicators,
   ]);
@@ -307,6 +308,7 @@ const ChartDataSelector = ({
 
               <ChartBuilderSaveButton
                 formId={formId}
+                forms={forms}
                 showSubmitError={submitCount > 0 && !canSaveChart}
                 onClick={() => {
                   setSubmitCount(submitCount + 1);

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/reducers/__tests__/chartBuilderReducer.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/reducers/__tests__/chartBuilderReducer.test.ts
@@ -83,9 +83,11 @@ describe('chartBuilderReducer', () => {
       forms: {
         options: {
           isValid: true,
+          submitCount: 0,
         },
         data: {
           isValid: true,
+          submitCount: 0,
         },
       },
     };
@@ -290,15 +292,19 @@ describe('chartBuilderReducer', () => {
       expect(nextState.forms).toEqual<ChartBuilderState['forms']>({
         options: {
           isValid: true,
+          submitCount: 0,
         },
         data: {
           isValid: true,
+          submitCount: 0,
         },
         major: {
           isValid: true,
+          submitCount: 0,
         },
         minor: {
           isValid: true,
+          submitCount: 0,
         },
       });
     });
@@ -323,12 +329,15 @@ describe('chartBuilderReducer', () => {
       forms: {
         options: {
           isValid: true,
+          submitCount: 0,
         },
         data: {
           isValid: true,
+          submitCount: 0,
         },
         major: {
           isValid: true,
+          submitCount: 0,
         },
       },
     };
@@ -425,12 +434,15 @@ describe('chartBuilderReducer', () => {
       forms: {
         options: {
           isValid: true,
+          submitCount: 0,
         },
         data: {
           isValid: true,
+          submitCount: 0,
         },
         major: {
           isValid: true,
+          submitCount: 0,
         },
       },
     };
@@ -576,12 +588,15 @@ describe('chartBuilderReducer', () => {
       forms: {
         options: {
           isValid: true,
+          submitCount: 0,
         },
         data: {
           isValid: true,
+          submitCount: 0,
         },
         major: {
           isValid: true,
+          submitCount: 0,
         },
       },
     };
@@ -624,6 +639,7 @@ describe('chartBuilderReducer', () => {
             ...initialState.forms,
             data: {
               isValid: false,
+              submitCount: 0,
             },
           },
         },
@@ -677,12 +693,15 @@ describe('chartBuilderReducer', () => {
       forms: {
         options: {
           isValid: true,
+          submitCount: 0,
         },
         data: {
           isValid: true,
+          submitCount: 0,
         },
         major: {
           isValid: true,
+          submitCount: 0,
         },
       },
     };
@@ -756,12 +775,15 @@ describe('chartBuilderReducer', () => {
       forms: {
         options: {
           isValid: true,
+          submitCount: 0,
         },
         data: {
           isValid: true,
+          submitCount: 0,
         },
         major: {
           isValid: true,
+          submitCount: 0,
         },
       },
     };
@@ -808,9 +830,11 @@ describe('chartBuilderReducer', () => {
       forms: {
         options: {
           isValid: true,
+          submitCount: 0,
         },
         data: {
           isValid: true,
+          submitCount: 0,
         },
       },
     };
@@ -836,11 +860,15 @@ describe('chartBuilderReducer', () => {
           form: 'options',
           state: {
             isValid: false,
+            submitCount: 1,
           },
         },
       } as ChartBuilderActions);
 
-      expect(nextState.forms.options.isValid).toBe(false);
+      expect(nextState.forms.options).toEqual({
+        isValid: false,
+        submitCount: 1,
+      });
     });
   });
 
@@ -864,12 +892,15 @@ describe('chartBuilderReducer', () => {
         forms: {
           options: {
             isValid: false,
+            submitCount: 1,
           },
           data: {
             isValid: false,
+            submitCount: 1,
           },
           major: {
             isValid: false,
+            submitCount: 1,
           },
         },
       };
@@ -889,9 +920,11 @@ describe('chartBuilderReducer', () => {
         forms: {
           options: {
             isValid: true,
+            submitCount: 0,
           },
           data: {
             isValid: true,
+            submitCount: 0,
           },
         },
       });
@@ -912,9 +945,11 @@ describe('chartBuilderReducer', () => {
         forms: {
           data: {
             isValid: true,
+            submitCount: 0,
           },
           options: {
             isValid: true,
+            submitCount: 0,
           },
         },
       });
@@ -1021,15 +1056,19 @@ describe('chartBuilderReducer', () => {
         forms: {
           data: {
             isValid: true,
+            submitCount: 0,
           },
           options: {
             isValid: true,
+            submitCount: 0,
           },
           major: {
             isValid: true,
+            submitCount: 0,
           },
           minor: {
             isValid: true,
+            submitCount: 0,
           },
         },
       });
@@ -1119,15 +1158,19 @@ describe('chartBuilderReducer', () => {
         forms: {
           data: {
             isValid: true,
+            submitCount: 0,
           },
           options: {
             isValid: true,
+            submitCount: 0,
           },
           major: {
             isValid: true,
+            submitCount: 0,
           },
           minor: {
             isValid: true,
+            submitCount: 0,
           },
         },
       });

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer.ts
@@ -195,8 +195,8 @@ export const chartBuilderReducer: Reducer<
       );
 
       const newAxisForms: Dictionary<FormState> = mapValues(
-        draft.axes as Required<AxesConfiguration>,
-        () => {
+        draft.definition.axes as Required<ChartDefinition['axes']>,
+        _ => {
           return {
             isValid: true,
             submitCount: 0,

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/reducers/chartBuilderReducer.ts
@@ -25,6 +25,7 @@ export interface ChartOptions extends ChartDefinitionOptions {
 
 export interface FormState {
   isValid: boolean;
+  submitCount: number;
 }
 
 export interface ChartBuilderState {
@@ -120,8 +121,8 @@ const getInitialState = (initialConfiguration?: Chart): ChartBuilderState => {
       height,
     },
     forms: {
-      data: { isValid: true },
-      options: { isValid: true },
+      data: { isValid: true, submitCount: 0 },
+      options: { isValid: true, submitCount: 0 },
     },
   };
 
@@ -151,9 +152,14 @@ const getInitialState = (initialConfiguration?: Chart): ChartBuilderState => {
 
   const forms: ChartBuilderState['forms'] = {
     ...initialState.forms,
-    ...(mapValues(axes, () => ({
-      isValid: true,
-    })) as Dictionary<FormState>),
+    ...mapValues(axes as Required<AxesConfiguration>, () => {
+      const formState: FormState = {
+        isValid: true,
+        submitCount: 0,
+      };
+
+      return formState;
+    }),
   };
 
   return {
@@ -193,6 +199,7 @@ export const chartBuilderReducer: Reducer<
         () => {
           return {
             isValid: true,
+            submitCount: 0,
           };
         },
       );
@@ -358,16 +365,15 @@ export function useChartBuilderReducer(initialConfiguration?: Chart) {
   const updateFormState = useCallback(
     ({
       form,
-      isValid,
+      ...formState
     }: {
       form: keyof ChartBuilderState['forms'];
-      isValid: boolean;
-    }) => {
+    } & FormState) => {
       dispatch({
         type: 'UPDATE_FORM',
         payload: {
           form,
-          state: { isValid },
+          state: formState,
         },
       });
     },

--- a/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
+++ b/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
@@ -28,7 +28,10 @@ const ErrorSummary = ({
   useEffect(() => {
     import('govuk-frontend/govuk/components/error-summary/error-summary').then(
       ({ default: GovUkErrorSummary }) => {
-        new GovUkErrorSummary(ref.current).init();
+        if (ref.current) {
+          const { handleClick } = new GovUkErrorSummary(ref.current);
+          ref.current.addEventListener('click', handleClick);
+        }
       },
     );
   }, [ref]);

--- a/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
+++ b/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { MouseEventHandler, useEffect, useRef } from 'react';
 import ErrorPrefixPageTitle from './ErrorPrefixPageTitle';
 
 export interface ErrorSummaryMessage {
@@ -12,6 +12,7 @@ interface Props {
   focusOnError?: boolean;
   title?: string;
   onFocus?: () => void;
+  onErrorClick?: MouseEventHandler<HTMLAnchorElement>;
 }
 
 const ErrorSummary = ({
@@ -20,6 +21,7 @@ const ErrorSummary = ({
   focusOnError = false,
   title = 'There is a problem',
   onFocus,
+  onErrorClick,
 }: Props) => {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -66,7 +68,9 @@ const ErrorSummary = ({
         <ul className="govuk-list govuk-error-summary__list">
           {errors.map(error => (
             <li key={error.id}>
-              <a href={`#${error.id}`}>{error.message}</a>
+              <a href={`#${error.id}`} onClick={onErrorClick}>
+                {error.message}
+              </a>
             </li>
           ))}
         </ul>

--- a/src/explore-education-statistics-common/src/components/Tabs.tsx
+++ b/src/explore-education-statistics-common/src/components/Tabs.tsx
@@ -94,7 +94,7 @@ const Tabs = ({ children, id, modifyHash = true, onToggle }: Props) => {
   }, [sections, selectTab]);
 
   return (
-    <div className={classNames('govuk-tabs', styles.tabs)}>
+    <div className={classNames('govuk-tabs', styles.tabs)} id={id}>
       <ul className="govuk-tabs__list" role="tablist">
         {sections.map(({ props }, index) => {
           const sectionId = props.id || `${id}-${index + 1}`;

--- a/src/explore-education-statistics-common/src/components/__tests__/ErrorSummary.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ErrorSummary.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, wait } from '@testing-library/react';
 import ErrorSummary from '../ErrorSummary';
 
 describe('ErrorSummary', () => {
@@ -20,7 +20,7 @@ describe('ErrorSummary', () => {
     expect(container.innerHTML).toMatchSnapshot();
   });
 
-  test('does not gain focus or scroll into view when there are errors by default', () => {
+  test('does not gain focus or scroll into view when there are errors by default', async () => {
     const { container } = render(
       <ErrorSummary
         id="test-errors"
@@ -34,6 +34,8 @@ describe('ErrorSummary', () => {
     const summary = container.querySelector(
       '.govuk-error-summary',
     ) as HTMLElement;
+
+    await wait();
 
     expect(summary).not.toHaveFocus();
     expect(summary).not.toHaveScrolledIntoView();

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tabs renders multiple tabs correctly with titles 1`] = `
-<div class="govuk-tabs tabs">
+<div class="govuk-tabs tabs"
+     id="test-tabs"
+>
   <ul class="govuk-tabs__list"
       role="tablist"
   >
@@ -63,7 +65,9 @@ exports[`Tabs renders multiple tabs correctly with titles 1`] = `
 `;
 
 exports[`Tabs renders multiple tabs correctly without titles 1`] = `
-<div class="govuk-tabs tabs">
+<div class="govuk-tabs tabs"
+     id="test-tabs"
+>
   <ul class="govuk-tabs__list"
       role="tablist"
   >
@@ -119,7 +123,9 @@ exports[`Tabs renders multiple tabs correctly without titles 1`] = `
 `;
 
 exports[`Tabs renders single tab correctly 1`] = `
-<div class="govuk-tabs tabs">
+<div class="govuk-tabs tabs"
+     id="test-tabs"
+>
   <ul class="govuk-tabs__list"
       role="tablist"
   >

--- a/src/explore-education-statistics-common/src/types/govuk-frontend.d.ts
+++ b/src/explore-education-statistics-common/src/types/govuk-frontend.d.ts
@@ -32,7 +32,11 @@ declare module 'govuk-frontend/govuk/components/details/details' {
 }
 
 declare module 'govuk-frontend/govuk/components/error-summary/error-summary' {
-  export default GovUkModule;
+  export class ErrorSummary extends GovUkModule {
+    public handleClick(event: MouseEvent): void;
+  }
+
+  export default ErrorSummary;
 }
 
 declare module 'govuk-frontend/govuk/components/radios/radios' {


### PR DESCRIPTION
:warning: Depends on `ees-763`

This PR adds the following tweaks to chart builder's error messages:

- Fixed requiring a second submission in certain instances to see the submit error message properly (as described by EES-826).
- Add additional error messages for individual chart builder tabs that have failing validation e.g. 'Chart configuration tab is not valid'. These error messages also allow the user to directly open the tab by clicking on them.
- Fixed error summary sometimes stealing focus when it renders. This was due to the GOVUK Error Summary component (that is used internally) calling `focus` when it initialises. We've fixed this by doing the initialisation of this component manually i.e.

  ```typescript
  const { handleClick } = new GovUkErrorSummary(ref.current);
  ref.current.addEventListener('click', handleClick);
  ```