### PR TITLE
EES-1237 Remove scheduling support for Methodology

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -22,11 +21,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         {
             var request = new CreateMethodologyRequest
             {
-                PublishScheduled = "2020-06-01",
                 Title = "Pupil absence statistics: methodology"
             };
 
-            await using (var context = DbUtils.InMemoryApplicationDbContext("Create"))
+            await using (var context = DbUtils.InMemoryApplicationDbContext())
             {
                 var viewModel = (await new MethodologyService(
                         context,
@@ -35,11 +33,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         new PersistenceHelper<ContentDbContext>(context))
                     .CreateMethodologyAsync(request)).Right;
 
-                var publishScheduled = new DateTime(2020, 6, 1, 0, 0, 0, DateTimeKind.Unspecified);
-
                 Assert.Null(viewModel.InternalReleaseNote);
                 Assert.Null(viewModel.Published);
-                Assert.Equal(publishScheduled, viewModel.PublishScheduled);
                 Assert.Equal(Draft, viewModel.Status);
                 Assert.Equal(request.Title, viewModel.Title);
             }
@@ -50,7 +45,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         {
             var request = new CreateMethodologyRequest
             {
-                PublishScheduled = "2020-06-01",
                 Title = "Pupil absence statistics: methodology"
             };
 
@@ -133,7 +127,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Id = Guid.NewGuid(),
                 InternalReleaseNote = "Test approval",
                 Published = new DateTime(2020, 5, 25),
-                PublishScheduled = new DateTime(2020, 6, 1, 0, 0, 0).AsStartOfDayUtc(),
                 Slug = "pupil-absence-statistics-methodology",
                 Status = Approved,
                 Title = "Pupil absence statistics: methodology"
@@ -157,7 +150,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(methodology.Id, viewModel.Id);
                 Assert.Equal(methodology.InternalReleaseNote, viewModel.InternalReleaseNote);
                 Assert.Equal(methodology.Published, viewModel.Published);
-                Assert.Equal(new DateTime(2020, 6, 1, 0, 0, 0), viewModel.PublishScheduled);
                 Assert.Equal(methodology.Status, viewModel.Status);
                 Assert.Equal(methodology.Title, viewModel.Title);
             }
@@ -171,7 +163,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Id = Guid.NewGuid(),
                 InternalReleaseNote = "Test approval",
                 Published = new DateTime(2020, 5, 25),
-                PublishScheduled = new DateTime(2020, 6, 1),
                 Slug = "pupil-absence-statistics-methodology",
                 Status = Draft,
                 Title = "Pupil absence statistics: methodology"
@@ -180,7 +171,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             var request = new UpdateMethodologyRequest
             {
                 InternalReleaseNote = null,
-                PublishScheduled = "2020-07-01",
                 Status = Draft,
                 Title = "Pupil absence statistics (updated): methodology"
             };
@@ -199,15 +189,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                         MockUtils.AlwaysTrueUserService().Object,
                         new PersistenceHelper<ContentDbContext>(context))
                     .UpdateMethodologyAsync(methodology.Id, request)).Right;
-                
-                var publishScheduled = new DateTime(2020, 7, 1, 0, 0, 0, DateTimeKind.Unspecified);
 
                 Assert.Equal(methodology.Id, viewModel.Id);
                 // TODO EES-331 is this correct?
                 // Original release note is not cleared if the update is not altering it
                 Assert.Equal(methodology.InternalReleaseNote, viewModel.InternalReleaseNote);
                 Assert.Equal(methodology.Published, viewModel.Published);
-                Assert.Equal(publishScheduled, viewModel.PublishScheduled);
                 Assert.Equal(request.Status, viewModel.Status);
                 Assert.Equal(request.Title, viewModel.Title);
             }
@@ -221,7 +208,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Id = Guid.NewGuid(),
                 InternalReleaseNote = "Test approval",
                 Published = new DateTime(2020, 5, 25),
-                PublishScheduled = new DateTime(2020, 6, 1),
                 Slug = "pupil-absence-statistics-methodology",
                 Status = Draft,
                 Title = "Pupil absence statistics: methodology"
@@ -232,7 +218,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Id = Guid.NewGuid(),
                 InternalReleaseNote = "Test approval",
                 Published = new DateTime(2020, 5, 25),
-                PublishScheduled = new DateTime(2020, 6, 1),
                 Slug = "pupil-exclusion-statistics-methodology",
                 Status = Draft,
                 Title = "Pupil exclusion statistics: methodology"
@@ -241,7 +226,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             var request = new UpdateMethodologyRequest
             {
                 InternalReleaseNote = null,
-                PublishScheduled = "2020-06-01",
                 Status = Draft,
                 Title = "Pupil exclusion statistics: methodology"
             };

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/CreateMethodologyRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/CreateMethodologyRequest.cs
@@ -1,30 +1,9 @@
-using System;
 using System.ComponentModel.DataAnnotations;
-using System.Globalization;
-using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using static System.Globalization.CultureInfo;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Methodologies
 {
     public class CreateMethodologyRequest
     {
-        [Required]
-        public string Title { get; set; }
-
-        [DateTimeFormatValidator("yyyy-MM-dd")]
-        public string PublishScheduled { get; set; }
-
-        public DateTime? PublishScheduledDate
-        {
-            get
-            {
-                DateTime.TryParseExact(PublishScheduled, "yyyy-MM-dd", InvariantCulture,DateTimeStyles.None,
-                    out var dateTime);
-                return dateTime.AsStartOfDayUtc();
-            }
-        }
-
-        // TODO EES-899 Contact in the request is being ignored!
+        [Required] public string Title { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/UpdateMethodologyRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/UpdateMethodologyRequest.cs
@@ -1,12 +1,7 @@
-using System;
 using System.ComponentModel.DataAnnotations;
-using System.Globalization;
-using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using static System.Globalization.CultureInfo;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Methodologies
 {
@@ -15,19 +10,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
         public string InternalReleaseNote { get; set; }
 
         [Required] public string Title { get; set; }
-
-        [DateTimeFormatValidator("yyyy-MM-dd")]
-        public string PublishScheduled { get; set; }
-
-        public DateTime? PublishScheduledDate
-        {
-            get
-            {
-                DateTime.TryParseExact(PublishScheduled, "yyyy-MM-dd", InvariantCulture,DateTimeStyles.None,
-                    out var dateTime);
-                return dateTime.AsStartOfDayUtc();
-            }
-        }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public MethodologyStatus Status { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -70,11 +70,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
             CreateMap<ReleaseStatus, ReleaseStatusViewModel>()
                 .ForMember(model => model.LastUpdated, m => m.MapFrom(status => status.Timestamp));
 
-            CreateMap<Methodology, MethodologySummaryViewModel>().ForMember(model => model.PublishScheduled,
-                m => m.MapFrom(model =>
-                    model.PublishScheduled.HasValue
-                        ? model.PublishScheduled.Value.ConvertTimeFromUtcToGmt()
-                        : (DateTime?) null));
+            CreateMap<Methodology, MethodologySummaryViewModel>();
 
             CreateMap<Methodology, MethodologyTitleViewModel>();
             CreateMap<Methodology, MethodologyPublicationsViewModel>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200810131121_EES1237RemoveMethodologyPublishScheduled.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200810131121_EES1237RemoveMethodologyPublishScheduled.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200810131121_EES1237RemoveMethodologyPublishScheduled")]
+    partial class EES1237RemoveMethodologyPublishScheduled
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200810131121_EES1237RemoveMethodologyPublishScheduled.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200810131121_EES1237RemoveMethodologyPublishScheduled.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES1237RemoveMethodologyPublishScheduled : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PublishScheduled",
+                table: "Methodologies");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "PublishScheduled",
+                table: "Methodologies",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "Methodologies",
+                keyColumn: "Id",
+                keyValue: new Guid("caa8e56f-41d2-4129-a5c3-53b051134bd7"),
+                column: "PublishScheduled",
+                value: new DateTime(2018, 3, 22, 0, 0, 0, 0, DateTimeKind.Utc));
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/MethodologySummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Api/MethodologySummaryViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -13,9 +12,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models.Api
         public string InternalReleaseNote { get; set; }
 
         public DateTime? Published { get; set; }
-
-        [JsonConverter(typeof(DateTimeToDateJsonConverter))]
-        public DateTime? PublishScheduled { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public MethodologyStatus Status { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -49,8 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                     var model = new Methodology
                     {
                         Title = request.Title,
-                        Slug = slug,
-                        PublishScheduled = request.PublishScheduledDate
+                        Slug = slug
                     };
 
                     var saved = await _context.Methodologies.AddAsync(model);
@@ -104,7 +103,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 {
                     _context.Methodologies.Update(methodology);
                     methodology.InternalReleaseNote = request.InternalReleaseNote ?? methodology.InternalReleaseNote;
-                    methodology.PublishScheduled = request.PublishScheduledDate;
                     methodology.Status = request.Status;
                     methodology.Title = request.Title;
                     methodology.Slug = slug;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -10,7 +10,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Newtonsoft.Json;
-using static GovUk.Education.ExploreEducationStatistics.Common.Extensions.DateTimeExtensions;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 
 // ReSharper disable StringLiteralTypo
@@ -138,12 +137,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .HasConversion(
                     v => JsonConvert.SerializeObject(v),
                     v => JsonConvert.DeserializeObject<List<ContentSection>>(v));
-
-            modelBuilder.Entity<Methodology>()
-                .Property(methodology => methodology.PublishScheduled)
-                .HasConversion(
-                    v => v,
-                    v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : (DateTime?) null);
 
             modelBuilder.Entity<Methodology>()
                 .Property(b => b.Status)
@@ -996,7 +989,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 {
                     Id = absenceMethodologyId,
                     Title = "Pupil absence statistics: methodology",
-                    PublishScheduled = new DateTime(2018, 3, 22).AsStartOfDayUtc(),
                     Published = new DateTime(2018, 3, 22),
                     LastUpdated = new DateTime(2019, 6, 26),
                     Slug = "pupil-absence-in-schools-in-england",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using Microsoft.Azure.Documents.SystemFunctions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
@@ -11,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         Draft,
         Approved
     }
-    
+
     public class Methodology
     {
         [Key] 
@@ -28,17 +26,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public MethodologyStatus Status { get; set; }
 
         public DateTime? Published { get; set; }
-        
-        public DateTime? PublishScheduled { get; set; }
 
         public DateTime? LastUpdated { get; set; }
- 
+
         public List<ContentSection> Content { get; set; }
-        
+
         public List<ContentSection> Annexes { get; set; }
 
         public List<Publication> Publications { get; set; }
-        
+
         public string InternalReleaseNote { get; set; }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/methodology/MethodologyCreatePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/MethodologyCreatePage.tsx
@@ -1,7 +1,6 @@
 import Page from '@admin/components/Page';
 import MethodologySummaryForm from '@admin/pages/methodology/components/MethodologySummaryForm';
 import methodologyService from '@admin/services/methodologyService';
-import { formatISO } from 'date-fns';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
@@ -28,9 +27,6 @@ const MethodologyCreatePage = ({ history }: RouteComponentProps) => {
           const createdMethodology = await methodologyService.createMethodology(
             {
               title: values.title,
-              publishScheduled: formatISO(values.publishScheduled, {
-                representation: 'date',
-              }),
               contactId: values.contactId,
             },
           );

--- a/src/explore-education-statistics-admin/src/pages/methodology/components/MethodologySummaryForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/components/MethodologySummaryForm.tsx
@@ -4,7 +4,6 @@ import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
 import Form from '@common/components/form/Form';
-import FormFieldDateInput from '@common/components/form/FormFieldDateInput';
 import FormFieldSelect from '@common/components/form/FormFieldSelect';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
 import SummaryList from '@common/components/SummaryList';
@@ -18,7 +17,6 @@ import React from 'react';
 export interface MethodologySummaryFormValues {
   title: string;
   contactId: string;
-  publishScheduled: Date;
 }
 
 const errorMappings = [
@@ -78,9 +76,6 @@ const MethodologySummaryForm = ({
         contactId: isContactEnabled
           ? Yup.string().required('Choose a methodology contact')
           : Yup.string(),
-        publishScheduled: Yup.date().required(
-          'Enter a valid scheduled publish date',
-        ),
       })}
       onSubmit={handleSubmit}
     >
@@ -91,13 +86,6 @@ const MethodologySummaryForm = ({
               id={`${id}-title`}
               label="Enter methodology title"
               name="title"
-            />
-
-            <FormFieldDateInput<MethodologySummaryFormValues>
-              id={`${id}-publishScheduled`}
-              name="publishScheduled"
-              legend="Schedule publish date"
-              legendSize="s"
             />
 
             {isContactEnabled && (

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/context/__tests__/MethodologyContext.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/context/__tests__/MethodologyContext.test.tsx
@@ -12,7 +12,6 @@ const basicMethodology: MethodologyContent = {
   title: 'Academic Year 2020/21',
   status: 'Draft',
   slug: '2020-21',
-  publishScheduled: '2019-10-10T00:00:00Z',
   content: [
     {
       id: 'content-section-0',

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryEditPage.tsx
@@ -3,7 +3,6 @@ import { MethodologyRouteParams } from '@admin/routes/methodologyRoutes';
 import methodologyService from '@admin/services/methodologyService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
-import { formatISO, parseISO } from 'date-fns';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
@@ -28,16 +27,12 @@ const MethodologySummaryEditPage = ({
             initialValues={{
               contactId: '',
               title: methodology.title,
-              publishScheduled: parseISO(methodology.publishScheduled),
             }}
             submitText="Update methodology"
             onSubmit={async values => {
               await methodologyService.updateMethodology(methodologyId, {
                 ...methodology,
                 title: values.title,
-                publishScheduled: formatISO(values.publishScheduled, {
-                  representation: 'date',
-                }),
                 contactId: values.contactId,
               });
 

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryPage.tsx
@@ -8,7 +8,6 @@ import SummaryListItem from '@common/components/SummaryListItem';
 import Tag from '@common/components/Tag';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
-import { parseISO } from 'date-fns';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
@@ -34,11 +33,6 @@ const MethodologySummaryPage = ({
               </SummaryListItem>
               <SummaryListItem term="Status">
                 <Tag>{currentMethodology.status}</Tag>
-              </SummaryListItem>
-              <SummaryListItem term="Scheduled release">
-                <FormattedDate>
-                  {parseISO(currentMethodology.publishScheduled)}
-                </FormattedDate>
               </SummaryListItem>
               <SummaryListItem term="Published on">
                 {currentMethodology.published ? (

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
@@ -22,14 +22,12 @@ describe('PublicationForm', () => {
       title: 'Methodology 1',
       slug: 'methodology-1',
       status: 'Approved',
-      publishScheduled: '',
     },
     {
       id: 'methodology-2',
       title: 'Methodology 2',
       slug: 'methodology-2',
       status: 'Approved',
-      publishScheduled: '',
     },
   ];
 

--- a/src/explore-education-statistics-admin/src/services/methodologyContentService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyContentService.ts
@@ -17,7 +17,6 @@ export interface MethodologyContent {
   slug: string;
   status: MethodologyStatus;
   published?: string;
-  publishScheduled: string;
   content: ContentSection<EditableContentBlock>[];
   annexes: ContentSection<EditableContentBlock>[];
 }

--- a/src/explore-education-statistics-admin/src/services/methodologyService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyService.ts
@@ -14,7 +14,6 @@ export interface MethodologyStatusListItem {
 
 interface SaveMethodologySummary {
   title: string;
-  publishScheduled: string;
   contactId: string;
 }
 
@@ -31,7 +30,6 @@ export interface BasicMethodology {
   // TODO: EES-899 methodology should have a contact attached
   contact?: ContactDetails;
   published?: string;
-  publishScheduled: string;
 }
 
 const methodologyService = {


### PR DESCRIPTION
Scheduling when creating methodology was not required since a new methodology is only published when a Publication using it has a Release published.

Also agreed with @lauraselby that updates to Methodology will be made as soon as they are approved, so no scheduling required on update either.

There will be a future enhancement to make amendments to methodology - EES-1263.
