### PR TITLE
EES-1339 Revert to regenerating the Publication with every Release

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -107,12 +107,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
             foreach (var publication in publications)
             {
-                // Only include the Publication if it's not already published
-                if (!publication.Published.HasValue)
-                {
-                    await CachePublication(publication.Id, context, releaseIds);
-                }
-
+                await CachePublication(publication.Id, context, releaseIds);
                 await CacheLatestRelease(publication, context, releaseIds);
                 foreach (var release in releases)
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -137,10 +137,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             contentRelease.Published ??= published;
             contentRelease.DataLastPublished = DateTime.UtcNow;
 
-            // Update the Publication date if it's the first time it's published
-            contentRelease.Publication.Published ??= published;
-            
-            // Update the Methodology date if it's the first time it's published
+            // Update the Publication published date since we always generate the Publication when generating Release Content
+            contentRelease.Publication.Published = published;
+
+            // Update the Methodology published date if it's the first time it's published
             var methodology = contentRelease.Publication.Methodology;
             if (methodology != null)
             {


### PR DESCRIPTION
This PR fixes a bug visible on Publications with more than one Release published since EES-1221 went live on 27/08/20 where the latest release displays an incorrect link to an older Release labelled as the "latest", and all the older Releases have no "Other Release" link back to the real latest Release.

As part of EES-1221 we made a change to prevent generating the Publication cache json file with every Release unless it's the first Release for the Publication (i.e. never published before).

We then only ever generated the Publication cache json again if there's an update to the Publication (title/contact details etc).

This has caused a bug because on publishing additional Releases for the same Publication (amendment or not, it doesn't matter), the Publication cache isn't getting updated.

The Publication cache json contains `latestReleaseId` and an array of all Releases which is used by the front end client to show an accurate list of "Other Releases" regardless of which Release you are viewing. `latestReleaseId` is also compared with a Releases own id to determine if it should be labelled as the latest.

This change reinstates generating the Publication cache while publishing a Release regardless of whether it's the first Release.