### PR TITLE
EES-738 Copy DecimalPlaces

### DIFF
--- a/infrastructure/templates/datafactory/components/template.json
+++ b/infrastructure/templates/datafactory/components/template.json
@@ -1128,6 +1128,16 @@
                                             "name": "IndicatorGroupId",
                                             "type": "Guid"
                                         }
+                                    },
+                                    {
+                                        "source": {
+                                            "name": "DecimalPlaces",
+                                            "type": "Int32"
+                                        },
+                                        "sink": {
+                                            "name": "DecimalPlaces",
+                                            "type": "Int32"
+                                        }
                                     }
                                 ]
                             }


### PR DESCRIPTION
In the CopyIndicators DataFactory pipeline step, copy the new column DecimalPlaces. Without this the data is formatted in the admin to the number of decimal places specified in the metadata, but not in the Public.

This won't fix any releases using the new decimal places feature that have already been published.