### PR TITLE
EES-1269 Cleanup checkbox/radios and other test keyword cleanup

### DIFF
--- a/src/explore-education-statistics-admin/src/App.tsx
+++ b/src/explore-education-statistics-admin/src/App.tsx
@@ -1,3 +1,6 @@
+// Load app styles first to ensure correct style ordering
+import './App.scss';
+
 import apiAuthorizationRouteList from '@admin/components/api-authorization/ApiAuthorizationRoutes';
 import PageErrorBoundary from '@admin/components/PageErrorBoundary';
 import ProtectedRoute from '@admin/components/ProtectedRoute';
@@ -13,7 +16,6 @@ import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import React, { lazy, Suspense, useEffect } from 'react';
 import { Route, Switch, useHistory } from 'react-router';
 import { BrowserRouter } from 'react-router-dom';
-import './App.scss';
 import PageNotFoundPage from './pages/errors/PageNotFoundPage';
 
 const PrototypeIndexPage = lazy(() =>

--- a/src/explore-education-statistics-common/src/components/DetailsMenu.module.scss
+++ b/src/explore-education-statistics-common/src/components/DetailsMenu.module.scss
@@ -1,16 +1,13 @@
 @import '../../src/styles/govuk-base';
 
 .details {
-  @include govuk-responsive-margin(2, 'bottom');
+  margin-bottom: govuk-spacing(2);
 
   :global(.govuk-details__text) {
-    padding-bottom: govuk-spacing(2);
-    padding-left: govuk-spacing(5);
-    padding-right: 0;
-    padding-top: govuk-spacing(2);
+    padding: govuk-spacing(2) 0 govuk-spacing(2) govuk-spacing(5);
   }
 
-  :global(.govuk-details__text .govuk-details__text) {
+  .details :global(.govuk-details__text) {
     border-left: 0;
   }
 }

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
@@ -326,7 +326,6 @@ describe('createDataSetCategories', () => {
         level: 'localAuthority',
         value: 'barnet',
       },
-      timePeriod: '2014_AY',
     });
 
     expect(dataSet1.value).toBe(2613);
@@ -1120,7 +1119,6 @@ describe('createDataSetCategories', () => {
     expect(JSON.parse(dataSet4Key)).toEqual({
       indicator: 'authorised-absence-sessions',
       filters: ['ethnicity-major-chinese', 'state-funded-primary'],
-      timePeriod: '2015_AY',
       location: {
         level: 'localAuthority',
         value: 'barnsley',

--- a/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
@@ -19,7 +19,6 @@ import parseNumber from '@common/utils/number/parseNumber';
 import camelCase from 'lodash/camelCase';
 import difference from 'lodash/difference';
 import groupBy from 'lodash/groupBy';
-import isEqual from 'lodash/isEqual';
 import orderBy from 'lodash/orderBy';
 
 /**
@@ -222,44 +221,8 @@ function createKeyedDataSets(
 ): DataSetCategory['dataSets'] {
   return dataSets.reduce<DataSetCategory['dataSets']>(
     (acc, [childDataSet, value]) => {
-      const { dataSet, parent } = childDataSet;
-
-      let expandedParent: DataSet = {
-        ...parent,
-      };
-
-      // This part is a little confusing as it's not
-      // particularly clear why we're doing this.
-      //
-      // We're basically trying to figure out if a
-      // data set should use it's parent (or original)
-      // data set's key or not.
-      //
-      // The parent data set may not include the location
-      // or time period, so we have to fill these in
-      // using the current category's filter.
-      // Failing to fill this in, we just fallback to
-      // using the expanded data set with all of its
-      // details filled out.
-      if (filter instanceof LocationFilter) {
-        expandedParent.location = {
-          value: filter.value,
-          level: filter.level,
-        };
-      } else if (filter instanceof TimePeriodFilter) {
-        expandedParent.timePeriod = filter.value;
-      } else {
-        expandedParent = {
-          ...dataSet,
-        };
-      }
-
-      // If we're using the parent key, we don't bother
-      // excluding the groupBy as we want to create a
-      // unique data point in the chart.
-      const key = isEqual(expandedParent, parent)
-        ? generateDataSetKey(parent)
-        : generateDataSetKey(dataSet, filter);
+      const { dataSet } = childDataSet;
+      const key = generateDataSetKey(dataSet, filter);
 
       acc[key] = {
         dataSet,

--- a/src/explore-education-statistics-frontend/src/pages/_app.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 // Import order is important - these should be at the top
 import '@frontend/polyfill';
+import '../styles/_all.scss';
 
 import {
   ApplicationInsightsContextProvider,
@@ -15,7 +16,6 @@ import NextApp, { AppContext, AppProps } from 'next/app';
 import { useRouter } from 'next/router';
 import { parseCookies } from 'nookies';
 import React, { useEffect } from 'react';
-import '../styles/_all.scss';
 
 loadEnv();
 

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -212,9 +212,8 @@ def create_test_topic():
 
 
 def delete_test_topic():
-    assert os.getenv('TEST_TOPIC_ID') is not None
-
-    return admin_request('DELETE', f'/api/topics/{os.getenv("TEST_TOPIC_ID")}')
+    if os.getenv('TEST_TOPIC_ID') is not None:
+        admin_request('DELETE', f'/api/topics/{os.getenv("TEST_TOPIC_ID")}')
 
 
 # Auth not required with general_public tests

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -82,8 +82,8 @@ Select time period
     lists should be equal  ${timePeriodStartList}   ${expectedList}
     lists should be equal  ${timePeriodEndList}   ${expectedList}
 
-    user selects start date    2005
-    user selects end date      2020
+    user selects from list by label  id:timePeriodForm-start  2005
+    user selects from list by label  id:timePeriodForm-end  2020
     user clicks element     id:timePeriodForm-submit
     user waits until page contains heading 2  Choose your filters
     user checks previous table tool step contains  3    Start date    2005

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -56,7 +56,7 @@ Navigate to Manage data blocks tab
 Select subject "UI test subject"
     [Tags]  HappyPath
     user waits until page contains   UI test subject
-    user selects radio    UI test subject
+    user clicks radio    UI test subject
     user clicks element   id:publicationSubjectForm-submit
     user waits until page contains heading 2   Choose locations
     user checks previous table tool step contains  1    Subject     UI test subject

--- a/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
+++ b/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
@@ -30,7 +30,7 @@ Go to Create publication page for "UI tests topic" topic
 Selects no methodology
     [Tags]  HappyPath
     user waits until page contains element   xpath://label[text()="No methodology"]
-    user selects radio  No methodology
+    user clicks radio  No methodology
 
 Enters contact details
     [Tags]  HappyPath
@@ -77,7 +77,7 @@ Go to edit publication
 Update publication
     [Tags]  HappyPath
     user enters text into element  id:publicationForm-title  ${PUBLICATION_NAME}
-    user selects radio  Choose an existing methodology
+    user clicks radio  Choose an existing methodology
     user waits until page contains element  xpath://option[text()="${METHODOLOGY_NAME} [Approved]"]
     user selects from list by label  id:publicationForm-methodologyId   ${METHODOLOGY_NAME} [Approved]
     user enters text into element  id:publicationForm-teamName      Special educational needs statistics team
@@ -107,7 +107,7 @@ Create new release
     user waits until page contains element  id:releaseSummaryForm-timePeriodCoverageStartYear
     user selects from list by label  id:releaseSummaryForm-timePeriodCoverage  Spring Term
     user enters text into element  id:releaseSummaryForm-timePeriodCoverageStartYear  2025
-    user clicks element   css:input[data-testid="National Statistics"]
+    user clicks radio  National Statistics
     user clicks button   Create new release
     user waits until page contains title caption  Edit release
     user waits until page contains heading 1  ${PUBLICATION_NAME}
@@ -132,7 +132,7 @@ Edit release summary
     user waits until page contains element  id:releaseSummaryForm-timePeriodCoverageStartYear
     user selects from list by label  id:releaseSummaryForm-timePeriodCoverage  Summer Term
     user enters text into element  id:releaseSummaryForm-timePeriodCoverageStartYear  2026
-    user clicks element   css:input[data-testid="Official Statistics"]
+    user clicks radio  Official Statistics
     user clicks button   Update release summary
 
 Verify updated release summary

--- a/tests/robot-tests/tests/admin/bau/delete_subject.robot
+++ b/tests/robot-tests/tests/admin/bau/delete_subject.robot
@@ -40,7 +40,7 @@ User fills in form
     user selects from list by label  id:releaseSummaryForm-timePeriodCoverage  Tax Year
     user enters text into element  id:releaseSummaryForm-timePeriodCoverageStartYear  2020
 
-    user clicks element   css:[data-testid="Ad Hoc"]
+    user clicks radio  Ad Hoc
 
 Click Create new release button
     [Tags]   HappyPath

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -45,7 +45,7 @@ Go to "Release status" tab
 Submit release for Higher Review
     [Tags]  HappyPath
     user clicks button  Edit release status
-    user clicks element   css:input[data-testid="Ready for higher review"]
+    user clicks radio  Ready for higher review
     user enters text into element  id:releaseStatusForm-internalReleaseNote     Submitted for Higher Review
     user enters text into element  id:releaseStatusForm-nextReleaseDate-month   12
     user enters text into element  id:releaseStatusForm-nextReleaseDate-year    3001
@@ -63,10 +63,10 @@ Approve release
     user clicks button  Edit release status
     user waits until page contains heading 2  Edit release status
 
-    user clicks element   css:input[data-testid="Approved for publication"]
+    user clicks radio   Approved for publication
     user enters text into element   id:releaseStatusForm-internalReleaseNote    Approved for release
 
-    user clicks element  css:input[data-testid="On a specific date"]
+    user clicks radio  On a specific date
     user enters text into element  id:releaseStatusForm-publishScheduled-day    1
     user enters text into element  id:releaseStatusForm-publishScheduled-month  12
     user enters text into element  id:releaseStatusForm-publishScheduled-year   3000
@@ -87,7 +87,7 @@ Verify release status is Approved
 Move release status back to Draft
     [Tags]  HappyPath
     user clicks button  Edit release status
-    user clicks element   css:input[data-testid="In draft"]
+    user clicks radio  In draft
 
     user enters text into element   id:releaseStatusForm-internalReleaseNote    Moved back to draft
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -59,7 +59,7 @@ Navigate to Manage data blocks tab
 Select subject "UI test subject"
     [Tags]  HappyPath
     user waits until page contains   UI test subject
-    user selects radio    UI test subject
+    user clicks radio    UI test subject
     user clicks element   css:#publicationSubjectForm-submit
 
 Select locations
@@ -171,7 +171,7 @@ Select publication in table tool
     [Tags]  HappyPath
     user opens details dropdown    Test theme
     user opens details dropdown    ${TOPIC_NAME}
-    user selects radio      ${PUBLICATION_NAME}
+    user clicks radio      ${PUBLICATION_NAME}
     user clicks element    css:#publicationForm-submit
     user waits until page contains heading 2   Choose a subject
     user checks previous table tool step contains  1    Publication    ${PUBLICATION_NAME}
@@ -179,7 +179,7 @@ Select publication in table tool
 Select subject "UI test subject" in table tool
     [Tags]  HappyPath
     user waits until page contains   UI test subject
-    user selects radio    UI test subject
+    user clicks radio    UI test subject
     user clicks element   css:#publicationSubjectForm-submit
     user waits until page contains heading 2  Choose locations
     user checks previous table tool step contains  2    Subject    UI test subject

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -78,8 +78,8 @@ Select locations
 Select time period
     [Tags]   HappyPath
     user waits until page contains heading 2  Choose time period
-    user selects start date    2005
-    user selects end date      2020
+    user selects from list by label  id:timePeriodForm-start  2005
+    user selects from list by label  id:timePeriodForm-end  2020
     user clicks element     css:#timePeriodForm-submit
 
 Select indicators
@@ -196,8 +196,8 @@ Select locations in table tool
 
 Select time period in table tool
     [Tags]   HappyPath
-    user selects start date    2014
-    user selects end date      2018
+    user selects from list by label  id:timePeriodForm-start  2014
+    user selects from list by label  id:timePeriodForm-end    2018
     user clicks element     css:#timePeriodForm-submit
 
 Select indicators in table tool

--- a/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
@@ -18,14 +18,14 @@ Select "Pupil absence" publication
     [Tags]  HappyPath
     user opens details dropdown    Pupils and schools
     user opens details dropdown    Pupil absence
-    user selects radio      Pupil absence in schools in England
+    user clicks radio      Pupil absence in schools in England
     user clicks element    css:#publicationForm-submit
     user waits until page contains heading 2  Choose a subject
     user checks previous table tool step contains  1   Publication   Pupil absence in schools in England
 
 Select subject "Absence by characteristic"
     [Tags]  HappyPath
-    user selects radio   Absence by characteristic
+    user clicks radio   Absence by characteristic
     user clicks element   css:#publicationSubjectForm-submit
     user waits until page contains heading 2  Choose locations
     user checks previous table tool step contains  2    Subject     Absence by characteristic
@@ -51,18 +51,18 @@ Select Start date and End date
 
 Select Indicators - Authorised absence rate
     [Tags]  HappyPath
-    user selects subheaded indicator checkbox                Absence fields    Authorised absence rate
-    user checks subheaded indicator checkbox is selected     Absence fields    Authorised absence rate
+    user clicks subheaded indicator checkbox                Absence fields    Authorised absence rate
+    user checks subheaded indicator checkbox is checked     Absence fields    Authorised absence rate
 
 Select Indicators - Overall absence rate
     [Tags]  HappyPath
-    user selects subheaded indicator checkbox                Absence fields    Overall absence rate
-    user checks subheaded indicator checkbox is selected     Absence fields    Overall absence rate
+    user clicks subheaded indicator checkbox                Absence fields    Overall absence rate
+    user checks subheaded indicator checkbox is checked     Absence fields    Overall absence rate
 
 Select Indicators - Unauthorised absence rate
     [Tags]  HappyPath
-    user selects subheaded indicator checkbox                Absence fields    Unauthorised absence rate
-    user checks subheaded indicator checkbox is selected     Absence fields    Unauthorised absence rate
+    user clicks subheaded indicator checkbox                Absence fields    Unauthorised absence rate
+    user checks subheaded indicator checkbox is checked     Absence fields    Unauthorised absence rate
 
 Select Characteristics
     [Tags]   HappyPath

--- a/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
@@ -41,8 +41,8 @@ Select Location Country, England
 
 Select Start date and End date
     [Tags]  HappyPath
-    user selects start date     2012/13
-    user selects end date       2015/16
+    user selects from list by label  id:timePeriodForm-start   2012/13
+    user selects from list by label  id:timePeriodForm-end   2015/16
     user clicks element     css:#timePeriodForm-submit
     user waits until page contains heading 2  Choose your filters
     user waits until page contains element   id:filtersForm-indicators

--- a/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
@@ -40,8 +40,8 @@ Select Location Country, England
 
 Select Start date and End date
     [Tags]  HappyPath
-    user selects start date     2013/14
-    user selects end date       2016/17
+    user selects from list by label  id:timePeriodForm-start   2013/14
+    user selects from list by label  id:timePeriodForm-end     2016/17
     user clicks element     css:#timePeriodForm-submit
     user waits until page contains heading 2  Choose your filters
     user waits until page contains element   id:filtersForm-indicators
@@ -105,8 +105,8 @@ Select locations LAs Barnet, Barnsley, Bedford
 
 Select new start and end date
     [Tags]   HappyPath
-    user selects start date     2014/15
-    user selects end date       2015/16
+    user selects from list by label  id:timePeriodForm-start   2014/15
+    user selects from list by label  id:timePeriodForm-end     2015/16
     user clicks element     css:#timePeriodForm-submit
     user waits until page contains heading 2  Choose your filters
     user waits until page contains element   id:filtersForm-indicators

--- a/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
@@ -18,14 +18,14 @@ Select "Pupil absence" publication
     [Tags]  HappyPath
     user opens details dropdown    Pupils and schools
     user opens details dropdown    Pupil absence
-    user selects radio      Pupil absence in schools in England
+    user clicks radio      Pupil absence in schools in England
     user clicks element    css:#publicationForm-submit
     user waits until page contains heading 2  Choose a subject
     user checks previous table tool step contains  1   Publication   Pupil absence in schools in England
 
 Select subject "Absence in prus"
     [Tags]  HappyPath
-    user selects radio   Absence in prus
+    user clicks radio   Absence in prus
     user clicks element   css:#publicationSubjectForm-submit
     user waits until page contains heading 2  Choose locations
     user checks previous table tool step contains  2    Subject     Absence in prus
@@ -50,7 +50,8 @@ Select Start date and End date
 
 Select Indicators
     [Tags]  HappyPath
-    user selects subheaded indicator checkbox   Absence fields        Number of schools
+    user clicks subheaded indicator checkbox   Absence fields        Number of schools
+    user checks subheaded indicator checkbox is checked   Absence fields        Number of schools
 
 Create table
     [Tags]  HappyPath
@@ -115,17 +116,17 @@ Select new start and end date
 
 Select indicator Number of pupil enrolments
     [Tags]   HappyPath
-    user selects subheaded indicator checkbox  Absence fields   Number of pupil enrolments
-    user checks subheaded indicator checkbox is selected  Absence fields  Number of pupil enrolments
+    user clicks subheaded indicator checkbox  Absence fields   Number of pupil enrolments
+    user checks subheaded indicator checkbox is checked  Absence fields  Number of pupil enrolments
 
 Select indicator Number of sessions available
     [Tags]   HappyPath
-    user selects subheaded indicator checkbox  Absence fields   Number of sessions possible
-    user checks subheaded indicator checkbox is selected  Absence fields  Number of sessions possible
+    user clicks subheaded indicator checkbox  Absence fields   Number of sessions possible
+    user checks subheaded indicator checkbox is checked  Absence fields  Number of sessions possible
 
 Verify indicator Number of schools is still selected
     [Tags]   HappyPath
-    user checks subheaded indicator checkbox is selected  Absence fields  Number of schools
+    user checks subheaded indicator checkbox is checked  Absence fields  Number of schools
 
 Create table again
     [Tags]   HappyPath

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -45,8 +45,8 @@ Select Locations LA, Bury, Sheffield, York
 
 Select Start date and End date
     [Tags]  HappyPath
-    user selects start date     2006/07
-    user selects end date       2008/09
+    user selects from list by label  id:timePeriodForm-start   2006/07
+    user selects from list by label  id:timePeriodForm-end     2008/09
     user clicks element     css:#timePeriodForm-submit
     user waits until page contains heading 2  Choose your filters
     user waits until page contains element   id:filtersForm-indicators

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -18,14 +18,14 @@ Select Exclusions publication
     [Tags]  HappyPath
     user opens details dropdown    Pupils and schools
     user opens details dropdown    Exclusions
-    user selects radio      Permanent and fixed-period exclusions in England
+    user clicks radio      Permanent and fixed-period exclusions in England
     user clicks element    css:#publicationForm-submit
     user waits until page contains heading 2  Choose a subject
     user checks previous table tool step contains  1   Publication   Permanent and fixed-period exclusions in England
 
 Select subject "Exclusions by geographic level"
     [Tags]  HappyPath
-    user selects radio   Exclusions by geographic level
+    user clicks radio   Exclusions by geographic level
     user clicks element   css:#publicationSubjectForm-submit
     user waits until page contains heading 2  Choose locations
     user checks previous table tool step contains  2    Subject     Exclusions by geographic level
@@ -56,17 +56,17 @@ Select Start date and End date
 Select Indicator - Number of pupils
     [Tags]  HappyPath
     user clicks indicator checkbox  Number of pupils
-    user checks indicator checkbox is selected  Number of pupils
+    user checks indicator checkbox is checked  Number of pupils
 
 Select Indicator - Number of permanent exclusions
     [Tags]  HappyPath
     user clicks indicator checkbox  Number of permanent exclusions
-    user checks indicator checkbox is selected  Number of permanent exclusions
+    user checks indicator checkbox is checked  Number of permanent exclusions
 
 Select Indicator - Number of fixed period exclusions
     [Tags]  HappyPath
     user clicks indicator checkbox  Number of fixed period exclusions
-    user checks indicator checkbox is selected  Number of fixed period exclusions
+    user checks indicator checkbox is checked  Number of fixed period exclusions
 
 Select Characteristics
     [Tags]   HappyPath
@@ -99,7 +99,7 @@ Validate Bury Number of fixed period exclusions row
 
 User generates a permanent link
     [Tags]   HappyPath
-    user clicks element    xpath://*[text()="Generate permanent link"]
+    user clicks button    Generate permanent link
     user waits until page contains element   xpath://a[text()="View permanent link"]   60
     user checks generated permalink is valid
 

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -57,7 +57,7 @@ user creates publication
     user waits until page contains heading 1  Create new publication
     user waits until page contains element  id:publicationForm-title
     user enters text into element  id:publicationForm-title   ${title}
-    user selects radio     No methodology
+    user clicks radio     No methodology
     user enters text into element  id:publicationForm-teamName        Attainment statistics team
     user enters text into element  id:publicationForm-teamEmail       Attainment.STATISTICS@education.gov.uk
     user enters text into element  id:publicationForm-contactName     Tingting Shu
@@ -72,7 +72,7 @@ User creates release for publication
     user waits until page contains element  id:releaseSummaryForm-timePeriodCoverage
     user selects from list by label  id:releaseSummaryForm-timePeriodCoverage  ${time_period_coverage}
     user enters text into element  id:releaseSummaryForm-timePeriodCoverageStartYear  ${start_year}
-    user selects radio   National Statistics
+    user clicks radio   National Statistics
     user clicks button  Create new release
     user waits until page contains element  xpath://span[text()="Edit release"]
     user waits until page contains heading 2  Release summary
@@ -112,7 +112,7 @@ user approves methodology
     user clicks link  Release status
     user clicks button  Edit status
     user waits until page contains heading 2  Edit methodology status
-    user selects radio  Approved for publication
+    user clicks radio  Approved for publication
     user enters text into element  id:methodologyStatusForm-internalReleaseNote  Test release note
     user clicks button  Update status
 

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -250,15 +250,15 @@ user checks page contains tag
 
 user waits until page contains heading 1
   [Arguments]   ${text}  ${wait}=${timeout}
-  user waits until page contains element  xpath://h1[text()="${text}"]  ${wait}
+  user waits until element is visible  xpath://h1[text()="${text}"]  ${wait}
 
 user waits until page contains heading 2
   [Arguments]   ${text}  ${wait}=${timeout}
-  wait until element is visible  xpath://h2[text()="${text}"]   timeout=${wait}
+  user waits until element is visible  xpath://h2[text()="${text}"]  ${wait}
 
 user waits until page contains heading 3
   [Arguments]   ${text}  ${wait}=${timeout}
-  user waits until page contains element  xpath://h3[text()="${text}"]  ${wait}
+  user waits until element is visible  xpath://h3[text()="${text}"]  ${wait}
 
 user waits until page contains title
   [Arguments]   ${text}  ${wait}=${timeout}

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -163,14 +163,6 @@ user checks element is not visible
   [Arguments]   ${element}
   element should not be visible   ${element}
 
-user checks checkbox is selected
-  [Arguments]    ${checkbox}
-  checkbox should be selected   ${checkbox}
-
-user checks checkbox is not selected
-  [Arguments]    ${checkbox}
-  checkbox should not be selected   ${checkbox}
-
 user waits until element is enabled
   [Arguments]   ${element}
   wait until element is enabled   ${element}
@@ -216,7 +208,6 @@ user clicks element
     [Arguments]     ${element}
     wait until page contains element  ${element}
     user scrolls to element  ${element}
-    set focus to element    ${element}
     wait until element is enabled   ${element}
     click element   ${element}
 
@@ -364,29 +355,60 @@ user waits until page contains key stat tile
   [Arguments]  ${title}   ${value}   ${wait}=${timeout}
   user waits until page contains element   xpath://*[@data-testid="keyStatTile-title" and text()="${title}"]/../*[@data-testid="keyStatTile-value" and text()="${value}"]    ${wait}
 
+user clicks radio
+    [Arguments]  ${label}
+    user clicks element  xpath://label[text()="${label}"]/../input[@type="radio"]
+
+user checks radio is checked
+    [Arguments]  ${label}
+    user checks page contains element  xpath://label[text()="${label}"]/../input[@type="radio" and @checked]
+
+user clicks checkbox
+    [Arguments]  ${label}
+    user clicks element  xpath://label[text()="${label}" or strong[text()="${label}"]]/../input[@type="checkbox"]
+
+user checks checkbox is checked
+    [Arguments]    ${label}
+    user checks checkbox input is checked  xpath://label[text()="${label}" or strong[text()="${label}"]]/../input[@type="checkbox"]
+
+user checks checkbox is not checked
+    [Arguments]    ${label}
+    user checks checkbox input is not checked  xpath://label[text()="${label}" or strong[text()="${label}"]]/../input[@type="checkbox"]
+
+user checks checkbox input is checked
+    [Arguments]    ${selector}
+    user waits until page contains element  ${selector}
+    checkbox should be selected   ${selector}
+
+user checks checkbox input is not checked
+    [Arguments]    ${selector}
+    user waits until page contains element  ${selector}
+    checkbox should not be selected   ${selector}
+
 user clicks indicator checkbox
     [Arguments]  ${indicator_label}
-    wait until page contains element  xpath://*[@id="filtersForm-indicators"]//label[text()="${indicator_label}"]/../input
-    page should contain checkbox  xpath://*[@id="filtersForm-indicators"]//label[text()="${indicator_label}"]/../input
-    user scrolls to element   xpath://*[@id="filtersForm-indicators"]//label[text()="${indicator_label}"]/../input
-    wait until element is enabled   xpath://*[@id="filtersForm-indicators"]//label[text()="${indicator_label}"]/../input
-    user clicks element     xpath://*[@id="filtersForm-indicators"]//label[text()="${indicator_label}"]/../input
+    user clicks element  xpath://*[@id="filtersForm-indicators"]//label[text()="${indicator_label}"]
 
-user selects subheaded indicator checkbox
+user checks indicator checkbox is checked
+    [Arguments]  ${indicator_label}
+    user checks checkbox input is checked  xpath://*[@id="filtersForm-indicators"]//label[contains(text(), "${indicator_label}")]/../input[@type="checkbox"]
+
+user clicks subheaded indicator checkbox
     [Arguments]  ${subheading_label}   ${indicator_label}
-    wait until page contains element  xpath://*[@id="filtersForm-indicators"]//legend[text()="${subheading_label}"]/..//label[text()="${indicator_label}"]/../input
-    page should contain checkbox   xpath://*[@id="filtersForm-indicators"]//legend[text()="${subheading_label}"]/..//label[text()="${indicator_label}"]/../input
-    user scrolls to element  xpath://*[@id="filtersForm-indicators"]//legend[text()="${subheading_label}"]/..//label[text()="${indicator_label}"]/../input
-    checkbox should not be selected   xpath://*[@id="filtersForm-indicators"]//legend[text()="${subheading_label}"]/..//label[text()="${indicator_label}"]/../input
-    wait until element is enabled   xpath://*[@id="filtersForm-indicators"]//legend[text()="${subheading_label}"]/..//label[text()="${indicator_label}"]/../input
-    user clicks element   xpath://*[@id="filtersForm-indicators"]//legend[text()="${subheading_label}"]/..//label[text()="${indicator_label}"]/../input
+    user clicks element  xpath://*[@id="filtersForm-indicators"]//legend[text()="${subheading_label}"]/..//label[text()="${indicator_label}"]/../input[@type="checkbox"]
 
-user checks indicator checkbox is selected
-  [Arguments]  ${indicator_label}
-  wait until element is enabled   xpath://*[@id="filtersForm-indicators"]//label[contains(text(), "${indicator_label}")]/../input
-  checkbox should be selected     xpath://*[@id="filtersForm-indicators"]//label[contains(text(), "${indicator_label}")]/../input
+user checks subheaded indicator checkbox is checked
+    [Arguments]  ${subheading_label}  ${indicator_label}
+    user checks checkbox input is checked  xpath://*[@id="filtersForm-indicators"]//legend[text()="${subheading_label}"]/..//label[text()="${indicator_label}"]/../input[@type="checkbox"]
 
-user checks subheaded indicator checkbox is selected
-  [Arguments]  ${subheading_label}  ${indicator_label}
-  wait until element is enabled   xpath://*[@id="filtersForm-indicators"]//legend[text()="${subheading_label}"]/..//label[text()="${indicator_label}"]/../input
-  checkbox should be selected     xpath://*[@id="filtersForm-indicators"]//legend[text()="${subheading_label}"]/..//label[text()="${indicator_label}"]/../input
+user clicks category checkbox
+    [Arguments]  ${subheading_label}  ${category_label}
+    user clicks element  xpath://legend[text()="${subheading_label}"]/..//label[text()="${category_label}"]/../input[@type="checkbox"]
+
+user checks category checkbox is checked
+    [Arguments]  ${subheading_label}  ${category_label}
+    user checks checkbox input is checked  xpath://legend[text()="${subheading_label}"]/..//label[text()="${category_label}"]/../input[@type="checkbox"]
+
+user clicks select all for category
+    [Arguments]  ${category_label}
+    user clicks element  xpath://legend[text()="{category_label}"]/..//button[contains(text(), "Select")]

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -364,14 +364,6 @@ user waits until page contains key stat tile
   [Arguments]  ${title}   ${value}   ${wait}=${timeout}
   user waits until page contains element   xpath://*[@data-testid="keyStatTile-title" and text()="${title}"]/../*[@data-testid="keyStatTile-value" and text()="${value}"]    ${wait}
 
-user selects start date
-  [Arguments]  ${start_date}
-  select from list by label   css:#timePeriodForm-start   ${start_date}
-
-user selects end date
-  [Arguments]  ${end_date}
-  select from list by label   css:#timePeriodForm-end   ${end_date}
-
 user clicks indicator checkbox
     [Arguments]  ${indicator_label}
     wait until page contains element  xpath://*[@id="filtersForm-indicators"]//label[text()="${indicator_label}"]/../input

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -192,22 +192,6 @@ def user_closes_details_dropdown(exact_details_text):
         raise_assertion_error(f'Details component "{exact_details_text}" is still expanded!')
 
 
-def user_selects_radio(radio_label):
-    sl.driver.find_element_by_xpath(f'//label[text()="{radio_label}"]').click()
-
-
-def user_checks_radio_is_checked(radio_label):
-    try:
-        sl.driver.find_element_by_css_selector(f'input[data-testid="{radio_label}"][checked]')
-    except NoSuchElementException:
-        raise_assertion_error('Unable to find checked radio!')
-
-
-def user_clicks_checkbox(checkbox_label):
-    sl.page_should_contain_checkbox(f'//label[text()="{checkbox_label}" or strong[text()="{checkbox_label}"]]/../input')
-    sl.driver.find_element_by_xpath(f'//label[text()="{checkbox_label}" or strong[text()="{checkbox_label}"]]/../input').click()
-
-
 def capture_large_screenshot():
     currentWindow = sl.get_window_size()
     page_height = sl.driver.execute_script(
@@ -235,21 +219,6 @@ def user_checks_previous_table_tool_step_contains(step, key, value, timeout=10):
     except:
         raise_assertion_error(
             f'Element "#tableToolWizard-step-{step}" containing "{key}" and "{value}" not found!')
-
-
-def user_clicks_category_checkbox(subheading_label, category_label):
-    sl.driver.find_element_by_xpath(
-        f'//legend[text()="{subheading_label}"]/..//label[text()="{category_label}"]').click()
-
-
-def user_checks_category_checkbox_is_selected(subheading_label, category_label):
-    sl.checkbox_should_be_selected(
-        f'xpath://legend[text()="{subheading_label}"]/..//label[text()="{category_label}"]/../input')
-
-
-def user_clicks_select_all_for_category(category_label):
-    sl.driver.find_element_by_xpath(
-        f'//legend[text()="{category_label}"]/..//button[contains(text(),"Select")]').click()
 
 
 def user_checks_results_table_column_heading_contains(table_selector, row, column, expected,


### PR DESCRIPTION
This PR:

- Refactors and cleans up checkbox/radio keywords:
  - Adds additional keywords to cover clicking and checking the checked/unchecked checkbox/radio state. Some of this has been moved out of `utilities.py` into `common.robot`.
  - Makes use of more lower-level keywords instead of relying on copy-pasta.
  - Adds stricter checks on `input` type being checkbox or radio.
- Removes `user selects start/end date` keywords as these are far too specific to the time period form in table tool.

## Other changes

- Fixes data data set categories being incorrectly generated when there is only grouping filter.
- Fixes incorrect style import order causing incorrect styling of things like the `DetailsMenu` component.