### PR TITLE
EES-1161 Delete FastTracks for previous version if Amendment

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -15,16 +15,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
     // ReSharper disable once UnusedType.Global
     public class PublishReleaseContentFunction
     {
+        private readonly IContentService _contentService;
         private readonly INotificationsService _notificationsService;
         private readonly IReleaseStatusService _releaseStatusService;
         private readonly IPublishingService _publishingService;
         private readonly IReleaseService _releaseService;
 
-        public PublishReleaseContentFunction(INotificationsService notificationsService,
+        public PublishReleaseContentFunction(IContentService contentService,
+            INotificationsService notificationsService,
             IReleaseStatusService releaseStatusService,
             IPublishingService publishingService,
             IReleaseService releaseService)
         {
+            _contentService = contentService;
             _notificationsService = notificationsService;
             _releaseStatusService = releaseStatusService;
             _publishingService = publishingService;
@@ -74,9 +77,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                     {
                         await _releaseService.DeletePreviousVersionsStatisticalData(releaseIds);
                     }
-
-                    // TODO EES-1161 Delete any FastTracks for old versions
-                    await _releaseService.DeletePreviousVersionsContent(releaseIds);
+                    
+                    await _contentService.DeletePreviousVersionsContent(releaseIds);
                     await _notificationsService.NotifySubscribersAsync(releaseIds);
                     await UpdateStage(published, Complete);
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentImmediateFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentImmediateFunction.cs
@@ -59,7 +59,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                     await _releaseService.DeletePreviousVersionsStatisticalData(new[] {message.ReleaseId});
                 }
                 
-                await _releaseService.DeletePreviousVersionsContent(new[] {message.ReleaseId});
+                await _contentService.DeletePreviousVersionsContent(new[] {message.ReleaseId});
                 await _notificationsService.NotifySubscribersAsync(new[] {message.ReleaseId});
                 await UpdateStage(message.ReleaseId, releaseStatusId, Stage.Complete);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -38,6 +38,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             _methodologyService = methodologyService;
         }
 
+
+        public async Task DeletePreviousVersionsContent(IEnumerable<Guid> releaseIds)
+        {
+            var releases = await _releaseService.GetAmendedReleases(releaseIds);
+
+            foreach (var release in releases)
+            {
+                await _fastTrackService.DeleteAllFastTracksByRelease(release.PreviousVersionId);
+
+                // Delete content which hasn't been overwritten because the Slug has changed
+                if (release.Slug != release.PreviousVersion.Slug)
+                {
+                    await _fileStorageService.DeletePublicBlob(
+                        PublicReleaseDirectoryPath(release.Publication.Slug, release.PreviousVersion.Slug));
+                }
+            }
+        }
+
         /**
          * Intended to be used as a Development / BAU Function to perform a full content refresh
          */

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FastTrackService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FastTrackService.cs
@@ -68,7 +68,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             await _tableStorageService.DeleteByPartitionKeys(PublicReleaseFastTrackTableName, allPartitionKeys);
         }
 
-        private async Task DeleteAllFastTracksByRelease(Guid releaseId)
+        public async Task DeleteAllFastTracksByRelease(Guid releaseId)
         {
             await _fileStorageService.DeletePublicBlobs(PublicContentReleaseFastTrackPath(releaseId.ToString()));
             await _tableStorageService.DeleteByPartitionKey(PublicReleaseFastTrackTableName, releaseId.ToString());

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
@@ -7,7 +7,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 {
     public interface IContentService
     {
+        Task DeletePreviousVersionsContent(IEnumerable<Guid> releaseIds);
+
         Task UpdateAllContentAsync();
+
         Task UpdateContentAsync(IEnumerable<Guid> releaseIds, PublishContext context);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IFastTrackService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IFastTrackService.cs
@@ -8,6 +8,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
     {
         Task CreateAllByRelease(Guid releaseId, PublishContext context);
 
+        Task DeleteAllFastTracksByRelease(Guid releaseId);
+
         Task DeleteAllReleaseFastTracks();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseService.cs
@@ -14,6 +14,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task<IEnumerable<Release>> GetAsync(IEnumerable<Guid> ids);
 
+        Task<IEnumerable<Release>> GetAmendedReleases(IEnumerable<Guid> releaseIds);
+
         CachedReleaseViewModel GetReleaseViewModel(Guid id, PublishContext context);
 
         Release GetLatestRelease(Guid publicationId, IEnumerable<Guid> includedReleaseIds);
@@ -24,8 +26,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
         Task SetPublishedDatesAsync(Guid id, DateTime published);
 
         List<ReleaseFileReference> GetReleaseFileReferences(Guid releaseId, params ReleaseFileTypes[] types);
-        
-        Task DeletePreviousVersionsContent(IEnumerable<Guid> releaseIds);
 
         Task DeletePreviousVersionsStatisticalData(IEnumerable<Guid> releaseIds);
     }


### PR DESCRIPTION
For Releases that have just been published which are Amendments we need to:
* Delete FastTrack json files and ReleaseFastTrackRows for each Releases previous version.
* Delete Release content which hasn't been overwritten i.e. delete the previous version if the Release Slug was amended.

We were already doing the latter in `ReleaseService`. I have moved the method to `ContentService` which seems more appropriate and combined both operations.

I also added a new method to ReleaseService to help get Amendments for a list of `releaseIds`.