### PR TITLE
EES-1205 Temporarily downgrading Notifier dependency Microsoft.NET.Sdk.Functions to 3.0.3

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
@@ -6,9 +6,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
+    <!-- EES-1205 Temporarily downgrading dependency Microsoft.NET.Sdk.Functions to 3.0.3
+    Prevents error when subscribing to Publications
+    'Could not load file or assembly 'Microsoft.IdentityModel.Tokens, Version=6.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified'
+    See https://github.com/Azure/azure-functions-host/issues/5894 --> 
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
     <PackageReference Include="Notify" Version="2.8.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.6.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Notifier.Model\GovUk.Education.ExploreEducationStatistics.Notifier.Model.csproj" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/PublicationNotifier.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/PublicationNotifier.cs
@@ -179,8 +179,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier
 
                 return new OkObjectResult("Thanks! Please check your email.");
             }
-            catch (NotifyClientException ex)
+            catch (NotifyClientException e)
             {
+                logger.LogError(e,"Caught exception sending email");
                 // Remove the subscriber from storage if we could not successfully send the email & just added it
                 if (!subscriptionPending)
                 {
@@ -189,11 +190,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier
                 }
 
                 return new BadRequestObjectResult(
-                    $"There are problems sending the subscription verification email: {ex.Message}");
+                    $"There are problems sending the subscription verification email: {e.Message}");
             }
-            catch (Exception ex)
+            catch (Exception e)
             {
-                return new BadRequestObjectResult($"There are problems storing your subscription: {ex.Message}");
+                logger.LogError(e,"Caught exception storing subscription");
+                return new BadRequestObjectResult($"There are problems storing your subscription: {e.Message}");
             }
         }
 


### PR DESCRIPTION
* Temporarily downgrade Notifier dependency Microsoft.NET.Sdk.Functions to 3.0.3
Prevents error when subscribing to Publications
`'Could not load file or assembly 'Microsoft.IdentityModel.Tokens, Version=6.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified'`

See https://github.com/Azure/azure-functions-host/issues/5894

* Add logging for caught exceptions.
* Update Azure IdentityModel Tokens extension library to 6.5.0.