### PR TITLE
EES-1221 Allow publishing of a Publication independently to a Release

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void CreatePublication()
         {
-            var (userService, repository, _) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -39,8 +39,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(methodology);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, new PersistenceHelper<ContentDbContext>(context));
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.CreatePublication(new SavePublicationViewModel()
@@ -89,12 +88,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void CreatePublication_FailsWithNonExistingTopic()
         {
-            var (userService, repository, persistenceHelper) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, persistenceHelper.Object);
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.CreatePublication(
@@ -115,7 +113,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void CreatePublication_FailsWithNonExistingMethodology()
         {
-            var (userService, repository, persistenceHelper) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -127,8 +125,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(topic);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, persistenceHelper.Object);
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.CreatePublication(
@@ -150,7 +147,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void CreatePublication_FailsWithMethodologyAndExternalMethodology()
         {
-            var (userService, repository, persistenceHelper) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -168,12 +165,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(methodology);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, persistenceHelper.Object);
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.CreatePublication(
-                new SavePublicationViewModel()
+                new SavePublicationViewModel
                 {
                     Title = "Test title",
                     TopicId = topic.Id,
@@ -197,7 +193,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void CreatePublication_FailsWithUnapprovedMethodology()
         {
-            var (userService, repository, persistenceHelper) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -215,8 +211,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(methodology);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, persistenceHelper.Object);
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.CreatePublication(
@@ -238,7 +233,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void CreatePublication_FailsWithNonUniqueSlug()
         {
-            var (userService, repository, persistenceHelper) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -255,8 +250,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             });
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, persistenceHelper.Object);
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.CreatePublication(
@@ -277,7 +271,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void UpdatePublication()
         {
-            var (userService, repository, _) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -315,8 +309,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(publication);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, new PersistenceHelper<ContentDbContext>(context));
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.UpdatePublication(publication.Id, new SavePublicationViewModel()
@@ -364,7 +357,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void UpdatePublication_SavesNewContact()
         {
-            var (userService, repository, _) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -385,8 +378,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(publication);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, new PersistenceHelper<ContentDbContext>(context));
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.UpdatePublication(publication.Id, new SavePublicationViewModel()
@@ -414,7 +406,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void UpdatePublication_SavesNewContactWhenSharedWithOtherPublication()
         {
-            var (userService, repository, _) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -446,11 +438,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Contact = sharedContact
             };
 
-            context.AddRange(publication, otherPublication);
+            await context.AddRangeAsync(publication, otherPublication);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, new PersistenceHelper<ContentDbContext>(context));
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.UpdatePublication(publication.Id, new SavePublicationViewModel()
@@ -479,7 +470,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void UpdatePublication_FailsWithNonExistingTopic()
         {
-            var (userService, repository, _) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -499,8 +490,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(publication);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, new PersistenceHelper<ContentDbContext>(context));
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.UpdatePublication(publication.Id, new SavePublicationViewModel()
@@ -520,7 +510,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void UpdatePublication_FailsWithNonExistingMethodology()
         {
-            var (userService, repository, _) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -535,8 +525,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(publication);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, new PersistenceHelper<ContentDbContext>(context));
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.UpdatePublication(publication.Id, new SavePublicationViewModel()
@@ -557,7 +546,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void UpdatePublication_FailsWithMethodologyAndExternalMethodology()
         {
-            var (userService, repository, _) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -572,8 +561,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(publication);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, new PersistenceHelper<ContentDbContext>(context));
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.UpdatePublication(publication.Id, new SavePublicationViewModel()
@@ -599,7 +587,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void UpdatePublication_FailsWithUnapprovedMethodology()
         {
-            var (userService, repository, _) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -620,8 +608,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(publication);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, new PersistenceHelper<ContentDbContext>(context));
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.UpdatePublication(publication.Id, new SavePublicationViewModel()
@@ -642,7 +629,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void UpdatePublication_FailsWithNonUniqueSlug()
         {
-            var (userService, repository, persistenceHelper) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -667,8 +654,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(otherPublication);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(context, AdminMapper(),
-                userService.Object, repository.Object, persistenceHelper.Object);
+            var publicationService = BuildPublicationService(context, mocks);
 
             // Service method under test
             var result = await publicationService.UpdatePublication(publication.Id, new SavePublicationViewModel()
@@ -688,7 +674,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void PartialUpdateLegacyReleases_OnlyMatchingEntities()
         {
-            var (userService, repository, _) = Mocks();
+            var mocks = Mocks();
 
             await using var context = InMemoryApplicationDbContext();
 
@@ -714,13 +700,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(publication);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(
-                context,
-                AdminMapper(),
-                userService.Object,
-                repository.Object,
-                new PersistenceHelper<ContentDbContext>(context)
-            );
+            var publicationService = BuildPublicationService(context, mocks);
 
             var result = await publicationService.PartialUpdateLegacyReleases(
                 publication.Id,
@@ -753,8 +733,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async void PartialUpdateLegacyReleases_OnlyNonNullFields()
         {
-            var (userService, repository, _) = Mocks();
-
+            var mocks = Mocks();
+            
             await using var context = InMemoryApplicationDbContext();
 
             var publication = new Publication
@@ -773,13 +753,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             context.Add(publication);
             await context.SaveChangesAsync();
 
-            var publicationService = new PublicationService(
-                context,
-                AdminMapper(),
-                userService.Object,
-                repository.Object,
-                new PersistenceHelper<ContentDbContext>(context)
-            );
+            var publicationService = BuildPublicationService(context, mocks);
 
             var result = await publicationService.PartialUpdateLegacyReleases(
                 publication.Id,
@@ -802,19 +776,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             Assert.Equal(1, legacyReleases[0].Order);
         }
 
-        private (
-            Mock<IUserService>,
-            Mock<IPublicationRepository>,
-            Mock<IPersistenceHelper<ContentDbContext>>) Mocks()
+        private static PublicationService BuildPublicationService(ContentDbContext context,
+            (Mock<IUserService> userService,
+                Mock<IPublicationRepository> publicationRepository,
+                Mock<IPublishingService> publishingService) mocks)
         {
-            var persistenceHelper = MockUtils.MockPersistenceHelper<ContentDbContext>();
-            MockUtils.SetupCall<ContentDbContext, Topic>(persistenceHelper);
-            MockUtils.SetupCall<ContentDbContext, Publication>(persistenceHelper);
+            var (userService, publicationRepository, publishingService) = mocks;
 
+            return new PublicationService(
+                context,
+                AdminMapper(),
+                userService.Object,
+                publicationRepository.Object,
+                publishingService.Object,
+                new PersistenceHelper<ContentDbContext>(context));
+        }
+
+        private static (Mock<IUserService> UserService,
+            Mock<IPublicationRepository> PublicationRepository,
+            Mock<IPublishingService> PublishingService) Mocks()
+        {
             return (
                 MockUtils.AlwaysTrueUserService(),
                 new Mock<IPublicationRepository>(),
-                persistenceHelper);
+                new Mock<IPublishingService>());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServicePermissionTests.cs
@@ -31,7 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var publishingService = BuildPublishingService(mocks);
 
             AssertSecurityPoliciesChecked(service =>
-                    service.RetryStage(_release.Id, ContentAndPublishing),
+                    service.RetryReleaseStage(_release.Id, ContentAndPublishing),
                 _release,
                 mocks.UserService,
                 publishingService,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/BAU/BauReleaseController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/BAU/BauReleaseController.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.RetryStage;
@@ -26,10 +27,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.BAU
         /// <param name="releaseId"></param>
         /// <returns></returns>
         [HttpPut("bau/release/{releaseId}/publish/content")]
-        public async Task<ActionResult<bool>> RetryContentAndPublishing(Guid releaseId)
+        public async Task<ActionResult<Unit>> RetryContentAndPublishing(Guid releaseId)
         {
             return await _publishingService
-                .RetryStage(releaseId, ContentAndPublishing)
+                .RetryReleaseStage(releaseId, ContentAndPublishing)
                 .HandleFailuresOrOk();
         }
 
@@ -43,10 +44,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.BAU
         /// <param name="releaseId"></param>
         /// <returns></returns>
         [HttpPut("bau/release/{releaseId}/publish/data")]
-        public async Task<ActionResult<bool>> RetryStatisticsData(Guid releaseId)
+        public async Task<ActionResult<Unit>> RetryStatisticsData(Guid releaseId)
         {
             return await _publishingService
-                .RetryStage(releaseId, StatisticsData)
+                .RetryReleaseStage(releaseId, StatisticsData)
                 .HandleFailuresOrOk();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200806145340_EES1121AddPublicationPublishedDateTime.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200806145340_EES1121AddPublicationPublishedDateTime.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200806145340_EES1121AddPublicationPublishedDateTime")]
+    partial class EES1121AddPublicationPublishedDateTime
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -59,19 +61,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("ContactName")
-                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ContactTelNo")
-                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("TeamEmail")
-                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("TeamName")
-                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200806145340_EES1121AddPublicationPublishedDateTime.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200806145340_EES1121AddPublicationPublishedDateTime.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES1121AddPublicationPublishedDateTime : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Published",
+                table: "Publications",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Published",
+                table: "Publications");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublishingService.cs
@@ -10,6 +10,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     {
         Task<Either<ActionResult, Unit>> RetryReleaseStage(Guid releaseId, RetryStage stage);
         Task<Either<ActionResult, Unit>> ReleaseChanged(Guid id, bool immediate = false);
-        Task<Either<ActionResult, Unit>> PublicationChanged(Guid id);
+        Task<Either<ActionResult, Unit>> PublicationChanged(Guid id, string oldSlug);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublishingService.cs
@@ -8,7 +8,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IPublishingService
     {
-        Task<Either<ActionResult, bool>> RetryStage(Guid releaseId, RetryStage stage);
-        Task<Either<ActionResult, bool>> NotifyChange(Guid releaseId, bool immediate = false);
+        Task<Either<ActionResult, Unit>> RetryReleaseStage(Guid releaseId, RetryStage stage);
+        Task<Either<ActionResult, Unit>> ReleaseChanged(Guid id, bool immediate = false);
+        Task<Either<ActionResult, Unit>> PublicationChanged(Guid id);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -26,6 +26,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IMapper _mapper;
         private readonly IUserService _userService;
         private readonly IPublicationRepository _publicationRepository;
+        private readonly IPublishingService _publishingService;
         private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
 
         public PublicationService(
@@ -33,12 +34,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IMapper mapper,
             IUserService userService,
             IPublicationRepository publicationRepository,
+            IPublishingService publishingService,
             IPersistenceHelper<ContentDbContext> persistenceHelper)
         {
             _context = context;
             _mapper = mapper;
             _userService = userService;
             _publicationRepository = publicationRepository;
+            _publishingService = publishingService;
             _persistenceHelper = persistenceHelper;
         }
 
@@ -142,6 +145,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     _context.Publications.Update(publication);
 
                     await _context.SaveChangesAsync();
+
+                    if (publication.Published.HasValue)
+                    {
+                        await _publishingService.PublicationChanged(publication.Id);
+                    }
 
                     return await GetViewModel(publication.Id);
                 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -121,6 +121,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         return ValidationActionResult(SlugNotUnique);
                     }
 
+                    var oldSlug = publication.Slug;
+                    
                     publication.Title = updatedPublication.Title;
                     publication.TopicId = updatedPublication.TopicId;
                     publication.MethodologyId = updatedPublication.MethodologyId;
@@ -148,7 +150,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     if (publication.Published.HasValue)
                     {
-                        await _publishingService.PublicationChanged(publication.Id);
+                        await _publishingService.PublicationChanged(publication.Id, oldSlug);
                     }
 
                     return await GetViewModel(publication.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
@@ -102,15 +102,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         /// Notify the Publisher that there has been a change to the Publication.
         /// </summary>
         /// <param name="id"></param>
+        /// <param name="oldSlug"></param>
         /// <returns></returns>
-        public async Task<Either<ActionResult, Unit>> PublicationChanged(Guid id)
+        public async Task<Either<ActionResult, Unit>> PublicationChanged(Guid id, string oldSlug)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Publication>(id)
                 .OnSuccess(async release =>
                 {
                     await _storageQueueService.AddMessagesAsync(
-                        PublishPublicationQueue, new PublishPublicationMessage(id));
+                        PublishPublicationQueue, new PublishPublicationMessage(id, oldSlug));
 
                     _logger.LogTrace($"Sent message for Publication: {id}");
                     return Unit.Instance;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -320,7 +320,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     // Only need to inform Publisher if changing release status to or from Approved
                     if (oldStatus == ReleaseStatus.Approved || request.Status == ReleaseStatus.Approved)
                     {
-                        await _publishingService.NotifyChange(releaseId, request.PublishMethod == PublishMethod.Immediate);
+                        await _publishingService.ReleaseChanged(releaseId, request.PublishMethod == PublishMethod.Immediate);
                     }
                     
                     _context.Update(release);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
@@ -8,6 +8,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
         public class CamelCaseTests
         {
             [Fact]
+            public void NullStringCanAppendTrailingSlash()
+            {
+                string input = null;
+                Assert.Null(input.AppendTrailingSlash());
+            }
+
+            [Fact]
+            public void EmptyStringCanAppendTrailingSlash()
+            {
+                Assert.Equal("/", string.Empty.AppendTrailingSlash());
+            }
+
+            [Fact]
+            public void AppendTrailingSlash()
+            {
+                Assert.Equal("foo/", "foo".AppendTrailingSlash());
+            }
+            
+            [Fact]
             public void NullStringCanBeCamelCased()
             {
                 string input = null;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
@@ -5,6 +5,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 {
     public static class StringExtensions
     {
+        public static string AppendTrailingSlash(this string input)
+        {
+            if (input == null)
+            {
+                return null;
+            }
+
+            return input.EndsWith("/") ? input : input + "/";
+        }
+        
         public static string CamelCase(this string input)
         {
             if (string.IsNullOrEmpty(input))

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -63,19 +63,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return $"{PublicContentMethodologiesPath(prefix)}/methodologies/{slug}.json";
         }
 
+        public static string PublicContentPublicationParentPath(string slug, string prefix = null)
+        {
+            return $"{PublicContentPublicationsPath(prefix)}/{slug}";
+        }
+
         public static string PublicContentPublicationPath(string slug, string prefix = null)
         {
-            return $"{PublicContentPublicationsPath(prefix)}/{slug}/publication.json";
+            return $"{PublicContentPublicationParentPath(slug, prefix)}/publication.json";
         }
 
         public static string PublicContentLatestReleasePath(string slug, string prefix = null)
         {
-            return $"{PublicContentPublicationsPath(prefix)}/{slug}/latest-release.json";
+            return $"{PublicContentPublicationParentPath(slug, prefix)}/latest-release.json";
         }
         
         public static string PublicContentReleasePath(string publicationSlug, string releaseSlug, string prefix = null)
         {
-            return $"{PublicContentPublicationsPath(prefix)}/{publicationSlug}/releases/{releaseSlug}.json";
+            return $"{PublicContentPublicationParentPath(publicationSlug, prefix)}/releases/{releaseSlug}.json";
         }
 
         /**

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -5,7 +5,7 @@ using System.Linq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
-    public class    Publication
+    public class Publication
     {
         public Guid Id { get; set; }
 
@@ -30,6 +30,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public Uri LegacyPublicationUrl { get; set; }
 
         public List<LegacyRelease> LegacyReleases { get; set; }
+
+        public DateTime? Published { get; set; }
 
         public Guid TopicId { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishPublicationMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishPublicationMessage.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
+{
+    public class PublishPublicationMessage
+    {
+        public Guid PublicationId { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishPublicationMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishPublicationMessage.cs
@@ -5,5 +5,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
     public class PublishPublicationMessage
     {
         public Guid PublicationId { get; set; }
+
+        public PublishPublicationMessage(Guid publicationId)
+        {
+            PublicationId = publicationId;
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishPublicationMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishPublicationMessage.cs
@@ -5,10 +5,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
     public class PublishPublicationMessage
     {
         public Guid PublicationId { get; set; }
+        public string OldSlug { get; set; }
 
-        public PublishPublicationMessage(Guid publicationId)
+        public PublishPublicationMessage(Guid publicationId, string oldSlug)
         {
             PublicationId = publicationId;
+            OldSlug = oldSlug;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherQueues.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherQueues.cs
@@ -4,6 +4,7 @@
     {
         public const string GenerateReleaseContentQueue = "generate-release-content";
         public const string PublishAllContentQueue = "publish-all-content";
+        public const string PublishPublicationQueue = "publish-publication";
         public const string PublishReleaseContentQueue = "publish-release-content";
         public const string PublishReleaseDataQueue = "publish-release-data";
         public const string PublishReleaseFilesQueue = "publish-release-files";

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/CachedReleaseViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/CachedReleaseViewModel.cs
@@ -83,12 +83,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels
 
         public List<LinkViewModel> RelatedInformation { get; set; }
 
-        private DateTime? dataLastPublished;
+        private DateTime? _dataLastPublished;
         
         public DateTime? DataLastPublished
         {
-            get => dataLastPublished;
-            set => dataLastPublished = value ?? DateTime.UtcNow;
+            get => _dataLastPublished;
+            set => _dataLastPublished = value ?? DateTime.UtcNow;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishPublicationFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishPublicationFunction.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
+{
+    // ReSharper disable once UnusedType.Global
+    public class PublishPublicationFunction
+    {
+        private readonly IContentService _contentService;
+        private readonly IPublicationService _publicationService;
+
+        public PublishPublicationFunction(IContentService contentService,
+            IPublicationService publicationService)
+        {
+            _contentService = contentService;
+            _publicationService = publicationService;
+        }
+
+        [FunctionName("PublishPublication")]
+        // ReSharper disable once UnusedMember.Global
+        public void PublishPublication(
+            [QueueTrigger(PublishPublicationQueue)]
+            PublishPublicationMessage message,
+            ExecutionContext executionContext,
+            ILogger logger)
+        {
+            logger.LogInformation($"{executionContext.FunctionName} triggered: {message}");
+
+            var context = new PublishContext(DateTime.UtcNow, false);
+
+            _contentService.UpdatePublication(context, message.PublicationId);
+            _publicationService.SetPublishedDate(message.PublicationId, context.Published);
+
+            logger.LogInformation($"{executionContext.FunctionName} completed");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishPublicationFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishPublicationFunction.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
@@ -23,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 
         [FunctionName("PublishPublication")]
         // ReSharper disable once UnusedMember.Global
-        public void PublishPublication(
+        public async Task PublishPublication(
             [QueueTrigger(PublishPublicationQueue)]
             PublishPublicationMessage message,
             ExecutionContext executionContext,
@@ -33,8 +34,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 
             var context = new PublishContext(DateTime.UtcNow, false);
 
-            _contentService.UpdatePublication(context, message.PublicationId);
-            _publicationService.SetPublishedDate(message.PublicationId, context.Published);
+            await _contentService.UpdatePublication(context, message.PublicationId);
+            await _publicationService.SetPublishedDate(message.PublicationId, context.Published);
 
             logger.LogInformation($"{executionContext.FunctionName} completed");
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishPublicationFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishPublicationFunction.cs
@@ -34,7 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 
             var context = new PublishContext(DateTime.UtcNow, false);
 
-            await _contentService.UpdatePublication(context, message.PublicationId);
+            await _contentService.UpdatePublication(context, message.PublicationId, message.OldSlug);
             await _publicationService.SetPublishedDate(message.PublicationId, context.Published);
 
             logger.LogInformation($"{executionContext.FunctionName} completed");

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -70,12 +69,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
          */
         public async Task UpdateAllContentAsync()
         {
-            // Content is not staged when performing a full refresh and there are no additional releases included
-            var includedReleaseIds = Enumerable.Empty<Guid>();
             var context = new PublishContext(DateTime.UtcNow, false);
 
             await DeleteAllContent();
-            await UpdateTrees(includedReleaseIds, context);
+            await CacheTrees(context);
 
             var publications = _publicationService.ListPublicationsWithPublishedReleases().ToList();
             var methodologyIds = publications.Where(publication => publication.MethodologyId.HasValue)
@@ -84,24 +81,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             foreach (var publication in publications)
             {
                 var releases = publication.Releases.Where(release => release.Live);
-                await UpdatePublication(publication, includedReleaseIds, context);
-                await UpdateLatestRelease(publication, includedReleaseIds, context);
+                await CachePublication(publication.Id, context);
+                await CacheLatestRelease(publication, context);
                 foreach (var release in releases)
                 {
-                    await UpdateFastTracks(release, context);
-                    await UpdateRelease(release, context);
+                    await CacheFastTracks(release, context);
+                    await CacheRelease(release, context);
                 }
             }
 
             foreach (var methodologyId in methodologyIds)
             {
-                await UpdateMethodology(methodologyId, context);
+                await CacheMethodology(methodologyId, context);
             }
         }
 
         public async Task UpdateContent(PublishContext context, params Guid[] releaseIds)
         {
-            await UpdateTrees(releaseIds, context);
+            await CacheTrees(context, releaseIds);
 
             var releases = await _releaseService.GetAsync(releaseIds);
             var publications = releases.Select(release => release.Publication).ToList();
@@ -110,19 +107,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
             foreach (var publication in publications)
             {
-                await UpdatePublication(publication, releaseIds, context);
-                await UpdateLatestRelease(publication, releaseIds, context);
+                // Only include the Publication if it's not already published
+                if (!publication.Published.HasValue)
+                {
+                    await CachePublication(publication.Id, context, releaseIds);
+                }
+
+                await CacheLatestRelease(publication, context, releaseIds);
                 foreach (var release in releases)
                 {
-                    await UpdateFastTracks(release, context);
-                    await UpdateRelease(release, context);
+                    await CacheFastTracks(release, context);
+                    await CacheRelease(release, context);
                 }
             }
 
             foreach (var methodologyId in methodologyIds)
             {
-                await UpdateMethodology(methodologyId, context);
+                await CacheMethodology(methodologyId, context);
             }
+        }
+
+        public async Task UpdatePublication(PublishContext context, Guid publicationId)
+        {
+            await CachePublication(publicationId, context);
         }
 
         private async Task DeleteAllContent()
@@ -131,60 +138,59 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             await _fileStorageService.DeleteAllContentAsyncExcludingStaging();
         }
         
-        private async Task UpdateDownloadTreeAsync(IEnumerable<Guid> includedReleaseIds, PublishContext context)
+        private async Task CacheDownloadTree(PublishContext context, params Guid[] includedReleaseIds)
         {
             // This assumes the files have been copied first
             var tree = _downloadService.GetTree(includedReleaseIds);
             await Upload(PublicContentDownloadTreePath, context, tree, _jsonSerializerSettingsCamelCase);
         }
 
-        private async Task UpdateFastTracks(Release release, PublishContext context)
+        private async Task CacheFastTracks(Release release, PublishContext context)
         {
             await _fastTrackService.CreateAllByRelease(release.Id, context);
         }
         
-        private async Task UpdateMethodologyTree(IEnumerable<Guid> includedReleaseIds, PublishContext context)
+        private async Task CacheMethodologyTree(PublishContext context, params Guid[] includedReleaseIds)
         {
             var tree = _methodologyService.GetTree(includedReleaseIds);
             await Upload(PublicContentMethodologyTreePath, context, tree, _jsonSerializerSettingsCamelCase);
         }
 
-        private async Task UpdatePublicationTree(IEnumerable<Guid> includedReleaseIds, PublishContext context)
+        private async Task CachePublicationTree(PublishContext context, params Guid[] includedReleaseIds)
         {
             var tree = _publicationService.GetTree(includedReleaseIds);
             await Upload(PublicContentPublicationsTreePath, context, tree, _jsonSerializerSettingsCamelCase);
         }
 
-        private async Task UpdateLatestRelease(Publication publication, IEnumerable<Guid> includedReleaseIds,
-            PublishContext context)
+        private async Task CacheLatestRelease(Publication publication, PublishContext context, params Guid[] includedReleaseIds)
         {
             var viewModel = _releaseService.GetLatestReleaseViewModel(publication.Id, includedReleaseIds, context);
             await Upload(prefix => PublicContentLatestReleasePath(publication.Slug, prefix), context, viewModel, _jsonSerializerSettingsCamelCase);
         }
 
-        private async Task UpdateMethodology(Guid methodologyId, PublishContext context)
+        private async Task CacheMethodology(Guid methodologyId, PublishContext context)
         {
             var viewModel = await _methodologyService.GetViewModelAsync(methodologyId, context);
             await Upload(prefix => PublicContentMethodologyPath(viewModel.Slug, prefix), context, viewModel, _jsonSerializerSettingsCamelCase);
         }
 
-        private async Task UpdatePublication(Publication publication, IEnumerable<Guid> includedReleaseIds, PublishContext context)
+        private async Task CachePublication(Guid publicationId, PublishContext context, params Guid[] includedReleaseIds)
         {
-            var viewModel = await _publicationService.GetViewModelAsync(publication.Id, includedReleaseIds);
-            await Upload(prefix => PublicContentPublicationPath(publication.Slug, prefix), context, viewModel, _jsonSerializerSettingsCamelCase);
+            var viewModel = await _publicationService.GetViewModelAsync(publicationId, includedReleaseIds);
+            await Upload(prefix => PublicContentPublicationPath(viewModel.Slug, prefix), context, viewModel, _jsonSerializerSettingsCamelCase);
         }
 
-        private async Task UpdateRelease(Release release, PublishContext context)
+        private async Task CacheRelease(Release release, PublishContext context)
         {
             var viewModel = _releaseService.GetReleaseViewModel(release.Id, context);
             await Upload(prefix => PublicContentReleasePath(release.Publication.Slug, release.Slug, prefix), context, viewModel, _jsonSerializerSettingsCamelCase);
         }
 
-        private async Task UpdateTrees(IEnumerable<Guid> includedReleaseIds, PublishContext context)
+        private async Task CacheTrees(PublishContext context, params Guid[] includedReleaseIds)
         {
-            await UpdateDownloadTreeAsync(includedReleaseIds, context);
-            await UpdateMethodologyTree(includedReleaseIds, context);
-            await UpdatePublicationTree(includedReleaseIds, context);
+            await CacheDownloadTree(context, includedReleaseIds);
+            await CacheMethodologyTree(context, includedReleaseIds);
+            await CachePublicationTree(context, includedReleaseIds);
         }
 
         private static JsonSerializerSettings GetJsonSerializerSettings(NamingStrategy namingStrategy)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileStorageService.cs
@@ -126,12 +126,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 publication, release);
         }
 
-        public async Task MoveStagedContentAsync()
+        public async Task MovePublicDirectory(string containerName, string sourceDirectoryPath, string destinationDirectoryPath)
         {
-            var container = await GetCloudBlobContainerAsync(_publicStorageConnectionString, PublicContentContainerName);
-            var sourceDirectoryPath = PublicContentStagingPath();
+            var container = await GetCloudBlobContainerAsync(_publicStorageConnectionString, containerName);
             var sourceDirectory = container.GetDirectoryReference(sourceDirectoryPath);
-            var destinationDirectory = container.GetDirectoryReference(string.Empty);
+            var destinationDirectory = container.GetDirectoryReference(destinationDirectoryPath);
 
             var options = new CopyDirectoryOptions
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileStorageService.cs
@@ -239,7 +239,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             
             if (!releaseFileReferences.Exists(rfr => rfr.ReleaseId == releaseId && rfr.Filename == name))
             {
-                _logger.LogError($"No release file reference found for releaseId {releaseId} and name : {name}");
+                _logger.LogError($"No release file reference found for releaseId {releaseId} and name: {name}");
                 return false;
             }
 
@@ -267,6 +267,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         private async Task DeleteBlobsAsync(CloudBlobContainer container, string directoryPath,
             string excludePattern = null)
         {
+            directoryPath = directoryPath.AppendTrailingSlash();
+            _logger.LogInformation($"Deleting blobs from {container.Name} directory {directoryPath}");
+
             var token = new BlobContinuationToken();
             do
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
@@ -13,5 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
         Task UpdateAllContentAsync();
 
         Task UpdateContent(PublishContext context, params Guid[] releaseIds);
+
+        Task UpdatePublication(PublishContext context, Guid publicationId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
@@ -14,6 +14,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task UpdateContent(PublishContext context, params Guid[] releaseIds);
 
-        Task UpdatePublication(PublishContext context, Guid publicationId);
+        Task UpdatePublication(PublishContext context, Guid publicationId, string oldSlug);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IFileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IFileStorageService.cs
@@ -15,16 +15,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
         Task DeleteAllContentAsyncExcludingStaging();
 
         Task DeleteDownloadFilesForPreviousVersion(Release release);
-        
+
         Task DeletePublicBlobs(string directoryPath, string excludePattern = null);
-        
+
         Task DeletePublicBlob(string blobName);
 
         Task<(CloudBlockBlob blob, string id)> AcquireLease(string blobName);
 
         IEnumerable<FileInfo> ListPublicFiles(string publication, string release);
 
-        Task MoveStagedContentAsync();
+        Task MovePublicDirectory(string containerName, string sourceDirectoryPath, string destinationDirectoryPath);
 
         Task UploadAsJson(string blobName, object value, JsonSerializerSettings settings = null);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublicationService.cs
@@ -8,6 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 {
     public interface IPublicationService
     {
+        Task<Publication> Get(Guid id);
         Task<CachedPublicationViewModel> GetViewModelAsync(Guid id, IEnumerable<Guid> includedReleaseIds);
         List<ThemeTree<PublicationTreeNode>> GetTree(IEnumerable<Guid> includedReleaseIds);
         IEnumerable<Publication> ListPublicationsWithPublishedReleases();

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublicationService.cs
@@ -11,5 +11,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
         Task<CachedPublicationViewModel> GetViewModelAsync(Guid id, IEnumerable<Guid> includedReleaseIds);
         List<ThemeTree<PublicationTreeNode>> GetTree(IEnumerable<Guid> includedReleaseIds);
         IEnumerable<Publication> ListPublicationsWithPublishedReleases();
+        Task SetPublishedDate(Guid id, DateTime published);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublicationService.cs
@@ -65,6 +65,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 .ToList();
         }
 
+        public async Task SetPublishedDate(Guid id, DateTime published)
+        {
+            var publication = await _context.Publications.SingleOrDefaultAsync(publication => publication.Id == id);
+
+            if (publication == null)
+            {
+                throw new ArgumentException("Publication does not exist", nameof(id));
+            }
+
+            _context.Update(publication);
+            publication.Published = published;
+            await _context.SaveChangesAsync();
+        }
+
         private static ThemeTree<PublicationTreeNode> BuildThemeTree(Theme theme, IEnumerable<Guid> includedReleaseIds)
         {
             return new ThemeTree<PublicationTreeNode>

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublicationService.cs
@@ -67,7 +67,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         public async Task SetPublishedDate(Guid id, DateTime published)
         {
-            var publication = await _context.Publications.SingleOrDefaultAsync(publication => publication.Id == id);
+            var publication = await _context.Publications.SingleOrDefaultAsync(p => p.Id == id);
 
             if (publication == null)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublicationService.cs
@@ -25,6 +25,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             _releaseService = releaseService;
         }
 
+        public async Task<Publication> Get(Guid id)
+        {
+            return await _context.Publications.FindAsync(id);
+        }
+
         public async Task<CachedPublicationViewModel> GetViewModelAsync(Guid id, IEnumerable<Guid> includedReleaseIds)
         {
             var publication = await _context.Publications

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -3,6 +3,8 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainerNames;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 {
@@ -20,7 +22,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         public async Task PublishStagedReleaseContentAsync(Guid releaseId)
         {
-            await _fileStorageService.MoveStagedContentAsync();
+            await _fileStorageService.MovePublicDirectory(PublicContentContainerName, PublicContentStagingPath(),
+                string.Empty);
             await _releaseService.SetPublishedDatesAsync(releaseId, DateTime.UtcNow);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -115,8 +115,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             var statisticsRelease = await _statisticsDbContext.Release
                 .SingleOrDefaultAsync(r => r.Id == id);
 
-            var methodology = contentRelease.Publication.Methodology;
-
             if (contentRelease == null)
             {
                 throw new ArgumentException("Content Release does not exist", nameof(id));
@@ -139,10 +137,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             contentRelease.Published ??= published;
             contentRelease.DataLastPublished = DateTime.UtcNow;
 
-            // TODO EES-913 Remove this when methodologies are published independently 
+            // Update the Publication date if it's the first time it's published
+            contentRelease.Publication.Published ??= published;
+            
+            // Update the Methodology date if it's the first time it's published
+            var methodology = contentRelease.Publication.Methodology;
             if (methodology != null)
             {
-                _contentDbContext.Methodologies.Update(methodology);
                 methodology.Published ??= published;
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/host.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/host.json
@@ -5,6 +5,7 @@
       "default": "None",
       "Function.PublishAllContent": "Information",
       "Function.GenerateReleaseContent": "Information",
+      "Function.PublishPublication": "Information",
       "Function.PublishReleases": "Information",
       "Function.PublishReleaseContent": "Information",
       "Function.PublishReleaseData": "Information",


### PR DESCRIPTION
This PR publishes a Publication when it is edited by sending a message to the Publisher.
The Publisher will regenerate the Publication cache, and move files and content for the Publication if the slug has changed.

A Publication still relies on first being published along with a Release when the first Release is published.
When a publication is edited, if it's not yet published, no message is sent.
