### PR TITLE
EES-1012 Fix data blocks throwing errors when page props change

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -41,7 +41,7 @@ const MethodologyStatusPage = ({
 
   const {
     value: model,
-    setValue: setModel,
+    setState: setModel,
     isLoading,
   } = useAsyncRetry(async () => {
     const [summary, canApprove] = await Promise.all([
@@ -71,9 +71,12 @@ const MethodologyStatusPage = ({
     );
 
     setModel({
-      ...model,
-      summary: {
-        ...nextSummary,
+      isLoading: false,
+      value: {
+        ...model,
+        summary: {
+          ...nextSummary,
+        },
       },
     });
 

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/ReleaseManageDataBlocksPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/ReleaseManageDataBlocksPage.tsx
@@ -32,7 +32,7 @@ const ReleaseManageDataBlocksPage = ({
     value: dataBlocks = emptyDataBlocks,
     isLoading,
     retry: fetchDataBlocks,
-    setValue: setDataBlocks,
+    setState: setDataBlocks,
   } = useAsyncRetry(() => dataBlocksService.getDataBlocks(releaseId), [
     releaseId,
   ]);
@@ -72,7 +72,10 @@ const ReleaseManageDataBlocksPage = ({
         );
       }
 
-      setDataBlocks(nextDataBlocks);
+      setDataBlocks({
+        isLoading: false,
+        value: nextDataBlocks,
+      });
     },
     [dataBlocks, setDataBlocks, history, publicationId, releaseId],
   );

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/manage-datablocks/components/ReleaseManageDataBlocksPageTabs.tsx
@@ -57,7 +57,7 @@ const ReleaseManageDataBlocksPageTabs = ({
 
   const {
     value: tableState,
-    setValue: setTableState,
+    setState: setTableState,
     error,
     isLoading,
   } = useAsyncRetry<TableState | undefined>(async () => {
@@ -102,8 +102,11 @@ const ReleaseManageDataBlocksPageTabs = ({
       }
 
       setTableState({
-        ...tableState,
-        ...nextTableState,
+        isLoading: false,
+        value: {
+          ...tableState,
+          ...nextTableState,
+        },
       });
     },
     [setTableState, tableState],
@@ -154,9 +157,12 @@ const ReleaseManageDataBlocksPageTabs = ({
       });
 
       setTableState({
-        query,
-        table,
-        tableHeaders,
+        isLoading: false,
+        value: {
+          query,
+          table,
+          tableHeaders,
+        },
       });
 
       await handleDataBlockSave({

--- a/src/explore-education-statistics-common/src/components/Gate.tsx
+++ b/src/explore-education-statistics-common/src/components/Gate.tsx
@@ -24,10 +24,7 @@ const Gate = ({
   fallback = null,
   loading = null,
 }: GateProps) => {
-  const [
-    { isLoading, value: isSuccess, error },
-    checkCondition,
-  ] = useAsyncCallback(
+  const [{ isLoading, value, error }, checkCondition] = useAsyncCallback(
     async () => (typeof condition === 'boolean' ? condition : condition()),
     [condition],
     {
@@ -37,16 +34,16 @@ const Gate = ({
   );
 
   useEffect(() => {
-    if (isLoading && !isSuccess && !error) {
+    if (isLoading && !value && !error) {
       checkCondition();
     }
-  }, [isLoading, isSuccess, error, checkCondition]);
+  }, [isLoading, value, error, checkCondition]);
 
   if (isLoading) {
     return loading;
   }
 
-  if (isSuccess) {
+  if (value) {
     return children;
   }
 

--- a/src/explore-education-statistics-common/src/hooks/__tests__/useAsyncCallback.test.ts
+++ b/src/explore-education-statistics-common/src/hooks/__tests__/useAsyncCallback.test.ts
@@ -1,0 +1,130 @@
+import useAsyncCallback from '@common/hooks/useAsyncCallback';
+import { renderHook } from '@testing-library/react-hooks';
+
+describe('useAsyncCallback', () => {
+  test('returns correct state when callback not invoked', () => {
+    const { result } = renderHook(() =>
+      useAsyncCallback(() => Promise.resolve('some value')),
+    );
+
+    const [state] = result.current;
+
+    expect(state.isLoading).toBe(false);
+    expect(state.value).toBeUndefined();
+    expect(state.error).toBeUndefined();
+  });
+
+  test('returns correct state when callback invoked', () => {
+    const { result } = renderHook(() =>
+      useAsyncCallback(() => Promise.resolve('some value')),
+    );
+
+    const [, callback] = result.current;
+
+    callback();
+
+    const [state] = result.current;
+
+    expect(state.isLoading).toBe(true);
+    expect(state.value).toBeUndefined();
+    expect(state.error).toBeUndefined();
+  });
+
+  test('returns correct state when callback promise is resolved', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAsyncCallback(() => Promise.resolve('some value')),
+    );
+
+    const [, callback] = result.current;
+
+    callback();
+
+    await waitForNextUpdate();
+
+    const [state] = result.current;
+
+    expect(state.isLoading).toBe(false);
+    expect(state.value).toBe('some value');
+    expect(state.error).toBeUndefined();
+  });
+
+  test('returns correct state when callback promise is rejected', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAsyncCallback(() => Promise.reject(new Error('some error'))),
+    );
+
+    const [, callback] = result.current;
+
+    callback();
+
+    await waitForNextUpdate();
+
+    const [state] = result.current;
+
+    expect(state.isLoading).toBe(false);
+    expect(state.value).toBeUndefined();
+    expect(state.error).toEqual(new Error('some error'));
+  });
+
+  test('can manually set loading state using setter', async () => {
+    const { result, wait } = renderHook(() =>
+      useAsyncCallback(() => Promise.resolve('some value')),
+    );
+
+    let [state] = result.current;
+
+    state.setState({
+      isLoading: true,
+    });
+
+    await wait(() => {
+      [state] = result.current;
+
+      expect(state.isLoading).toBe(true);
+      expect(state.value).toBeUndefined();
+      expect(state.error).toBeUndefined();
+    });
+  });
+
+  test('can manually set value state using setter', async () => {
+    const { result, wait } = renderHook(() =>
+      useAsyncCallback(() => Promise.resolve('some value')),
+    );
+
+    let [state] = result.current;
+
+    state.setState({
+      isLoading: false,
+      value: 'a custom value',
+    });
+
+    await wait(() => {
+      [state] = result.current;
+
+      expect(state.isLoading).toBe(false);
+      expect(state.value).toBe('a custom value');
+      expect(state.error).toBeUndefined();
+    });
+  });
+
+  test('can manually set error state using setter', async () => {
+    const { result, wait } = renderHook(() =>
+      useAsyncCallback(() => Promise.resolve('some value')),
+    );
+
+    let [state] = result.current;
+
+    state.setState({
+      isLoading: false,
+      error: new Error('some error'),
+    });
+
+    await wait(() => {
+      [state] = result.current;
+
+      expect(state.isLoading).toBe(false);
+      expect(state.value).toBeUndefined();
+      expect(state.error).toEqual(new Error('some error'));
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/hooks/__tests__/useAsyncHandledRetry.test.tsx
+++ b/src/explore-education-statistics-common/src/hooks/__tests__/useAsyncHandledRetry.test.tsx
@@ -1,0 +1,65 @@
+import { ErrorControlContextProvider } from '@common/contexts/ErrorControlContext';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import { renderHook } from '@testing-library/react-hooks';
+import noop from 'lodash/noop';
+import React, { FunctionComponent } from 'react';
+
+describe('useAsyncHandledRetry', () => {
+  test('calls `handleApiErrors` if callback promise is rejected', async () => {
+    const handleApiErrors = jest.fn();
+
+    const wrapper: FunctionComponent = ({ children }) => (
+      <ErrorControlContextProvider
+        value={{
+          handleApiErrors,
+          handleManualErrors: {
+            forbidden: noop,
+          },
+        }}
+      >
+        {children}
+      </ErrorControlContextProvider>
+    );
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useAsyncHandledRetry(() => Promise.reject(new Error('some error'))),
+      { wrapper },
+    );
+
+    await waitForNextUpdate();
+
+    expect(handleApiErrors).toHaveBeenCalled();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.value).toBeUndefined();
+  });
+
+  test('does not call `handleApiErrors` if callback promise is resolved', async () => {
+    const handleApiErrors = jest.fn();
+
+    const wrapper: FunctionComponent = ({ children }) => (
+      <ErrorControlContextProvider
+        value={{
+          handleApiErrors,
+          handleManualErrors: {
+            forbidden: noop,
+          },
+        }}
+      >
+        {children}
+      </ErrorControlContextProvider>
+    );
+
+    const { result, waitForNextUpdate } = renderHook(
+      () => useAsyncHandledRetry(() => Promise.resolve('some value')),
+      { wrapper },
+    );
+
+    await waitForNextUpdate();
+
+    expect(handleApiErrors).not.toHaveBeenCalled();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.value).toBe('some value');
+  });
+});

--- a/src/explore-education-statistics-common/src/hooks/__tests__/useAsyncRetry.test.ts
+++ b/src/explore-education-statistics-common/src/hooks/__tests__/useAsyncRetry.test.ts
@@ -85,4 +85,56 @@ describe('useAsyncRetry', () => {
     expect(result.current.value).toBeUndefined();
     expect(result.current.error).toEqual(new Error('some error'));
   });
+
+  test('resets to initial state when dependencies change', async () => {
+    const { result, rerender, waitForNextUpdate } = renderHook(
+      ({ deps }) => useAsyncRetry(() => Promise.resolve('some value'), deps),
+      {
+        initialProps: {
+          deps: ['first-dep'],
+        },
+      },
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.value).toBe('some value');
+    expect(result.current.error).toBeUndefined();
+
+    rerender({ deps: ['second-dep'] });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.value).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.value).toBe('some value');
+    expect(result.current.error).toBeUndefined();
+  });
+
+  test('does not reset to initial state if dependencies do not change', async () => {
+    const { result, rerender, waitForNextUpdate } = renderHook(
+      ({ deps }) => useAsyncRetry(() => Promise.resolve('some value'), deps),
+      {
+        initialProps: {
+          deps: ['first-dep'],
+        },
+      },
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.value).toBe('some value');
+    expect(result.current.error).toBeUndefined();
+
+    rerender({ deps: ['first-dep'] });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.value).toBe('some value');
+    expect(result.current.error).toBeUndefined();
+  });
 });

--- a/src/explore-education-statistics-common/src/hooks/__tests__/useAsyncRetry.test.ts
+++ b/src/explore-education-statistics-common/src/hooks/__tests__/useAsyncRetry.test.ts
@@ -1,0 +1,88 @@
+import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import { renderHook } from '@testing-library/react-hooks';
+
+describe('useAsyncRetry', () => {
+  test('returns correct state when callback has not completed', () => {
+    const { result } = renderHook(() =>
+      useAsyncRetry(() => Promise.resolve('some value')),
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.value).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+  });
+
+  test('returns correct state when callback promise is resolved', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAsyncRetry(() => Promise.resolve('some value')),
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.value).toBe('some value');
+    expect(result.current.error).toBeUndefined();
+  });
+
+  test('returns correct state when callback promise is rejected', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAsyncRetry(() => Promise.reject(new Error('some error'))),
+    );
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.value).toBeUndefined();
+    expect(result.current.error).toEqual(new Error('some error'));
+  });
+
+  test('resets state when `retry` is called', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAsyncRetry(() => Promise.resolve('some value')),
+    );
+
+    await waitForNextUpdate();
+
+    result.current.retry();
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.value).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+  });
+
+  test('returns correct state when `retry` has succeeded', async () => {
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAsyncRetry(() => Promise.resolve('some value')),
+    );
+
+    await waitForNextUpdate();
+
+    result.current.retry();
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.value).toBe('some value');
+    expect(result.current.error).toBeUndefined();
+  });
+
+  test('returns correct state when `retry` has failed', async () => {
+    const callback = jest.fn(() => Promise.resolve('some value'));
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useAsyncRetry(callback),
+    );
+
+    await waitForNextUpdate();
+
+    callback.mockImplementation(() => Promise.reject(new Error('some error')));
+
+    result.current.retry();
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.value).toBeUndefined();
+    expect(result.current.error).toEqual(new Error('some error'));
+  });
+});

--- a/src/explore-education-statistics-common/src/hooks/__tests__/usePrevious.test.ts
+++ b/src/explore-education-statistics-common/src/hooks/__tests__/usePrevious.test.ts
@@ -1,0 +1,24 @@
+import usePrevious from '@common/hooks/usePrevious';
+import { renderHook } from '@testing-library/react-hooks';
+
+describe('usePrevious', () => {
+  test('returns undefined for initial render', () => {
+    const { result } = renderHook(() => usePrevious('first'));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  test('returns previous value when updated with new value', async () => {
+    const { result, rerender } = renderHook(({ value }) => usePrevious(value), {
+      initialProps: {
+        value: 'first',
+      },
+    });
+
+    rerender({
+      value: 'second',
+    });
+
+    expect(result.current).toBe('first');
+  });
+});

--- a/src/explore-education-statistics-common/src/hooks/useAsyncHandledRetry.ts
+++ b/src/explore-education-statistics-common/src/hooks/useAsyncHandledRetry.ts
@@ -6,11 +6,13 @@ import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 import { DependencyList, useEffect, useMemo } from 'react';
 
+export type AsyncHandledStateSetter<T> = OmitStrict<AsyncState<T>, 'error'>;
+
 export type AsyncHandledRetryState<T> = OmitStrict<
   AsyncRetryState<T>,
   'error' | 'setState'
 > & {
-  setState: (state: OmitStrict<AsyncState<T>, 'error'>) => void;
+  setState: (state: AsyncHandledStateSetter<T>) => void;
 };
 
 /**
@@ -23,7 +25,7 @@ export type AsyncHandledRetryState<T> = OmitStrict<
 export default function useAsyncHandledRetry<T>(
   task: () => Promise<T>,
   deps: DependencyList = [],
-  initialState?: AsyncState<T>,
+  initialState?: AsyncHandledStateSetter<T>,
 ): AsyncHandledRetryState<T> {
   const { handleApiErrors } = useErrorControl();
 

--- a/src/explore-education-statistics-common/src/hooks/useAsyncRetry.ts
+++ b/src/explore-education-statistics-common/src/hooks/useAsyncRetry.ts
@@ -1,8 +1,10 @@
 import useAsyncCallback, {
   AsyncCallbackState,
-  AsyncState,
+  AsyncStateSetter,
 } from '@common/hooks/useAsyncCallback';
-import { DependencyList, useCallback, useEffect } from 'react';
+import usePrevious from '@common/hooks/usePrevious';
+import isEqual from 'lodash/isEqual';
+import { DependencyList, useCallback, useEffect, useMemo } from 'react';
 
 export interface AsyncRetryState<T> extends AsyncCallbackState<T> {
   retry: () => void;
@@ -16,10 +18,12 @@ export interface AsyncRetryState<T> extends AsyncCallbackState<T> {
 export default function useAsyncRetry<T>(
   task: () => Promise<T>,
   deps: DependencyList = [],
-  initialState: AsyncState<T> = {
+  initialState: AsyncStateSetter<T> = {
     isLoading: true,
   },
 ): AsyncRetryState<T> {
+  const prevDeps = usePrevious<DependencyList>(deps);
+
   const [state, run] = useAsyncCallback<T, []>(task, deps, initialState);
   const { isLoading } = state;
 
@@ -33,8 +37,23 @@ export default function useAsyncRetry<T>(
     }
   }, [isLoading, run]);
 
-  return {
-    ...state,
-    retry,
-  };
+  return useMemo(() => {
+    // The current state is only valid for the previous
+    // dependencies, so we have to reset to initial
+    // state if the dependencies change.
+    // This avoids potential stale state issues due
+    // to the task not having ran yet.
+    if (prevDeps && !isEqual(prevDeps, deps)) {
+      return {
+        isLoading: true,
+        setState: state.setState,
+        retry,
+      };
+    }
+
+    return {
+      ...state,
+      retry,
+    };
+  }, [deps, prevDeps, retry, state]);
 }

--- a/src/explore-education-statistics-common/src/hooks/useAsyncRetry.ts
+++ b/src/explore-education-statistics-common/src/hooks/useAsyncRetry.ts
@@ -16,7 +16,9 @@ export interface AsyncRetryState<T> extends AsyncCallbackState<T> {
 export default function useAsyncRetry<T>(
   task: () => Promise<T>,
   deps: DependencyList = [],
-  initialState?: AsyncState<T>,
+  initialState: AsyncState<T> = {
+    isLoading: true,
+  },
 ): AsyncRetryState<T> {
   const [state, run] = useAsyncCallback<T, []>(task, deps, initialState);
   const { isLoading } = state;

--- a/src/explore-education-statistics-common/src/hooks/usePrevious.ts
+++ b/src/explore-education-statistics-common/src/hooks/usePrevious.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Hook that returns the previous render's
+ * version of a given {@param value}.
+ */
+export default function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T>();
+
+  useEffect(() => {
+    ref.current = value;
+  });
+
+  return ref.current;
+}

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockRenderer.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockRenderer.tsx
@@ -1,6 +1,8 @@
+import ErrorBoundary from '@common/components/ErrorBoundary';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
+import WarningMessage from '@common/components/WarningMessage';
 import ChartRenderer from '@common/modules/charts/components/ChartRenderer';
 import { GetInfographic } from '@common/modules/charts/components/InfographicBlock';
 import { AxesConfiguration } from '@common/modules/charts/types/chart';
@@ -45,38 +47,54 @@ const DataBlockRenderer = ({
   );
 
   return (
-    <LoadingSpinner loading={isLoading}>
-      <Tabs id={id} onToggle={onToggle}>
-        {firstTabs}
+    <ErrorBoundary
+      fallback={<WarningMessage>Could not load content</WarningMessage>}
+    >
+      <LoadingSpinner loading={isLoading}>
+        <Tabs id={id} onToggle={onToggle}>
+          {firstTabs}
 
-        {dataBlock?.charts?.length && fullTable && (
-          <TabsSection id={`${id}-charts`} title="Chart">
-            <a
-              className="govuk-visually-hidden"
-              href={`#${id}-tables`}
-              aria-live="assertive"
-            >
-              If you are using a keyboard or a screen reader you may wish to
-              view the accessible table instead. Press enter to switch to the
-              data tables tab.
-            </a>
+          {dataBlock?.charts?.length && fullTable && (
+            <TabsSection id={`${id}-charts`} title="Chart">
+              <a
+                className="govuk-visually-hidden"
+                href={`#${id}-tables`}
+                aria-live="assertive"
+              >
+                If you are using a keyboard or a screen reader you may wish to
+                view the accessible table instead. Press enter to switch to the
+                data tables tab.
+              </a>
 
-            {dataBlock?.charts.map((chart, index) => {
-              const key = index;
+              {dataBlock?.charts.map((chart, index) => {
+                const key = index;
 
-              const axes = { ...chart.axes } as Required<AxesConfiguration>;
+                const axes = { ...chart.axes } as Required<AxesConfiguration>;
 
-              if (
-                axes.major?.dataSets?.some(dataSet => !dataSet.config) &&
-                chart.labels
-              ) {
-                axes.major.dataSets = getLabelDataSetConfigurations(
-                  chart.labels,
-                  axes.major.dataSets,
-                );
-              }
+                if (
+                  axes.major?.dataSets?.some(dataSet => !dataSet.config) &&
+                  chart.labels
+                ) {
+                  axes.major.dataSets = getLabelDataSetConfigurations(
+                    chart.labels,
+                    axes.major.dataSets,
+                  );
+                }
 
-              if (chart.type === 'infographic') {
+                if (chart.type === 'infographic') {
+                  return (
+                    <ChartRenderer
+                      {...chart}
+                      key={key}
+                      axes={axes}
+                      data={fullTable?.results}
+                      meta={fullTable?.subjectMeta}
+                      source={dataBlock?.source}
+                      getInfographic={getInfographic}
+                    />
+                  );
+                }
+
                 return (
                   <ChartRenderer
                     {...chart}
@@ -85,55 +103,43 @@ const DataBlockRenderer = ({
                     data={fullTable?.results}
                     meta={fullTable?.subjectMeta}
                     source={dataBlock?.source}
-                    getInfographic={getInfographic}
                   />
                 );
-              }
+              })}
 
-              return (
-                <ChartRenderer
-                  {...chart}
-                  key={key}
-                  axes={axes}
-                  data={fullTable?.results}
-                  meta={fullTable?.subjectMeta}
-                  source={dataBlock?.source}
-                />
-              );
-            })}
+              {additionalTabContent}
+            </TabsSection>
+          )}
 
-            {additionalTabContent}
-          </TabsSection>
-        )}
+          {dataBlock?.tables?.length && fullTable && (
+            <TabsSection id={`${id}-tables`} title="Table">
+              {dataBlock?.tables.map((table, index) => {
+                return (
+                  <TimePeriodDataTable
+                    key={index}
+                    fullTable={fullTable}
+                    captionTitle={dataBlock?.heading}
+                    source={dataBlock?.source}
+                    tableHeadersConfig={
+                      table.tableHeaders
+                        ? mapTableHeadersConfig(
+                            table.tableHeaders,
+                            fullTable.subjectMeta,
+                          )
+                        : getDefaultTableHeaderConfig(fullTable.subjectMeta)
+                    }
+                  />
+                );
+              })}
 
-        {dataBlock?.tables?.length && fullTable && (
-          <TabsSection id={`${id}-tables`} title="Table">
-            {dataBlock?.tables.map((table, index) => {
-              return (
-                <TimePeriodDataTable
-                  key={index}
-                  fullTable={fullTable}
-                  captionTitle={dataBlock?.heading}
-                  source={dataBlock?.source}
-                  tableHeadersConfig={
-                    table.tableHeaders
-                      ? mapTableHeadersConfig(
-                          table.tableHeaders,
-                          fullTable.subjectMeta,
-                        )
-                      : getDefaultTableHeaderConfig(fullTable.subjectMeta)
-                  }
-                />
-              );
-            })}
+              {additionalTabContent}
+            </TabsSection>
+          )}
 
-            {additionalTabContent}
-          </TabsSection>
-        )}
-
-        {lastTabs}
-      </Tabs>
-    </LoadingSpinner>
+          {lastTabs}
+        </Tabs>
+      </LoadingSpinner>
+    </ErrorBoundary>
   );
 };
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -99,7 +99,7 @@ const TableToolWizard = ({
     },
   );
 
-  const { value: subjects = [], setValue: setSubjects } = useAsyncRetry<
+  const { value: subjects = [], setState: setSubjects } = useAsyncRetry<
     PublicationSubject[]
   >(async () => {
     if (releaseId) {
@@ -126,7 +126,10 @@ const TableToolWizard = ({
       subjects: publicationSubjects,
     } = await tableBuilderService.getPublicationMeta(selectedPublicationId);
 
-    setSubjects(publicationSubjects);
+    setSubjects({
+      isLoading: false,
+      value: publicationSubjects,
+    });
     setPublication(selectedPublication);
   };
 


### PR DESCRIPTION
This PR fixes data blocks throwing errors and causing release pages to break when navigating to other releases.

This issue stems from stale `useAsyncRetry` state even though its dependencies may have changed. As the async task's effect is ran on the next render, the current render may still be referencing the incorrect state in combination with its new dependencies.  In the case of `DataBlockRenderer`, we will try to call `mapTableHeadersConfig` with the stale table data leading to errors being thrown.

To avoid this, we now do a equality check on the prev/current `useAsyncRetry` dependencies. If the dependencies are different, we reset to the initial state.

For good measure, we also wrap `DataBlockRenderer` with an `ErrorBoundary` that just shows 'Could not load content' if any error is thrown. This should prevent other cases where the data block might stop the entire page rendering.

## Other changes

- Changed `useAsyncCallback`'s to return a `setState` function instead of individual constitutent state setters. This improves the atomicity of the state update and also prevents invalid states being set as we can enforce a stricter setter param type using discriminated unions.
- Added tests for `useAsync*` tests.
- Added `usePrevious` hook for easily inspecting previous values.