### PR TITLE
EES-875 Add Application Insights logging across frontend code

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ConfigurationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ConfigurationController.cs
@@ -15,6 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             _configuration = configuration;
         }
 
+        [AllowAnonymous]
         [HttpGet("api/config")]
         public ActionResult<Dictionary<string, string>> GetConfig()
         {

--- a/src/explore-education-statistics-admin/src/App.tsx
+++ b/src/explore-education-statistics-admin/src/App.tsx
@@ -2,13 +2,37 @@ import apiAuthorizationRouteList from '@admin/components/api-authorization/ApiAu
 import PageErrorBoundary from '@admin/components/PageErrorBoundary';
 import ProtectedRoute from '@admin/components/ProtectedRoute';
 import ThemeAndTopic from '@admin/components/ThemeAndTopic';
+import { getConfig } from '@admin/config';
 import { AuthContextProvider } from '@admin/contexts/AuthContext';
-import React from 'react';
-import { Route, Switch } from 'react-router';
+import {
+  ApplicationInsightsContextProvider,
+  useApplicationInsights,
+} from '@common/contexts/ApplicationInsightsContext';
+import React, { useEffect } from 'react';
+import { Route, Switch, useHistory } from 'react-router';
 import { BrowserRouter } from 'react-router-dom';
 import './App.scss';
 import PageNotFoundPage from './pages/errors/PageNotFoundPage';
 import appRouteList from './routes/dashboard/routes';
+
+function ApplicationInsightsTracking() {
+  const appInsights = useApplicationInsights();
+  const history = useHistory();
+
+  useEffect(() => {
+    appInsights.trackPageView({
+      uri: history.location.pathname,
+    });
+
+    history.listen(location => {
+      appInsights.trackPageView({
+        uri: location.pathname,
+      });
+    });
+  }, [appInsights, history]);
+
+  return null;
+}
 
 function App() {
   const authRoutes = Object.entries(apiAuthorizationRouteList).map(
@@ -28,22 +52,28 @@ function App() {
   });
 
   return (
-    <ThemeAndTopic>
-      <BrowserRouter>
-        <AuthContextProvider>
-          <PageErrorBoundary>
-            <Switch>
-              {authRoutes}
-              {appRoutes}
-              <ProtectedRoute
-                allowAnonymousUsers
-                component={PageNotFoundPage}
-              />
-            </Switch>
-          </PageErrorBoundary>
-        </AuthContextProvider>
-      </BrowserRouter>
-    </ThemeAndTopic>
+    <ApplicationInsightsContextProvider
+      instrumentationKey={getConfig().then(config => config.AppInsightsKey)}
+    >
+      <ThemeAndTopic>
+        <BrowserRouter>
+          <ApplicationInsightsTracking />
+
+          <AuthContextProvider>
+            <PageErrorBoundary>
+              <Switch>
+                {authRoutes}
+                {appRoutes}
+                <ProtectedRoute
+                  allowAnonymousUsers
+                  component={PageNotFoundPage}
+                />
+              </Switch>
+            </PageErrorBoundary>
+          </AuthContextProvider>
+        </BrowserRouter>
+      </ThemeAndTopic>
+    </ApplicationInsightsContextProvider>
   );
 }
 

--- a/src/explore-education-statistics-admin/src/index.tsx
+++ b/src/explore-education-statistics-admin/src/index.tsx
@@ -1,6 +1,4 @@
-import { getConfig } from '@admin/config';
 import '@admin/polyfill';
-import { initApplicationInsights } from '@common/services/applicationInsightsService';
 import configureAxios from '@admin/services/utils/configureAxios';
 import { enableES5 } from 'immer';
 import React from 'react';
@@ -11,10 +9,6 @@ process.env.APP_ROOT_ID = 'root';
 
 enableES5();
 configureAxios();
-
-getConfig().then(config => {
-  initApplicationInsights(config.AppInsightsKey);
-});
 
 import('./App').then(({ default: App }) => {
   ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/explore-education-statistics-common/src/contexts/ApplicationInsightsContext.tsx
+++ b/src/explore-education-statistics-common/src/contexts/ApplicationInsightsContext.tsx
@@ -1,0 +1,56 @@
+import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import React, {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+const ApplicationInsightsContext = createContext<
+  ApplicationInsights | undefined
+>(undefined);
+
+interface ApplicationInsightsContextProviderProps {
+  children: ReactNode;
+  instrumentationKey: string | Promise<string>;
+}
+
+export const ApplicationInsightsContextProvider = ({
+  children,
+  instrumentationKey,
+}: ApplicationInsightsContextProviderProps) => {
+  const [isLoading, setLoading] = useState(true);
+  const [appInsights, setAppInsights] = useState<ApplicationInsights>();
+
+  useEffect(() => {
+    import('@common/services/applicationInsightsService').then(
+      async ({ initApplicationInsights }) => {
+        const applicationInsights = initApplicationInsights(
+          await instrumentationKey,
+        );
+
+        setAppInsights(applicationInsights);
+        setLoading(false);
+      },
+    );
+  }, [instrumentationKey]);
+
+  return (
+    <ApplicationInsightsContext.Provider value={appInsights}>
+      {!isLoading ? children : null}
+    </ApplicationInsightsContext.Provider>
+  );
+};
+
+export function useApplicationInsights(): ApplicationInsights {
+  const appInsights = useContext(ApplicationInsightsContext);
+
+  if (!appInsights) {
+    throw new Error(
+      'ApplicationInsightsContextProvider has not been initialised',
+    );
+  }
+
+  return appInsights;
+}

--- a/src/explore-education-statistics-common/src/services/applicationInsightsService.ts
+++ b/src/explore-education-statistics-common/src/services/applicationInsightsService.ts
@@ -1,24 +1,31 @@
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 
-// eslint-disable-next-line import/prefer-default-export
+export { ApplicationInsights };
+
+const appInsights = new ApplicationInsights({
+  config: {
+    autoTrackPageVisitTime: true,
+  },
+});
+
 export function initApplicationInsights(
-  key: string,
-): ApplicationInsights | undefined {
-  if (key) {
-    const appInsights = new ApplicationInsights({
-      config: {
-        instrumentationKey: key,
-        enableAutoRouteTracking: true,
-        autoTrackPageVisitTime: true,
-      },
-    });
+  instrumentationKey: string,
+): ApplicationInsights {
+  if (instrumentationKey) {
+    appInsights.config.instrumentationKey = instrumentationKey;
     appInsights.loadAppInsights();
 
     // eslint-disable-next-line no-console
     console.log('Application Insights initialised');
-
-    return appInsights;
   }
 
-  return undefined;
+  return appInsights;
+}
+
+/**
+ * Escape hatch to get the Application Insights client
+ * directly. Prefer to use context if possible.
+ */
+export function getApplicationInsights(): ApplicationInsights {
+  return appInsights;
 }

--- a/src/explore-education-statistics-common/src/services/applicationInsightsService.ts
+++ b/src/explore-education-statistics-common/src/services/applicationInsightsService.ts
@@ -1,6 +1,9 @@
-import { ApplicationInsights } from '@microsoft/applicationinsights-web';
+import {
+  ApplicationInsights,
+  SeverityLevel,
+} from '@microsoft/applicationinsights-web';
 
-export { ApplicationInsights };
+export { ApplicationInsights, SeverityLevel };
 
 const appInsights = new ApplicationInsights({
   config: {

--- a/src/explore-education-statistics-common/src/services/applicationInsightsService.ts
+++ b/src/explore-education-statistics-common/src/services/applicationInsightsService.ts
@@ -5,6 +5,8 @@ import {
 
 export { ApplicationInsights, SeverityLevel };
 
+let isInitialised = false;
+
 const appInsights = new ApplicationInsights({
   config: {
     autoTrackPageVisitTime: true,
@@ -16,10 +18,14 @@ export function initApplicationInsights(
 ): ApplicationInsights {
   if (instrumentationKey) {
     appInsights.config.instrumentationKey = instrumentationKey;
-    appInsights.loadAppInsights();
 
-    // eslint-disable-next-line no-console
-    console.log('Application Insights initialised');
+    if (!isInitialised) {
+      appInsights.loadAppInsights();
+      isInitialised = true;
+
+      // eslint-disable-next-line no-console
+      console.log('Application Insights initialised');
+    }
   }
 
   return appInsights;

--- a/src/explore-education-statistics-common/src/services/logger.ts
+++ b/src/explore-education-statistics-common/src/services/logger.ts
@@ -1,25 +1,45 @@
+/* eslint-disable no-console */
+import { getApplicationInsights } from '@common/services/applicationInsightsService';
+import { SeverityLevel } from '@microsoft/applicationinsights-web';
+
 const logger = {
   debugGroup(name: string, ...args: unknown[]) {
     if (process.env.NODE_ENV === 'development') {
-      // eslint-disable-next-line no-console
       console.group(name, ...args);
     }
   },
   debugGroupEnd() {
     if (process.env.NODE_ENV === 'development') {
-      // eslint-disable-next-line no-console
       console.groupEnd();
     }
   },
   debug(...args: unknown[]) {
     if (process.env.NODE_ENV === 'development') {
-      // eslint-disable-next-line no-console
       console.log(...args);
     }
   },
-  error(...args: unknown[]) {
-    // eslint-disable-next-line no-console
-    console.error(...args);
+  info(message: string) {
+    console.info(message);
+
+    getApplicationInsights().trackTrace({
+      message,
+      severityLevel: SeverityLevel.Information,
+    });
+  },
+  warn(message: string) {
+    console.warn(message);
+
+    getApplicationInsights().trackTrace({
+      message,
+      severityLevel: SeverityLevel.Warning,
+    });
+  },
+  error(error: Error) {
+    console.error(error);
+
+    getApplicationInsights().trackException({
+      exception: error,
+    });
   },
 };
 

--- a/src/explore-education-statistics-frontend/next.config.js
+++ b/src/explore-education-statistics-frontend/next.config.js
@@ -8,7 +8,9 @@ const withTranspileModules = require('next-transpile-modules');
 const path = require('path');
 
 const envFilePath = fs.existsSync('.env.local') ? '.env.local' : '.env';
-const envConfig = DotEnv.config(fs.readFileSync(envFilePath));
+const envConfig = DotEnv.config({
+  path: envFilePath,
+});
 
 const createPlugin = plugin => {
   return (nextConfig = {}) =>

--- a/src/explore-education-statistics-frontend/server.js
+++ b/src/explore-education-statistics-frontend/server.js
@@ -144,6 +144,8 @@ async function startServer(port = process.env.PORT || 3000) {
 }
 
 startServer().catch(err => {
+  appInsights.defaultClient.trackException({ exception: err });
+
   console.error(err);
   process.exit(1);
 });


### PR DESCRIPTION
This PR adds Application Insights tracking/logging to the public frontend and admin. 

 We now try to log errors in as many places as possible such as:

- Error boundary components
- Next's `_error` page
- `logger.error`
- Public frontend server startup errors

Additionally, we have also enabled page view tracking by hooking into each app's respective router and detecting changes to the URL.

As part of this, we have also introduced a new `ApplicationInsightsContext` for better integration with React. This can be accessed in components using the `useApplicationInsights` hook.