### PR TITLE
Bugfix/ees 1197 review transactions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ImportService.cs
@@ -84,6 +84,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             );
             return true;
         }
+        
+        public async Task FailImport(Guid releaseId, string dataFileName, string message)
+        {
+            await _table.ExecuteAsync(TableOperation.InsertOrReplace(
+                new DatafileImport(releaseId.ToString(), dataFileName, 0, message, IStatus.FAILED))
+            );
+        }
 
         private async Task UpdateImportTableRow(Guid releaseId, string dataFileName, int numberOfRows, ImportMessage message)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IImportService.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     public interface IImportService
     {
         void Import(string dataFileName, string metaFileName, Guid releaseId, IFormFile dataFile);
-
         Task<Either<ActionResult, bool>> CreateImportTableRow(Guid releaseId, string dataFileName);
+        Task FailImport(Guid releaseId, string dataFileName, string message);
     }
 }


### PR DESCRIPTION
This change adds logic to try to ensure that uploaded files are not left in a state whereby the storage details are not in line with the database file references. While it isn't possible with these type of distributed transactions to guard against that completely - in the odd scenario where files could be out of step then the user is now notified & the uploads in question can now be deleted.