### PR TITLE
EES-957 Allow BAU users to move unpublished releases back to Draft

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ApproveSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ApproveSpecificReleaseAuthorizationHandlersTests.cs
@@ -1,3 +1,4 @@
+using System;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Xunit;
@@ -15,21 +16,41 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             // Assert that any users with the "ApproveAllReleases" claim can approve an arbitrary Release
             // (and no other claim allows this)
             AssertReleaseHandlerSucceedsWithCorrectClaims<ApproveSpecificReleaseRequirement>(
-                new CanApproveAllReleasesAuthorizationHandler(), ApproveAllReleases);
+                new CanApproveAllReleasesAuthorizationHandler(), 
+                ApproveAllReleases
+            );
         }
-        
+
         [Fact]
-        public void CanApproveAllReleasesAuthorizationHandler_ReleaseApproved()
+        public void CanApproveAllReleasesAuthorizationHandler_ReleaseUnpublished()
         {
             var release = new Release
             {
                 Status = ReleaseStatus.Approved
             };
             
+            // Assert that any users with the "ApproveAllReleases" claim can approve an arbitrary Release
+            AssertReleaseHandlerSucceedsWithCorrectClaims<ApproveSpecificReleaseRequirement>(
+                new CanApproveAllReleasesAuthorizationHandler(),
+                release,
+                ApproveAllReleases
+            );
+        }
+
+        [Fact]
+        public void CanApproveAllReleasesAuthorizationHandler_ReleasePublished()
+        {
+            var release = new Release
+            {
+                Status = ReleaseStatus.Approved,
+                Published = DateTime.Now
+            };
+            
             // Assert that no users can approve an approved Release
             AssertReleaseHandlerSucceedsWithCorrectClaims<ApproveSpecificReleaseRequirement>(
                 new CanApproveAllReleasesAuthorizationHandler(),
-                release);
+                release
+            );
         }
         
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkSpecificReleaseAsDraftAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkSpecificReleaseAsDraftAuthorizationHandlersTests.cs
@@ -1,3 +1,4 @@
+using System;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Xunit;
@@ -12,24 +13,44 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         [Fact]
         public void CanMarkAllReleasesAsDraftAuthorizationHandler()
         {
-            // Assert that any users with the "MarkAllReleasesAsDraft" claim can mark an arbitrary Release as draft
+            // Assert that any users with the "MarkAllReleasesAsDraft" claim can mark an arbitrary Release as Draft
             // (and no other claim allows this)
             AssertReleaseHandlerSucceedsWithCorrectClaims<MarkSpecificReleaseAsDraftRequirement>(
-                new CanMarkAllReleasesAsDraftAuthorizationHandler(), MarkAllReleasesAsDraft);
+                new CanMarkAllReleasesAsDraftAuthorizationHandler(),
+                MarkAllReleasesAsDraft
+            );
         }
-        
+
         [Fact]
-        public void CanMarkAllReleasesAsDraftAuthorizationHandler_ReleaseApproved()
+        public void CanMarkAllReleasesAsDraftAuthorizationHandler_ReleaseNotPublished()
         {
             var release = new Release
             {
-                Status = ReleaseStatus.Approved
+                Status = ReleaseStatus.Approved,
             };
             
-            // Assert that no users can mark an approved Release as Draft
+            // Assert that any users with the "MarkAllReleasesAsDraft" claim can mark an arbitrary Release as Draft
             AssertReleaseHandlerSucceedsWithCorrectClaims<MarkSpecificReleaseAsDraftRequirement>(
                 new CanMarkAllReleasesAsDraftAuthorizationHandler(),
-                release);
+                release,
+                MarkAllReleasesAsDraft
+            );
+        }
+
+        [Fact]
+        public void CanMarkAllReleasesAsDraftAuthorizationHandler_ReleasePublished()
+        {
+            var release = new Release
+            {
+                Status = ReleaseStatus.Approved,
+                Published = DateTime.Now
+            };
+            
+            // Assert that no users can mark a published Release as Draft
+            AssertReleaseHandlerSucceedsWithCorrectClaims<MarkSpecificReleaseAsDraftRequirement>(
+                new CanMarkAllReleasesAsDraftAuthorizationHandler(),
+                release
+            );
         }
         
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/SubmitSpecificReleaseToHigherReviewAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/SubmitSpecificReleaseToHigherReviewAuthorizationHandlersTests.cs
@@ -1,3 +1,4 @@
+using System;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Xunit;
@@ -15,21 +16,41 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             // Assert that any users with the "SubmitAllReleasesToHigherReview" claim can submit an arbitrary Release to higher review
             // (and no other claim allows this)
             AssertReleaseHandlerSucceedsWithCorrectClaims<SubmitSpecificReleaseToHigherReviewRequirement>(
-                new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(), SubmitAllReleasesToHigherReview);
+                new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(), 
+                SubmitAllReleasesToHigherReview
+            );
         }
         
         [Fact]
-        public void CanSubmitAllReleasesToHigherReviewAuthorizationHandler_ReleaseApproved()
+        public void CanSubmitAllReleasesToHigherReviewAuthorizationHandler_ReleaseUnpublished()
         {
             var release = new Release
             {
                 Status = ReleaseStatus.Approved
             };
             
+            // Assert that any users with the "SubmitAllReleasesToHigherReview" claim can submit an arbitrary Release to higher review
+            AssertReleaseHandlerSucceedsWithCorrectClaims<SubmitSpecificReleaseToHigherReviewRequirement>(
+                new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(),
+                release,
+                SubmitAllReleasesToHigherReview
+            );
+        }
+
+        [Fact]
+        public void CanSubmitAllReleasesToHigherReviewAuthorizationHandler_ReleasePublished()
+        {
+            var release = new Release
+            {
+                Status = ReleaseStatus.Approved,
+                Published = DateTime.Now
+            };
+            
             // Assert that no users can submit an approved Release to higher review
             AssertReleaseHandlerSucceedsWithCorrectClaims<SubmitSpecificReleaseToHigherReviewRequirement>(
                 new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(),
-                release);
+                release
+            );
         }
         
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlersTests.cs
@@ -13,27 +13,50 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
     public class UpdateSpecificReleaseAuthorizationHandlersTests
     {
         [Fact]
-        public void CanUpdateAllReleasesAuthorizationHandler()
+        public void CanUpdateAllReleasesAuthorizationHandler_ReleaseUnpublished()
         {
-            // Assert that any users with the "UpdateAllReleases" claim can update an arbitrary Release if it is not
-            // in Approved state
-            // (and no other claim allows this)
-            AssertReleaseHandlerSucceedsWithCorrectClaimsWithCorrectReleaseStatuses(
-                ReleaseStatus.Draft, ReleaseStatus.HigherLevelReview);
+            // Assert that any users with the "UpdateAllReleases" claim can update an arbitrary 
+            // Release if it is not published (and no other claim allows this)
+            GetEnumValues<ReleaseStatus>().ForEach(status =>
+            {
+                var release = new Release
+                {
+                    Id = Guid.NewGuid(),
+                    Status = status
+                };
+
+                AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
+                    new CanUpdateAllReleasesAuthorizationHandler(),
+                    release,
+                    UpdateAllReleases
+                );
+            });
         }
+
+        [Fact]
+        public void CanUpdateAllReleasesAuthorizationHandler_ReleasePublished()
+        {
+            // Assert that no usres can update an arbitrary Release 
+            // if it is published (and no other claim allows this)
+            GetEnumValues<ReleaseStatus>().ForEach(status =>
+            {
+                var release = new Release
+                {
+                    Id = Guid.NewGuid(),
+                    Status = status,
+                    Published = DateTime.Now
+                };
+
+                AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
+                    new CanUpdateAllReleasesAuthorizationHandler(),
+                    release
+                );
+            });
+        }        
         
         [Fact]
         public void HasEditorRoleOnReleaseAuthorizationHandler()
         {
-            // Assert that a User who has the "Contributor", "Lead" or "Approver" role on a Release can update a Release
-            // if it is not in Approved state
-            // (and no other role or Release Status)
-            AssertReleaseHandlerSucceedsWithCorrectReleaseRolesWithCorrectReleaseStatuses(
-                ReleaseStatus.Draft, ReleaseStatus.HigherLevelReview);
-        }
-
-        private void AssertReleaseHandlerSucceedsWithCorrectClaimsWithCorrectReleaseStatuses(params ReleaseStatus[] succeedingStatuses)
-        {
             GetEnumValues<ReleaseStatus>().ForEach(status =>
             {
                 var release = new Release
@@ -42,40 +65,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     Status = status
                 };
 
-                if (succeedingStatuses.Contains(status))
-                {
-                    AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
-                        new CanUpdateAllReleasesAuthorizationHandler(), release, UpdateAllReleases);
-                }
-                else
-                {
-                    AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(new CanUpdateAllReleasesAuthorizationHandler(), release);
-                }
-            });
-        }
-
-        private void AssertReleaseHandlerSucceedsWithCorrectReleaseRolesWithCorrectReleaseStatuses(params ReleaseStatus[] succeedingStatuses)
-        {
-            GetEnumValues<ReleaseStatus>().ForEach(status =>
-            {
-                var release = new Release
-                {
-                    Id = Guid.NewGuid(),
-                    Status = status
-                };
-
-                if (succeedingStatuses.Contains(status))
+                // Assert that a User who has the "Contributor", "Lead" or "Approver" role on a Release can update it
+                // if it is not in Approved status (and no other role or Release status)
+                if (status != ReleaseStatus.Approved)
                 {
                     AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<UpdateSpecificReleaseRequirement>(
                         contentDbContext => new HasEditorRoleOnReleaseAuthorizationHandler(contentDbContext),
                         release,
-                        ReleaseRole.Contributor, ReleaseRole.Lead, ReleaseRole.Approver);
+                        ReleaseRole.Contributor, 
+                        ReleaseRole.Lead, 
+                        ReleaseRole.Approver
+                    );
                 }
                 else
                 {
                     AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<UpdateSpecificReleaseRequirement>(
                         contentDbContext => new HasEditorRoleOnReleaseAuthorizationHandler(contentDbContext),
-                        release);
+                        release
+                    );
                 }
             });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ApproveSpecificReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ApproveSpecificReleaseAuthorizationHandlers.cs
@@ -23,8 +23,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
         {
             public CanApproveAllReleasesAuthorizationHandler() 
                 : base(ctx => 
-                    ctx.Entity.Status != ReleaseStatus.Approved 
-                    && SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.ApproveAllReleases)) {}
+                {
+                    if (ctx.Entity.Published != null) 
+                    {
+                        return false;
+                    }
+
+                    return SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.ApproveAllReleases);
+                }) {}
         }
 
         public class HasApproverRoleOnReleaseAuthorizationHandler

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkSpecificReleaseAsDraftAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkSpecificReleaseAsDraftAuthorizationHandlers.cs
@@ -24,8 +24,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
         {
             public CanMarkAllReleasesAsDraftAuthorizationHandler() 
                 : base(ctx => 
-                    ctx.Entity.Status != ReleaseStatus.Approved 
-                    && SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.MarkAllReleasesAsDraft)) {}
+                {
+                    if (ctx.Entity.Published != null)
+                    {
+                        return false;
+                    }
+
+                    return SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.MarkAllReleasesAsDraft);
+                }) {}
         }
     
         public class HasEditorRoleOnReleaseAuthorizationHandler

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/SubmitSpecificReleaseToHigherApprovalAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/SubmitSpecificReleaseToHigherApprovalAuthorizationHandlers.cs
@@ -24,8 +24,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
         {
             public CanSubmitAllReleasesToHigherReviewAuthorizationHandler() 
                 : base(ctx => 
-                    ctx.Entity.Status != ReleaseStatus.Approved 
-                    && SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.SubmitAllReleasesToHigherReview)) {}
+                {
+                    if (ctx.Entity.Published != null) 
+                    {
+                        return false;
+                    }
+
+                    return SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.SubmitAllReleasesToHigherReview);
+                }) {}
         }
 
         public class HasEditorRoleOnReleaseAuthorizationHandler

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlers.cs
@@ -22,12 +22,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
         {
             public CanUpdateAllReleasesAuthorizationHandler()
                 : base(ctx =>
-                    ctx.Entity.Status != ReleaseStatus.Approved && 
-                    SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.UpdateAllReleases)
-                )
-            {
-            
-            }
+                {
+                    if (ctx.Entity.Published != null) 
+                    {
+                        return false;
+                    }
+
+                    return SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.UpdateAllReleases);
+                }) {}
         }
 
         public class HasEditorRoleOnReleaseAuthorizationHandler

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -80,27 +80,27 @@ const ReleaseStatusPage = () => {
 
   const { value: statusOptions = [] } = useAsyncRetry<RadioOption[]>(
     async () => {
-      const [canMarkAsDraft, canSubmit, canApprove] = await Promise.all([
-        permissionService.canMarkReleaseAsDraft(releaseId),
-        permissionService.canSubmitReleaseForHigherLevelReview(releaseId),
-        permissionService.canApproveRelease(releaseId),
-      ]);
+      const {
+        canMarkDraft,
+        canMarkHigherLevelReview,
+        canMarkApproved,
+      } = await permissionService.getReleaseStatusPermissions(releaseId);
 
       return [
         {
           label: 'In draft',
           value: 'Draft',
-          disabled: !canMarkAsDraft,
+          disabled: !canMarkDraft,
         },
         {
           label: 'Ready for higher review',
           value: 'HigherLevelReview',
-          disabled: !canSubmit,
+          disabled: !canMarkHigherLevelReview,
         },
         {
           label: 'Approved for publication',
           value: 'Approved',
-          disabled: !canApprove,
+          disabled: !canMarkApproved,
         },
       ];
     },

--- a/src/explore-education-statistics-admin/src/services/permissionService.ts
+++ b/src/explore-education-statistics-admin/src/services/permissionService.ts
@@ -1,14 +1,6 @@
 import { User } from '@admin/contexts/AuthContext';
 import client from '@admin/services/utils/service';
 
-export type PreReleaseAccess = 'Before' | 'After' | 'Within' | 'NoneSet';
-
-export interface PreReleaseWindowStatus {
-  access: PreReleaseAccess;
-  start: Date;
-  end: Date;
-}
-
 export interface GlobalPermissions {
   canAccessSystem: boolean;
   canAccessPrereleasePages: boolean;
@@ -17,54 +9,62 @@ export interface GlobalPermissions {
   canAccessMethodologyAdministrationPages: boolean;
 }
 
+export interface ReleaseStatusPermissions {
+  canMarkDraft: boolean;
+  canMarkHigherLevelReview: boolean;
+  canMarkApproved: boolean;
+}
+
+export type PreReleaseAccess = 'Before' | 'After' | 'Within' | 'NoneSet';
+
+export interface PreReleaseWindowStatus {
+  access: PreReleaseAccess;
+  start: Date;
+  end: Date;
+}
+
 const permissionService = {
-  getGlobalPermissions: (): Promise<GlobalPermissions> => {
+  getGlobalPermissions(): Promise<GlobalPermissions> {
     return client.get(`/permissions/access`);
   },
-  canAccessPrereleasePages: (user?: User): Promise<boolean> => {
+  canAccessPrereleasePages(user?: User): Promise<boolean> {
     return Promise.resolve(
       user ? user.permissions.canAccessPrereleasePages : false,
     );
   },
-  canUpdateRelease: (releaseId: string): Promise<boolean> => {
+  canUpdateRelease(releaseId: string): Promise<boolean> {
     return client.get(`/permissions/release/${releaseId}/update`);
   },
-  canMarkReleaseAsDraft: (releaseId: string): Promise<boolean> => {
-    return client.get(`/permissions/release/${releaseId}/status/draft`);
-  },
-  canSubmitReleaseForHigherLevelReview: (
+  getReleaseStatusPermissions(
     releaseId: string,
-  ): Promise<boolean> => {
-    return client.get(`/permissions/release/${releaseId}/status/submit`);
+  ): Promise<ReleaseStatusPermissions> {
+    return client.get(`/permissions/release/${releaseId}/status`);
   },
-  canApproveRelease: (releaseId: string): Promise<boolean> => {
-    return client.get(`/permissions/release/${releaseId}/status/approve`);
-  },
-  canMakeAmendmentOfRelease: (releaseId: string): Promise<boolean> => {
+  canMakeAmendmentOfRelease(releaseId: string): Promise<boolean> {
     return client.get(`/permissions/release/${releaseId}/amend`);
   },
-  canCreatePublicationForTopic: (topicId: string): Promise<boolean> => {
+  canCreatePublicationForTopic(topicId: string): Promise<boolean> {
     return client.get(`/permissions/topic/${topicId}/publication/create`);
   },
-  canCreateReleaseForPublication: (publicationId: string): Promise<boolean> => {
+  canCreateReleaseForPublication(publicationId: string): Promise<boolean> {
     return client.get(
       `/permissions/publication/${publicationId}/release/create`,
     );
   },
-  canUpdateMethodology: (methodologyId: string): Promise<boolean> => {
+  canUpdateMethodology(methodologyId: string): Promise<boolean> {
     return client.get(`/permissions/methodology/${methodologyId}/update`);
   },
-  canMarkMethodologyAsDraft: (methodologyId: string): Promise<boolean> => {
+  canMarkMethodologyAsDraft(methodologyId: string): Promise<boolean> {
     return client.get(`/permissions/methodology/${methodologyId}/status/draft`);
   },
-  canApproveMethodology: (methodologyId: string): Promise<boolean> => {
+  canApproveMethodology(methodologyId: string): Promise<boolean> {
     return client.get(
       `/permissions/methodology/${methodologyId}/status/approve`,
     );
   },
-  getPreReleaseWindowStatus: (
+  getPreReleaseWindowStatus(
     releaseId: string,
-  ): Promise<PreReleaseWindowStatus> => {
+  ): Promise<PreReleaseWindowStatus> {
     return client
       .get<{
         access: PreReleaseAccess;


### PR DESCRIPTION
This PR allows BAU users to move releases back to Draft as long as they haven't been published yet.

As part of this, we've aggregated the current `/api/permissions/release/{releaseId}/status` permissions into a single endpoint, rather than needing to make 3 requests for each status type.