### PR TITLE
EES-990 Find the correct ReleaseFileReference when importing files

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ReleaseProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ReleaseProcessorService.cs
@@ -48,10 +48,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         private static void CreateReleaseFileLink(ImportMessage message, ContentDbContext contentDbContext, Release release,
             Subject subject)
         {
-            var releaseFileLink = contentDbContext
+            var releaseFileLinks = contentDbContext
                 .ReleaseFiles
                 .Include(f => f.ReleaseFileReference)
-                .FirstOrDefault(f => f.ReleaseId == release.Id && f.ReleaseFileReference.Filename == message.DataFileName);
+                .Where(f => f.ReleaseId == release.Id);
+
+            // Make sure the filename predicate is case sensitive by executing in memory rather than in the db
+            var releaseFileLink = releaseFileLinks.ToList()
+                .FirstOrDefault(file => file.ReleaseFileReference.Filename == message.DataFileName);
 
             if (releaseFileLink != null)
             {


### PR DESCRIPTION
This PR makes sure when files are imported and the Subject Id is added to the ReleaseFileReference that the correct ReleaseFileReference is found by case sensitive filename check.

Previously the check was case insensitive due to being executed Linq-to-SQL where the SQLServer database is operating case insensitive, and could lead to the wrong ReleaseFileReference being found.

An additional file being imported with the same name (except for case) as an existing file would overwrite the Subjectd of the first ReleaseFileReference matching that name case insensitive.