### PR TITLE
EES-1020 Show 'Select all options' button consistently when single subgroup 

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.tsx
@@ -1,5 +1,6 @@
 import ButtonText from '@common/components/ButtonText';
 import FormCheckboxGroup, {
+  BaseFormCheckboxGroup,
   CheckboxGroupAllChangeEvent,
   CheckboxOption,
   FormCheckboxGroupProps,
@@ -126,7 +127,7 @@ const FormCheckboxSearchSubGroups = ({
     <FormFieldset {...fieldsetProps}>
       {isMounted && (
         <>
-          {totalOptions > 1 && (
+          {totalOptions > 1 && options.length > 1 && (
             <ButtonText
               id={`${id}-all`}
               className="govuk-!-margin-bottom-4"
@@ -158,29 +159,47 @@ const FormCheckboxSearchSubGroups = ({
         aria-live={onMounted('assertive')}
         className={styles.optionsContainer}
       >
-        {filteredOptions.map((optionGroup, index) => (
-          <FormCheckboxGroup
+        {options.length > 1 ? (
+          <>
+            {filteredOptions.map((optionGroup, index) => (
+              <FormCheckboxGroup
+                {...groupProps}
+                key={optionGroup.legend}
+                name={name}
+                id={optionGroup.id ? optionGroup.id : `${id}-${index + 1}`}
+                legend={optionGroup.legend}
+                legendSize="s"
+                options={optionGroup.options}
+                value={value}
+                selectAll
+                selectAllText={(allChecked, opts) =>
+                  `${allChecked ? 'Unselect' : 'Select'} all ${
+                    opts.length
+                  } subgroup options`
+                }
+                onAllChange={(event, checked) => {
+                  if (onSubGroupAllChange) {
+                    onSubGroupAllChange(event, checked, optionGroup.options);
+                  }
+                }}
+              />
+            ))}
+          </>
+        ) : (
+          <BaseFormCheckboxGroup
             {...groupProps}
-            key={optionGroup.legend}
             name={name}
-            id={optionGroup.id ? optionGroup.id : `${id}-${index + 1}`}
-            legend={optionGroup.legend}
-            legendSize="s"
-            options={optionGroup.options}
+            id={options[0].id ? options[0].id : `${id}-1`}
+            options={options[0].options}
             value={value}
             selectAll
-            selectAllText={(allChecked, opts) =>
-              `${allChecked ? 'Unselect' : 'Select'} all ${
-                opts.length
-              } subgroup options`
-            }
             onAllChange={(event, checked) => {
               if (onSubGroupAllChange) {
-                onSubGroupAllChange(event, checked, optionGroup.options);
+                onSubGroupAllChange(event, checked, options[0].options);
               }
             }}
           />
-        ))}
+        )}
       </div>
     </FormFieldset>
   );

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.tsx
@@ -140,18 +140,20 @@ const FormCheckboxSearchSubGroups = ({
             </ButtonText>
           )}
 
-          <FormTextSearchInput
-            id={`${id}-search`}
-            name={`${name}-search`}
-            label={searchLabel}
-            width={20}
-            onChange={event => setSearchTerm(event.target.value)}
-            onKeyPress={event => {
-              if (event.key === 'Enter') {
-                event.preventDefault();
-              }
-            }}
-          />
+          {totalOptions > 1 && (
+            <FormTextSearchInput
+              id={`${id}-search`}
+              name={`${name}-search`}
+              label={searchLabel}
+              width={20}
+              onChange={event => setSearchTerm(event.target.value)}
+              onKeyPress={event => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                }
+              }}
+            />
+          )}
         </>
       )}
 

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchSubGroups.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import FormCheckboxSearchSubGroups, {
   FormCheckboxSearchSubGroupsProps,
 } from './FormCheckboxSearchSubGroups';
-import FormFieldCheckboxSearchGroup from './FormFieldCheckboxSearchGroup';
 import handleAllChange from './util/handleAllCheckboxChange';
 
 export type FormFieldCheckboxSearchSubGroupsProps<FormValues> = OmitStrict<
@@ -20,72 +19,56 @@ const FormFieldCheckboxSearchSubGroups = <FormValues extends {}>(
   const { options } = props;
 
   return (
-    <>
-      {options.length > 1 && (
-        <FormField<string[]> {...props}>
-          {({ field, helpers, meta }) => {
-            return (
-              <FormCheckboxSearchSubGroups
-                {...props}
-                {...field}
-                small
-                onAllChange={(event, checked) => {
-                  if (event.isDefaultPrevented()) {
-                    return;
-                  }
+    <FormField<string[]> {...props}>
+      {({ field, helpers, meta }) => {
+        return (
+          <FormCheckboxSearchSubGroups
+            {...props}
+            {...field}
+            small
+            onAllChange={(event, checked) => {
+              if (event.isDefaultPrevented()) {
+                return;
+              }
 
-                  handleAllChange({
-                    checked,
-                    meta,
-                    helpers,
-                    options: options.flatMap(group => group.options),
-                  });
-                }}
-                onSubGroupAllChange={(event, checked, groupOptions) => {
-                  if (props.onSubGroupAllChange) {
-                    props.onSubGroupAllChange(event, checked, groupOptions);
-                  }
+              handleAllChange({
+                checked,
+                meta,
+                helpers,
+                options: options.flatMap(group => group.options),
+              });
+            }}
+            onSubGroupAllChange={(event, checked, groupOptions) => {
+              if (props.onSubGroupAllChange) {
+                props.onSubGroupAllChange(event, checked, groupOptions);
+              }
 
-                  if (event.isDefaultPrevented()) {
-                    return;
-                  }
+              if (event.isDefaultPrevented()) {
+                return;
+              }
 
-                  handleAllChange({
-                    checked,
-                    meta,
-                    helpers,
-                    options: groupOptions,
-                  });
-                }}
-                onChange={(event, option) => {
-                  if (props.onChange) {
-                    props.onChange(event, option);
-                  }
+              handleAllChange({
+                checked,
+                meta,
+                helpers,
+                options: groupOptions,
+              });
+            }}
+            onChange={(event, option) => {
+              if (props.onChange) {
+                props.onChange(event, option);
+              }
 
-                  if (event.isDefaultPrevented()) {
-                    return;
-                  }
+              if (event.isDefaultPrevented()) {
+                return;
+              }
 
-                  field.onChange(event);
-                }}
-              />
-            );
-          }}
-        </FormField>
-      )}
-
-      {options.length === 1 && (
-        <FormFieldCheckboxSearchGroup
-          {...props}
-          onAllChange={(event, checked) => {
-            if (props.onSubGroupAllChange) {
-              props.onSubGroupAllChange(event, checked, options[0].options);
-            }
-          }}
-          options={options[0].options}
-        />
-      )}
-    </>
+              field.onChange(event);
+            }}
+          />
+        );
+      }}
+    </FormField>
   );
 };
 

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxSearchSubGroups.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxSearchSubGroups.test.tsx
@@ -29,20 +29,55 @@ describe('FormCheckboxSearchSubGroups', () => {
       />,
     );
 
-    const groups = screen.getAllByText(/Group/);
+    const group1 = within(screen.getByRole('group', { name: 'Group A' }));
+    const group2 = within(screen.getByRole('group', { name: 'Group B' }));
 
-    expect(groups[0]).toHaveTextContent('Group A');
-    expect(groups[1]).toHaveTextContent('Group B');
+    const group1Checkboxes = group1.getAllByRole('checkbox');
+    const group2Checkboxes = group2.getAllByRole('checkbox');
 
-    const checkboxes = screen.getAllByLabelText(
-      /Checkbox/,
-    ) as HTMLInputElement[];
+    expect(group1Checkboxes).toHaveLength(2);
+    expect(group1Checkboxes[0]).toHaveAttribute('value', '1');
+    expect(group1Checkboxes[1]).toHaveAttribute('value', '2');
 
-    expect(checkboxes).toHaveLength(4);
+    expect(group2Checkboxes).toHaveLength(2);
+    expect(group2Checkboxes[0]).toHaveAttribute('value', '3');
+    expect(group2Checkboxes[1]).toHaveAttribute('value', '4');
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders single group of checkboxes correctly', () => {
+    const { container } = render(
+      <FormCheckboxSearchSubGroups
+        name="testCheckboxes"
+        id="test-checkboxes"
+        legend="Choose options"
+        value={[]}
+        options={[
+          {
+            legend: 'Group A',
+            options: [
+              { label: 'Checkbox 1', value: '1' },
+              { label: 'Checkbox 2', value: '2' },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('group', { name: 'Group A' }),
+    ).not.toBeInTheDocument();
+
+    const fieldset = within(
+      screen.getByRole('group', { name: 'Choose options' }),
+    );
+
+    const checkboxes = fieldset.getAllByRole('checkbox');
+
+    expect(checkboxes).toHaveLength(2);
     expect(checkboxes[0]).toHaveAttribute('value', '1');
     expect(checkboxes[1]).toHaveAttribute('value', '2');
-    expect(checkboxes[2]).toHaveAttribute('value', '3');
-    expect(checkboxes[3]).toHaveAttribute('value', '4');
 
     expect(container.innerHTML).toMatchSnapshot();
   });
@@ -160,6 +195,42 @@ describe('FormCheckboxSearchSubGroups', () => {
     expect(
       group2.getByRole('button', {
         name: 'Select all 2 subgroup options',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('does not render `Select all subgroup options` button if there is only one subgroup', () => {
+    render(
+      <FormCheckboxSearchSubGroups
+        id="test-checkboxes"
+        name="test-checkboxes"
+        legend="Test checkboxes"
+        value={[]}
+        options={[
+          {
+            legend: 'Group A',
+            options: [
+              { label: 'Checkbox 1', value: '1' },
+              { label: 'Checkbox 2', value: '2' },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const fieldset = within(
+      screen.getByRole('group', { name: 'Test checkboxes' }),
+    );
+
+    expect(
+      fieldset.queryByRole('button', {
+        name: 'Select all 2 subgroup options',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      fieldset.getByRole('button', {
+        name: 'Select all 2 options',
       }),
     ).toBeInTheDocument();
   });

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxSearchSubGroups.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxSearchSubGroups.test.tsx
@@ -238,7 +238,7 @@ describe('FormCheckboxSearchSubGroups', () => {
   test('providing a search term renders only relevant checkboxes', () => {
     jest.useFakeTimers();
 
-    const { getByLabelText, getAllByLabelText } = render(
+    render(
       <FormCheckboxSearchSubGroups
         name="testCheckboxes"
         id="test-checkboxes"
@@ -264,9 +264,7 @@ describe('FormCheckboxSearchSubGroups', () => {
       />,
     );
 
-    const searchInput = getByLabelText('Search options');
-
-    fireEvent.change(searchInput, {
+    fireEvent.change(screen.getByLabelText('Search options'), {
       target: {
         value: '2',
       },
@@ -274,7 +272,9 @@ describe('FormCheckboxSearchSubGroups', () => {
 
     jest.runAllTimers();
 
-    const checkboxes = getAllByLabelText(/Checkbox/) as HTMLInputElement[];
+    const checkboxes = screen.getAllByLabelText(
+      /Checkbox/,
+    ) as HTMLInputElement[];
 
     expect(checkboxes).toHaveLength(1);
     expect(checkboxes[0]).toHaveAttribute('value', '2');
@@ -283,7 +283,7 @@ describe('FormCheckboxSearchSubGroups', () => {
   test('does not throw error if search term that is invalid regex is used', () => {
     jest.useFakeTimers();
 
-    const { getByLabelText, queryAllByLabelText } = render(
+    render(
       <FormCheckboxSearchSubGroups
         name="testCheckboxes"
         id="test-checkboxes"
@@ -309,9 +309,7 @@ describe('FormCheckboxSearchSubGroups', () => {
       />,
     );
 
-    const searchInput = getByLabelText('Search options');
-
-    fireEvent.change(searchInput, {
+    fireEvent.change(screen.getByLabelText('Search options'), {
       target: {
         value: '[',
       },
@@ -319,7 +317,9 @@ describe('FormCheckboxSearchSubGroups', () => {
 
     jest.runAllTimers();
 
-    const checkboxes = queryAllByLabelText(/Checkbox/) as HTMLInputElement[];
+    const checkboxes = screen.queryAllByLabelText(
+      /Checkbox/,
+    ) as HTMLInputElement[];
 
     expect(checkboxes).toHaveLength(0);
   });
@@ -327,7 +327,7 @@ describe('FormCheckboxSearchSubGroups', () => {
   test('providing a search term does not remove checkboxes that have already been checked', () => {
     jest.useFakeTimers();
 
-    const { getByLabelText, getAllByLabelText } = render(
+    render(
       <FormCheckboxSearchSubGroups
         name="testCheckboxes"
         id="test-checkboxes"
@@ -353,7 +353,7 @@ describe('FormCheckboxSearchSubGroups', () => {
       />,
     );
 
-    const searchInput = getByLabelText('Search options');
+    const searchInput = screen.getByLabelText('Search options');
 
     fireEvent.change(searchInput, {
       target: {
@@ -363,10 +363,55 @@ describe('FormCheckboxSearchSubGroups', () => {
 
     jest.runAllTimers();
 
-    const checkboxes = getAllByLabelText(/Checkbox/) as HTMLInputElement[];
+    const checkboxes = screen.getAllByLabelText(
+      /Checkbox/,
+    ) as HTMLInputElement[];
 
     expect(checkboxes).toHaveLength(2);
     expect(checkboxes[0]).toHaveAttribute('value', '1');
     expect(checkboxes[1]).toHaveAttribute('value', '2');
+  });
+
+  test('renders search input if more than one option in a single group', () => {
+    render(
+      <FormCheckboxSearchSubGroups
+        name="testCheckboxes"
+        id="test-checkboxes"
+        legend="Choose options"
+        searchLabel="Search options"
+        value={[]}
+        options={[
+          {
+            legend: 'Group A',
+            options: [
+              { label: 'Checkbox 1', value: '1' },
+              { label: 'Checkbox 2', value: '2' },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByLabelText('Search options')).toBeInTheDocument();
+  });
+
+  test('does not render search input if only a single option', () => {
+    render(
+      <FormCheckboxSearchSubGroups
+        name="testCheckboxes"
+        id="test-checkboxes"
+        legend="Choose options"
+        searchLabel="Search options"
+        value={[]}
+        options={[
+          {
+            legend: 'Group A',
+            options: [{ label: 'Checkbox 1', value: '1' }],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByLabelText('Search options')).not.toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchSubGroups.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchSubGroups.test.tsx.snap
@@ -117,3 +117,63 @@ exports[`FormCheckboxSearchSubGroups renders groups of checkboxes in correct ord
   </fieldset>
 </div>
 `;
+
+exports[`FormCheckboxSearchSubGroups renders single group of checkboxes correctly 1`] = `
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset"
+            id="test-checkboxes"
+  >
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      Choose options
+    </legend>
+    <label class="govuk-label"
+           for="test-checkboxes-search"
+    >
+      Search options
+    </label>
+    <input name="testCheckboxes-search"
+           class="govuk-input searchInput govuk-input--width-20"
+           id="test-checkboxes-search"
+           type="text"
+    >
+    <div class="optionsContainer"
+         aria-live="assertive"
+    >
+      <div class="govuk-checkboxes">
+        <button id="test-checkboxes-1-all"
+                class="button noUnderline selectAll"
+                type="button"
+        >
+          Select all 2 options
+        </button>
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input"
+                 id="test-checkboxes-1-1"
+                 name="testCheckboxes"
+                 type="checkbox"
+                 value="1"
+          >
+          <label class="govuk-label govuk-checkboxes__label"
+                 for="test-checkboxes-1-1"
+          >
+            Checkbox 1
+          </label>
+        </div>
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input"
+                 id="test-checkboxes-1-2"
+                 name="testCheckboxes"
+                 type="checkbox"
+                 value="2"
+          >
+          <label class="govuk-label govuk-checkboxes__label"
+                 for="test-checkboxes-1-2"
+          >
+            Checkbox 2
+          </label>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>
+`;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldCheckboxGroupsMenu.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldCheckboxGroupsMenu.tsx
@@ -1,6 +1,4 @@
 import DetailsMenu from '@common/components/DetailsMenu';
-import { FormFieldCheckboxGroup } from '@common/components/form';
-import FormFieldCheckboxSearchGroup from '@common/components/form/FormFieldCheckboxSearchGroup';
 import FormFieldCheckboxSearchSubGroups, {
   FormFieldCheckboxSearchSubGroupsProps,
 } from '@common/components/form/FormFieldCheckboxSearchSubGroups';
@@ -11,7 +9,7 @@ import FormCheckboxSelectionCount from './FormCheckboxSelectedCount';
 const FormFieldCheckboxGroupsMenu = <T extends {}>(
   props: FormFieldCheckboxSearchSubGroupsProps<T>,
 ) => {
-  const { name, options, onAllChange, legend } = props;
+  const { name, legend } = props;
   const [open, setOpen] = useState(false);
 
   const [, meta] = useField(name);
@@ -21,36 +19,6 @@ const FormFieldCheckboxGroupsMenu = <T extends {}>(
       setOpen(true);
     }
   }, [meta.error, meta.touched]);
-
-  const renderSingleGroup = () => {
-    return options[0].options.length > 1 ? (
-      <FormFieldCheckboxSearchGroup
-        {...props}
-        legendHidden
-        selectAll
-        options={options[0].options}
-        onAllChange={(event, checked) => {
-          if (onAllChange) {
-            onAllChange(event, checked);
-          }
-        }}
-      />
-    ) : (
-      <FormFieldCheckboxGroup
-        {...props}
-        legendHidden
-        selectAll
-        small
-        name={name}
-        options={options[0].options}
-        onAllChange={(event, checked) => {
-          if (onAllChange) {
-            onAllChange(event, checked);
-          }
-        }}
-      />
-    );
-  };
 
   return (
     <DetailsMenu
@@ -68,11 +36,7 @@ const FormFieldCheckboxGroupsMenu = <T extends {}>(
         </>
       }
     >
-      {options.length > 1 && (
-        <FormFieldCheckboxSearchSubGroups {...props} legendHidden />
-      )}
-
-      {options.length === 1 && renderSingleGroup()}
+      <FormFieldCheckboxSearchSubGroups {...props} legendHidden />
     </DetailsMenu>
   );
 };

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FormFieldCheckboxGroupsMenu.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FormFieldCheckboxGroupsMenu.test.tsx
@@ -1,11 +1,11 @@
-import { fireEvent, render, wait } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { Formik } from 'formik';
 import React from 'react';
 import FormFieldCheckboxGroupsMenu from '../FormFieldCheckboxGroupsMenu';
 
 describe('FormFieldCheckboxGroupsMenu', () => {
   test('renders multiple checkbox groups in correct order with search input', () => {
-    const { container, getAllByLabelText, queryByLabelText } = render(
+    const { container } = render(
       <Formik
         initialValues={{
           test: '',
@@ -36,9 +36,9 @@ describe('FormFieldCheckboxGroupsMenu', () => {
       </Formik>,
     );
 
-    expect(queryByLabelText('Search options')).not.toBeNull();
+    expect(screen.queryByLabelText('Search options')).not.toBeNull();
 
-    const checkboxes = getAllByLabelText(/Option/);
+    const checkboxes = screen.getAllByLabelText(/Option/);
 
     expect(checkboxes[0]).toHaveAttribute('value', '1');
     expect(checkboxes[1]).toHaveAttribute('value', '2');
@@ -49,7 +49,7 @@ describe('FormFieldCheckboxGroupsMenu', () => {
   });
 
   test('renders single checkbox group with search input', () => {
-    const { container, getAllByLabelText, queryByLabelText } = render(
+    const { container } = render(
       <Formik
         initialValues={{
           test: '',
@@ -73,9 +73,9 @@ describe('FormFieldCheckboxGroupsMenu', () => {
       </Formik>,
     );
 
-    expect(queryByLabelText('Search options')).not.toBeNull();
+    expect(screen.queryByLabelText('Search options')).not.toBeNull();
 
-    const checkboxes = getAllByLabelText(/Option/);
+    const checkboxes = screen.getAllByLabelText(/Option/);
 
     expect(checkboxes[0]).toHaveAttribute('value', '1');
     expect(checkboxes[1]).toHaveAttribute('value', '2');
@@ -111,7 +111,7 @@ describe('FormFieldCheckboxGroupsMenu', () => {
   });
 
   test('menu contents is expanded if there is a field error', async () => {
-    const { container } = render(
+    render(
       <Formik
         initialValues={{
           test: '',
@@ -141,15 +141,13 @@ describe('FormFieldCheckboxGroupsMenu', () => {
       </Formik>,
     );
 
-    await wait();
-
-    const summary = container.querySelector('summary') as HTMLElement;
-
-    expect(summary).toHaveAttribute('aria-expanded', 'true');
+    expect(
+      screen.getByRole('button', { name: 'Choose options' }),
+    ).toHaveAttribute('aria-expanded', 'true');
   });
 
   test('clicking menu does not collapse it if there is a field error', async () => {
-    const { container } = render(
+    render(
       <Formik
         initialValues={{
           test: '',
@@ -179,9 +177,7 @@ describe('FormFieldCheckboxGroupsMenu', () => {
       </Formik>,
     );
 
-    await wait();
-
-    const summary = container.querySelector('summary') as HTMLElement;
+    const summary = screen.getByRole('button', { name: 'Choose options' });
 
     expect(summary).toHaveAttribute('aria-expanded', 'true');
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FormFieldCheckboxGroupsMenu.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FormFieldCheckboxGroupsMenu.test.tsx.snap
@@ -188,7 +188,7 @@ exports[`FormFieldCheckboxGroupsMenu renders single checkbox group with search i
     >
       <button
         class="button noUnderline selectAll"
-        id="test-checkboxes-all"
+        id="test-1-all"
         type="button"
       >
         Select all 2 options
@@ -198,14 +198,14 @@ exports[`FormFieldCheckboxGroupsMenu renders single checkbox group with search i
       >
         <input
           class="govuk-checkboxes__input"
-          id="test-checkboxes-1"
+          id="test-1-1"
           name="test"
           type="checkbox"
           value="1"
         />
         <label
           class="govuk-label govuk-checkboxes__label"
-          for="test-checkboxes-1"
+          for="test-1-1"
         >
           Option 1
         </label>
@@ -215,14 +215,14 @@ exports[`FormFieldCheckboxGroupsMenu renders single checkbox group with search i
       >
         <input
           class="govuk-checkboxes__input"
-          id="test-checkboxes-2"
+          id="test-1-2"
           name="test"
           type="checkbox"
           value="2"
         />
         <label
           class="govuk-label govuk-checkboxes__label"
-          for="test-checkboxes-2"
+          for="test-1-2"
         >
           Option 2
         </label>
@@ -244,24 +244,29 @@ exports[`FormFieldCheckboxGroupsMenu renders single checkbox group with single c
   </legend>
   
   <div
-    class="govuk-checkboxes govuk-checkboxes--small"
+    aria-live="assertive"
+    class="optionsContainer"
   >
     <div
-      class="govuk-checkboxes__item"
+      class="govuk-checkboxes govuk-checkboxes--small"
     >
-      <input
-        class="govuk-checkboxes__input"
-        id="test-1"
-        name="test"
-        type="checkbox"
-        value="1"
-      />
-      <label
-        class="govuk-label govuk-checkboxes__label"
-        for="test-1"
+      <div
+        class="govuk-checkboxes__item"
       >
-        Option 1
-      </label>
+        <input
+          class="govuk-checkboxes__input"
+          id="test-1-1"
+          name="test"
+          type="checkbox"
+          value="1"
+        />
+        <label
+          class="govuk-label govuk-checkboxes__label"
+          for="test-1-1"
+        >
+          Option 1
+        </label>
+      </div>
     </div>
   </div>
 </fieldset>


### PR DESCRIPTION
This PR fixes the 'Select all options' button not showing in instances where there is only a single checkbox subgroup.

We also take this opportunity to do some additional cleanup of the subgroup rendering behaviour to stuff more of it into  `FormCheckboxSearchSubGroups`. Currently this logic is fragmented across multiple consumer components rather than just being handled internally. We've now stripped this all back and removed a lot of the duplication.