### PR TITLE
EES-986 Delete observation filter items when delete subject.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
@@ -94,6 +94,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
             
                 if (subject != null)
                 {
+                    var observationFilterItems = _context.ObservationFilterItem
+                        .Include(ofi => ofi.Observation)
+                        .ThenInclude(o => o.Subject)
+                        .Where(ofi => ofi.Observation.Subject.Id == subjectId);
+                
+                    _context.ObservationFilterItem.RemoveRange(observationFilterItems);
+                    
                     var orphanFootnotes = await GetFootnotesOnlyForSubjectAsync(subjectId);
 
                     _context.Subject.Remove(subject);


### PR DESCRIPTION
Could not delete a subject once imported & footnotes created which link to filter. Had to delete the observation filter items rows first. 