### PR TITLE
EES-1148 Fix public frontend not rendering when JS is disabled

### DIFF
--- a/src/explore-education-statistics-common/src/contexts/ApplicationInsightsContext.tsx
+++ b/src/explore-education-statistics-common/src/contexts/ApplicationInsightsContext.tsx
@@ -20,7 +20,6 @@ export const ApplicationInsightsContextProvider = ({
   children,
   instrumentationKey,
 }: ApplicationInsightsContextProviderProps) => {
-  const [isLoading, setLoading] = useState(true);
   const [appInsights, setAppInsights] = useState<ApplicationInsights>();
 
   useEffect(() => {
@@ -31,26 +30,17 @@ export const ApplicationInsightsContextProvider = ({
         );
 
         setAppInsights(applicationInsights);
-        setLoading(false);
       },
     );
   }, [instrumentationKey]);
 
   return (
     <ApplicationInsightsContext.Provider value={appInsights}>
-      {!isLoading ? children : null}
+      {children}
     </ApplicationInsightsContext.Provider>
   );
 };
 
-export function useApplicationInsights(): ApplicationInsights {
-  const appInsights = useContext(ApplicationInsightsContext);
-
-  if (!appInsights) {
-    throw new Error(
-      'ApplicationInsightsContextProvider has not been initialised',
-    );
-  }
-
-  return appInsights;
+export function useApplicationInsights(): ApplicationInsights | undefined {
+  return useContext(ApplicationInsightsContext);
 }

--- a/src/explore-education-statistics-frontend/src/modules/ErrorPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/ErrorPage.tsx
@@ -3,7 +3,7 @@ import Link from '@frontend/components/Link';
 import NotFoundPage from '@frontend/modules/NotFoundPage';
 import { AxiosError } from 'axios';
 import { NextPageContext } from 'next';
-import React from 'react';
+import React, { useEffect } from 'react';
 import Page from '../components/Page';
 
 interface Props {
@@ -14,16 +14,18 @@ interface Props {
 const ErrorPage = ({ statusCode, error }: Props) => {
   const appInsights = useApplicationInsights();
 
-  if (error) {
-    // `error` is not actually an Error instance,
-    // (it's an object) so we have to convert
-    // it into one first before tracking it.
-    const exception = new Error(error.message);
-    exception.name = error.name;
-    exception.stack = error.stack;
+  useEffect(() => {
+    if (error && appInsights) {
+      // `error` is not actually an Error instance,
+      // (it's an object) so we have to convert
+      // it into one first before tracking it.
+      const exception = new Error(error.message);
+      exception.name = error.name;
+      exception.stack = error.stack;
 
-    appInsights.trackException({ exception });
-  }
+      appInsights.trackException({ exception });
+    }
+  }, [appInsights, error]);
 
   switch (statusCode) {
     case 404:

--- a/src/explore-education-statistics-frontend/src/pages/_app.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/_app.tsx
@@ -24,6 +24,10 @@ const ApplicationInsightsTracking = () => {
   const router = useRouter();
 
   useEffect(() => {
+    if (!appInsights) {
+      return;
+    }
+
     appInsights.trackPageView({
       uri: router.pathname,
     });


### PR DESCRIPTION
This was due to the conditional child rendering that was taking place in`ApplicationInsightsContextProvider`. We have been doing this primarily to prevent `useApplicationInsights` from returning an optional `ApplicationInsights`.

We've now allowed `ApplicationInsights` to be optional and consequently `ApplicationInsightsContextProvider` will always render its children. This has meant some tweaks to our code where we `useApplicationInsights` to avoid potential null pointer errors.