### PR TITLE
EES-957 Prevent changing of release status if publishing has started/completed

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkSpecificReleaseAsDraftAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkSpecificReleaseAsDraftAuthorizationHandlersTests.cs
@@ -1,7 +1,12 @@
 using System;
+using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Moq;
 using Xunit;
+using ReleaseStatusOverallStage = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusOverallStage;
+using PublisherReleaseStatus = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatus;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.MarkSpecificReleaseAsDraftAuthorizationHandler;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.ReleaseAuthorizationHandlersTestUtil;
@@ -13,10 +18,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         [Fact]
         public void CanMarkAllReleasesAsDraftAuthorizationHandler()
         {
+            var release = new Release
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
+
+            releaseStatusRepository.Setup(s => s.GetAllByOverallStage(
+                release.Id, 
+                ReleaseStatusOverallStage.Started,
+                ReleaseStatusOverallStage.Complete
+            ))
+                .ReturnsAsync(new List<PublisherReleaseStatus> {});
+
             // Assert that any users with the "MarkAllReleasesAsDraft" claim can mark an arbitrary Release as Draft
             // (and no other claim allows this)
             AssertReleaseHandlerSucceedsWithCorrectClaims<MarkSpecificReleaseAsDraftRequirement>(
-                new CanMarkAllReleasesAsDraftAuthorizationHandler(),
+                new CanMarkAllReleasesAsDraftAuthorizationHandler(releaseStatusRepository.Object),
                 MarkAllReleasesAsDraft
             );
         }
@@ -26,14 +45,53 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         {
             var release = new Release
             {
+                Id = Guid.NewGuid(),
                 Status = ReleaseStatus.Approved,
             };
+
+            var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
+
+            releaseStatusRepository.Setup(s => s.GetAllByOverallStage(
+                release.Id, 
+                ReleaseStatusOverallStage.Started,
+                ReleaseStatusOverallStage.Complete
+            ))
+                .ReturnsAsync(new List<PublisherReleaseStatus> {});
+
             
             // Assert that any users with the "MarkAllReleasesAsDraft" claim can mark an arbitrary Release as Draft
             AssertReleaseHandlerSucceedsWithCorrectClaims<MarkSpecificReleaseAsDraftRequirement>(
-                new CanMarkAllReleasesAsDraftAuthorizationHandler(),
+                new CanMarkAllReleasesAsDraftAuthorizationHandler(releaseStatusRepository.Object),
                 release,
                 MarkAllReleasesAsDraft
+            );
+        }
+
+        [Fact]
+        public void CanMarkAllReleasesAsDraftAuthorizationHandler_ReleaseStartedPublishing()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                Status = ReleaseStatus.Approved,
+                Published = DateTime.Now 
+            };
+
+            var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
+
+            releaseStatusRepository.Setup(s => s.GetAllByOverallStage(
+                release.Id, 
+                ReleaseStatusOverallStage.Started,
+                ReleaseStatusOverallStage.Complete
+            ))
+                .ReturnsAsync(new List<PublisherReleaseStatus> {
+                    new PublisherReleaseStatus()
+                });
+
+            // Assert that no users can mark a Release as Draft once it has started publishing
+            AssertReleaseHandlerSucceedsWithCorrectClaims<MarkSpecificReleaseAsDraftRequirement>(
+                new CanMarkAllReleasesAsDraftAuthorizationHandler(releaseStatusRepository.Object),
+                release
             );
         }
 
@@ -42,13 +100,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         {
             var release = new Release
             {
+                Id = Guid.NewGuid(),
                 Status = ReleaseStatus.Approved,
                 Published = DateTime.Now
             };
-            
+
+            var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
+
+            releaseStatusRepository.Setup(s => s.GetAllByOverallStage(
+                release.Id, 
+                ReleaseStatusOverallStage.Started,
+                ReleaseStatusOverallStage.Complete
+            ))
+                .ReturnsAsync(new List<PublisherReleaseStatus> {});
+
             // Assert that no users can mark a published Release as Draft
             AssertReleaseHandlerSucceedsWithCorrectClaims<MarkSpecificReleaseAsDraftRequirement>(
-                new CanMarkAllReleasesAsDraftAuthorizationHandler(),
+                new CanMarkAllReleasesAsDraftAuthorizationHandler(releaseStatusRepository.Object),
                 release
             );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/SubmitSpecificReleaseToHigherReviewAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/SubmitSpecificReleaseToHigherReviewAuthorizationHandlersTests.cs
@@ -1,7 +1,12 @@
 using System;
+using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using Moq;
 using Xunit;
+using ReleaseStatusOverallStage = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusOverallStage;
+using PublisherReleaseStatus = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatus;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.SubmitSpecificReleaseToHigherReviewAuthorizationHandler;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.ReleaseAuthorizationHandlersTestUtil;
@@ -13,10 +18,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         [Fact]
         public void CanSubmitAllReleasesToHigherReviewAuthorizationHandler()
         {
+            var release = new Release
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
+
+            releaseStatusRepository.Setup(s => s.GetAllByOverallStage(
+                release.Id, 
+                ReleaseStatusOverallStage.Started, 
+                ReleaseStatusOverallStage.Complete
+            ))
+                .ReturnsAsync(new List<PublisherReleaseStatus> {});
+
             // Assert that any users with the "SubmitAllReleasesToHigherReview" claim can submit an arbitrary Release to higher review
             // (and no other claim allows this)
             AssertReleaseHandlerSucceedsWithCorrectClaims<SubmitSpecificReleaseToHigherReviewRequirement>(
-                new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(), 
+                new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(releaseStatusRepository.Object), 
                 SubmitAllReleasesToHigherReview
             );
         }
@@ -26,14 +45,50 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         {
             var release = new Release
             {
+                Id = Guid.NewGuid(),
                 Status = ReleaseStatus.Approved
             };
+
+            var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
+
+            releaseStatusRepository.Setup(s => s.GetAllByOverallStage(
+                release.Id, 
+                ReleaseStatusOverallStage.Started, 
+                ReleaseStatusOverallStage.Complete
+            ))
+                .ReturnsAsync(new List<PublisherReleaseStatus> {});
             
             // Assert that any users with the "SubmitAllReleasesToHigherReview" claim can submit an arbitrary Release to higher review
             AssertReleaseHandlerSucceedsWithCorrectClaims<SubmitSpecificReleaseToHigherReviewRequirement>(
-                new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(),
+                new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(releaseStatusRepository.Object),
                 release,
                 SubmitAllReleasesToHigherReview
+            );
+        }
+
+        [Fact]
+        public void CanSubmitAllReleasesToHigherReviewAuthorizationHandler_ReleaseStartedPublishing()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                Status = ReleaseStatus.Approved,
+                Published = DateTime.Now
+            };
+
+            var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
+
+            releaseStatusRepository.Setup(s => s.GetAllByOverallStage(
+                release.Id, 
+                ReleaseStatusOverallStage.Started, 
+                ReleaseStatusOverallStage.Complete
+            ))
+                .ReturnsAsync(new List<PublisherReleaseStatus> {});
+            
+            // Assert that no users can submit a Release to higher review once it has started publishing
+            AssertReleaseHandlerSucceedsWithCorrectClaims<SubmitSpecificReleaseToHigherReviewRequirement>(
+                new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(releaseStatusRepository.Object),
+                release
             );
         }
 
@@ -42,13 +97,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         {
             var release = new Release
             {
+                Id = Guid.NewGuid(),
                 Status = ReleaseStatus.Approved,
                 Published = DateTime.Now
             };
+
+            var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
+
+            releaseStatusRepository.Setup(s => s.GetAllByOverallStage(
+                release.Id, 
+                ReleaseStatusOverallStage.Started, 
+                ReleaseStatusOverallStage.Complete
+            ))
+                .ReturnsAsync(new List<PublisherReleaseStatus> {});
             
-            // Assert that no users can submit an approved Release to higher review
+            // Assert that no users can submit a Release to higher review once it has published
             AssertReleaseHandlerSucceedsWithCorrectClaims<SubmitSpecificReleaseToHigherReviewRequirement>(
-                new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(),
+                new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(releaseStatusRepository.Object),
                 release
             );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlersTests.cs
@@ -1,8 +1,12 @@
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Moq;
 using Xunit;
+using ReleaseStatusOverallStage = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusOverallStage;
+using PublisherReleaseStatus = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatus;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.UpdateSpecificReleaseAuthorizationHandler;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.ReleaseAuthorizationHandlersTestUtil;
@@ -25,10 +29,50 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     Status = status
                 };
 
+                var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
+
+                releaseStatusRepository.Setup(s => s.GetAllByOverallStage(
+                    release.Id, 
+                    ReleaseStatusOverallStage.Started, 
+                    ReleaseStatusOverallStage.Complete
+                ))
+                    .ReturnsAsync(new List<PublisherReleaseStatus> {});
+
                 AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
-                    new CanUpdateAllReleasesAuthorizationHandler(),
+                    new CanUpdateAllReleasesAuthorizationHandler(releaseStatusRepository.Object),
                     release,
                     UpdateAllReleases
+                );
+            });
+        }
+
+        [Fact]
+        public void CanUpdateAllReleasesAuthorizationHandler_ReleaseStartedPublishing()
+        {
+            // Assert that no usres can update an arbitrary Release 
+            // if it is published (and no other claim allows this)
+            GetEnumValues<ReleaseStatus>().ForEach(status =>
+            {
+                var release = new Release
+                {
+                    Id = Guid.NewGuid(),
+                    Status = status,
+                };
+
+                var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
+
+                releaseStatusRepository.Setup(s => s.GetAllByOverallStage(
+                    release.Id, 
+                    ReleaseStatusOverallStage.Started, 
+                    ReleaseStatusOverallStage.Complete
+                ))
+                    .ReturnsAsync(new List<PublisherReleaseStatus> {
+                        new PublisherReleaseStatus()
+                    });
+
+                AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
+                    new CanUpdateAllReleasesAuthorizationHandler(releaseStatusRepository.Object),
+                    release
                 );
             });
         }
@@ -47,12 +91,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     Published = DateTime.Now
                 };
 
+                var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
+
+                releaseStatusRepository.Setup(s => s.GetAllByOverallStage(
+                    release.Id, 
+                    ReleaseStatusOverallStage.Started, 
+                    ReleaseStatusOverallStage.Complete
+                ))
+                    .ReturnsAsync(new List<PublisherReleaseStatus> {});
+
                 AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
-                    new CanUpdateAllReleasesAuthorizationHandler(),
+                    new CanUpdateAllReleasesAuthorizationHandler(releaseStatusRepository.Object),
                     release
                 );
             });
-        }        
+        }
         
         [Fact]
         public void HasEditorRoleOnReleaseAuthorizationHandler()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ApproveSpecificReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ApproveSpecificReleaseAuthorizationHandlers.cs
@@ -1,8 +1,11 @@
-using GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlers;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
+using ReleaseStatusOverallStage = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusOverallStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
@@ -11,26 +14,44 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
     
     public class ApproveSpecificReleaseAuthorizationHandler : CompoundAuthorizationHandler<ApproveSpecificReleaseRequirement, Release>
     {
-        public ApproveSpecificReleaseAuthorizationHandler(ContentDbContext context) : base(
-            new CanApproveAllReleasesAuthorizationHandler(),
+        public ApproveSpecificReleaseAuthorizationHandler(ContentDbContext context, IReleaseStatusRepository releaseStatusRepository) : base(
+            new CanApproveAllReleasesAuthorizationHandler(releaseStatusRepository),
             new HasApproverRoleOnReleaseAuthorizationHandler(context))
         {
             
         }
         
         public class CanApproveAllReleasesAuthorizationHandler : 
-            EntityAuthorizationHandler<ApproveSpecificReleaseRequirement, Release>
+            AuthorizationHandler<ApproveSpecificReleaseRequirement, Release>
         {
-            public CanApproveAllReleasesAuthorizationHandler() 
-                : base(ctx => 
-                {
-                    if (ctx.Entity.Published != null) 
-                    {
-                        return false;
-                    }
+            private IReleaseStatusRepository _releaseStatusRepository;
 
-                    return SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.ApproveAllReleases);
-                }) {}
+            public CanApproveAllReleasesAuthorizationHandler(IReleaseStatusRepository releaseStatusRepository)
+            {
+                _releaseStatusRepository = releaseStatusRepository;
+            }
+
+            protected override async Task HandleRequirementAsync(
+                AuthorizationHandlerContext context, 
+                ApproveSpecificReleaseRequirement requirement,
+                Release release)
+            {
+                var statuses = await _releaseStatusRepository.GetAllByOverallStage(
+                    release.Id, 
+                    ReleaseStatusOverallStage.Started, 
+                    ReleaseStatusOverallStage.Complete
+                );
+
+                if (statuses.Any() || release.Published != null)
+                {
+                    return;
+                }
+
+                if (SecurityUtils.HasClaim(context.User, SecurityClaimTypes.ApproveAllReleases)) 
+                {
+                    context.Succeed(requirement);
+                }
+            }
         }
 
         public class HasApproverRoleOnReleaseAuthorizationHandler

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkSpecificReleaseAsDraftAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkSpecificReleaseAsDraftAuthorizationHandlers.cs
@@ -1,7 +1,10 @@
-using GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlers;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
+using ReleaseStatusOverallStage = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusOverallStage;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
@@ -12,26 +15,44 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
     public class MarkSpecificReleaseAsDraftAuthorizationHandler 
         : CompoundAuthorizationHandler<MarkSpecificReleaseAsDraftRequirement, Release>
     {
-        public MarkSpecificReleaseAsDraftAuthorizationHandler(ContentDbContext context) : base(
-            new CanMarkAllReleasesAsDraftAuthorizationHandler(),
+        public MarkSpecificReleaseAsDraftAuthorizationHandler(ContentDbContext context, IReleaseStatusRepository releaseStatusRepository) : base(
+            new CanMarkAllReleasesAsDraftAuthorizationHandler(releaseStatusRepository),
             new HasEditorRoleOnReleaseAuthorizationHandler(context))
         {
             
         }
         
         public class CanMarkAllReleasesAsDraftAuthorizationHandler 
-            : EntityAuthorizationHandler<MarkSpecificReleaseAsDraftRequirement, Release>
+            : AuthorizationHandler<MarkSpecificReleaseAsDraftRequirement, Release>
         {
-            public CanMarkAllReleasesAsDraftAuthorizationHandler() 
-                : base(ctx => 
-                {
-                    if (ctx.Entity.Published != null)
-                    {
-                        return false;
-                    }
+            private readonly IReleaseStatusRepository _releaseStatusRepository;
+            
+            public CanMarkAllReleasesAsDraftAuthorizationHandler(IReleaseStatusRepository releaseStatusRepository)
+            {
+                _releaseStatusRepository = releaseStatusRepository;
+            }
 
-                    return SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.MarkAllReleasesAsDraft);
-                }) {}
+            protected override async Task HandleRequirementAsync(
+                AuthorizationHandlerContext context, 
+                MarkSpecificReleaseAsDraftRequirement requirement,
+                Release release)
+            {
+                var statuses = await _releaseStatusRepository.GetAllByOverallStage(
+                    release.Id, 
+                    ReleaseStatusOverallStage.Started, 
+                    ReleaseStatusOverallStage.Complete
+                );
+
+                if (statuses.Any() || release.Published != null)
+                {
+                    return;
+                }
+
+                if (SecurityUtils.HasClaim(context.User, SecurityClaimTypes.MarkAllReleasesAsDraft)) 
+                {
+                    context.Succeed(requirement);
+                }
+            }
         }
     
         public class HasEditorRoleOnReleaseAuthorizationHandler

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/SubmitSpecificReleaseToHigherApprovalAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/SubmitSpecificReleaseToHigherApprovalAuthorizationHandlers.cs
@@ -1,8 +1,11 @@
-using GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlers;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
+using ReleaseStatusOverallStage = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusOverallStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
@@ -12,26 +15,44 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
     public class SubmitSpecificReleaseToHigherReviewAuthorizationHandler 
         : CompoundAuthorizationHandler<SubmitSpecificReleaseToHigherReviewRequirement, Release>
     {
-        public SubmitSpecificReleaseToHigherReviewAuthorizationHandler(ContentDbContext context) : base(
-            new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(),
+        public SubmitSpecificReleaseToHigherReviewAuthorizationHandler(ContentDbContext context, IReleaseStatusRepository releaseStatusRepository) : base(
+            new CanSubmitAllReleasesToHigherReviewAuthorizationHandler(releaseStatusRepository),
             new HasEditorRoleOnReleaseAuthorizationHandler(context))
         {
             
         }
         
         public class CanSubmitAllReleasesToHigherReviewAuthorizationHandler 
-            : EntityAuthorizationHandler<SubmitSpecificReleaseToHigherReviewRequirement, Release>
+            : AuthorizationHandler<SubmitSpecificReleaseToHigherReviewRequirement, Release>
         {
-            public CanSubmitAllReleasesToHigherReviewAuthorizationHandler() 
-                : base(ctx => 
-                {
-                    if (ctx.Entity.Published != null) 
-                    {
-                        return false;
-                    }
+            private IReleaseStatusRepository _releaseStatusRepository;
 
-                    return SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.SubmitAllReleasesToHigherReview);
-                }) {}
+            public CanSubmitAllReleasesToHigherReviewAuthorizationHandler(IReleaseStatusRepository releaseStatusRepository)
+            {
+                _releaseStatusRepository = releaseStatusRepository;
+            }
+
+            protected override async Task HandleRequirementAsync(
+                AuthorizationHandlerContext context, 
+                SubmitSpecificReleaseToHigherReviewRequirement requirement,
+                Release release)
+            {
+                var statuses = await _releaseStatusRepository.GetAllByOverallStage(
+                    release.Id, 
+                    ReleaseStatusOverallStage.Started, 
+                    ReleaseStatusOverallStage.Complete
+                );
+
+                if (statuses.Any() || release.Published != null)
+                {
+                    return;
+                }
+
+                if (SecurityUtils.HasClaim(context.User, SecurityClaimTypes.SubmitAllReleasesToHigherReview)) 
+                {
+                    context.Succeed(requirement);
+                }
+            }
         }
 
         public class HasEditorRoleOnReleaseAuthorizationHandler

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificCommentAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificCommentAuthorizationHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -17,10 +18,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
         UpdateSpecificCommentAuthorizationHandler : AuthorizationHandler<UpdateSpecificCommentRequirement, Comment>
     {
         private readonly ContentDbContext _contentDbContext;
+        private readonly IReleaseStatusRepository _releaseStatusRepository;
 
-        public UpdateSpecificCommentAuthorizationHandler(ContentDbContext contentDbContext)
+        public UpdateSpecificCommentAuthorizationHandler(ContentDbContext contentDbContext, IReleaseStatusRepository releaseStatusRepository)
         {
             _contentDbContext = contentDbContext;
+            _releaseStatusRepository = releaseStatusRepository;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context,
@@ -30,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             var release = GetRelease(_contentDbContext, resource);
             var updateSpecificReleaseContext = new AuthorizationHandlerContext(
                 new[] {new UpdateSpecificReleaseRequirement()}, context.User, release);
-            await new UpdateSpecificReleaseAuthorizationHandler(_contentDbContext).HandleAsync(
+            await new UpdateSpecificReleaseAuthorizationHandler(_contentDbContext, _releaseStatusRepository).HandleAsync(
                 updateSpecificReleaseContext);
 
             if (!updateSpecificReleaseContext.HasSucceeded)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlers.cs
@@ -1,8 +1,11 @@
-using GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlers;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
+using ReleaseStatusOverallStage = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusOverallStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
@@ -11,25 +14,43 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
 
     public class UpdateSpecificReleaseAuthorizationHandler : CompoundAuthorizationHandler<UpdateSpecificReleaseRequirement, Release>
     {
-        public UpdateSpecificReleaseAuthorizationHandler(ContentDbContext context) : base(
-            new CanUpdateAllReleasesAuthorizationHandler(),
+        public UpdateSpecificReleaseAuthorizationHandler(ContentDbContext context, IReleaseStatusRepository releaseStatusRepository) : base(
+            new CanUpdateAllReleasesAuthorizationHandler(releaseStatusRepository),
             new HasEditorRoleOnReleaseAuthorizationHandler(context))
         {
             
         }
     
-        public class CanUpdateAllReleasesAuthorizationHandler : EntityAuthorizationHandler<UpdateSpecificReleaseRequirement, Release>
+        public class CanUpdateAllReleasesAuthorizationHandler : AuthorizationHandler<UpdateSpecificReleaseRequirement, Release>
         {
-            public CanUpdateAllReleasesAuthorizationHandler()
-                : base(ctx =>
-                {
-                    if (ctx.Entity.Published != null) 
-                    {
-                        return false;
-                    }
+            private readonly IReleaseStatusRepository _releaseStatusRepository;
 
-                    return SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.UpdateAllReleases);
-                }) {}
+            public CanUpdateAllReleasesAuthorizationHandler(IReleaseStatusRepository releaseStatusRepository) 
+            {
+                _releaseStatusRepository = releaseStatusRepository;
+            }
+
+            protected override async Task HandleRequirementAsync(
+                AuthorizationHandlerContext context, 
+                UpdateSpecificReleaseRequirement requirement,
+                Release release)
+            {
+                var statuses = await _releaseStatusRepository.GetAllByOverallStage(
+                    release.Id, 
+                    ReleaseStatusOverallStage.Started, 
+                    ReleaseStatusOverallStage.Complete
+                );
+
+                if (statuses.Any() || release.Published != null) 
+                {
+                    return;
+                }
+
+                if (SecurityUtils.HasClaim(context.User, SecurityClaimTypes.UpdateAllReleases)) 
+                {
+                    context.Succeed(requirement);
+                }
+            }
         }
 
         public class HasEditorRoleOnReleaseAuthorizationHandler

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseStatusRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseStatusRepository.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
+{
+    public interface IReleaseStatusRepository
+    {
+        Task<IEnumerable<ReleaseStatus>> GetAllByOverallStage(Guid releaseId, params ReleaseStatusOverallStage[] overallStages);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseStatusRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseStatusRepository.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using Microsoft.Azure.Cosmos.Table;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
+{
+    public class ReleaseStatusRepository : IReleaseStatusRepository
+    {
+        private const string TableName = "ReleaseStatus";
+
+        private readonly ITableStorageService _publisherTableStorageService;
+
+        public ReleaseStatusRepository(ITableStorageService publisherTableStorageService)
+        {
+            _publisherTableStorageService = publisherTableStorageService;
+        }
+
+        public Task<IEnumerable<ReleaseStatus>> GetAllByOverallStage(Guid releaseId, params ReleaseStatusOverallStage[] overallStages)
+        {
+            var filter = TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.PartitionKey),
+                    QueryComparisons.Equal, releaseId.ToString());
+
+            if (overallStages.Any())
+            {
+                var allStageFilters = overallStages.ToList().Aggregate("", (acc, stage) => 
+                {
+                   var stageFilter = TableQuery.GenerateFilterCondition(
+                       nameof(ReleaseStatus.OverallStage),
+                       QueryComparisons.Equal,
+                       stage.ToString()
+                    );
+                
+                    if (acc == "")  {
+                        return stageFilter;
+                    }
+
+                    return TableQuery.CombineFilters(acc, TableOperators.Or, stageFilter); 
+                });
+
+                filter = TableQuery.CombineFilters(filter, TableOperators.And, allStageFilters);
+            }
+
+            var query = new TableQuery<ReleaseStatus>().Where(filter);
+            return _publisherTableStorageService.ExecuteQueryAsync(TableName, query);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseStatusService.cs
@@ -9,11 +9,11 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Cosmos.Table;
-using ReleaseStatus = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatus;
+using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -213,6 +213,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                     s.GetService<IUserService>(),
                     s.GetService<IPersistenceHelper<ContentDbContext>>(),
                     new TableStorageService(Configuration.GetValue<string>("PublisherStorage"))));
+            services.AddTransient<IReleaseStatusRepository, ReleaseStatusRepository>(s => 
+                new ReleaseStatusRepository(
+                    new TableStorageService(Configuration.GetValue<string>("PublisherStorage"))
+                )
+            );
             services.AddTransient<IThemeService, ThemeService>();
             services.AddTransient<IThemeRepository, ThemeRepository>();
             services.AddTransient<ITopicService, TopicService>();


### PR DESCRIPTION
This PR adds additional checks to release status permissions to prevent users from changing the status if publishing has already started or has completed.