### PR TITLE
EES-1091 Add `parseISO` to prerelease window status dates

### DIFF
--- a/src/explore-education-statistics-admin/src/services/permissionService.ts
+++ b/src/explore-education-statistics-admin/src/services/permissionService.ts
@@ -1,5 +1,6 @@
 import { User } from '@admin/contexts/AuthContext';
 import client from '@admin/services/utils/service';
+import { parseISO } from 'date-fns';
 
 export interface GlobalPermissions {
   canAccessSystem: boolean;
@@ -73,8 +74,8 @@ const permissionService = {
       }>(`/permissions/release/${releaseId}/prerelease/status`)
       .then(status => ({
         access: status.access,
-        start: new Date(status.start),
-        end: new Date(status.end),
+        start: parseISO(status.start),
+        end: parseISO(status.end),
       }));
   },
 };


### PR DESCRIPTION
The start/end dates for `PreReleaseWindowStatus` were missing `parseISO` to convert them UTC dates to local times, leading to them being incorrectly displayed.