### PR TITLE
EES-911: Pre release email should use release title not release name

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseContactsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseContactsService.cs
@@ -284,7 +284,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             var emailValues = new Dictionary<string, dynamic>
             {
                 {"newUser", newUser ? "yes" : "no"},
-                {"release name", release.ReleaseName},
+                {"release name", release.Title},
                 {"publication name", release.Publication.Title},
                 {"prerelease link", prereleaseUrl},
                 { "daybeforereleaseday", release.PublishScheduled.Value.AddDays(-1).ToString("dddd dd MMMM yyyy")},


### PR DESCRIPTION
Should use release.Title as this has the full time period description.

This will need testing.