### PR TITLE
EES-1166 Delete ReleaseFastTracks and FastTrack files prior to generating them

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -38,9 +38,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return $"{PublicContentDownloadPath(prefix)}/tree.json";
         }
 
+        public static string PublicContentReleaseFastTrackPath(string releaseId, string prefix = null)
+        {
+            return $"{PublicContentFastTrackPath(prefix)}/{releaseId}";
+        }
+        
         public static string PublicContentFastTrackPath(string releaseId, string id, string prefix = null)
         {
-            return $"{PublicContentFastTrackPath(prefix)}/{releaseId}/{id}.json";
+            return $"{PublicContentReleaseFastTrackPath(releaseId, prefix)}/{id}.json";
         }
 
         public static string PublicContentMethodologyTreePath(string prefix = null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -74,7 +74,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                     {
                         await _releaseService.DeletePreviousVersionsStatisticalData(releaseIds);
                     }
-                    
+
+                    // TODO EES-1161 Delete any FastTracks for old versions
                     await _releaseService.DeletePreviousVersionsContent(releaseIds);
                     await _notificationsService.NotifySubscribersAsync(releaseIds);
                     await UpdateStage(published, Complete);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Models/CopyReleaseFilesCommand.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Models/CopyReleaseFilesCommand.cs
@@ -10,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Models
         public string PublicationSlug { get; set; }
         public string ReleaseSlug { get; set; }
         public DateTime PublishScheduled { get; set; }
-        public string PreviousVersionSlug { get; set; }
         public List<ReleaseFileReference> ReleaseFileReferences { get; set; }
+        public List<string> AdditionalDeleteDirectoryPaths { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FastTrackService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FastTrackService.cs
@@ -31,6 +31,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         public async Task CreateAllByRelease(Guid releaseId, PublishContext context)
         {
+            // Delete any existing FastTracks in case of republishing
+            await DeleteAllFastTracksByRelease(releaseId);
+
             var dataBlocks = await _contentDbContext.ReleaseContentBlocks
                 .Include(block => block.ContentBlock)
                 .Where(block => block.ReleaseId == releaseId)
@@ -63,6 +66,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 .Distinct();
 
             await _tableStorageService.DeleteByPartitionKeys(PublicReleaseFastTrackTableName, allPartitionKeys);
+        }
+
+        private async Task DeleteAllFastTracksByRelease(Guid releaseId)
+        {
+            await _fileStorageService.DeletePublicBlobs(PublicContentReleaseFastTrackPath(releaseId.ToString()));
+            await _tableStorageService.DeleteByPartitionKey(PublicReleaseFastTrackTableName, releaseId.ToString());
         }
 
         private async Task Upload(Guid releaseId, FastTrack fastTrack, PublishContext context)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IFileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IFileStorageService.cs
@@ -12,12 +12,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task DeleteAllContentAsyncExcludingStaging();
 
+        Task DeletePublicBlobs(string directoryPath, string excludePattern = null);
+        
+        Task DeletePublicBlob(string blobName);
+        
         IEnumerable<FileInfo> ListPublicFiles(string publication, string release);
 
         Task MoveStagedContentAsync();
 
         Task UploadAsJson(string blobName, object value, JsonSerializerSettings settings = null);
-
-        Task DeletePreviousVersionContent(string publicationSlug, string previousVersionSlug);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -1,18 +1,25 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 {
     public class PublishingService : IPublishingService
     {
+        private readonly IFastTrackService _fastTrackService;
         private readonly IFileStorageService _fileStorageService;
         private readonly IReleaseService _releaseService;
 
-        public PublishingService(IFileStorageService fileStorageService, IReleaseService releaseService)
+        public PublishingService(IFastTrackService fastTrackService,
+            IFileStorageService fileStorageService,
+            IReleaseService releaseService)
         {
+            _fastTrackService = fastTrackService;
             _fileStorageService = fileStorageService;
             _releaseService = releaseService;
         }
@@ -32,11 +39,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 PublicationSlug = release.Publication.Slug,
                 PublishScheduled = release.PublishScheduled.Value,
                 ReleaseSlug = release.Slug,
-                PreviousVersionSlug = release.PreviousVersion.Slug,
                 ReleaseFileReferences = _releaseService.GetReleaseFileReferences(
-                    releaseId, ReleaseFileTypes.Ancillary, ReleaseFileTypes.Chart, ReleaseFileTypes.Data)
+                    releaseId, ReleaseFileTypes.Ancillary, ReleaseFileTypes.Chart, ReleaseFileTypes.Data),
+                AdditionalDeleteDirectoryPaths = GetAdditionalDeletePaths(release)
             };
             await _fileStorageService.CopyReleaseFilesToPublicContainer(copyReleaseCommand);
+        }
+
+        private static List<string> GetAdditionalDeletePaths(Release release)
+        {
+            var result = new List<string>();
+            
+            // Slug may have changed for the amendment so also remove the previous contents if it has
+            if (release.Slug != release.PreviousVersion.Slug)
+            {
+                result.Add(GetPreviousVersionReleaseDirectoryPath(release));
+            }
+
+            return result;
+        }
+
+        private static string GetPreviousVersionReleaseDirectoryPath(Release release)
+        {
+            return PublicReleaseDirectoryPath(release.Publication.Slug, release.PreviousVersion.Slug);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -12,6 +12,7 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 using IReleaseService = GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces.IReleaseService;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.utils.PublisherUtils;
 
@@ -167,8 +168,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
             foreach (var r in releases)
             {
-                await _fileStorageService.DeletePreviousVersionContent(r.Publication.Slug,
-                    r.PreviousVersion.Slug);
+                await _fileStorageService.DeletePublicBlob(PublicContentReleasePath(r.Publication.Slug,r.PreviousVersion.Slug));
             }
         }
 


### PR DESCRIPTION
If any data blocks have been deleted when republishing then both ReleaseFastTracks and the FastTrack file for the datablock need to be deleted.
Similarly if a datablock HighlightName has been updated when republishing then the ReleaseFastTrack HighlightName needs updating.

 We cover both by deleting all ReleaseFastTracks and FastTrack files prior to regenerating them all.

This PR also tries to tidy up some of the logic around deleting statistics Files for Previous versions in FileStorageService, making it a more generic `AdditionalDeleteDirectoryPaths` and moving the logic around whether the additional delete is required or not to `PublishingService `. I suspect there is a bug here anyway though, if the files are deleted during the same stage that they are copied (midnight), files will be missing between midnight and 09:30 until the Amendment is published. This is raised as EES-1168.
