### PR TITLE
EES-1079 Fix incorrect PascalCasing of filter group keys

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
@@ -5,129 +5,158 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
 {
     public class StringExtensionTests
     {
-        [Fact]
-        public void NullStringCanBeCamelCased()
+        public class CamelCaseTests
         {
-            string input = null;
-            Assert.Null(input.CamelCase());
+            [Fact]
+            public void NullStringCanBeCamelCased()
+            {
+                string input = null;
+                Assert.Null(input.CamelCase());
+            }
+
+            [Fact]
+            public void EmptyStringCanBeCamelCased()
+            {
+                Assert.Equal(string.Empty, string.Empty.CamelCase());
+            }
+
+            [Fact]
+            public void StringsWithNonAlphaNumericCharactersAreCamelCased()
+            {
+                Assert.Equal("fooBarBaz", "foo bar  baz".CamelCase());
+                Assert.Equal("fooBarBaz", "foo-bar--baz".CamelCase());
+                Assert.Equal("fooBarBaz", "foo.bar..baz".CamelCase());
+                Assert.Equal("fooBarBaz", "foo_bar__baz".CamelCase());
+                Assert.Equal("fooBarBaz", "foo,bar,,baz".CamelCase());
+            }
+
+            [Fact]
+            public void AcronymsAreCamelCased()
+            {
+                Assert.Equal("aBC", "ABC".CamelCase());
+            }
+
+            [Fact]
+            public void CamelCasedStringRemainsCamelCased()
+            {
+                Assert.Equal("foo", "foo".CamelCase());
+                Assert.Equal("camelCase", "camelCase".CamelCase());
+            }
+
+            [Fact]
+            public void PascalCaseStringIsCamelCased()
+            {
+                Assert.Equal("fooBar", "FooBar".CamelCase());
+            }
+
+            [Fact]
+            public void UnderscoreSeparatedStringsAreCamelCased()
+            {
+                Assert.Equal("fooBar", "foo_bar".CamelCase());
+                Assert.Equal("fooBar", "foo_Bar".CamelCase());
+                Assert.Equal("fooBar", "Foo_Bar".CamelCase());
+                Assert.Equal("fOOBar", "FOO_Bar".CamelCase());
+            }
         }
 
-        [Fact]
-        public void EmptyStringCanBeCamelCased()
+        public class PascalCaseTests
         {
-            Assert.Equal(string.Empty, string.Empty.CamelCase());
+            [Fact]
+            public void NullStringCanBePascalCased()
+            {
+                string input = null;
+                Assert.Null(input.PascalCase());
+            }
+
+            [Fact]
+            public void StringsWithNonAlphaNumericCharactersArePascalCased()
+            {
+                Assert.Equal("FooBarBaz", "foo bar  baz".PascalCase());
+                Assert.Equal("FooBarBaz", "foo-bar--baz".PascalCase());
+                Assert.Equal("FooBarBaz", "foo.bar..baz".PascalCase());
+                Assert.Equal("FooBarBaz", "foo_bar__baz".PascalCase());
+                Assert.Equal("FooBarBaz", "foo,bar,,baz".PascalCase());
+            }
+
+            [Fact]
+            public void EmptyStringCanBePascalCased()
+            {
+                Assert.Equal(string.Empty, string.Empty.PascalCase());
+            }
+
+            [Fact]
+            public void ValuesAreNotTouchedByPascalCase()
+            {
+                Assert.Equal("Foo", "Foo".PascalCase());
+                Assert.Equal("FOO", "FOO".PascalCase());
+            }
+
+            [Fact]
+            public void PascalCasedStringRemainsPascalCased()
+            {
+                Assert.Equal("PascalCase", "PascalCase".PascalCase());
+            }
+
+            [Fact]
+            public void CamelCaseStringIsPascalCased()
+            {
+                Assert.Equal("FooBar", "fooBar".PascalCase());
+                Assert.Equal("FooBAR", "fooBAR".PascalCase());
+            }
+
+            [Fact]
+            public void UnderscoreSeparatedStringsArePascalCased()
+            {
+                Assert.Equal("FooBar", "foo_bar".PascalCase());
+                Assert.Equal("FooBar", "foo_Bar".PascalCase());
+                Assert.Equal("FooBar", "Foo_Bar".PascalCase());
+                Assert.Equal("FOOBar", "FOO_Bar".PascalCase());
+            }
         }
 
-        [Fact]
-        public void AcronymsAreCamelCased()
+        public class ScreamingSnakeCaseTests
         {
-            Assert.Equal("aBC", "ABC".CamelCase());
-        }
+            [Fact]
+            public void NullStringsCanBeScreamingSnakeCased()
+            {
+                string input = null;
+                Assert.Null(input.ScreamingSnakeCase());
+            }
 
-        [Fact]
-        public void CamelCasedStringRemainsCamelCased()
-        {
-            Assert.Equal("foo", "foo".CamelCase());
-            Assert.Equal("camelCase", "camelCase".CamelCase());
-        }
+            [Fact]
+            public void EmptyStringCanBeScreamingSnakeCased()
+            {
+                Assert.Equal(string.Empty, string.Empty.ScreamingSnakeCase());
+            }
 
-        [Fact]
-        public void PascalCaseStringIsCamelCased()
-        {
-            Assert.Equal("fooBar", "FooBar".CamelCase());
-        }
+            [Fact]
+            public void AcronymsAreAlreadyScreamingSnakeCased()
+            {
+                Assert.Equal("ABC", "ABC".ScreamingSnakeCase());
+            }
 
-        [Fact]
-        public void UnderscoreSeparatedStringsAreCamelCased()
-        {
-            Assert.Equal("fooBar", "foo_bar".CamelCase());
-            Assert.Equal("fooBar", "foo_Bar".CamelCase());
-            Assert.Equal("fooBar", "Foo_Bar".CamelCase());
-            Assert.Equal("fOOBar", "FOO_Bar".CamelCase());
-        }
+            [Fact]
+            public void CamelCasedStringsAreScreamingSnakeCased()
+            {
+                Assert.Equal("FOO", "foo".ScreamingSnakeCase());
+                Assert.Equal("CAMEL_CASE_STRING", "camelCaseString".ScreamingSnakeCase());
+            }
 
-        [Fact]
-        public void NullStringCanBePascalCased()
-        {
-            string input = null;
-            Assert.Null(input.PascalCase());
-        }
-
-        [Fact]
-        public void EmptyStringCanBePascalCased()
-        {
-            Assert.Equal(string.Empty, string.Empty.PascalCase());
-        }
-
-        [Fact]
-        public void ValuesAreNotTouchedByPascalCase()
-        {
-            Assert.Equal("Foo", "Foo".PascalCase());
-            Assert.Equal("FOO", "FOO".PascalCase());
-        }
-
-        [Fact]
-        public void PascalCasedStringRemainsPascalCased()
-        {
-            Assert.Equal("PascalCase", "PascalCase".PascalCase());
-        }
-
-        [Fact]
-        public void CamelCaseStringIsPascalCased()
-        {
-            Assert.Equal("FooBar", "fooBar".PascalCase());
-            Assert.Equal("FooBAR", "fooBAR".PascalCase());
-        }
-
-        [Fact]
-        public void UnderscoreSeparatedStringsArePascalCased()
-        {
-            Assert.Equal("FooBar", "foo_bar".PascalCase());
-            Assert.Equal("FooBar", "foo_Bar".PascalCase());
-            Assert.Equal("FooBar", "Foo_Bar".PascalCase());
-            Assert.Equal("FOOBar", "FOO_Bar".PascalCase());
-        }
-
-        [Fact]
-        public void NullStringsCanBeScreamingSnakeCased()
-        {
-            string input = null;
-            Assert.Null(input.ScreamingSnakeCase());
-        }
-
-        [Fact]
-        public void EmptyStringCanBeScreamingSnakeCased()
-        {
-            Assert.Equal(string.Empty, string.Empty.ScreamingSnakeCase());
-        }
-
-        [Fact]
-        public void AcronymsAreAlreadyScreamingSnakeCased()
-        {
-            Assert.Equal("ABC", "ABC".ScreamingSnakeCase());
-        }
-
-        [Fact]
-        public void CamelCasedStringsAreScreamingSnakeCased()
-        {
-            Assert.Equal("FOO", "foo".ScreamingSnakeCase());
-            Assert.Equal("CAMEL_CASE_STRING", "camelCaseString".ScreamingSnakeCase());
-        }
-
-        [Fact]
-        public void UnderscoreSeparatedStringsAreScreamingSnakeCased()
-        {
-            Assert.Equal("FOO_BAR", "foo_bar".ScreamingSnakeCase());
-            Assert.Equal("FOO_BAR", "foo_Bar".ScreamingSnakeCase());
-            Assert.Equal("FOO_BAR", "Foo_Bar".ScreamingSnakeCase());
-            Assert.Equal("FOO_BAR", "FOO_Bar".ScreamingSnakeCase());
-        }
-        
-        [Fact]
-        public void PascalCasedStringsAreScreamingSnakeCased()
-        {
-            Assert.Equal("FOO_BAR", "FooBar".ScreamingSnakeCase());
-            Assert.Equal("FOO_BAR", "FooBAr".ScreamingSnakeCase());
+            [Fact]
+            public void UnderscoreSeparatedStringsAreScreamingSnakeCased()
+            {
+                Assert.Equal("FOO_BAR", "foo_bar".ScreamingSnakeCase());
+                Assert.Equal("FOO_BAR", "foo_Bar".ScreamingSnakeCase());
+                Assert.Equal("FOO_BAR", "Foo_Bar".ScreamingSnakeCase());
+                Assert.Equal("FOO_BAR", "FOO_Bar".ScreamingSnakeCase());
+            }
+            
+            [Fact]
+            public void PascalCasedStringsAreScreamingSnakeCased()
+            {
+                Assert.Equal("FOO_BAR", "FooBar".ScreamingSnakeCase());
+                Assert.Equal("FOO_BAR", "FooBAr".ScreamingSnakeCase());
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
@@ -24,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             }
 
             var cultInfo = CultureInfo.CurrentCulture.TextInfo;
-            input = input.Replace("_", " ");
+            input = Regex.Replace(input, "[^A-Za-z0-9]", " ");
             input = Regex.Replace(input, "([A-Z]+)", " $1");
             input = cultInfo.ToTitleCase(input);
             input = input.Replace(" ", "");


### PR DESCRIPTION
This fixes filter group keys not being PascalCased correctly so that non-alphanumeric characters are filtered out. This is leading to characters such as dots appearing in the keys.

These keys are used for the Formik field names and unfortunately cause validation to fail due to the dots being considered as 
object path notation by Formik.

We have now corrected the `PascalCase` function (and ergo the `CamelCase` function) so that only alphanumeric characters are allowed.