### PR TITLE
EES-910 Date and time string parameters for Prerelease email body

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
@@ -45,7 +45,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 .Setup(s => s.GetPreReleaseWindowStatus(release, It.IsAny<DateTime>()))
                 .Returns(new PreReleaseWindowStatus
                 {
-                    PreReleaseAccess = PreReleaseAccess.Within
+                    Access = PreReleaseAccess.Within
                 });
             
             // Assert that a User who specifically has the Pre Release role will cause this handler to pass 
@@ -96,7 +96,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         .Setup(s => s.GetPreReleaseWindowStatus(release, It.IsAny<DateTime>()))
                         .Returns(new PreReleaseWindowStatus
                         {
-                            PreReleaseAccess = access
+                            Access = access
                         });
             
                     // Assert that a User who specifically has the Pre Release role will cause this handler to fail 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Security/PermissionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Security/PermissionsController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindow.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindow.cs
@@ -4,8 +4,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
 {
     public class PreReleaseWindow
     {
-        public DateTime PreReleaseWindowStartTime { get; set; }
+        public DateTime Start { get; set; }
 
-        public DateTime PreReleaseWindowEndTime { get; set; }
+        public DateTime End { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindow.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindow.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
+{
+    public class PreReleaseWindow
+    {
+        public DateTime PreReleaseWindowStartTime { get; set; }
+
+        public DateTime PreReleaseWindowEndTime { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindowStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindowStatus.cs
@@ -7,11 +7,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
     public class PreReleaseWindowStatus
     {
         [JsonConverter(typeof(StringEnumConverter))]
-        public PreReleaseAccess PreReleaseAccess { get; set; }
+        public PreReleaseAccess Access { get; set; }
 
-        public DateTime PreReleaseWindowStartTime { get; set; }
+        public DateTime Start { get; set; }
 
-        public DateTime PreReleaseWindowEndTime { get; set; }
+        public DateTime End { get; set; }
     }
 
     public enum PreReleaseAccess

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindowStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/PreReleaseWindowStatus.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
+{
+    public class PreReleaseWindowStatus
+    {
+        [JsonConverter(typeof(StringEnumConverter))]
+        public PreReleaseAccess PreReleaseAccess { get; set; }
+
+        public DateTime PreReleaseWindowStartTime { get; set; }
+
+        public DateTime PreReleaseWindowEndTime { get; set; }
+    }
+
+    public enum PreReleaseAccess
+    {
+        NoneSet,
+        Before,
+        Within,
+        After
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlers.cs
@@ -50,7 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                     }
 
                     var windowStatus = preReleaseService.GetPreReleaseWindowStatus(ctx.Release, UtcNow);
-                    return windowStatus.PreReleaseAccess == PreReleaseAccess.Within;
+                    return windowStatus.Access == PreReleaseAccess.Within;
                 })
             {}
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlers.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPreReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPreReleaseService.cs
@@ -1,30 +1,12 @@
 ﻿using System;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
-    public class PreReleaseWindowStatus
-    {
-        [JsonConverter(typeof(StringEnumConverter))]
-        public PreReleaseAccess PreReleaseAccess { get; set; }
-
-        public DateTime PreReleaseWindowStartTime { get; set; }
-
-        public DateTime PreReleaseWindowEndTime { get; set; }
-    }
-
-    public enum PreReleaseAccess
-    {
-        NoneSet,
-        Before,
-        Within,
-        After
-    }
-
     public interface IPreReleaseService
     {
+        PreReleaseWindow GetPreReleaseWindow(Release release);
         PreReleaseWindowStatus GetPreReleaseWindowStatus(Release release, DateTime referenceTime);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseContactsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseContactsService.cs
@@ -290,7 +290,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             var prereleaseUrl = $"{scheme}://{host}/publication/{release.PublicationId}/release/{releaseId}/prerelease";
 
             var preReleaseWindow = _preReleaseService.GetPreReleaseWindow(release);
-            var preReleaseWindowStart = preReleaseWindow.PreReleaseWindowStartTime.ConvertTimeFromUtcToGmt();
+            var preReleaseWindowStart = preReleaseWindow.Start.ConvertTimeFromUtcToGmt();
             var publishScheduled = release.PublishScheduled?.ConvertTimeFromUtcToGmt();
             // TODO EES-828 This time should depend on the Publisher schedule
             var publishScheduledTime = new TimeSpan(9, 30, 0);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseService.cs
@@ -26,8 +26,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             return new PreReleaseWindow
             {
-                PreReleaseWindowStartTime = GetAccessWindowStart(publishScheduled),
-                PreReleaseWindowEndTime = GetAccessWindowEnd(publishScheduled)
+                Start = GetStartTime(publishScheduled),
+                End = GetEndTime(publishScheduled)
             };
         }
 
@@ -37,36 +37,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             {
                 return new PreReleaseWindowStatus
                 {
-                    PreReleaseAccess = PreReleaseAccess.NoneSet
+                    Access = PreReleaseAccess.NoneSet
                 };
             }
 
             var publishScheduled = release.PublishScheduled.Value;
-            var accessWindowStart = GetAccessWindowStart(publishScheduled);
-            var accessWindowEnd = GetAccessWindowEnd(publishScheduled);
+            var startTime = GetStartTime(publishScheduled);
+            var endTime = GetEndTime(publishScheduled);
 
             return new PreReleaseWindowStatus
             {
-                PreReleaseWindowStartTime = accessWindowStart,
-                PreReleaseWindowEndTime = accessWindowEnd,
-                PreReleaseAccess = GetPreReleaseAccess(release, accessWindowStart, accessWindowEnd, referenceTime)
+                Start = startTime,
+                End = endTime,
+                Access = GetAccess(release, startTime, endTime, referenceTime)
             };
         }
 
-        private DateTime GetAccessWindowStart(DateTime publishScheduled)
+        private DateTime GetStartTime(DateTime publishScheduled)
         {
             return publishScheduled.AddMinutes(-_preReleaseOptions.MinutesBeforeReleaseTimeStart);
         }
 
-        private DateTime GetAccessWindowEnd(DateTime publishScheduled)
+        private DateTime GetEndTime(DateTime publishScheduled)
         {
             return publishScheduled.AddMinutes(-_preReleaseOptions.MinutesBeforeReleaseTimeEnd);
         }
 
-        private static PreReleaseAccess GetPreReleaseAccess(
+        private static PreReleaseAccess GetAccess(
             Release release,
-            DateTime accessWindowStart,
-            DateTime accessWindowEnd,
+            DateTime startTime,
+            DateTime endTime,
             DateTime referenceTime)
         {
             if (!release.PublishScheduled.HasValue || release.Status != ReleaseStatus.Approved)
@@ -74,12 +74,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 return PreReleaseAccess.NoneSet;
             }
 
-            if (referenceTime.CompareTo(accessWindowStart) < 0)
+            if (referenceTime.CompareTo(startTime) < 0)
             {
                 return PreReleaseAccess.Before;
             }
 
-            if (referenceTime.CompareTo(accessWindowEnd) >= 0)
+            if (referenceTime.CompareTo(endTime) >= 0)
             {
                 return PreReleaseAccess.After;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DateTimeExtensions.cs
@@ -14,6 +14,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return TimeZoneInfo.ConvertTimeToUtc(dateTimeStartOfDay, GetGmtStandardTimeTimezone());
         }
 
+        public static DateTime ConvertTimeFromUtcToGmt(this DateTime dateTime)
+        {
+            return TimeZoneInfo.ConvertTimeFromUtc(dateTime, GetGmtStandardTimeTimezone());
+        }
+        
         public static TimeZoneInfo GetGmtStandardTimeTimezone()
         {
             return TimeZoneInfo.FindSystemTimeZoneById(

--- a/src/explore-education-statistics-admin/src/services/permissions/permissionService.ts
+++ b/src/explore-education-statistics-admin/src/services/permissions/permissionService.ts
@@ -64,14 +64,14 @@ const permissionService = {
   ): Promise<PreReleaseWindowStatus> => {
     return client
       .get<{
-        preReleaseAccess: PreReleaseAccess;
-        preReleaseWindowStartTime: string;
-        preReleaseWindowEndTime: string;
+        access: PreReleaseAccess;
+        start: string;
+        end: string;
       }>(`/permissions/release/${releaseId}/prerelease/status`)
       .then(status => ({
-        access: status.preReleaseAccess,
-        start: new Date(status.preReleaseWindowStartTime),
-        end: new Date(status.preReleaseWindowEndTime),
+        access: status.access,
+        start: new Date(status.start),
+        end: new Date(status.end),
       }));
   },
 };


### PR DESCRIPTION
- Retrieves the Prerelease access window to use the start date.
- Converts the Prerelease start date and the Release PublishScheduled date to GMT/BST timezone from UTC. We assume GMT/BST to be the timezone of our users receiving the email.
- Formats date and times for the email.
- Removes the hard coded publish time of 09:30 from the template body in Gov.uk Notify. This will be set by EES-828.
- Makes PreReleaseWindowStatus field names less verbose.
This impacts the front end usage of `release/{releaseId}/prerelease/status`
`PreReleaseAccess` -> `Access`
`PreReleaseWindowStartTime` -> `Start`
`PreReleaseWindowEndTime` -> `End`
- Depends on a template change to Gov.uk Notify to add and remove altered template keys. This has been set in the Explore Education Statistics (Test) account.