### PR TITLE
EES-1070 Reinstate publishing for this and other failed Releases after a successful retry of the Data Stage

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/DataFactoryPipelineStatusFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/DataFactoryPipelineStatusFunction.cs
@@ -50,8 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 
             if (response.Status == "Complete")
             {
-                await _releaseStatusService.UpdateDataStageAsync(response.ReleaseId, response.ReleaseStatusId,
-                    Complete);
+                await UpdateStageOnSuccess(response);
 
                 if (await _releaseStatusService.IsImmediate(response.ReleaseId, response.ReleaseStatusId))
                 {
@@ -72,6 +71,40 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             return response.Status != null
                 ? (ActionResult) new OkObjectResult($"status, {response.Status}")
                 : new BadRequestObjectResult("No status was passed in the request body");
+        }
+
+        private async Task UpdateStageOnSuccess(PipelineResponse response)
+        {
+            var releaseStatus = await _releaseStatusService.GetAsync(response.ReleaseId, response.ReleaseStatusId);
+            var existingState = releaseStatus.State;
+            var retriedAfterFailure = existingState.Data == Failed;
+
+            if (retriedAfterFailure)
+            {
+                // Revert to the original starting state for the Publishing stage before it was cancelled
+                var startedState = releaseStatus.Immediate
+                    ? ReleaseStatusStates.ImmediateReleaseStartedState
+                    : ReleaseStatusStates.ScheduledReleaseStartedState;
+
+                var newPublishingState = existingState.Publishing == ReleaseStatusPublishingStage.Cancelled
+                    ? startedState.Publishing
+                    : existingState.Publishing;
+
+                var newOverallState = existingState.Overall == ReleaseStatusOverallStage.Failed
+                    ? startedState.Overall
+                    : existingState.Overall;
+
+                await _releaseStatusService.UpdateStagesAsync(response.ReleaseId,
+                    response.ReleaseStatusId,
+                    data: Complete,
+                    publishing: newPublishingState,
+                    overall: newOverallState);
+            }
+            else
+            {
+                await _releaseStatusService.UpdateDataStageAsync(response.ReleaseId, response.ReleaseStatusId,
+                    Complete);
+            }
         }
     }
 


### PR DESCRIPTION
This PR reinstates publishing for this Release and other failed Releases after a successful retry of the Data Stage.

Calculates the states for reinstating stages before they were cancelled due to a failure.
Checks that the states are still Cancelled/Failed as expected, and if not, leaves them untouched.

Updates the succeeding row at the same time that the Data stage state is changed to Complete and then goes on to reinstate publishing of any other releases sharing a dependency with the content of that Release which were also cancelled.