### PR TITLE
EES-1262 Fix SummmaryListItem actions not rendering correctly when no children

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -10,6 +10,7 @@ import releaseMetaFileService from '@admin/services/releaseMetaFileService';
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
 import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
 import { Form, FormFieldset } from '@common/components/form';
 import FormFieldFileInput from '@common/components/form/FormFieldFileInput';
@@ -259,19 +260,14 @@ const ReleaseDataUploadsSection = ({ publicationId, releaseId }: Props) => {
                   />
                 </FormFieldset>
 
-                <Button
-                  type="submit"
-                  id="upload-data-files-button"
-                  className="govuk-button govuk-!-margin-right-6"
-                >
-                  Upload data files
-                </Button>
-                <ButtonText
-                  className="govuk-button govuk-button--secondary"
-                  onClick={() => resetPage(form)}
-                >
-                  Cancel
-                </ButtonText>
+                <ButtonGroup>
+                  <Button type="submit" id="upload-data-files-button">
+                    Upload data files
+                  </Button>
+                  <ButtonText onClick={() => resetPage(form)}>
+                    Cancel
+                  </ButtonText>
+                </ButtonGroup>
               </>
             )}
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -6,6 +6,7 @@ import releaseAncillaryFileService, {
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
 import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
 import { Form, FormFieldset } from '@common/components/form';
 import FormFieldFileInput from '@common/components/form/FormFieldFileInput';
@@ -163,20 +164,15 @@ const ReleaseFileUploadsSection = ({ publicationId, releaseId }: Props) => {
                   />
                 </FormFieldset>
 
-                <Button
-                  type="submit"
-                  id="upload-file-button"
-                  className="govuk-button govuk-!-margin-right-6"
-                >
-                  Upload file
-                </Button>
+                <ButtonGroup>
+                  <Button type="submit" id="upload-file-button">
+                    Upload file
+                  </Button>
 
-                <ButtonText
-                  className="govuk-button govuk-button--secondary"
-                  onClick={() => resetPage(form)}
-                >
-                  Cancel
-                </ButtonText>
+                  <ButtonText onClick={() => resetPage(form)}>
+                    Cancel
+                  </ButtonText>
+                </ButtonGroup>
               </>
             )}
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/footnotes/form/FootnoteForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/footnotes/form/FootnoteForm.tsx
@@ -20,6 +20,7 @@ import { Formik } from 'formik';
 import get from 'lodash/get';
 import merge from 'lodash/merge';
 import React from 'react';
+import ButtonGroup from '@common/components/ButtonGroup';
 
 const footnoteFormValidation = (footnote: BaseFootnote) => {
   const errors: { [key: string]: string } = {};
@@ -245,18 +246,13 @@ const FootnoteForm = ({
                     name="content"
                     label="Footnote"
                   />
-                  <Button
-                    type="submit"
-                    className="govuk-button govuk-!-margin-right-6"
-                  >
-                    {`${!footnote ? 'Create' : 'Update'} footnote`}
-                  </Button>
-                  <ButtonText
-                    className="govuk-button govuk-button--secondary"
-                    onClick={onCancel}
-                  >
-                    Cancel
-                  </ButtonText>
+
+                  <ButtonGroup>
+                    <Button type="submit">
+                      {`${!footnote ? 'Create' : 'Update'} footnote`}
+                    </Button>
+                    <ButtonText onClick={onCancel}>Cancel</ButtonText>
+                  </ButtonGroup>
                 </FormFieldset>
               </Form>
             </div>
@@ -268,12 +264,7 @@ const FootnoteForm = ({
 
   const renderNewForm = () => {
     return state !== 'create' ? (
-      <Button
-        type="button"
-        id="add-footnote-button"
-        className="govuk-button"
-        onClick={onOpen}
-      >
+      <Button type="button" id="add-footnote-button" onClick={onOpen}>
         Add {!isFirst && `another `}footnote
       </Button>
     ) : (

--- a/src/explore-education-statistics-common/src/components/SummaryListItem.tsx
+++ b/src/explore-education-statistics-common/src/components/SummaryListItem.tsx
@@ -11,7 +11,7 @@ const SummaryListItem = ({ actions, children, term }: Props) => {
     <div className="govuk-summary-list__row">
       <dt className="govuk-summary-list__key">{term}</dt>
 
-      <dd className="govuk-summary-list__value">{children}</dd>
+      {children && <dd className="govuk-summary-list__value">{children}</dd>}
       {actions && <dd className="govuk-summary-list__actions">{actions}</dd>}
     </div>
   );


### PR DESCRIPTION
This PR fixes `SummaryListItem` not rendering its `actions` prop correctly if it has no `children`.

## Other changes

- Fixed incorrectly styled cancel buttons across 'Manage data' section forms