### PR TITLE
EES-415 Add validation to prevent external methodology URL containing current host

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ExternalMethodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ExternalMethodology.cs
@@ -1,10 +1,15 @@
+using System.ComponentModel.DataAnnotations;
 using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
     public class ExternalMethodology
     {
+        [Required]
         public string Title { get; set; }
+
+        [Required]
+        [Url]
         public Uri Url { get; set; }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/theme/topic/CreatePublicationPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/theme/topic/CreatePublicationPage.tsx
@@ -161,7 +161,15 @@ const CreatePublicationPage = ({
               is: 'external',
               then: Yup.object().shape({
                 title: Yup.string().required('Enter a link title'),
-                url: Yup.string().url('Enter a valid URL'),
+                url: Yup.string()
+                  .required('Enter a URL')
+                  .url('Enter a valid URL')
+                  .test({
+                    name: 'currentHostUrl',
+                    message: 'URL cannot be for this website',
+                    test: (value: string) =>
+                      Boolean(value && !value.includes(window.location.host)),
+                  }),
               }),
             }),
           })}

--- a/src/explore-education-statistics-admin/src/pages/theme/topic/publication/AssignMethodologyForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/theme/topic/publication/AssignMethodologyForm.tsx
@@ -158,7 +158,15 @@ const AssignMethodologyForm = ({
               is: 'external',
               then: Yup.object().shape({
                 title: Yup.string().required('Enter a link title'),
-                url: Yup.string().url('Enter a valid URL'),
+                url: Yup.string()
+                  .required('Enter a URL')
+                  .url('Enter a valid URL')
+                  .test({
+                    name: 'currentHostUrl',
+                    message: 'URL cannot be for this website',
+                    test: (value: string) =>
+                      Boolean(value && !value.includes(window.location.host)),
+                  }),
               }),
             }),
           })}


### PR DESCRIPTION
This PR prevents analysts from using entering external methodology URLs for the actual admin service.