### PR TITLE
EES-1200 - fileInput premature validation (part 2)

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormFieldFileInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldFileInput.tsx
@@ -4,6 +4,7 @@ import FormField, {
 import FormFileInput, {
   FormFileInputProps,
 } from '@common/components/form/FormFileInput';
+import useToggle from '@common/hooks/useToggle';
 import React from 'react';
 
 type Props<FormValues> = FormFieldComponentProps<
@@ -14,6 +15,8 @@ type Props<FormValues> = FormFieldComponentProps<
 const FormFieldFileInput = <FormValues extends {}>(
   props: Props<FormValues>,
 ) => {
+  const [fileHasBeenSelected, toggleFileHasBeenSelected] = useToggle(false);
+
   return (
     <FormField<File | null> {...props}>
       {({ field, helpers }) => (
@@ -21,6 +24,8 @@ const FormFieldFileInput = <FormValues extends {}>(
           {...props}
           {...field}
           onChange={event => {
+            toggleFileHasBeenSelected();
+
             if (props.onChange) {
               props.onChange(event);
             }
@@ -35,6 +40,9 @@ const FormFieldFileInput = <FormValues extends {}>(
                 : null;
 
             helpers.setValue(file);
+          }}
+          onBlur={event => {
+            if (fileHasBeenSelected) field.onBlur(event);
           }}
         />
       )}

--- a/src/explore-education-statistics-common/src/components/form/FormFieldFileInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldFileInput.tsx
@@ -20,44 +20,42 @@ const FormFieldFileInput = <FormValues extends {}>(
 
   return (
     <FormField<File | null> {...props}>
-      {({ field, helpers }) => {
-        return (
-          <FormFileInput
-            {...props}
-            {...field}
-            onChange={event => {
-              toggleFileHasBeenSelected();
+      {({ field, helpers }) => (
+        <FormFileInput
+          {...props}
+          {...field}
+          onChange={event => {
+            toggleFileHasBeenSelected();
 
-              if (props.onChange) {
-                props.onChange(event);
-              }
+            if (props.onChange) {
+              props.onChange(event);
+            }
 
-              if (event.isDefaultPrevented()) {
-                return;
-              }
+            if (event.isDefaultPrevented()) {
+              return;
+            }
 
-              const file =
-                event.target.files && event.target.files.length > 0
-                  ? event.target.files[0]
-                  : null;
+            const file =
+              event.target.files && event.target.files.length > 0
+                ? event.target.files[0]
+                : null;
 
-              setInputValue(file);
-              helpers.setValue(file);
-            }}
-            onBlur={event => {
-              if (inputValue !== field.value) {
-                // formField value was outside of the input (e.g form reset)
-                // reset field touched state
-                helpers.setTouched(false);
-                toggleFileHasBeenSelected(false);
-              } else if (fileHasBeenSelected) {
-                // only allow field validation if a file has been previously selected
-                field.onBlur(event);
-              }
-            }}
-          />
-        );
-      }}
+            setInputValue(file);
+            helpers.setValue(file);
+          }}
+          onBlur={event => {
+            if (inputValue !== field.value) {
+              // formField value was outside of the input (e.g form reset)
+              // reset field touched state
+              helpers.setTouched(false);
+              toggleFileHasBeenSelected(false);
+            } else if (fileHasBeenSelected) {
+              // only allow field validation if a file has been previously selected
+              field.onBlur(event);
+            }
+          }}
+        />
+      )}
     </FormField>
   );
 };

--- a/src/explore-education-statistics-common/src/components/form/FormFieldFileInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldFileInput.tsx
@@ -5,7 +5,7 @@ import FormFileInput, {
   FormFileInputProps,
 } from '@common/components/form/FormFileInput';
 import useToggle from '@common/hooks/useToggle';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 type Props<FormValues> = FormFieldComponentProps<
   FormFileInputProps,
@@ -16,36 +16,48 @@ const FormFieldFileInput = <FormValues extends {}>(
   props: Props<FormValues>,
 ) => {
   const [fileHasBeenSelected, toggleFileHasBeenSelected] = useToggle(false);
+  const [inputValue, setInputValue] = useState<File | null>(null);
 
   return (
     <FormField<File | null> {...props}>
-      {({ field, helpers }) => (
-        <FormFileInput
-          {...props}
-          {...field}
-          onChange={event => {
-            toggleFileHasBeenSelected();
+      {({ field, helpers }) => {
+        return (
+          <FormFileInput
+            {...props}
+            {...field}
+            onChange={event => {
+              toggleFileHasBeenSelected();
 
-            if (props.onChange) {
-              props.onChange(event);
-            }
+              if (props.onChange) {
+                props.onChange(event);
+              }
 
-            if (event.isDefaultPrevented()) {
-              return;
-            }
+              if (event.isDefaultPrevented()) {
+                return;
+              }
 
-            const file =
-              event.target.files && event.target.files.length > 0
-                ? event.target.files[0]
-                : null;
+              const file =
+                event.target.files && event.target.files.length > 0
+                  ? event.target.files[0]
+                  : null;
 
-            helpers.setValue(file);
-          }}
-          onBlur={event => {
-            if (fileHasBeenSelected) field.onBlur(event);
-          }}
-        />
-      )}
+              setInputValue(file);
+              helpers.setValue(file);
+            }}
+            onBlur={event => {
+              if (inputValue !== field.value) {
+                // formField value was outside of the input (e.g form reset)
+                // reset field touched state
+                helpers.setTouched(false);
+                toggleFileHasBeenSelected(false);
+              } else if (fileHasBeenSelected) {
+                // only allow field validation if a file has been previously selected
+                field.onBlur(event);
+              }
+            }}
+          />
+        );
+      }}
     </FormField>
   );
 };


### PR DESCRIPTION
Added additional checking for the forms field value, against the input value - if they differ, then the formField value was changed outside of the input controls - for instance, when the form is reset programatically. If this happens, we now reset the (previously added) field touched state