### PR TITLE
EES-1200 - fileInput premature validation

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormFieldFileInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldFileInput.tsx
@@ -4,6 +4,7 @@ import FormField, {
 import FormFileInput, {
   FormFileInputProps,
 } from '@common/components/form/FormFileInput';
+import useToggle from '@common/hooks/useToggle';
 import React from 'react';
 
 type Props<FormValues> = FormFieldComponentProps<
@@ -14,6 +15,8 @@ type Props<FormValues> = FormFieldComponentProps<
 const FormFieldFileInput = <FormValues extends {}>(
   props: Props<FormValues>,
 ) => {
+  const [fileHasBeenSelected, toggleFileHasBeenSelected] = useToggle(false);
+
   return (
     <FormField<File | null> {...props}>
       {({ field, helpers }) => (
@@ -21,6 +24,8 @@ const FormFieldFileInput = <FormValues extends {}>(
           {...props}
           {...field}
           onChange={event => {
+            toggleFileHasBeenSelected();
+
             if (props.onChange) {
               props.onChange(event);
             }
@@ -35,6 +40,9 @@ const FormFieldFileInput = <FormValues extends {}>(
                 : null;
 
             helpers.setValue(file);
+          }}
+          onBlur={event => {
+            if (fileHasBeenSelected) field.onBlur(event);
           }}
         />
       )}


### PR DESCRIPTION
The validation error was being thrown on screen as the user clicked to choose a file on the file input.
This was caused by the `field.onBlur` being ran as soon as the file selector was opened which lead to the file input being blurred.

To combat this, I've added a `useToggle` (`fileHasBeenSelected`) to track if the user has previously added a file to the input.
If a file was never added, the validation will not run, even if the file selection is cancelled.
If a file was previously added, and then it was removed, an error will be thrown.

The changes will not affect the onSubmit form validation, so if the user doesn't add a file and they try to submit, an error will still be displayed onscreen as expected.