### PR TITLE
EES-913 Allow BAU users to mark Methodology as Draft. Don't Alter Publication or Methodology slugs

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkSpecificMethodologyAsDraftAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkSpecificMethodologyAsDraftAuthorizationHandlerTests.cs
@@ -1,0 +1,20 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
+    ReleaseAuthorizationHandlersTestUtil;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
+{
+    public class MarkSpecificMethodologyAsDraftAuthorizationHandlerTests
+    {
+        [Fact]
+        public void MarkSpecificMethodologyAsDraftAuthorizationHandler()
+        {
+            AssertReleaseHandlerSucceedsWithCorrectClaims<MarkSpecificMethodologyAsDraftRequirement>(
+                new MarkSpecificMethodologyAsDraftAuthorizationHandler(),
+                MarkAllMethodologiesDraft
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlerTests.cs
@@ -1,0 +1,20 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
+    ReleaseAuthorizationHandlersTestUtil;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
+{
+    public class UpdateSpecificMethodologyAuthorizationHandlerTests
+    {
+        [Fact]
+        public void UpdateSpecificMethodologyAuthorizationHandler()
+        {
+            AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificMethodologyRequirement>(
+                new UpdateSpecificMethodologyAuthorizationHandler(),
+                UpdateAllMethodologies
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -38,7 +38,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 Assert.False(model.Live);
                 Assert.Equal("pupil-absence-statistics-methodology", model.Slug);
-                Assert.False(model.LastUpdated.HasValue);
+                Assert.False(model.Updated.HasValue);
 
                 Assert.Null(viewModel.InternalReleaseNote);
                 Assert.Null(viewModel.Published);
@@ -187,8 +187,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 Assert.False(model.Live);
                 Assert.Equal("pupil-absence-statistics-updated-methodology", model.Slug);
-                Assert.True(model.LastUpdated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(model.LastUpdated.Value).Milliseconds, 0, 1500);
+                Assert.True(model.Updated.HasValue);
+                Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
 
                 Assert.Equal(methodology.Id, viewModel.Id);
                 Assert.Null(viewModel.InternalReleaseNote);
@@ -235,8 +235,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.True(model.Live);
                 // Slug remains unchanged
                 Assert.Equal("pupil-absence-statistics-methodology", model.Slug);
-                Assert.True(model.LastUpdated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(model.LastUpdated.Value).Milliseconds, 0, 1500);
+                Assert.True(model.Updated.HasValue);
+                Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
                 
                 Assert.Equal(methodology.Id, viewModel.Id);
                 // TODO EES-331 is this correct?

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServiceTests.cs
@@ -101,13 +101,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using (var context = InMemoryApplicationDbContext("PublicationChanged"))
             {
                 var publishingService = BuildPublishingService(context, mocks);
-                var result = publishingService.PublicationChanged(publication.Id, "old-slug").Result;
+                var result = publishingService.PublicationChanged(publication.Id).Result;
 
                 mocks.StorageQueueService.Verify(
                     mock => mock.AddMessagesAsync(PublishPublicationQueue,
                         It.Is<PublishPublicationMessage>(message =>
-                            message.PublicationId == publication.Id 
-                            && message.OldSlug == "old-slug")), Times.Once());
+                            message.PublicationId == publication.Id)), Times.Once());
 
                 Assert.True(result.IsRight);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Data/UsersAndRolesDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Data/UsersAndRolesDbContext.cs
@@ -332,6 +332,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data
                         RoleId = bauUserRoleId,
                         ClaimType = SecurityClaimTypes.UpdateAllPublications.ToString(),
                         ClaimValue = "",
+                    },
+                    new IdentityRoleClaim<string>
+                    {
+                        Id = -35,
+                        RoleId = bauUserRoleId,
+                        ClaimType = SecurityClaimTypes.MarkAllMethodologiesDraft.ToString(),
+                        ClaimValue = "",
                     }
                 );
             

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Security/PermissionsController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Security/PermissionsController.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/20200813105224_EES913AssignClaimToRole.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/20200813105224_EES913AssignClaimToRole.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations
 {
     [DbContext(typeof(UsersAndRolesDbContext))]
-    partial class UsersAndRolesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200813105224_EES913AssignClaimToRole")]
+    partial class EES913AssignClaimToRole
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/20200813105224_EES913AssignClaimToRole.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/20200813105224_EES913AssignClaimToRole.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations
+{
+    public partial class EES913AssignClaimToRole : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "AspNetRoleClaims",
+                columns: new[] { "Id", "ClaimType", "ClaimValue", "RoleId" },
+                values: new object[] { -35, "MarkAllMethodologiesDraft", "", "cf67b697-bddd-41bd-86e0-11b7e11d99b3" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "AspNetRoleClaims",
+                keyColumn: "Id",
+                keyValue: -35);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200812154820_EES913AddUpdatedFields.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200812154820_EES913AddUpdatedFields.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200812154820_EES913AddUpdatedFields")]
+    partial class EES913AddUpdatedFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -608,7 +610,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
+                    b.Property<string>("Description")
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<string>("Slug")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Summary")
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<Guid>("ThemeId")
@@ -629,6 +637,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         {
                             Id = new Guid("67c249de-1cca-446e-8ccb-dcdac542f460"),
                             Slug = "pupil-absence",
+                            Summary = "",
                             ThemeId = new Guid("ee1855ca-d1e1-4f04-a795-cbd61d326a1f"),
                             Title = "Pupil absence"
                         });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200812154820_EES913AddUpdatedFields.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200812154820_EES913AddUpdatedFields.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES913AddUpdatedFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "LastUpdated",
+                table: "Methodologies",
+                newName: "Updated");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Updated",
+                table: "Publications",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Updated",
+                table: "Publications");
+
+            migrationBuilder.RenameColumn(
+                name: "Updated",
+                table: "Methodologies",
+                newName: "LastUpdated");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkSpecificMethodologyAsDraftAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MarkSpecificMethodologyAsDraftAuthorizationHandlers.cs
@@ -1,28 +1,18 @@
-using GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlers;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
     public class MarkSpecificMethodologyAsDraftRequirement : IAuthorizationRequirement
-    {}
-    
-    public class MarkSpecificMethodologyAsDraftAuthorizationHandler 
-        : CompoundAuthorizationHandler<MarkSpecificMethodologyAsDraftRequirement, Methodology>
     {
-        public MarkSpecificMethodologyAsDraftAuthorizationHandler() : base(
-            new CanMarkAllMethodologiesAsDraftAuthorizationHandler())
-        {}
-        
-        public class CanMarkAllMethodologiesAsDraftAuthorizationHandler : 
-            EntityAuthorizationHandler<MarkSpecificMethodologyAsDraftRequirement, Methodology>
+    }
+
+    public class
+        MarkSpecificMethodologyAsDraftAuthorizationHandler : HasClaimAuthorizationHandler<
+            MarkSpecificMethodologyAsDraftRequirement>
+    {
+        public MarkSpecificMethodologyAsDraftAuthorizationHandler() : base(MarkAllMethodologiesDraft)
         {
-            // TODO - for now, no-one can unapprove a Methodology, and you cannot mark it as Draft if it is already in
-            // Draft, so currently there is no way to get it back into Draft (until work is done to allow BAU to do this 
-            // via the UI)
-            public CanMarkAllMethodologiesAsDraftAuthorizationHandler() 
-                : base(ctx => false) {}
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlers.cs
@@ -1,27 +1,18 @@
-using GovUk.Education.ExploreEducationStatistics.Common.Security.AuthorizationHandlers;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Authorization;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
     public class UpdateSpecificMethodologyRequirement : IAuthorizationRequirement
-    {}
-
-    public class UpdateSpecificMethodologyAuthorizationHandler : CompoundAuthorizationHandler<UpdateSpecificMethodologyRequirement, Methodology>
     {
-        public UpdateSpecificMethodologyAuthorizationHandler() : base(
-            new CanUpdateAllMethodologiesAuthorizationHandler())
-        {}
-    
-        public class CanUpdateAllMethodologiesAuthorizationHandler 
-            : EntityAuthorizationHandler<UpdateSpecificMethodologyRequirement, Methodology>
+    }
+
+    public class
+        UpdateSpecificMethodologyAuthorizationHandler : HasClaimAuthorizationHandler<
+            UpdateSpecificMethodologyRequirement>
+    {
+        public UpdateSpecificMethodologyAuthorizationHandler() : base(UpdateAllMethodologies)
         {
-            public CanUpdateAllMethodologiesAuthorizationHandler()
-                : base(ctx =>
-                    ctx.Entity.Status != MethodologyStatus.Approved && 
-                    SecurityUtils.HasClaim(ctx.User, SecurityClaimTypes.UpdateAllMethodologies)
-                )
-            {}
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityClaimTypes.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityClaimTypes.cs
@@ -51,6 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
         CreateAnyMethodology,
         AccessAllMethodologies,
         UpdateAllMethodologies,
-        ApproveAllMethodologies
+        ApproveAllMethodologies,
+        MarkAllMethodologiesDraft,
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublishingService.cs
@@ -11,6 +11,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, Unit>> RetryReleaseStage(Guid releaseId, RetryStage stage);
         Task<Either<ActionResult, Unit>> ReleaseChanged(Guid id, bool immediate = false);
         Task<Either<ActionResult, Unit>> MethodologyChanged(Guid id);
-        Task<Either<ActionResult, Unit>> PublicationChanged(Guid id, string oldSlug);
+        Task<Either<ActionResult, Unit>> PublicationChanged(Guid id);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -120,7 +120,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                     methodology.InternalReleaseNote = request.InternalReleaseNote ?? methodology.InternalReleaseNote;
                     methodology.Status = request.Status;
                     methodology.Title = request.Title;
-                    methodology.LastUpdated = DateTime.UtcNow;
+                    methodology.Updated = DateTime.UtcNow;
 
                     _context.Methodologies.Update(methodology);
                     await _context.SaveChangesAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -98,19 +98,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         public async Task<Either<ActionResult, MethodologySummaryViewModel>> UpdateMethodologyAsync(Guid id,
             UpdateMethodologyRequest request)
         {
-            var slug = SlugFromTitle(request.Title);
             return await _persistenceHelper.CheckEntityExists<Methodology>(id)
                 .OnSuccess(methodology => CheckCanUpdateMethodologyStatus(methodology, request.Status))
-                .OnSuccess(methodology => _userService.CheckCanUpdateMethodology(methodology))
-                .OnSuccessDo(() => ValidateMethodologySlugUniqueForUpdate(id, slug))
+                .OnSuccess(_userService.CheckCanUpdateMethodology)
                 .OnSuccess(async methodology =>
                 {
-                    _context.Methodologies.Update(methodology);
+                    if (methodology.Live)
+                    {
+                        // Leave slug
+                        return methodology;
+                    }
+                    var slug = SlugFromTitle(request.Title);
+                    return (await ValidateMethodologySlugUniqueForUpdate(methodology.Id, slug)).Map(_ =>
+                    {
+                        methodology.Slug = slug;
+                        return methodology;
+                    });
+                })
+                .OnSuccess(async methodology =>
+                {
                     methodology.InternalReleaseNote = request.InternalReleaseNote ?? methodology.InternalReleaseNote;
                     methodology.Status = request.Status;
                     methodology.Title = request.Title;
-                    methodology.Slug = slug;
+                    methodology.LastUpdated = DateTime.UtcNow;
 
+                    _context.Methodologies.Update(methodology);
                     await _context.SaveChangesAsync();
 
                     if (methodology.Status == MethodologyStatus.Approved && methodology.Live)
@@ -139,24 +151,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             };
         }
 
-        private async Task<Either<ActionResult, bool>> ValidateMethodologySlugUnique(string slug)
+        private async Task<Either<ActionResult, Unit>> ValidateMethodologySlugUnique(string slug)
         {
             if (await _context.Methodologies.AnyAsync(methodology => methodology.Slug == slug))
             {
                 return ValidationActionResult(SlugNotUnique);
             }
 
-            return true;
+            return Unit.Instance;
         }
 
-        private async Task<Either<ActionResult, bool>> ValidateMethodologySlugUniqueForUpdate(Guid id, string slug)
+        private async Task<Either<ActionResult, Unit>> ValidateMethodologySlugUniqueForUpdate(Guid id, string slug)
         {
             if (await _context.Methodologies.AnyAsync(methodology => methodology.Slug == slug && methodology.Id != id))
             {
                 return ValidationActionResult(SlugNotUnique);
             }
 
-            return true;
+            return Unit.Instance;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
@@ -123,14 +123,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         /// <param name="id"></param>
         /// <param name="oldSlug"></param>
         /// <returns></returns>
-        public async Task<Either<ActionResult, Unit>> PublicationChanged(Guid id, string oldSlug)
+        public async Task<Either<ActionResult, Unit>> PublicationChanged(Guid id)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Publication>(id)
                 .OnSuccess(async release =>
                 {
                     await _storageQueueService.AddMessagesAsync(
-                        PublishPublicationQueue, new PublishPublicationMessage(id, oldSlug));
+                        PublishPublicationQueue, new PublishPublicationMessage(id));
 
                     _logger.LogTrace($"Sent message for Publication: {id}");
                     return Unit.Instance;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -989,7 +989,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     Id = absenceMethodologyId,
                     Title = "Pupil absence statistics: methodology",
                     Published = new DateTime(2018, 3, 22),
-                    LastUpdated = new DateTime(2019, 6, 26),
+                    Updated = new DateTime(2019, 6, 26),
                     Slug = "pupil-absence-in-schools-in-england",
                     Status = MethodologyStatus.Draft,
                     Summary = "",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public DateTime? Published { get; set; }
 
-        public DateTime? LastUpdated { get; set; }
+        public DateTime? Updated { get; set; }
 
         public List<ContentSection> Content { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -41,6 +41,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public Contact Contact { get; set; }
 
+        public DateTime? Updated { get; set; }
+
         public bool Live => Published.HasValue && DateTime.Compare(DateTime.UtcNow, Published.Value) > 0;
 
         public Release LatestRelease()

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishPublicationMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishPublicationMessage.cs
@@ -5,17 +5,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
     public class PublishPublicationMessage
     {
         public Guid PublicationId { get; set; }
-        public string OldSlug { get; set; }
 
-        public PublishPublicationMessage(Guid publicationId, string oldSlug)
+        public PublishPublicationMessage(Guid publicationId)
         {
             PublicationId = publicationId;
-            OldSlug = oldSlug;
         }
 
         public override string ToString()
         {
-            return $"{nameof(PublicationId)}: {PublicationId}, {nameof(OldSlug)}: {OldSlug}";
+            return $"{nameof(PublicationId)}: {PublicationId}";
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/MethodologyViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/MethodologyViewModel.cs
@@ -15,7 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels
 
         public DateTime? Published { get; set; }
 
-        public DateTime? LastUpdated { get; set; }
+        public DateTime? Updated { get; set; }
 
         public List<ContentSectionViewModel> Content { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
@@ -39,7 +39,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Title = "Methodology A",
             Summary = "first methodology",
             Published = new DateTime(2019, 1, 01),
-            LastUpdated = new DateTime(2019, 1, 15),
+            Updated = new DateTime(2019, 1, 15),
             Annexes = new List<ContentSection>(),
             Content = new List<ContentSection>()
         };
@@ -51,7 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Title = "Methodology B",
             Summary = "second methodology",
             Published = new DateTime(2019, 3, 01),
-            LastUpdated = new DateTime(2019, 3, 15),
+            Updated = new DateTime(2019, 3, 15),
             Annexes = new List<ContentSection>(),
             Content = new List<ContentSection>()
         };
@@ -63,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Title = "Methodology C",
             Summary = "third methodology",
             Published = null,
-            LastUpdated = new DateTime(2019, 6, 15),
+            Updated = new DateTime(2019, 6, 15),
             Annexes = new List<ContentSection>(),
             Content = new List<ContentSection>()
         };
@@ -185,7 +185,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Assert.Equal(MethodologyA.Id, result.Id);
                 Assert.Equal("Methodology A", result.Title);
                 Assert.Equal(new DateTime(2019, 1, 01), result.Published);
-                Assert.Equal(new DateTime(2019, 1, 15), result.LastUpdated);
+                Assert.Equal(new DateTime(2019, 1, 15), result.Updated);
                 Assert.Equal("first methodology", result.Summary);
 
                 var annexes = result.Annexes;
@@ -221,7 +221,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Assert.Equal(MethodologyC.Id, result.Id);
                 Assert.Equal("Methodology C", result.Title);
                 Assert.Equal(context.Published, result.Published);
-                Assert.Equal(new DateTime(2019, 6, 15), result.LastUpdated);
+                Assert.Equal(new DateTime(2019, 6, 15), result.Updated);
                 Assert.Equal("third methodology", result.Summary);
 
                 var annexes = result.Annexes;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublicationServiceTests.cs
@@ -66,7 +66,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Slug = "methodology-slug",
             Summary = "methodology summary",
             Published = new DateTime(2020, 2, 10),
-            LastUpdated = new DateTime(2020, 2, 11)
+            Updated = new DateTime(2020, 2, 11)
         };
 
         private static readonly Publication PublicationA = new Publication

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishPublicationFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishPublicationFunction.cs
@@ -31,7 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 
             var context = new PublishContext(DateTime.UtcNow, false);
 
-            await _contentService.UpdatePublication(context, message.PublicationId, message.OldSlug);
+            await _contentService.UpdatePublication(context, message.PublicationId);
 
             logger.LogInformation($"{executionContext.FunctionName} completed");
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -6,7 +6,6 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainerNames;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
@@ -139,20 +138,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             await _methodologyService.SetPublishedDate(methodologyId, context.Published);
         }
 
-        public async Task UpdatePublication(PublishContext context, Guid publicationId, string oldSlug)
+        public async Task UpdatePublication(PublishContext context, Guid publicationId)
         {
             var publication = await _publicationService.Get(publicationId);
-
-            if (publication.Slug != oldSlug)
-            {
-                var pathPrefix = context.Staging ? PublicContentStagingPath() : null;
-                await _fileStorageService.MovePublicDirectory(PublicContentContainerName,
-                    PublicContentPublicationParentPath(oldSlug, pathPrefix),
-                    PublicContentPublicationParentPath(publication.Slug, pathPrefix)
-                );
-
-                await _fileStorageService.MovePublicDirectory(PublicFilesContainerName, oldSlug, publication.Slug);
-            }
 
             await CacheTrees(context);
             await CachePublication(publication.Id, context);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
@@ -16,6 +16,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task UpdateMethodology(PublishContext context, Guid methodologyId);
 
-        Task UpdatePublication(PublishContext context, Guid publicationId, string oldSlug);
+        Task UpdatePublication(PublishContext context, Guid publicationId);
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -44,14 +44,16 @@ const MethodologyStatusPage = ({
     setState: setModel,
     isLoading,
   } = useAsyncRetry(async () => {
-    const [summary, canApprove] = await Promise.all([
+    const [summary, canApprove, canMarkAsDraft] = await Promise.all([
       methodologyService.getMethodology(methodologyId),
       permissionService.canApproveMethodology(methodologyId),
+      permissionService.canMarkMethodologyAsDraft(methodologyId),
     ]);
 
     return {
       summary,
       canApprove,
+      canMarkAsDraft,
     };
   }, [methodologyId]);
 
@@ -83,7 +85,8 @@ const MethodologyStatusPage = ({
     toggleForm.off();
   });
 
-  const isEditable = model?.canApprove && model?.summary.status !== 'Approved';
+  const isEditable = model?.canApprove || model?.canMarkAsDraft;
+  const isPublished = model?.summary.published;
 
   return (
     <>
@@ -132,7 +135,10 @@ const MethodologyStatusPage = ({
 
                       <FormFieldRadioGroup<FormValues, MethodologyStatus>
                         legend="Status"
-                        hint="Once approved, the status cannot be reverted."
+                        hint={
+                          isPublished &&
+                          'Once approved, changes will be available to the public immediately.'
+                        }
                         name="status"
                         id={`${formId}-status`}
                         options={[


### PR DESCRIPTION
- Allow BAU users to mark a Methodology as Draft to make further changes after it has already been approved.
- Don't Alter Publication or Methodology slugs if the they are already published.  We shouldn't be updating the slugs as we have no other way to handle redirecting links.