### PR TITLE
EES-330 Link publication's previous releases to public frontend

### DIFF
--- a/src/explore-education-statistics-admin/src/components/Link.tsx
+++ b/src/explore-education-statistics-admin/src/components/Link.tsx
@@ -1,3 +1,4 @@
+import { OmitStrict } from '@common/types';
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
 import {
@@ -9,19 +10,24 @@ export type LinkProps = {
   children: ReactNode;
   className?: string;
   unvisited?: boolean;
-} & RouterLinkProps;
+} & OmitStrict<RouterLinkProps, 'href'>;
 
 const Link = ({
   children,
   className,
   to,
   unvisited = false,
-  href,
   ...props
 }: LinkProps) => {
-  if (href && !to) {
+  const isAbsolute = typeof to === 'string' && to.startsWith('http');
+
+  if (isAbsolute) {
     return (
       <a
+        rel="noopener noreferrer"
+        target="_blank"
+        {...props}
+        href={to as string}
         className={classNames(
           'govuk-link',
           {
@@ -29,15 +35,12 @@ const Link = ({
           },
           className,
         )}
-        href={href}
-        {...props}
-        rel="noopener noreferrer"
-        target="_blank"
       >
         {children}
       </a>
     );
   }
+
   return (
     <RouterLink
       {...props}

--- a/src/explore-education-statistics-admin/src/components/__tests__/Link.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/__tests__/Link.test.tsx
@@ -30,7 +30,7 @@ describe('Link', () => {
     expect(link).toMatchSnapshot();
   });
 
-  test('anchor href is correct', () => {
+  test('links to relative URL correctly', () => {
     const { getByText } = render(
       <MemoryRouter>
         <Link to="/the-link">Test Link</Link>
@@ -39,6 +39,20 @@ describe('Link', () => {
 
     const link = getByText('Test Link') as HTMLLinkElement;
 
-    expect(link.href).toBe('http://localhost/the-link');
+    expect(link).toHaveAttribute('href', '/the-link');
+  });
+
+  test('links to absolute URL correctly', () => {
+    const { getByText } = render(
+      <MemoryRouter>
+        <Link to="https://www.gov.uk">Test Link</Link>
+      </MemoryRouter>,
+    );
+
+    const link = getByText('Test Link');
+
+    expect(link).toHaveAttribute('href', 'https://www.gov.uk');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).toHaveAttribute('target', '_blank');
   });
 });

--- a/src/explore-education-statistics-admin/src/components/editable/EditableLink.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableLink.tsx
@@ -17,25 +17,13 @@ const EditableLink = ({
   const { isEditing } = useEditingContext();
 
   return !isEditing ? (
-    <Link
-      to=""
-      href={href}
-      {...props}
-      rel="noopener noreferrer"
-      target="_blank"
-    >
+    <Link {...props} to={href}>
       {children}
     </Link>
   ) : (
     <div>
       <div>
-        <Link
-          to=""
-          href={href}
-          {...props}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
+        <Link {...props} to={href}>
           {children}
         </Link>
       </div>

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
@@ -180,11 +180,7 @@ const PublicationReleaseContent = () => {
                         ...release.publication.legacyReleases.map(
                           ({ id, description, url }) => (
                             <li key={id} data-testid="other-release-item">
-                              {!isEditing ? (
-                                <a href={url}>{description}</a>
-                              ) : (
-                                <a>{description}</a>
-                              )}
+                              <Link to={url}>{description}</Link>
                             </li>
                           ),
                         ),

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
@@ -1,6 +1,7 @@
 import EditableSectionBlocks from '@admin/components/editable/EditableSectionBlocks';
 import Link from '@admin/components/Link';
 import { useEditingContext } from '@admin/contexts/EditingContext';
+import useConfig from '@admin/hooks/useConfig';
 import AdminPublicationReleaseHelpAndSupportSection from '@admin/modules/find-statistics/components/AdminPublicationReleaseHelpAndSupportSection';
 import BasicReleaseSummary from '@admin/modules/find-statistics/components/BasicReleaseSummary';
 import PrintThisPage from '@admin/modules/find-statistics/components/PrintThisPage';
@@ -19,6 +20,7 @@ import ReleaseHeadlines from './components/ReleaseHeadlines';
 import ReleaseNotesSection from './components/ReleaseNotesSection';
 
 const PublicationReleaseContent = () => {
+  const { value: config } = useConfig();
   const { isEditing } = useEditingContext();
   const { release } = useReleaseState();
   const {
@@ -165,9 +167,13 @@ const PublicationReleaseContent = () => {
                     <ul className="govuk-list">
                       {[
                         ...release.publication.otherReleases.map(
-                          ({ id, title }) => (
+                          ({ id, title, slug }) => (
                             <li key={id} data-testid="other-release-item">
-                              <Link to="#">{title}</Link>
+                              <Link
+                                to={`${config?.PublicAppUrl}/find-statistics/${release.publication.slug}/${slug}`}
+                              >
+                                {title}
+                              </Link>
                             </li>
                           ),
                         ),

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/AdminPublicationReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/AdminPublicationReleaseHelpAndSupportSection.tsx
@@ -46,12 +46,7 @@ const AdminPublicationReleaseHelpAndSupportSection = ({
                 (isEditing ? (
                   <a>{`${publication.title}: methodology`}</a>
                 ) : (
-                  <Link
-                    to=""
-                    rel="external"
-                    target="_blank"
-                    href={publication.externalMethodology.url}
-                  >
+                  <Link to={publication.externalMethodology.url}>
                     {`${publication.title}: methodology`}
                   </Link>
                 ))}{' '}

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/components/RelatedInformationSection.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/components/RelatedInformationSection.tsx
@@ -115,12 +115,7 @@ const RelatedInformationSection = ({ release }: Props) => {
               (isEditing ? (
                 <a>{release.publication.externalMethodology.title}</a>
               ) : (
-                <Link
-                  to=""
-                  href={release.publication.externalMethodology.url}
-                  target="_blank"
-                  rel="external"
-                >
+                <Link to={release.publication.externalMethodology.url}>
                   {release.publication.externalMethodology.title}
                 </Link>
               ))}


### PR DESCRIPTION
This PR adds proper URLs to `PublicationReleaseContent`'s previous release links. Previously they were empty and wouldn't go anywhere.

## Other changes

- `Link` now handles absolute URLs via the `to` prop. This makes it easier to link to external URLs without using the confusing `href` prop. We've changed the type definition here to remove `href` as a prop completely.