### PR TITLE
EES-901 Add IE browser warnings to admin content pages

### DIFF
--- a/src/explore-education-statistics-admin/package-lock.json
+++ b/src/explore-education-statistics-admin/package-lock.json
@@ -3198,135 +3198,6 @@
         }
       }
     },
-    "@microsoft/applicationinsights-analytics-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.5.4.tgz",
-      "integrity": "sha512-Eda0bcThQJA/zNVzmU3+Vo9WJT/55LzUxpEATOCB6BbN1uGGUp3hGOdlV/hRl652TPutXII/gvhg8Z4uqq+VsA==",
-      "requires": {
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "@microsoft/dynamicproto-js": "^0.5.2",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-channel-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.5.4.tgz",
-      "integrity": "sha512-xDgI+7LAT5xPdxbBu/fueufH/j7p+hqfPJkkyG9BYdLa77mp+UfnP1kKjthcsdrhJiVIAbx08hmZpo72espIng==",
-      "requires": {
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-common": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.5.4.tgz",
-      "integrity": "sha512-lrLwBUKqK4SZq2nCegUs/O8Ew2KPtL+JUCARoo6YdT8vSiUSxVk+XvwnMOViv27+NWsM3HpqOcjMn+C3kwULZQ==",
-      "requires": {
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-core-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.5.4.tgz",
-      "integrity": "sha512-U3spLDr99R8X7X7VH49RJhx7KhB8HZpKo7rb3ymFG6z6hB7eWQQyLyMsFnThNJI3sVqwEPCQd7dBs7viheLqjw==",
-      "requires": {
-        "@microsoft/dynamicproto-js": "^0.5.2",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-dependencies-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.5.4.tgz",
-      "integrity": "sha512-C01PkF7nQSYFpHiTo4Ltz5VOJqyTaQMHk2fNLBnyxLF2VhSUlfowPhyS6mGU3miscd5sQuktrlYol7LqjiRCXw==",
-      "requires": {
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "@microsoft/dynamicproto-js": "^0.5.2",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-properties-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.5.4.tgz",
-      "integrity": "sha512-2ueiQYhMiNIf9Iua7zrUGIDBiO8zPLau1yBePqLvEQ2CewBE9ZrTbdqhzpBrUQUKFbmWlETXYsIWQNz+T2rRfw==",
-      "requires": {
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-web": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.5.4.tgz",
-      "integrity": "sha512-5nBgxEDkM61E0irdi78DcEwfiLvYueyU5tQsCxovPfhbt5Ub8KzzT8cvmrh6p9Rt9DcpKP/uHD8k6OqMvdgvVg==",
-      "requires": {
-        "@microsoft/applicationinsights-analytics-js": "2.5.4",
-        "@microsoft/applicationinsights-channel-js": "2.5.4",
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "@microsoft/applicationinsights-dependencies-js": "2.5.4",
-        "@microsoft/applicationinsights-properties-js": "2.5.4",
-        "@microsoft/dynamicproto-js": "^0.5.2",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/dynamicproto-js": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-0.5.2.tgz",
-      "integrity": "sha512-tGwZJLtLVK96OKl5/pHeZFgi28rnKJB2DQ0V/28SVQnv9tC/OXCNOrvvvtIZM6wp1YJwqVSFnyp46w3azDjC0Q=="
-    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -10936,9 +10807,9 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "immer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.3.tgz",
-      "integrity": "sha512-12VvNrfSrXZdm/BJgi/KDW2soq5freVSf3I1+4CLunUM8mAGx2/0Njy0xBVzi5zewQZiwM7z1/1T+8VaI7NkmQ=="
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.5.tgz",
+      "integrity": "sha512-TtRAKZyuqld2eYjvWgXISLJ0ZlOl1OOTzRmrmiY8SlB0dnAhZ1OiykIDL5KDFNaPHDXiLfGQFNJGtet8z8AEmg=="
     },
     "import-cwd": {
       "version": "2.1.0",

--- a/src/explore-education-statistics-admin/package.json
+++ b/src/explore-education-statistics-admin/package.json
@@ -76,7 +76,7 @@
     "html-webpack-plugin": "4.0.4",
     "i": "^0.3.6",
     "identity-obj-proxy": "3.0.0",
-    "immer": "^6.0.3",
+    "immer": "^7.0.5",
     "jest": "^25.2.7",
     "jest-junit": "^10.0.0",
     "jest-pnp-resolver": "^1.2.1",

--- a/src/explore-education-statistics-admin/src/components/BrowserWarning.tsx
+++ b/src/explore-education-statistics-admin/src/components/BrowserWarning.tsx
@@ -1,0 +1,37 @@
+import isBrowser from '@common/utils/isBrowser';
+import React, { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  id?: string;
+}
+
+const BrowserWarning = ({ children, id = 'browserWarning' }: Props) => {
+  if (!isBrowser('IE')) {
+    return null;
+  }
+
+  return (
+    <div className="govuk-error-summary" role="alert" aria-labelledby={id}>
+      <h2 className="govuk-error-summary__title" id={id}>
+        Incompatible web browser detected
+      </h2>
+
+      <div className="govuk-error-summary__body">
+        <p>
+          The following features on this page are not supported by your web
+          browser:
+        </p>
+
+        {children}
+
+        <p>
+          To enable all features, we recommend changing your web browser to
+          Google Chrome or Microsoft Edge.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default BrowserWarning;

--- a/src/explore-education-statistics-admin/src/components/PageTitle.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageTitle.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
+interface Props {
+  caption?: string;
+  title: string;
+}
+
+const PageTitle = ({ caption, title }: Props) => {
+  return (
+    <>
+      <Helmet>
+        <title>{`${title} - Explore education statistics - GOV.UK`}</title>
+      </Helmet>
+
+      <h1 className="govuk-heading-xl" data-testid={`page-title ${title}`}>
+        {caption && (
+          <span className="govuk-caption-xl" data-testid="page-title-caption">
+            {caption}
+          </span>
+        )}
+        {title}
+      </h1>
+    </>
+  );
+};
+
+export default PageTitle;

--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useState } from 'react';
 import styles from './EditableContentBlock.module.scss';
 
 interface EditableContentBlockProps
-  extends OmitStrict<FormEditorProps, 'onChange'> {
+  extends OmitStrict<FormEditorProps, 'onChange' | 'name'> {
   editable?: boolean;
   id: string;
   onSave: (value: string) => void;
@@ -64,6 +64,7 @@ const EditableContentBlock = ({
       <>
         <FormEditor
           {...props}
+          name="content"
           hideLabel={hideLabel}
           value={content}
           onChange={setContent}

--- a/src/explore-education-statistics-admin/src/components/editable/EditableSectionBlocks.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableSectionBlocks.tsx
@@ -8,6 +8,7 @@ import { EditableBlock } from '@admin/services/types/content';
 import SectionBlocks, {
   SectionBlocksProps,
 } from '@common/modules/find-statistics/components/SectionBlocks';
+import isBrowser from '@common/utils/isBrowser';
 import reorder from '@common/utils/reorder';
 import React, { useCallback } from 'react';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
@@ -103,7 +104,7 @@ const EditableSectionBlocks = (props: EditableSectionBlockProps) => {
 
               <EditableBlockRenderer
                 block={block}
-                editable={!isReordering}
+                editable={!isReordering && !isBrowser('IE')}
                 allowHeadings={allowHeadings}
                 getInfographic={getInfographic}
                 onContentSave={onBlockContentSave}

--- a/src/explore-education-statistics-admin/src/components/form/FormEditor.tsx
+++ b/src/explore-education-statistics-admin/src/components/form/FormEditor.tsx
@@ -5,6 +5,8 @@ import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 // @ts-ignore
 import CKEditor from '@ckeditor/ckeditor5-react';
 import ErrorMessage from '@common/components/ErrorMessage';
+import FormTextArea from '@common/components/form/FormTextArea';
+import isBrowser from '@common/utils/isBrowser';
 import classNames from 'classnames';
 import React, { ChangeEvent, useCallback, useMemo } from 'react';
 
@@ -15,6 +17,7 @@ export interface FormEditorProps {
   hint?: string;
   id: string;
   label: string;
+  name: string;
   toolbarConfig?: string[];
   value: string;
   onChange: (content: string) => void;
@@ -47,6 +50,7 @@ const FormEditor = ({
   hint,
   id,
   label,
+  name,
   toolbarConfig = toolbarConfigs.full,
   value,
   onChange,
@@ -98,6 +102,10 @@ const FormEditor = ({
     },
     [],
   );
+
+  if (isBrowser('IE')) {
+    return <FormTextArea id={id} name={name} label={label} disabled />;
+  }
 
   return (
     <>

--- a/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/modules/find-statistics/PublicationReleaseContent.tsx
@@ -15,10 +15,10 @@ import Details from '@common/components/Details';
 import PageSearchForm from '@common/components/PageSearchForm';
 import RelatedAside from '@common/components/RelatedAside';
 import React, { useCallback, useMemo } from 'react';
+import { CommentsChangeHandler } from './components/Comments';
 import RelatedInformationSection from './components/RelatedInformationSection';
 import ReleaseHeadlines from './components/ReleaseHeadlines';
 import ReleaseNotesSection from './components/ReleaseNotesSection';
-import { CommentsChangeHandler } from './components/Comments';
 
 const PublicationReleaseContent = () => {
   const { value: config } = useConfig();
@@ -95,10 +95,10 @@ const PublicationReleaseContent = () => {
 
   return (
     <>
-      <h1 className="govuk-heading-l dfe-print-break-before">
+      <h2 className="govuk-heading-l dfe-print-break-before">
         <span className="govuk-caption-l">{release.title}</span>
         {release.publication.title}
-      </h1>
+      </h2>
 
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/MethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/MethodologyPage.tsx
@@ -1,6 +1,7 @@
 import Link from '@admin/components/Link';
 import NavBar from '@admin/components/NavBar';
 import Page from '@admin/components/Page';
+import PageTitle from '@admin/components/PageTitle';
 import PreviousNextLinks from '@admin/components/PreviousNextLinks';
 import methodologyRoutes, {
   MethodologyRouteParams,
@@ -67,10 +68,7 @@ const MethodologyPage = ({
           <>
             <div className="govuk-grid-row">
               <div className="govuk-grid-column-two-thirds">
-                <h1 className="govuk-heading-xl">
-                  <span className="govuk-caption-xl">Edit methodology</span>
-                  {value?.title}
-                </h1>
+                <PageTitle title={value.title} caption="Edit methodology" />
               </div>
 
               <div className="govuk-grid-column-one-third">

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/MethodologyContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/MethodologyContentPage.tsx
@@ -1,3 +1,4 @@
+import BrowserWarning from '@admin/components/BrowserWarning';
 import EditablePageModeToggle from '@admin/components/editable/EditablePageModeToggle';
 import { EditingContextProvider } from '@admin/contexts/EditingContext';
 import PrintThisPage from '@admin/modules/find-statistics/components/PrintThisPage';
@@ -31,6 +32,14 @@ const MethodologyContentPageInternal = () => {
             <section
               className={isEditing ? 'dfe-page-editing' : 'dfe-page-preview'}
             >
+              {isEditing && (
+                <BrowserWarning>
+                  <ul>
+                    <li>Editing text blocks</li>
+                  </ul>
+                </BrowserWarning>
+              )}
+
               <h2
                 aria-hidden
                 className="govuk-heading-lg"

--- a/src/explore-education-statistics-admin/src/pages/release/ManageReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ManageReleasePageContainer.tsx
@@ -1,6 +1,7 @@
 import Link from '@admin/components/Link';
 import NavBar from '@admin/components/NavBar';
 import Page from '@admin/components/Page';
+import PageTitle from '@admin/components/PageTitle';
 import PreviousNextLinks from '@admin/components/PreviousNextLinks';
 import { getReleaseStatusLabel } from '@admin/pages/release/util/releaseSummaryUtil';
 import releaseRoutes, { viewRoutes } from '@admin/routes/edit-release/routes';
@@ -81,14 +82,14 @@ const ManageReleasePageContainer = ({
         <Page wide breadcrumbs={[{ name: 'Edit release' }]}>
           <div className="govuk-grid-row">
             <div className="govuk-grid-column-two-thirds">
-              <h1 className="govuk-heading-xl">
-                <span className="govuk-caption-xl">
-                  {releasePublicationStatus.amendment
+              <PageTitle
+                title={publication.title}
+                caption={
+                  releasePublicationStatus.amendment
                     ? 'Amend release'
-                    : 'Edit release'}
-                </span>
-                {publication.title}
-              </h1>
+                    : 'Edit release'
+                }
+              />
             </div>
 
             <div className="govuk-grid-column-one-third">

--- a/src/explore-education-statistics-admin/src/pages/release/edit-release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/edit-release/content/ReleaseContentPage.tsx
@@ -1,3 +1,4 @@
+import BrowserWarning from '@admin/components/BrowserWarning';
 import EditablePageModeToggle from '@admin/components/editable/EditablePageModeToggle';
 import { EditingContextProvider } from '@admin/contexts/EditingContext';
 import PublicationReleaseContent from '@admin/modules/find-statistics/PublicationReleaseContent';
@@ -31,6 +32,16 @@ const ReleaseContentPageLoaded = () => {
     >
       {({ isEditing }) => (
         <>
+          {isEditing && (
+            <BrowserWarning>
+              <ul>
+                <li>Editing key statistic guidance text</li>
+                <li>Editing headline text</li>
+                <li>Editing text blocks</li>
+              </ul>
+            </BrowserWarning>
+          )}
+
           {canUpdateRelease && (
             <div className="govuk-form-group">
               {unresolvedComments.length > 0 && (

--- a/src/explore-education-statistics-common/package-lock.json
+++ b/src/explore-education-statistics-common/package-lock.json
@@ -9295,17 +9295,23 @@
       "dev": true
     },
     "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.0.0.tgz",
+      "integrity": "sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@babel/runtime": "^7.7.6"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
+          "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "hmac-drbg": {
@@ -9532,9 +9538,9 @@
       "dev": true
     },
     "immer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.3.tgz",
-      "integrity": "sha512-12VvNrfSrXZdm/BJgi/KDW2soq5freVSf3I1+4CLunUM8mAGx2/0Njy0xBVzi5zewQZiwM7z1/1T+8VaI7NkmQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.5.tgz",
+      "integrity": "sha512-TtRAKZyuqld2eYjvWgXISLJ0ZlOl1OOTzRmrmiY8SlB0dnAhZ1OiykIDL5KDFNaPHDXiLfGQFNJGtet8z8AEmg==",
       "dev": true
     },
     "import-fresh": {
@@ -16429,12 +16435,6 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "dev": true
-    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -18898,12 +18898,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "dev": true
     },
     "vary": {
       "version": "1.1.2",

--- a/src/explore-education-statistics-common/package.json
+++ b/src/explore-education-statistics-common/package.json
@@ -52,7 +52,7 @@
     "govuk-frontend": "^3.6.0",
     "history": "latest",
     "identity-obj-proxy": "^3.0.0",
-    "immer": "^6.0.3",
+    "immer": "^7.0.5",
     "intersection-observer": "^0.7.0",
     "jest": "^25.2.7",
     "jest-junit": "^10.0.0",

--- a/src/explore-education-statistics-common/src/components/form/FormTextArea.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormTextArea.tsx
@@ -12,6 +12,7 @@ import ErrorMessage from '../ErrorMessage';
 
 export interface FormTextAreaProps extends FormLabelProps {
   className?: string;
+  disabled?: boolean;
   error?: ReactNode | string;
   hint?: string;
   id: string;
@@ -27,6 +28,7 @@ export interface FormTextAreaProps extends FormLabelProps {
 
 const FormTextArea = ({
   className,
+  disabled,
   error,
   hint,
   id,
@@ -62,6 +64,7 @@ const FormTextArea = ({
           'govuk-js-character-count govuk-textarea--error':
             maxLength && (value?.length ?? 0) > maxLength,
         })}
+        disabled={disabled}
         id={id}
         rows={rows}
         value={value}

--- a/src/explore-education-statistics-common/src/styles/_form.scss
+++ b/src/explore-education-statistics-common/src/styles/_form.scss
@@ -1,3 +1,8 @@
 .govuk-form-group:last-child {
   margin-bottom: 0;
 }
+
+.govuk-input[disabled],
+.govuk-textarea[disabled] {
+  cursor: not-allowed;
+}

--- a/src/explore-education-statistics-common/src/utils/isBrowser.ts
+++ b/src/explore-education-statistics-common/src/utils/isBrowser.ts
@@ -1,0 +1,11 @@
+type ExpectedBrowser = 'IE';
+
+export default function isBrowser(browser: ExpectedBrowser): boolean {
+  switch (browser) {
+    case 'IE':
+      // @ts-ignore
+      return !!document.documentMode;
+    default:
+      throw new Error('Invalid browser argument');
+  }
+}

--- a/src/explore-education-statistics-frontend/package-lock.json
+++ b/src/explore-education-statistics-frontend/package-lock.json
@@ -4085,153 +4085,6 @@
         }
       }
     },
-    "@microsoft/applicationinsights-analytics-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-2.5.4.tgz",
-      "integrity": "sha512-Eda0bcThQJA/zNVzmU3+Vo9WJT/55LzUxpEATOCB6BbN1uGGUp3hGOdlV/hRl652TPutXII/gvhg8Z4uqq+VsA==",
-      "requires": {
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "@microsoft/dynamicproto-js": "^0.5.2",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-channel-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-2.5.4.tgz",
-      "integrity": "sha512-xDgI+7LAT5xPdxbBu/fueufH/j7p+hqfPJkkyG9BYdLa77mp+UfnP1kKjthcsdrhJiVIAbx08hmZpo72espIng==",
-      "requires": {
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-common": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-2.5.4.tgz",
-      "integrity": "sha512-lrLwBUKqK4SZq2nCegUs/O8Ew2KPtL+JUCARoo6YdT8vSiUSxVk+XvwnMOViv27+NWsM3HpqOcjMn+C3kwULZQ==",
-      "requires": {
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-core-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.5.4.tgz",
-      "integrity": "sha512-U3spLDr99R8X7X7VH49RJhx7KhB8HZpKo7rb3ymFG6z6hB7eWQQyLyMsFnThNJI3sVqwEPCQd7dBs7viheLqjw==",
-      "requires": {
-        "@microsoft/dynamicproto-js": "^0.5.2",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-dependencies-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-2.5.4.tgz",
-      "integrity": "sha512-C01PkF7nQSYFpHiTo4Ltz5VOJqyTaQMHk2fNLBnyxLF2VhSUlfowPhyS6mGU3miscd5sQuktrlYol7LqjiRCXw==",
-      "requires": {
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "@microsoft/dynamicproto-js": "^0.5.2",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-properties-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-2.5.4.tgz",
-      "integrity": "sha512-2ueiQYhMiNIf9Iua7zrUGIDBiO8zPLau1yBePqLvEQ2CewBE9ZrTbdqhzpBrUQUKFbmWlETXYsIWQNz+T2rRfw==",
-      "requires": {
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-react-js": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-react-js/-/applicationinsights-react-js-2.5.4.tgz",
-      "integrity": "sha512-BB8Od5ikGYkaN6VqxciUycfF3xY/8V2/sdoIyLZVz4310kQLamogwQtcMu1bb3gI9qpreSD/JzkiSSQa9GkQ2g==",
-      "requires": {
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "history": "^4.9.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/applicationinsights-web": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-2.5.4.tgz",
-      "integrity": "sha512-5nBgxEDkM61E0irdi78DcEwfiLvYueyU5tQsCxovPfhbt5Ub8KzzT8cvmrh6p9Rt9DcpKP/uHD8k6OqMvdgvVg==",
-      "requires": {
-        "@microsoft/applicationinsights-analytics-js": "2.5.4",
-        "@microsoft/applicationinsights-channel-js": "2.5.4",
-        "@microsoft/applicationinsights-common": "2.5.4",
-        "@microsoft/applicationinsights-core-js": "2.5.4",
-        "@microsoft/applicationinsights-dependencies-js": "2.5.4",
-        "@microsoft/applicationinsights-properties-js": "2.5.4",
-        "@microsoft/dynamicproto-js": "^0.5.2",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
-      }
-    },
-    "@microsoft/dynamicproto-js": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-0.5.2.tgz",
-      "integrity": "sha512-tGwZJLtLVK96OKl5/pHeZFgi28rnKJB2DQ0V/28SVQnv9tC/OXCNOrvvvtIZM6wp1YJwqVSFnyp46w3azDjC0Q=="
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -10634,19 +10487,6 @@
       "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.1.0.tgz",
       "integrity": "sha512-Io1zA2yOA1YJslkr+AJlWSf2yWFkKjvkcL9Ni1XSUqnGLr/qRQe2UI3Cn/J9MsJht7yEVCe0SscY1HgVMujbgg=="
     },
-    "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -10934,9 +10774,9 @@
       "dev": true
     },
     "immer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.3.tgz",
-      "integrity": "sha512-12VvNrfSrXZdm/BJgi/KDW2soq5freVSf3I1+4CLunUM8mAGx2/0Njy0xBVzi5zewQZiwM7z1/1T+8VaI7NkmQ=="
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.5.tgz",
+      "integrity": "sha512-TtRAKZyuqld2eYjvWgXISLJ0ZlOl1OOTzRmrmiY8SlB0dnAhZ1OiykIDL5KDFNaPHDXiLfGQFNJGtet8z8AEmg=="
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -21249,11 +21089,6 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
-    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -23878,11 +23713,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/src/explore-education-statistics-frontend/package.json
+++ b/src/explore-education-statistics-frontend/package.json
@@ -16,7 +16,7 @@
     "formik": "^2.1.4",
     "govuk-frontend": "^3.6.0",
     "helmet": "^3.22.0",
-    "immer": "^6.0.3",
+    "immer": "^7.0.5",
     "leaflet": "^1.6.0",
     "lodash": "^4.17.15",
     "memoizee": "^0.4.14",


### PR DESCRIPTION
This PR adds the following warning message to the top of the release and methodology content pages:

![image](https://user-images.githubusercontent.com/9917868/85539560-e3bf0c00-b60d-11ea-9294-e70993498105.png)

We also prevent the user from editing any `FormEditor` components if it is detected they are using IE. This prevents them from having the false perception that they can actually edit the content and gives them a hard nudge to change browser.

## Other changes

- Adds proper page titles to release/methodology pages. This was mainly motivated by the incorrect heading tag hierarchy used for the release content page. This relates to the wider issue EES-68 for adding proper page titles across the admin.
- Upgraded Immer to v7. This was previously causing out of stack space crashes on IE11.