### PR TITLE
EES-1214 Fix KeyStatTiles having black text (instead of white)

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
@@ -6,10 +6,10 @@ import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import { Form, FormFieldTextInput } from '@common/components/form';
 import useToggle from '@common/hooks/useToggle';
-import KeyStatTile, {
+import KeyStat, {
   KeyStatProps,
-} from '@common/modules/find-statistics/components/KeyStatTile';
-import styles from '@common/modules/find-statistics/components/KeyStatTile.module.scss';
+} from '@common/modules/find-statistics/components/KeyStat';
+import styles from '@common/modules/find-statistics/components/KeyStat.module.scss';
 import { Formik } from 'formik';
 import React from 'react';
 
@@ -27,7 +27,7 @@ interface EditableKeyStatProps extends KeyStatProps {
   onSubmit: (values: KeyStatsFormValues) => void;
 }
 
-const EditableKeyStatTile = ({
+const EditableKeyStat = ({
   id,
   isEditing = false,
   name,
@@ -40,7 +40,7 @@ const EditableKeyStatTile = ({
   const [removing, toggleRemoving] = useToggle(false);
 
   if (!isEditing) {
-    return <KeyStatTile query={query} summary={summary} />;
+    return <KeyStat query={query} summary={summary} />;
   }
 
   return showForm ? (
@@ -65,7 +65,7 @@ const EditableKeyStatTile = ({
           <Form id={`key-stats-form-${id}`}>
             <h3 className="govuk-heading-s">{name}</h3>
 
-            <KeyStatTile
+            <KeyStat
               query={query}
               renderDataSummary={
                 <FormFieldTextInput<KeyStatsFormValues>
@@ -101,13 +101,13 @@ const EditableKeyStatTile = ({
                   Cancel
                 </Button>
               </ButtonGroup>
-            </KeyStatTile>
+            </KeyStat>
           </Form>
         );
       }}
     </Formik>
   ) : (
-    <KeyStatTile query={query} summary={summary}>
+    <KeyStat query={query} summary={summary}>
       <ButtonGroup className="govuk-!-margin-top-2">
         <Button onClick={toggleShowForm.on}>Edit</Button>
 
@@ -124,8 +124,8 @@ const EditableKeyStatTile = ({
           </Button>
         )}
       </ButtonGroup>
-    </KeyStatTile>
+    </KeyStat>
   );
 };
 
-export default EditableKeyStatTile;
+export default EditableKeyStat;

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatSelectForm.tsx
@@ -3,7 +3,7 @@ import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import Details from '@common/components/Details';
 import { FormSelect } from '@common/components/form';
-import KeyStatTile from '@common/modules/find-statistics/components/KeyStatTile';
+import KeyStat from '@common/modules/find-statistics/components/KeyStat';
 import orderBy from 'lodash/orderBy';
 import React, { useMemo, useState } from 'react';
 
@@ -55,7 +55,7 @@ const KeyStatSelectForm = ({
           summary="Key statistic preview"
           open
         >
-          <KeyStatTile
+          <KeyStat
             summary={selectedDataBlock.summary}
             query={{
               ...selectedDataBlock.query,

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
@@ -1,13 +1,13 @@
-import EditableKeyStatTile from '@admin/components/editable/EditableKeyStatTile';
+import EditableKeyStat from '@admin/components/editable/EditableKeyStat';
 import KeyStatSelectForm from '@admin/pages/release/content/components/KeyStatSelectForm';
 import useReleaseContentActions from '@admin/pages/release/content/contexts/useReleaseContentActions';
 import { EditableContentBlock } from '@admin/services/types/content';
 import Button from '@common/components/Button';
 import WarningMessage from '@common/components/WarningMessage';
 import {
-  KeyStatTileColumn,
-  KeyStatTileContainer,
-} from '@common/modules/find-statistics/components/KeyStatTile';
+  KeyStatColumn,
+  KeyStatContainer,
+} from '@common/modules/find-statistics/components/KeyStat';
 import { Release } from '@common/services/publicationService';
 import React, { useCallback, useState } from 'react';
 
@@ -36,12 +36,12 @@ const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
           <AddKeyStatistics release={release} />
         </>
       )}
-      <KeyStatTileContainer>
+      <KeyStatContainer>
         {release.keyStatisticsSection.content
           .filter(block => block.type === 'DataBlock')
           .map(block => (
-            <KeyStatTileColumn key={block.id}>
-              <EditableKeyStatTile
+            <KeyStatColumn key={block.id}>
+              <EditableKeyStat
                 id={block.id}
                 name={block.name}
                 query={{
@@ -68,9 +68,9 @@ const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
                   });
                 }}
               />
-            </KeyStatTileColumn>
+            </KeyStatColumn>
           ))}
-      </KeyStatTileContainer>
+      </KeyStatContainer>
     </>
   );
 };

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/useReleaseContentActions.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/useReleaseContentActions.ts
@@ -1,4 +1,4 @@
-import { KeyStatsFormValues } from '@admin/components/editable/EditableKeyStatTile';
+import { KeyStatsFormValues } from '@admin/components/editable/EditableKeyStat';
 import { useReleaseContentDispatch } from '@admin/pages/release/content/contexts/ReleaseContentContext';
 import { ContentSectionKeys } from '@admin/pages/release/content/contexts/ReleaseContentContextActionTypes';
 import releaseContentService, {

--- a/src/explore-education-statistics-admin/src/services/releaseContentService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseContentService.ts
@@ -1,4 +1,4 @@
-import { KeyStatsFormValues } from '@admin/components/editable/EditableKeyStatTile';
+import { KeyStatsFormValues } from '@admin/components/editable/EditableKeyStat';
 import {
   ContentBlockPostModel,
   ContentBlockPutModel,

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -13,10 +13,10 @@ import getCategoryDataSetConfigurations, {
   CategoryDataSetConfiguration,
 } from '@common/modules/charts/util/getCategoryDataSetConfigurations';
 import {
-  KeyStatTileColumn,
-  KeyStatTileContainer,
-} from '@common/modules/find-statistics/components/KeyStatTile';
-import stylesIndicators from '@common/modules/find-statistics/components/KeyStatTile.module.scss';
+  KeyStatColumn,
+  KeyStatContainer,
+} from '@common/modules/find-statistics/components/KeyStat';
+import KeyStatTile from '@common/modules/find-statistics/components/KeyStatTile';
 import {
   GeoJsonFeature,
   GeoJsonFeatureProperties,
@@ -30,6 +30,7 @@ import classNames from 'classnames';
 import { Feature, FeatureCollection, Geometry } from 'geojson';
 import { Layer, Path, PathOptions, Polyline } from 'leaflet';
 import keyBy from 'lodash/keyBy';
+import orderBy from 'lodash/orderBy';
 import times from 'lodash/times';
 import React, {
   useCallback,
@@ -39,7 +40,6 @@ import React, {
   useState,
 } from 'react';
 import { GeoJSON, LatLngBounds, Map } from 'react-leaflet';
-import orderBy from 'lodash/orderBy';
 
 interface MapFeatureProperties extends GeoJsonFeatureProperties {
   colour: string;
@@ -505,7 +505,7 @@ export const MapBlockInternal = ({
           </h3>
 
           {selectedFeature?.properties?.dataSets && selectedDataSetKey && (
-            <KeyStatTileContainer tag="dl">
+            <KeyStatContainer>
               {Object.entries(selectedFeature?.properties.dataSets).map(
                 ([dataSetKey, dataSet]) => {
                   if (!dataSetConfigurations[dataSetKey]) {
@@ -518,28 +518,20 @@ export const MapBlockInternal = ({
                   } = dataSetConfigurations[dataSetKey];
 
                   return (
-                    <KeyStatTileColumn key={dataSetKey}>
-                      <div
-                        className={stylesIndicators.keyStat}
-                        data-testid="indicatorTile"
-                      >
-                        <dt className="govuk-heading-s">{config.label}</dt>
-
-                        <dd
-                          className="govuk-heading-xl govuk-!-margin-bottom-2"
-                          aria-label={config.label}
-                        >
-                          {formatPretty(
-                            dataSet.value,
-                            expandedDataSet.indicator.unit,
-                          )}
-                        </dd>
-                      </div>
-                    </KeyStatTileColumn>
+                    <KeyStatColumn key={dataSetKey}>
+                      <KeyStatTile
+                        testId="mapBlock-indicator"
+                        title={config.label}
+                        value={formatPretty(
+                          dataSet.value,
+                          expandedDataSet.indicator.unit,
+                        )}
+                      />
+                    </KeyStatColumn>
                   );
                 },
               )}
-            </KeyStatTileContainer>
+            </KeyStatContainer>
           )}
         </>
       )}

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlock.test.tsx
@@ -6,6 +6,7 @@ import MapBlock, {
   MapBlockProps,
 } from '@common/modules/charts/components/MapBlock';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
+import { within } from '@testing-library/dom';
 import { render, wait, fireEvent } from '@testing-library/react';
 import React from 'react';
 
@@ -179,17 +180,26 @@ describe('MapBlock', () => {
       },
     });
 
-    const tiles = getAllByTestId('indicatorTile');
+    const tiles = getAllByTestId('mapBlock-indicator');
 
     expect(tiles).toHaveLength(2);
-    expect(tiles[0].querySelector('dt')).toHaveTextContent(
+
+    const tile1 = within(tiles[0]);
+
+    expect(tile1.getByTestId('mapBlock-indicator-title')).toHaveTextContent(
       'Authorised absence rate (2016/17)',
     );
-    expect(tiles[0].querySelector('dd')).toHaveTextContent('3%');
+    expect(tile1.getByTestId('mapBlock-indicator-value')).toHaveTextContent(
+      '3%',
+    );
 
-    expect(tiles[1].querySelector('dt')).toHaveTextContent(
+    const tile2 = within(tiles[1]);
+
+    expect(tile2.getByTestId('mapBlock-indicator-title')).toHaveTextContent(
       'Overall absence rate (2016/17)',
     );
-    expect(tiles[1].querySelector('dd')).toHaveTextContent('4.7%');
+    expect(tile2.getByTestId('mapBlock-indicator-value')).toHaveTextContent(
+      '4.7%',
+    );
   });
 });

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.module.scss
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.module.scss
@@ -1,0 +1,72 @@
+@import '../../../../src/styles/govuk-base';
+
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0 -#{govuk-spacing(1)} govuk-spacing(2);
+}
+
+.column {
+  display: flex;
+  flex: 1 0 100%;
+  flex-direction: column;
+  margin-bottom: govuk-spacing(2);
+  max-width: 100%;
+  padding: 0 govuk-spacing(1);
+
+  @include govuk-media-query($from: tablet, $until: desktop) {
+    flex: 0 1 50%;
+    max-width: 50%;
+  }
+
+  @include govuk-media-query($from: desktop) {
+    flex: 1 0 33.33%;
+    max-width: 33.33%;
+
+    // If there are four key stat tiles, have two per row
+    &:first-child:nth-last-child(4),
+    &:first-child:nth-last-child(4) ~ & {
+      flex: 0 1 50%;
+      max-width: 50%;
+    }
+  }
+}
+
+.definition {
+  background: govuk-colour('white');
+  font-size: 16px !important;
+  margin: 0;
+  padding: 0.2rem 0 0.2rem 0.5rem;
+  position: relative;
+  width: 100%;
+
+  &[open] {
+    box-shadow: 3px govuk-colour('black');
+  }
+
+  :global(.govuk-details__summary) {
+    margin-bottom: 0;
+    max-width: calc(100% - 1rem);
+    overflow: hidden;
+    padding-left: 16px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(.govuk-details__text) {
+    background: govuk-colour('white');
+    border: 2px solid govuk-colour('black');
+    border-top: 0;
+    box-sizing: border-box;
+    max-height: 40vh;
+    overflow: auto;
+    position: absolute;
+    text-align: left;
+    width: 100%;
+    z-index: 2;
+  }
+}
+
+.trendText {
+  color: govuk-colour('white');
+}

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
@@ -1,0 +1,102 @@
+import Details from '@common/components/Details';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import KeyStatTile from '@common/modules/find-statistics/components/KeyStatTile';
+import useTableQuery, {
+  TableQueryOptions,
+} from '@common/modules/find-statistics/hooks/useTableQuery';
+import { ReleaseTableDataQuery } from '@common/services/tableBuilderService';
+import { Summary } from '@common/services/types/blocks';
+import formatPretty from '@common/utils/number/formatPretty';
+import React, { FC, ReactNode, useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import styles from './KeyStat.module.scss';
+
+interface KeyStatContainerProps {
+  children: ReactNode;
+  tag?: keyof JSX.IntrinsicElements;
+}
+
+export const KeyStatContainer = ({
+  children,
+  tag: ElementTag = 'div',
+}: KeyStatContainerProps) => {
+  return <ElementTag className={styles.container}>{children}</ElementTag>;
+};
+
+export const KeyStatColumn: FC = ({ children }) => {
+  return <div className={styles.column}>{children}</div>;
+};
+
+export interface KeyStatProps {
+  children?: ReactNode;
+  query: ReleaseTableDataQuery;
+  queryOptions?: TableQueryOptions;
+  summary?: Summary;
+  renderDataSummary?: ReactNode;
+}
+
+const KeyStat = ({
+  children,
+  query,
+  queryOptions,
+  summary,
+  renderDataSummary,
+}: KeyStatProps) => {
+  const { value: tableData, isLoading, error } = useTableQuery(
+    {
+      ...query,
+      includeGeoJson: false,
+    },
+    queryOptions,
+  );
+
+  const resultValue = useMemo<string>(() => {
+    if (tableData) {
+      const [indicator] = tableData.subjectMeta.indicators;
+
+      return formatPretty(
+        tableData.results[0].measures[indicator.value],
+        indicator.unit,
+        indicator.decimalPlaces,
+      );
+    }
+
+    return '';
+  }, [tableData]);
+
+  const indicator = tableData?.subjectMeta?.indicators[0];
+
+  if (error) {
+    return null;
+  }
+
+  return (
+    <LoadingSpinner loading={isLoading}>
+      {indicator && tableData && resultValue && (
+        <>
+          <KeyStatTile title={indicator.label} value={resultValue}>
+            {renderDataSummary ||
+              (summary?.dataSummary && (
+                <p className="govuk-body-s">{summary.dataSummary}</p>
+              ))}
+          </KeyStatTile>
+
+          {summary?.dataDefinition?.[0] && (
+            <Details
+              summary={summary?.dataDefinitionTitle || 'Help'}
+              className={styles.definition}
+            >
+              {summary.dataDefinition.map(data => (
+                <ReactMarkdown key={data}>{data}</ReactMarkdown>
+              ))}
+            </Details>
+          )}
+
+          {children}
+        </>
+      )}
+    </LoadingSpinner>
+  );
+};
+
+export default KeyStat;

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.module.scss
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.module.scss
@@ -1,38 +1,6 @@
-@import '../../../../src/styles/govuk-base';
+@import '../../../styles/govuk-base';
 
-.container {
-  display: flex;
-  flex-wrap: wrap;
-  margin: 0 -#{govuk-spacing(1)} govuk-spacing(2);
-}
-
-.column {
-  display: flex;
-  flex: 1 0 100%;
-  flex-direction: column;
-  margin-bottom: govuk-spacing(2);
-  max-width: 100%;
-  padding: 0 govuk-spacing(1);
-
-  @include govuk-media-query($from: tablet, $until: desktop) {
-    flex: 0 1 50%;
-    max-width: 50%;
-  }
-
-  @include govuk-media-query($from: desktop) {
-    flex: 1 0 33.33%;
-    max-width: 33.33%;
-
-    // If there are four key stat tiles, have two per row
-    &:first-child:nth-last-child(4),
-    &:first-child:nth-last-child(4) ~ & {
-      flex: 0 1 50%;
-      max-width: 50%;
-    }
-  }
-}
-
-.keyStat {
+.tile {
   background: $govuk-brand-colour;
   display: flex;
   flex-direction: column;
@@ -51,54 +19,15 @@
   }
 
   > * {
-    color: govuk-colour('white');
-    margin: 0;
+    color: govuk-colour('white') !important;
+    margin: 0 !important;
 
     @media print {
-      color: govuk-colour('black');
+      color: govuk-colour('black') !important;
     }
   }
 }
 
-:global(.dfe-page-editing) .keyStat {
+:global(.dfe-page-editing) .tile {
   flex-grow: 0;
-}
-
-.definition {
-  background: govuk-colour('white');
-  font-size: 1rem;
-  margin: 0;
-  padding: 0.2rem 0 0.2rem 0.5rem;
-  position: relative;
-  width: 100%;
-
-  &[open] {
-    box-shadow: 3px govuk-colour('black');
-  }
-
-  :global(.govuk-details__summary) {
-    margin-bottom: 0;
-    max-width: calc(100% - 1rem);
-    overflow: hidden;
-    padding-left: 16px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  :global(.govuk-details__text) {
-    background: govuk-colour('white');
-    border: 2px solid govuk-colour('black');
-    border-top: 0;
-    box-sizing: border-box;
-    max-height: 40vh;
-    overflow: auto;
-    position: absolute;
-    text-align: left;
-    width: 100%;
-    z-index: 2;
-  }
-}
-
-.trendText {
-  color: govuk-colour('white');
 }

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.tsx
@@ -1,108 +1,31 @@
-import Details from '@common/components/Details';
-import LoadingSpinner from '@common/components/LoadingSpinner';
-import useTableQuery, {
-  TableQueryOptions,
-} from '@common/modules/find-statistics/hooks/useTableQuery';
-import { ReleaseTableDataQuery } from '@common/services/tableBuilderService';
-import { Summary } from '@common/services/types/blocks';
-import formatPretty from '@common/utils/number/formatPretty';
-import React, { FunctionComponent, ReactNode, useMemo } from 'react';
-import ReactMarkdown from 'react-markdown';
+import React, { ReactNode } from 'react';
 import styles from './KeyStatTile.module.scss';
 
-interface KeyStatTileContainerProps {
-  children: ReactNode;
-  tag?: keyof JSX.IntrinsicElements;
-}
-
-export const KeyStatTileContainer = ({
-  children,
-  tag: ElementTag = 'div',
-}: KeyStatTileContainerProps) => {
-  return <ElementTag className={styles.container}>{children}</ElementTag>;
-};
-
-export const KeyStatTileColumn: FunctionComponent = ({ children }) => {
-  return <div className={styles.column}>{children}</div>;
-};
-
-export interface KeyStatProps {
+interface Props {
   children?: ReactNode;
-  query: ReleaseTableDataQuery;
-  queryOptions?: TableQueryOptions;
-  summary?: Summary;
-  renderDataSummary?: ReactNode;
+  testId?: string;
+  title: string;
+  value: string;
 }
 
 const KeyStatTile = ({
   children,
-  query,
-  queryOptions,
-  summary,
-  renderDataSummary,
-}: KeyStatProps) => {
-  const { value: tableData, isLoading, error } = useTableQuery(
-    {
-      ...query,
-      includeGeoJson: false,
-    },
-    queryOptions,
-  );
-
-  const resultValue = useMemo<string>(() => {
-    if (tableData) {
-      const [indicator] = tableData.subjectMeta.indicators;
-
-      return formatPretty(
-        tableData.results[0].measures[indicator.value],
-        indicator.unit,
-        indicator.decimalPlaces,
-      );
-    }
-
-    return '';
-  }, [tableData]);
-
-  const indicator = tableData?.subjectMeta?.indicators[0];
-
-  if (error) {
-    return null;
-  }
-
+  testId = 'keyStatTile',
+  title,
+  value,
+}: Props) => {
   return (
-    <LoadingSpinner loading={isLoading}>
-      {tableData && resultValue && (
-        <>
-          <div className={styles.keyStat} data-testid="key-stat-tile">
-            <h3 className="govuk-heading-s" data-testid="key-stat-tile-title">
-              {indicator?.label}
-            </h3>
+    <div className={styles.tile} data-testid={testId}>
+      <h3 className="govuk-heading-s" data-testid={`${testId}-title`}>
+        {title}
+      </h3>
 
-            <p className="govuk-heading-xl" data-testid="key-stat-tile-value">
-              {resultValue}
-            </p>
+      <p className="govuk-heading-xl" data-testid={`${testId}-value`}>
+        {value}
+      </p>
 
-            {renderDataSummary ||
-              (summary?.dataSummary && (
-                <p className="govuk-body-s">{summary.dataSummary}</p>
-              ))}
-          </div>
-
-          {summary?.dataDefinition?.[0] && (
-            <Details
-              summary={summary?.dataDefinitionTitle || 'Help'}
-              className={styles.definition}
-            >
-              {summary.dataDefinition.map(data => (
-                <ReactMarkdown key={data}>{data}</ReactMarkdown>
-              ))}
-            </Details>
-          )}
-
-          {children}
-        </>
-      )}
-    </LoadingSpinner>
+      {children}
+    </div>
   );
 };
 

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationReleaseHeadlinesSection.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationReleaseHeadlinesSection.tsx
@@ -3,10 +3,10 @@ import TabsSection from '@common/components/TabsSection';
 import useGetChartFile from '@common/modules/charts/hooks/useGetChartFile';
 import ContentBlockRenderer from '@common/modules/find-statistics/components/ContentBlockRenderer';
 import DataBlockTabs from '@common/modules/find-statistics/components/DataBlockTabs';
-import KeyStatTile, {
-  KeyStatTileColumn,
-  KeyStatTileContainer,
-} from '@common/modules/find-statistics/components/KeyStatTile';
+import KeyStat, {
+  KeyStatColumn,
+  KeyStatContainer,
+} from '@common/modules/find-statistics/components/KeyStat';
 import { Release } from '@common/services/publicationService';
 import orderBy from 'lodash/orderBy';
 import React from 'react';
@@ -30,15 +30,15 @@ const PublicationReleaseHeadlinesSection = ({
 
   const summaryTab = (
     <TabsSection title="Summary">
-      <KeyStatTileContainer>
+      <KeyStatContainer>
         {keyStatisticsSection.content.map(block => {
           if (block.type !== 'DataBlock') {
             return null;
           }
 
           return (
-            <KeyStatTileColumn key={block.id}>
-              <KeyStatTile
+            <KeyStatColumn key={block.id}>
+              <KeyStat
                 query={{
                   releaseId: id,
                   ...block.query,
@@ -49,10 +49,10 @@ const PublicationReleaseHeadlinesSection = ({
                   expiresIn: 60 * 60 * 24,
                 }}
               />
-            </KeyStatTileColumn>
+            </KeyStatColumn>
           );
         })}
-      </KeyStatTileContainer>
+      </KeyStatContainer>
 
       {orderBy(headlinesSection.content, 'order').map(block => (
         <ContentBlockRenderer key={block.id} block={block} />

--- a/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
@@ -87,7 +87,7 @@ Validate Analyst1 can see 'Manage content' page key stats
     user waits until page contains key stat tile   Overall absence rate        4.7%    60
     user waits until page contains key stat tile   Authorised absence rate     3.4%
     user waits until page contains key stat tile   Unauthorised absence rate   1.3%
-    user checks element count is x    css:[data-testid="key-stat-tile"]   3
+    user checks element count is x    css:[data-testid="keyStatTile"]   3
 
 Validate Analyst1 can see 'Manage content' page accordion sections
     [Tags]  HappyPath

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -380,5 +380,5 @@ user checks publication bullet does not contain link
 
 user waits until page contains key stat tile
   [Arguments]  ${title}   ${value}   ${wait}=${timeout}
-  user waits until page contains element   xpath://*[@data-testid="key-stat-tile-title" and text()="${title}"]/../*[@data-testid="key-stat-tile-value" and text()="${value}"]    ${wait}
+  user waits until page contains element   xpath://*[@data-testid="keyStatTile-title" and text()="${title}"]/../*[@data-testid="keyStatTile-value" and text()="${value}"]    ${wait}
 

--- a/tests/robot-tests/tests/libs/public-utilities.py
+++ b/tests/robot-tests/tests/libs/public-utilities.py
@@ -39,7 +39,7 @@ def cookie_names_should_be_on_page():
 def user_checks_key_stat_tile_contents(tile_title, tile_value, tile_context):
     try:
         elem = sl.driver.find_element_by_xpath(
-            f'.//*[@data-testid="key-stat-tile-title" and contains(text(), "{tile_title}")]')
+            f'.//*[@data-testid="keyStatTile-title" and contains(text(), "{tile_title}")]')
     except NoSuchElementException:
         raise_assertion_error(f'Cannot find key stats tile "{tile_title}"')
 


### PR DESCRIPTION
Unfortunately we've had to abuse `!important` to style the contents correctly. This is mostly to make it easier to style the rendered `children` correctly.

It's also quite awkward to emulate GOVUK heading/body styles without using `@extends`. I'm not particularly a big fan of some of their choices here in regards to extensibility.

We've also moved logic out `KeyStatTile` and placed it in `KeyStat` instead. This allows us to more easily re-use `KeyStatTile` itself in other places such as `MapBlockInternal`.