### PR TITLE
EES-1035 Add sorting of indicators and observational units by label.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
@@ -2,19 +2,15 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Statistics;
-using GovUk.Education.ExploreEducationStatistics.Admin.Mappings;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api.Statistics;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Data.Services.Mappings;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.MapperUtils;
 using IFootnoteService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IFootnoteService;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Statistics
@@ -141,8 +137,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             _controller = new FootnoteController(filterService.Object,
                 footnoteService.Object,
                 indicatorGroupService.Object,
-                releaseMetaService.Object,
-                MapperForProfiles(new Profile[] {new MappingProfiles(), new DataServiceMappingProfiles()}));
+                releaseMetaService.Object);
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/AbstractSubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/AbstractSubjectMetaService.cs
@@ -98,6 +98,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             return observationalUnits.Any(pair => HasBoundaryLevelForGeographicLevel(pair.Key));
         }
 
+        protected static IEnumerable<IndicatorMetaViewModel> BuildIndicatorViewModels(IEnumerable<Indicator> indicators)
+        {
+            return indicators.OrderBy(indicator => indicator.Label, LabelComparer)
+                .Select(indicator => new IndicatorMetaViewModel
+                {
+                    Label = indicator.Label,
+                    Name = indicator.Name,
+                    Unit = indicator.Unit.GetEnumValue(),
+                    Value = indicator.Id.ToString(),
+                    DecimalPlaces = indicator.DecimalPlaces
+                });
+        }
+
         protected static FilterItemsMetaViewModel BuildFilterItemsViewModel(FilterGroup filterGroup,
             IEnumerable<FilterItem> filterItems)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Mappings/DataServiceMappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Mappings/DataServiceMappingProfiles.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using AutoMapper;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
@@ -16,11 +15,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Mappings
         public DataServiceMappingProfiles()
         {
             CreateMap<BoundaryLevel, BoundaryLevelIdLabel>();
-
-            CreateMap<Indicator, IndicatorMetaViewModel>()
-                .ForMember(dest => dest.Value, opts => opts.MapFrom(indicator => indicator.Id))
-                .ForMember(dest => dest.Name, opts => opts.MapFrom(indicator => indicator.Name))
-                .ForMember(dest => dest.Unit, opts => opts.MapFrom(indicator => indicator.Unit.GetEnumValue()));
 
             CreateMap<Location, LocationViewModel>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
@@ -138,7 +138,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     geoJsonRequested,
                     boundaryLevelId));
 
-            return TransformDuplicateObservationalUnitsWithUniqueLabels(viewModels);
+            return TransformDuplicateObservationalUnitsWithUniqueLabels(viewModels)
+                .OrderBy(model => model.Level.ToString())
+                .ThenBy(model => model.Label);
         }
 
         private IEnumerable<BoundaryLevelIdLabel> GetBoundaryLevelOptions(long? boundaryLevelId,
@@ -152,8 +154,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         private IEnumerable<IndicatorMetaViewModel> GetIndicators(SubjectMetaQueryContext query)
         {
-            return _mapper.Map<IEnumerable<IndicatorMetaViewModel>>(
-                _indicatorService.GetIndicators(query.SubjectId, query.Indicators));
+            var indicators = _indicatorService.GetIndicators(query.SubjectId, query.Indicators);
+            return BuildIndicatorViewModels(indicators);
         }
 
         private IEnumerable<FootnoteViewModel> GetFootnotes(IQueryable<Observation> observations,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -160,31 +160,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         private Dictionary<string, IndicatorsMetaViewModel> GetIndicators(Guid subjectId)
         {
-            return _indicatorGroupService.GetIndicatorGroups(subjectId).ToDictionary(
-                group => group.Label.PascalCase(),
-                group => new IndicatorsMetaViewModel
-                {
-                    Label = group.Label,
-                    Options = _mapper.Map<IEnumerable<IndicatorMetaViewModel>>(group.Indicators)
-                }
-            );
+            return _indicatorGroupService.GetIndicatorGroups(subjectId)
+                .OrderBy(group => group.Label, LabelComparer)
+                .ToDictionary(
+                    group => group.Label.PascalCase(),
+                    group => new IndicatorsMetaViewModel
+                    {
+                        Label = group.Label,
+                        Options = BuildIndicatorViewModels(group.Indicators)
+                    }
+                );
         }
 
         private static Dictionary<string, ObservationalUnitsMetaViewModel> BuildObservationalUnitsViewModels(
             Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>> observationalUnits)
         {
-            var viewModels = observationalUnits.ToDictionary(
-                pair => pair.Key.ToString().CamelCase(),
-                pair => new ObservationalUnitsMetaViewModel
-                {
-                    Hint = "",
-                    Legend = pair.Key.GetEnumLabel(),
-                    Options = pair.Value.Select(MapObservationalUnitToLabelValue)
-                });
+            var viewModels = observationalUnits
+                .OrderBy(pair => pair.Key.GetEnumLabel())
+                .ToDictionary(
+                    pair => pair.Key.ToString().CamelCase(),
+                    pair => new ObservationalUnitsMetaViewModel
+                    {
+                        Hint = "",
+                        Legend = pair.Key.GetEnumLabel(),
+                        Options = pair.Value.Select(MapObservationalUnitToLabelValue)
+                    });
 
             foreach (var (_, viewModel) in viewModels)
             {
-                viewModel.Options = TransformDuplicateObservationalUnitsWithUniqueLabels(viewModel.Options);
+                viewModel.Options = TransformDuplicateObservationalUnitsWithUniqueLabels(viewModel.Options)
+                    .OrderBy(value => value.Label);
             }
 
             return viewModels;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/IndicatorMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/IndicatorMetaViewModel.cs
@@ -6,6 +6,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Me
         public string Unit { get; set; }
         public string Value { get; set; }
         public string Name { get; set; }
-        public string DecimalPlaces { get; set; }
+        public int? DecimalPlaces { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/ObservationalUnitMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/ObservationalUnitMetaViewModel.cs
@@ -1,7 +1,6 @@
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
-using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -129,6 +129,7 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
                       legendSize="m"
                       hint="Select at least one indicator below"
                       disabled={form.isSubmitting}
+                      order={[]}
                       options={Object.values(subjectMeta.indicators).map(
                         group => ({
                           legend: group.label,

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -116,6 +116,7 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
                           name={`locations.${levelKey}`}
                           key={levelKey}
                           options={level.options}
+                          order={[]}
                           id={`${formId}-levels-${levelKey}`}
                           legend={level.legend}
                           legendHidden


### PR DESCRIPTION
Follow on from https://github.com/dfe-analytical-services/explore-education-statistics/pull/1761 which added sorting to filter groups and filter items.

This PR adds sorting to Indicators and Observational Units at the API level.