### PR TITLE
EES-881 Fix 'Add summary' button showing for prerelease content

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableBlockRenderer.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableBlockRenderer.tsx
@@ -22,7 +22,7 @@ function EditableBlockRenderer({
   onContentSave,
   onDelete,
 }: Props) {
-  const id = `editableBlockRenderer-${block.id}`;
+  const blockId = `block-${block.id}`;
 
   const handleContentSave = useMemo(
     () => (content: string) => {
@@ -41,7 +41,7 @@ function EditableBlockRenderer({
         <div className="dfe-content-overflow">
           <EditableBlockWrapper onDelete={editable ? handleDelete : undefined}>
             <DataBlockRenderer
-              id={id}
+              id={blockId}
               dataBlock={block}
               getInfographic={getInfographic}
             />
@@ -54,7 +54,7 @@ function EditableBlockRenderer({
         <EditableContentBlock
           allowHeadings={allowHeadings}
           editable={editable}
-          id={id}
+          id={blockId}
           label="Block content"
           value={block.body}
           useMarkdown={block.type === 'MarkDownBlock'}

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
@@ -106,7 +106,7 @@ const PublicationReleaseContent = () => {
                 onBlockContentSave={summaryBlockUpdate}
                 onBlockDelete={summaryBlockDelete}
               />
-              {release.summarySection.content?.length === 0 && (
+              {isEditing && release.summarySection.content?.length === 0 && (
                 <div className="govuk-!-margin-bottom-8 dfe-align--centre">
                   <Button variant="secondary" onClick={addSummaryBlock}>
                     Add a summary text block

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/ContentBlockRenderer.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/ContentBlockRenderer.tsx
@@ -8,11 +8,13 @@ interface Props {
 }
 
 const ContentBlockRenderer = ({ block }: Props) => {
+  const { body = '' } = block;
+
   switch (block.type) {
     case 'MarkDownBlock':
-      return <ReactMarkdown className="govuk-body" source={block.body} />;
+      return <ReactMarkdown className="govuk-body" source={body} />;
     case 'HtmlBlock':
-      return <SanitizeHtml dirtyHtml={block.body} />;
+      return <SanitizeHtml dirtyHtml={body} />;
     default:
       return null;
   }


### PR DESCRIPTION
Other changes:

- Fixes 'undefined' showing in empty read-only content blocks.
- Changes rendered block ids to use the format `block-{id}` instead of `editableBlockRenderer-{id}`