### PR TITLE
EES-222 Generate replacement validity plan for replacing Subject data

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleaseControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleaseControllerTests.cs
@@ -52,12 +52,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         public async Task AddAncillaryFilesAsync_UploadsTheFiles_Returns_Ok()
         {
             var testFile = new FileInfo
-                            {
-                                Extension = "doc",
-                                Name = "File name",
-                                Path = "ancillaryFile.doc",
-                                Size = "1 Kb"
-                            };
+            {
+                Extension = "doc",
+                Name = "File name",
+                Path = "ancillaryFile.doc",
+                Size = "1 Kb"
+            };
 
             var mocks = Mocks();
             var ancillaryFile = MockFile("ancillaryFile.doc");
@@ -97,21 +97,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             mocks.FileStorageService.Setup(s => s.ListFilesAsync(_releaseId, ReleaseFileTypes.Ancillary))
                 .ReturnsAsync(new Either<ActionResult, IEnumerable<FileInfo>>(testFiles));
             var controller = ReleasesControllerWithMocks(mocks);
-            
+
             // Call the method under test
             var result = await controller.GetAncillaryFilesAsync(_releaseId);
             AssertOkResult(result);
         }
 
-        [Fact(Skip="Needs principal setting")]
+        [Fact(Skip = "Needs principal setting")]
         public async Task AddDataFilesAsync_UploadsTheFiles_Returns_Ok()
         {
             var mocks = Mocks();
             var dataFile = MockFile("datafile.csv");
             var metaFile = MockFile("metafile.csv");
-            
+
             mocks.FileStorageService
-                .Setup(service => service.UploadDataFilesAsync(_releaseId, dataFile, metaFile, "Subject name", "test user"))
+                .Setup(service =>
+                    service.UploadDataFilesAsync(_releaseId, dataFile, metaFile, "Subject name", "test user"))
                 .ReturnsAsync(true);
 
             // Call the method under test
@@ -120,20 +121,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             Assert.True(result.Value);
         }
 
-        [Fact(Skip="Needs principal setting")]
+        [Fact(Skip = "Needs principal setting")]
         public async Task AddDataFilesAsync_UploadsTheFiles_Returns_ValidationProblem()
         {
             var mocks = Mocks();
             var dataFile = MockFile("datafile.csv");
             var metaFile = MockFile("metafile.csv");
-            
+
             mocks.FileStorageService
                 .Setup(service => service.UploadDataFilesAsync(_releaseId, dataFile, metaFile, "Subject name",
                     "test user"))
                 .ReturnsAsync(new BadRequestObjectResult(CannotOverwriteFile));
 
             var controller = ReleasesControllerWithMocks(mocks);
-            
+
             // Call the method under test
             var result = await controller.AddDataFilesAsync(_releaseId, "Subject name", dataFile, metaFile);
             AssertValidationProblem(result.Result, CannotOverwriteFile);
@@ -161,7 +162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             };
 
             var mocks = Mocks();
-            
+
             mocks.FileStorageService.Setup(s => s.ListDataFilesAsync(_releaseId))
                 .ReturnsAsync(new Either<ActionResult, IEnumerable<DataFileInfo>>(testFiles));
             var controller = ReleasesControllerWithMocks(mocks);
@@ -177,14 +178,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         public async Task DeleteDataFilesAsync_Returns_OK()
         {
             var mocks = Mocks();
-            
+
             mocks.ReleaseService
                 .Setup(service => service.RemoveDataFilesAsync(_releaseId, "datafilename", "subject title"))
                 .ReturnsAsync(new Either<ActionResult, bool>(true));
             var controller = ReleasesControllerWithMocks(mocks);
 
             // Call the method under test
-            var result = await controller.DeleteDataFiles(_releaseId, "datafilename","subject title");
+            var result = await controller.DeleteDataFiles(_releaseId, "datafilename", "subject title");
             Assert.IsAssignableFrom<NoContentResult>(result);
         }
 
@@ -192,14 +193,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         public async Task DeleteDataFilesAsync_Returns_ValidationProblem()
         {
             var mocks = Mocks();
-            
+
             mocks.ReleaseService
                 .Setup(service => service.RemoveDataFilesAsync(_releaseId, "datafilename", "subject title"))
                 .ReturnsAsync(ValidationActionResult(UnableToFindMetadataFileToDelete));
             var controller = ReleasesControllerWithMocks(mocks);
 
             // Call the method under test
-            var result = await controller.DeleteDataFiles(_releaseId, "datafilename","subject title");
+            var result = await controller.DeleteDataFiles(_releaseId, "datafilename", "subject title");
             AssertValidationProblem(result, UnableToFindMetadataFileToDelete);
         }
 
@@ -207,10 +208,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         public async void UpdateRelease_Returns_Ok()
         {
             var mocks = Mocks();
-            
+
             mocks.ReleaseService
                 .Setup(s => s.UpdateRelease(
-                    It.Is<Guid>(id => id.Equals(_releaseId)), 
+                    It.Is<Guid>(id => id.Equals(_releaseId)),
                     It.IsAny<UpdateReleaseViewModel>())
                 )
                 .ReturnsAsync(new ReleaseViewModel {Id = _releaseId});
@@ -228,7 +229,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var mocks = Mocks();
             mocks.ReleaseService
                 .Setup(s => s.GetReleaseSummaryAsync(It.IsAny<Guid>()))
-                .Returns<Guid>(id => Task.FromResult(new Either<ActionResult, ReleaseSummaryViewModel>(new ReleaseSummaryViewModel {Id = id})));
+                .Returns<Guid>(id => Task.FromResult(
+                    new Either<ActionResult, ReleaseSummaryViewModel>(new ReleaseSummaryViewModel {Id = id})));
             var controller = ReleasesControllerWithMocks(mocks);
 
             // Method under test
@@ -278,12 +280,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             Mock<IReleaseService> ReleaseService,
             Mock<IReleaseFilesService> FileStorageService,
             Mock<IReleaseStatusService> ReleaseStatusService,
+            Mock<IReplacementService> ReplacementService,
             Mock<UserManager<ApplicationUser>> UserManager,
             Mock<IDataBlockService> DataBlockService) Mocks()
         {
             return (new Mock<IReleaseService>(),
                     new Mock<IReleaseFilesService>(),
                     new Mock<IReleaseStatusService>(),
+                    new Mock<IReplacementService>(),
                     MockUserManager(Users),
                     new Mock<IDataBlockService>()
                 );
@@ -293,6 +297,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             Mock<IReleaseService> ReleaseService,
             Mock<IReleaseFilesService> FileStorageService,
             Mock<IReleaseStatusService> ReleaseStatusService,
+            Mock<IReplacementService> ReplacementService,
             Mock<UserManager<ApplicationUser>> UserManager,
             Mock<IDataBlockService> DataBlockService
             ) mocks)
@@ -301,10 +306,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 mocks.ReleaseService.Object,
                 mocks.FileStorageService.Object,
                 mocks.ReleaseStatusService.Object,
+                mocks.ReplacementService.Object,
                 mocks.UserManager.Object,
                 mocks.DataBlockService.Object);
         }
-        
+
         private static Mock<UserManager<TUser>> MockUserManager<TUser>(List<TUser> ls) where TUser : class
         {
             var store = new Mock<IUserStore<TUser>>();
@@ -313,7 +319,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             mgr.Object.PasswordValidators.Add(new PasswordValidator<TUser>());
 
             mgr.Setup(x => x.DeleteAsync(It.IsAny<TUser>())).ReturnsAsync(IdentityResult.Success);
-            mgr.Setup(x => x.CreateAsync(It.IsAny<TUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success).Callback<TUser, string>((x, y) => ls.Add(x));
+            mgr.Setup(x => x.CreateAsync(It.IsAny<TUser>(), It.IsAny<string>()))
+                .ReturnsAsync(IdentityResult.Success).Callback<TUser, string>((x, y) => ls.Add(x));
             mgr.Setup(x => x.UpdateAsync(It.IsAny<TUser>())).ReturnsAsync(IdentityResult.Success);
 
             return mgr;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.ValidationTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
+using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
+using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
+{
+    public class ReplacementServiceTests
+    {
+        [Fact]
+        public async Task GetReplacementPlan_SubjectsBelongToDifferentReleases()
+        {
+            var originalSubject = new Subject
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var replacementSubject = new Subject
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var contentRelease1 = new Release
+            {
+                Id = new Guid()
+            };
+
+            var contentRelease2 = new Release
+            {
+                Id = new Guid()
+            };
+
+            var statsRelease1 = new Data.Model.Release
+            {
+                Id = contentRelease1.Id
+            };
+
+            var statsRelease2 = new Data.Model.Release
+            {
+                Id = contentRelease2.Id
+            };
+
+            var originalReleaseSubject = new ReleaseSubject
+            {
+                Release = statsRelease1,
+                Subject = originalSubject
+            };
+
+            var replacementReleaseSubject = new ReleaseSubject
+            {
+                Release = statsRelease2,
+                Subject = replacementSubject
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.AddRangeAsync(contentRelease1, contentRelease2);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.AddRangeAsync(statsRelease1, statsRelease2);
+                await statisticsDbContext.AddRangeAsync(originalSubject, replacementSubject);
+                await statisticsDbContext.AddRangeAsync(originalReleaseSubject, replacementReleaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var replacementService = BuildReplacementService(contentDbContext, statisticsDbContext, Mocks());
+
+                var result = await replacementService.GetReplacementPlan(originalSubject.Id, replacementSubject.Id);
+
+                Assert.True(result.IsLeft);
+                AssertValidationProblem(result.Left, ReplacementDataFileMustBeForSameRelease);
+            }
+        }
+
+        [Fact]
+        public async Task GetReplacementPlan_OriginalSubjectNotUsed()
+        {
+            var originalSubject = new Subject
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var replacementSubject = new Subject
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var contentRelease = new Release
+            {
+                Id = new Guid()
+            };
+
+            var statsRelease = new Data.Model.Release
+            {
+                Id = contentRelease.Id
+            };
+
+            var originalReleaseSubject = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = originalSubject
+            };
+
+            var replacementReleaseSubject = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = replacementSubject
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.AddAsync(contentRelease);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.AddRangeAsync(statsRelease);
+                await statisticsDbContext.AddRangeAsync(originalSubject, replacementSubject);
+                await statisticsDbContext.AddRangeAsync(originalReleaseSubject, replacementReleaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var replacementService = BuildReplacementService(contentDbContext, statisticsDbContext, Mocks());
+
+                var result = await replacementService.GetReplacementPlan(originalSubject.Id, replacementSubject.Id);
+
+                Assert.True(result.IsRight);
+                var replacementPlan = result.Right;
+                Assert.True(replacementPlan.Valid);
+                Assert.Empty(replacementPlan.DataBlocks);
+                Assert.Empty(replacementPlan.Footnotes);
+            }
+        }
+
+        private static ReplacementService BuildReplacementService(
+            ContentDbContext contentDbContext,
+            StatisticsDbContext statisticsDbContext,
+            (
+                Mock<IFilterService> filterService,
+                Mock<IIndicatorService> indicatorService,
+                Mock<ILocationService> locationService,
+                Mock<IFootnoteService> footnoteService,
+                Mock<ITimePeriodService> timePeriodService) mocks)
+        {
+            var (filterService, indicatorService, locationService, footnoteService, timePeriodService) = mocks;
+
+            return new ReplacementService(
+                contentDbContext,
+                statisticsDbContext,
+                filterService.Object,
+                indicatorService.Object,
+                locationService.Object,
+                footnoteService.Object,
+                timePeriodService.Object,
+                new PersistenceHelper<StatisticsDbContext>(statisticsDbContext));
+        }
+
+        private static (Mock<IFilterService>,
+            Mock<IIndicatorService>,
+            Mock<ILocationService>,
+            Mock<IFootnoteService>,
+            Mock<ITimePeriodService>) Mocks()
+        {
+            return (
+                new Mock<IFilterService>(),
+                new Mock<IIndicatorService>(),
+                new Mock<ILocationService>(),
+                new Mock<IFootnoteService>(),
+                new Mock<ITimePeriodService>());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -17,7 +17,6 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
 {
-    // TODO rename to Releases once the current Crud releases controller is removed
     [Route("api")]
     [ApiController]
     [Authorize]
@@ -26,6 +25,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         private readonly IReleaseService _releaseService;
         private readonly IReleaseFilesService _releaseFilesService;
         private readonly IReleaseStatusService _releaseStatusService;
+        private readonly IReplacementService _replacementService;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IDataBlockService _dataBlockService;
 
@@ -33,6 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             IReleaseService releaseService,
             IReleaseFilesService releaseFilesService,
             IReleaseStatusService releaseStatusService,
+            IReplacementService replacementService,
             UserManager<ApplicationUser> userManager,
             IDataBlockService dataBlockService
             )
@@ -40,6 +41,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             _releaseService = releaseService;
             _releaseFilesService = releaseFilesService;
             _releaseStatusService = releaseStatusService;
+            _replacementService = replacementService;
             _userManager = userManager;
             _dataBlockService = dataBlockService;
         }
@@ -254,6 +256,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         {
             return await _releaseService
                 .GetDeleteDataFilePlan(releaseId, fileName, subjectTitle)
+                .HandleFailuresOrOk();
+        }
+
+        [HttpGet("release/data/replacement-plan")]
+        [AllowAnonymous]
+        public async Task<ActionResult<ReplacementPlan>> GetReplacementPlan()
+        {
+            //var releaseId = new Guid("6a0e101a-b69f-4daf-a5dc-08d849c07f00");
+
+            var original = new Guid("624CE37E-1760-4EF8-A5DD-08D849C07F00");
+            var replacement = new Guid("711FFF20-BF5D-45F2-A5DE-08D849C07F00");
+
+            return await _replacementService
+                .GetReplacementPlan(original, replacement)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/ReplacementPlan.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/ReplacementPlan.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
+{
+    public class ReplacementPlan
+    {
+        public IEnumerable<DataBlockInfo> DataBlocks { get; set; }
+        public IEnumerable<FootnoteInfo> Footnotes { get; set; }
+
+        public ReplacementPlan(IEnumerable<DataBlockInfo> dataBlocks,
+            IEnumerable<FootnoteInfo> footnotes)
+        {
+            DataBlocks = dataBlocks;
+            Footnotes = footnotes;
+        }
+
+        public bool Valid => DataBlocks.All(info => info.Valid)
+                             && Footnotes.All(info => info.Valid);
+    }
+
+    public class DataBlockInfo
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public IEnumerable<FilterItemReplacementViewModel> FilterItems { get; set; }
+        public IEnumerable<IndicatorReplacementViewModel> Indicators { get; set; }
+        public Dictionary<string, ObservationalUnitReplacementViewModel> ObservationalUnits { get; set; }
+        public TimePeriodReplacementViewModel TimePeriods { get; set; }
+
+        public DataBlockInfo(Guid id,
+            string name,
+            IEnumerable<FilterItemReplacementViewModel> filterItems,
+            IEnumerable<IndicatorReplacementViewModel> indicators,
+            Dictionary<string, ObservationalUnitReplacementViewModel> observationalUnits,
+            TimePeriodReplacementViewModel timePeriods)
+        {
+            Id = id;
+            Name = name;
+            FilterItems = filterItems;
+            Indicators = indicators;
+            ObservationalUnits = observationalUnits;
+            TimePeriods = timePeriods;
+        }
+
+        public bool Valid => FilterItems.All(model => model.Valid)
+                             && Indicators.All(model => model.Valid)
+                             && ObservationalUnits.Values.All((model => model.Valid))
+                             && TimePeriods.Valid;
+    }
+
+    public class FootnoteInfo
+    {
+        public Guid Id { get; set; }
+        public string Content { get; set; }
+        public IEnumerable<FilterReplacementViewModel> Filters { get; set; }
+        public IEnumerable<FilterGroupReplacementViewModel> FilterGroups { get; set; }
+        public IEnumerable<FilterItemReplacementViewModel> FilterItems { get; set; }
+        public IEnumerable<IndicatorReplacementViewModel> Indicators { get; set; }
+
+        public FootnoteInfo(Guid id,
+            string content,
+            IEnumerable<FilterReplacementViewModel> filters,
+            IEnumerable<FilterGroupReplacementViewModel> filterGroups,
+            IEnumerable<FilterItemReplacementViewModel> filterItems,
+            IEnumerable<IndicatorReplacementViewModel> indicators)
+        {
+            Id = id;
+            Content = content;
+            Filters = filters;
+            FilterGroups = filterGroups;
+            FilterItems = filterItems;
+            Indicators = indicators;
+        }
+
+        public bool Valid => Filters.All(model => model.Valid)
+                             && FilterGroups.All(model => model.Valid)
+                             && FilterItems.All(model => model.Valid)
+                             && Indicators.All(model => model.Valid);
+    }
+
+    public class FilterReplacementViewModel : TargetableReplacementViewModel
+    {
+        public string Name { get; set; }
+    }
+
+    public class FilterGroupReplacementViewModel : TargetableReplacementViewModel
+    {
+        public string FilterLabel { get; set; }
+    }
+
+    public class FilterItemReplacementViewModel : TargetableReplacementViewModel
+    {
+    }
+
+    public class IndicatorReplacementViewModel : TargetableReplacementViewModel
+    {
+        public string Name { get; set; }
+    }
+
+    public class ObservationalUnitReplacementViewModel : ReplacementViewModel
+    {
+        public IEnumerable<string> Matched { get; set; }
+        public IEnumerable<string> Unmatched { get; set; }
+        public new bool Valid => !Unmatched.Any();
+    }
+
+    public class TimePeriodReplacementViewModel : ReplacementViewModel
+    {
+        public TimePeriodQuery Query;
+    }
+
+    public abstract class TargetableReplacementViewModel
+    {
+        public Guid Id { get; set; }
+        public string Label { get; set; }
+        public Guid? Target { get; set; }
+        public bool Valid => Target.HasValue;
+    }
+
+    public abstract class ReplacementViewModel
+    {
+        public bool Valid { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FootnoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FootnoteService.cs
@@ -169,7 +169,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public IEnumerable<Footnote> GetFootnotes(Guid releaseId, Guid subjectId)
         {
-            return _commonFootnoteService.GetFootnotes(releaseId, new List<Guid>(){subjectId});
+            return _commonFootnoteService.GetFootnotes(releaseId, subjectId);
         }
 
         private void CreateSubjectLinks(Footnote footnote, IEnumerable<Guid> subjectIds)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementService.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
+{
+    public interface IReplacementService
+    {
+        Task<Either<ActionResult, ReplacementPlan>> GetReplacementPlan(
+            Guid originalSubjectId,
+            Guid replacementSubjectId);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -1,0 +1,338 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
+using IFootnoteService = GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces.IFootnoteService;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
+{
+    public class ReplacementService : IReplacementService
+    {
+        private readonly ContentDbContext _contentDbContext;
+        private readonly StatisticsDbContext _statisticsDbContext;
+        private readonly IFilterService _filterService;
+        private readonly IIndicatorService _indicatorService;
+        private readonly ILocationService _locationService;
+        private readonly IFootnoteService _footnoteService;
+        private readonly ITimePeriodService _timePeriodService;
+        private readonly IPersistenceHelper<StatisticsDbContext> _persistenceHelper;
+
+        public ReplacementService(ContentDbContext contentDbContext,
+            StatisticsDbContext statisticsDbContext,
+            IFilterService filterService,
+            IIndicatorService indicatorService,
+            ILocationService locationService,
+            IFootnoteService footnoteService,
+            ITimePeriodService timePeriodService,
+            IPersistenceHelper<StatisticsDbContext> persistenceHelper)
+        {
+            _contentDbContext = contentDbContext;
+            _statisticsDbContext = statisticsDbContext;
+            _filterService = filterService;
+            _indicatorService = indicatorService;
+            _locationService = locationService;
+            _footnoteService = footnoteService;
+            _timePeriodService = timePeriodService;
+            _persistenceHelper = persistenceHelper;
+        }
+
+        public async Task<Either<ActionResult, ReplacementPlan>> GetReplacementPlan(Guid originalSubjectId,
+            Guid replacementSubjectId)
+        {
+            return await _persistenceHelper
+                .CheckEntityExists<Subject>(originalSubjectId)
+                .OnSuccessDo(() => _persistenceHelper.CheckEntityExists<Subject>(replacementSubjectId))
+                .OnSuccess(() => GetReleaseId(originalSubjectId, replacementSubjectId))
+                .OnSuccess(releaseId =>
+                {
+                    var replacementSubjectMeta = GetReplacementSubjectMeta(replacementSubjectId);
+
+                    var dataBlocks = ValidateDataBlocks(releaseId, originalSubjectId, replacementSubjectMeta);
+                    var footnotes = ValidateFootnotes(releaseId, originalSubjectId, replacementSubjectMeta);
+
+                    return new ReplacementPlan(dataBlocks, footnotes);
+                });
+        }
+
+        private async Task<Either<ActionResult, Guid>> GetReleaseId(Guid originalSubjectId, Guid replacementSubjectId)
+        {
+            var originalReleaseSubject = await _statisticsDbContext.ReleaseSubject
+                .FirstAsync(releaseSubject => releaseSubject.SubjectId == originalSubjectId);
+
+            var replacementReleaseSubject = await _statisticsDbContext.ReleaseSubject
+                .FirstAsync(releaseSubject => releaseSubject.SubjectId == replacementSubjectId);
+
+            if (originalReleaseSubject.ReleaseId != replacementReleaseSubject.ReleaseId)
+            {
+                return ValidationActionResult(ReplacementDataFileMustBeForSameRelease);
+            }
+
+            return originalReleaseSubject.ReleaseId;
+        }
+
+        private ReplacementSubjectMeta GetReplacementSubjectMeta(Guid subjectId)
+        {
+            var filtersIncludingItems = _filterService.GetFiltersIncludingItems(subjectId)
+                .ToList();
+
+            var filters = filtersIncludingItems
+                .ToDictionary(filter => filter.Name, filter => filter.Id);
+
+            var filterGroups = filtersIncludingItems.SelectMany(filter => filter.FilterGroups)
+                .ToDictionary(filterGroup => filterGroup.Label, filterGroup => filterGroup.Id);
+
+            var filterItems = filtersIncludingItems.SelectMany(filter => filter.FilterGroups)
+                .SelectMany(group => group.FilterItems)
+                .ToDictionary(filterItem => filterItem.Label, filterItem => filterItem.Id);
+
+            var indicators = _indicatorService.GetIndicators(subjectId)
+                .ToDictionary(filterItem => filterItem.Name, filterItem => filterItem.Id);
+
+            var observationalUnits = _locationService.GetObservationalUnits(subjectId);
+
+            var timePeriods = _timePeriodService.GetTimePeriods(subjectId);
+
+            return new ReplacementSubjectMeta
+            {
+                Filters = filters,
+                FilterGroups = filterGroups,
+                FilterItems = filterItems,
+                Indicators = indicators,
+                ObservationalUnits = observationalUnits,
+                TimePeriods = timePeriods
+            };
+        }
+
+        private List<DataBlockInfo> ValidateDataBlocks(Guid releaseId, Guid subjectId,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return _contentDbContext
+                .ReleaseContentBlocks
+                .Include(join => join.ContentBlock)
+                .Where(join => join.ReleaseId == releaseId)
+                .Select(join => join.ContentBlock)
+                .OfType<DataBlock>()
+                .ToList()
+                .Where(dataBlock => dataBlock.Query.SubjectId == subjectId)
+                .Select(dataBlock => ValidateDataBlock(dataBlock, replacementSubjectMeta))
+                .ToList();
+        }
+
+        private DataBlockInfo ValidateDataBlock(DataBlock dataBlock, ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            var filterItems = ValidateFilterItemsForDataBlock(dataBlock, replacementSubjectMeta);
+            var indicators = ValidateIndicatorsForDataBlock(dataBlock, replacementSubjectMeta);
+            var observationalUnits = ValidateObservationalUnitsForDataBlock(dataBlock, replacementSubjectMeta);
+            var timePeriods = ValidateTimePeriodsForDataBlock(dataBlock, replacementSubjectMeta);
+
+            return new DataBlockInfo(dataBlock.Id,
+                dataBlock.Name,
+                filterItems,
+                indicators,
+                observationalUnits,
+                timePeriods);
+        }
+
+        private List<FootnoteInfo> ValidateFootnotes(Guid releaseId, Guid subjectId,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return _footnoteService.GetFootnotes(releaseId, subjectId)
+                .Select(footnote => ValidateFootnote(footnote, replacementSubjectMeta))
+                .ToList();
+        }
+
+        private static FootnoteInfo ValidateFootnote(Footnote footnote, ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            var filters = ValidateFiltersForFootnote(footnote, replacementSubjectMeta);
+            var filterGroups = ValidateFilterGroupsForFootnote(footnote, replacementSubjectMeta);
+            var filterItems = ValidateFilterItemsForFootnote(footnote, replacementSubjectMeta);
+            var indicators = ValidateIndicatorsForFootnote(footnote, replacementSubjectMeta);
+
+            return new FootnoteInfo(footnote.Id,
+                footnote.Content,
+                filters,
+                filterGroups,
+                filterItems,
+                indicators);
+        }
+
+        private static List<FilterReplacementViewModel> ValidateFiltersForFootnote(Footnote footnote,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return footnote.Filters
+                .Select(filterFootnote => filterFootnote.Filter)
+                .Select(filter => ValidateFilterForReplacement(filter, replacementSubjectMeta))
+                .ToList();
+        }
+
+        private static List<FilterGroupReplacementViewModel> ValidateFilterGroupsForFootnote(Footnote footnote,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return footnote.FilterGroups
+                .Select(filterGroupFootnote => filterGroupFootnote.FilterGroup)
+                .Select(filterGroup => ValidateFilterGroupForReplacement(filterGroup, replacementSubjectMeta))
+                .ToList();
+        }
+
+        private static List<FilterItemReplacementViewModel> ValidateFilterItemsForFootnote(Footnote footnote,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return footnote.FilterItems
+                .Select(filterItemFootnote => filterItemFootnote.FilterItem)
+                .Select(filterItem => ValidateFilterItemForReplacement(filterItem, replacementSubjectMeta))
+                .ToList();
+        }
+
+        private static List<IndicatorReplacementViewModel> ValidateIndicatorsForFootnote(Footnote footnote,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return footnote.Indicators
+                .Select(indicatorFootnote => indicatorFootnote.Indicator)
+                .Select(indicator => ValidateIndicatorForReplacement(indicator, replacementSubjectMeta))
+                .ToList();
+        }
+
+        private List<FilterItemReplacementViewModel> ValidateFilterItemsForDataBlock(DataBlock dataBlock,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return _statisticsDbContext.FilterItem
+                .Where(filterItem => dataBlock.Query.Filters.Contains(filterItem.Id))
+                .Select(filterItem => ValidateFilterItemForReplacement(filterItem, replacementSubjectMeta))
+                .ToList();
+        }
+
+        private List<IndicatorReplacementViewModel> ValidateIndicatorsForDataBlock(DataBlock dataBlock,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return _statisticsDbContext.Indicator
+                .Where(indicator => dataBlock.Query.Indicators.Contains(indicator.Id))
+                .Select(indicator => ValidateIndicatorForReplacement(indicator, replacementSubjectMeta))
+                .ToList();
+        }
+
+        private static Dictionary<string, ObservationalUnitReplacementViewModel> ValidateObservationalUnitsForDataBlock(
+            DataBlock dataBlock,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return new Dictionary<string, ObservationalUnitReplacementViewModel>
+            {
+                {
+                    "Country",
+                    ValidateObservationalUnitsForReplacement(dataBlock.Query.Locations,
+                        GeographicLevel.Country,
+                        replacementSubjectMeta)
+                }
+            };
+        }
+
+        private static TimePeriodReplacementViewModel ValidateTimePeriodsForDataBlock(DataBlock dataBlock,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            var range = TimePeriodUtil.Range(dataBlock.Query.TimePeriod);
+            return new TimePeriodReplacementViewModel
+            {
+                Query = dataBlock.Query.TimePeriod,
+                Valid = range.Intersect(replacementSubjectMeta.TimePeriods).Any()
+            };
+        }
+
+        private static FilterReplacementViewModel ValidateFilterForReplacement(Filter filter,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return new FilterReplacementViewModel
+            {
+                Id = filter.Id,
+                Name = filter.Name,
+                Label = filter.Label,
+                Target = replacementSubjectMeta.Filters.GetValueOrDefault(filter.Name)
+            };
+        }
+
+        private static FilterGroupReplacementViewModel ValidateFilterGroupForReplacement(FilterGroup filterGroup,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return new FilterGroupReplacementViewModel
+            {
+                Id = filterGroup.Id,
+                Label = filterGroup.Label,
+                FilterLabel = filterGroup.Filter.Label,
+                Target = replacementSubjectMeta.FilterGroups.GetValueOrDefault(filterGroup.Label)
+            };
+        }
+
+        private static FilterItemReplacementViewModel ValidateFilterItemForReplacement(FilterItem filterItem,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return new FilterItemReplacementViewModel
+            {
+                Id = filterItem.Id,
+                Label = filterItem.Label,
+                Target = replacementSubjectMeta.FilterItems.GetValueOrDefault(filterItem.Label)
+            };
+        }
+
+        private static IndicatorReplacementViewModel ValidateIndicatorForReplacement(Indicator indicator,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            return new IndicatorReplacementViewModel
+            {
+                Id = indicator.Id,
+                Name = indicator.Name,
+                Label = indicator.Label,
+                Target = replacementSubjectMeta.Indicators.GetValueOrDefault(indicator.Name)
+            };
+        }
+
+        private static ObservationalUnitReplacementViewModel ValidateObservationalUnitsForReplacement(
+            LocationQuery locationQuery,
+            GeographicLevel geographicLevel,
+            ReplacementSubjectMeta replacementSubjectMeta)
+        {
+            var queryProperty = typeof(LocationQuery).GetProperty(geographicLevel.ToString());
+            if (queryProperty == null || queryProperty.GetMethod == null)
+            {
+                throw new ArgumentException(
+                    $"{nameof(LocationQuery)} does not have a property {geographicLevel.ToString()} with get method");
+            }
+            
+            var originalCodes = queryProperty.GetMethod.Invoke(locationQuery, new object[] { }) as IEnumerable<string>;
+
+            var replacementCodes = replacementSubjectMeta.ObservationalUnits[geographicLevel]
+                .Select(unit => unit.Code)
+                .ToList();
+
+            return new ObservationalUnitReplacementViewModel
+            {
+                Matched = originalCodes.Intersect(replacementCodes),
+                Unmatched = originalCodes.Except(replacementCodes),
+            };
+        }
+
+        private class ReplacementSubjectMeta
+        {
+            public Dictionary<string, Guid> Filters { get; set; }
+            public Dictionary<string, Guid> FilterGroups { get; set; }
+            public Dictionary<string, Guid> FilterItems { get; set; }
+            public Dictionary<string, Guid> Indicators { get; set; }
+            public Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>> ObservationalUnits { get; set; }
+            public IEnumerable<(int Year, TimeIdentifier TimeIdentifier)> TimePeriods { get; set; }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -243,6 +243,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IManageContentPageService, ManageContentPageService>();
             services.AddTransient<IContentService, ContentService>();
             services.AddTransient<IRelatedInformationService, RelatedInformationService>();
+            services.AddTransient<IReplacementService, ReplacementService>();
 
             services.AddTransient<INotificationClient>(s =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -118,6 +118,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         CannotRemoveDataFilesUntilImportComplete,
         CannotRemoveDataFilesOnceReleaseApproved,
         AllDatafilesUploadedMustBeComplete,
+        ReplacementDataFileMustBeForSameRelease,
 
         // Meta file
         CannotOverwriteMetadataFile,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/FootnoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/FootnoteService.cs
@@ -47,7 +47,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
 
         public async Task DeleteAllFootnotesBySubject(Guid releaseId, Guid subjectId)
         {
-            var footnotesLinkedToSubject = GetFootnotes(releaseId, new List<Guid> {subjectId});
+            var footnotesLinkedToSubject = GetFootnotes(releaseId, subjectId);
 
             foreach (var footnote in footnotesLinkedToSubject)
             {
@@ -104,12 +104,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
         {
             var subjectsIdsForRelease = _context.ReleaseSubject
                 .Where(rs => rs.ReleaseId == releaseId)
-                .Select(rs => rs.SubjectId).ToList();
+                .Select(rs => rs.SubjectId).ToArray();
 
             return GetFootnotes(releaseId, subjectsIdsForRelease);
         }
 
-        public IEnumerable<Footnote> GetFootnotes(Guid releaseId, List<Guid> subjects)
+        public IEnumerable<Footnote> GetFootnotes(Guid releaseId, params Guid[] subjects)
         {
             return _context.Footnote
                     .Include(footnote => footnote.Filters)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/IFootnoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/IFootnoteService.cs
@@ -16,7 +16,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfa
         
         IEnumerable<Footnote> GetFootnotes(Guid releaseId);
 
-        IEnumerable<Footnote> GetFootnotes(Guid releaseId, List<Guid> subjects);
+        IEnumerable<Footnote> GetFootnotes(Guid releaseId, params Guid[] subjects);
 
         Task DeleteFootnote(Guid releaseId, Guid id);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/LocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/LocationService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
@@ -11,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
 {
     public class LocationService : AbstractRepository<Location, Guid>, ILocationService
     {
-        private static readonly List<GeographicLevel> IgnoredLevels = new List<GeographicLevel>
+        public static readonly List<GeographicLevel> IgnoredLevels = new List<GeographicLevel>
         {
             GeographicLevel.School,
             GeographicLevel.Provider


### PR DESCRIPTION
Assumes we have two uploaded, processed subjects, and finds out if one is a valid replacement of the other.

For the purpose of demonstrating this, this delivers an API endpoint that takes two subject id's, 'original' and 'replacement' and produces a report of all the datablocks and footnotes, describing whether they are valid for replacement or not.

If they are valid, the report includes their target replacement UUID's.

Comparisons are ultimately done by label or name fields from CSV data which are either the cell values or column headings.

Internally this looks up:
- What are the datablocks in use for the original subject?
- What are the footnotes in use for the original subect?

For each data block of the original subject what are the:
- Filter items
- Indicators
- Locations
- Time periods

For each footnote of the original subject what are the:
- Filters
- Filter groups
- Filter items
- Indicators

For the replacement subject what are the:
- Filters
- Filter groups
- Filters items
- Indicators
- Locations
- Time periods

The comparison works out the validity for replacement and the plan is produced looking at 

- Which datablocks are invalid because the replacement doesn't contain all the filter items/indicators/locations/time periods?
- Which footnotes are invalid because the replacement doesn't contain all the filters/filter groups/filter items/indicators?