### PR TITLE
EES-1189 Prevent creating Amendments of older versions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfReleaseAuthorizationHandlersTests.cs
@@ -1,5 +1,6 @@
 using System;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.MakeAmendmentOfSpecificReleaseAuthorizationHandler;
@@ -13,24 +14,50 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         [Fact]
         public void CanMakeAmendmentOfAllReleasesAuthorizationHandler()
         {
-            // Assert that no users can amend a non-Live Release
-            AssertReleaseHandlerSucceedsWithCorrectClaims<MakeAmendmentOfSpecificReleaseRequirement>(
-                new CanMakeAmendmentOfAllReleasesAuthorizationHandler());
-        }
-        
-        [Fact]
-        public void MakeAmendmentOfSpecificReleaseCanMakeAmendmentOfAllReleasesAuthorizationHandler_ReleaseApproved()
-        {
-            var release = new Release
+            using (var context = DbUtils.InMemoryApplicationDbContext())
             {
+                // Assert that no users can amend a non-Live Release
+                AssertReleaseHandlerSucceedsWithCorrectClaims<MakeAmendmentOfSpecificReleaseRequirement>(
+                    new CanMakeAmendmentOfAllReleasesAuthorizationHandler(context));
+            }
+        }
+
+        [Fact]
+        public void 
+            MakeAmendmentOfSpecificReleaseCanMakeAmendmentOfAllReleasesAuthorizationHandler_LiveAndLatestVersion()
+        {
+            var publication = new Publication
+            {
+                Id = Guid.NewGuid()
+            };
+            
+            var previousVersion = new Release
+            {
+                Id = new Guid("08f7c576-6e52-44ad-a98f-5215394d9abf"),
+                PreviousVersionId = new Guid("08f7c576-6e52-44ad-a98f-5215394d9abf"),
+                Publication = publication,
                 Published = DateTime.UtcNow
             };
             
-            // Assert that any users with the "MakeAmendmentOfAllReleases" claim can approve an arbitrary Release
-            // (and no other claim allows this)
-            AssertReleaseHandlerSucceedsWithCorrectClaims<MakeAmendmentOfSpecificReleaseRequirement>(
-                new CanMakeAmendmentOfAllReleasesAuthorizationHandler(),
-                release, MakeAmendmentsOfAllReleases);
+            var latestVersion = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                PreviousVersionId = previousVersion.Id,
+                Published = DateTime.UtcNow
+            };
+
+            using (var context = DbUtils.InMemoryApplicationDbContext())
+            {
+                context.AddRange(previousVersion, latestVersion);
+                context.SaveChanges();
+                
+                // Assert that any users with the "MakeAmendmentOfAllReleases" claim can amend an arbitrary Live and latest Release
+                // (and no other claim allows this)
+                AssertReleaseHandlerSucceedsWithCorrectClaims<MakeAmendmentOfSpecificReleaseRequirement>(
+                    new CanMakeAmendmentOfAllReleasesAuthorizationHandler(context),
+                    latestVersion, MakeAmendmentsOfAllReleases);
+            }
         }
         
         [Fact]
@@ -40,19 +67,40 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<MakeAmendmentOfSpecificReleaseRequirement>(
                 contentDbContext => new HasEditorRoleOnReleaseAuthorizationHandler(contentDbContext));
         }
-        
+
         [Fact]
-        public void HasEditorRoleOnReleaseAuthorizationHandler_ReleaseLive()
+        public void HasEditorRoleOnReleaseAuthorizationHandler_LiveAndLatestVersion()
         {
-            var release = new Release
+            var publication = new Publication
             {
+                Id = Guid.NewGuid()
+            };
+            
+            var previousVersion = new Release
+            {
+                Id = new Guid("08f7c576-6e52-44ad-a98f-5215394d9abf"),
+                PreviousVersionId = new Guid("08f7c576-6e52-44ad-a98f-5215394d9abf"),
+                Publication = publication,
                 Published = DateTime.UtcNow
             };
             
-            // Assert that users with an editor role on the release can amend it if it is Live
+            var latestVersion = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                PreviousVersionId = previousVersion.Id,
+                Published = DateTime.UtcNow
+            };
+
+            // Assert that users with an editor role on the release can amend it if it is Live and the latest version
             AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<MakeAmendmentOfSpecificReleaseRequirement>(
-                contentDbContext => new HasEditorRoleOnReleaseAuthorizationHandler(contentDbContext),
-                release,
+                contentDbContext =>
+                {
+                    contentDbContext.Releases.AddRange(previousVersion, latestVersion);
+                    contentDbContext.SaveChanges();
+                    return new HasEditorRoleOnReleaseAuthorizationHandler(contentDbContext);
+                },
+                latestVersion,
                 ReleaseRole.Contributor, ReleaseRole.Approver, ReleaseRole.Lead);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
@@ -428,8 +428,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(release.Id, amendment.PreviousVersionId);
                 Assert.Equal(_userId, amendment.CreatedBy.Id);
                 Assert.Equal(_userId, amendment.CreatedById);
-                Assert.True(amendment.Created.CompareTo(DateTime.UtcNow.AddSeconds(-1)) > 0 
-                            && amendment.Created.CompareTo(DateTime.UtcNow) <= 0);
+                Assert.InRange(DateTime.UtcNow.Subtract(amendment.Created).Milliseconds, 0, 1500);
                 Assert.Null(amendment.InternalReleaseNote);
 
                 Assert.Equal(releaseType, amendment.Type);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificReleaseAuthorizationHandlers.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -12,29 +15,42 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
     public class MakeAmendmentOfSpecificReleaseAuthorizationHandler : CompoundAuthorizationHandler<MakeAmendmentOfSpecificReleaseRequirement, Release>
     {
         public MakeAmendmentOfSpecificReleaseAuthorizationHandler(ContentDbContext context) : base(
-            new CanMakeAmendmentOfAllReleasesAuthorizationHandler(),
+            new CanMakeAmendmentOfAllReleasesAuthorizationHandler(context),
             new HasEditorRoleOnReleaseAuthorizationHandler(context))
         {
             
         }
-        
-        public class CanMakeAmendmentOfAllReleasesAuthorizationHandler : 
+
+        public class CanMakeAmendmentOfAllReleasesAuthorizationHandler :
             EntityAuthorizationHandler<MakeAmendmentOfSpecificReleaseRequirement, Release>
         {
-            public CanMakeAmendmentOfAllReleasesAuthorizationHandler() 
-                : base(ctx => 
-                    ctx.Entity.Live 
+            public CanMakeAmendmentOfAllReleasesAuthorizationHandler(ContentDbContext context)
+                : base(ctx =>
+                    ctx.Entity.Live
+                    && IsLatestVersionOfRelease(context, ctx.Entity)
                     && SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.MakeAmendmentsOfAllReleases)) {}
         }
 
         public class HasEditorRoleOnReleaseAuthorizationHandler
             : HasRoleOnReleaseAuthorizationHandler<MakeAmendmentOfSpecificReleaseRequirement>
         {
-            public HasEditorRoleOnReleaseAuthorizationHandler(ContentDbContext context) 
-                : base(context, ctx => 
-                    ctx.Release.Live 
+            public HasEditorRoleOnReleaseAuthorizationHandler(ContentDbContext context)
+                : base(context, ctx =>
+                    ctx.Release.Live
+                    && IsLatestVersionOfRelease(context, ctx.Release)
                     && ContainsEditorRole(ctx.Roles))
             {}
+        }
+
+        private static bool IsLatestVersionOfRelease(ContentDbContext context, Release release)
+        {
+            var releases = context.Releases.Where(r => r.PublicationId == release.PublicationId);
+            return IsLatestVersionOfRelease(releases, release.Id);
+        }
+
+        private static bool IsLatestVersionOfRelease(IEnumerable<Release> releases, Guid releaseId)
+        {
+            return !releases.Any(r => r.PreviousVersionId == releaseId && r.Id != releaseId);
         }
     }
 }


### PR DESCRIPTION
It was previously possible to create an Amendment of an older version, at least at an API level, and also by clicking the confirmation multiple times in quick succession.