### PR TITLE
EES-1208 Add ancillary has incorrect return value.

### DIFF
--- a/src/explore-education-statistics-admin/src/services/releaseAncillaryFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseAncillaryFileService.ts
@@ -50,11 +50,13 @@ const releaseAncillaryFileService = {
     const data = new FormData();
     data.append('file', request.file);
     return client
-      .post<AncillaryFileInfo>(
+      .post<AncillaryFileInfo[]>(
         `/release/${releaseId}/ancillary?name=${request.name}`,
         data,
       )
-      .then(mapFile);
+      .then(response => {
+        return response.map(mapFile)[0];
+      });
   },
   deleteAncillaryFile(releaseId: string, fileName: string): Promise<null> {
     return client.delete<null>(`/release/${releaseId}/ancillary/${fileName}`);


### PR DESCRIPTION
This fixes the immediate problem of not being able to add ancillary files but there's no need to return arrays from the back end as the frontend re-requests all row files anyway on successful addition. This is probably a historical hangover.
I have raised https://dfedigital.atlassian.net/browse/EES-1210 to address the further changes needed.