### PR TITLE
EES-1185 Don't validate Release if Publishing State is already Started

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
 using IFootnoteService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IFootnoteService;
+using Unit = GovUk.Education.ExploreEducationStatistics.Data.Model.Unit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Statistics
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Unit.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Unit.cs
@@ -1,0 +1,14 @@
+﻿namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+{
+    /// <summary>
+    /// Class that can be used as a return type representing no meaningful value. 
+    /// </summary>
+    public sealed class Unit
+    {
+        private Unit()
+        {
+        }
+
+        public static readonly Unit Instance = new Unit();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IValidationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IValidationService.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces
 {
     public interface IValidationService
     {
-        Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidatePublishingState(Guid releaseId);
-        Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidateRelease(Guid releaseId);
+        Task<bool> ValidatePublishingState(Guid releaseId);
+        Task<Either<IEnumerable<ReleaseStatusLogMessage>, Unit>> ValidateRelease(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IValidationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IValidationService.cs
@@ -7,6 +7,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 {
     public interface IValidationService
     {
-        Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidateAsync(Guid releaseId);
+        Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidatePublishingState(Guid releaseId);
+        Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidateRelease(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ValidationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ValidationService.cs
@@ -28,7 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             _logger = logger;
         }
 
-        public async Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidateAsync(Guid releaseId)
+        public async Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidateRelease(Guid releaseId)
         {
             _logger.LogTrace($"Validating release: {releaseId}");
 
@@ -36,24 +36,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
             var (approvalValid, approvalMessages) = ValidateApproval(release);
             var (scheduledPublishDateValid, scheduledPublishDateMessages) = ValidateScheduledPublishDate(release);
-            var (publishingStateValid, publishingStateMessages) = await ValidatePublishingState(release);
 
             var valid = approvalValid
-                        && scheduledPublishDateValid
-                        && publishingStateValid;
+                        && scheduledPublishDateValid;
 
             var logMessages = approvalMessages
-                .Concat(scheduledPublishDateMessages)
-                .Concat(publishingStateMessages);
+                .Concat(scheduledPublishDateMessages);
 
             return Result(valid, logMessages);
         }
 
-        private async Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidatePublishingState(
-            Release release)
+        public async Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidatePublishingState(
+            Guid releaseId)
         {
+            _logger.LogTrace($"Validating publishing state: {releaseId}");
+            
             var releaseStatuses =
-                (await _releaseStatusService.GetAllByOverallStage(release.Id, Scheduled, Started)).ToList();
+                (await _releaseStatusService.GetAllByOverallStage(releaseId, Scheduled, Started)).ToList();
             var scheduled = releaseStatuses.FirstOrDefault(status => status.State.Overall == Scheduled);
             var started = releaseStatuses.FirstOrDefault(status => status.State.Overall == Started);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ValidationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ValidationService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
@@ -28,61 +29,66 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             _logger = logger;
         }
 
-        public async Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidateRelease(Guid releaseId)
+        public async Task<Either<IEnumerable<ReleaseStatusLogMessage>, Unit>> ValidateRelease(Guid releaseId)
         {
             _logger.LogTrace($"Validating release: {releaseId}");
 
             var release = await GetReleaseAsync(releaseId);
 
-            var (approvalValid, approvalMessages) = ValidateApproval(release);
-            var (scheduledPublishDateValid, scheduledPublishDateMessages) = ValidateScheduledPublishDate(release);
+            var approvalResult = ValidateApproval(release);
+            var scheduledPublishDateResult = ValidateScheduledPublishDate(release);
+            var valid = approvalResult.IsRight && scheduledPublishDateResult.IsRight;
 
-            var valid = approvalValid
-                        && scheduledPublishDateValid;
-
-            var logMessages = approvalMessages
-                .Concat(scheduledPublishDateMessages);
-
-            return Result(valid, logMessages);
-        }
-
-        public async Task<(bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages)> ValidatePublishingState(
-            Guid releaseId)
-        {
-            _logger.LogTrace($"Validating publishing state: {releaseId}");
-            
-            var releaseStatuses =
-                (await _releaseStatusService.GetAllByOverallStage(releaseId, Scheduled, Started)).ToList();
-            var scheduled = releaseStatuses.FirstOrDefault(status => status.State.Overall == Scheduled);
-            var started = releaseStatuses.FirstOrDefault(status => status.State.Overall == Started);
-
-            // Should never happen as we mark scheduled releases as superseded prior to validation
-            if (scheduled != null)
+            if (!valid)
             {
-                return Failure(ValidationStage.ReleasePublishingStateNotScheduledOrStarted,
-                    $"Publishing is already scheduled. ReleaseStatus: {scheduled.Id}");
+                return CollateMessages(approvalResult, scheduledPublishDateResult).ToList();
             }
 
-            return started == null
-                ? Success()
-                : Failure(ValidationStage.ReleasePublishingStateNotScheduledOrStarted,
-                    $"Publishing has already started. ReleaseStatus: {started.Id}");
+            return Unit.Instance;
         }
 
-        private static (bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages) ValidateApproval(Release release)
+        public async Task<bool> ValidatePublishingState(Guid releaseId)
+        {
+            _logger.LogTrace($"Validating publishing state: {releaseId}");
+
+            var releaseStatuses =
+                (await _releaseStatusService.GetAllByOverallStage(releaseId, Scheduled, Started)).ToList();
+
+            // Should never happen as we mark scheduled releases as superseded prior to validation
+            var scheduled = releaseStatuses.FirstOrDefault(status => status.State.Overall == Scheduled);
+            if (scheduled != null)
+            {
+                _logger.LogError(
+                    $"Validating {ValidationStage.ReleasePublishingStateNotScheduledOrStarted.ToString()} failed: " +
+                    $"Publishing is already scheduled. ReleaseStatus: {scheduled.Id}");
+                return false;
+            }
+
+            var started = releaseStatuses.FirstOrDefault(status => status.State.Overall == Started);
+            if (started != null)
+            {
+                _logger.LogError(
+                    $"Validating {ValidationStage.ReleasePublishingStateNotScheduledOrStarted.ToString()} failed: " +
+                    $"Publishing has already started. ReleaseStatus: {started.Id}");
+                return false;
+            }
+
+            return true;
+        }
+
+        private static Either<IEnumerable<ReleaseStatusLogMessage>, Unit> ValidateApproval(Release release)
         {
             return release.Status == ReleaseStatus.Approved
-                ? Success()
+                ? Unit.Instance
                 : Failure(ValidationStage.ReleaseMustBeApproved, $"Release status is {release.Status}");
         }
 
-        private static (bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages) ValidateScheduledPublishDate(
+        private static Either<IEnumerable<ReleaseStatusLogMessage>, Unit> ValidateScheduledPublishDate(
             Release release)
         {
             return release.PublishScheduled.HasValue
-                ? Success()
-                : Failure(ValidationStage.ReleaseMustHavePublishScheduledDate,
-                    $"Scheduled publish date is not set");
+                ? Unit.Instance
+                : Failure(ValidationStage.ReleaseMustHavePublishScheduledDate, "Scheduled publish date is not set");
         }
 
         private Task<Release> GetReleaseAsync(Guid releaseId)
@@ -93,30 +99,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 .SingleAsync(release => release.Id == releaseId);
         }
 
-        private static (bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages) Success()
+        private static Either<IEnumerable<ReleaseStatusLogMessage>, Unit> Failure(ValidationStage stage, string message)
         {
-            return (Valid: true, LogMessages: new List<ReleaseStatusLogMessage>());
-        }
-
-        private static (bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages) Failure(ValidationStage stage,
-            string message)
-        {
-            return Result(false, $"Validating {stage.ToString()}: {message}");
-        }
-
-        private static (bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages) Result(bool valid,
-            string message)
-        {
-            return Result(valid, new List<ReleaseStatusLogMessage>
+            return new List<ReleaseStatusLogMessage>
             {
-                new ReleaseStatusLogMessage(message)
-            });
+                new ReleaseStatusLogMessage($"Validating {stage.ToString()}: {message}")
+            };
         }
 
-        private static (bool Valid, IEnumerable<ReleaseStatusLogMessage> LogMessages) Result(bool valid,
-            IEnumerable<ReleaseStatusLogMessage> logMessages)
+        private static IEnumerable<ReleaseStatusLogMessage> CollateMessages(
+            params Either<IEnumerable<ReleaseStatusLogMessage>, Unit>[] results)
         {
-            return (Valid: valid, LogMessages: logMessages);
+            return results.SelectMany(either => either.IsLeft ? either.Left : new ReleaseStatusLogMessage[] {});
         }
 
         private enum ValidationStage


### PR DESCRIPTION
**Depends on https://github.com/dfe-analytical-services/explore-education-statistics/pull/1881**

Previously we were validating the Release regardless of any state in a ReleaseStatus row for the Release and as part of the validation we checked that state. A new ReleaseStatus row was always added for every invocation regardless of passing or failing validation.

This PR separates out the validation of any existing state to the rest of the validation.

If an existing state is found which is Started or Scheduled execution stops and no ReleaseStatus row is written.
(Scheduled should never occur anyway since any existing scheduled Releases are superseded at the beginning).

This fixes a problem where multiple `Immediate=true` approvals  in quick succession resulted in invalid ReleaseStatus rows being added after failing validation for all but the first approval which is `Started`.

Since the Admin backend always fetches the most recent ReleaseStatus row, it appeared to the user that the Release was Invalid even though it was Started.