### PR TITLE
EES-1271 Fix prerelease window start/end time assertions for all timezones

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ requests = "==2.21.0"
 python-dotenv = "==0.13.0"
 robotframework-pabot = "~=1.8"
 pyderman = "~=2.0"
+pytz = "~=2020.1"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bac04d5126f13cf49ffa8c20f46f81713a7ba84d3f23df4ef68910fcd1f795c3"
+            "sha256": "9463e5fc81849c791f606064461791b7e03f6add316c6bd0f3b8c5bbe046130b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,10 +18,10 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
-                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
             ],
-            "version": "==2020.4.5.1"
+            "version": "==2020.6.20"
         },
         "chardet": {
             "hashes": [
@@ -52,6 +52,14 @@
             "index": "pypi",
             "version": "==0.13.0"
         },
+        "pytz": {
+            "hashes": [
+                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
+                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
+            ],
+            "index": "pypi",
+            "version": "==2020.1"
+        },
         "requests": {
             "hashes": [
                 "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
@@ -69,10 +77,10 @@
         },
         "robotframework-pabot": {
             "hashes": [
-                "sha256:dbae4340159875026540f6456922a5893431701cbbc2d165b6b24661e2ca665c"
+                "sha256:966118780eb1b2fe2455750c2bccfa2491cae14625c859de91008771486e714c"
             ],
             "index": "pypi",
-            "version": "==1.8.0"
+            "version": "==1.8.1"
         },
         "robotframework-seleniumlibrary": {
             "hashes": [
@@ -123,43 +131,43 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
-                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+                "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3",
+                "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"
             ],
-            "version": "==2020.4.5.1"
+            "version": "==2020.6.20"
         },
         "cffi": {
             "hashes": [
-                "sha256:001bf3242a1bb04d985d63e138230802c6c8d4db3668fb545fb5005ddf5bb5ff",
-                "sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b",
-                "sha256:028a579fc9aed3af38f4892bdcc7390508adabc30c6af4a6e4f611b0c680e6ac",
-                "sha256:14491a910663bf9f13ddf2bc8f60562d6bc5315c1f09c704937ef17293fb85b0",
-                "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384",
-                "sha256:2089ed025da3919d2e75a4d963d008330c96751127dd6f73c8dc0c65041b4c26",
-                "sha256:2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6",
-                "sha256:337d448e5a725bba2d8293c48d9353fc68d0e9e4088d62a9571def317797522b",
-                "sha256:399aed636c7d3749bbed55bc907c3288cb43c65c4389964ad5ff849b6370603e",
-                "sha256:3b911c2dbd4f423b4c4fcca138cadde747abdb20d196c4a48708b8a2d32b16dd",
-                "sha256:3d311bcc4a41408cf5854f06ef2c5cab88f9fded37a3b95936c9879c1640d4c2",
-                "sha256:62ae9af2d069ea2698bf536dcfe1e4eed9090211dbaafeeedf5cb6c41b352f66",
-                "sha256:66e41db66b47d0d8672d8ed2708ba91b2f2524ece3dee48b5dfb36be8c2f21dc",
-                "sha256:675686925a9fb403edba0114db74e741d8181683dcf216be697d208857e04ca8",
-                "sha256:7e63cbcf2429a8dbfe48dcc2322d5f2220b77b2e17b7ba023d6166d84655da55",
-                "sha256:8a6c688fefb4e1cd56feb6c511984a6c4f7ec7d2a1ff31a10254f3c817054ae4",
-                "sha256:8c0ffc886aea5df6a1762d0019e9cb05f825d0eec1f520c51be9d198701daee5",
-                "sha256:95cd16d3dee553f882540c1ffe331d085c9e629499ceadfbda4d4fde635f4b7d",
-                "sha256:99f748a7e71ff382613b4e1acc0ac83bf7ad167fb3802e35e90d9763daba4d78",
-                "sha256:b8c78301cefcf5fd914aad35d3c04c2b21ce8629b5e4f4e45ae6812e461910fa",
-                "sha256:c420917b188a5582a56d8b93bdd8e0f6eca08c84ff623a4c16e809152cd35793",
-                "sha256:c43866529f2f06fe0edc6246eb4faa34f03fe88b64a0a9a942561c8e22f4b71f",
-                "sha256:cab50b8c2250b46fe738c77dbd25ce017d5e6fb35d3407606e7a4180656a5a6a",
-                "sha256:cef128cb4d5e0b3493f058f10ce32365972c554572ff821e175dbc6f8ff6924f",
-                "sha256:cf16e3cf6c0a5fdd9bc10c21687e19d29ad1fe863372b5543deaec1039581a30",
-                "sha256:e56c744aa6ff427a607763346e4170629caf7e48ead6921745986db3692f987f",
-                "sha256:e577934fc5f8779c554639376beeaa5657d54349096ef24abe8c74c5d9c117c3",
-                "sha256:f2b0fa0c01d8a0c7483afd9f31d7ecf2d71760ca24499c8697aeb5ca37dc090c"
+                "sha256:0da50dcbccd7cb7e6c741ab7912b2eff48e85af217d72b57f80ebc616257125e",
+                "sha256:12a453e03124069b6896107ee133ae3ab04c624bb10683e1ed1c1663df17c13c",
+                "sha256:15419020b0e812b40d96ec9d369b2bc8109cc3295eac6e013d3261343580cc7e",
+                "sha256:15a5f59a4808f82d8ec7364cbace851df591c2d43bc76bcbe5c4543a7ddd1bf1",
+                "sha256:23e44937d7695c27c66a54d793dd4b45889a81b35c0751ba91040fe825ec59c4",
+                "sha256:29c4688ace466a365b85a51dcc5e3c853c1d283f293dfcc12f7a77e498f160d2",
+                "sha256:57214fa5430399dffd54f4be37b56fe22cedb2b98862550d43cc085fb698dc2c",
+                "sha256:577791f948d34d569acb2d1add5831731c59d5a0c50a6d9f629ae1cefd9ca4a0",
+                "sha256:6539314d84c4d36f28d73adc1b45e9f4ee2a89cdc7e5d2b0a6dbacba31906798",
+                "sha256:65867d63f0fd1b500fa343d7798fa64e9e681b594e0a07dc934c13e76ee28fb1",
+                "sha256:672b539db20fef6b03d6f7a14b5825d57c98e4026401fce838849f8de73fe4d4",
+                "sha256:6843db0343e12e3f52cc58430ad559d850a53684f5b352540ca3f1bc56df0731",
+                "sha256:7057613efefd36cacabbdbcef010e0a9c20a88fc07eb3e616019ea1692fa5df4",
+                "sha256:76ada88d62eb24de7051c5157a1a78fd853cca9b91c0713c2e973e4196271d0c",
+                "sha256:837398c2ec00228679513802e3744d1e8e3cb1204aa6ad408b6aff081e99a487",
+                "sha256:8662aabfeab00cea149a3d1c2999b0731e70c6b5bac596d95d13f643e76d3d4e",
+                "sha256:95e9094162fa712f18b4f60896e34b621df99147c2cee216cfa8f022294e8e9f",
+                "sha256:99cc66b33c418cd579c0f03b77b94263c305c389cb0c6972dac420f24b3bf123",
+                "sha256:9b219511d8b64d3fa14261963933be34028ea0e57455baf6781fe399c2c3206c",
+                "sha256:ae8f34d50af2c2154035984b8b5fc5d9ed63f32fe615646ab435b05b132ca91b",
+                "sha256:b9aa9d8818c2e917fa2c105ad538e222a5bce59777133840b93134022a7ce650",
+                "sha256:bf44a9a0141a082e89c90e8d785b212a872db793a0080c20f6ae6e2a0ebf82ad",
+                "sha256:c0b48b98d79cf795b0916c57bebbc6d16bb43b9fc9b8c9f57f4cf05881904c75",
+                "sha256:da9d3c506f43e220336433dffe643fbfa40096d408cb9b7f2477892f369d5f82",
+                "sha256:e4082d832e36e7f9b2278bc774886ca8207346b99f278e54c9de4834f17232f7",
+                "sha256:e4b9b7af398c32e408c00eb4e0d33ced2f9121fd9fb978e6c1b57edd014a7d15",
+                "sha256:e613514a82539fc48291d01933951a13ae93b6b444a88782480be32245ed4afa",
+                "sha256:f5033952def24172e60493b68717792e3aebb387a8d186c43c020d9363ee7281"
             ],
-            "version": "==1.14.0"
+            "version": "==1.14.2"
         },
         "chardet": {
             "hashes": [
@@ -170,28 +178,28 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:091d31c42f444c6f519485ed528d8b451d1a0c7bf30e8ca583a0cac44b8a0df6",
-                "sha256:18452582a3c85b96014b45686af264563e3e5d99d226589f057ace56196ec78b",
-                "sha256:1dfa985f62b137909496e7fc182dac687206d8d089dd03eaeb28ae16eec8e7d5",
-                "sha256:1e4014639d3d73fbc5ceff206049c5a9a849cefd106a49fa7aaaa25cc0ce35cf",
-                "sha256:22e91636a51170df0ae4dcbd250d318fd28c9f491c4e50b625a49964b24fe46e",
-                "sha256:3b3eba865ea2754738616f87292b7f29448aec342a7c720956f8083d252bf28b",
-                "sha256:651448cd2e3a6bc2bb76c3663785133c40d5e1a8c1a9c5429e4354201c6024ae",
-                "sha256:726086c17f94747cedbee6efa77e99ae170caebeb1116353c6cf0ab67ea6829b",
-                "sha256:844a76bc04472e5135b909da6aed84360f522ff5dfa47f93e3dd2a0b84a89fa0",
-                "sha256:88c881dd5a147e08d1bdcf2315c04972381d026cdb803325c03fe2b4a8ed858b",
-                "sha256:96c080ae7118c10fcbe6229ab43eb8b090fccd31a09ef55f83f690d1ef619a1d",
-                "sha256:a0c30272fb4ddda5f5ffc1089d7405b7a71b0b0f51993cb4e5dbb4590b2fc229",
-                "sha256:bb1f0281887d89617b4c68e8db9a2c42b9efebf2702a3c5bf70599421a8623e3",
-                "sha256:c447cf087cf2dbddc1add6987bbe2f767ed5317adb2d08af940db517dd704365",
-                "sha256:c4fd17d92e9d55b84707f4fd09992081ba872d1a0c610c109c18e062e06a2e55",
-                "sha256:d0d5aeaedd29be304848f1c5059074a740fa9f6f26b84c5b63e8b29e73dfc270",
-                "sha256:daf54a4b07d67ad437ff239c8a4080cfd1cc7213df57d33c97de7b4738048d5e",
-                "sha256:e993468c859d084d5579e2ebee101de8f5a27ce8e2159959b6673b418fd8c785",
-                "sha256:f118a95c7480f5be0df8afeb9a11bd199aa20afab7a96bcf20409b411a3a85f0"
+                "sha256:0c608ff4d4adad9e39b5057de43657515c7da1ccb1807c3a27d4cf31fc923b4b",
+                "sha256:0cbfed8ea74631fe4de00630f4bb592dad564d57f73150d6f6796a24e76c76cd",
+                "sha256:124af7255ffc8e964d9ff26971b3a6153e1a8a220b9a685dc407976ecb27a06a",
+                "sha256:384d7c681b1ab904fff3400a6909261cae1d0939cc483a68bdedab282fb89a07",
+                "sha256:45741f5499150593178fc98d2c1a9c6722df88b99c821ad6ae298eff0ba1ae71",
+                "sha256:4b9303507254ccb1181d1803a2080a798910ba89b1a3c9f53639885c90f7a756",
+                "sha256:4d355f2aee4a29063c10164b032d9fa8a82e2c30768737a2fd56d256146ad559",
+                "sha256:51e40123083d2f946794f9fe4adeeee2922b581fa3602128ce85ff813d85b81f",
+                "sha256:8713ddb888119b0d2a1462357d5946b8911be01ddbf31451e1d07eaa5077a261",
+                "sha256:8e924dbc025206e97756e8903039662aa58aa9ba357d8e1d8fc29e3092322053",
+                "sha256:8ecef21ac982aa78309bb6f092d1677812927e8b5ef204a10c326fc29f1367e2",
+                "sha256:8ecf9400d0893836ff41b6f977a33972145a855b6efeb605b49ee273c5e6469f",
+                "sha256:9367d00e14dee8d02134c6c9524bb4bd39d4c162456343d07191e2a0b5ec8b3b",
+                "sha256:a09fd9c1cca9a46b6ad4bea0a1f86ab1de3c0c932364dbcf9a6c2a5eeb44fa77",
+                "sha256:ab49edd5bea8d8b39a44b3db618e4783ef84c19c8b47286bf05dfdb3efb01c83",
+                "sha256:bea0b0468f89cdea625bb3f692cd7a4222d80a6bdafd6fb923963f2b9da0e15f",
+                "sha256:bec7568c6970b865f2bcebbe84d547c52bb2abadf74cefce396ba07571109c67",
+                "sha256:ce82cc06588e5cbc2a7df3c8a9c778f2cb722f56835a23a68b5a7264726bb00c",
+                "sha256:dea0ba7fe6f9461d244679efa968d215ea1f989b9c1957d7f10c21e5c7c09ad6"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.9.2"
+            "version": "==3.0"
         },
         "docker": {
             "hashes": [

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ManagePublicationsAndReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ManagePublicationsAndReleasesTab.tsx
@@ -110,6 +110,7 @@ const ManagePublicationsAndReleasesTab = () => {
     }
   }, [
     history,
+    location.pathname,
     savedThemeTopic,
     selectedTheme,
     selectedTopic,

--- a/tests/robot-tests/tests/admin/bau/manage_content.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_content.robot
@@ -55,7 +55,7 @@ Add release note to release
     user enters text into element  css:textarea#reason  Test release note one
     user clicks button   Add note
     user opens details dropdown  See all 1 updates  id:releaseLastUpdated
-    ${date}=  get datetime   %d %B %Y
+    ${date}=  get current datetime   %-d %B %Y
     user checks element contains  css:#releaseNotes li:nth-of-type(1) time  ${date}
     user checks element contains  css:#releaseNotes li:nth-of-type(1) p     Test release note one
 

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -52,10 +52,10 @@ Go to "Release status" tab
 
 Approve release and wait for it to be Scheduled
     [Tags]  HappyPath
-    ${day}=         get datetime  %d  2
-    ${month}=       get datetime  %m  2
-    ${month_word}=  get datetime  %B  2
-    ${year}=        get datetime  %Y  2
+    ${day}=         get current datetime  %-d  2
+    ${month}=       get current datetime  %-m  2
+    ${month_word}=  get current datetime  %B  2
+    ${year}=        get current datetime  %Y  2
 
     user clicks button  Edit release status
     user clicks radio   Approved for publication
@@ -89,10 +89,13 @@ Validate prerelease has not started
     user checks breadcrumb count should be   2
     user checks nth breadcrumb contains   1    Home
     user checks nth breadcrumb contains   2    Pre Release access
-    ${day}=         get datetime  %d  1
-    ${month_word}=  get datetime  %B  1
-    ${year}=        get datetime  %Y  1
-    user checks page contains   Pre Release access will be available from ${day} ${month_word} ${year} at 00:00 until ${day} ${month_word} ${year} at 23:59.
+
+    ${day}=         get current datetime  %d   1
+    ${month}=       get current datetime  %m   1
+    ${year}=        get current datetime  %Y   1
+    ${time_start}=  format uk to local datetime  ${year}-${month}-${day}T00:00:00  %-d %B %Y at %H:%M
+    ${time_end}=    format uk to local datetime  ${year}-${month}-${day}T23:59:00  %-d %B %Y at %H:%M
+    user checks page contains   Pre Release access will be available from ${time_start} until ${time_end}.
 
 Navigate to Admin dashboard
     [Tags]  HappyPath
@@ -132,18 +135,20 @@ Validate prerelease has not started for Analyst user
     user checks nth breadcrumb contains   1    Home
     user checks nth breadcrumb contains   2    Pre Release access
 
-    ${day}=         get datetime  %d  1
-    ${month_word}=  get datetime  %B  1
-    ${year}=        get datetime  %Y  1
-    user checks page contains   Pre Release access will be available from ${day} ${month_word} ${year} at 00:00 until ${day} ${month_word} ${year} at 23:59.
+    ${day}=         get current datetime  %d   1
+    ${month}=       get current datetime  %m   1
+    ${year}=        get current datetime  %Y   1
+    ${time_start}=  format uk to local datetime  ${year}-${month}-${day}T00:00:00  %-d %B %Y at %H:%M
+    ${time_end}=    format uk to local datetime  ${year}-${month}-${day}T23:59:00  %-d %B %Y at %H:%M
+    user checks page contains   Pre Release access will be available from ${time_start} until ${time_end}.
 
 Start prerelease
     [Tags]  HappyPath
     user changes to bau1
-    ${day}=         get datetime  %d  1
-    ${month}=       get datetime  %m  1
-    ${month_word}=  get datetime  %B  1
-    ${year}=        get datetime  %Y  1
+    ${day}=         get current datetime  %-d  1
+    ${month}=       get current datetime  %-m  1
+    ${month_word}=  get current datetime  %B  1
+    ${year}=        get current datetime  %Y  1
     user goes to url  ${RELEASE_URL}/status
     user clicks button  Edit release status
     user enters text into element  id:releaseStatusForm-publishScheduled-day    ${day}

--- a/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
@@ -212,10 +212,10 @@ Go to "Release status" tab
 
 Approve release
     [Tags]  HappyPath
-    ${PUBLISH_DATE_DAY}=  get datetime  %d
-    ${PUBLISH_DATE_MONTH}=  get datetime  %m
-    ${PUBLISH_DATE_MONTH_WORD}=  get datetime  %B
-    ${PUBLISH_DATE_YEAR}=  get datetime  %Y
+    ${PUBLISH_DATE_DAY}=  get current datetime  %-d
+    ${PUBLISH_DATE_MONTH}=  get current datetime  %-m
+    ${PUBLISH_DATE_MONTH_WORD}=  get current datetime  %B
+    ${PUBLISH_DATE_YEAR}=  get current datetime  %Y
     set suite variable  ${PUBLISH_DATE_DAY}
     set suite variable  ${PUBLISH_DATE_MONTH}
     set suite variable  ${PUBLISH_DATE_MONTH_WORD}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -113,10 +113,10 @@ Go to "Release status" tab
 
 Approve release
     [Tags]  HappyPath
-    ${PUBLISH_DATE_DAY}=  get datetime  %d
-    ${PUBLISH_DATE_MONTH}=  get datetime  %m
-    ${PUBLISH_DATE_MONTH_WORD}=  get datetime  %B
-    ${PUBLISH_DATE_YEAR}=  get datetime  %Y
+    ${PUBLISH_DATE_DAY}=  get current datetime  %-d
+    ${PUBLISH_DATE_MONTH}=  get current datetime  %-m
+    ${PUBLISH_DATE_MONTH_WORD}=  get current datetime  %B
+    ${PUBLISH_DATE_YEAR}=  get current datetime  %Y
     set suite variable  ${PUBLISH_DATE_DAY}
     set suite variable  ${PUBLISH_DATE_MONTH}
     set suite variable  ${PUBLISH_DATE_MONTH_WORD}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -45,9 +45,9 @@ Go to "Release status" tab
 
 Approve release
     [Tags]  HappyPath
-    ${PUBLISH_DATE_DAY}=  get datetime  %d
-    ${PUBLISH_DATE_MONTH}=  get datetime  %B
-    ${PUBLISH_DATE_YEAR}=  get datetime  %Y
+    ${PUBLISH_DATE_DAY}=  get current datetime  %-d
+    ${PUBLISH_DATE_MONTH}=  get current datetime  %B
+    ${PUBLISH_DATE_YEAR}=  get current datetime  %Y
     set suite variable  ${PUBLISH_DATE_DAY}
     set suite variable  ${PUBLISH_DATE_MONTH}
     set suite variable  ${PUBLISH_DATE_YEAR}

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -111,7 +111,7 @@ User validates permanent link works correctly
 
 User validates permalink contains correct date
     [Tags]  HappyPath
-    ${date}=  get datetime  %d %B %Y
+    ${date}=  get current datetime  %-d %B %Y
     user checks page contains element   xpath://*[@data-testid="created-date"]//time[text()="${date}"]
 
 User validates permalink table headers

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -1,4 +1,6 @@
 import json
+
+import pytz
 import time
 import re
 import datetime
@@ -141,9 +143,23 @@ def set_cookie_from_json(cookie_json):
     sl.driver.add_cookie(cookie_dict)
 
 
-def get_datetime(strf, days=0):
-    now = datetime.datetime.now() + datetime.timedelta(days=days)
-    return now.strftime(strf).lstrip('0')
+def format_uk_to_local_datetime(uk_local_datetime: str, strf: str) -> str:
+    if os.name == 'nt':
+        strf = strf.replace('%-', '%#')
+
+    tz = pytz.timezone('Europe/London')
+
+    return tz.localize(datetime.datetime.fromisoformat(uk_local_datetime)) \
+        .astimezone().strftime(strf)
+
+
+def get_current_datetime(strf: str, offset_days: int = 0) -> str:
+    now = datetime.datetime.now() + datetime.timedelta(days=offset_days)
+
+    if os.name == 'nt':
+        strf = strf.replace('%-', '%#')
+
+    return now.strftime(strf)
 
 
 def user_should_be_at_top_of_page():


### PR DESCRIPTION
This PR fixes test assertions on the prerelease start/end times being incorrect when running the tests from a non-UK timezone. This is currently problematic as the build agents run on UTC and these time assertions will usually be off by an hour.

We resolve this by converting the expected UK local time (i.e. midnight of the scheduled publish date) to the test runner's local timezone via a new `format uk to local date time` keyword.