### PR TITLE
EES-1019 Add sorting to filter groups and filter items in Subject metadata requests

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/AbstractSubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/AbstractSubjectMetaService.cs
@@ -15,6 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         private readonly IBoundaryLevelService _boundaryLevelService;
         private readonly IFilterItemService _filterItemService;
         private readonly IGeoJsonService _geoJsonService;
+        protected static IComparer<string> LabelComparer { get; } = new LabelRelationalComparer();
 
         protected AbstractSubjectMetaService(IBoundaryLevelService boundaryLevelService,
             IFilterItemService filterItemService,
@@ -43,6 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                         Name = itemsGroupedByFilter.Key.Name,
                         Options = itemsGroupedByFilter
                             .GroupBy(item => item.FilterGroup, item => item, FilterGroup.IdComparer)
+                            .OrderBy(items => items.Key.Label, LabelComparer)
                             .ToDictionary(
                                 itemsGroupedByFilterGroup => itemsGroupedByFilterGroup.Key.Label.PascalCase(),
                                 itemsGroupedByFilterGroup => BuildFilterItemsViewModel(itemsGroupedByFilterGroup.Key,
@@ -102,7 +104,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             return new FilterItemsMetaViewModel
             {
                 Label = filterGroup.Label,
-                Options = filterItems.Select(item => new LabelValue
+                Options = filterItems
+                    .OrderBy(item => item.Label, LabelComparer)
+                    .Select(item => new LabelValue
                 {
                     Label = item.Label,
                     Value = item.Id.ToString()

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LabelRelationalComparer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LabelRelationalComparer.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using static System.Globalization.CultureInfo;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services
+{
+    /**
+     * Compares two strings which may be integer or DateTime values represented as strings.
+     * If both values can be converted to integer then they are compared as integer values.
+     * If both values can be converted to DateTime then they are compared as DateTime values.
+     * If conversion is not possible then they are compared as strings.  
+     */
+    public class LabelRelationalComparer : IComparer<string>
+    {
+        public int Compare(string x, string y)
+        {
+            if (ReferenceEquals(x, y)) return 0;
+            if (ReferenceEquals(null, y)) return 1;
+            if (ReferenceEquals(null, x)) return -1;
+
+            if (int.TryParse(x, out var xIntValue) && int.TryParse(y, out var yIntValue))
+            {
+                return xIntValue.CompareTo(yIntValue);
+            }
+
+            const string dateFormat = "dd/MM/yyyy";
+            const DateTimeStyles style = DateTimeStyles.None;
+            if (DateTime.TryParseExact(x, dateFormat, InvariantCulture, style, out var xDateTimeValue)
+                && DateTime.TryParseExact(y, dateFormat, InvariantCulture, style, out var yDateTimeValue))
+            {
+                return xDateTimeValue.CompareTo(yDateTimeValue);
+            }
+
+            return string.Compare(x, y, StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -124,7 +124,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     {
                         Hint = filter.Hint,
                         Legend = filter.Label,
-                        Options = filter.FilterGroups.ToDictionary(
+                        Options = filter.FilterGroups
+                            .OrderBy(filterGroup => filterGroup.Label, LabelComparer)
+                            .ToDictionary(
                             filterGroup => filterGroup.Label.PascalCase(),
                             filterGroup => BuildFilterItemsViewModel(filterGroup, filterGroup.FilterItems)),
                         TotalValue = GetTotalValue(filter)


### PR DESCRIPTION
This change adds sorting to filter group and filter items by their labels in Subject metadata requests.

It compares them as strings but caters for integer and DateTime values represented as strings.

* If both values can be converted to integer then they are compared as integer values.
* If both values can be converted to DateTime then they are compared as DateTime values.
* If conversion is not possible then they are compared as strings. 

This should add sorting but also mean that integer sequences are not sorted as 1,10,11,12,.. and date sequences are properly ordered too.