### PR TITLE
EES-1227 Add awaits to all `Either.OnSuccessDo` overloads

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ImportService.cs
@@ -46,7 +46,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _guidGenerator = guidGenerator;
         }
 
-        public async void Import(string dataFileName, string metaFileName, Guid releaseId, IFormFile dataFile)
+        public async Task Import(string dataFileName, string metaFileName, Guid releaseId, IFormFile dataFile)
         {
             var storageAccount = CloudStorageAccount.Parse(_storageConnectionString);
             var client = storageAccount.CreateCloudQueueClient();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IImportService.cs
@@ -8,7 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IImportService
     {
-        void Import(string dataFileName, string metaFileName, Guid releaseId, IFormFile dataFile);
+        Task Import(string dataFileName, string metaFileName, Guid releaseId, IFormFile dataFile);
 
         Task<Either<ActionResult, bool>> CreateImportTableRow(Guid releaseId, string dataFileName);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/EitherTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/EitherTest.cs
@@ -104,7 +104,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Model
         public async void OnSuccessDo_WithVoid()
         {
             var either = await Task.FromResult(new Either<int, string>("a success"))
-                .OnSuccessDo(() => {});
+                .OnSuccessDo(async () => 
+                {
+                    await Task.Run(() => {});
+                });
 
             Assert.True(either.IsRight);
             Assert.Equal("a success", either.Right);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -46,9 +46,9 @@ public class Either<Tl, Tr> {
 
     public static class EitherTaskExtensions
     {
-        public static async Task<Either<Tl, Tr>> OnSuccessDo<Tl, Tr>(this Task<Either<Tl, Tr>> task, Action successTask)
+        public static async Task<Either<Tl, Tr>> OnSuccessDo<Tl, Tr>(this Task<Either<Tl, Tr>> task, Func<Task> successTask)
         {
-            return await task.OnSuccessDo(async _ => await Task.Run(successTask));
+            return await task.OnSuccessDo(async _ => await successTask());
         }
 
         public static async Task<Either<Tl, Tr>> OnSuccessDo<Tl, Tr>(this Task<Either<Tl, Tr>> task, Func<Tr, Task> successTask)
@@ -66,7 +66,7 @@ public class Either<Tl, Tr> {
 
         public static async Task<Either<Tl, Tr>> OnSuccessDo<Tl, Tr, T>(this Task<Either<Tl, Tr>> task, Func<Task<Either<Tl, T>>> successTask)
         {
-            return await task.OnSuccessDo(_ => successTask());
+            return await task.OnSuccessDo(async _ => await successTask());
         }
 
         public static async Task<Either<Tl, Tr>> OnSuccessDo<Tl, Tr, T>(this Task<Either<Tl, Tr>> task, Func<Tr, Task<Either<Tl, T>>> successTask)


### PR DESCRIPTION
This PR attempts to fix EES-1227 which appears to be being caused by threading issues arising from `Either.OnSuccessDo`. 

We think this is due to the current implementation having overloads that don't `await` the result of their success task, meaning that execution continues without waiting for all async methods to complete (i.e. database transactions) in the success task before moving onto the next chained `Either`.