### PR TITLE
EES-1091 Fix incorrect publish and next release dates in IE11

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryEditPage.tsx
@@ -3,7 +3,7 @@ import { MethodologyRouteParams } from '@admin/routes/edit-methodology/routes';
 import methodologyService from '@admin/services/methodologyService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
-import { formatISO } from 'date-fns';
+import { formatISO, parseISO } from 'date-fns';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
@@ -28,7 +28,7 @@ const MethodologySummaryEditPage = ({
             initialValues={{
               contactId: '',
               title: methodology.title,
-              publishScheduled: new Date(methodology.publishScheduled),
+              publishScheduled: parseISO(methodology.publishScheduled),
             }}
             submitText="Update methodology"
             onSubmit={async values => {

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryPage.tsx
@@ -8,6 +8,7 @@ import SummaryListItem from '@common/components/SummaryListItem';
 import Tag from '@common/components/Tag';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import { parseISO } from 'date-fns';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
@@ -36,7 +37,7 @@ const MethodologySummaryPage = ({
               </SummaryListItem>
               <SummaryListItem term="Scheduled release">
                 <FormattedDate>
-                  {currentMethodology.publishScheduled}
+                  {parseISO(currentMethodology.publishScheduled)}
                 </FormattedDate>
               </SummaryListItem>
               <SummaryListItem term="Published on">

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -24,7 +24,7 @@ import {
   formatPartialDate,
   isPartialDateEmpty,
   isValidPartialDate,
-  parsePartialDateToUtcDate,
+  parsePartialDateToLocalDate,
   PartialDate,
 } from '@common/utils/date/partialDate';
 import { mapFieldErrors } from '@common/validation/serverValidations';
@@ -228,7 +228,7 @@ const ReleaseStatusPage = () => {
                     return false;
                   }
 
-                  return isValid(parsePartialDateToUtcDate(value));
+                  return isValid(parsePartialDateToLocalDate(value));
                 },
               }),
           })}

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -29,7 +29,7 @@ import {
 } from '@common/utils/date/partialDate';
 import { mapFieldErrors } from '@common/validation/serverValidations';
 import Yup from '@common/validation/yup';
-import { endOfDay, format, formatISO, isValid } from 'date-fns';
+import { endOfDay, format, formatISO, isValid, parseISO } from 'date-fns';
 import { Formik } from 'formik';
 import React, { useState } from 'react';
 import { StringSchema } from 'yup';
@@ -145,7 +145,9 @@ const ReleaseStatusPage = () => {
             )}
             <SummaryListItem term="Scheduled release">
               {release.publishScheduled ? (
-                <FormattedDate>{release.publishScheduled}</FormattedDate>
+                <FormattedDate>
+                  {parseISO(release.publishScheduled)}
+                </FormattedDate>
               ) : (
                 'Not scheduled'
               )}
@@ -176,7 +178,7 @@ const ReleaseStatusPage = () => {
             internalReleaseNote: release.internalReleaseNote ?? '',
             publishMethod: release.publishScheduled ? 'Scheduled' : undefined,
             publishScheduled: release.publishScheduled
-              ? new Date(release.publishScheduled)
+              ? parseISO(release.publishScheduled)
               : undefined,
             nextReleaseDate: release.nextReleaseDate,
           }}

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryPage.tsx
@@ -14,6 +14,7 @@ import {
   formatPartialDate,
   isValidPartialDate,
 } from '@common/utils/date/partialDate';
+import { parseISO } from 'date-fns';
 import React from 'react';
 
 const ReleaseSummaryPage = () => {
@@ -49,7 +50,9 @@ const ReleaseSummaryPage = () => {
             </SummaryListItem>
             <SummaryListItem term="Scheduled release">
               {release.publishScheduled ? (
-                <FormattedDate>{release.publishScheduled}</FormattedDate>
+                <FormattedDate>
+                  {parseISO(release.publishScheduled)}
+                </FormattedDate>
               ) : (
                 'Not scheduled'
               )}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/BasicReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/BasicReleaseSummary.tsx
@@ -9,6 +9,7 @@ import {
   formatPartialDate,
   isValidPartialDate,
 } from '@common/utils/date/partialDate';
+import { parseISO } from 'date-fns';
 import React, { useEffect, useState } from 'react';
 import styles from './BasicReleaseSummary.module.scss';
 
@@ -65,7 +66,9 @@ const BasicReleaseSummary = ({ release }: Props) => {
               <dd>
                 {release.publishScheduled && (
                   <strong>
-                    <FormattedDate>{release.publishScheduled}</FormattedDate>
+                    <FormattedDate>
+                      {parseISO(release.publishScheduled)}
+                    </FormattedDate>
                   </strong>
                 )}
               </dd>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ChartBuilderTabSection.tsx
@@ -93,7 +93,7 @@ const ChartBuilderTabSection = ({
         query: nextQuery,
       });
     },
-    [onTableUpdate, query, releaseId],
+    [onTableUpdate, query],
   );
 
   return (

--- a/src/explore-education-statistics-common/src/utils/date/__tests__/partialDate.test.ts
+++ b/src/explore-education-statistics-common/src/utils/date/__tests__/partialDate.test.ts
@@ -1,42 +1,42 @@
 import {
   formatPartialDate,
-  parsePartialDateToUtcDate,
+  parsePartialDateToLocalDate,
 } from '@common/utils/date/partialDate';
 import { isValid } from 'date-fns';
 
 describe('partialDate', () => {
-  describe('parsePartialDateToUtcDate', () => {
+  describe('parsePartialDateToLocalDate', () => {
     test('returns fully parsed UTC date', () => {
       expect(
-        parsePartialDateToUtcDate({
+        parsePartialDateToLocalDate({
           year: 2020,
           month: 7,
           day: 13,
         }),
-      ).toEqual(new Date('2020-07-13'));
+      ).toEqual(new Date(2020, 6, 13));
     });
 
     test('returns parsed UTC date when there is only a year', () => {
       expect(
-        parsePartialDateToUtcDate({
+        parsePartialDateToLocalDate({
           year: 2020,
         }),
-      ).toEqual(new Date('2020-01-01'));
+      ).toEqual(new Date(2020, 0, 1));
     });
 
     test('returns parsed UTC date when there is only a year and month', () => {
       expect(
-        parsePartialDateToUtcDate({
+        parsePartialDateToLocalDate({
           year: 2020,
           month: 7,
         }),
-      ).toEqual(new Date('2020-07-01'));
+      ).toEqual(new Date(2020, 6));
     });
 
     test('returns invalid UTC date when month is invalid number', () => {
       expect(
         isValid(
-          parsePartialDateToUtcDate({
+          parsePartialDateToLocalDate({
             year: 2020,
             month: 40,
           }),
@@ -47,7 +47,7 @@ describe('partialDate', () => {
     test('returns invalid UTC date when day is invalid number', () => {
       expect(
         isValid(
-          parsePartialDateToUtcDate({
+          parsePartialDateToLocalDate({
             year: 2020,
             month: 7,
             day: 40,
@@ -58,7 +58,7 @@ describe('partialDate', () => {
 
     test('throw error if missing year', () => {
       expect(() =>
-        parsePartialDateToUtcDate({
+        parsePartialDateToLocalDate({
           year: 0,
           month: 7,
           day: 13,

--- a/src/explore-education-statistics-common/src/utils/date/partialDate.ts
+++ b/src/explore-education-statistics-common/src/utils/date/partialDate.ts
@@ -16,24 +16,16 @@ export const isValidPartialDate = (
   return !!dmy?.year;
 };
 
-export const parsePartialDateToUtcDate = (dmy: PartialDate): Date => {
+export const parsePartialDateToLocalDate = (dmy: PartialDate): Date => {
   if (!isValidPartialDate(dmy)) {
     throw new Error(
       `Could not parse invalid PartialDate to date: ${JSON.stringify(dmy)}`,
     );
   }
 
-  if (!dmy.month && !dmy.day) {
-    return parse(`${dmy.year}Z`, 'yyyyX', new Date());
-  }
-
-  if (!dmy.day) {
-    return parse(`${dmy.year}-${dmy.month}Z`, `yyyy-MX`, new Date());
-  }
-
   return parse(
-    `${dmy.year}-${dmy.month}-${dmy.day}Z`,
-    `yyyy-M-ddX`,
+    `${dmy.year}-${dmy.month || 1}-${dmy.day || 1}`,
+    'yyyy-M-dd',
     new Date(),
   );
 };
@@ -51,7 +43,7 @@ export const formatPartialDate = (
     ...options,
   };
 
-  const date = parsePartialDateToUtcDate(dmy);
+  const date = parsePartialDateToLocalDate(dmy);
 
   try {
     if (!dmy.month && !dmy.day) {


### PR DESCRIPTION
This PR fixes issues with `publishScheduled` and `nextReleaseDate` fields being parsed and formatted incorrectly when displayed on pages such as the 'Manage content' or 'Release status' pages.

As this was a fairly weird problem, let's look a bit more into why this happens and see what we can learn.

## The issue

Javascript's `Date` can accept ISO8601 date strings passed into its constructor e.g.

```javascript
new Date('2020-01-01');
new Date('2020-01-01T12:00:00');
new Date('2020-01-01T12:00:00Z');
```

When we are just parsing an ISO8601 date without the time component in cases such as the `publishScheduled` or `nextReleaseDate` field, the date will be parsed to UTC i.e.

```javascript
new Date('2020-01-01').toISOString() === '2020-01-01T00:00:00.000Z'
```

This is great if we're only working with UTC times, but timezones make things awkward when trying to display this to the user using a function like date-fns `format`. We can get incorrect dates being displayed:

```javascript
// At BST in London i.e. +1 hour
format(new Date('2020-01-01'), 'd MMMM yyyy', new Date()) === '1 January 2020'
// At EDT in New York i.e. -4 hours
format(new Date('2020-01-01'), 'd MMMM yyyy', new Date()) === '31 December 2019'
```

## Solution

To fix this we simply need to use local time instead of UTC when constructing the date. We could achieve this with the argument variant of the `Date` constructor:

```javascript
// At BST in London i.e. +1 hour
format(new Date(2020, 0, 1), 'd MMMM yyyy', new Date()) === '1 January 2020'
// At EDT in New York i.e. -4 hours
format(new Date(2020, 0, 1), 'd MMMM yyyy', new Date()) === '1 January 2020'
```

Unfortunately, this is quite error prone as there are a multitude of potential bugs that can arise using this approach without validation e.g. `new Date(2020, 13, 1)` is parsed to 1 February 2020.
 
A safer approach is to use date-fns `parse` function as this returns an `Invalid Date` if you try to construct an invalid date.

Unfortunately, `parse` isn't the correct choice in instances when explicitly setting the timezone e.g. in `partialDate`, where we pin the timezone to UTC.

We've consequently:

- Used `parseISO` instead of `new Date('2020-01-01'')` (which parses to local time in accordance with the ISO8601 spec)
- Removed explicit UTC-based parsing from `partialDate` code