### PR TITLE
ci: move all test files into the same test artifact

### DIFF
--- a/azure-pipelines.dfe.yml
+++ b/azure-pipelines.dfe.yml
@@ -292,24 +292,14 @@ jobs:
       vmImage: 'ubuntu-16.04'
     steps:
       - task: CopyFiles@2
-        displayName: 'Copy Pipfiles to robot-tests'
+        displayName: 'Copy Pipfiles to tests'
         inputs:
           Contents: |
             Pipfile
             Pipfile.lock
-          TargetFolder: 'tests/robot-tests'
+          TargetFolder: 'tests'
       - task: PublishPipelineArtifact@0
-        displayName: 'Publish Robot tests'
+        displayName: 'Publish test files'
         inputs:
-          artifactName: 'robot-tests'
-          targetPath: 'tests/robot-tests'
-      - task: PublishPipelineArtifact@0
-        displayName: 'Publish Newman tests'
-        inputs:
-          artifactName: 'newman-tests'
-          targetPath: 'tests/newman'
-      - task: PublishPipelineArtifact@0
-        displayName: 'Publish Auth Token script'
-        inputs:
-          artifactName: 'auth-token-script'
-          targetPath: 'useful-scripts/auth-tokens'
+          artifactName: 'tests'
+          targetPath: 'tests'

--- a/azure-pipelines.pr.yml
+++ b/azure-pipelines.pr.yml
@@ -250,22 +250,3 @@ jobs:
           searchFolder: './src'
           testRunTitle: 'PR Jest tests'
           mergeTestResults: true
-  - job: 'MiscellaneousArtifacts'
-    pool:
-      vmImage: 'ubuntu-16.04'
-    steps:
-      - task: PublishPipelineArtifact@0
-        displayName: 'Publish Robot tests'
-        inputs:
-          artifactName: 'robot-tests'
-          targetPath: 'tests/robot-tests'
-      - task: PublishPipelineArtifact@0
-        displayName: 'Publish Newman tests'
-        inputs:
-          artifactName: 'newman-tests'
-          targetPath: 'tests/newman'
-      - task: PublishPipelineArtifact@0
-        displayName: 'Publish Auth Token script'
-        inputs:
-          artifactName: 'auth-token-script'
-          targetPath: 'useful-scripts/auth-tokens'

--- a/tests/robot-tests/README.md
+++ b/tests/robot-tests/README.md
@@ -82,7 +82,7 @@ At the time of writing, the pipeline runs the tests against the Dev environment,
 
 ## Authentication
 
-To run the admin tests, the run_tests.py script uses `../../useful-scripts/auth-tokens/get_auth_tokens.py`. The `get_identity_info` function logs in as a user and then returns the relevant local storage and cookies for the authenticated user. This is done so that if an authenticated user is required, a test run only needs to log in once rather than once for each test suite.
+To run the admin tests, the `run_tests.py` script uses `scripts/get_auth_tokens.py`. The `get_identity_info` function logs in as a user and then returns the relevant local storage and cookies for the authenticated user. This is done so that if an authenticated user is required, a test run only needs to log in once rather than once for each test suite.
 
 After the user has been logged in by the run_tests.py script, the local storage and cookie data for the authenticated user is saved in the `IDENTITY_LOCAL_STORAGE.txt` and `IDENTITY_COOKIE.txt` files. This is done so that if you're running the tests locally, you don't need to authenticate every time you rerun the tests, as the run_tests.py script will use the data they contain if they exist.
 

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -6,28 +6,26 @@
 Run 'python run_tests.py -h' to see argument options
 """
 
-import os
 import argparse
-from pathlib import Path
-from robot import run_cli as robot_run_cli
-from pabot.pabot import main as pabot_run_cli
 import cProfile
-import pstats
-import scripts.keyword_profile as kp
-import pyderman
-from dotenv import load_dotenv
-import time
-import requests
 import json
+import os
+import pstats
 import shutil
-import sys
+import time
+from pathlib import Path
+
+import pyderman
+import requests
+from dotenv import load_dotenv
+from pabot.pabot import main as pabot_run_cli
+from robot import run_cli as robot_run_cli
+
+import scripts.keyword_profile as kp
+from scripts.get_auth_tokens import get_identity_info
 
 current_dir = Path(__file__).absolute().parent
 os.chdir(current_dir)
-
-sys.path.append(str(Path("../../useful-scripts/auth-tokens")))
-
-from get_auth_tokens import get_identity_info
 
 # Parse arguments
 parser = argparse.ArgumentParser(prog="pipenv run python run_tests.py",
@@ -189,6 +187,7 @@ if args.tests and "general_public" not in args.tests:
                 password=os.getenv('ANALYST_PASSWORD'),
                 clear_existing=clear_existing
             )
+
 
     def create_test_topic():
         # To prevent InsecureRequestWarning

--- a/tests/robot-tests/scripts/get_auth_tokens.py
+++ b/tests/robot-tests/scripts/get_auth_tokens.py
@@ -22,7 +22,7 @@ def wait_until_page_contains_xpath(context, selector):
 
 def get_identity_info(url, email, password, first_name="Bau1", last_name="EESADMIN",
                       chromedriver_version='80.0.3987.106'):
-    pyderman.install(file_directory="./webdriver/",
+    pyderman.install(file_directory="../webdriver/",
                      filename='chromedriver',
                      verbose=False,
                      chmod=True,

--- a/tests/robot-tests/scripts/get_auth_tokens.py
+++ b/tests/robot-tests/scripts/get_auth_tokens.py
@@ -21,7 +21,7 @@ def wait_until_page_contains_xpath(context, selector):
 
 
 def get_identity_info(url, email, password, first_name="Bau1", last_name="EESADMIN",
-                      chromedriver_version='80.0.3987.106'):
+                      chromedriver_version='latest'):
     pyderman.install(file_directory="../webdriver/",
                      filename='chromedriver',
                      verbose=False,

--- a/tests/robot-tests/scripts/pipeline-run-rf-tests.sh
+++ b/tests/robot-tests/scripts/pipeline-run-rf-tests.sh
@@ -11,4 +11,4 @@ google-chrome-stable --version
 python -m pip install --upgrade pip
 pip install pipenv
 pipenv install
-pipenv run python run_tests.py --admin-pass $1 --analyst-pass $2 -e $3 --ci --chromedriver 80.0.3987.106 --file $4
+pipenv run python run_tests.py --admin-pass $1 --analyst-pass $2 -e $3 --ci --file $4

--- a/useful-scripts/auth-tokens/get_auth_tokens.sh
+++ b/useful-scripts/auth-tokens/get_auth_tokens.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-pip3 install -r requirements.txt
-python3 get_auth_tokens.py $1 $2 $3

--- a/useful-scripts/auth-tokens/requirements.txt
+++ b/useful-scripts/auth-tokens/requirements.txt
@@ -1,2 +1,0 @@
-selenium==3.141.0
-chromedriver-install==0.3


### PR DESCRIPTION
Currently Robot and Newman tests are separated out into separate pipeline artifacts which is causing us issues as they both rely on shared dependencies such as `get_auth_tokens.py`. We've moved this into the `tests/scripts` directory and now package the entires `tests` directory as an artifact.