### PR TITLE
EES-1145 Make `Release.PreviousVersionId` field nullable

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
     public class ReleaseServiceAmendmentTests
     {
         private readonly Guid _userId = Guid.NewGuid();
-        
+
        [Fact]
        public void CreateReleaseAmendmentAsync()
         {
@@ -82,10 +82,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Id = Guid.NewGuid(),
                 Name = "Data Block 2"
             };
-            
+
             var release = new Release
             {
-                
+
                 Id = releaseId,
                 Type = releaseType,
                 TypeId = releaseType.Id,
@@ -264,7 +264,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Release = release,
                 ReleaseId = releaseId
             };
-            
+
             var userReleaseRoles = new List<UserReleaseRole>
             {
                 approverReleaseRole,
@@ -279,7 +279,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 ReleaseId = releaseId,
                 SubjectId = Guid.NewGuid()
             };
-            
+
             var dataFileReference2 = new ReleaseFileReference
             {
                 Id = Guid.NewGuid(),
@@ -308,13 +308,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     ReleaseFileReferenceId = dataFileReference2.Id
                 }
             };
-            
+
             var subject1 = new Subject
             {
                 Id = Guid.NewGuid(),
                 Name = "Subject 1"
             };
-            
+
             var subject2 = new Subject
             {
                 Id = Guid.NewGuid(),
@@ -361,7 +361,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
                 statisticsDbContext.Subject.AddRange(subject1, subject2);
-                
+
                 statisticsDbContext.ReleaseSubject.AddRange(
                     new ReleaseSubject
                     {
@@ -379,7 +379,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             }
 
             var newReleaseId = Guid.Empty;
-            
+
             using (var contentDbContext = InMemoryApplicationDbContext("CreateReleaseAmendment"))
             {
                 using (var statisticsDbContext = InMemoryStatisticsDbContext("CreateReleaseAmendment"))
@@ -392,14 +392,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         importStatusService.Object, footnoteService.Object, statisticsDbContext,
                         dataBlockService.Object, releaseSubjectService.Object, new SequentialGuidGenerator());
 
-                    // Method under test 
+                    // Method under test
                     var amendmentViewModel = releaseService.CreateReleaseAmendmentAsync(releaseId).Result.Right;
                     Assert.NotEqual(release.Id, amendmentViewModel.Id);
                     Assert.NotEqual(Guid.Empty, amendmentViewModel.Id);
                     newReleaseId = amendmentViewModel.Id;
                 }
             }
-            
+
             using (var contentDbContext = InMemoryApplicationDbContext("CreateReleaseAmendment"))
             {
                 var amendment = contentDbContext
@@ -424,7 +424,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Null( amendment.Published);
                 Assert.Equal(release.Version + 1, amendment.Version);
                 Assert.Equal(ReleaseStatus.Draft, amendment.Status);
-                Assert.Equal(release.Id, amendment.PreviousVersion.Id);
+                Assert.Equal(release.Id, amendment.PreviousVersion?.Id);
                 Assert.Equal(release.Id, amendment.PreviousVersionId);
                 Assert.Equal(_userId, amendment.CreatedBy.Id);
                 Assert.Equal(_userId, amendment.CreatedById);
@@ -433,11 +433,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(releaseType, amendment.Type);
                 Assert.Equal(releaseType.Id, amendment.TypeId);
-                Assert.Equal(nextReleaseDate, amendment.NextReleaseDate); 
+                Assert.Equal(nextReleaseDate, amendment.NextReleaseDate);
                 Assert.Equal(releaseName, amendment.ReleaseName);
                 Assert.Equal(timePeriodCoverage, amendment.TimePeriodCoverage);
                 Assert.Equal(publicationId, amendment.PublicationId);
-                
+
                 Assert.Equal(release.RelatedInformation.Count, amendment.RelatedInformation.Count);
                 amendment.RelatedInformation.ForEach(amended =>
                 {
@@ -445,7 +445,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     var previous = release.RelatedInformation[index];
                     AssertAmendedLinkCorrect(amended, previous);
                 });
-                
+
                 Assert.Equal(release.Updates.Count, amendment.Updates.Count);
                 amendment.Updates.ForEach(amended =>
                 {
@@ -453,7 +453,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     var previous = release.Updates[index];
                     AssertAmendedUpdateCorrect(amended, previous, amendment);
                 });
-             
+
                 Assert.Equal(release.Content.Count, amendment.Content.Count);
                 amendment.Content.ForEach(amended =>
                 {
@@ -461,21 +461,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     var previous = release.Content[index];
                     AssertAmendedContentSectionCorrect(amendment, amended, previous);
                 });
-                
+
                 Assert.Equal(release.ContentBlocks.Count, amendment.ContentBlocks.Count);
                 var amendmentContentBlock1 = amendment.ContentBlocks[0].ContentBlock;
                 var amendmentContentBlock2 = amendment.ContentBlocks[1].ContentBlock;
                 var amendmentContentBlock1InContent = amendment.Content[0].ContentSection.Content[0];
 
                 // Check that the DataBlock that is included in this Release amendment's Content is successfully
-                // identified as the exact same DataBlock that is attached to the Release amendment through the 
+                // identified as the exact same DataBlock that is attached to the Release amendment through the
                 // additional "Release.ContentBlocks" relationship (which is used to determine which Data Blocks
-                // belong to which Release when a Data Block has not yet been - or is removed from - the Release's 
+                // belong to which Release when a Data Block has not yet been - or is removed from - the Release's
                 // Content
                 Assert.NotEqual(dataBlock1.Id, amendmentContentBlock1.Id);
                 Assert.Equal(amendmentContentBlock1, amendmentContentBlock1InContent);
-                
-                // and check that the Data Block that is not yet included in any content is copied across OK still 
+
+                // and check that the Data Block that is not yet included in any content is copied across OK still
                 Assert.NotEqual(dataBlock2.Id, amendmentContentBlock2.Id);
                 Assert.Equal((amendmentContentBlock2 as DataBlock).Name, dataBlock2.Name);
 
@@ -483,7 +483,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .UserReleaseRoles
                     .Where(r => r.ReleaseId == amendment.Id)
                     .ToList();
-                
+
                 Assert.Equal(userReleaseRoles.Count, amendmentReleaseRoles.Count);
                 var approverAmendmentRole = amendmentReleaseRoles.First(r => r.Role == ReleaseRole.Approver);
                 AssertAmendedReleaseRoleCorrect(approverReleaseRole, approverAmendmentRole, amendment);
@@ -497,7 +497,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .Include(f => f.ReleaseFileReference)
                     .Where(f => f.ReleaseId == amendment.Id)
                     .ToList();
-                
+
                 Assert.Equal(releaseFiles.Count, amendmentDataFiles.Count);
 
                 var amendmentDataFile = amendmentDataFiles[0];
@@ -519,7 +519,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReleaseSubject
                     .Where(r => r.ReleaseId == newReleaseId)
                     .ToList();
-                
+
                 Assert.Equal(2, releaseSubjectLinks.Count);
                 Assert.Contains(subject1.Id, releaseSubjectLinks.Select(r => r.SubjectId));
                 Assert.Contains(subject2.Id, releaseSubjectLinks.Select(r => r.SubjectId));
@@ -592,19 +592,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
        private static void AssertAmendedReleaseFileCorrect(ReleaseFile originalFile, ReleaseFile amendmentDataFile, Release amendment)
        {
-           // assert it's a new link table entry between the Release amendment and the data file reference 
+           // assert it's a new link table entry between the Release amendment and the data file reference
            Assert.NotEqual(originalFile.Id, amendmentDataFile.Id);
            Assert.Equal(amendment, amendmentDataFile.Release);
            Assert.Equal(amendment.Id, amendmentDataFile.ReleaseId);
-           
+
            // and assert that the file referenced is the SAME file reference as linked from the original Release's
            // link table entry
            Assert.Equal(originalFile.ReleaseFileReference.Id, amendmentDataFile.ReleaseFileReference.Id);
        }
 
        private (
-            Mock<IUserService>, 
-            Mock<IPersistenceHelper<ContentDbContext>>, 
+            Mock<IUserService>,
+            Mock<IPersistenceHelper<ContentDbContext>>,
             Mock<IPublishingService>,
             Mock<IReleaseRepository>,
             Mock<ISubjectService>,
@@ -625,14 +625,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var persistenceHelper = MockUtils.MockPersistenceHelper<ContentDbContext>();
             MockUtils.SetupCall<ContentDbContext, Release>(persistenceHelper);
             MockUtils.SetupCall<ContentDbContext, Publication>(persistenceHelper);
-            
+
             return (
-                userService, 
-                persistenceHelper, 
-                new Mock<IPublishingService>(), 
+                userService,
+                persistenceHelper,
+                new Mock<IPublishingService>(),
                 new Mock<IReleaseRepository>(),
-                new Mock<ISubjectService>(), 
-                new Mock<ITableStorageService>(), 
+                new Mock<ISubjectService>(),
+                new Mock<ITableStorageService>(),
                 new Mock<IReleaseFilesService>(),
                 new Mock<IImportStatusService>(),
                 new Mock<IFootnoteService>(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200825153306_EES1145AllowReleasePreviousVersionIdToBeNullable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200825153306_EES1145AllowReleasePreviousVersionIdToBeNullable.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200825153306_EES1145AllowReleasePreviousVersionIdToBeNullable")]
+    partial class EES1145AllowReleasePreviousVersionIdToBeNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200825153306_EES1145AllowReleasePreviousVersionIdToBeNullable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200825153306_EES1145AllowReleasePreviousVersionIdToBeNullable.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES1145AllowReleasePreviousVersionIdToBeNullable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "PreviousVersionId",
+                table: "Releases",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier");
+
+            migrationBuilder.UpdateData(
+                table: "Releases",
+                keyColumn: "Id",
+                keyValue: new Guid("4fa4fe8e-9a15-46bb-823f-49bf8e0cdec5"),
+                column: "PreviousVersionId",
+                value: null);
+
+            migrationBuilder.Sql(@"
+                UPDATE Releases SET Releases.PreviousVersionId = null 
+                WHERE Releases.PreviousVersionId = Releases.Id
+                   OR Releases.PreviousVersionId = '00000000-0000-0000-0000-000000000000'");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                UPDATE Releases SET Releases.PreviousVersionId = Releases.Id 
+                WHERE Releases.PreviousVersionId IS NULL");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "PreviousVersionId",
+                table: "Releases",
+                type: "uniqueidentifier",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldNullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "Releases",
+                keyColumn: "Id",
+                keyValue: new Guid("4fa4fe8e-9a15-46bb-823f-49bf8e0cdec5"),
+                column: "PreviousVersionId",
+                value: new Guid("4fa4fe8e-9a15-46bb-823f-49bf8e0cdec5"));
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificReleaseAuthorizationHandlers.cs
@@ -12,14 +12,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
 {
     public class MakeAmendmentOfSpecificReleaseRequirement : IAuthorizationRequirement
     {}
-    
+
     public class MakeAmendmentOfSpecificReleaseAuthorizationHandler : CompoundAuthorizationHandler<MakeAmendmentOfSpecificReleaseRequirement, Release>
     {
         public MakeAmendmentOfSpecificReleaseAuthorizationHandler(ContentDbContext context) : base(
             new CanMakeAmendmentOfAllReleasesAuthorizationHandler(context),
             new HasEditorRoleOnReleaseAuthorizationHandler(context))
         {
-            
+
         }
 
         public class CanMakeAmendmentOfAllReleasesAuthorizationHandler :
@@ -45,13 +45,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
 
         private static bool IsLatestVersionOfRelease(ContentDbContext context, Release release)
         {
-            var releases = context.Releases.AsNoTracking().Where(r => r.PublicationId == release.PublicationId);
-            return IsLatestVersionOfRelease(releases, release.Id);
-        }
+            var releases = context.Releases.AsNoTracking()
+                .Where(r => r.PublicationId == release.PublicationId && r.Id != release.Id);
 
-        private static bool IsLatestVersionOfRelease(IEnumerable<Release> releases, Guid releaseId)
-        {
-            return !releases.Any(r => r.PreviousVersionId == releaseId && r.Id != releaseId);
+            return !releases.Any(r => r.PreviousVersionId == release.Id);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -131,7 +131,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     };
                     release.Created = DateTime.UtcNow;
                     release.CreatedById = _userService.GetUserId();
-                    release.PreviousVersionId = release.Id;
 
                     _context.Releases.Add(release);
                     await _context.SaveChangesAsync();
@@ -165,7 +164,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     _context.UpdateRange(invites);
 
                     await _context.SaveChangesAsync();
-                    
+
                     await _releaseSubjectService.SoftDeleteAllSubjectsOrBreakReleaseLinks(releaseId);
 
                     return true;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -382,7 +382,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     TypeId = new Guid("9d333457-9132-4e55-ae78-c55cb3673d7c"),
                     Created = new DateTime(2017, 8, 1, 23, 59, 54, DateTimeKind.Utc),
                     CreatedById = bauMvcUser1Id,
-                    PreviousVersionId = absenceReleaseId
+                    PreviousVersionId = null
                 }
             );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -47,15 +47,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public Release LatestRelease()
         {
-            return Releases?.Where(r => r.Live && IsLatestVersionOfRelease(r.Publication, r.Id))
+            return Releases?.Where(r => r.Live && IsLatestVersionOfRelease(r.Id))
                 .OrderBy(r => r.Year)
                 .ThenBy(r => r.TimePeriodCoverage)
                 .LastOrDefault();
         }
-        
-        private static bool IsLatestVersionOfRelease(Publication publication, Guid releaseId)
+
+        private bool IsLatestVersionOfRelease(Guid releaseId)
         {
-            return !publication.Releases.Any(r => r.PreviousVersionId == releaseId && r.Id != releaseId);
+            return !Releases.Any(r => r.PreviousVersionId == releaseId && r.Id != releaseId);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Versioned.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Versioned.cs
@@ -1,19 +1,20 @@
+#nullable enable
 using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
-    public abstract class Versioned<TSelf>
+    public abstract class Versioned
     {
         public DateTime Created { get; set; }
-        
-        public User CreatedBy { get; set; } 
-        
-        public Guid CreatedById { get; set; }
-        
-        public TSelf PreviousVersion { get; set; }
 
-        public Guid PreviousVersionId { get; set; }
-        
+        public User CreatedBy { get; set; } = null!;
+
+        public Guid CreatedById { get; set; }
+
+        public Versioned? PreviousVersion { get; set; }
+
+        public Guid? PreviousVersionId { get; set; }
+
         public int Version { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20200825161515_EES1445AllowReleasePreviousVersionIdToBeNullable.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20200825161515_EES1445AllowReleasePreviousVersionIdToBeNullable.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
-    partial class StatisticsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200825161515_EES1445AllowReleasePreviousVersionIdToBeNullable")]
+    partial class EES1445AllowReleasePreviousVersionIdToBeNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20200825161515_EES1445AllowReleasePreviousVersionIdToBeNullable.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20200825161515_EES1445AllowReleasePreviousVersionIdToBeNullable.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
+{
+    public partial class EES1445AllowReleasePreviousVersionIdToBeNullable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "PreviousVersionId",
+                table: "Release",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier");
+
+            migrationBuilder.Sql(@"
+                UPDATE Release SET Release.PreviousVersionId = null 
+                WHERE Release.PreviousVersionId = Release.Id 
+                   OR Release.PreviousVersionId = '00000000-0000-0000-0000-000000000000'");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                UPDATE Release SET Release.PreviousVersionId = Release.Id 
+                WHERE Release.PreviousVersionId IS NULL");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "PreviousVersionId",
+                table: "Release",
+                type: "uniqueidentifier",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldNullable: true);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Release.cs
@@ -22,14 +22,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         // TODO by the PublishReleaseContentFunction. See method PublishingService.PublishReleaseContentAsync
         // TODO where the Published date on a Release is set in the Content db for the same Live check there.
         public bool Live => Published.HasValue && Compare(UtcNow, Published.Value) > 0;
-        public Guid PreviousVersionId { get; set; }
-        
-        public Release CreateReleaseAmendment(Guid contentReleaseAmendmentId, Guid previousReleaseAmendment)
+        public Guid? PreviousVersionId { get; set; }
+
+        public Release CreateReleaseAmendment(Guid contentAmendmentId, Guid? amendmentPreviousVersionId)
         {
             var copy = MemberwiseClone() as Release;
-            copy.Id = contentReleaseAmendmentId;
+            copy.Id = contentAmendmentId;
             copy.Published = null;
-            copy.PreviousVersionId = previousReleaseAmendment;
+            copy.PreviousVersionId = amendmentPreviousVersionId;
             return copy;
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Model/Release.cs
@@ -10,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Model
         public Publication Publication { get; set; }
         public TimeIdentifier TimeIdentifier { get; set; }
         public int Year { get; set; }
-        public Guid PreviousVersionId { get; set; }
+        public Guid? PreviousVersionId { get; set; }
 
         public override string ToString()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ReleaseProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ReleaseProcessorService.cs
@@ -36,10 +36,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         {
             // Avoid potential collisions
             Thread.Sleep(new Random().Next(1, 5) * 1000);
-            
+
             var release = CreateOrUpdateRelease(message, statisticsDbContext);
             RemoveSubjectIfExisting(subjectData.Name, release, statisticsDbContext);
-            
+
             var subject = CreateSubject(message.SubjectId, subjectData.Name, release, statisticsDbContext);
 
             if (!UpdateReleaseFileReferenceLinks(message, contentDbContext, release, subject))
@@ -47,7 +47,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 throw new Exception(
                     "Unable to create release file links when importing : Check file references are correct");
             }
-            
+
             return subject;
         }
 
@@ -93,7 +93,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             var releaseSubject = statisticsDbContext.ReleaseSubject
                 .Include(rs => rs.Subject)
                 .FirstOrDefault(r => r.Subject.Name == name && r.ReleaseId == release.Id);
-            
+
             // If the subject exists then this must be a reload of the same release/subject so delete & re-create.
             if (releaseSubject != null)
             {
@@ -112,14 +112,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     Name = name
                 }
             ).Entity;
-            
+
             statisticsDbContext.ReleaseSubject.Add(
                 new ReleaseSubject
                 {
                     ReleaseId = release.Id,
                     SubjectId = subjectId
                 });
-            
+
             statisticsDbContext.SaveChanges();
 
             return newSubject;
@@ -129,7 +129,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         {
             Release release;
 
-            if (!statisticsDbContext.Release.Any((r => r.Id.Equals(message.Release.Id))))
+            if (!statisticsDbContext.Release.Any(r => r.Id.Equals(message.Release.Id)))
             {
                 release = new Release
                 {
@@ -179,7 +179,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         private Topic CreateOrUpdateTopic(ImportMessage message, StatisticsDbContext statisticsDbContext)
         {
             Topic topic;
-            
+
             if (!statisticsDbContext.Topic.Any(t => t.Id.Equals(message.Release.Publication.Topic.Id)))
             {
                 topic = new Topic
@@ -217,7 +217,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             else
             {
                 theme = _mapper.Map(message.Release.Publication.Topic.Theme, (Theme) null);
-                theme = statisticsDbContext.Theme.Update(theme).Entity;  
+                theme = statisticsDbContext.Theme.Update(theme).Entity;
             }
             statisticsDbContext.SaveChanges();
             return theme;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublicationServiceTests.cs
@@ -152,7 +152,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Slug = "publication-a-release-2018-q1",
             Status = Approved,
             Version = 0,
-            PreviousVersionId = new Guid("240ca03c-6c22-4b9d-9f15-40fc9017890e")
+            PreviousVersionId = null
         };
 
         private static readonly Release PublicationARelease1V1Deleted = new Release
@@ -192,7 +192,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Slug = "publication-a-release-2018-q2",
             Status = Approved,
             Version = 0,
-            PreviousVersionId = new Guid("874d4e4f-5568-482f-a5a4-d41e5bf6632a")
+            PreviousVersionId = null
         };
 
         private static readonly Release PublicationARelease3 = new Release
@@ -205,7 +205,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Slug = "publication-a-release-2017-q4",
             Status = Approved,
             Version = 0,
-            PreviousVersionId = new Guid("676ff979-9b1d-4bd2-a3f1-f126c4e2e8d4")
+            PreviousVersionId = null
         };
 
         private static readonly Release PublicationBRelease1 = new Release
@@ -218,7 +218,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Slug = "publication-b-release-2018-q1",
             Status = Draft,
             Version = 0,
-            PreviousVersionId = new Guid("e66247d7-b350-4d81-a223-3080edc55623")
+            PreviousVersionId = null
         };
 
         private static readonly List<Release> Releases = new List<Release>
@@ -238,7 +238,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Slug = "publication-a-release-2018-q3",
                 Status = Draft,
                 Version = 0,
-                PreviousVersionId = new Guid("3c7b1338-4c41-43b4-b4ae-67c21c8734fb")
+                PreviousVersionId = null
             },
             PublicationBRelease1
         };

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -80,7 +80,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Published = new DateTime(2019, 1, 01),
             Status = Approved,
             Version = 0,
-            PreviousVersionId = new Guid("36725e6b-8682-480b-a04a-0564253b7160"),
+            PreviousVersionId = null,
             SoftDeleted = false
         };
 
@@ -146,7 +146,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Published = new DateTime(2019, 1, 01),
             Status = Approved,
             Version = 0,
-            PreviousVersionId = new Guid("e7e1aae3-a0a1-44b7-bdf3-3df4a363ce20")
+            PreviousVersionId = null
         };
 
         private static readonly Release PublicationARelease3 = new Release
@@ -159,7 +159,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             Published = null,
             Status = Approved,
             Version = 0,
-            PreviousVersionId = new Guid("2286f83d-c567-40f0-a7bd-f7cc5ca266ea")
+            PreviousVersionId = null
         };
 
         private static readonly List<Release> Releases = new List<Release>
@@ -178,7 +178,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Published = new DateTime(2019, 1, 01),
                 Status = Approved,
                 Version = 0,
-                PreviousVersionId = new Guid("b647f4cd-4aba-47d9-ab8d-82ece32dca86")
+                PreviousVersionId = null
             },
             new Release
             {
@@ -189,7 +189,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Published = null,
                 Status = Draft,
                 Version = 0,
-                PreviousVersionId = new Guid("21109205-6362-4746-bc37-0e6db2838173")
+                PreviousVersionId = null
             }
         };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Utils/PublisherUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Utils/PublisherUtilsTests.cs
@@ -14,7 +14,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Utils
             var release1Version1 = new Release
             {
                 Id = Guid.NewGuid(),
-                Published = DateTime.UtcNow.AddSeconds(-1)
+                Published = DateTime.UtcNow.AddSeconds(-1),
+                PreviousVersionId = null
             };
 
             var release1Version2 = new Release
@@ -23,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Utils
                 Published = DateTime.UtcNow.AddSeconds(-1),
                 PreviousVersionId = release1Version1.Id
             };
-            
+
             var release1Version3 = new Release
             {
                 Id = Guid.NewGuid(),
@@ -34,11 +35,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Utils
             var release2Version1 = new Release
             {
                 Id = Guid.NewGuid(),
-                Published = DateTime.UtcNow.AddSeconds(-1)
+                Published = DateTime.UtcNow.AddSeconds(-1),
+                PreviousVersionId = null
             };
-
-            // TODO EES-1145 Don't need to do this when PreviousVersionId is made optional
-            SelfReferenceOnlyVersions(release1Version1, release2Version1);
 
             var releases = new List<Release>
             {
@@ -62,7 +61,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Utils
             var release1Version1 = new Release
             {
                 Id = Guid.NewGuid(),
-                Published = DateTime.UtcNow.AddSeconds(-1)
+                Published = DateTime.UtcNow.AddSeconds(-1),
+                PreviousVersionId = null
             };
 
             var release1Version2 = new Release
@@ -89,11 +89,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Utils
             var release2Version1 = new Release
             {
                 Id = Guid.NewGuid(),
-                Published = DateTime.UtcNow.AddSeconds(-1)
+                Published = DateTime.UtcNow.AddSeconds(-1),
+                PreviousVersionId = null
             };
-
-            // TODO EES-1145 Don't need to do this when PreviousVersionId is made optional
-            SelfReferenceOnlyVersions(release1Version1, release2Version1);
 
             var releases = new List<Release>
             {
@@ -150,18 +148,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Utils
             {
                 release.Id
             }));
-        }
-
-        /// <summary>
-        /// TODO EES-1145 Remove this when PreviousVersionId is made optional
-        /// </summary>
-        /// <param name="releases"></param>
-        private static void SelfReferenceOnlyVersions(params Release[] releases)
-        {
-            foreach (var release in releases)
-            {
-                release.PreviousVersionId = release.Id;
-            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -51,14 +51,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             logger.LogInformation($"{executionContext.FunctionName} triggered at: {DateTime.Now}");
 
             await UpdateStage(message.ReleaseId, message.ReleaseStatusId, State.Started);
-            
+
             var context = new PublishContext(DateTime.UtcNow, false);
-            
+
             try
             {
                 await _contentService.UpdateContent(context, message.ReleaseId);
                 await _releaseService.SetPublishedDatesAsync(message.ReleaseId, context.Published);
-                
+
                 if (!PublisherUtils.IsDevelopment())
                 {
                     await _releaseService.DeletePreviousVersionsStatisticalData(message.ReleaseId);
@@ -72,6 +72,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             catch (Exception e)
             {
                 logger.LogError(e, $"Exception occured while executing {executionContext.FunctionName}");
+                logger.LogError(e.StackTrace);
+
                 await UpdateStage(message.ReleaseId, message.ReleaseStatusId, State.Failed,
                     new ReleaseStatusLogMessage($"Exception publishing release immediately: {e.Message}"));
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -43,17 +43,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
             foreach (var release in releases)
             {
-                await _fastTrackService.DeleteAllFastTracksByRelease(release.PreviousVersionId);
+                if (release.PreviousVersion == null)
+                {
+                    break;
+                }
+
+                await _fastTrackService.DeleteAllFastTracksByRelease(release.PreviousVersion.Id);
 
                 // Delete content which hasn't been overwritten because the Slug has changed
                 if (release.Slug != release.PreviousVersion.Slug)
                 {
                     await _fileStorageService.DeletePublicBlob(
-                        PublicContentReleasePath(release.Publication.Slug, release.PreviousVersion.Slug));
+                        PublicContentReleasePath(release.Publication.Slug, release.PreviousVersion.Slug)
+                    );
                 }
             }
         }
-        
+
         public async Task DeletePreviousVersionsDownloadFiles(params Guid[] releaseIds)
         {
             var releases = await _releaseService.GetAsync(releaseIds);
@@ -157,7 +163,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             await _fastTrackService.DeleteAllReleaseFastTracks();
             await _fileStorageService.DeleteAllContentAsyncExcludingStaging();
         }
-        
+
         private async Task CacheDownloadTree(PublishContext context, params Guid[] includedReleaseIds)
         {
             // This assumes the files have been copied first
@@ -169,7 +175,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         {
             await _fastTrackService.CreateAllByRelease(release.Id, context);
         }
-        
+
         private async Task CacheMethodologyTree(PublishContext context, params Guid[] includedReleaseIds)
         {
             var tree = _methodologyService.GetTree(includedReleaseIds);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileStorageService.cs
@@ -93,7 +93,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         public async Task DeleteDownloadFilesForPreviousVersion(Release release)
         {
-            if (release.Slug != release.PreviousVersion.Slug)
+            if (release.PreviousVersion != null && release.Slug != release.PreviousVersion.Slug)
             {
                 var directoryPath = PublicReleaseDirectoryPath(release.Publication.Slug, release.PreviousVersion.Slug);
                 var publicContainer = await GetCloudBlobContainerAsync(_publicStorageConnectionString, PublicFilesContainerName);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -60,7 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             return await _contentDbContext.Releases
                 .Include(r => r.PreviousVersion)
                 .Include(r => r.Publication)
-                .Where(r => releaseIds.Contains(r.Id) && r.PreviousVersionId != r.Id)
+                .Where(r => releaseIds.Contains(r.Id) && r.PreviousVersionId != null)
                 .ToListAsync();
         }
 
@@ -156,7 +156,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 await _statisticsDbContext.SaveChangesAsync();
             }
         }
-        
+
         public List<ReleaseFileReference> GetReleaseFileReferences(Guid releaseId, params ReleaseFileTypes[] types)
         {
             return _contentDbContext
@@ -171,7 +171,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         public async Task DeletePreviousVersionsStatisticalData(params Guid[] releaseIds)
         {
             var releases = await GetAmendedReleases(releaseIds);
-            var previousVersions = releases.Select(r => r.PreviousVersionId).ToList();
+            var previousVersions = releases.Select(r => r.PreviousVersionId)
+                .Where(id => id.HasValue)
+                .Cast<Guid>()
+                .ToList();
 
             foreach (var previousVersion in previousVersions)
             {
@@ -189,7 +192,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             var releases = await _statisticsDbContext.Release
                 .Where(r => releaseIds.Contains(r.Id))
                 .ToListAsync();
-            
+
             _statisticsDbContext.Release.RemoveRange(releases);
         }
     }


### PR DESCRIPTION
This PR changes `Release.PreviousVersionId` to nullable so that we can make it easier to bulk delete releases when deleting themes/topics. Currently `PreviousVersionId` cannot be nulled and EF is consequently unable to delete all of a theme/topic's releases in a single operation due to the self-referential nature of the `Release` -> `PreviousVersion` relationship.

Additionally, `PreviousVersionId` can take on non-sensical IDs such as `Guid.Empty` or its own `Id` when it is the first release (doesn't make sense as the previous version shouldn't be itself). These changes should correct the semantics of `PreviousVersion` and `PreviousVersionId` i.e. make them properly optional.