### PR TITLE
ci: copy Pipfiles into tests/robot-tests for robot-tests artifact

### DIFF
--- a/azure-pipelines.dfe.yml
+++ b/azure-pipelines.dfe.yml
@@ -291,6 +291,13 @@ jobs:
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
+      - task: CopyFiles@2
+        displayName: 'Copy Pipfiles to robot-tests'
+        inputs:
+          Contents: |
+            Pipfile
+            Pipfile.lock
+          TargetFolder: 'tests/robot-tests'
       - task: PublishPipelineArtifact@0
         displayName: 'Publish Robot tests'
         inputs:


### PR DESCRIPTION
This is required to ensure that the `robot-tests` artifact has the correct dependencies to run the tests after deployment to each environment.