### PR TITLE
EES-932 Force server-side renders (reverting Next static optimisations)

### DIFF
--- a/src/explore-education-statistics-frontend/src/pages/_app.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/_app.tsx
@@ -1,11 +1,11 @@
-import useMounted from '@common/hooks/useMounted';
-import '@frontend/loadEnv';
 import '@frontend/polyfill';
+import '@frontend/loadEnv';
 
+import useMounted from '@common/hooks/useMounted';
 import { initApplicationInsights } from '@frontend/services/applicationInsightsService';
 import { logPageView } from '@frontend/services/googleAnalyticsService';
 import { initHotJar } from '@frontend/services/hotjarService';
-import { AppProps } from 'next/app';
+import NextApp, { AppContext, AppProps } from 'next/app';
 import { useRouter } from 'next/router';
 import React from 'react';
 import '../styles/_all.scss';
@@ -24,6 +24,12 @@ const App = ({ Component, pageProps }: AppProps) => {
   });
 
   return <Component {...pageProps} />;
+};
+
+App.getInitialProps = async (appContext: AppContext) => {
+  const appProps = await NextApp.getInitialProps(appContext);
+
+  return { ...appProps };
 };
 
 export default App;


### PR DESCRIPTION
This change reverts the static optimisations implemented by EES-892 as it appears that they cause strange behaviour when it comes to the injection of environment variables. It appears that loading the app from a statically generated page (like the home page), will cause the environment variables not to be loaded in later when client-side rendering takes place.

This could be potentially remedied by re-loading the environment variables upon client-side mounting, but for the time being, it seems to just be safer to force server-side rendering on all pages.