### PR TITLE
Add a basic BAU page for listing contacts

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauDashboardPage.tsx
@@ -30,6 +30,14 @@ const BauDashboardPage = () => {
             </p>
           </div>
         )}
+        <div className="govuk-grid-column-one-third">
+          <h3 className="govuk-heading-s govuk-!-margin-bottom-0">
+            <Link to="/administration/contacts">Manage contacts</Link>
+          </h3>
+          <p className="govuk-caption-m govuk-!-margin-top-1">
+            View a list of all publication contacts.
+          </p>
+        </div>
       </div>
 
       <hr className="govuk-!-margin-top-9" />

--- a/src/explore-education-statistics-admin/src/pages/contacts/ContactsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/contacts/ContactsPage.tsx
@@ -1,0 +1,74 @@
+import Link from '@admin/components/Link';
+import Page from '@admin/components/Page';
+import React, { useEffect, useState } from 'react';
+import contactService, { ContactDetails } from '@admin/services/contactService';
+
+interface Model {
+  contacts: ContactDetails[];
+}
+
+const ContactsPage = () => {
+  const [model, setModel] = useState<Model>();
+
+  useEffect(() => {
+    contactService.getContacts().then(contacts => {
+      setModel({
+        contacts,
+      });
+    });
+  }, []);
+
+  return (
+    <Page
+      wide
+      breadcrumbs={[
+        { name: 'Platform administration', link: '/administration' },
+        { name: 'Manage contacts' },
+      ]}
+    >
+      <h1 className="govuk-heading-xl">
+        <span className="govuk-caption-xl">Content and data</span>
+        Manage contacts
+      </h1>
+
+      {model && (
+        <table className="govuk-table">
+          <thead className="govuk-table__head">
+            <tr className="govuk-table__row">
+              <th scope="col" className="govuk-table__header">
+                Team
+              </th>
+              <th scope="col" className="govuk-table__header">
+                Name
+              </th>
+              <th scope="col" className="govuk-table__header">
+                Email
+              </th>
+              <th scope="col" className="govuk-table__header">
+                Tel
+              </th>
+            </tr>
+          </thead>
+          <tbody className="govuk-table__body">
+            {model.contacts.map(contact => (
+              <tr className="govuk-table__row" key={contact.id}>
+                <td className="govuk-table__header">{contact.teamName}</td>
+                <td className="govuk-table__cell">{contact.contactName}</td>
+                <td className="govuk-table__cell">{contact.teamEmail}</td>
+                <td className="govuk-table__cell">{contact.contactTelNo}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <div className="govuk-!-margin-top-6">
+        <Link to="/administration/" className="govuk-back-link">
+          Back
+        </Link>
+      </div>
+    </Page>
+  );
+};
+
+export default ContactsPage;

--- a/src/explore-education-statistics-admin/src/routes/dashboard/routes.ts
+++ b/src/explore-education-statistics-admin/src/routes/dashboard/routes.ts
@@ -4,6 +4,7 @@ import BauDashboardPage from '@admin/pages/bau/BauDashboardPage';
 import BauMethodologyPage from '@admin/pages/bau/BauMethodologyPage';
 import BauUsersPage from '@admin/pages/bau/BauUsersPage';
 import ContactUsPage from '@admin/pages/ContactUsPage';
+import ContactsPage from '@admin/pages/contacts/ContactsPage';
 import AdminDocumentationConfigureCharts from '@admin/pages/documentation/DocumentationConfigureCharts';
 import AdminDocumentationCreateNewPublication from '@admin/pages/documentation/DocumentationCreateNewPublication';
 import AdminDocumentationCreateNewRelease from '@admin/pages/documentation/DocumentationCreateNewRelease';
@@ -80,6 +81,12 @@ const appRouteList: Dictionary<ProtectedRouteProps> = {
     component: BauMethodologyPage,
     protectedAction: user =>
       user.permissions.canAccessMethodologyAdministrationPages,
+    exact: true,
+  },
+  administrationContacts: {
+    path: '/administration/contacts',
+    component: ContactsPage,
+    protectedAction: user => user.permissions.canAccessUserAdministrationPages,
     exact: true,
   },
   administrationUsers: {


### PR DESCRIPTION
Adds a new administration section for contacts.

Adds a new contacts page that lists all contacts currently in the service.

This is a `quick win` piece of work to allow some visibility to what contact data we have in the service to BAU users using an existing API.

Further work will follow to tidy up and expand the page with edit, add, delete functionality etc.