### PR TITLE
Revert "EES-986 Delete observation filter items when delete subject."

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
@@ -94,13 +94,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
             
                 if (subject != null)
                 {
-                    var observationFilterItems = _context.ObservationFilterItem
-                        .Include(ofi => ofi.Observation)
-                        .ThenInclude(o => o.Subject)
-                        .Where(ofi => ofi.Observation.Subject.Id == subjectId);
-                
-                    _context.ObservationFilterItem.RemoveRange(observationFilterItems);
-                    
                     var orphanFootnotes = await GetFootnotesOnlyForSubjectAsync(subjectId);
 
                     _context.Subject.Remove(subject);


### PR DESCRIPTION
The fix for EES-986 https://github.com/dfe-analytical-services/explore-education-statistics/pull/1750 is retrieving all Observation Filter items in order to delete them which is a long running query. There is an example in Prod failing in method RemoveReleaseSubjectLinkAsync taking 29.8 minutes before failing.

This PR reverts the change in https://github.com/dfe-analytical-services/explore-education-statistics/pull/1750