### PR TITLE
EES-415 Add migration for external methodology's required url/title

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200707170022_EES415UpdateExternalMethodologyWithRequiredTitleAndUrl.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200707170022_EES415UpdateExternalMethodologyWithRequiredTitleAndUrl.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200707170022_EES415UpdateExternalMethodologyWithRequiredTitleAndUrl")]
+    partial class EES415UpdateExternalMethodologyWithRequiredTitleAndUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200707170022_EES415UpdateExternalMethodologyWithRequiredTitleAndUrl.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200707170022_EES415UpdateExternalMethodologyWithRequiredTitleAndUrl.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES415UpdateExternalMethodologyWithRequiredTitleAndUrl : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Url",
+                table: "ExternalMethodology",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "ExternalMethodology",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Url",
+                table: "ExternalMethodology",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "ExternalMethodology",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a missing migration that EF is detecting we need due to the new  `Required` annotations on `ExternalMethodology` `Url` and `Title` fields.