### PR TITLE
EES-824 Only inform Publisher if ReleaseStatus changes to or from App…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -407,25 +407,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         public Task<Either<ActionResult, ReleaseSummaryViewModel>> UpdateReleaseStatusAsync(
-            Guid releaseId, ReleaseStatus status, string internalReleaseNote)
+            Guid releaseId, ReleaseStatus newStatus, string internalReleaseNote)
         {
             return _persistenceHelper
                 .CheckEntityExists<Release>(releaseId)
-                .OnSuccess(release => _userService.CheckCanUpdateReleaseStatus(release, status))
-                .OnSuccessDo(() => CheckAllDatafilesUploadedComplete(releaseId, status))
+                .OnSuccess(release => _userService.CheckCanUpdateReleaseStatus(release, newStatus))
+                .OnSuccessDo(() => CheckAllDatafilesUploadedComplete(releaseId, newStatus))
                 .OnSuccess(async release =>
                 {
-                    if (status == ReleaseStatus.Approved && !release.PublishScheduled.HasValue)
+                    if (newStatus == ReleaseStatus.Approved && !release.PublishScheduled.HasValue)
                     {
                         return ValidationActionResult(ApprovedReleaseMustHavePublishScheduledDate);
                     }
 
-                    release.Status = status;
+                    var oldStatus = release.Status;
+
+                    release.Status = newStatus;
                     release.InternalReleaseNote = internalReleaseNote;
                     _context.Releases.Update(release);
                     await _context.SaveChangesAsync();
 
-                    await _publishingService.QueueValidateReleaseAsync(releaseId);
+                    // Only need to inform Publisher if changing release status to or from Approved
+                    if(ReleaseStatus.Approved.Equals(oldStatus) || ReleaseStatus.Approved.Equals(newStatus))
+                    {
+                        await _publishingService.QueueValidateReleaseAsync(releaseId);
+                    }
 
                     return await GetReleaseSummaryAsync(releaseId);
                 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -428,7 +428,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     await _context.SaveChangesAsync();
 
                     // Only need to inform Publisher if changing release status to or from Approved
-                    if(ReleaseStatus.Approved.Equals(oldStatus) || ReleaseStatus.Approved.Equals(newStatus))
+                    if(oldStatus == ReleaseStatus.Approved || newStatus == ReleaseStatus.Approved)
                     {
                         await _publishingService.QueueValidateReleaseAsync(releaseId);
                     }


### PR DESCRIPTION
…roved

Currently, when a release status is updated in these ways, a message is
put on the releases queue, which leads the Publisher to add a new row to
the ReleaseStatus storage table:
- Draft -> Draft
- Draft -> Higher Review
- Higher Review -> Draft
- Higher Review -> Higher Review

When the same release is updated to Approved, the Admin API will check for
a row associated with the release in the ReleaseStatus storage table. If
there is no created row -- as the queued message can take up to 60 seconds to
process -- it will currently return a 204, and the frontend will display
the release status as "Validating" as intended.

If, however, the is already a row in the ReleaseStatus storage table,
then the Admin API will use the status provided in this row. If that row
was created during one of the above updates, then the frontend will
incorrectly display "Invalid". The Invalid status will be displayed
until the newly queued message has been processed.

This commit's change prevents a new ReleaseStatus row being created if a release
status is changed in the above ways, and therefore will prevent an
incorrect "Invalid" status being displayed in most instances.