### PR TITLE
EES-620 Stop axis labels from causing chart to break out of its container

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ChartAxisConfiguration.tsx
@@ -250,14 +250,14 @@ const ChartAxisConfiguration = ({
         label: Yup.object<Label>({
           text: Yup.string(),
           rotated: Yup.boolean(),
-          width: Yup.number(),
+          width: Yup.number().positive('Label width must be positive'),
         }),
       });
     } else {
       schema = schema.shape({
         label: Yup.object<Label>({
           text: Yup.string(),
-          width: Yup.number(),
+          width: Yup.number().positive('Label width must be positive'),
         }),
       });
     }
@@ -398,6 +398,7 @@ const ChartAxisConfiguration = ({
                     label="Width (px)"
                     name="label.width"
                     width={5}
+                    min={0}
                   />
 
                   {(validationSchema.fields.label as ObjectSchema<Label>).fields

--- a/src/explore-education-statistics-common/src/components/TabsSection.module.scss
+++ b/src/explore-education-statistics-common/src/components/TabsSection.module.scss
@@ -15,7 +15,8 @@
   }
 }
 
-.forceFullWidth {
+.panelHidden {
+  display: none;
   position: relative !important;
   width: 100% !important;
 }

--- a/src/explore-education-statistics-common/src/components/TabsSection.tsx
+++ b/src/explore-education-statistics-common/src/components/TabsSection.tsx
@@ -11,7 +11,6 @@ import styles from './TabsSection.module.scss';
 
 export const classes = {
   panel: 'govuk-tabs__panel',
-  panelHidden: 'govuk-visually-hidden',
 };
 
 export interface TabsSectionProps {
@@ -43,14 +42,14 @@ const TabsSection = forwardRef<HTMLElement, TabsSectionProps>(
     // Hide additional props from the component's public API to
     // avoid any confusion over this component's usage as
     // it should only be used in combination with Tabs.
-    const tabProps = restProps as HTMLAttributes<HTMLElement>;
+    const { hidden, ...tabProps } = restProps as HTMLAttributes<HTMLElement>;
 
     return (
       <section
         aria-labelledby={onMedia(tabProps['aria-labelledby'])}
+        hidden={hidden}
         className={classNames(classes.panel, styles.panel, {
-          [classes.panelHidden]: tabProps.hidden,
-          [styles.forceFullWidth]: tabProps.hidden,
+          [styles.panelHidden]: hidden,
         })}
         id={id}
         ref={ref}

--- a/src/explore-education-statistics-common/src/components/__tests__/Tabs.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Tabs.test.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import Tabs from '../Tabs';
 import TabsSection from '../TabsSection';
 
-const hiddenSectionClass = 'govuk-visually-hidden';
-
 describe('Tabs', () => {
   test('renders single tab correctly', () => {
-    const { container, getAllByText } = render(
+    const { container } = render(
       <Tabs id="test-tabs">
         <TabsSection title="Tab 1" headingTitle="Tab 1">
           <p>Test section 1 content</p>
@@ -15,13 +13,30 @@ describe('Tabs', () => {
       </Tabs>,
     );
 
-    expect(getAllByText('Tab 1')[0]).toHaveAttribute('aria-selected', 'true');
+    const tabs = screen.getAllByRole('tab');
+    const sections = screen.getAllByRole('tabpanel', {
+      hidden: true,
+    });
 
-    expect(container.innerHTML).toMatchSnapshot();
+    expect(tabs).toHaveLength(1);
+    expect(sections).toHaveLength(1);
+
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+    expect(tabs[0]).toHaveTextContent('Tab 1');
+
+    expect(
+      within(sections[0]).getByRole('heading', {
+        name: 'Tab 1',
+      }),
+    ).toBeInTheDocument();
+
+    expect(sections[0]).toHaveTextContent('Test section 1 content');
+
+    expect(container).toMatchSnapshot();
   });
 
   test('renders multiple tabs correctly with titles', () => {
-    const { container, getAllByText } = render(
+    const { container } = render(
       <Tabs id="test-tabs">
         <TabsSection title="Tab 1" headingTitle="Tab 1">
           <p>Test section 1 content</p>
@@ -32,14 +47,38 @@ describe('Tabs', () => {
       </Tabs>,
     );
 
-    expect(getAllByText('Tab 1')[0]).toHaveAttribute('aria-selected', 'true');
-    expect(getAllByText('Tab 2')[0]).toHaveAttribute('aria-selected', 'false');
+    const tabs = screen.getAllByRole('tab');
+    const sections = screen.getAllByRole('tabpanel', {
+      hidden: true,
+    });
 
-    expect(container.innerHTML).toMatchSnapshot();
+    expect(tabs).toHaveLength(2);
+    expect(sections).toHaveLength(2);
+
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+    expect(tabs[0]).toHaveTextContent('Tab 1');
+
+    expect(
+      within(sections[0]).getByRole('heading', {
+        name: 'Tab 1',
+      }),
+    ).toBeInTheDocument();
+
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+    expect(tabs[1]).toHaveTextContent('Tab 2');
+
+    expect(
+      within(sections[1]).getByRole('heading', {
+        name: 'Tab 2',
+        hidden: true,
+      }),
+    ).toBeInTheDocument();
+
+    expect(container).toMatchSnapshot();
   });
 
   test('renders multiple tabs correctly without titles', () => {
-    const { container, getAllByText } = render(
+    const { container } = render(
       <Tabs id="test-tabs">
         <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
@@ -50,14 +89,38 @@ describe('Tabs', () => {
       </Tabs>,
     );
 
-    expect(getAllByText('Tab 1')[0]).toHaveAttribute('aria-selected', 'true');
-    expect(getAllByText('Tab 2')[0]).toHaveAttribute('aria-selected', 'false');
+    const tabs = screen.getAllByRole('tab');
+    const sections = screen.getAllByRole('tabpanel', {
+      hidden: true,
+    });
 
-    expect(container.innerHTML).toMatchSnapshot();
+    expect(tabs).toHaveLength(2);
+    expect(sections).toHaveLength(2);
+
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+    expect(tabs[0]).toHaveTextContent('Tab 1');
+
+    expect(
+      within(sections[0]).queryByRole('heading', {
+        name: 'Tab 1',
+      }),
+    ).toBeNull();
+
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
+    expect(tabs[1]).toHaveTextContent('Tab 2');
+
+    expect(
+      within(sections[1]).queryByRole('heading', {
+        name: 'Tab 2',
+        hidden: true,
+      }),
+    ).toBeNull();
+
+    expect(container).toMatchSnapshot();
   });
 
   test('can use custom section IDs', () => {
-    const { container } = render(
+    render(
       <Tabs id="test-tabs">
         <TabsSection title="Tab 1" id="custom-section">
           <p>Test section 1 content</p>
@@ -68,22 +131,24 @@ describe('Tabs', () => {
       </Tabs>,
     );
 
-    expect(container.querySelector('#test-tabs-1-tab')).toBeNull();
-    expect(container.querySelector('#test-tabs-1')).toBeNull();
+    expect(
+      screen.getByRole('tab', {
+        name: 'Tab 1',
+      }),
+    ).toHaveAttribute('id', 'custom-section-tab');
 
-    expect(container.querySelector('#custom-section-tab')).toHaveTextContent(
-      'Tab 1',
-    );
-    expect(container.querySelector('#custom-section')).toHaveTextContent(
-      'Test section 1 content',
-    );
+    expect(
+      screen.getByRole('tab', {
+        name: 'Tab 2',
+      }),
+    ).toHaveAttribute('id', 'test-tabs-2-tab');
 
-    expect(container.querySelector('#test-tabs-2-tab')).toHaveTextContent(
-      'Tab 2',
-    );
-    expect(container.querySelector('#test-tabs-2')).toHaveTextContent(
-      'Test section 2 content',
-    );
+    const sections = screen.getAllByRole('tabpanel', {
+      hidden: true,
+    });
+
+    expect(sections[0]).toHaveAttribute('id', 'custom-section');
+    expect(sections[1]).toHaveAttribute('id', 'test-tabs-2');
   });
 
   test('setting `headingTag` changes section heading size', () => {
@@ -106,7 +171,7 @@ describe('Tabs', () => {
   });
 
   test('does not immediately render lazy tab section', () => {
-    const { queryByText } = render(
+    render(
       <Tabs id="test-tabs">
         <TabsSection title="Tab 1" headingTitle="Tab 1">
           <p>Test section 1 content</p>
@@ -117,12 +182,12 @@ describe('Tabs', () => {
       </Tabs>,
     );
 
-    expect(queryByText('Test section 1 content')).not.toBeNull();
-    expect(queryByText('Test section 2 content')).toBeNull();
+    expect(screen.queryByText('Test section 1 content')).not.toBeNull();
+    expect(screen.queryByText('Test section 2 content')).toBeNull();
   });
 
   test('tab links match section ids', () => {
-    const { getAllByText } = render(
+    render(
       <Tabs id="test-tabs">
         <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
@@ -133,14 +198,20 @@ describe('Tabs', () => {
       </Tabs>,
     );
 
-    expect(getAllByText('Tab 1')[0]).toHaveAttribute('href', '#test-tabs-1');
-    expect(getAllByText('Tab 2')[0]).toHaveAttribute('href', '#test-tabs-2');
+    expect(screen.getAllByText('Tab 1')[0]).toHaveAttribute(
+      'href',
+      '#test-tabs-1',
+    );
+    expect(screen.getAllByText('Tab 2')[0]).toHaveAttribute(
+      'href',
+      '#test-tabs-2',
+    );
   });
 
   test('renders with tab open that matches location hash', () => {
     window.location.hash = '#test-tabs-2';
 
-    const { container, getByText } = render(
+    render(
       <Tabs id="test-tabs">
         <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
@@ -151,20 +222,27 @@ describe('Tabs', () => {
       </Tabs>,
     );
 
-    expect(getByText('Tab 1')).toHaveAttribute('aria-selected', 'false');
-    expect(getByText('Tab 2')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Tab 1' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+    expect(screen.getByRole('tab', { name: 'Tab 2' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
 
-    const tabSection1 = container.querySelector<HTMLElement>('#test-tabs-1');
-    const tabSection2 = container.querySelector<HTMLElement>('#test-tabs-2');
+    const tabSections = screen.getAllByRole('tabpanel', {
+      hidden: true,
+    });
 
-    expect(tabSection1).toHaveClass(hiddenSectionClass);
-    expect(tabSection2).not.toHaveClass(hiddenSectionClass);
+    expect(tabSections[0]).not.toBeVisible();
+    expect(tabSections[1]).toBeVisible();
   });
 
   test('renders with tab with custom id open that matches location hash', () => {
     window.location.hash = '#tab2';
 
-    const { container, getByText } = render(
+    render(
       <Tabs id="test-tabs">
         <TabsSection title="Tab 1" id="tab1">
           <p>Test section 1 content</p>
@@ -175,18 +253,25 @@ describe('Tabs', () => {
       </Tabs>,
     );
 
-    expect(getByText('Tab 1')).toHaveAttribute('aria-selected', 'false');
-    expect(getByText('Tab 2')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Tab 1' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+    expect(screen.getByRole('tab', { name: 'Tab 2' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
 
-    const tabSection1 = container.querySelector<HTMLElement>('#tab1');
-    const tabSection2 = container.querySelector<HTMLElement>('#tab2');
+    const tabSections = screen.getAllByRole('tabpanel', {
+      hidden: true,
+    });
 
-    expect(tabSection1).toHaveClass(hiddenSectionClass);
-    expect(tabSection2).not.toHaveClass(hiddenSectionClass);
+    expect(tabSections[0]).not.toBeVisible();
+    expect(tabSections[1]).toBeVisible();
   });
 
   test('clicking tab reveals correct section', () => {
-    const { getAllByText, container } = render(
+    render(
       <Tabs id="test-tabs">
         <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
@@ -197,20 +282,21 @@ describe('Tabs', () => {
       </Tabs>,
     );
 
-    const tabSection1 = container.querySelector('#test-tabs-1') as HTMLElement;
-    const tabSection2 = container.querySelector('#test-tabs-2') as HTMLElement;
+    const tabSections = screen.getAllByRole('tabpanel', {
+      hidden: true,
+    });
 
-    expect(tabSection1).not.toHaveClass(hiddenSectionClass);
-    expect(tabSection2).toHaveClass(hiddenSectionClass);
+    expect(tabSections[0]).toBeVisible();
+    expect(tabSections[1]).not.toBeVisible();
 
-    fireEvent.click(getAllByText('Tab 2')[0]);
+    fireEvent.click(screen.getByRole('tab', { name: 'Tab 2' }));
 
-    expect(tabSection1).toHaveClass(hiddenSectionClass);
-    expect(tabSection2).not.toHaveClass(hiddenSectionClass);
+    expect(tabSections[0]).not.toBeVisible();
+    expect(tabSections[1]).toBeVisible();
   });
 
   test('clicking tab changes location hash', () => {
-    const { getAllByText } = render(
+    render(
       <Tabs id="test-tabs">
         <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
@@ -223,13 +309,13 @@ describe('Tabs', () => {
 
     expect(window.location.hash).toBe('');
 
-    fireEvent.click(getAllByText('Tab 2')[0]);
+    fireEvent.click(screen.getByRole('tab', { name: 'Tab 2' }));
 
     expect(window.location.hash).toBe('#test-tabs-2');
   });
 
   test('clicking tab does not change location hash if `modifyHash` is false', () => {
-    const { getAllByText } = render(
+    render(
       <Tabs id="test-tabs" modifyHash={false}>
         <TabsSection title="Tab 1">
           <p>Test section 1 content</p>
@@ -242,7 +328,7 @@ describe('Tabs', () => {
 
     expect(window.location.hash).toBe('');
 
-    fireEvent.click(getAllByText('Tab 2')[0]);
+    fireEvent.click(screen.getByRole('tab', { name: 'Tab 2' }));
 
     expect(window.location.hash).toBe('');
   });
@@ -275,7 +361,7 @@ describe('Tabs', () => {
     let tabSection3: HTMLElement;
 
     beforeEach(() => {
-      const { getAllByText, container } = render(
+      render(
         <Tabs id="test-tabs">
           <TabsSection title="Tab 1">
             <p>Test section 1 content</p>
@@ -289,13 +375,17 @@ describe('Tabs', () => {
         </Tabs>,
       );
 
-      tab1 = getAllByText('Tab 1')[0] as HTMLAnchorElement;
-      tab2 = getAllByText('Tab 2')[0] as HTMLAnchorElement;
-      tab3 = getAllByText('Tab 3')[0] as HTMLAnchorElement;
+      tab1 = screen.getByRole('tab', { name: 'Tab 1' }) as HTMLAnchorElement;
+      tab2 = screen.getByRole('tab', { name: 'Tab 2' }) as HTMLAnchorElement;
+      tab3 = screen.getByRole('tab', { name: 'Tab 3' }) as HTMLAnchorElement;
 
-      tabSection1 = container.querySelector('#test-tabs-1') as HTMLElement;
-      tabSection2 = container.querySelector('#test-tabs-2') as HTMLElement;
-      tabSection3 = container.querySelector('#test-tabs-3') as HTMLElement;
+      const tabSections = screen.getAllByRole('tabpanel', {
+        hidden: true,
+      });
+
+      tabSection1 = tabSections[0] as HTMLElement;
+      tabSection2 = tabSections[1] as HTMLElement;
+      tabSection3 = tabSections[2] as HTMLElement;
     });
 
     test('pressing left arrow key moves to previous tab', () => {
@@ -304,8 +394,8 @@ describe('Tabs', () => {
       expect(tab1).toHaveAttribute('aria-selected', 'false');
       expect(tab2).toHaveAttribute('aria-selected', 'true');
 
-      expect(tabSection1).toHaveClass(hiddenSectionClass);
-      expect(tabSection2).not.toHaveClass(hiddenSectionClass);
+      expect(tabSection1).not.toBeVisible();
+      expect(tabSection2).toBeVisible();
 
       expect(window.location.hash).toBe('#test-tabs-2');
 
@@ -315,8 +405,8 @@ describe('Tabs', () => {
       expect(tab1).toHaveFocus();
       expect(tab2).toHaveAttribute('aria-selected', 'false');
 
-      expect(tabSection1).not.toHaveClass(hiddenSectionClass);
-      expect(tabSection2).toHaveClass(hiddenSectionClass);
+      expect(tabSection1).toBeVisible();
+      expect(tabSection2).not.toBeVisible();
 
       expect(window.location.hash).toBe('#test-tabs-1');
     });
@@ -327,8 +417,8 @@ describe('Tabs', () => {
       expect(tab1).toHaveAttribute('aria-selected', 'true');
       expect(tab3).toHaveAttribute('aria-selected', 'false');
 
-      expect(tabSection1).not.toHaveClass(hiddenSectionClass);
-      expect(tabSection3).toHaveClass(hiddenSectionClass);
+      expect(tabSection1).toBeVisible();
+      expect(tabSection3).not.toBeVisible();
 
       expect(window.location.hash).toBe('#test-tabs-1');
 
@@ -338,8 +428,8 @@ describe('Tabs', () => {
       expect(tab3).toHaveAttribute('aria-selected', 'true');
       expect(tab3).toHaveFocus();
 
-      expect(tabSection1).toHaveClass(hiddenSectionClass);
-      expect(tabSection3).not.toHaveClass(hiddenSectionClass);
+      expect(tabSection1).not.toBeVisible();
+      expect(tabSection3).toBeVisible();
 
       expect(window.location.hash).toBe('#test-tabs-3');
     });
@@ -350,8 +440,8 @@ describe('Tabs', () => {
       expect(tab2).toHaveAttribute('aria-selected', 'true');
       expect(tab3).toHaveAttribute('aria-selected', 'false');
 
-      expect(tabSection2).not.toHaveClass(hiddenSectionClass);
-      expect(tabSection3).toHaveClass(hiddenSectionClass);
+      expect(tabSection2).toBeVisible();
+      expect(tabSection3).not.toBeVisible();
 
       expect(window.location.hash).toBe('#test-tabs-2');
 
@@ -361,8 +451,8 @@ describe('Tabs', () => {
       expect(tab3).toHaveAttribute('aria-selected', 'true');
       expect(tab3).toHaveFocus();
 
-      expect(tabSection2).toHaveClass(hiddenSectionClass);
-      expect(tabSection3).not.toHaveClass(hiddenSectionClass);
+      expect(tabSection2).not.toBeVisible();
+      expect(tabSection3).toBeVisible();
 
       expect(window.location.hash).toBe('#test-tabs-3');
     });
@@ -373,8 +463,8 @@ describe('Tabs', () => {
       expect(tab1).toHaveAttribute('aria-selected', 'false');
       expect(tab3).toHaveAttribute('aria-selected', 'true');
 
-      expect(tabSection1).toHaveClass(hiddenSectionClass);
-      expect(tabSection3).not.toHaveClass(hiddenSectionClass);
+      expect(tabSection1).not.toBeVisible();
+      expect(tabSection3).toBeVisible();
 
       expect(window.location.hash).toBe('#test-tabs-3');
 
@@ -384,8 +474,8 @@ describe('Tabs', () => {
       expect(tab1).toHaveFocus();
       expect(tab3).toHaveAttribute('aria-selected', 'false');
 
-      expect(tabSection1).not.toHaveClass(hiddenSectionClass);
-      expect(tabSection3).toHaveClass(hiddenSectionClass);
+      expect(tabSection1).toBeVisible();
+      expect(tabSection3).not.toBeVisible();
 
       expect(window.location.hash).toBe('#test-tabs-1');
     });

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -1,160 +1,191 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tabs renders multiple tabs correctly with titles 1`] = `
-<div class="govuk-tabs tabs"
-     id="test-tabs"
->
-  <ul class="govuk-tabs__list"
+<div>
+  <div
+    class="govuk-tabs tabs"
+    id="test-tabs"
+  >
+    <ul
+      class="govuk-tabs__list"
       role="tablist"
-  >
-    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected"
-        role="presentation"
     >
-      <a class="govuk-tabs__tab"
-         href="#test-tabs-1"
-         id="test-tabs-1-tab"
-         aria-controls="test-tabs-1"
-         aria-selected="true"
-         role="tab"
+      <li
+        class="govuk-tabs__list-item govuk-tabs__list-item--selected"
+        role="presentation"
       >
+        <a
+          aria-controls="test-tabs-1"
+          aria-selected="true"
+          class="govuk-tabs__tab"
+          href="#test-tabs-1"
+          id="test-tabs-1-tab"
+          role="tab"
+        >
+          Tab 1
+        </a>
+      </li>
+      <li
+        class="govuk-tabs__list-item"
+        role="presentation"
+      >
+        <a
+          aria-controls="test-tabs-2"
+          aria-selected="false"
+          class="govuk-tabs__tab"
+          href="#test-tabs-2"
+          id="test-tabs-2-tab"
+          role="tab"
+          tabindex="-1"
+        >
+          Tab 2
+        </a>
+      </li>
+    </ul>
+    <section
+      aria-labelledby="test-tabs-1-tab"
+      class="govuk-tabs__panel panel"
+      id="test-tabs-1"
+      role="tabpanel"
+      tabindex="-1"
+    >
+      <h3>
         Tab 1
-      </a>
-    </li>
-    <li class="govuk-tabs__list-item"
-        role="presentation"
+      </h3>
+      <p>
+        Test section 1 content
+      </p>
+    </section>
+    <section
+      aria-labelledby="test-tabs-2-tab"
+      class="govuk-tabs__panel panel panelHidden"
+      hidden=""
+      id="test-tabs-2"
+      role="tabpanel"
+      tabindex="-1"
     >
-      <a class="govuk-tabs__tab"
-         href="#test-tabs-2"
-         id="test-tabs-2-tab"
-         tabindex="-1"
-         aria-controls="test-tabs-2"
-         aria-selected="false"
-         role="tab"
-      >
+      <h3>
         Tab 2
-      </a>
-    </li>
-  </ul>
-  <section class="govuk-tabs__panel panel"
-           id="test-tabs-1"
-           aria-labelledby="test-tabs-1-tab"
-           role="tabpanel"
-           tabindex="-1"
-  >
-    <h3>
-      Tab 1
-    </h3>
-    <p>
-      Test section 1 content
-    </p>
-  </section>
-  <section class="govuk-tabs__panel panel govuk-visually-hidden forceFullWidth"
-           id="test-tabs-2"
-           aria-labelledby="test-tabs-2-tab"
-           role="tabpanel"
-           tabindex="-1"
-  >
-    <h3>
-      Tab 2
-    </h3>
-    <p>
-      Test section 2 content
-    </p>
-  </section>
+      </h3>
+      <p>
+        Test section 2 content
+      </p>
+    </section>
+  </div>
 </div>
 `;
 
 exports[`Tabs renders multiple tabs correctly without titles 1`] = `
-<div class="govuk-tabs tabs"
-     id="test-tabs"
->
-  <ul class="govuk-tabs__list"
+<div>
+  <div
+    class="govuk-tabs tabs"
+    id="test-tabs"
+  >
+    <ul
+      class="govuk-tabs__list"
       role="tablist"
-  >
-    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected"
-        role="presentation"
     >
-      <a class="govuk-tabs__tab"
-         href="#test-tabs-1"
-         id="test-tabs-1-tab"
-         aria-controls="test-tabs-1"
-         aria-selected="true"
-         role="tab"
-      >
-        Tab 1
-      </a>
-    </li>
-    <li class="govuk-tabs__list-item"
+      <li
+        class="govuk-tabs__list-item govuk-tabs__list-item--selected"
         role="presentation"
-    >
-      <a class="govuk-tabs__tab"
-         href="#test-tabs-2"
-         id="test-tabs-2-tab"
-         tabindex="-1"
-         aria-controls="test-tabs-2"
-         aria-selected="false"
-         role="tab"
       >
-        Tab 2
-      </a>
-    </li>
-  </ul>
-  <section class="govuk-tabs__panel panel"
-           id="test-tabs-1"
-           aria-labelledby="test-tabs-1-tab"
-           role="tabpanel"
-           tabindex="-1"
-  >
-    <p>
-      Test section 1 content
-    </p>
-  </section>
-  <section class="govuk-tabs__panel panel govuk-visually-hidden forceFullWidth"
-           id="test-tabs-2"
-           aria-labelledby="test-tabs-2-tab"
-           role="tabpanel"
-           tabindex="-1"
-  >
-    <p>
-      Test section 2 content
-    </p>
-  </section>
+        <a
+          aria-controls="test-tabs-1"
+          aria-selected="true"
+          class="govuk-tabs__tab"
+          href="#test-tabs-1"
+          id="test-tabs-1-tab"
+          role="tab"
+        >
+          Tab 1
+        </a>
+      </li>
+      <li
+        class="govuk-tabs__list-item"
+        role="presentation"
+      >
+        <a
+          aria-controls="test-tabs-2"
+          aria-selected="false"
+          class="govuk-tabs__tab"
+          href="#test-tabs-2"
+          id="test-tabs-2-tab"
+          role="tab"
+          tabindex="-1"
+        >
+          Tab 2
+        </a>
+      </li>
+    </ul>
+    <section
+      aria-labelledby="test-tabs-1-tab"
+      class="govuk-tabs__panel panel"
+      id="test-tabs-1"
+      role="tabpanel"
+      tabindex="-1"
+    >
+      
+      <p>
+        Test section 1 content
+      </p>
+    </section>
+    <section
+      aria-labelledby="test-tabs-2-tab"
+      class="govuk-tabs__panel panel panelHidden"
+      hidden=""
+      id="test-tabs-2"
+      role="tabpanel"
+      tabindex="-1"
+    >
+      
+      <p>
+        Test section 2 content
+      </p>
+    </section>
+  </div>
 </div>
 `;
 
 exports[`Tabs renders single tab correctly 1`] = `
-<div class="govuk-tabs tabs"
-     id="test-tabs"
->
-  <ul class="govuk-tabs__list"
+<div>
+  <div
+    class="govuk-tabs tabs"
+    id="test-tabs"
+  >
+    <ul
+      class="govuk-tabs__list"
       role="tablist"
-  >
-    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected"
-        role="presentation"
     >
-      <a class="govuk-tabs__tab"
-         href="#test-tabs-1"
-         id="test-tabs-1-tab"
-         aria-controls="test-tabs-1"
-         aria-selected="true"
-         role="tab"
+      <li
+        class="govuk-tabs__list-item govuk-tabs__list-item--selected"
+        role="presentation"
       >
+        <a
+          aria-controls="test-tabs-1"
+          aria-selected="true"
+          class="govuk-tabs__tab"
+          href="#test-tabs-1"
+          id="test-tabs-1-tab"
+          role="tab"
+        >
+          Tab 1
+        </a>
+      </li>
+    </ul>
+    <section
+      aria-labelledby="test-tabs-1-tab"
+      class="govuk-tabs__panel panel"
+      id="test-tabs-1"
+      role="tabpanel"
+      tabindex="-1"
+    >
+      <h3>
         Tab 1
-      </a>
-    </li>
-  </ul>
-  <section class="govuk-tabs__panel panel"
-           id="test-tabs-1"
-           aria-labelledby="test-tabs-1-tab"
-           role="tabpanel"
-           tabindex="-1"
-  >
-    <h3>
-      Tab 1
-    </h3>
-    <p>
-      Test section 1 content
-    </p>
-  </section>
+      </h3>
+      <p>
+        Test section 1 content
+      </p>
+    </section>
+  </div>
 </div>
 `;

--- a/src/explore-education-statistics-common/src/modules/charts/components/AxisLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/AxisLabel.tsx
@@ -8,7 +8,7 @@ interface Props {
   className?: string;
   rotated?: boolean;
   style?: CSSProperties;
-  width?: number;
+  textStyle?: CSSProperties;
 }
 
 const AxisLabel = ({
@@ -17,7 +17,7 @@ const AxisLabel = ({
   className,
   rotated,
   style,
-  width,
+  textStyle,
 }: Props) => {
   return (
     <div
@@ -31,12 +31,7 @@ const AxisLabel = ({
           [styles.labelRotated]: rotated,
         })}
       >
-        <div
-          className="dfe-align--centre"
-          style={{
-            width,
-          }}
-        >
+        <div className="dfe-align--centre" style={textStyle}>
           {children}
         </div>
       </div>

--- a/src/explore-education-statistics-common/src/modules/charts/components/ChartContainer.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/ChartContainer.tsx
@@ -29,8 +29,6 @@ const ChartContainer = ({
 }: Props) => {
   const { isMounted } = useMounted();
 
-  const yAxisLabelWidth = yAxisLabel?.text ? yAxisLabel?.width ?? 100 : 0;
-
   if (!isMounted) {
     return null;
   }
@@ -52,34 +50,49 @@ const ChartContainer = ({
           {yAxisLabel?.text && (
             <AxisLabel
               data-testid="y-axis-label"
-              width={
-                yAxisLabel.rotated ? height - xAxisHeight : yAxisLabelWidth
-              }
               rotated={yAxisLabel.rotated}
               style={{
+                flexBasis: yAxisLabel.rotated
+                  ? yAxisLabel.width || 50
+                  : yAxisLabel.width || 100,
+                maxWidth: '40%',
                 marginBottom: xAxisHeight,
                 marginRight: 10,
+              }}
+              textStyle={{
+                maxWidth: '100%',
+                width: yAxisLabel.rotated
+                  ? height - xAxisHeight
+                  : yAxisLabel.width || 100,
               }}
             >
               {yAxisLabel.text}
             </AxisLabel>
           )}
 
-          {children}
-        </div>
-
-        {xAxisLabel?.text && (
-          <AxisLabel
-            data-testid="x-axis-label"
-            className="dfe-flex dfe-justify-content--center"
-            width={xAxisLabel.width}
+          <div
             style={{
-              marginLeft: yAxisWidth + yAxisLabelWidth,
+              width: '100%',
             }}
           >
-            {xAxisLabel.text}
-          </AxisLabel>
-        )}
+            {children}
+
+            {xAxisLabel?.text && (
+              <AxisLabel
+                data-testid="x-axis-label"
+                className="dfe-flex dfe-justify-content--center"
+                style={{
+                  marginLeft: yAxisWidth,
+                }}
+                textStyle={{
+                  maxWidth: xAxisLabel.width,
+                }}
+              >
+                {xAxisLabel.text}
+              </AxisLabel>
+            )}
+          </div>
+        </div>
       </div>
 
       {legendPosition === 'bottom' && legend && (

--- a/src/explore-education-statistics-common/src/modules/charts/components/ChartContainer.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/ChartContainer.tsx
@@ -1,3 +1,4 @@
+import useMounted from '@common/hooks/useMounted';
 import AxisLabel from '@common/modules/charts/components/AxisLabel';
 import { ChartProps, Label } from '@common/modules/charts/types/chart';
 import classNames from 'classnames';
@@ -26,7 +27,13 @@ const ChartContainer = ({
   xAxisLabel,
   xAxisHeight = 0,
 }: Props) => {
+  const { isMounted } = useMounted();
+
   const yAxisLabelWidth = yAxisLabel?.text ? yAxisLabel?.width ?? 100 : 0;
+
+  if (!isMounted) {
+    return null;
+  }
 
   return (
     <>
@@ -50,7 +57,6 @@ const ChartContainer = ({
               }
               rotated={yAxisLabel.rotated}
               style={{
-                flexBasis: yAxisLabelWidth,
                 marginBottom: xAxisHeight,
                 marginRight: 10,
               }}

--- a/src/explore-education-statistics-common/src/modules/charts/components/ChartContainer.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/ChartContainer.tsx
@@ -1,8 +1,9 @@
+import useDebouncedCallback from '@common/hooks/useDebouncedCallback';
 import useMounted from '@common/hooks/useMounted';
 import AxisLabel from '@common/modules/charts/components/AxisLabel';
 import { ChartProps, Label } from '@common/modules/charts/types/chart';
 import classNames from 'classnames';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { LegendProps } from 'recharts';
 import DefaultLegendContent from 'recharts/lib/component/DefaultLegendContent';
 
@@ -27,7 +28,19 @@ const ChartContainer = ({
   xAxisLabel,
   xAxisHeight = 0,
 }: Props) => {
-  const { isMounted } = useMounted();
+  const [renderCount, setRenderCount] = useState(0);
+
+  const [handleResize] = useDebouncedCallback(() => {
+    setRenderCount(renderCount + 1);
+  }, 500);
+
+  const { isMounted } = useMounted(() => {
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  });
 
   if (!isMounted) {
     return null;
@@ -41,7 +54,7 @@ const ChartContainer = ({
         </div>
       )}
 
-      <div className="govuk-!-margin-bottom-6">
+      <div className="govuk-!-margin-bottom-6" key={renderCount}>
         <div
           className={classNames('dfe-flex', {
             'dfe-align-items--center': !yAxisLabel?.rotated,


### PR DESCRIPTION
This PR:

- Fixes Y axis label from pushing the chart too far to the right when a label width has been set. We have used a combination of `max-width` and `width` styles to prevent this. Consequently, the label can no longer be larger than 40% of the container width. Any additional width will not be considered past this.
- Fixes initial chart sizing issue that can occur due to trying to render before the container has the correct rendered width for it to use. We `useMounted` to check that the component has mounted before rendering the chart.
- Fixes initial chart sizing issue due to `TabSections` using `govuk-visually-hidden`. This was removing padding from the `TabSection` causing the wrong width to be calculated by Recharts. We've removed this in favour of the `hidden` attribute and `display: none` styling.
- Adds re-rendering of the `ChartContainer` when the window resizes. This recalculates the correct dimensions for the chart for the new window size.
