### PR TITLE
EES-357 Remove chart definition constants in favour of defaults

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/reducers/__tests__/chartBuilderReducer.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/reducers/__tests__/chartBuilderReducer.test.ts
@@ -145,41 +145,6 @@ describe('chartBuilderReducer', () => {
       });
     });
 
-    test('overrides `options` if definition has constants', () => {
-      const initialStateWithOptions: ChartBuilderState = {
-        ...initialState,
-        options: {
-          height: 400,
-          title: 'Some title',
-          alt: 'Some alt',
-          legend: 'bottom',
-        },
-      };
-
-      const testChartDefinitionWithConstants = {
-        ...testChartDefinition,
-        options: {
-          defaults: testChartDefinition.options.defaults,
-          constants: {
-            height: 600,
-            legend: 'top',
-          },
-        },
-      };
-
-      const nextState = produce(chartBuilderReducer)(initialStateWithOptions, {
-        type: 'UPDATE_CHART_DEFINITION',
-        payload: testChartDefinitionWithConstants,
-      } as ChartBuilderActions);
-
-      expect(nextState.options).toEqual<ChartOptions>({
-        height: 600,
-        title: 'Some title',
-        alt: 'Some alt',
-        legend: 'top',
-      });
-    });
-
     test('sets `axes` with defaults', () => {
       const nextState = produce(chartBuilderReducer)(initialState, {
         type: 'UPDATE_CHART_DEFINITION',
@@ -253,45 +218,6 @@ describe('chartBuilderReducer', () => {
       expect(nextState.axes.minor).toMatchObject<Partial<AxisConfiguration>>({
         sortBy: 'something else',
         visible: false,
-      });
-    });
-
-    test('overrides `axes` options if definition has constants', () => {
-      const testChartDefinitionWithConstants: ChartDefinition = {
-        ...testChartDefinition,
-        axes: {
-          ...testChartDefinition.axes,
-          major: {
-            ...testChartDefinition.axes.major,
-            constants: {
-              visible: true,
-              sortBy: 'overriding value',
-            },
-          } as ChartDefinition['axes']['major'],
-        },
-      };
-
-      const initialStateWithAxes: ChartBuilderState = {
-        ...initialState,
-        axes: {
-          major: {
-            type: 'major',
-            dataSets: [],
-            referenceLines: [],
-            visible: false,
-            sortBy: 'override me',
-          },
-        },
-      };
-
-      const nextState = produce(chartBuilderReducer)(initialStateWithAxes, {
-        type: 'UPDATE_CHART_DEFINITION',
-        payload: testChartDefinitionWithConstants,
-      } as ChartBuilderActions);
-
-      expect(nextState.axes.major).toMatchObject<Partial<AxisConfiguration>>({
-        sortBy: 'overriding value',
-        visible: true,
       });
     });
 
@@ -384,42 +310,6 @@ describe('chartBuilderReducer', () => {
         label: {
           text: 'Some label',
         },
-      });
-    });
-
-    test('does not override chart definition constants', () => {
-      const initialStateWithConstants: ChartBuilderState = {
-        ...initialState,
-        definition: {
-          ...testChartDefinition,
-          axes: {
-            ...testChartDefinition.axes,
-            major: {
-              ...testChartDefinition.axes.major,
-              constants: {
-                groupBy: 'filters',
-                visible: true,
-              },
-            },
-          },
-        } as ChartDefinition,
-      };
-
-      const nextState = produce(chartBuilderReducer)(
-        initialStateWithConstants,
-        {
-          type: 'UPDATE_CHART_AXIS',
-          payload: {
-            type: 'major',
-            groupBy: 'indicators',
-            visible: false,
-          },
-        } as ChartBuilderActions,
-      );
-
-      expect(nextState.axes.major).toMatchObject<Partial<AxisConfiguration>>({
-        groupBy: 'filters',
-        visible: true,
       });
     });
 
@@ -538,43 +428,6 @@ describe('chartBuilderReducer', () => {
         legend: 'top',
         title: '',
         alt: '',
-      });
-    });
-
-    test('overrides `options` with chart definition constants', () => {
-      const initialStateWithConstants: ChartBuilderState = {
-        ...initialState,
-        definition: {
-          ...testChartDefinition,
-          options: {
-            ...testChartDefinition.options,
-            constants: {
-              height: 400,
-              title: 'overrides title',
-              alt: 'overrides alt',
-              legend: 'bottom',
-            },
-          },
-        } as ChartDefinition,
-      };
-
-      const nextState = produce(chartBuilderReducer)(
-        initialStateWithConstants,
-        {
-          type: 'UPDATE_CHART_OPTIONS',
-          payload: {
-            height: 500,
-            legend: 'top',
-            title: 'override me',
-          },
-        } as ChartBuilderActions,
-      );
-
-      expect(nextState.options).toEqual<ChartOptions>({
-        height: 400,
-        title: 'overrides title',
-        alt: 'overrides alt',
-        legend: 'bottom',
       });
     });
   });

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/reducers/chartBuilderReducer.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/reducers/chartBuilderReducer.ts
@@ -100,7 +100,6 @@ const updateAxis = (
       (axisDefinition.defaults ?? {}) as Partial<AxisConfiguration>,
       current,
       next,
-      (axisDefinition.constants ?? {}) as Partial<AxisConfiguration>,
       {
         // Ensure `type` will not be unset
         // by one of the previous objects.
@@ -196,7 +195,6 @@ export const chartBuilderReducer: Reducer<
         ...defaultOptions,
         ...(action.payload.options.defaults ?? {}),
         ...draft.options,
-        ...(action.payload.options.constants ?? {}),
       };
 
       draft.axes = mapValues(
@@ -253,7 +251,6 @@ export const chartBuilderReducer: Reducer<
         ...(draft?.definition?.options.defaults ?? {}),
         ...draft.options,
         ...action.payload,
-        ...(draft?.definition?.options.constants ?? {}),
       };
 
       break;

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.tsx
@@ -62,7 +62,7 @@ export const mapBlockDefinition: ChartDefinition = {
       capabilities: {
         canRotateLabel: false,
       },
-      constants: {
+      defaults: {
         groupBy: 'locations',
       },
     },

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -107,7 +107,6 @@ export interface ChartDefinition {
   capabilities: ChartCapabilities;
   options: {
     defaults?: Partial<ChartDefinitionOptions>;
-    constants?: Partial<ChartDefinitionOptions>;
   };
   data: {
     type: string;
@@ -131,7 +130,6 @@ export interface ChartDefinitionAxis {
   hide?: boolean;
   capabilities: ChartDefinitionAxisCapabilities;
   defaults?: NestedPartial<AxisConfiguration>;
-  constants?: NestedPartial<AxisConfiguration>;
 }
 
 export const chartDefinitions: ChartDefinition[] = [


### PR DESCRIPTION
Currently chart definitions allow you to specify constant values that will always be set in the current chart/axes options. Whilst this was a nice idea on paper, this causes issues when trying to swap between charts.

We've specifically found that changing from/to a map chart causes the `groupBy` option to be forced to 'locations'. This isn't a major problem but doesn't make a very nice user experience as the user will most likely not want this groupBy.

Instead of defining constants in the chart, we can just set these in the chart component itself. For exmaple, we are already doing this in `MapBlockInternal` to force the `groupBy` to 'locations'.