### PR TITLE
EES-994 App Insights configuration

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
@@ -1,12 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information"
-    },
-    "ApplicationInsights": {
-      "LogLevel": {
-        "Default": "Information"
-      }
+      "Default": "Information",
+      "Microsoft": "Warning"
     }
   },
   "AllowedHosts": "*",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/appsettings.json
@@ -1,12 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information"
-    },
-    "ApplicationInsights": {
-      "LogLevel": {
-        "Default": "Information"
-      }
+      "Default": "Information",
+      "Microsoft": "Warning"
     }
   },
   "AllowedHosts": "*"

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
@@ -1,12 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information"
-    },
-    "ApplicationInsights": {
-      "LogLevel": {
-        "Default": "Information"
-      }
+      "Default": "Information",
+      "Microsoft": "Warning"
     }
   },
   "AllowedHosts": "*"

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Startup.cs
@@ -37,7 +37,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
                 .AddTransient<IImportStatusService, ImportStatusService>()
                 .AddSingleton<IValidatorService, ValidatorService>()
                 .AddSingleton<IGuidGenerator, SequentialGuidGenerator>()
-                .AddApplicationInsightsTelemetry()
                 .BuildServiceProvider();
 
             FailedImportsHandler.CheckIncompleteImports(GetConfigurationValue(serviceProvider, "CoreStorage"));


### PR DESCRIPTION
Tweaks found as part of work testing that App Insights logging is correctly installed (https://dfedigital.atlassian.net/browse/EES-994)

* We shouldn't be calling AddApplicationInsightsTelemetry() in Function projects as documented here
https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection

![image](https://user-images.githubusercontent.com/4147126/86157883-e8992980-baff-11ea-956c-bda2c572782e.png)

* Removing ApplicationInsights sections from log level configuration. While we are not differing the level for ApplicationInsights these sections are just duplicating the default config unnecessarily.

* Setting "Microsoft" category from Information to Warning to reduce logging. In the Admin application in the last 24 hours we had 244K Information level traces. At least of 230K of these traces are "Microsoft" and don't add much value.