### PR TITLE
EES-342 Ad table highlights column to table tool

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -116,8 +116,8 @@ const DataBlockSourceWizardFinalStep = ({
 
 interface DataBlockSourceWizardProps {
   dataBlock?: ReleaseDataBlock;
-  initialTableToolState?: TableToolState;
   query?: ReleaseTableDataQuery;
+  releaseId?: string;
   subjectMeta?: PublicationSubjectMeta;
   table?: FullTable;
   tableHeaders?: TableHeadersConfig;
@@ -127,6 +127,7 @@ interface DataBlockSourceWizardProps {
 const DataBlockSourceWizard = ({
   dataBlock,
   query: initialQuery,
+  releaseId,
   subjectMeta,
   table,
   tableHeaders,
@@ -154,7 +155,17 @@ const DataBlockSourceWizard = ({
 
       <TableToolWizard
         themeMeta={[]}
-        initialState={initialTableToolState}
+        initialState={
+          initialTableToolState ?? {
+            query: {
+              releaseId,
+              subjectId: '',
+              indicators: [],
+              filters: [],
+              locations: {},
+            },
+          }
+        }
         finalStep={({ response, query }) => (
           <WizardStep>
             {wizardStepProps => (

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ReleaseDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ReleaseDataBlocksPageTabs.tsx
@@ -219,6 +219,7 @@ const ReleaseDataBlocksPageTabs = ({
               <DataBlockSourceWizard
                 key={saveNumber}
                 dataBlock={selectedDataBlock}
+                releaseId={releaseId}
                 query={query}
                 subjectMeta={subjectMeta}
                 table={table}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.tsx
@@ -38,6 +38,7 @@ const WizardStepHeading = ({
           })}
         >
           <button
+            data-testid={`wizardStep-${stepNumber}-goToButton`}
             type="button"
             onClick={() => setCurrentStep(stepNumber)}
             className={styles.stepButton}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -140,6 +140,7 @@ describe('TableToolWizard', () => {
       Promise.resolve<PublicationMeta>({
         publicationId: 'publication-1',
         subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+        highlights: [],
       }),
     );
 
@@ -169,7 +170,7 @@ describe('TableToolWizard', () => {
     });
   });
 
-  test('does not render publication step if `releaseId` is set', async () => {
+  test('does not render publication step if `initialState.query.releaseId` is set', async () => {
     tableBuilderService.getReleaseMeta.mockImplementation(() =>
       Promise.resolve<ReleaseMeta>({
         releaseId: 'release-1',
@@ -204,11 +205,12 @@ describe('TableToolWizard', () => {
     });
   });
 
-  test('renders fetched publication release subjects if `releaseId` is set', async () => {
+  test('renders fetched publication release subjects if `initialState.query.releaseId` is set', async () => {
     tableBuilderService.getPublicationMeta.mockImplementation(() =>
       Promise.resolve<PublicationMeta>({
         publicationId: 'publication-1',
         subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+        highlights: [],
       }),
     );
 
@@ -248,11 +250,127 @@ describe('TableToolWizard', () => {
     });
   });
 
+  test('renders table highlights on step 2 when it is the current step', async () => {
+    tableBuilderService.getPublicationMeta.mockImplementation(() =>
+      Promise.resolve<PublicationMeta>({
+        publicationId: 'publication-1',
+        subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+        highlights: [
+          { id: 'highlight-1', label: 'Test highlight 1' },
+          { id: 'highlight-2', label: 'Test highlight 2' },
+          { id: 'highlight-3', label: 'Test highlight 3' },
+        ],
+      }),
+    );
+
+    render(
+      <TableToolWizard
+        themeMeta={testThemeMeta}
+        initialState={{
+          initialStep: 2,
+          subjectMeta: testSubjectMeta,
+          query: {
+            publicationId: 'publication-1',
+            subjectId: '',
+            locations: {},
+            filters: [],
+            indicators: [],
+          },
+        }}
+        renderHighlights={highlights => (
+          <ul>
+            {highlights.map(highlight => (
+              <li key={highlight.id} id={highlight.id}>
+                {highlight.label}
+              </li>
+            ))}
+          </ul>
+        )}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wizardStep-2')).toHaveAttribute(
+        'aria-current',
+        'step',
+      );
+
+      const step2 = within(screen.getByTestId('wizardStep-2'));
+
+      expect(step2.getByText('Test highlight 1')).toHaveAttribute(
+        'id',
+        'highlight-1',
+      );
+      expect(step2.getByText('Test highlight 2')).toHaveAttribute(
+        'id',
+        'highlight-2',
+      );
+      expect(step2.getByText('Test highlight 3')).toHaveAttribute(
+        'id',
+        'highlight-3',
+      );
+    });
+  });
+
+  test('does not render table highlights when step 2 is not the current step', async () => {
+    tableBuilderService.getPublicationMeta.mockImplementation(() =>
+      Promise.resolve<PublicationMeta>({
+        publicationId: 'publication-1',
+        subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+        highlights: [
+          { id: 'highlight-1', label: 'Test highlight 1' },
+          { id: 'highlight-2', label: 'Test highlight 2' },
+          { id: 'highlight-3', label: 'Test highlight 3' },
+        ],
+      }),
+    );
+
+    render(
+      <TableToolWizard
+        themeMeta={testThemeMeta}
+        initialState={{
+          initialStep: 3,
+          subjectMeta: testSubjectMeta,
+          query: {
+            publicationId: 'publication-1',
+            subjectId: 'subject-1',
+            locations: {},
+            filters: [],
+            indicators: [],
+          },
+        }}
+        renderHighlights={highlights => (
+          <ul>
+            {highlights.map(highlight => (
+              <li key={highlight.id} id={highlight.id}>
+                {highlight.label}
+              </li>
+            ))}
+          </ul>
+        )}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wizardStep-2')).not.toHaveAttribute(
+        'aria-current',
+        'step',
+      );
+
+      const step2 = within(screen.getByTestId('wizardStep-2'));
+
+      expect(step2.queryByText('Test highlight 1')).not.toBeInTheDocument();
+      expect(step2.queryByText('Test highlight 2')).not.toBeInTheDocument();
+      expect(step2.queryByText('Test highlight 3')).not.toBeInTheDocument();
+    });
+  });
+
   test('renders all steps correctly when full `initialState` is provided', async () => {
     tableBuilderService.getPublicationMeta.mockImplementation(() =>
       Promise.resolve<PublicationMeta>({
         publicationId: 'publication-1',
         subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+        highlights: [],
       }),
     );
 

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -79,9 +79,15 @@ export interface PublicationSubject {
   label: string;
 }
 
+export interface TableHighlight {
+  id: string;
+  label: string;
+}
+
 export interface PublicationMeta {
   publicationId: string;
   subjects: PublicationSubject[];
+  highlights: TableHighlight[];
 }
 
 export interface ReleaseMeta {

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -11,6 +11,7 @@ import tableBuilderService, {
   ThemeMeta,
 } from '@common/services/tableBuilderService';
 import { Dictionary } from '@common/types';
+import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
 import { GetServerSideProps, NextPage } from 'next';
 import dynamic from 'next/dynamic';
@@ -89,9 +90,32 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
       </p>
 
       <TableToolWizard
+        key={fastTrack?.id}
         scrollOnMount
         themeMeta={themeMeta}
         initialState={initialTableToolState}
+        renderHighlights={highlights => (
+          <aside>
+            <h3>Table highlights</h3>
+
+            <p>View popular tables related to this publication:</p>
+
+            <ul>
+              {highlights
+                .filter(highlight => highlight.id !== fastTrack?.id)
+                .map(highlight => (
+                  <li key={highlight.id}>
+                    <Link
+                      to="/data-tables/fast-track/[fastTrackId]"
+                      as={`/data-tables/fast-track/${highlight.id}`}
+                    >
+                      {highlight.label}
+                    </Link>
+                  </li>
+                ))}
+            </ul>
+          </aside>
+        )}
         finalStep={({ publication, query, response }) => (
           <WizardStep>
             {wizardStepProps => (

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -33,13 +33,13 @@ Upload subject
     [Tags]  HappyPath
     user waits until page contains element    xpath://h2[text()="Release summary"]
     user checks summary list item "Publication title" should be "Datablock test %{RUN_IDENTIFIER}"
-    user clicks element  xpath://li/a[text()="Manage data"]
+    user clicks link  Manage data
     user enters text into element  css:#dataFileUploadForm-subjectTitle   UI test subject
     choose file   css:#dataFileUploadForm-dataFile       ${CURDIR}${/}files${/}upload-file-test.csv
     choose file   css:#dataFileUploadForm-metadataFile   ${CURDIR}${/}files${/}upload-file-test.meta.csv
-    user clicks element   xpath://button[text()="Upload data files"]
+    user clicks button  Upload data files
 
-    user waits until page contains element   xpath://h2[text()="Uploaded data files"]
+    user waits until page contains heading 2  Uploaded data files
     user waits until page contains accordion section   UI test subject
     user opens accordion section   UI test subject
     user checks page contains element   xpath://dt[text()="Subject title"]/../dd/h4[text()="UI test subject"]
@@ -47,9 +47,8 @@ Upload subject
 
 Navigate to Manage data blocks tab
     [Tags]  HappyPath
-    scroll element into view  xpath://li/a[text()="Manage data blocks"]
-    user clicks element  xpath://li/a[text()="Manage data blocks"]
-    user waits until page contains element   xpath://h2[text()="Choose a subject"]
+    user clicks link    Manage data blocks
+    user waits until page contains heading 2   Choose a subject
 
 Select subject "UI test subject"
     [Tags]  HappyPath
@@ -170,10 +169,9 @@ Validate table rows for Syon
 
 Save data block
     [Tags]  HappyPath
-    user enters text into element  css:#data-block-name        UI Test data block name
-    user clears element text   css:#data-block-title
-    user enters text into element  css:#data-block-title       UI Test table title
-    user enters text into element  css:#data-block-source      UI Test source
+    user enters text into element  id:dataBlockDetailsForm-name         UI Test data block name
+    user enters text into element  id:dataBlockDetailsForm-heading      UI Test table title
+    user enters text into element  id:dataBlockDetailsForm-source       UI Test source
     user clicks button   Save data block
     user waits until page contains    Delete this data block
 

--- a/tests/robot-tests/tests/admin_and_public/bau/files/upload-file-test.csv
+++ b/tests/robot-tests/tests/admin_and_public/bau/files/upload-file-test.csv
@@ -1,0 +1,159 @@
+time_period,time_identifier,geographic_level,country_code,country_name,old_la_code,new_la_code,la_name,region_code,region_name,lad_code,lad_name,local_enterprise_partnership_code,local_enterprise_partnership_name,rsc_region_lead_name,opportunity_area_code,opportunity_area_name,pcon_code,pcon_name,ward_code,ward_name,admission_numbers
+2018,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,3962
+2018,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,8123
+2018,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,5669
+2018,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,2399
+2017,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,8530
+2017,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,5032
+2017,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,6981
+2017,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,4180
+2016,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,8856
+2016,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,7419
+2016,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,8427
+2016,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,3548
+2015,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,9303
+2015,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,1134
+2015,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,6114
+2015,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,9790
+2014,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,3708
+2014,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,9854
+2014,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,8247
+2014,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,1054
+2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,6765
+2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,8024
+2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,2911
+2013,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,5456
+2012,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,6480
+2014,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,2284
+2020,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,4195
+2012,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,6005
+2016,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,2014
+2007,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,7769
+2013,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,3758
+2015,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,2787
+2011,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,9043
+2017,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,3001
+2017,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,9123
+2006,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,8052
+2020,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,1506
+2012,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,1090
+2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,8730
+2018,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,7423
+2011,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,5876
+2017,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,5124
+2017,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,2076
+2018,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,6170
+2014,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,3085
+2020,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,4503
+2011,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,1574
+2016,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,3221
+2010,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,4368
+2006,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,7360
+2017,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,6385
+2012,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,9216
+2010,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,1816
+2020,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,6078
+2014,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,5018
+2015,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,6882
+2016,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,6493
+2011,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,3902
+2019,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,8179
+2019,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,2701
+2013,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,3908
+2007,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,9023
+2018,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,7612
+2008,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,7916
+2011,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,8639
+2016,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,5346
+2011,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,6888
+2011,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,6526
+2010,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,6781
+2013,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,9961
+2007,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,6637
+2017,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,4896
+2008,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,4890
+2017,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,7242
+2015,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,2748
+2008,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,1010
+2009,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,4900
+2006,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,3338
+2019,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,1258
+2019,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,1023
+2019,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000984,Bolton 001,,,,,8533
+2008,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000985,Bolton 002,,,,,4587
+2010,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000986,Bolton 003,,,,,4621
+2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000987,Bolton 004,,,,,6031
+2009,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,5815
+2016,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,5831
+2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,1028
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,3481
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,6373
+2006,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,9341
+2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,6641
+2005,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,8557
+2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,5680
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,1869
+2010,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,5595
+2019,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,6945
+2014,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,8084
+2018,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,8630
+2018,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,5549
+2020,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,6676
+2009,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,2409
+2010,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,2321
+2015,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,5653
+2016,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,1433
+2006,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,1605
+2020,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,7569
+2016,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,1617
+2019,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,9468
+2015,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,8650
+2009,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,3004
+2011,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,5099
+2005,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,2179
+2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,4066
+2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,2003
+2017,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,4465
+2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,9208
+2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,8322
+2019,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,3927
+2009,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,2287
+2016,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,7357
+2006,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,7066
+2007,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,7004
+2015,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,6850
+2005,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,7988
+2019,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,1695
+2015,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,5872
+2018,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,4496
+2010,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,2266
+2019,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,6296
+2008,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,5901
+2009,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,4157
+2015,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,7731
+2012,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,6383
+2011,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,7904
+2017,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,1615
+2016,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,9207
+2009,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,2848
+2009,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,2192
+2017,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,1959
+2017,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,9857
+2005,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,3612
+2011,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,4415
+2007,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,9914
+2016,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,6772
+2016,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,4198
+2015,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,4613
+2010,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,6060
+2014,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,3646
+2010,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,9304
+2020,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,6650
+2012,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,1109
+2018,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,1926
+2012,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,8150
+2016,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,4035
+2008,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,5505
+2007,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,7499
+2011,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,9603
+2007,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,9884

--- a/tests/robot-tests/tests/admin_and_public/bau/files/upload-file-test.meta.csv
+++ b/tests/robot-tests/tests/admin_and_public/bau/files/upload-file-test.meta.csv
@@ -1,0 +1,2 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+admission_numbers,Indicator,Admission Numbers,,,,,

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -1,0 +1,309 @@
+*** Settings ***
+Resource    ../../libs/admin-common.robot
+
+Force Tags  Admin  Local  Dev  AltersData
+
+Suite Setup       user signs in as bau1
+Suite Teardown    user closes the browser
+
+*** Variables ***
+${TOPIC_NAME}        UI test topic %{RUN_IDENTIFIER}
+${PUBLICATION_NAME}  UI tests - publish data %{RUN_IDENTIFIER}
+
+*** Test Cases ***
+Create new publication for "UI tests topic" topic
+    [Tags]  HappyPath
+    environment variable should be set   RUN_IDENTIFIER
+    user selects theme "Test theme" and topic "${TOPIC_NAME}" from the admin dashboard
+    user waits until page contains link    Create new publication
+    user checks page does not contain button   ${PUBLICATION_NAME}
+    user clicks link  Create new publication
+    user creates publication without methodology  ${PUBLICATION_NAME}   Tingting Shu - (Attainment statistics team)
+
+Verify new publication
+    [Tags]  HappyPath
+    user selects theme "Test theme" and topic "${TOPIC_NAME}" from the admin dashboard
+    user waits until page contains button  ${PUBLICATION_NAME}
+
+Create new release
+    [Tags]  HappyPath
+    user opens accordion section  ${PUBLICATION_NAME}
+    user clicks element  css:[data-testid="Create new release link for ${PUBLICATION_NAME}"]
+    user creates release for publication  ${PUBLICATION_NAME}  Financial Year  3000
+
+Verify release summary
+    [Tags]  HappyPath
+    user checks page contains element   xpath://li/a[text()="Release summary" and contains(@aria-current, 'page')]
+    user waits until page contains heading 2  Release summary
+    user checks summary list item "Publication title" should be "${PUBLICATION_NAME}"
+
+Upload subject
+    [Tags]  HappyPath
+    user clicks link  Manage data
+    user enters text into element  css:#dataFileUploadForm-subjectTitle   UI test subject
+    choose file   css:#dataFileUploadForm-dataFile       ${CURDIR}${/}files${/}upload-file-test.csv
+    choose file   css:#dataFileUploadForm-metadataFile   ${CURDIR}${/}files${/}upload-file-test.meta.csv
+    user clicks button  Upload data files
+
+    user waits until page contains heading 2  Uploaded data files
+    user waits until page contains accordion section   UI test subject
+    user opens accordion section   UI test subject
+    user checks page contains element   xpath://dt[text()="Subject title"]/../dd/h4[text()="UI test subject"]
+    user waits until page contains element  xpath://dt[text()="Status"]/../dd//strong[text()="Complete"]     180
+
+Navigate to Manage data blocks tab
+    [Tags]  HappyPath
+    user clicks link    Manage data blocks
+    user waits until page contains heading 2   Choose a subject
+
+Select subject "UI test subject"
+    [Tags]  HappyPath
+    user waits until page contains   UI test subject
+    user selects radio    UI test subject
+    user clicks element   css:#publicationSubjectForm-submit
+
+Select locations
+    [Tags]   HappyPath
+    user waits until element is visible  xpath://h2[text()="Choose locations"]     90
+    user opens details dropdown   Opportunity Area
+    user clicks checkbox   Bolton 001 (E02000984)
+    user clicks checkbox   Bolton 001 (E05000364)
+    user clicks checkbox   Bolton 004 (E02000987)
+    user clicks checkbox   Bolton 004 (E05010450)
+    user opens details dropdown   Ward
+    user clicks checkbox   Nailsea Youngwood
+    user clicks checkbox   Syon
+    user clicks element     css:#locationFiltersForm-submit
+
+Select time period
+    [Tags]   HappyPath
+    user waits until element is visible  xpath://h2[text()="Choose time period"]   90
+    user selects start date    2005
+    user selects end date      2020
+    user clicks element     css:#timePeriodForm-submit
+
+Select indicators
+    [Tags]  HappyPath
+    user waits until element is visible  xpath://h2[text()="Choose your filters"]
+    user clicks indicator checkbox    Admission Numbers
+
+Create table
+    [Tags]  HappyPath
+    user clicks element   css:#filtersForm-submit
+    user waits until results table appears     180
+
+Save data block as a highlight
+    [Tags]  HappyPath
+    user enters text into element  id:dataBlockDetailsForm-name         UI Test data block name
+    user enters text into element  id:dataBlockDetailsForm-heading      UI Test table title
+    user enters text into element  id:dataBlockDetailsForm-source       UI Test source
+
+    user clicks checkbox  Set as a table highlight for this publication
+    user waits until page contains element  id:dataBlockDetailsForm-highlightName
+    user enters text into element  id:dataBlockDetailsForm-highlightName    Test highlight name
+
+    user clicks button   Save data block
+    user waits until page contains    Delete this data block
+
+Go to "Release status" tab
+    [Tags]  HappyPath
+    user clicks link   Release status
+    user waits until page contains heading 2  Release status
+    user waits until page contains button  Edit release status
+
+Approve release
+    [Tags]  HappyPath
+    ${PUBLISH_DATE_DAY}=  get datetime  %d
+    ${PUBLISH_DATE_MONTH}=  get datetime  %m
+    ${PUBLISH_DATE_MONTH_WORD}=  get datetime  %B
+    ${PUBLISH_DATE_YEAR}=  get datetime  %Y
+    set suite variable  ${PUBLISH_DATE_DAY}
+    set suite variable  ${PUBLISH_DATE_MONTH}
+    set suite variable  ${PUBLISH_DATE_MONTH_WORD}
+    set suite variable  ${PUBLISH_DATE_YEAR}
+
+    user clicks button  Edit release status
+    user waits until page contains heading 2  Edit release status
+
+    user clicks element   css:input[data-testid="Approved for publication"]
+    user enters text into element  id:releaseStatusForm-internalReleaseNote  Approved by UI tests
+    user clicks element  css:input[data-testid="As soon as possible"]
+    user enters text into element  id:releaseStatusForm-nextReleaseDate-month   12
+    user enters text into element  id:releaseStatusForm-nextReleaseDate-year    3001
+
+    user clicks button   Update status
+
+Wait for release process status to be Complete
+    [Tags]  HappyPath
+    # EES-1007 - Release process status doesn't automatically update
+    user waits until page contains heading 2  Release status
+    user checks summary list item "Current status" should be "Approved"
+    user checks summary list item "Scheduled release" should be "${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}"
+    user waits for release process status to be  Complete    900
+    user checks page does not contain button  Edit release status
+
+User goes to public Find Statistics page
+    [Tags]  HappyPath
+    environment variable should be set   PUBLIC_URL
+    user goes to url   %{PUBLIC_URL}/find-statistics
+    user waits until page contains heading  Find statistics and data
+    user waits for page to finish loading
+
+Verify newly published release is on Find Statistics page
+    [Tags]  HappyPath
+    user checks page contains accordion   Test theme
+    user opens accordion section  Test theme
+    user checks accordion section contains text   Test theme   ${TOPIC_NAME}
+
+    user opens details dropdown  ${TOPIC_NAME}
+    user checks details dropdown contains publication    ${TOPIC_NAME}  ${PUBLICATION_NAME}
+    user checks publication bullet contains link   ${PUBLICATION_NAME}  View statistics and data
+    user checks publication bullet contains link   ${PUBLICATION_NAME}  Create your own tables online
+    user checks publication bullet does not contain link  ${PUBLICATION_NAME}   Statistics at DfE
+
+Go to Table Tool page
+    [Tags]  HappyPath
+    user goes to url  %{PUBLIC_URL}/data-tables
+    user waits until page contains heading  Create your own tables online
+
+Select publication
+    [Tags]  HappyPath
+    user opens details dropdown    Test theme
+    user opens details dropdown    ${TOPIC_NAME}
+    user selects radio      ${PUBLICATION_NAME}
+    user clicks element    css:#publicationForm-submit
+
+Select subject "UI test subject"
+    [Tags]  HappyPath
+    user waits until page contains   UI test subject
+    user selects radio    UI test subject
+    user clicks element   css:#publicationSubjectForm-submit
+
+Select locations
+    [Tags]   HappyPath
+    user waits until element is visible  xpath://h2[text()="Choose locations"]     90
+    user opens details dropdown   Local Authority
+    user clicks checkbox   Barnsley
+    user clicks checkbox   Birmingham
+    user clicks element     css:#locationFiltersForm-submit
+
+Select time period
+    [Tags]   HappyPath
+    user waits until element is visible  xpath://h2[text()="Choose time period"]   90
+    user selects start date    2014
+    user selects end date      2018
+    user clicks element     css:#timePeriodForm-submit
+
+Select indicators
+    [Tags]  HappyPath
+    user waits until element is visible  xpath://h2[text()="Choose your filters"]
+    user clicks indicator checkbox    Admission Numbers
+    user clicks element   css:#filtersForm-submit
+
+Validate table column headings
+    [Tags]  HappyPath
+    user waits until results table appears  180
+    user checks results table column heading contains  css:table  1  1  2014
+    user checks results table column heading contains  css:table  1  2  2015
+    user checks results table column heading contains  css:table  1  3  2016
+    user checks results table column heading contains  css:table  1  4  2017
+    user checks results table column heading contains  css:table  1  5  2018
+
+Validate table rows for Barnsley
+    [Tags]  HappyPath
+    ${row}=  user gets row number with heading  Barnsley
+    user checks results table cell in offset row contains  ${row}  0  1  9,854
+    user checks results table cell in offset row contains  ${row}  0  2  1,134
+    user checks results table cell in offset row contains  ${row}  0  3  7,419
+    user checks results table cell in offset row contains  ${row}  0  4  5,032
+    user checks results table cell in offset row contains  ${row}  0  5  8,123
+
+Validate table rows for Birmingham
+    [Tags]  HappyPath
+    ${row}=  user gets row number with heading   Birmingham
+    user checks results table cell in offset row contains  ${row}  0  1  3,708
+    user checks results table cell in offset row contains  ${row}  0  2  9,303
+    user checks results table cell in offset row contains  ${row}  0  3  8,856
+    user checks results table cell in offset row contains  ${row}  0  4  8,530
+    user checks results table cell in offset row contains  ${row}  0  5  3,962
+
+Select table highlight from subjects step
+    [Tags]  HappyPath
+    user clicks element  css:[data-testid="wizardStep-2-goToButton"]
+    user waits until page contains heading 1  Go back to previous step
+    user clicks button  Confirm
+
+    user waits until element is visible  xpath://h3[text()="Table highlights"]
+    user clicks link  Test highlight name
+    user waits until results table appears  180
+    user waits until page contains element   xpath://*[@id="dataTableCaption" and text()="Table showing Admission Numbers for 'UI test subject' from '${PUBLICATION_NAME}' in Bolton 001 (E02000984), Bolton 001 (E05000364), Bolton 004 (E02000987), Bolton 004 (E05010450), Nailsea Youngwood and Syon between 2005 and 2020"]
+
+Validate table column headings for table highlight
+    [Tags]  HappyPath
+    user checks results table column heading contains  css:table  1  1  Admission Numbers
+
+Validate table rows for Bolton 001 (E02000984)
+    [Tags]  HappyPath
+    ${row}=  user gets row number with heading  Bolton 001 (E02000984)
+    user checks results table heading in offset row contains  ${row}  0  2  2019
+
+    user checks results table cell in offset row contains  ${row}  0  1  8,533
+
+Validate table rows for Bolton 001 (E05000364)
+    [Tags]  HappyPath
+    ${row}=  user gets row number with heading   Bolton 001 (E05000364)
+    user checks results table heading in offset row contains  ${row}  0  2  2009
+    user checks results table heading in offset row contains  ${row}  1  1  2010
+    user checks results table heading in offset row contains  ${row}  2  1  2017
+
+    user checks results table cell in offset row contains  ${row}  0  1  5,815
+    user checks results table cell in offset row contains  ${row}  1  1  5,595
+    user checks results table cell in offset row contains  ${row}  2  1  6,373
+
+Validate table rows for Bolton 004 (E02000987)
+    [Tags]  HappyPath
+    ${row}=  user gets row number with heading   Bolton 004 (E02000987)
+    user checks results table heading in offset row contains  ${row}  0  2  2020
+
+    user checks results table cell in offset row contains  ${row}  0  1  6,031
+
+Validate table rows for Bolton 004 (E05010450)
+    [Tags]  HappyPath
+    ${row}=  user gets row number with heading   Bolton 004 (E05010450)
+    user checks results table heading in offset row contains  ${row}  0  2  2005
+    user checks results table heading in offset row contains  ${row}  1  1  2017
+    user checks results table heading in offset row contains  ${row}  2  1  2018
+
+    user checks results table cell in offset row contains  ${row}  0  1  8,557
+    user checks results table cell in offset row contains  ${row}  1  1  3,481
+    user checks results table cell in offset row contains  ${row}  2  1  8,630
+
+Validate table rows for Nailsea Youngwood
+    [Tags]  HappyPath
+    ${row}=  user gets row number with heading   Nailsea Youngwood
+    user checks results table heading in offset row contains  ${row}  0  2  2005
+    user checks results table heading in offset row contains  ${row}  1  1  2010
+    user checks results table heading in offset row contains  ${row}  2  1  2011
+    user checks results table heading in offset row contains  ${row}  3  1  2012
+    user checks results table heading in offset row contains  ${row}  4  1  2016
+
+    user checks results table cell in offset row contains  ${row}  0  1  3,612
+    user checks results table cell in offset row contains  ${row}  1  1  9,304
+    user checks results table cell in offset row contains  ${row}  2  1  9,603
+    user checks results table cell in offset row contains  ${row}  3  1  8,150
+    user checks results table cell in offset row contains  ${row}  4  1  4,198
+
+Validate table rows for Syon
+    [Tags]  HappyPath
+    ${row}=  user gets row number with heading   Syon
+    user checks results table heading in offset row contains  ${row}  0  2  2007
+    user checks results table heading in offset row contains  ${row}  1  1  2008
+    user checks results table heading in offset row contains  ${row}  2  1  2010
+    user checks results table heading in offset row contains  ${row}  3  1  2012
+    user checks results table heading in offset row contains  ${row}  4  1  2017
+
+    user checks results table cell in offset row contains  ${row}  0  1  9,914
+    user checks results table cell in offset row contains  ${row}  1  1  5,505
+    user checks results table cell in offset row contains  ${row}  2  1  6,060
+    user checks results table cell in offset row contains  ${row}  3  1  1,109
+    user checks results table cell in offset row contains  ${row}  4  1  1,959

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release.robot
@@ -58,11 +58,8 @@ Approve release
     user waits until page contains heading 2  Edit release status
 
     user clicks element   css:input[data-testid="Approved for publication"]
-
     user enters text into element  id:releaseStatusForm-internalReleaseNote  Approved by UI tests
-
     user clicks element  css:input[data-testid="As soon as possible"]
-
     user enters text into element  id:releaseStatusForm-nextReleaseDate-month   12
     user enters text into element  id:releaseStatusForm-nextReleaseDate-year    3001
 


### PR DESCRIPTION
This PR:

- Adds table highlights column to 'Choose a subject' step on table tool page for public frontend.
- Fixes 'Manage data blocks' page showing 'Choose a publication' step when creating a new data block.
- Adds UI tests to cover publishing of data and table highlights.