### PR TITLE
EES-1142 Add warning message to 'As soon as possible' option for release publishing

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableAccordionSection.tsx
@@ -5,6 +5,7 @@ import AccordionSection, {
   AccordionSectionProps,
 } from '@common/components/AccordionSection';
 import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
 import { FormTextInput } from '@common/components/form';
 import ModalConfirm from '@common/components/ModalConfirm';
 import useToggle from '@common/hooks/useToggle';
@@ -139,7 +140,7 @@ const EditableAccordionSection = (props: EditableAccordionSectionProps) => {
             heading={heading}
             header={header}
           >
-            <div>
+            <ButtonGroup>
               {onHeadingChange &&
                 (isEditingHeading ? (
                   <Button onClick={saveHeading}>Save section title</Button>
@@ -176,7 +177,7 @@ const EditableAccordionSection = (props: EditableAccordionSectionProps) => {
                   </ModalConfirm>
                 </>
               )}
-            </div>
+            </ButtonGroup>
 
             {children}
           </AccordionSection>

--- a/src/explore-education-statistics-admin/src/components/editable/EditableBlockWrapper.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableBlockWrapper.tsx
@@ -1,5 +1,6 @@
 import styles from '@admin/components/editable/EditableBlockWrapper.module.scss';
 import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
 import ModalConfirm from '@common/components/ModalConfirm';
 import useToggle from '@common/hooks/useToggle';
 import React, { ReactNode } from 'react';
@@ -20,7 +21,7 @@ const EditableBlockWrapper = ({
     <article>
       <div className={styles.block}>{children}</div>
 
-      <div className={styles.buttons}>
+      <ButtonGroup className={styles.buttons}>
         {onEdit && (
           <Button variant="secondary" onClick={() => onEdit()}>
             Edit block
@@ -47,7 +48,7 @@ const EditableBlockWrapper = ({
             </ModalConfirm>
           </>
         )}
-      </div>
+      </ButtonGroup>
     </article>
   );
 };

--- a/src/explore-education-statistics-admin/src/components/editable/EditableKeyStatTile.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableKeyStatTile.tsx
@@ -3,6 +3,7 @@ import FormFieldEditor from '@admin/components/form/FormFieldEditor';
 import toHtml from '@admin/utils/markdown/toHtml';
 import toMarkdown from '@admin/utils/markdown/toMarkdown';
 import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
 import { Form, FormFieldTextInput } from '@common/components/form';
 import useToggle from '@common/hooks/useToggle';
 import KeyStatTile, {
@@ -93,16 +94,18 @@ const EditableKeyStatTile = ({
                 label="Guidance text"
               />
 
-              <Button
-                disabled={!form.isValid}
-                type="submit"
-                className="govuk-!-margin-right-2"
-              >
-                Save
-              </Button>
-              <Button variant="secondary" onClick={toggleShowForm.off}>
-                Cancel
-              </Button>
+              <ButtonGroup>
+                <Button
+                  disabled={!form.isValid}
+                  type="submit"
+                  className="govuk-!-margin-right-2"
+                >
+                  Save
+                </Button>
+                <Button variant="secondary" onClick={toggleShowForm.off}>
+                  Cancel
+                </Button>
+              </ButtonGroup>
             </KeyStatTile>
           </Form>
         );
@@ -110,7 +113,7 @@ const EditableKeyStatTile = ({
     </Formik>
   ) : (
     <KeyStatTile releaseId={releaseId} query={query} summary={summary}>
-      <div className="govuk-!-margin-top-2">
+      <ButtonGroup className="govuk-!-margin-top-2">
         <Button onClick={toggleShowForm.on}>Edit</Button>
 
         {onRemove && (
@@ -125,7 +128,7 @@ const EditableKeyStatTile = ({
             Remove
           </Button>
         )}
-      </div>
+      </ButtonGroup>
     </KeyStatTile>
   );
 };

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/__snapshots__/EditableBlockRenderer.test.tsx.snap
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/__snapshots__/EditableBlockRenderer.test.tsx.snap
@@ -16,15 +16,15 @@ exports[`EditableBlockRenderer MarkDownBlock renders editable version correctly 
       </div>
     </div>
   </div>
-  <div class="buttons">
+  <div class="group buttons">
     <button aria-disabled="false"
-            class="govuk-button button govuk-button--secondary"
+            class="govuk-button govuk-button--secondary"
             type="button"
     >
       Edit block
     </button>
     <button aria-disabled="false"
-            class="govuk-button button govuk-button--warning"
+            class="govuk-button govuk-button--warning"
             type="button"
     >
       Remove block
@@ -44,7 +44,7 @@ exports[`EditableBlockRenderer MarkDownBlock renders non-editable version correc
       </div>
     </div>
   </div>
-  <div class="buttons">
+  <div class="group buttons">
   </div>
 </article>
 `;

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -16,6 +16,7 @@ import FormattedDate from '@common/components/FormattedDate';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
+import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import { ReleaseApprovalStatus } from '@common/services/publicationService';
@@ -288,6 +289,13 @@ const ReleaseStatusPage = () => {
                       {
                         label: 'As soon as possible',
                         value: 'Immediate',
+                        conditional: (
+                          <WarningMessage className="govuk-!-width-two-thirds">
+                            This will start the release process immediately and
+                            make statistics available to the public. Make sure
+                            this is okay before continuing.
+                          </WarningMessage>
+                        ),
                       },
                     ]}
                   />

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/AddSecondaryStats.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/AddSecondaryStats.tsx
@@ -3,6 +3,7 @@ import DataBlockSelectForm from '@admin/pages/release/content/components/DataBlo
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
 import { EditableRelease } from '@admin/services/releaseContentService';
 import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
 import ModalConfirm from '@common/components/ModalConfirm';
 import React, { useState } from 'react';
 
@@ -28,7 +29,7 @@ const AddSecondaryStats = ({ release, updating = false }: Props) => {
 
   if (!isFormOpen) {
     return (
-      <>
+      <ButtonGroup>
         <Button
           className="govuk-!-margin-top-4 govuk-!-margin-bottom-4"
           onClick={() => {
@@ -79,7 +80,7 @@ const AddSecondaryStats = ({ release, updating = false }: Props) => {
             Are you sure you want to remove this this secondary stats section?
           </p>
         </ModalConfirm>
-      </>
+      </ButtonGroup>
     );
   }
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/DataBlockSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/DataBlockSelectForm.tsx
@@ -1,6 +1,7 @@
 import useGetChartFile from '@admin/hooks/useGetChartFile';
 import { useReleaseContentState } from '@admin/pages/release/content/contexts/ReleaseContentContext';
 import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
 import Details from '@common/components/Details';
 import { FormSelect } from '@common/components/form';
 import DataBlockRenderer from '@common/modules/find-statistics/components/DataBlockRenderer';
@@ -72,19 +73,22 @@ const DataBlockSelectForm = ({
           })),
         ]}
       />
+
       <Button className="govuk-button--secondary" onClick={onCancel}>
         Cancel
       </Button>
+
       {getDataBlockPreview(selectedDataBlockId)}
+
       {selectedDataBlockId !== '' && (
-        <>
+        <ButtonGroup>
           <Button onClick={() => onSelect(selectedDataBlockId)}>Embed</Button>
           {!hideCancel && (
             <Button className="govuk-button--secondary" onClick={onCancel}>
               Cancel
             </Button>
           )}
-        </>
+        </ButtonGroup>
       )}
     </div>
   );

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatSelectForm.tsx
@@ -1,5 +1,6 @@
 import { useReleaseContentState } from '@admin/pages/release/content/contexts/ReleaseContentContext';
 import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
 import Details from '@common/components/Details';
 import { FormSelect } from '@common/components/form';
 import KeyStatTile from '@common/modules/find-statistics/components/KeyStatTile';
@@ -89,14 +90,17 @@ const KeyStatSelectForm = ({
         ]}
       />
       {getKeyStatPreview()}
-      {selectedDataBlockId !== '' && (
-        <Button onClick={() => onSelect(selectedDataBlockId)}>Embed</Button>
-      )}
-      {!hideCancel && (
-        <Button className="govuk-button--secondary" onClick={onCancel}>
-          Cancel
-        </Button>
-      )}
+
+      <ButtonGroup>
+        {selectedDataBlockId !== '' && (
+          <Button onClick={() => onSelect(selectedDataBlockId)}>Embed</Button>
+        )}
+        {!hideCancel && (
+          <Button className="govuk-button--secondary" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
+      </ButtonGroup>
     </>
   );
 };

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -8,6 +8,7 @@ import useReleaseContentActions from '@admin/pages/release/content/contexts/useR
 import { EditableRelease } from '@admin/services/releaseContentService';
 import { EditableBlock } from '@admin/services/types/content';
 import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
 import { ContentSection } from '@common/services/publicationService';
 import { Dictionary } from '@common/types';
 import React, { memo, useCallback, useEffect, useState } from 'react';
@@ -171,7 +172,7 @@ const ReleaseContentAccordionSection = ({
       />
 
       {isEditing && !isReordering && (
-        <div className="govuk-!-margin-bottom-8 dfe-align--centre">
+        <ButtonGroup className="govuk-!-margin-bottom-8 dfe-justify-content--center">
           <Button variant="secondary" onClick={addBlock}>
             Add text block
           </Button>
@@ -179,7 +180,7 @@ const ReleaseContentAccordionSection = ({
             releaseId={release.id}
             onAddDataBlock={attachDataBlock}
           />
-        </div>
+        </ButtonGroup>
       )}
     </EditableAccordionSection>
   );

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ChartAxisConfiguration.tsx
@@ -3,6 +3,7 @@ import { ChartBuilderForm } from '@admin/pages/release/datablocks/components/Cha
 import ChartBuilderSaveButton from '@admin/pages/release/datablocks/components/ChartBuilderSaveButton';
 import { FormState } from '@admin/pages/release/datablocks/reducers/chartBuilderReducer';
 import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
 import Effect from '@common/components/Effect';
 import {
   Form,
@@ -636,15 +637,17 @@ const ChartAxisConfiguration = ({
             </table>
           )}
 
-          <ChartBuilderSaveButton
-            formId={id}
-            forms={forms}
-            showSubmitError={
-              form.isValid && form.submitCount > 0 && !canSaveChart
-            }
-          />
+          <ButtonGroup>
+            <ChartBuilderSaveButton
+              formId={id}
+              forms={forms}
+              showSubmitError={
+                form.isValid && form.submitCount > 0 && !canSaveChart
+              }
+            />
 
-          {buttons}
+            {buttons}
+          </ButtonGroup>
         </Form>
       )}
     </Formik>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ChartConfiguration.tsx
@@ -5,6 +5,7 @@ import {
   ChartOptions,
   FormState,
 } from '@admin/pages/release/datablocks/reducers/chartBuilderReducer';
+import ButtonGroup from '@common/components/ButtonGroup';
 import Effect from '@common/components/Effect';
 import { Form, FormFieldSelect, FormGroup } from '@common/components/form';
 import FormFieldCheckbox from '@common/components/form/FormFieldCheckbox';
@@ -286,15 +287,17 @@ const ChartConfiguration = ({
               </>
             )}
 
-            <ChartBuilderSaveButton
-              formId={formId}
-              forms={forms}
-              showSubmitError={
-                form.isValid && form.submitCount > 0 && !canSaveChart
-              }
-            />
+            <ButtonGroup>
+              <ChartBuilderSaveButton
+                formId={formId}
+                forms={forms}
+                showSubmitError={
+                  form.isValid && form.submitCount > 0 && !canSaveChart
+                }
+              />
 
-            {buttons}
+              {buttons}
+            </ButtonGroup>
           </Form>
         )}
       </Formik>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ChartDataSelector.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ChartDataSelector.tsx
@@ -4,6 +4,7 @@ import ChartDataConfiguration from '@admin/pages/release/datablocks/components/C
 import styles from '@admin/pages/release/datablocks/components/ChartDataSelector.module.scss';
 import { FormState } from '@admin/pages/release/datablocks/reducers/chartBuilderReducer';
 import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
 import Details from '@common/components/Details';
 import { Form, FormFieldSelect } from '@common/components/form';
 import { ChartDefinition } from '@common/modules/charts/types/chart';
@@ -306,20 +307,22 @@ const ChartDataSelector = ({
                 })}
               </ul>
 
-              <ChartBuilderSaveButton
-                formId={formId}
-                forms={forms}
-                showSubmitError={submitCount > 0 && !canSaveChart}
-                onClick={() => {
-                  setSubmitCount(submitCount + 1);
+              <ButtonGroup>
+                <ChartBuilderSaveButton
+                  formId={formId}
+                  forms={forms}
+                  showSubmitError={submitCount > 0 && !canSaveChart}
+                  onClick={() => {
+                    setSubmitCount(submitCount + 1);
 
-                  if (canSaveChart) {
-                    onSubmit(dataSetConfigs);
-                  }
-                }}
-              />
+                    if (canSaveChart) {
+                      onSubmit(dataSetConfigs);
+                    }
+                  }}
+                />
 
-              {buttons}
+                {buttons}
+              </ButtonGroup>
             </>
           )}
         </>

--- a/src/explore-education-statistics-common/src/components/Button.module.scss
+++ b/src/explore-education-statistics-common/src/components/Button.module.scss
@@ -1,7 +1,0 @@
-@import '../styles/govuk-base';
-
-.button:not(:last-of-type) {
-  @include govuk-media-query($from: tablet) {
-    margin-right: govuk-spacing(2);
-  }
-}

--- a/src/explore-education-statistics-common/src/components/Button.tsx
+++ b/src/explore-education-statistics-common/src/components/Button.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React, { MouseEventHandler, ReactNode } from 'react';
-import styles from './Button.module.scss';
 
 export interface ButtonProps {
   children: ReactNode;
@@ -27,7 +26,6 @@ const Button = ({
       aria-disabled={disabled}
       className={classNames(
         'govuk-button',
-        styles.button,
         {
           'govuk-button--disabled': disabled,
           'govuk-button--secondary': variant === 'secondary',

--- a/src/explore-education-statistics-common/src/components/ButtonGroup.module.scss
+++ b/src/explore-education-statistics-common/src/components/ButtonGroup.module.scss
@@ -6,12 +6,12 @@
   flex-direction: column;
   margin-bottom: govuk-spacing(6);
 
-  button {
+  > * {
     margin-bottom: govuk-spacing(4);
-    margin-right: govuk-spacing(2);
+    margin-right: 0;
   }
 
-  button:last-child {
+  > :last-child {
     margin-right: 0;
   }
 
@@ -19,8 +19,9 @@
   @include govuk-media-query($from: tablet) {
     flex-direction: row;
 
-    button {
+    > * {
       margin-bottom: 0;
+      margin-right: govuk-spacing(2);
     }
   }
 }

--- a/src/explore-education-statistics-common/src/components/WarningMessage.module.scss
+++ b/src/explore-education-statistics-common/src/components/WarningMessage.module.scss
@@ -1,0 +1,17 @@
+@import '../styles/govuk-base';
+
+.warning {
+  align-items: center;
+  display: flex;
+}
+
+.icon {
+  margin-top: 0;
+  min-height: 35px;
+  min-width: 35px;
+  position: relative;
+}
+
+.text {
+  padding-left: govuk-spacing(3);
+}

--- a/src/explore-education-statistics-common/src/components/WarningMessage.tsx
+++ b/src/explore-education-statistics-common/src/components/WarningMessage.tsx
@@ -1,17 +1,25 @@
+import classNames from 'classnames';
 import React, { ReactNode } from 'react';
+import styles from './WarningMessage.module.scss';
 
 interface Props {
   children: ReactNode;
+  className?: string;
   icon?: string;
 }
 
-const WarningMessage = ({ icon = '!', children }: Props) => {
+const WarningMessage = ({ children, className, icon = '!' }: Props) => {
   return (
-    <div className="govuk-warning-text">
-      <span className="govuk-warning-text__icon" aria-hidden="true">
+    <div
+      className={classNames('govuk-warning-text', styles.warning, className)}
+    >
+      <span
+        className={classNames('govuk-warning-text__icon', styles.icon)}
+        aria-hidden="true"
+      >
         {icon}
       </span>
-      <strong className="govuk-warning-text__text">
+      <strong className={classNames('govuk-warning-text__text', styles.text)}>
         <span className="govuk-warning-text__assistive">Warning</span>
         {children}
       </strong>

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Button renders correctly with required props 1`] = `
 <button aria-disabled="false"
-        class="govuk-button button"
+        class="govuk-button"
         type="button"
 >
   Test button

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepFormActions.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepFormActions.tsx
@@ -1,3 +1,4 @@
+import ButtonGroup from '@common/components/ButtonGroup';
 import { FormikState } from 'formik';
 import React, { MouseEventHandler } from 'react';
 import Button from '@common/components/Button';
@@ -28,41 +29,43 @@ const WizardStepFormActions = ({
 }: Props) => {
   return (
     <FormGroup>
-      {stepNumber > 1 && (
+      <ButtonGroup>
+        {stepNumber > 1 && (
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={event => {
+              if (onPreviousStep) {
+                onPreviousStep(event);
+              }
+
+              if (!event.isDefaultPrevented()) {
+                goToPreviousStep();
+              }
+            }}
+          >
+            Previous step
+          </Button>
+        )}
+
         <Button
-          type="button"
-          variant="secondary"
-          onClick={event => {
-            if (onPreviousStep) {
-              onPreviousStep(event);
-            }
-
-            if (!event.isDefaultPrevented()) {
-              goToPreviousStep();
-            }
-          }}
+          disabled={form.isSubmitting}
+          id={`${formId}-submit`}
+          type="submit"
+          onClick={onSubmitClick}
         >
-          Previous step
+          {form.isSubmitting ? submittingText : submitText}
         </Button>
-      )}
 
-      <Button
-        disabled={form.isSubmitting}
-        id={`${formId}-submit`}
-        type="submit"
-        onClick={onSubmitClick}
-      >
-        {form.isSubmitting ? submittingText : submitText}
-      </Button>
-
-      <LoadingSpinner
-        alert
-        inline
-        hideText
-        loading={form.isSubmitting}
-        size="md"
-        text="Page is loading"
-      />
+        <LoadingSpinner
+          alert
+          inline
+          hideText
+          loading={form.isSubmitting}
+          size="md"
+          text="Page is loading"
+        />
+      </ButtonGroup>
     </FormGroup>
   );
 };

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -1,0 +1,107 @@
+*** Settings ***
+Resource    ../../libs/admin-common.robot
+
+Force Tags  Admin  Local  Dev  AltersData
+
+Suite Setup       user signs in as bau1
+Suite Teardown    user closes the browser
+
+*** Variables ***
+${TOPIC_NAME}        UI test topic %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}  UI tests - release status %{RUN_IDENTIFIER}
+
+*** Test Cases ***
+Create new publication for "UI tests topic" topic
+    [Tags]  HappyPath
+    environment variable should be set   RUN_IDENTIFIER
+    user selects theme "Test theme" and topic "${TOPIC_NAME}" from the admin dashboard
+    user waits until page contains link    Create new publication
+    user checks page does not contain button   ${PUBLICATION_NAME}
+    user clicks link  Create new publication
+    user creates publication without methodology  ${PUBLICATION_NAME}   Tingting Shu - (Attainment statistics team)
+
+Verify new publication
+    [Tags]  HappyPath
+    user selects theme "Test theme" and topic "${TOPIC_NAME}" from the admin dashboard
+    user waits until page contains button  ${PUBLICATION_NAME}
+
+Create new release
+    [Tags]  HappyPath
+    user selects theme "Test theme" and topic "${TOPIC_NAME}" from the admin dashboard
+    user waits until page contains button  ${PUBLICATION_NAME}
+    user opens accordion section  ${PUBLICATION_NAME}
+    user clicks element  css:[data-testid="Create new release link for ${PUBLICATION_NAME}"]
+    user creates release for publication  ${PUBLICATION_NAME}  Financial Year  3000
+
+Verify release summary
+    [Tags]  HappyPath
+    user checks page contains element   xpath://li/a[text()="Release summary" and contains(@aria-current, 'page')]
+    user waits until page contains heading 2  Release summary
+    user checks summary list item "Publication title" should be "${PUBLICATION_NAME}"
+
+Go to "Release status" tab
+    [Tags]  HappyPath
+    user clicks link   Release status
+    user waits until page contains heading 2  Release status
+    user waits until page contains button  Edit release status
+
+Submit release for Higher Review
+    [Tags]  HappyPath
+    user clicks button  Edit release status
+    user clicks element   css:input[data-testid="Ready for higher review"]
+    user enters text into element  id:releaseStatusForm-internalReleaseNote     Submitted for Higher Review
+    user enters text into element  id:releaseStatusForm-nextReleaseDate-month   12
+    user enters text into element  id:releaseStatusForm-nextReleaseDate-year    3001
+    user clicks button   Update status
+
+Verify release status is Higher Review
+    [Tags]  HappyPath
+    user waits until page contains heading 2  Release status
+    user checks summary list item "Current status" should be "Awaiting higher review"
+    user checks summary list item "Scheduled release" should be "Not scheduled"
+    user checks summary list item "Next release expected" should be "December 3001"
+
+Approve release
+    [Tags]  HappyPath
+    user clicks button  Edit release status
+    user waits until page contains heading 2  Edit release status
+
+    user clicks element   css:input[data-testid="Approved for publication"]
+    user enters text into element   id:releaseStatusForm-internalReleaseNote    Approved for release
+
+    user clicks element  css:input[data-testid="On a specific date"]
+    user enters text into element  id:releaseStatusForm-publishScheduled-day    1
+    user enters text into element  id:releaseStatusForm-publishScheduled-month  12
+    user enters text into element  id:releaseStatusForm-publishScheduled-year   3000
+
+    user enters text into element  id:releaseStatusForm-nextReleaseDate-month   3
+    user enters text into element  id:releaseStatusForm-nextReleaseDate-year    3002
+
+    user clicks button   Update status
+
+Verify release status is Approved
+    [Tags]  HappyPath
+    user waits until page contains heading 2  Release status
+    user checks summary list item "Current status" should be "Approved"
+    user checks summary list item "Scheduled release" should be "1 December 3000"
+    user checks summary list item "Next release expected" should be "March 3002"
+    user waits for release process status to be  Scheduled  180
+
+Move release status back to Draft
+    [Tags]  HappyPath
+    user clicks button  Edit release status
+    user clicks element   css:input[data-testid="In draft"]
+
+    user enters text into element   id:releaseStatusForm-internalReleaseNote    Moved back to draft
+
+    user enters text into element  id:releaseStatusForm-nextReleaseDate-month   1
+    user enters text into element  id:releaseStatusForm-nextReleaseDate-year    3001
+
+    user clicks button   Update status
+
+Verify release status is Draft
+    [Tags]  HappyPath
+    user waits until page contains heading 2  Release status
+    user checks summary list item "Current status" should be "Draft"
+    user checks summary list item "Scheduled release" should be "Not scheduled"
+    user checks summary list item "Next release expected" should be "January 3001"

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release.robot
@@ -6,41 +6,36 @@ Force Tags  Admin  Local  Dev  AltersData
 Suite Setup       user signs in as bau1
 Suite Teardown    user closes the browser
 
+*** Variables ***
+${TOPIC_NAME}        UI test topic %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}  UI tests - publish release %{RUN_IDENTIFIER}
+
 *** Test Cases ***
 Create new publication for "UI tests topic" topic
     [Tags]  HappyPath
     environment variable should be set   RUN_IDENTIFIER
-    user selects theme "Test theme" and topic "UI test topic %{RUN_IDENTIFIER}" from the admin dashboard
+    user selects theme "Test theme" and topic "${TOPIC_NAME}" from the admin dashboard
     user waits until page contains link    Create new publication
-    user checks page does not contain button   UI tests - publish release %{RUN_IDENTIFIER}
+    user checks page does not contain button   ${PUBLICATION_NAME}
     user clicks link  Create new publication
-    user creates publication  UI tests - publish release %{RUN_IDENTIFIER}   Test methodology   Tingting Shu - (Attainment statistics team)
+    user creates publication without methodology  ${PUBLICATION_NAME}   Tingting Shu - (Attainment statistics team)
 
 Verify new publication
     [Tags]  HappyPath
-    user selects theme "Test theme" and topic "UI test topic %{RUN_IDENTIFIER}" from the admin dashboard
-    user waits until page contains button  UI tests - publish release %{RUN_IDENTIFIER}
-    user checks page contains accordion   UI tests - publish release %{RUN_IDENTIFIER}
-    user opens accordion section  UI tests - publish release %{RUN_IDENTIFIER}
-    user checks summary list item "Methodology" should be "Test methodology"
-    user checks summary list item "Releases" should be "No releases created"
+    user selects theme "Test theme" and topic "${TOPIC_NAME}" from the admin dashboard
+    user waits until page contains button  ${PUBLICATION_NAME}
 
 Create new release
-    [Tags]   HappyPath
-    user clicks element  css:[data-testid="Create new release link for UI tests - publish release %{RUN_IDENTIFIER}"]
-    user creates release for publication  UI tests - publish release %{RUN_IDENTIFIER}  Financial Year  2000
+    [Tags]  HappyPath
+    user opens accordion section  ${PUBLICATION_NAME}
+    user clicks element  css:[data-testid="Create new release link for ${PUBLICATION_NAME}"]
+    user creates release for publication  ${PUBLICATION_NAME}  Financial Year  3000
 
 Verify release summary
     [Tags]  HappyPath
     user checks page contains element   xpath://li/a[text()="Release summary" and contains(@aria-current, 'page')]
     user waits until page contains heading 2  Release summary
-    user checks summary list item "Publication title" should be "UI tests - publish release %{RUN_IDENTIFIER}"
-    user checks summary list item "Time period" should be "Financial Year"
-    user checks summary list item "Release period" should be "2000"
-    user checks summary list item "Lead statistician" should be "Tingting Shu"
-    user checks summary list item "Scheduled release" should be "Not scheduled"
-    user checks summary list item "Next release expected" should be "Not set"
-    user checks summary list item "Release type" should be "National Statistics"
+    user checks summary list item "Publication title" should be "${PUBLICATION_NAME}"
 
 Go to "Release status" tab
     [Tags]  HappyPath
@@ -48,54 +43,43 @@ Go to "Release status" tab
     user waits until page contains heading 2  Release status
     user waits until page contains button  Edit release status
 
-Approve the release
+Approve release
     [Tags]  HappyPath
     ${PUBLISH_DATE_DAY}=  get datetime  %d
     ${PUBLISH_DATE_MONTH}=  get datetime  %m
     ${PUBLISH_DATE_MONTH_WORD}=  get datetime  %B
     ${PUBLISH_DATE_YEAR}=  get datetime  %Y
-    ${NEXT_RELEASE_YEAR}=  evaluate  str(int(${PUBLISH_DATE_YEAR}) + 1)
     set suite variable  ${PUBLISH_DATE_DAY}
     set suite variable  ${PUBLISH_DATE_MONTH}
     set suite variable  ${PUBLISH_DATE_MONTH_WORD}
     set suite variable  ${PUBLISH_DATE_YEAR}
-    set suite variable  ${NEXT_RELEASE_YEAR}
 
     user clicks button  Edit release status
     user waits until page contains heading 2  Edit release status
 
     user clicks element   css:input[data-testid="Approved for publication"]
-    user clicks element   id:releaseStatusForm-internalReleaseNote
-    user presses keys  Approved by UI tests on ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}
-    user clicks element  css:input[data-testid="On a specific date"]
 
-    user enters text into element  id:releaseStatusForm-publishScheduled-day  ${PUBLISH_DATE_DAY}
-    user enters text into element  id:releaseStatusForm-publishScheduled-month  ${PUBLISH_DATE_MONTH}
-    user enters text into element  id:releaseStatusForm-publishScheduled-year   ${PUBLISH_DATE_YEAR}
+    user enters text into element  id:releaseStatusForm-internalReleaseNote  Approved by UI tests
 
-    user enters text into element  id:releaseStatusForm-nextReleaseDate-month  ${PUBLISH_DATE_MONTH}
-    user enters text into element  id:releaseStatusForm-nextReleaseDate-year  ${NEXT_RELEASE_YEAR}
+    user clicks element  css:input[data-testid="As soon as possible"]
+
+    user enters text into element  id:releaseStatusForm-nextReleaseDate-month   12
+    user enters text into element  id:releaseStatusForm-nextReleaseDate-year    3001
 
     user clicks button   Update status
 
-Verify that the release is Scheduled
+Verify release is scheduled
     [Tags]  HappyPath
     user waits until page contains heading 2  Release status
-    user waits until page contains element  id:release-process-status-Scheduled   180
-    # EES-1029
-    #user checks summary list item "Scheduled release" should be "${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}"
-    user checks summary list item "Next release expected" should be "${PUBLISH_DATE_MONTH_WORD} ${NEXT_RELEASE_YEAR}"
-
-Trigger release on demand
-    [Tags]  HappyPath
-    ${CURRENT_URL}=  get location
-    ${RELEASE_GUID}=  get release guid from release status page url  ${CURRENT_URL}
-    user triggers release on demand  ${RELEASE_GUID}
+    user checks summary list item "Current status" should be "Approved"
+    user checks summary list item "Scheduled release" should be "${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}"
+    user checks summary list item "Next release expected" should be "December 3001"
 
 Wait for release process status to be Complete
     [Tags]  HappyPath
     # EES-1007 - Release process status doesn't automatically update
     user waits for release process status to be  Complete    900
+    user checks page does not contain button  Edit release status
 
 User goes to public Find Statistics page
     [Tags]  HappyPath
@@ -108,32 +92,30 @@ Verify newly published release is on Find Statistics page
     [Tags]  HappyPath
     user checks page contains accordion   Test theme
     user opens accordion section  Test theme
-    user checks accordion section contains text   Test theme   UI test topic %{RUN_IDENTIFIER}
+    user checks accordion section contains text   Test theme   ${TOPIC_NAME}
 
-    user opens details dropdown  UI test topic %{RUN_IDENTIFIER}
-    user checks details dropdown contains publication    UI test topic %{RUN_IDENTIFIER}    UI tests - publish release %{RUN_IDENTIFIER}
-    user checks publication bullet contains link   UI tests - publish release %{RUN_IDENTIFIER}    View statistics and data
-    user checks publication bullet contains link   UI tests - publish release %{RUN_IDENTIFIER}    Create your own tables online
-    user checks publication bullet does not contain link  UI tests - publish release %{RUN_IDENTIFIER}   Statistics at DfE
+    user opens details dropdown  ${TOPIC_NAME}
+    user checks details dropdown contains publication    ${TOPIC_NAME}  ${PUBLICATION_NAME}
+    user checks publication bullet contains link   ${PUBLICATION_NAME}  View statistics and data
+    user checks publication bullet contains link   ${PUBLICATION_NAME}  Create your own tables online
+    user checks publication bullet does not contain link  ${PUBLICATION_NAME}   Statistics at DfE
 
 Navigate to newly published release page
     [Tags]  HappyPath
     user clicks element   css:[data-testid="view-stats-ui-tests-publish-release-%{RUN_IDENTIFIER}"]
-    user waits until page contains heading  UI tests - publish release %{RUN_IDENTIFIER}
+    user waits until page contains heading  ${PUBLICATION_NAME}
 
 Verify release URL and page caption
     [Tags]  HappyPath
     user checks url contains  %{PUBLIC_URL}/find-statistics/ui-tests-publish-release-%{RUN_IDENTIFIER}
-    user checks element contains  css:[data-testid="page-title-caption"]  Financial Year 2000-01
+    user checks element contains  css:[data-testid="page-title-caption"]  Financial Year 3000-01
 
 Verify publish and update dates
-    [Tags]  HappyPath   Failing
-    [Documentation]   EES-952
+    [Tags]  HappyPath
     user checks element contains  css:[data-testid="published-date"]   ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}
-    user checks element contains  xpath://*[@data-testid="next-update"]/strong/time   ${PUBLISH_DATE_MONTH_WORD} ${NEXT_RELEASE_YEAR}
+    user checks element contains  css:[data-testid="next-update"] time   December 3001
 
 Verify accordions are correct
     [Tags]  HappyPath
-    user checks accordion is in position   Methodology  1
-    user checks accordion is in position   National Statistics  2
-    user checks accordion is in position   Contact us  3
+    user checks accordion is in position   National Statistics  1
+    user checks accordion is in position   Contact us  2

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -24,6 +24,15 @@ user creates publication
     user clicks button   Create publication
     user waits until page contains element   xpath://span[text()="Welcome"]
 
+user creates publication without methodology
+    [Arguments]   ${title}   ${contact}
+    user waits until page contains heading    Create new publication
+    user enters text into element  id:createPublicationForm-publicationTitle   ${title}
+    user selects radio     Select a methodology later
+    user selects from list by label  id:createPublicationForm-selectedContactId   ${contact}
+    user clicks button   Create publication
+    user waits until page contains element   xpath://span[text()="Welcome"]
+
 User creates release for publication
     [Arguments]  ${publication}  ${time_period_coverage}  ${start_year}
     user waits until page contains heading   Create new release


### PR DESCRIPTION
This PR adds the following warning message to make users aware of the consequences of using the 'As soon as possible' option:

![image](https://user-images.githubusercontent.com/9917868/87052753-0d288c00-c1f9-11ea-99be-e6f85812a4df.png)

## Other changes

- Fix `WarningMessage` icon looking squashed despite using out of the box `govuk-frontend` styling. We also now vertically centre all the child elements.
- Refactor instances of groups of buttons to use `ButtonGroup` component. This ensures that the group's elements are spaced consistently and centrally consistently.
- Add UI tests to cover release status more comprehensively.