### PR TITLE
EES-890 Fix methodology unique slug validation failing when updating methodology

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleaseControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleaseControllerTests.cs
@@ -6,7 +6,6 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Http;
@@ -14,6 +13,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.ValidationTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using FileInfo = GovUk.Education.ExploreEducationStatistics.Admin.Models.FileInfo;
@@ -266,23 +266,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         {
             Assert.IsAssignableFrom<T>(result.Value);
             return result.Value;
-        }
-        
-        private static ValidationProblemDetails AssertValidationProblem<T>(ActionResult<T> result) where T : class
-        {
-            Assert.IsAssignableFrom<BadRequestObjectResult>(result.Result);
-            var badRequestObjectResult = result.Result as BadRequestObjectResult;
-            Assert.IsAssignableFrom<ValidationProblemDetails>(badRequestObjectResult?.Value);
-            var validationProblemDetails = badRequestObjectResult.Value as ValidationProblemDetails;
-            return validationProblemDetails;
-        }
-        
-        private static ValidationProblemDetails AssertValidationProblem<T>(ActionResult<T> result, ValidationErrorMessages message) where T : class
-        {
-            var validationProblem = AssertValidationProblem(result);
-            Assert.True(validationProblem.Errors.ContainsKey(string.Empty));
-            Assert.Contains(ValidationResult(message).ErrorMessage, validationProblem.Errors[string.Empty]);
-            return validationProblem;
         }
 
         private static (

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -8,6 +8,8 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.ValidationTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Common.Extensions.DateTimeExtensions;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
 
@@ -35,14 +37,47 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 var gmtStandardTimeTimezone = GetGmtStandardTimeTimezone();
                 var publishScheduledStartOfDay = new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Unspecified);
-                var publishScheduledStartOfDayGmtOffset = new DateTimeOffset(publishScheduledStartOfDay, gmtStandardTimeTimezone.GetUtcOffset(publishScheduledStartOfDay));
+                var publishScheduledStartOfDayGmtOffset = new DateTimeOffset(publishScheduledStartOfDay,
+                    gmtStandardTimeTimezone.GetUtcOffset(publishScheduledStartOfDay));
                 var publishScheduledStartOfDayUtc = publishScheduledStartOfDayGmtOffset.UtcDateTime;
-                
+
                 Assert.Null(viewModel.InternalReleaseNote);
                 Assert.Null(viewModel.Published);
                 Assert.Equal(publishScheduledStartOfDayUtc, viewModel.PublishScheduled);
                 Assert.Equal(Draft, viewModel.Status);
                 Assert.Equal(request.Title, viewModel.Title);
+            }
+        }
+
+        [Fact]
+        public async Task CreateAsync_SlugNotUnique()
+        {
+            var request = new CreateMethodologyRequest
+            {
+                PublishScheduled = new DateTime(2020, 6, 1),
+                Title = "Pupil absence statistics: methodology"
+            };
+
+            await using (var context = DbUtils.InMemoryApplicationDbContext("CreateSlugNotUnique"))
+            {
+                var createResult = await new MethodologyService(
+                        context,
+                        AdminMapper(),
+                        MockUtils.AlwaysTrueUserService().Object,
+                        new PersistenceHelper<ContentDbContext>(context))
+                    .CreateMethodologyAsync(request);
+
+                Assert.True(createResult.IsRight);
+
+                var repeatedCreateResult = await new MethodologyService(
+                        context,
+                        AdminMapper(),
+                        MockUtils.AlwaysTrueUserService().Object,
+                        new PersistenceHelper<ContentDbContext>(context))
+                    .CreateMethodologyAsync(request);
+
+                Assert.True(repeatedCreateResult.IsLeft);
+                AssertValidationProblem(repeatedCreateResult.Left, SlugNotUnique);
             }
         }
 
@@ -53,7 +88,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 Id = Guid.NewGuid(),
                 Title = "Methodology 1",
-                Published = DateTime.UtcNow,
                 Status = Approved
             };
 
@@ -66,12 +100,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             using (var context = DbUtils.InMemoryApplicationDbContext("List"))
             {
-                var methodologies = new List<Methodology>
+                context.AddRange(new List<Methodology>
                 {
                     methodology1, methodology2
-                };
-
-                context.AddRange(methodologies);
+                });
                 context.SaveChanges();
             }
 
@@ -106,6 +138,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 InternalReleaseNote = "Test approval",
                 Published = new DateTime(2020, 5, 25),
                 PublishScheduled = new DateTime(2020, 6, 1),
+                Slug = "pupil-absence-statistics-methodology",
                 Status = Approved,
                 Title = "Pupil absence statistics: methodology"
             };
@@ -143,7 +176,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 InternalReleaseNote = "Test approval",
                 Published = new DateTime(2020, 5, 25),
                 PublishScheduled = new DateTime(2020, 6, 1),
-                Status = Approved,
+                Slug = "pupil-absence-statistics-methodology",
+                Status = Draft,
                 Title = "Pupil absence statistics: methodology"
             };
 
@@ -172,9 +206,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 var gmtStandardTimeTimezone = GetGmtStandardTimeTimezone();
                 var publishScheduledStartOfDay = new DateTime(2020, 7, 1, 0, 0, 0, DateTimeKind.Unspecified);
-                var publishScheduledStartOfDayGmtOffset = new DateTimeOffset(publishScheduledStartOfDay, gmtStandardTimeTimezone.GetUtcOffset(publishScheduledStartOfDay));
+                var publishScheduledStartOfDayGmtOffset = new DateTimeOffset(publishScheduledStartOfDay,
+                    gmtStandardTimeTimezone.GetUtcOffset(publishScheduledStartOfDay));
                 var publishScheduledStartOfDayUtc = publishScheduledStartOfDayGmtOffset.UtcDateTime;
-                
+
                 Assert.Equal(methodology.Id, viewModel.Id);
                 // TODO EES-331 is this correct?
                 // Original release note is not cleared if the update is not altering it
@@ -183,6 +218,62 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(publishScheduledStartOfDayUtc, viewModel.PublishScheduled);
                 Assert.Equal(request.Status, viewModel.Status);
                 Assert.Equal(request.Title, viewModel.Title);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateAsync_SlugNotUnique()
+        {
+            var methodology1 = new Methodology
+            {
+                Id = Guid.NewGuid(),
+                InternalReleaseNote = "Test approval",
+                Published = new DateTime(2020, 5, 25),
+                PublishScheduled = new DateTime(2020, 6, 1),
+                Slug = "pupil-absence-statistics-methodology",
+                Status = Draft,
+                Title = "Pupil absence statistics: methodology"
+            };
+
+            var methodology2 = new Methodology
+            {
+                Id = Guid.NewGuid(),
+                InternalReleaseNote = "Test approval",
+                Published = new DateTime(2020, 5, 25),
+                PublishScheduled = new DateTime(2020, 6, 1),
+                Slug = "pupil-exclusion-statistics-methodology",
+                Status = Draft,
+                Title = "Pupil exclusion statistics: methodology"
+            };
+
+            var request = new UpdateMethodologyRequest
+            {
+                InternalReleaseNote = null,
+                PublishScheduled = new DateTime(2020, 6, 1),
+                Status = Draft,
+                Title = "Pupil exclusion statistics: methodology"
+            };
+
+            await using (var context = DbUtils.InMemoryApplicationDbContext("UpdateSlugNotUnique"))
+            {
+                await context.AddRangeAsync(new List<Methodology>
+                {
+                    methodology1, methodology2
+                });
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = DbUtils.InMemoryApplicationDbContext("UpdateSlugNotUnique"))
+            {
+                var result = await new MethodologyService(
+                        context,
+                        AdminMapper(),
+                        MockUtils.AlwaysTrueUserService().Object,
+                        new PersistenceHelper<ContentDbContext>(context))
+                    .UpdateMethodologyAsync(methodology1.Id, request);
+
+                Assert.True(result.IsLeft);
+                AssertValidationProblem(result.Left, SlugNotUnique);
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ValidationTestUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ValidationTestUtil.cs
@@ -1,0 +1,55 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
+{
+    public static class ValidationTestUtil
+    {
+        public static ValidationProblemDetails AssertValidationProblem(ActionResult result,
+            ValidationErrorMessages message)
+        {
+            var validationProblem = AssertValidationProblemIsBadDetails(result);
+            return AssertValidationProblemDetails(validationProblem, message);
+        }
+
+        public static ValidationProblemDetails AssertValidationProblem<T>(ActionResult<T> result,
+            ValidationErrorMessages message) where T : class
+        {
+            var validationProblem = AssertValidationProblemIsBadDetails(result);
+            return AssertValidationProblemDetails(validationProblem, message);
+        }
+
+        private static ValidationProblemDetails AssertValidationProblemIsBadDetails(ActionResult result)
+        {
+            Assert.IsAssignableFrom<BadRequestObjectResult>(result);
+            var badRequestObjectResult = result as BadRequestObjectResult;
+            return AssertValidationProblemHasDetails(badRequestObjectResult);
+        }
+
+        private static ValidationProblemDetails AssertValidationProblemIsBadDetails<T>(ActionResult<T> result)
+            where T : class
+        {
+            Assert.IsAssignableFrom<BadRequestObjectResult>(result.Result);
+            var badRequestObjectResult = result.Result as BadRequestObjectResult;
+            return AssertValidationProblemHasDetails(badRequestObjectResult);
+        }
+
+        private static ValidationProblemDetails AssertValidationProblemHasDetails(
+            BadRequestObjectResult badRequestObjectResult)
+        {
+            Assert.IsAssignableFrom<ValidationProblemDetails>(badRequestObjectResult?.Value);
+            var validationProblemDetails = badRequestObjectResult.Value as ValidationProblemDetails;
+            return validationProblemDetails;
+        }
+
+        private static ValidationProblemDetails AssertValidationProblemDetails(
+            ValidationProblemDetails validationProblem, ValidationErrorMessages message)
+        {
+            Assert.True(validationProblem.Errors.ContainsKey(string.Empty));
+            Assert.Contains(ValidationResult(message).ErrorMessage, validationProblem.Errors[string.Empty]);
+            return validationProblem;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -100,7 +100,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             return await _persistenceHelper.CheckEntityExists<Methodology>(id)
                 .OnSuccess(_userService.CheckCanUpdateMethodology)
                 .OnSuccess(methodology => CheckCanUpdateMethodologyStatus(methodology, request.Status))
-                .OnSuccessDo(() => ValidateMethodologySlugUnique(slug))
+                .OnSuccessDo(() => ValidateMethodologySlugUniqueForUpdate(id, slug))
                 .OnSuccess(async methodology =>
                 {
                     _context.Methodologies.Update(methodology);
@@ -154,6 +154,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         private async Task<Either<ActionResult, bool>> ValidateMethodologySlugUnique(string slug)
         {
             if (await _context.Methodologies.AnyAsync(methodology => methodology.Slug == slug))
+            {
+                return ValidationActionResult(SlugNotUnique);
+            }
+
+            return true;
+        }
+        
+        private async Task<Either<ActionResult, bool>> ValidateMethodologySlugUniqueForUpdate(Guid id, string slug)
+        {
+            if (await _context.Methodologies.AnyAsync(methodology => methodology.Slug == slug && methodology.Id != id))
             {
                 return ValidationActionResult(SlugNotUnique);
             }


### PR DESCRIPTION
When updating the methodology the check for a unique slug needs to exclude the existing methodology.

Prior to this any update not changing the title received an error

`{
    "errors": {
        "": [
            "SLUG_NOT_UNIQUE"
        ]
    },
    "title": "One or more validation errors occurred.",
    "status": 400
}`

This problem wasn't previously raised by the update unit test in `MethdodologyServiceTests` because there was no slug saved to the database prior to the update.