### PR TITLE
EES-1100 Set allowed username characters

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -159,19 +159,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                 .AddIdentityServerJwt();
 
             // This configuration has to occur after the AddAuthentication() block as it is otherwise overridden.
-            // This config tells UserManager to expect the logged in user's id to be in a Claim called
-            // "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" rather than "sub" (because
-            // this Claim is renamed via the DefaultInboundClaimTypeMap earlier in the login process).
-            //
-            // It doesn't seem to be possible to remove the renaming (via
-            // JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Remove("sub")) because some mechanism earlier in the 
-            // authentication process requires it to be in the Claim named
-            // "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" rather than "sub".
             services.Configure<IdentityOptions>(options =>
             {
+                // This config tells UserManager to expect the logged in user's id to be in a Claim called
+                // "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" rather than "sub" (because
+                // this Claim is renamed via the DefaultInboundClaimTypeMap earlier in the login process).
+                //
+                // It doesn't seem to be possible to remove the renaming (via
+                // JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Remove("sub")) because some mechanism earlier in the 
+                // authentication process requires it to be in the Claim named
+                // "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" rather than "sub".
                 options.ClaimsIdentity.UserIdClaimType = ClaimTypes.NameIdentifier;
+
+                // Default User settings
+                options.User.AllowedUserNameCharacters =
+                    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+'";
             });
-            
+
             services.Configure<PreReleaseOptions>(Configuration);
 
             // here we configure our security policies


### PR DESCRIPTION
Override the default allowed username characters in the `Microsoft.AspNetCore.Identity.UserValidator` to include an apostrophe.

In `ExternalLogin.cshtml` after checking the invite exists we call await `_userManager.CreateAsync(user)` where the `user.UserName` is the email which can contain an apostrophe.

Without this override the UserManager username validation fails when creating a new user and the invited user cannot login.

https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity-configuration?view=aspnetcore-3.1