### PR TITLE
EES-1077 Use sequentially generated Guid's

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -390,7 +391,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         userService.Object,
                         repository.Object,
                         subjectService.Object, tableStorageService.Object, fileStorageService.Object,
-                        importStatusService.Object, footnoteService.Object, statisticsDbContext, dataBlockService.Object);
+                        importStatusService.Object, footnoteService.Object, statisticsDbContext, dataBlockService.Object, new SequentialGuidGenerator());
 
                     // Method under test 
                     var amendmentViewModel = releaseService.CreateReleaseAmendmentAsync(releaseId).Result.Right;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -179,7 +180,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             
             var service = new ReleaseService(contentDbContext.Object, AdminMapper(), 
                 publishingService.Object, releaseHelper.Object, userService.Object, repository.Object,
-                subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object);
+                subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
             
             var result = await service.GetMyReleasesForReleaseStatusesAsync(ReleaseStatus.Approved);
             Assert.Equal(list, result.Right);
@@ -224,7 +225,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             
             var service = new ReleaseService(contentDbContext.Object, AdminMapper(), 
                 publishingService.Object, releaseHelper.Object, userService.Object, repository.Object,
-                subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object);
+                subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
             
             var result = await service.GetMyReleasesForReleaseStatusesAsync(ReleaseStatus.Approved);
             
@@ -251,7 +252,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             
             var service = new ReleaseService(contentDbContext.Object, AdminMapper(), 
                 publishingService.Object, releaseHelper.Object, userService.Object, repository.Object,
-                subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object);
+                subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
             
             var result = await service.GetMyReleasesForReleaseStatusesAsync(ReleaseStatus.Approved);
             
@@ -281,7 +282,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var service = new ReleaseService(contentDbContext.Object, AdminMapper(), 
                 publishingService.Object, releaseHelper.Object, userService.Object, repository.Object,
-                subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object);
+                subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
 
             PermissionTestUtil.AssertSecurityPoliciesChecked(protectedAction, protectedEntity, userService, service, policies);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -151,12 +151,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 _release,
                 CanDeleteSpecificRelease);
         }
-        
+
         [Fact]
         public async void GetMyReleasesForReleaseStatusesAsync_CanViewAllReleases()
         {
-            var (userService, releaseHelper, publishingService, contentDbContext, repository, 
-                subjectService, tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
+            var mocks = Mocks();
+            var repository = mocks.ReleaseRepository;
+            var userService = mocks.UserService;
 
             var list = new List<MyReleaseViewModel>
             {
@@ -165,11 +166,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Id = Guid.NewGuid()
                 }
             };
-            
+
             userService
                 .Setup(s => s.MatchesPolicy(CanAccessSystem))
                 .ReturnsAsync(true);
-            
+
             userService
                 .Setup(s => s.MatchesPolicy(CanViewAllReleases))
                 .ReturnsAsync(true);
@@ -177,14 +178,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             repository
                 .Setup(s => s.GetAllReleasesForReleaseStatusesAsync(ReleaseStatus.Approved))
                 .ReturnsAsync(list);
-            
-            var service = new ReleaseService(contentDbContext.Object, AdminMapper(), 
-                publishingService.Object, releaseHelper.Object, userService.Object, repository.Object,
-                subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
-            
+
+            var service = BuildReleaseService(mocks);
+
             var result = await service.GetMyReleasesForReleaseStatusesAsync(ReleaseStatus.Approved);
             Assert.Equal(list, result.Right);
-            
+
             userService.Verify(s => s.MatchesPolicy(CanAccessSystem));
             userService.Verify(s => s.MatchesPolicy(CanViewAllReleases));
             userService.VerifyNoOtherCalls();
@@ -196,8 +195,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void GetMyReleasesForReleaseStatusesAsync_CanViewRelatedReleases()
         {
-            var (userService, releaseHelper, publishingService, contentDbContext, repository, 
-                subjectService, tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
+            var mocks = Mocks();
+            var repository = mocks.ReleaseRepository;
+            var userService = mocks.UserService;
 
             var list = new List<MyReleaseViewModel>
             {
@@ -222,10 +222,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             repository
                 .Setup(s => s.GetReleasesForReleaseStatusRelatedToUserAsync(_userId, ReleaseStatus.Approved))
                 .ReturnsAsync(list);
-            
-            var service = new ReleaseService(contentDbContext.Object, AdminMapper(), 
-                publishingService.Object, releaseHelper.Object, userService.Object, repository.Object,
-                subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
+
+            var service = BuildReleaseService(mocks);
             
             var result = await service.GetMyReleasesForReleaseStatusesAsync(ReleaseStatus.Approved);
             
@@ -243,17 +241,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void GetMyReleasesForReleaseStatusesAsync_NoAccessToSystem()
         {
-            var (userService, releaseHelper, publishingService, contentDbContext, repository, 
-                subjectService, tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
+            var mocks = Mocks();
+            var repository = mocks.ReleaseRepository;
+            var userService = mocks.UserService;
 
-            userService
+            mocks.UserService
                 .Setup(s => s.MatchesPolicy(CanAccessSystem))
                 .ReturnsAsync(false);
-            
-            var service = new ReleaseService(contentDbContext.Object, AdminMapper(), 
-                publishingService.Object, releaseHelper.Object, userService.Object, repository.Object,
-                subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
-            
+
+            var service = BuildReleaseService(mocks);
             var result = await service.GetMyReleasesForReleaseStatusesAsync(ReleaseStatus.Approved);
             
             Assert.IsAssignableFrom<ForbidResult>(result.Left);
@@ -272,34 +268,52 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 _release,
                 CanUpdateSpecificRelease);
         }
-        
+
+        private static ReleaseService BuildReleaseService((Mock<IUserService> userService,
+            Mock<IPersistenceHelper<ContentDbContext>> persistenceHelper,
+            Mock<IPublishingService> publishingService,
+            Mock<ContentDbContext> contentDbContext,
+            Mock<IReleaseRepository> releaseRepository,
+            Mock<ISubjectService> subjectService,
+            Mock<ITableStorageService> tableStorageService,
+            Mock<IFileStorageService> fileStorageService,
+            Mock<IImportStatusService> importStatusService,
+            Mock<IFootnoteService> footnoteService,
+            Mock<StatisticsDbContext> statisticsDbContext,
+            Mock<IDataBlockService> dataBlockService) mocks)
+        {
+            var (userService, persistenceHelper, publishingService, contentDbContext, releaseRepository, subjectService,
+                tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext,
+                dataBlockService) = mocks;
+
+            return new ReleaseService(
+                contentDbContext.Object, AdminMapper(), publishingService.Object, persistenceHelper.Object,
+                userService.Object, releaseRepository.Object, subjectService.Object, tableStorageService.Object,
+                fileStorageService.Object, importStatusService.Object, footnoteService.Object,
+                statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
+        }
+
         private void AssertSecurityPoliciesChecked<T, TEntity>(
             Func<ReleaseService, Task<Either<ActionResult, T>>> protectedAction, TEntity protectedEntity, params SecurityPolicies[] policies)
             where TEntity : class
         {
-            var (userService, releaseHelper, publishingService, contentDbContext, repository, 
-                subjectService, tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
-
-            var service = new ReleaseService(contentDbContext.Object, AdminMapper(), 
-                publishingService.Object, releaseHelper.Object, userService.Object, repository.Object,
-                subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
-
-            PermissionTestUtil.AssertSecurityPoliciesChecked(protectedAction, protectedEntity, userService, service, policies);
+            var mocks = Mocks();
+            var service = BuildReleaseService(mocks);
+            PermissionTestUtil.AssertSecurityPoliciesChecked(protectedAction, protectedEntity, mocks.UserService, service, policies);
         }
-        
-        private (
-            Mock<IUserService>, 
-            Mock<IPersistenceHelper<ContentDbContext>>, 
-            Mock<IPublishingService>,
-            Mock<ContentDbContext>,
-            Mock<IReleaseRepository>,
-            Mock<ISubjectService>,
-            Mock<ITableStorageService>,
-            Mock<IFileStorageService>,
-            Mock<IImportStatusService>,
-            Mock<IFootnoteService>,
-            Mock<StatisticsDbContext>,
-            Mock<IDataBlockService>) Mocks()
+
+        private (Mock<IUserService> UserService,
+            Mock<IPersistenceHelper<ContentDbContext>> PersistenceHelper,
+            Mock<IPublishingService> PublishingService,
+            Mock<ContentDbContext> ContentDbContext,
+            Mock<IReleaseRepository> ReleaseRepository,
+            Mock<ISubjectService> SubjectService,
+            Mock<ITableStorageService> TableStorageService,
+            Mock<IFileStorageService> FileStorageService,
+            Mock<IImportStatusService> ImportStatusService,
+            Mock<IFootnoteService> FootnoteService,
+            Mock<StatisticsDbContext> StatisticsDbContext,
+            Mock<IDataBlockService> DataBlockService) Mocks()
         {
             var persistenceHelper = MockUtils.MockPersistenceHelper<ContentDbContext, Release>();
             MockUtils.SetupCall(persistenceHelper, _release.Id, _release);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -31,7 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void CreateReleaseNoTemplate()
         {
-            var (userService, _, publishingService, repository, subjectService, tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
+            var mocks = Mocks();
 
             var publication = new Publication
             {
@@ -48,10 +48,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext("CreateReleaseNoTemplate"))
             {
-                var releaseService = new ReleaseService(context, AdminMapper(), 
-                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
-                
+                var releaseService = BuildReleaseService(context, mocks);
+
                 var publishScheduled = new DateTime(2050, 6, 30, 14, 0, 0);
 
                 var result = releaseService.CreateReleaseAsync(
@@ -80,7 +78,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void CreateReleaseWithTemplate()
         {
-            var (userService, _, publishingService, repository, subjectService, tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
+            var mocks = Mocks();
             
             var dataBlock1 = new DataBlock
             {
@@ -186,12 +184,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext("Create"))
             {
-                var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
-                
-                // Service method under test
-                var result = releaseService.CreateReleaseAsync(
+                var releaseService = BuildReleaseService(context, mocks);
+                    var result = releaseService.CreateReleaseAsync(
                     new CreateReleaseViewModel
                     {
                         PublicationId = new Guid("403d3c5d-a8cd-4d54-a029-0c74c86c55b2"),
@@ -229,7 +223,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void LatestReleaseCorrectlyReported()
         {
-            var (userService, _, publishingService, repository, subjectService, tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
+            var mocks = Mocks();
 
             var publication = new Publication
             {
@@ -272,24 +266,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             // loading of the entity graph as we go.
             using (var context = InMemoryApplicationDbContext("LatestReleaseCorrectlyReported"))
             {
-                var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
-                
-                // Method under test
+                var releaseService = BuildReleaseService(context, mocks);
                 var notLatest = (await releaseService.GetReleaseForIdAsync(notLatestRelease.Id)).Right;
+                
                 Assert.Equal(notLatestRelease.Id, notLatest.Id);
                 Assert.False(notLatest.LatestRelease);
             }
             
             using (var context = InMemoryApplicationDbContext("LatestReleaseCorrectlyReported"))
             {
-                var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
-                
-                // Method under test
+                var releaseService = BuildReleaseService(context, mocks);
                 var latest = (await releaseService.GetReleaseForIdAsync(latestRelease.Id)).Right;
+                
                 Assert.Equal(latestRelease.Id, latest.Id);
                 Assert.True(latest.LatestRelease);
             }
@@ -298,7 +286,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void EditReleaseSummary()
         {
-            var (userService, _, publishingService, repository, subjectService, tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
+            var mocks = Mocks();
 
             var releaseId = new Guid("02c73027-3e06-4495-82a4-62b778c005a9");
             var addHocReleaseTypeId = new Guid("f3800c32-1e1c-4d42-8165-d1bcb3c8b47c");
@@ -344,11 +332,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             
             using (var context = InMemoryApplicationDbContext("LatestReleaseCorrectlyReported"))
             {
-                var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
-                
-                // Method under test 
+                var releaseService = BuildReleaseService(context, mocks);
                 var edited = await releaseService
                     .EditReleaseSummaryAsync(
                         releaseId,
@@ -377,7 +361,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void GetReleaseSummaryAsync()
         {
-            var (userService, _, publishingService, repository, subjectService, tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
+            var mocks = Mocks();
             
             var releaseId = new Guid("5cf345d4-7f7b-425c-8267-de785cfc040b");
             var adhocReleaseType = new ReleaseType
@@ -420,9 +404,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext("GetReleaseSummaryAsync"))
             {
-                var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
+                var releaseService = BuildReleaseService(context, mocks);
                 
                 // Method under test 
                 var summaryResult = await releaseService.GetReleaseSummaryAsync(releaseId);
@@ -440,7 +422,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void GetLatestReleaseAsync()
         {
-            var (userService, _, publishingService, repository, subjectService, tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
+            var mocks = Mocks();
 
             var publication = new Publication
             {
@@ -510,12 +492,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext("GetReleasesForPublicationAsync"))
             {
-                var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
-
-                // Method under test 
+                var releaseService = BuildReleaseService(context, mocks);
                 var latest = releaseService.GetLatestReleaseAsync(publication.Id).Result.Right;
+
                 Assert.NotNull(latest);
                 Assert.Equal(latestReleaseV1.Id, latest.Id);
                 Assert.Equal("June 2036", latest.Title);
@@ -525,7 +504,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void DeleteReleaseAsync()
         {
-            var (userService, _, publishingService, repository, subjectService, tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
+            var mocks = Mocks();
 
             var publication = new Publication
             {
@@ -584,11 +563,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext("DeleteReleaseAsync"))
             {
-                var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
-
-                // Method under test 
+                var releaseService = BuildReleaseService(context, mocks);
                 var result = releaseService.DeleteReleaseAsync(release.Id).Result.Right;
                 Assert.True(result);
             }
@@ -676,8 +651,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void PublishReleaseAsync()
         {
-            var (userService, _, publishingService, repository, subjectService, tableStorageService, fileStorageService,
-                importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
+            var mocks = Mocks();
 
             var release = new Release
             {
@@ -695,23 +669,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext("PublishReleaseAsync"))
             {
-                var releaseService = new ReleaseService(context,
-                    AdminMapper(),
-                    publishingService.Object,
-                    new PersistenceHelper<ContentDbContext>(context), userService.Object,
-                    repository.Object,
-                    subjectService.Object,
-                    tableStorageService.Object,
-                    fileStorageService.Object,
-                    importStatusService.Object,
-                    footnoteService.Object,
-                    statisticsDbContext.Object,
-                    dataBlockService.Object,
-                    new SequentialGuidGenerator());
-
+                var releaseService = BuildReleaseService(context, mocks);
                 var result = releaseService.PublishReleaseAsync(release.Id).Result.Right;
 
-                publishingService.Verify(mock => mock.QueueValidateReleaseAsync(release.Id, true), Times.Once());
+                mocks.PublishingService.Verify(mock => mock.QueueValidateReleaseAsync(release.Id, true), Times.Once());
 
                 Assert.True(result);
             }
@@ -720,8 +681,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void PublishReleaseContentAsync()
         {
-            var (userService, _, publishingService, repository, subjectService, tableStorageService, fileStorageService,
-                importStatusService, footnoteService, statisticsDbContext, dataBlockService) = Mocks();
+            var mocks = Mocks();
 
             var release = new Release
             {
@@ -739,36 +699,48 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext("PublishReleaseContentAsync"))
             {
-                var releaseService = new ReleaseService(context, AdminMapper(),
-                    publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object,
-                    repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object,
-                    importStatusService.Object,
-                    footnoteService.Object,
-                    statisticsDbContext.Object,
-                    dataBlockService.Object,
-                    new SequentialGuidGenerator());
-
+                var releaseService = BuildReleaseService(context, mocks);
                 var result = releaseService.PublishReleaseAsync(release.Id).Result.Right;
 
-                publishingService.Verify(mock => mock.QueueValidateReleaseAsync(release.Id, true), Times.Once());
+                mocks.PublishingService.Verify(mock => mock.QueueValidateReleaseAsync(release.Id, true), Times.Once());
 
                 Assert.True(result);
             }
         }
 
-        private (
-            Mock<IUserService>, 
-            Mock<IPersistenceHelper<ContentDbContext>>, 
-            Mock<IPublishingService>,
-            Mock<IReleaseRepository>,
-            Mock<ISubjectService>,
-            Mock<ITableStorageService>,
-            Mock<IFileStorageService>,
-            Mock<IImportStatusService>,
-            Mock<IFootnoteService>,
-            Mock<StatisticsDbContext>,
-            Mock<IDataBlockService>) Mocks()
+        private static ReleaseService BuildReleaseService(ContentDbContext context,
+            (Mock<IUserService> userService,
+                Mock<IPublishingService> publishingService,
+                Mock<IReleaseRepository> releaseRepository,
+                Mock<ISubjectService> subjectService,
+                Mock<ITableStorageService> tableStorageService,
+                Mock<IFileStorageService> fileStorageService,
+                Mock<IImportStatusService> importStatusService,
+                Mock<IFootnoteService> footnoteService,
+                Mock<StatisticsDbContext> statisticsDbContext,
+                Mock<IDataBlockService> dataBlockService) mocks)
+        {
+            var (userService, publishingService, releaseRepository, subjectService,
+                tableStorageService, fileStorageService, importStatusService, footnoteService, statisticsDbContext,
+                dataBlockService) = mocks;
+
+            return new ReleaseService(
+                context, AdminMapper(), publishingService.Object, new PersistenceHelper<ContentDbContext>(context),
+                userService.Object, releaseRepository.Object, subjectService.Object, tableStorageService.Object,
+                fileStorageService.Object, importStatusService.Object, footnoteService.Object,
+                statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
+        }
+
+        private (Mock<IUserService> UserService,
+            Mock<IPublishingService> PublishingService,
+            Mock<IReleaseRepository> ReleaseRepository,
+            Mock<ISubjectService> SubjectService,
+            Mock<ITableStorageService> TableStorageService,
+            Mock<IFileStorageService> FileStorageService,
+            Mock<IImportStatusService> ImportStatusService,
+            Mock<IFootnoteService> FootnoteService,
+            Mock<StatisticsDbContext> StatisticsDbContext,
+            Mock<IDataBlockService> DataBlockService) Mocks()
         {
             var userService = MockUtils.AlwaysTrueUserService();
 
@@ -776,13 +748,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Setup(s => s.GetUserId())
                 .Returns(_userId);
 
-            var persistenceHelper = MockUtils.MockPersistenceHelper<ContentDbContext>();
-            MockUtils.SetupCall<ContentDbContext, Release>(persistenceHelper);
-            MockUtils.SetupCall<ContentDbContext, Publication>(persistenceHelper);
-            
             return (
-                userService, 
-                persistenceHelper, 
+                userService,
                 new Mock<IPublishingService>(), 
                 new Mock<IReleaseRepository>(),
                 new Mock<ISubjectService>(), 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -49,7 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var releaseService = new ReleaseService(context, AdminMapper(), 
                     publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object);
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
                 
                 var publishScheduled = new DateTime(2050, 6, 30, 14, 0, 0);
 
@@ -187,7 +188,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
                     publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object);
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
                 
                 // Service method under test
                 var result = releaseService.CreateReleaseAsync(
@@ -273,7 +274,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
                     publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object);
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
                 
                 // Method under test
                 var notLatest = (await releaseService.GetReleaseForIdAsync(notLatestRelease.Id)).Right;
@@ -285,7 +286,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
                     publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object);
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
                 
                 // Method under test
                 var latest = (await releaseService.GetReleaseForIdAsync(latestRelease.Id)).Right;
@@ -345,7 +346,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
                     publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object);
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
                 
                 // Method under test 
                 var edited = await releaseService
@@ -421,7 +422,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
                     publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object);
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
                 
                 // Method under test 
                 var summaryResult = await releaseService.GetReleaseSummaryAsync(releaseId);
@@ -511,7 +512,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
                     publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object);
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
 
                 // Method under test 
                 var latest = releaseService.GetLatestReleaseAsync(publication.Id).Result.Right;
@@ -585,7 +586,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var releaseService = new ReleaseService(context, AdminMapper(),
                     publishingService.Object, new PersistenceHelper<ContentDbContext>(context), userService.Object, repository.Object,
-                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object);
+                    subjectService.Object, tableStorageService.Object, fileStorageService.Object, importStatusService.Object, footnoteService.Object, statisticsDbContext.Object, dataBlockService.Object, new SequentialGuidGenerator());
 
                 // Method under test 
                 var result = releaseService.DeleteReleaseAsync(release.Id).Result.Right;
@@ -705,7 +706,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     importStatusService.Object,
                     footnoteService.Object,
                     statisticsDbContext.Object,
-                    dataBlockService.Object);
+                    dataBlockService.Object,
+                    new SequentialGuidGenerator());
 
                 var result = releaseService.PublishReleaseAsync(release.Id).Result.Right;
 
@@ -744,7 +746,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     importStatusService.Object,
                     footnoteService.Object,
                     statisticsDbContext.Object,
-                    dataBlockService.Object);
+                    dataBlockService.Object,
+                    new SequentialGuidGenerator());
 
                 var result = releaseService.PublishReleaseAsync(release.Id).Result.Right;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -53,16 +53,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(async release =>
                 {
                     var dataBlock = _mapper.Map<DataBlock>(createDataBlock);
-                    dataBlock.Id = Guid.NewGuid();
+                    
+                    var added = (await _context.DataBlocks.AddAsync(dataBlock)).Entity;
 
-                    await _context.DataBlocks.AddAsync(dataBlock);
-            
-                    release.AddContentBlock(dataBlock);
+                    release.AddContentBlock(added);
                     _context.Releases.Update(release);
             
                     await _context.SaveChangesAsync();
 
-                    return await GetAsync(dataBlock.Id);
+                    return await GetAsync(added.Id);
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileStorageService.cs
@@ -365,18 +365,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             var fileLink = new ReleaseFile
             {
-                Id = Guid.NewGuid(),
                 ReleaseId = releaseId,
                 ReleaseFileReference = new ReleaseFileReference
                 {
-                    Id = Guid.NewGuid(),
                     ReleaseId = releaseId,
                     Filename = filename,
                     ReleaseFileType = type
                 }
             };
 
-            _context.ReleaseFiles.Add(fileLink);
+            await _context.ReleaseFiles.AddAsync(fileLink);
             await _context.SaveChangesAsync();
             return true;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ImportService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
@@ -30,18 +29,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly string _storageConnectionString;
         private readonly ILogger _logger;
         private readonly CloudTable _table;
+        private readonly IGuidGenerator _guidGenerator;
 
         public ImportService(ContentDbContext contentDbContext,
             IMapper mapper,
             ILogger<ImportService> logger,
             IConfiguration config,
-            ITableStorageService tableStorageService)
+            ITableStorageService tableStorageService,
+            IGuidGenerator guidGenerator)
         {
             _context = contentDbContext;
             _mapper = mapper;
             _storageConnectionString = config.GetValue<string>("CoreStorage");
             _logger = logger;
             _table = tableStorageService.GetTableAsync("imports").Result;
+            _guidGenerator = guidGenerator;
         }
 
         public async void Import(string dataFileName, Guid releaseId, IFormFile dataFile)
@@ -103,7 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             
             return new ImportMessage
             {
-                SubjectId = Guid.NewGuid(),
+                SubjectId = _guidGenerator.NewGuid(),
                 DataFileName = dataFileName,
                 OrigDataFileName = dataFileName,
                 Release = importMessageRelease,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -66,9 +66,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         return ValidationActionResult<PublicationViewModel>(SlugNotUnique);
                     }
 
-                    var saved = _context.Publications.Add(new Publication
+                    var saved = await _context.Publications.AddAsync(new Publication
                     {
-                        Id = Guid.NewGuid(),
                         ContactId = publication.ContactId,
                         Title = publication.Title,
                         TopicId = publication.TopicId,
@@ -77,7 +76,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         ExternalMethodology = publication.ExternalMethodology
                     });
 
-                    _context.SaveChanges();
+                    await _context.SaveChangesAsync();
                     return await GetViewModelAsync(saved.Entity.Id);
                 });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -50,7 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IDataBlockService _dataBlockService;
         private readonly IGuidGenerator _guidGenerator;
 
-        // TODO PP-318 - ReleaseService needs breaking into smaller services as it feels like it is now doing too
+        // TODO EES-212 - ReleaseService needs breaking into smaller services as it feels like it is now doing too
         // much work and has too many dependencies
         public ReleaseService(
             ContentDbContext context,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -48,23 +48,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IImportStatusService _importStatusService;
 	    private readonly IFootnoteService _footnoteService;
         private readonly IDataBlockService _dataBlockService;
+        private readonly IGuidGenerator _guidGenerator;
 
         // TODO PP-318 - ReleaseService needs breaking into smaller services as it feels like it is now doing too
         // much work and has too many dependencies
         public ReleaseService(
-            ContentDbContext context, 
-            IMapper mapper, 
+            ContentDbContext context,
+            IMapper mapper,
             IPublishingService publishingService,
-            IPersistenceHelper<ContentDbContext> persistenceHelper, 
-            IUserService userService, 
-            IReleaseRepository repository, 
+            IPersistenceHelper<ContentDbContext> persistenceHelper,
+            IUserService userService,
+            IReleaseRepository repository,
             ISubjectService subjectService,
-            ITableStorageService coreTableStorageService, 
-            IFileStorageService fileStorageService, 
+            ITableStorageService coreTableStorageService,
+            IFileStorageService fileStorageService,
             IImportStatusService importStatusService,
-	        IFootnoteService footnoteService, 
+            IFootnoteService footnoteService,
             StatisticsDbContext statisticsDbContext,
-            IDataBlockService dataBlockService)
+            IDataBlockService dataBlockService, 
+            IGuidGenerator guidGenerator)
         {
             _context = context;
             _publishingService = publishingService;
@@ -79,6 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _footnoteService = footnoteService;
             _statisticsDbContext = statisticsDbContext;
             _dataBlockService = dataBlockService;
+            _guidGenerator = guidGenerator;
         }
 
         public async Task<Either<ActionResult, ReleaseViewModel>> GetReleaseForIdAsync(Guid id)
@@ -99,7 +102,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 {
                     var release = _mapper.Map<Release>(createRelease);
                     
-                    release.Id = Guid.NewGuid();
+                    release.Id = _guidGenerator.NewGuid();
                     
                     if (createRelease.TemplateReleaseId.HasValue)
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
@@ -36,14 +36,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 return ValidationActionResult(ValidationErrorMessages.SlugNotUnique);
             }
             
-            var saved = _context.Topics.Add(new Topic
+            var saved = await _context.Topics.AddAsync(new Topic
             {
-                Id = Guid.NewGuid(),
                 Title = topic.Title,
                 Slug = topic.Slug,
                 Description = topic.Description,
                 ThemeId = themeId,
-                Summary = topic.Summary,
+                Summary = topic.Summary
             });
             await _context.SaveChangesAsync();
             return await GetViewModelAsync(saved.Entity.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -283,6 +283,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IFileUploadsValidatorService, FileUploadsValidatorService>();
             services.AddTransient<ITableStorageService, TableStorageService>(s =>
                 new TableStorageService(Configuration.GetValue<string>("CoreStorage")));
+            services.AddSingleton<IGuidGenerator, SequentialGuidGenerator>();
             AddPersistenceHelper<ContentDbContext>(services);
             AddPersistenceHelper<StatisticsDbContext>(services);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IGuidGenerator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IGuidGenerator.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
+{
+    public interface IGuidGenerator
+    {
+        Guid NewGuid();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/SequentialGuidGenerator.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/SequentialGuidGenerator.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services
+{
+    /**
+     * Generates sequential <see cref="Guid" /> values using the same algorithm as NEWSEQUENTIALID() in Microsoft SQL Server.
+     * Copy of <see cref="Microsoft.EntityFrameworkCore.ValueGeneration.SequentialGuidValueGenerator" /> without the ValueGenerator interface.
+     * Used to reduce fragmentation of clustered indexes on Guid fields.
+     * See https://edgamat.com/2020/01/19/Sequential-Guid-Values-For-SQL-Server.html.
+     */
+    public class SequentialGuidGenerator : IGuidGenerator
+    {
+        private long _counter = DateTime.UtcNow.Ticks;
+
+        public Guid NewGuid()
+        {
+            var guidBytes = Guid.NewGuid().ToByteArray();
+            var counterBytes = BitConverter.GetBytes(Interlocked.Increment(ref _counter));
+
+            if (!BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(counterBytes);
+            }
+
+            guidBytes[08] = counterBytes[1];
+            guidBytes[09] = counterBytes[0];
+            guidBytes[10] = counterBytes[7];
+            guidBytes[11] = counterBytes[6];
+            guidBytes[12] = counterBytes[5];
+            guidBytes[13] = counterBytes[4];
+            guidBytes[14] = counterBytes[3];
+            guidBytes[15] = counterBytes[2];
+
+            return new Guid(guidBytes);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterLocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterLocationService.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
@@ -9,8 +9,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
 {
     public class ImporterLocationService : BaseImporterService
     {
-        public ImporterLocationService(ImporterMemoryCache cache) : base(cache)
+        private readonly IGuidGenerator _guidGenerator;
+        
+        public ImporterLocationService(
+            IGuidGenerator guidGenerator,
+            ImporterMemoryCache cache) : base(cache)
         {
+            _guidGenerator = guidGenerator;
         }
 
         public Location Find(
@@ -114,7 +119,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             {
                 var entityEntry = context.Location.Add(new Location
                 {
-                    Id = Guid.NewGuid(),
+                    Id = _guidGenerator.NewGuid(),
                     Country = country ?? Country.Empty(),
                     Institution = institution ?? Institution.Empty(),
                     LocalAuthority = localAuthority ?? LocalAuthority.Empty(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterMetaService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Models;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
@@ -22,9 +23,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
     }
 
     public class ImporterMetaService : IImporterMetaService
-    {        
-        public ImporterMetaService()
+    {
+        private readonly IGuidGenerator _guidGenerator;
+        
+        public ImporterMetaService(IGuidGenerator guidGenerator)
         {
+            _guidGenerator = guidGenerator;
         }
 
         public SubjectMeta Import(DataColumnCollection cols, DataRowCollection rows, Subject subject, StatisticsDbContext context)
@@ -144,7 +148,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
                             i.IndicatorGroupId == indicatorGroup.Id && i.Label == row.Label &&
                             i.Unit == row.IndicatorUnit) ?? new Indicator
                         {
-                            Id = Guid.NewGuid(),
+                            Id = _guidGenerator.NewGuid(),
                             IndicatorGroup = indicatorGroup,
                             Label = row.Label,
                             Name = row.ColumnName,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Exceptions;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Models;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Services.Interfaces;
@@ -17,6 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
 {
     public class ImporterService : IImporterService
     {
+        private readonly IGuidGenerator _guidGenerator;
         private readonly ImporterLocationService _importerLocationService;
         private readonly ImporterFilterService _importerFilterService;
         private readonly IImporterMetaService _importerMetaService;
@@ -99,10 +101,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
         };
         
         public ImporterService(
+            IGuidGenerator guidGenerator,
             ImporterFilterService importerFilterService,
             ImporterLocationService importerLocationService,
             IImporterMetaService importerMetaService)
         {
+            _guidGenerator = guidGenerator;
             _importerFilterService = importerFilterService;
             _importerLocationService = importerLocationService;
             _importerMetaService = importerMetaService;
@@ -231,7 +235,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             SubjectMeta subjectMeta,
             int csvRowNum)
         {
-            var observationId = Guid.NewGuid();
+            var observationId = _guidGenerator.NewGuid();
 
             return new Observation
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Startup.cs
@@ -36,6 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
                 .AddTransient<IBatchService, BatchService>()
                 .AddTransient<IImportStatusService, ImportStatusService>()
                 .AddSingleton<IValidatorService, ValidatorService>()
+                .AddSingleton<IGuidGenerator, SequentialGuidGenerator>()
                 .AddApplicationInsightsTelemetry()
                 .BuildServiceProvider();
 


### PR DESCRIPTION
By convention, primary keys of type Guid are set up to have values generated for inserted entities using `Microsoft.EntityFrameworkCore.ValueGeneration.SequentialGuidValueGenerator` which generates sequential values using the same algorithm as `NEWSEQUENTIALID()` in Microsoft SQL Server.

There are some cases in our application where `Id = Guid.NewGuid` has been set prior to adding the entity e.g. in `CreatePublicationAsync`. 

These are generating non-sequential Guid's which are impacting the clustered PK indexes, causing fragmentation. Each row of data is inserted into the middle of the clustered index (out of sequential order) causing SQL Server to make room for the data by rearranging the cluster.

Where the Id does not need to be known prior to adding, they have been removed to force generation using the default value generator when the entity is added.

Where the Id does need to be known prior to adding, they have been replaced by the value from `SequentialValueGenerator.NewGuid`. This is a copy of the EF Core value generator without the `ValueGenerator` interface so it can be used without the database entity.

With this PR for example, we can see that for an imported Subject, Observations ordered by Id are in order of the Csv Row Id that they were originally generated from.  Prior to this because the Observation Id was `Id = Guid.NewGuid` the order was completely random.

Values created by different machines or different function instances will create gaps but should still be unique and sequential.