### PR TITLE
EES-994 EES-1022 Configuring App Insights SDK

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -558,16 +558,6 @@
       },
       "resources": [
         {
-          "type": "siteextensions",
-          "name": "Microsoft.ApplicationInsights.AzureWebSites",
-          "apiVersion": "2015-08-01",
-          "dependsOn": [
-            "[resourceId('Microsoft.Web/Sites', variables('dataAppName'))]"
-          ],
-          "properties": {
-          }
-        },
-        {
           "condition": "[parameters('useSubnets')]",
           "name": "virtualNetwork",
           "type": "config",
@@ -769,16 +759,6 @@
       },
       "resources": [
         {
-          "type": "siteextensions",
-          "name": "Microsoft.ApplicationInsights.AzureWebSites",
-          "apiVersion": "2015-08-01",
-          "dependsOn": [
-            "[resourceId('Microsoft.Web/Sites', variables('contentAppName'))]"
-          ],
-          "properties": {
-          }
-        },
-        {
           "condition": "[parameters('useSubnets')]",
           "name": "virtualNetwork",
           "type": "config",
@@ -973,16 +953,6 @@
         "DeploymentScript": "[parameters('deploymentScript')]"
       },
       "resources": [
-        // {
-        //   "type": "siteextensions",
-        //   "name": "Microsoft.ApplicationInsights.AzureWebSites",
-        //   "apiVersion": "2016-08-01",
-        //   "dependsOn": [
-        //     "[resourceId('Microsoft.Web/Sites', variables('adminAppName'))]"
-        //   ],
-        //   "properties": {
-        //   }
-        // },
         {
           "condition": "[parameters('useSubnets')]",
           "name": "virtualNetwork",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.5" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
     <PackageReference Include="Mime" Version="3.1.0" />
     <PackageReference Include="Mime-Detective" Version="0.0.6-beta5" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Program.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.ApplicationInsights;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin
 {
@@ -13,6 +15,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseKestrel(options => options.AddServerHeader = false)
-                .UseStartup<Startup>();
+                .UseStartup<Startup>()
+                .ConfigureLogging(
+                    builder =>
+                    {
+                        // Capture logs from early in the application startup 
+                        // pipeline from Startup.cs or Program.cs itself.
+                        builder.AddApplicationInsights();
+
+                        // Adding the filter below to ensure logs of all severity from Program.cs
+                        // is sent to ApplicationInsights.
+                        builder.AddFilter<ApplicationInsightsLoggerProvider>(typeof(Program).FullName, LogLevel.Debug);
+
+                        // Adding the filter below to ensure logs of all severity from Startup.cs
+                        // is sent to ApplicationInsights.
+                        builder.AddFilter<ApplicationInsightsLoggerProvider>(typeof(Startup).FullName, LogLevel.Debug);
+
+                        // Allow capturing logs in the App Service if turned on in the App Service logs settings page.
+                        builder.AddAzureWebAppDiagnostics();
+                    }
+                );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -44,7 +44,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.ApplicationInsights;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
@@ -72,12 +71,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddLogging(builder =>
-            {
-                builder.AddApplicationInsights(Configuration.GetSection("AppInsights").GetValue<string>("InstrumentationKey"));
-                builder.AddFilter<ApplicationInsightsLoggerProvider>("", HostingEnvironment.IsDevelopment() ? LogLevel.Debug : LogLevel.Information);
-                builder.AddFilter<ApplicationInsightsLoggerProvider>("Microsoft", LogLevel.Information);
-            });
             services.AddApplicationInsightsTelemetry();
             
             services.Configure<CookiePolicyOptions>(options =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
@@ -10,6 +10,7 @@
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
         <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="10.0.3" />
         <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.5" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
         <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.ApplicationInsights;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api
 {
@@ -14,7 +16,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
 
         private static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseApplicationInsights()
-                .UseStartup<Startup>();
+                .UseStartup<Startup>()
+                .ConfigureLogging(
+                    builder =>
+                    {
+                        // Capture logs from early in the application startup 
+                        // pipeline from Startup.cs or Program.cs itself.
+                        builder.AddApplicationInsights();
+
+                        // Adding the filter below to ensure logs of all severity from Program.cs
+                        // is sent to ApplicationInsights.
+                        builder.AddFilter<ApplicationInsightsLoggerProvider>(typeof(Program).FullName, LogLevel.Debug);
+
+                        // Adding the filter below to ensure logs of all severity from Startup.cs
+                        // is sent to ApplicationInsights.
+                        builder.AddFilter<ApplicationInsightsLoggerProvider>(typeof(Startup).FullName, LogLevel.Debug);
+
+                        // Allow capturing logs in the App Service if turned on in the App Service logs settings page.
+                        builder.AddAzureWebAppDiagnostics();
+                    }
+                );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -34,6 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddApplicationInsightsTelemetry();
             services.AddMvc(options => { options.EnableEndpointRouting = false; })
                 .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddNewtonsoftJson(options => {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Program.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Program.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.ApplicationInsights;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api
 {
@@ -16,7 +17,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
         private static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .ConfigureLogging(logging => logging.AddAzureWebAppDiagnostics())
-                .UseApplicationInsights()
-                .UseStartup<Startup>();
+                .UseStartup<Startup>()
+                .ConfigureLogging(builder =>
+                {
+                    // Capture logs from early in the application startup 
+                    // pipeline from Startup.cs or Program.cs itself.
+                    builder.AddApplicationInsights();
+
+                    // Adding the filter below to ensure logs of all severity from Program.cs
+                    // is sent to ApplicationInsights.
+                    builder.AddFilter<ApplicationInsightsLoggerProvider>(typeof(Program).FullName, LogLevel.Debug);
+
+                    // Adding the filter below to ensure logs of all severity from Startup.cs
+                    // is sent to ApplicationInsights.
+                    builder.AddFilter<ApplicationInsightsLoggerProvider>(typeof(Startup).FullName, LogLevel.Debug);
+
+                    // Allow capturing logs in the App Service if turned on in the App Service logs settings page.
+                    builder.AddAzureWebAppDiagnostics();
+                });
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -47,6 +47,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddApplicationInsightsTelemetry();
             services.AddMvc(options =>
             {
                 options.RespectBrowserAcceptHeader = true;


### PR DESCRIPTION
Follows the documentation here to make sure we've got the App Insights SDK installed correctly and attempts to capture logs from early in the application startup pipeline from Startup.cs and Program.cs themselves.

**Installation:**
https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core

**A note on logging Startup.cs and Program.cs:**
https://docs.microsoft.com/en-us/azure/azure-monitor/app/ilogger#aspnet-core-applications

**Provision for App Service logs should we need it:**
https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1#azure-app-service