### PR TITLE
EES-887 PreRelease fixes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseRepository.cs
@@ -39,7 +39,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             var userReleaseIds = await _context
                 .UserReleaseRoles
-                .Where(r => r.UserId == userId)
+                .Where(r => r.UserId == userId && r.Role != ReleaseRole.PrereleaseViewer)
                 .Select(r => r.ReleaseId)
                 .ToListAsync();
             

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -1,4 +1,5 @@
 {
+  "AdminUri": "localhost:5021",
   "NotifyApiKey": "change-me",
   "NotifyInviteTemplateId": "change-me",
   "NotifyReleaseRoleTemplateId": "change-me",

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
@@ -8,16 +8,12 @@ import ReleasesTab from '@admin/pages/admin-dashboard/components/ReleasesByStatu
 import ReleaseSummary from '@admin/pages/admin-dashboard/components/ReleaseSummary';
 import { summaryRoute } from '@admin/routes/edit-release/routes';
 import loginService from '@admin/services/loginService';
-import preReleaseContactService, {
-  PrereleaseContactDetails,
-} from '@admin/services/preReleaseContactService';
 import releaseService, { Release } from '@admin/services/releaseService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import RelatedInformation from '@common/components/RelatedInformation';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
-import { Dictionary } from '@common/types';
 import React from 'react';
 import ManagePublicationsAndReleasesTab from './components/ManagePublicationsAndReleasesTab';
 
@@ -32,24 +28,6 @@ const AdminDashboardPage = () => {
       releaseService.getDraftReleases(),
       releaseService.getScheduledReleases(),
     ]);
-
-    const contactResultsByRelease = scheduledReleases.map(release =>
-      preReleaseContactService
-        .getPreReleaseContactsForRelease(release.id)
-        .then(contacts => ({
-          releaseId: release.id,
-          contacts,
-        })),
-    );
-
-    const contactResults = await Promise.all(contactResultsByRelease);
-
-    const preReleaseContactsByScheduledRelease: Dictionary<PrereleaseContactDetails[]> = {};
-
-    contactResults.forEach(result => {
-      const { releaseId, contacts } = result;
-      preReleaseContactsByScheduledRelease[releaseId] = contacts;
-    });
 
     return [draftReleases, scheduledReleases];
   }, []);

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
@@ -130,7 +130,9 @@ const AdminDashboardPage = () => {
                     </ButtonLink>
                   }
                 >
-                  <PrereleaseAccessManagement release={release} />
+                  {release.permissions.canUpdateRelease && (
+                    <PrereleaseAccessManagement release={release} />
+                  )}
                 </ReleaseSummary>
               )}
             />


### PR DESCRIPTION
- Don't include Releases that a user only has PreRelease role for when getting scheduled Releases. Fixes a 403 error getting the Release Status on them. User must use e-mail link to access pre releases.
- Don't attempt to get pre release contacts without Release update permission by hiding the `PreReleaseManagement `component. Fixes 403 error when user only has Viewer role on Releases.
- Remove unused Prerelease code from `AdminDashboardPage.tsx`.
- Add missing `AdminUri `param fixing e-mail link when inviting new users to EES.