### PR TITLE
EES-648 Cancel publishing of releases sharing a dependency with the content of a failing release

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatus.cs
@@ -66,10 +66,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
                 DataStage = value.Data.ToString();
                 FilesStage = value.Files.ToString();
                 PublishingStage = value.Publishing.ToString();
-                OverallStage = value.ReleaseStatusOverall.ToString();
+                OverallStage = value.Overall.ToString();
 
                 _state = new ReleaseStatusState(value.Content, value.Files, value.Data, value.Publishing,
-                    value.ReleaseStatusOverall);
+                    value.Overall);
                 _state.PropertyChanged += StateChangedCallback;
             }
         }
@@ -112,7 +112,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
                     break;
             }
 
-            OverallStage = _state.ReleaseStatusOverall.ToString();
+            OverallStage = _state.Overall.ToString();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusState.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusState.cs
@@ -10,19 +10,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         private ReleaseStatusFilesStage _files;
         private ReleaseStatusDataStage _data;
         private ReleaseStatusPublishingStage _publishing;
-        public ReleaseStatusOverallStage ReleaseStatusOverall { get; private set; }
+        private ReleaseStatusOverallStage _overall;
 
         public ReleaseStatusState(ReleaseStatusContentStage content,
             ReleaseStatusFilesStage files,
             ReleaseStatusDataStage data,
             ReleaseStatusPublishingStage publishing,
-            ReleaseStatusOverallStage releaseStatusOverall)
+            ReleaseStatusOverallStage overall)
         {
             _content = content;
             _files = files;
             _data = data;
             _publishing = publishing;
-            ReleaseStatusOverall = releaseStatusOverall;
+            _overall = overall;
         }
 
         public ReleaseStatusState(string content, string files, string data, string publishing, string overall) : this(
@@ -94,6 +94,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
             }
         }
 
+        public ReleaseStatusOverallStage Overall
+        {
+            get => _overall;
+            set
+            {
+                if (value == _overall)
+                {
+                    return;
+                }
+
+                _overall = value;
+                NotifyPropertyChanged();
+            }
+        }
+
         private void NotifyPropertyChanged([CallerMemberName] string propertyName = "")
         {
             if (Content == ReleaseStatusContentStage.Complete
@@ -101,7 +116,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
                 && Files == ReleaseStatusFilesStage.Complete
                 && Publishing == ReleaseStatusPublishingStage.Complete)
             {
-                ReleaseStatusOverall = ReleaseStatusOverallStage.Complete;
+                Overall = ReleaseStatusOverallStage.Complete;
             }
 
             if (Content == ReleaseStatusContentStage.Failed
@@ -115,7 +130,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
                 {
                     Publishing = ReleaseStatusPublishingStage.Cancelled;
                 }
-                ReleaseStatusOverall = ReleaseStatusOverallStage.Failed;
+                Overall = ReleaseStatusOverallStage.Failed;
             }
 
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -5,11 +5,9 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.utils;
-using Microsoft.Azure.Cosmos.Table;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusPublishingStage;
-using static GovUk.Education.ExploreEducationStatistics.Publisher.Services.ReleaseStatusTableQueryUtil;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
@@ -95,12 +93,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 
         private async Task<IEnumerable<ReleaseStatus>> QueryScheduledReleases()
         {
-            var query = QueryPublishLessThanEndOfTodayWithStages(
+            return await _releaseStatusService.GetWherePublishingDueTodayWithStages(
                 content: ReleaseStatusContentStage.Complete,
                 data: ReleaseStatusDataStage.Complete,
                 publishing: Scheduled);
-
-            return await _releaseStatusService.ExecuteQueryAsync(query);
         }
 
         private async Task UpdateStage(IEnumerable<ReleaseStatus> releaseStatuses, ReleaseStatusPublishingStage stage,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentImmediateFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentImmediateFunction.cs
@@ -82,22 +82,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                     await _releaseStatusService.UpdateStagesAsync(releaseId,
                         releaseStatusId,
                         logMessage: logMessage,
-                        publishingStage: ReleaseStatusPublishingStage.Started,
-                        contentStage: ReleaseStatusContentStage.Started);
+                        publishing: ReleaseStatusPublishingStage.Started,
+                        content: ReleaseStatusContentStage.Started);
                     break;
                 case Stage.Complete:
                     await _releaseStatusService.UpdateStagesAsync(releaseId,
                         releaseStatusId,
                         logMessage: logMessage,
-                        publishingStage: ReleaseStatusPublishingStage.Complete,
-                        contentStage: ReleaseStatusContentStage.Complete);
+                        publishing: ReleaseStatusPublishingStage.Complete,
+                        content: ReleaseStatusContentStage.Complete);
                     break;
                 case Stage.Failed:
                     await _releaseStatusService.UpdateStagesAsync(releaseId,
                         releaseStatusId,
                         logMessage: logMessage,
-                        publishingStage: ReleaseStatusPublishingStage.Failed,
-                        contentStage: ReleaseStatusContentStage.Failed);
+                        publishing: ReleaseStatusPublishingStage.Failed,
+                        content: ReleaseStatusContentStage.Failed);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(stage), stage, null);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleasesFunction.cs
@@ -4,10 +4,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
-using Microsoft.Azure.Cosmos.Table;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusStates;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Services.ReleaseStatusTableQueryUtil;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
@@ -58,14 +58,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 
         private async Task<IEnumerable<ReleaseStatus>> QueryScheduledReleases()
         {
-            var dateFilter = TableQuery.GenerateFilterConditionForDate(nameof(ReleaseStatus.Publish),
-                QueryComparisons.LessThan, DateTime.Today.AddDays(1));
-            var stageFilter = TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.OverallStage),
-                QueryComparisons.Equal,
-                ReleaseStatusOverallStage.Scheduled.ToString());
-            var combinedFilter = TableQuery.CombineFilters(dateFilter, TableOperators.And, stageFilter);
-            var query = new TableQuery<ReleaseStatus>().Where(combinedFilter);
-
+            var query = QueryPublishLessThanEndOfTodayWithStages(overall: ReleaseStatusOverallStage.Scheduled);
             return await _releaseStatusService.ExecuteQueryAsync(query);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleasesFunction.cs
@@ -7,7 +7,6 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusStates;
-using static GovUk.Education.ExploreEducationStatistics.Publisher.Services.ReleaseStatusTableQueryUtil;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 {
@@ -58,8 +57,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 
         private async Task<IEnumerable<ReleaseStatus>> QueryScheduledReleases()
         {
-            var query = QueryPublishLessThanEndOfTodayWithStages(overall: ReleaseStatusOverallStage.Scheduled);
-            return await _releaseStatusService.ExecuteQueryAsync(query);
+            return await _releaseStatusService.GetWherePublishingDueTodayWithStages(
+                overall: ReleaseStatusOverallStage.Scheduled);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseStatusService.cs
@@ -15,6 +15,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task<ReleaseStatus> GetAsync(Guid releaseId, Guid releaseStatusId);
 
+        Task<IEnumerable<ReleaseStatus>> GetWherePublishingDueTodayWithStages(ReleaseStatusContentStage? content = null,
+            ReleaseStatusDataStage? data = null,
+            ReleaseStatusFilesStage? files = null,
+            ReleaseStatusPublishingStage? publishing = null,
+            ReleaseStatusOverallStage? overall = null);
+
         Task<IEnumerable<ReleaseStatus>> GetAllByOverallStage(Guid releaseId, params ReleaseStatusOverallStage[] overallStages);
 
         Task<ReleaseStatus> GetLatestAsync(Guid releaseId);
@@ -23,9 +29,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task UpdateStateAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusState state);
 
-        Task UpdateStagesAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusContentStage? contentStage = null,
-            ReleaseStatusDataStage? dataStage = null, ReleaseStatusFilesStage? filesStage = null,
-            ReleaseStatusPublishingStage? publishingStage = null, ReleaseStatusLogMessage logMessage = null);
+        Task UpdateStagesAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusContentStage? content = null,
+            ReleaseStatusDataStage? data = null, ReleaseStatusFilesStage? files = null,
+            ReleaseStatusPublishingStage? publishing = null, ReleaseStatusOverallStage? overall = null, 
+            ReleaseStatusLogMessage logMessage = null);
 
         Task UpdateContentStageAsync(Guid releaseId, Guid releaseStatusId, ReleaseStatusContentStage stage,
             ReleaseStatusLogMessage logMessage = null);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseStatusTableQueryUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseStatusTableQueryUtil.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using Microsoft.Azure.Cosmos.Table;
+using static Microsoft.Azure.Cosmos.Table.QueryComparisons;
+using static Microsoft.Azure.Cosmos.Table.TableOperators;
+using static Microsoft.Azure.Cosmos.Table.TableQuery;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
+{
+    public static class ReleaseStatusTableQueryUtil
+    {
+        public static TableQuery<ReleaseStatus> QueryPublishLessThanEndOfTodayWithStages(
+            ReleaseStatusContentStage? content = null,
+            ReleaseStatusDataStage? data = null,
+            ReleaseStatusFilesStage? files = null,
+            ReleaseStatusPublishingStage? publishing = null,
+            ReleaseStatusOverallStage? overall = null)
+        {
+            var filter = FilterPublishLessThanEndOfToday();
+
+            if (content.HasValue)
+            {
+                filter = CombineFilters(filter, And, FilterContentStageEquals(content.Value));
+            }
+
+            if (data.HasValue)
+            {
+                filter = CombineFilters(filter, And, FilterDataStageEquals(data.Value));
+            }
+
+            if (files.HasValue)
+            {
+                filter = CombineFilters(filter, And, FilterFilesStageEquals(files.Value));
+            }
+
+            if (publishing.HasValue)
+            {
+                filter = CombineFilters(filter, And, FilterPublishingStageEquals(publishing.Value));
+            }
+
+            if (overall.HasValue)
+            {
+                filter = CombineFilters(filter, And, FilterOverallStageEquals(overall.Value));
+            }
+
+            return new TableQuery<ReleaseStatus>().Where(filter);
+        }
+
+        private static string FilterPublishLessThanEndOfToday() =>
+            GenerateFilterConditionForDate(nameof(ReleaseStatus.Publish), LessThan, DateTime.Today.AddDays(1));
+
+        private static string FilterContentStageEquals(ReleaseStatusContentStage stage) =>
+            GenerateFilterCondition(nameof(ReleaseStatus.ContentStage), Equal, stage.ToString());
+
+        private static string FilterDataStageEquals(ReleaseStatusDataStage stage) =>
+            GenerateFilterCondition(nameof(ReleaseStatus.DataStage), Equal, stage.ToString());
+
+        private static string FilterFilesStageEquals(ReleaseStatusFilesStage stage) =>
+            GenerateFilterCondition(nameof(ReleaseStatus.FilesStage), Equal, stage.ToString());
+
+        private static string FilterPublishingStageEquals(ReleaseStatusPublishingStage stage) =>
+            GenerateFilterCondition(nameof(ReleaseStatus.PublishingStage), Equal, stage.ToString());
+
+        private static string FilterOverallStageEquals(ReleaseStatusOverallStage stage) =>
+            GenerateFilterCondition(nameof(ReleaseStatus.OverallStage), Equal, stage.ToString());
+    }
+}


### PR DESCRIPTION
Cancel publishing of any other releases sharing a dependency with the content of a failing release.

**Reason:** Publishing any Release copies the whole staging directory.
Cancelling the publishing stage of other Releases is necessary to avoid publishing staged content of the Release which is now failing, and other parts of content which were calculated expecting that Release to exist.

Future work in EES-1070 will mean the failing stage can be retried and successful retry attempts will reschedule publishing of all affected Releases.