### PR TITLE
EES-1185 Acquire lease on Release Id when validating Release approval notification

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/BlobContainerNames.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/BlobContainerNames.cs
@@ -7,5 +7,6 @@
         public const string PublicContentContainerName = "cache";
         public const string PublicPermalinkContainerName = "permalinks";
         public const string PublicPermalinkMigrationContainerName = "permalink-migrations";
+        public const string PublisherLeasesContainerName = "leases";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStorageUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStorageUtils.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.Storage.RetryPolicies;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 using FileInfo = GovUk.Education.ExploreEducationStatistics.Common.Model.FileInfo;
 
@@ -60,10 +61,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         }
         
         public static async Task<CloudBlobContainer> GetCloudBlobContainerAsync(string storageConnectionString,
-            string containerName, BlobContainerPermissions permissions = null)
+            string containerName, BlobContainerPermissions permissions = null, BlobRequestOptions requestOptions = null)
         {
             var storageAccount = CloudStorageAccount.Parse(storageConnectionString);
             var blobClient = storageAccount.CreateCloudBlobClient();
+
+            if (requestOptions != null)
+            {
+                blobClient.DefaultRequestOptions = requestOptions;
+            }
+            
             var blobContainer = blobClient.GetContainerReference(containerName);
             await blobContainer.CreateIfNotExistsAsync();
 
@@ -154,10 +161,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             }
         }
         
-        public static async Task UploadFromStreamAsync(string storageConnectionString, string containerName,
-            string blobName, string contentType, string content)
+        public static async Task<CloudBlockBlob> UploadFromStreamAsync(string storageConnectionString, string containerName,
+            string blobName, string contentType, string content, BlobRequestOptions requestOptions = null)
         {
-            var blobContainer = await GetCloudBlobContainerAsync(storageConnectionString, containerName);
+            var blobContainer = await GetCloudBlobContainerAsync(storageConnectionString,
+                containerName,
+                requestOptions: requestOptions);
 
             var blob = blobContainer.GetBlockBlobReference(blobName);
             blob.Properties.ContentType = contentType;
@@ -166,6 +175,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             {
                 await blob.UploadFromStreamAsync(stream);
             }
+
+            return blob;
         }
 
         public static string GetExtension(CloudBlob blob)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/FileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/FileStorageService.cs
@@ -6,7 +6,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Storage.Blob;
-using Microsoft.Extensions.Configuration;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStorageUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseDataFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseDataFunction.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IFileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IFileStorageService.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
+using Microsoft.Azure.Storage.Blob;
 using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces
@@ -18,7 +19,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
         Task DeletePublicBlobs(string directoryPath, string excludePattern = null);
         
         Task DeletePublicBlob(string blobName);
-        
+
+        Task<(CloudBlockBlob blob, string id)> AcquireLease(string blobName);
+
         IEnumerable<FileInfo> ListPublicFiles(string publication, string release);
 
         Task MoveStagedContentAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseStatusService.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
-using Microsoft.Azure.Cosmos.Table;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces
 {
@@ -10,8 +9,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
     {
         Task<ReleaseStatus> CreateAsync(Guid releaseId, ReleaseStatusState state, bool immediate,
             IEnumerable<ReleaseStatusLogMessage> logMessages = null);
-
-        Task<IEnumerable<ReleaseStatus>> ExecuteQueryAsync(TableQuery<ReleaseStatus> query);
 
         Task<ReleaseStatus> GetAsync(Guid releaseId, Guid releaseStatusId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseStatusService.cs
@@ -78,33 +78,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             return await ExecuteQueryAsync(query);
         }
 
-        public Task<IEnumerable<ReleaseStatus>> GetAllByOverallStage(Guid releaseId, params ReleaseStatusOverallStage[] overallStages)
+        public async Task<IEnumerable<ReleaseStatus>> GetAllByOverallStage(Guid releaseId, params ReleaseStatusOverallStage[] overallStages)
         {
             var filter = TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.PartitionKey),
                     QueryComparisons.Equal, releaseId.ToString());
 
             if (overallStages.Any())
             {
-                var allStageFilters = overallStages.ToList().Aggregate("", (acc, stage) => 
+                var allStageFilters = overallStages.ToList().Aggregate("", (acc, stage) =>
                 {
                     var stageFilter = TableQuery.GenerateFilterCondition(
                         nameof(ReleaseStatus.OverallStage),
                         QueryComparisons.Equal,
                         stage.ToString()
                     );
-                
-                    if (acc == "")  {
+
+                    if (acc == "")
+                    {
                         return stageFilter;
                     }
 
-                    return TableQuery.CombineFilters(acc, TableOperators.Or, stageFilter); 
+                    return TableQuery.CombineFilters(acc, TableOperators.Or, stageFilter);
                 });
                 
-                filter = TableQuery.CombineFilters(filter, TableOperators.And,allStageFilters);
+                filter = TableQuery.CombineFilters(filter, TableOperators.And, allStageFilters);
             }
 
             var query = new TableQuery<ReleaseStatus>().Where(filter);
-            return _tableStorageService.ExecuteQueryAsync(PublisherReleaseStatusTableName, query);
+            return await ExecuteQueryAsync(query);
         }
 
         public async Task<ReleaseStatus> GetLatestAsync(Guid releaseId)
@@ -113,7 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 .Where(TableQuery.GenerateFilterCondition(nameof(ReleaseStatus.PartitionKey),
                     QueryComparisons.Equal, releaseId.ToString()));
 
-            var result = await _tableStorageService.ExecuteQueryAsync(PublisherReleaseStatusTableName, query);
+            var result = await ExecuteQueryAsync(query);
             return result.OrderByDescending(releaseStatus => releaseStatus.Created).FirstOrDefault();
         }
 
@@ -123,7 +124,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             return releaseStatus.Immediate;
         }
 
-        public Task<IEnumerable<ReleaseStatus>> ExecuteQueryAsync(TableQuery<ReleaseStatus> query)
+        private Task<IEnumerable<ReleaseStatus>> ExecuteQueryAsync(TableQuery<ReleaseStatus> query)
         {
             return _tableStorageService.ExecuteQueryAsync(PublisherReleaseStatusTableName, query);
         }


### PR DESCRIPTION
https://github.com/dfe-analytical-services/explore-education-statistics/pull/1885 made an improvement to stop further validation and stop Invalid ReleaseStatus rows from being written if publishing has already Started.

This PR makes sure that if approval messages are being processed concurrently that they can't enter the `ValidatePublishingState ` or  `CreateReleaseStatusAsync ` methods without being aware of each other if they are for the same Release Id by acquiring a lease on the Release id for a short amount of time.

Previously it was possible for multiple messages for the same Release processed concurrently to all pass the validation due to seeing no existing rows, and then all enter the create method and write multiple `ReleaseStatus ` rows. This resulted in stages running concurrently for the same Release, e.g. concurrent executions of ADF pipelines for the same Release Id.

Retries to acquire a lease will take place at the very least when execution of the Function fails because the function host will already retry a message up to 5 times on failure. This PR attempts to make the lease retry automatic without throwing an exception by using a retry option of the blob client.

