### PR TITLE
EES-342 Add Top Table Highlights to PublicationSubjectsMetaViewModel

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/MetaControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/MetaControllerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
@@ -20,8 +21,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             var publicationMetaService = new Mock<IPublicationMetaService>();
             var themeMetaService = new Mock<IThemeMetaService>();
 
-            publicationMetaService.Setup(s => s.GetSubjectsForLatestRelease(_publicationId))
-                .Returns(new PublicationSubjectsMetaViewModel());
+            publicationMetaService
+                .Setup(s => s.GetSubjectsForLatestRelease(_publicationId))
+                .ReturnsAsync(new PublicationSubjectsMetaViewModel());
+
+            publicationMetaService
+                .Setup(s => s.GetSubjectsForLatestRelease(It.Is<Guid>(guid => guid != _publicationId)))
+                .ReturnsAsync(new NotFoundResult());
 
             themeMetaService.Setup(s => s.GetThemes())
                 .Returns(new List<ThemeMetaViewModel>
@@ -33,18 +39,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
         }
 
         [Fact]
-        public void Get_SubjectsForLatestRelease_Returns_Ok()
+        public async Task Get_SubjectsForLatestRelease_Returns_Ok()
         {
-            var result = _controller.GetSubjectsForLatestRelease(_publicationId);
-
+            var result = await _controller.GetSubjectsForLatestRelease(_publicationId);
             Assert.IsAssignableFrom<PublicationSubjectsMetaViewModel>(result.Value);
         }
 
         [Fact]
-        public void Get_SubjectsForLatestRelease_Returns_NotFound()
+        public async Task Get_SubjectsForLatestRelease_Returns_NotFound()
         {
-            var result = _controller.GetSubjectsForLatestRelease(new Guid("9ad58d8b-997a-4dba-9255-d0caeae176ab"));
-
+            var result = await _controller.GetSubjectsForLatestRelease(Guid.NewGuid());
             Assert.IsAssignableFrom<NotFoundResult>(result.Result);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/MetaController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/MetaController.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
 using Microsoft.AspNetCore.Mvc;
@@ -27,16 +29,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
         }
 
         [HttpGet("publication/{publicationId}")]
-        public ActionResult<PublicationSubjectsMetaViewModel> GetSubjectsForLatestRelease(Guid publicationId)
+        public async Task<ActionResult<PublicationSubjectsMetaViewModel>> GetSubjectsForLatestRelease(
+            Guid publicationId)
         {
-            var viewModel = _publicationMetaService.GetSubjectsForLatestRelease(publicationId);
-
-            if (viewModel == null)
-            {
-                return NotFound();
-            }
-
-            return viewModel;
+            return await _publicationMetaService.GetSubjectsForLatestRelease(publicationId).HandleFailuresOrOk();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ReleaseFastTrack.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ReleaseFastTrack.cs
@@ -7,15 +7,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
     {
         public Guid FastTrackId => Guid.Parse(RowKey);
         public Guid ReleaseId => Guid.Parse(PartitionKey);
+        public string HighlightName { get; set; }
 
         public ReleaseFastTrack()
         {
         }
 
-        public ReleaseFastTrack(Guid releaseId, Guid fastTrackId)
+        public ReleaseFastTrack(Guid releaseId, Guid fastTrackId, string highlightName)
         {
             PartitionKey = releaseId.ToString();
             RowKey = fastTrackId.ToString();
+            HighlightName = highlightName;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/PublicationMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/PublicationMetaServiceTests.cs
@@ -104,10 +104,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 SubjectId = publicationRelease3Subject.Id
             };
 
-            var releaseFastTrack1 = new ReleaseFastTrack(publicationRelease1.Id, Guid.NewGuid(), null);
+            var releaseFastTrack1 = new ReleaseFastTrack(publicationRelease1.Id, Guid.NewGuid(), "table 1");
             var releaseFastTrack2 = new ReleaseFastTrack(publicationRelease1.Id, Guid.NewGuid(), "table 2");
-            var releaseFastTrack3 = new ReleaseFastTrack(publicationRelease1.Id, Guid.NewGuid(), "table 3");
-            var releaseFastTrack4 = new ReleaseFastTrack(publicationRelease1.Id, Guid.NewGuid(), "");
 
             var builder = new DbContextOptionsBuilder<StatisticsDbContext>();
             builder.UseInMemoryDatabase(Guid.NewGuid().ToString());
@@ -146,7 +144,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     storageService.ExecuteQueryAsync(PublicReleaseFastTrackTableName,
                         It.IsAny<TableQuery<ReleaseFastTrack>>())).ReturnsAsync(new List<ReleaseFastTrack>
                 {
-                    releaseFastTrack1, releaseFastTrack2, releaseFastTrack3, releaseFastTrack4
+                    releaseFastTrack1, releaseFastTrack2
                 });
 
                 var service = BuildPublicationMetaService(context, mocks);
@@ -157,10 +155,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 Assert.Equal(publication.Id, result.PublicationId);
                 Assert.Equal(2, highlights.Count);
-                Assert.Equal(releaseFastTrack2.FastTrackId, highlights[0].Id);
-                Assert.Equal(releaseFastTrack2.HighlightName, highlights[0].Label);
-                Assert.Equal(releaseFastTrack3.FastTrackId, highlights[1].Id);
-                Assert.Equal(releaseFastTrack3.HighlightName, highlights[1].Label);
+                Assert.Equal(releaseFastTrack1.FastTrackId, highlights[0].Id);
+                Assert.Equal(releaseFastTrack1.HighlightName, highlights[0].Label);
+                Assert.Equal(releaseFastTrack2.FastTrackId, highlights[1].Id);
+                Assert.Equal(releaseFastTrack2.HighlightName, highlights[1].Label);
                 Assert.Equal(2, subjects.Count);
                 Assert.Equal(publicationRelease1Subject1.Id, subjects[0].Id);
                 Assert.Equal(publicationRelease1Subject1.Name, subjects[0].Label);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/PublicationMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/PublicationMetaServiceTests.cs
@@ -1,23 +1,28 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Mappings;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Cosmos.Table;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
+using static GovUk.Education.ExploreEducationStatistics.Common.TableStorageTableNames;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 {
     public class PublicationMetaServiceTests
     {
         [Fact]
-        public void GetSubjectsForLatestRelease()
+        public async Task GetSubjectsForLatestRelease()
         {
             var publication = new Publication
             {
@@ -50,25 +55,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 TimeIdentifier = AcademicYearQ2,
                 Year = 2018
             };
-            
+
             var publicationRelease1Subject1 = new Subject
             {
                 Id = Guid.NewGuid(),
                 Name = "Release 1 subject 1",
             };
-            
+
             var publicationRelease1Subject1Link = new ReleaseSubject
             {
                 ReleaseId = publicationRelease1.Id,
                 SubjectId = publicationRelease1Subject1.Id
             };
-            
+
             var publicationRelease1Subject2 = new Subject
             {
                 Id = Guid.NewGuid(),
                 Name = "Release 1 subject 2"
             };
-            
+
             var publicationRelease1Subject2Link = new ReleaseSubject
             {
                 ReleaseId = publicationRelease1.Id,
@@ -80,39 +85,44 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Id = Guid.NewGuid(),
                 Name = "Release 2 subject"
             };
-            
+
             var publicationRelease2SubjectLink = new ReleaseSubject
             {
                 ReleaseId = publicationRelease2.Id,
                 SubjectId = publicationRelease2Subject.Id
             };
-            
+
             var publicationRelease3Subject = new Subject
             {
                 Id = Guid.NewGuid(),
                 Name = "Release 3 subject"
             };
-            
+
             var publicationRelease3SubjectLink = new ReleaseSubject
             {
                 ReleaseId = publicationRelease3.Id,
                 SubjectId = publicationRelease3Subject.Id
             };
-            
+
+            var releaseFastTrack1 = new ReleaseFastTrack(publicationRelease1.Id, Guid.NewGuid(), null);
+            var releaseFastTrack2 = new ReleaseFastTrack(publicationRelease1.Id, Guid.NewGuid(), "table 2");
+            var releaseFastTrack3 = new ReleaseFastTrack(publicationRelease1.Id, Guid.NewGuid(), "table 3");
+            var releaseFastTrack4 = new ReleaseFastTrack(publicationRelease1.Id, Guid.NewGuid(), "");
+
             var builder = new DbContextOptionsBuilder<StatisticsDbContext>();
             builder.UseInMemoryDatabase(Guid.NewGuid().ToString());
             var options = builder.Options;
 
-            using (var context = new StatisticsDbContext(options, null))
+            await using (var context = new StatisticsDbContext(options, null))
             {
                 context.Add(publication);
 
-                context.AddRange(new List<Release>
+                await context.AddRangeAsync(new List<Release>
                 {
                     publicationRelease1, publicationRelease2, publicationRelease3
                 });
 
-                context.AddRange(new List<Subject>
+                await context.AddRangeAsync(new List<Subject>
                 {
                     publicationRelease1Subject1,
                     publicationRelease1Subject2,
@@ -120,32 +130,82 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     publicationRelease3Subject
                 });
 
-                context.AddRange(new List<ReleaseSubject>
+                await context.AddRangeAsync(new List<ReleaseSubject>
                 {
                     publicationRelease1Subject1Link,
                     publicationRelease1Subject2Link,
                     publicationRelease2SubjectLink,
                     publicationRelease3SubjectLink
                 });
-                
-                context.SaveChanges();
 
-                var releaseService = new ReleaseService(context, new Mock<ILogger<ReleaseService>>().Object);
-                var subjectService =
-                    new SubjectService(context, new Mock<ILogger<SubjectService>>().Object, releaseService);
-                var service = new PublicationMetaService(releaseService, subjectService,
-                    MapperUtils.MapperForProfile<DataServiceMappingProfiles>());
+                await context.SaveChangesAsync();
 
-                var result = service.GetSubjectsForLatestRelease(publication.Id);
+                var mocks = Mocks();
+
+                mocks.TableStorageService.Setup(storageService =>
+                    storageService.ExecuteQueryAsync(PublicReleaseFastTrackTableName,
+                        It.IsAny<TableQuery<ReleaseFastTrack>>())).ReturnsAsync(new List<ReleaseFastTrack>
+                {
+                    releaseFastTrack1, releaseFastTrack2, releaseFastTrack3, releaseFastTrack4
+                });
+
+                var service = BuildPublicationMetaService(context, mocks);
+
+                var result = (await service.GetSubjectsForLatestRelease(publication.Id)).Right;
+                var highlights = result.Highlights.ToList();
                 var subjects = result.Subjects.ToList();
 
                 Assert.Equal(publication.Id, result.PublicationId);
+                Assert.Equal(2, highlights.Count);
+                Assert.Equal(releaseFastTrack2.FastTrackId, highlights[0].Id);
+                Assert.Equal(releaseFastTrack2.HighlightName, highlights[0].Label);
+                Assert.Equal(releaseFastTrack3.FastTrackId, highlights[1].Id);
+                Assert.Equal(releaseFastTrack3.HighlightName, highlights[1].Label);
                 Assert.Equal(2, subjects.Count);
                 Assert.Equal(publicationRelease1Subject1.Id, subjects[0].Id);
                 Assert.Equal(publicationRelease1Subject1.Name, subjects[0].Label);
                 Assert.Equal(publicationRelease1Subject2.Id, subjects[1].Id);
                 Assert.Equal(publicationRelease1Subject2.Name, subjects[1].Label);
             }
+        }
+
+        [Fact]
+        public async Task GetSubjectsForLatestRelease_PublicationNotFound()
+        {
+            var builder = new DbContextOptionsBuilder<StatisticsDbContext>();
+            builder.UseInMemoryDatabase(Guid.NewGuid().ToString());
+            var options = builder.Options;
+
+            await using (var context = new StatisticsDbContext(options, null))
+            {
+                var mocks = Mocks();
+                var service = BuildPublicationMetaService(context, mocks);
+
+                var result = await service.GetSubjectsForLatestRelease(Guid.NewGuid());
+                Assert.IsAssignableFrom<NotFoundResult>(result.Left);
+            }
+        }
+
+        private static PublicationMetaService BuildPublicationMetaService(StatisticsDbContext context,
+            (Mock<ILogger<ReleaseService>> LoggerReleaseService,
+                Mock<ILogger<SubjectService>> LoggerSubjectService,
+                Mock<ITableStorageService> TableStorageService) mocks)
+        {
+            var releaseService = new ReleaseService(context, mocks.LoggerReleaseService.Object);
+            var subjectService = new SubjectService(context, mocks.LoggerSubjectService.Object, releaseService);
+            return new PublicationMetaService(releaseService,
+                subjectService,
+                mocks.TableStorageService.Object,
+                MapperUtils.MapperForProfile<DataServiceMappingProfiles>());
+        }
+
+        private static (Mock<ILogger<ReleaseService>> LoggerReleaseService,
+            Mock<ILogger<SubjectService>> LoggerSubjectService,
+            Mock<ITableStorageService> TableStorageService) Mocks()
+        {
+            return (new Mock<ILogger<ReleaseService>>(),
+                new Mock<ILogger<SubjectService>>(),
+                new Mock<ITableStorageService>());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IPublicationMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IPublicationMetaService.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
 {
     public interface IPublicationMetaService
     {
-        PublicationSubjectsMetaViewModel GetSubjectsForLatestRelease(Guid publicationId);
+        Task<Either<ActionResult, PublicationSubjectsMetaViewModel>> GetSubjectsForLatestRelease(Guid publicationId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/PublicationMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/PublicationMetaService.cs
@@ -52,12 +52,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         private async Task<IEnumerable<IdLabel>> GetHighlights(Guid releaseId)
         {
-            var filter = TableQuery.GenerateFilterCondition(nameof(ReleaseFastTrack.PartitionKey),
+            var releaseFilter = TableQuery.GenerateFilterCondition(nameof(ReleaseFastTrack.PartitionKey),
                 QueryComparisons.Equal, releaseId.ToString());
-            var query = new TableQuery<ReleaseFastTrack>().Where(filter);
+            
+            var highlightFilter = TableQuery.GenerateFilterCondition(nameof(ReleaseFastTrack.HighlightName), QueryComparisons.NotEqual,
+                    string.Empty);
+            
+            var combineFilter = TableQuery.CombineFilters(releaseFilter, TableOperators.And, highlightFilter);
+            var query = new TableQuery<ReleaseFastTrack>().Where(combineFilter);
 
             return (await _tableStorageService.ExecuteQueryAsync(PublicReleaseFastTrackTableName, query))
-                .Where(releaseFastTrack => !string.IsNullOrEmpty(releaseFastTrack.HighlightName))
                 .Select(releaseFastTrack => new IdLabel(releaseFastTrack.FastTrackId, releaseFastTrack.HighlightName));
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/PublicationMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/PublicationMetaService.cs
@@ -1,10 +1,17 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Cosmos.Table;
+using static GovUk.Education.ExploreEducationStatistics.Common.TableStorageTableNames;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 {
@@ -12,29 +19,52 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
     {
         private readonly IReleaseService _releaseService;
         private readonly ISubjectService _subjectService;
+        private readonly ITableStorageService _tableStorageService;
         private readonly IMapper _mapper;
 
-        public PublicationMetaService(
-            IReleaseService releaseService,
+        public PublicationMetaService(IReleaseService releaseService,
             ISubjectService subjectService,
+            ITableStorageService tableStorageService,
             IMapper mapper)
         {
             _releaseService = releaseService;
             _subjectService = subjectService;
+            _tableStorageService = tableStorageService;
             _mapper = mapper;
         }
 
-        public PublicationSubjectsMetaViewModel GetSubjectsForLatestRelease(Guid publicationId)
+        public async Task<Either<ActionResult, PublicationSubjectsMetaViewModel>> GetSubjectsForLatestRelease(
+            Guid publicationId)
         {
             var releaseId = _releaseService.GetLatestPublishedRelease(publicationId);
-            var subjects = _subjectService.GetSubjectsForReleaseAsync(releaseId.Value).Result;
-            var subjectMetaViewModels = _mapper.Map<IEnumerable<IdLabel>>(subjects);
+            if (!releaseId.HasValue)
+            {
+                return new NotFoundResult();
+            }
 
             return new PublicationSubjectsMetaViewModel
             {
                 PublicationId = publicationId,
-                Subjects = subjectMetaViewModels
+                Highlights = await GetHighlights(releaseId.Value),
+                Subjects = await GetSubjects(releaseId.Value)
             };
+        }
+
+        private async Task<IEnumerable<IdLabel>> GetHighlights(Guid releaseId)
+        {
+            var filter = TableQuery.GenerateFilterCondition(nameof(ReleaseFastTrack.PartitionKey),
+                QueryComparisons.Equal, releaseId.ToString());
+            var query = new TableQuery<ReleaseFastTrack>().Where(filter);
+
+            return (await _tableStorageService.ExecuteQueryAsync(PublicReleaseFastTrackTableName, query))
+                .Where(releaseFastTrack => !string.IsNullOrEmpty(releaseFastTrack.HighlightName))
+                .Select(releaseFastTrack => new IdLabel(releaseFastTrack.FastTrackId, releaseFastTrack.HighlightName));
+        }
+
+        private async Task<IEnumerable<IdLabel>> GetSubjects(Guid releaseId)
+        {
+            var subjects = await _subjectService.GetSubjectsForReleaseAsync(releaseId);
+            return _mapper.Map<IEnumerable<IdLabel>>(subjects);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/PublicationSubjectsMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/PublicationSubjectsMetaViewModel.cs
@@ -7,6 +7,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Me
     public class PublicationSubjectsMetaViewModel
     {
         public Guid PublicationId { get; set; }
+        public IEnumerable<IdLabel> Highlights { get; set; }
         public IEnumerable<IdLabel> Subjects { get; set; }
     }
 }


### PR DESCRIPTION
Add the highlights field to the PublicationSubjectsMetaViewModel to be used for displaying top tables.

`{
    "publicationId": "ce4d9287-3e4a-4f1f-b6a5-08d824c9830f",
    "highlights": [
        {
            "id": "fad75800-6871-4a5a-0e76-08d824c9ca91",
            "label": "Top table name"
        }
    ],
    "subjects": [
        {
            "id": "f56cb03b-0f50-4037-897f-08d824c9775f",
            "label": "EES-342 Test Subject"
        }
    ]
}`