### PR TITLE
Admin prototype pages

### DIFF
--- a/src/explore-education-statistics-admin/src/App.tsx
+++ b/src/explore-education-statistics-admin/src/App.tsx
@@ -4,16 +4,22 @@ import ProtectedRoute from '@admin/components/ProtectedRoute';
 import ThemeAndTopic from '@admin/components/ThemeAndTopic';
 import { getConfig } from '@admin/config';
 import { AuthContextProvider } from '@admin/contexts/AuthContext';
+import ServiceProblemsPage from '@admin/pages/errors/ServiceProblemsPage';
 import {
   ApplicationInsightsContextProvider,
   useApplicationInsights,
 } from '@common/contexts/ApplicationInsightsContext';
-import React, { useEffect } from 'react';
+import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import React, { lazy, Suspense, useEffect } from 'react';
 import { Route, Switch, useHistory } from 'react-router';
 import { BrowserRouter } from 'react-router-dom';
 import './App.scss';
 import PageNotFoundPage from './pages/errors/PageNotFoundPage';
 import appRouteList from './routes/dashboard/routes';
+
+const PrototypeIndexPage = lazy(() =>
+  import('@admin/prototypes/PrototypeIndexPage'),
+);
 
 function ApplicationInsightsTracking() {
   const appInsights = useApplicationInsights();
@@ -34,23 +40,24 @@ function ApplicationInsightsTracking() {
   return null;
 }
 
-function App() {
-  const authRoutes = Object.entries(apiAuthorizationRouteList).map(
-    ([key, authRoute]) => {
-      return <Route exact key={`authRoute-${key}`} {...authRoute} />;
-    },
+function PrototypesEntry() {
+  const { value: routes = [] } = useAsyncRetry(() =>
+    import('./prototypes/prototypeRoutes').then(module => module.default),
   );
 
-  const appRoutes = Object.entries(appRouteList).map(([key, appRoute]) => {
-    return (
-      <ProtectedRoute
-        key={`appRoute-${key}`}
-        protectionAction={appRoute.protectedAction}
-        {...appRoute}
-      />
-    );
-  });
+  return (
+    <Suspense fallback={<ServiceProblemsPage />}>
+      <Switch>
+        <Route exact path="/prototypes" component={PrototypeIndexPage} />
+        {routes?.map(route => (
+          <Route key={route.path} exact={route.exact ?? true} {...route} />
+        ))}
+      </Switch>
+    </Suspense>
+  );
+}
 
+function App() {
   return (
     <ApplicationInsightsContextProvider
       instrumentationKey={getConfig().then(config => config.AppInsightsKey)}
@@ -62,8 +69,28 @@ function App() {
           <AuthContextProvider>
             <PageErrorBoundary>
               <Switch>
-                {authRoutes}
-                {appRoutes}
+                {Object.entries(apiAuthorizationRouteList).map(
+                  ([key, authRoute]) => (
+                    <Route exact key={key} {...authRoute} />
+                  ),
+                )}
+
+                {Object.entries(appRouteList).map(([key, appRoute]) => (
+                  <ProtectedRoute
+                    key={key}
+                    protectionAction={appRoute.protectedAction}
+                    {...appRoute}
+                  />
+                ))}
+
+                <ProtectedRoute
+                  path="/prototypes"
+                  protectionAction={user =>
+                    user.permissions.canAccessUserAdministrationPages
+                  }
+                  component={PrototypesEntry}
+                />
+
                 <ProtectedRoute
                   allowAnonymousUsers
                   component={PageNotFoundPage}

--- a/src/explore-education-statistics-admin/src/components/Breadcrumbs.tsx
+++ b/src/explore-education-statistics-admin/src/components/Breadcrumbs.tsx
@@ -6,21 +6,21 @@ export interface BreadcrumbsProps {
     link?: string;
     name: string;
   }[];
-  includeHomeBreadcrumb?: boolean;
+  homePath?: string;
 }
 
 const Breadcrumbs = ({
   breadcrumbs = [],
-  includeHomeBreadcrumb = true,
+  homePath = '/',
 }: BreadcrumbsProps) => {
   const currentBreadcrumbIndex = breadcrumbs.length - 1;
 
   return (
     <div className="govuk-breadcrumbs">
       <ol className="govuk-breadcrumbs__list" data-testid="breadcrumbs--list">
-        {includeHomeBreadcrumb && (
+        {homePath && (
           <li className="govuk-breadcrumbs__list-item">
-            <Link className="govuk-breadcrumbs__link" to="/">
+            <Link className="govuk-breadcrumbs__link" to={homePath}>
               Home
             </Link>
           </li>

--- a/src/explore-education-statistics-admin/src/components/Page.tsx
+++ b/src/explore-education-statistics-admin/src/components/Page.tsx
@@ -6,13 +6,20 @@ import Breadcrumbs, { BreadcrumbsProps } from './Breadcrumbs';
 import PageBanner from './PageBanner';
 import PageHeader from './PageHeader';
 
-type Props = {
+export type PageProps = {
   children: ReactNode;
   wide?: boolean;
   pageTitle?: string;
+  pageBanner?: ReactNode;
 } & BreadcrumbsProps;
 
-const Page = ({ children, wide, pageTitle, ...breadcrumbProps }: Props) => {
+const Page = ({
+  children,
+  wide,
+  pageTitle,
+  pageBanner,
+  ...breadcrumbProps
+}: PageProps) => {
   return (
     <>
       <Helmet>
@@ -30,7 +37,7 @@ const Page = ({ children, wide, pageTitle, ...breadcrumbProps }: Props) => {
           'dfe-width-container--wide': wide,
         })}
       >
-        <PageBanner />
+        {pageBanner ?? <PageBanner />}
 
         <Breadcrumbs {...breadcrumbProps} />
 

--- a/src/explore-education-statistics-admin/src/components/PageFooter.tsx
+++ b/src/explore-education-statistics-admin/src/components/PageFooter.tsx
@@ -21,17 +21,21 @@ const PageFooter = ({ wide }: Props) => {
           <div className="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 className="govuk-visually-hidden">Support links</h2>
             <ul className="govuk-footer__inline-list">
-              {user &&
-                (user.permissions.canAccessUserAdministrationPages ||
-                  user.permissions.canAccessMethodologyAdministrationPages) && (
-                  <>
-                    <li className="govuk-footer__inline-list-item">
-                      <a className="govuk-footer__link" href="/docs">
-                        API Documentation
-                      </a>
-                    </li>
-                  </>
-                )}
+              {(user?.permissions.canAccessUserAdministrationPages ||
+                user?.permissions.canAccessMethodologyAdministrationPages) && (
+                <>
+                  <li className="govuk-footer__inline-list-item">
+                    <a className="govuk-footer__link" href="/docs">
+                      API Documentation
+                    </a>
+                  </li>
+                  <li className="govuk-footer__inline-list-item">
+                    <Link className="govuk-footer__link" to="/prototypes">
+                      Prototypes
+                    </Link>
+                  </li>
+                </>
+              )}
               <li className="govuk-footer__inline-list-item">
                 <Link className="govuk-footer__link" to="/contact-us">
                   Contact us

--- a/src/explore-education-statistics-admin/src/components/__tests__/Breadcrumbs.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/__tests__/Breadcrumbs.test.tsx
@@ -105,17 +105,17 @@ describe('Breadcrumbs', () => {
     expect(lastBreadcrumb.querySelector('a')).toBeNull();
   });
 
-  test('does not render Home breadcrumb if explicitly asked to exclude', () => {
+  test('does not render Home breadcrumb if empty path', () => {
     const { container } = render(
       <MemoryRouter>
         <Breadcrumbs
+          homePath=""
           breadcrumbs={[
             {
               link: '/publications',
               name: 'Publications',
             },
           ]}
-          includeHomeBreadcrumb={false}
         />
         ,
       </MemoryRouter>,

--- a/src/explore-education-statistics-admin/src/pages/release/PreReleasePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/PreReleasePage.tsx
@@ -79,7 +79,7 @@ const PreReleasePage = ({ match }: RouteComponentProps<MatchProps>) => {
           ? [{ name: 'Pre Release access' }]
           : []
       }
-      includeHomeBreadcrumb={user && user.permissions.canAccessAnalystPages}
+      homePath={user?.permissions.canAccessAnalystPages ? '/' : ''}
     >
       {preReleaseWindowStatus?.access === 'Within' && content && (
         <ReleaseContentProvider

--- a/src/explore-education-statistics-admin/src/prototypes/PrototypeExamplePage.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/PrototypeExamplePage.tsx
@@ -1,0 +1,12 @@
+import PrototypePage from '@admin/prototypes/components/PrototypePage';
+import React from 'react';
+
+const PrototypeExamplePage = () => {
+  return (
+    <PrototypePage pageTitle="Example prototype">
+      <p>Here's an example</p>
+    </PrototypePage>
+  );
+};
+
+export default PrototypeExamplePage;

--- a/src/explore-education-statistics-admin/src/prototypes/PrototypeIndexPage.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/PrototypeIndexPage.tsx
@@ -1,0 +1,22 @@
+import Link from '@admin/components/Link';
+import PrototypePage from '@admin/prototypes/components/PrototypePage';
+import prototypeRoutes from '@admin/prototypes/prototypeRoutes';
+import React from 'react';
+
+const PrototypeIndexPage = () => {
+  return (
+    <PrototypePage pageTitle="Prototypes">
+      <ul>
+        {prototypeRoutes.map(route => {
+          return (
+            <li key={route.path}>
+              <Link to={route.path}>{route.name}</Link>
+            </li>
+          );
+        })}
+      </ul>
+    </PrototypePage>
+  );
+};
+
+export default PrototypeIndexPage;

--- a/src/explore-education-statistics-admin/src/prototypes/components/PrototypePage.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/components/PrototypePage.tsx
@@ -1,0 +1,17 @@
+import Page, { PageProps } from '@admin/components/Page';
+import PrototypePageBanner from '@admin/prototypes/components/PrototypePageBanner';
+import React from 'react';
+
+const PrototypePage = ({ children, ...props }: PageProps) => {
+  return (
+    <Page
+      {...props}
+      homePath="/prototypes"
+      pageBanner={<PrototypePageBanner />}
+    >
+      {children}
+    </Page>
+  );
+};
+
+export default PrototypePage;

--- a/src/explore-education-statistics-admin/src/prototypes/components/PrototypePageBanner.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/components/PrototypePageBanner.tsx
@@ -1,0 +1,27 @@
+import Link from '@admin/components/Link';
+import classNames from 'classnames';
+import React from 'react';
+
+const PrototypePageBanner = () => {
+  return (
+    <div className="govuk-phase-banner">
+      <p className="govuk-phase-banner__content">
+        <strong
+          className={classNames(
+            'govuk-tag',
+            'govuk-phase-banner__content__tag',
+          )}
+        >
+          Prototype
+        </strong>
+
+        <span className="govuk-phase-banner__text">
+          This is a prototype page –{' '}
+          <Link to="/prototypes">View prototype index</Link>
+        </span>
+      </p>
+    </div>
+  );
+};
+
+export default PrototypePageBanner;

--- a/src/explore-education-statistics-admin/src/prototypes/prototypeRoutes.ts
+++ b/src/explore-education-statistics-admin/src/prototypes/prototypeRoutes.ts
@@ -1,0 +1,17 @@
+import { RouteProps } from 'react-router';
+import PrototypeExamplePage from './PrototypeExamplePage';
+
+interface PrototypeRoute extends RouteProps {
+  name: string;
+  path: string;
+}
+
+const prototypeRoutes: PrototypeRoute[] = [
+  {
+    name: 'Example prototype',
+    path: '/prototypes/example',
+    component: PrototypeExamplePage,
+  },
+];
+
+export default prototypeRoutes;


### PR DESCRIPTION
This PR adds prototype pages that are accessible via `/prototypes` or the footer link.