### PR TITLE
EES-1347 Fixes 'Manage content' key stats not showing summaries/definitions

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.tsx
@@ -11,7 +11,7 @@ import React, { useCallback, useState } from 'react';
 import styles from './EditableContentBlock.module.scss';
 
 interface EditableContentBlockProps
-  extends OmitStrict<FormEditorProps, 'onChange' | 'name'> {
+  extends OmitStrict<FormEditorProps, 'onChange'> {
   editable?: boolean;
   id: string;
   onSave: (value: string) => void;
@@ -65,7 +65,6 @@ const EditableContentBlock = ({
       <>
         <FormEditor
           {...props}
-          name="content"
           hideLabel={hideLabel}
           value={content}
           onChange={setContent}

--- a/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
@@ -52,6 +52,8 @@ const EditableKeyStat = ({
     includeGeoJson: false,
   });
 
+  const formId = `editableKeyStatForm-${id}`;
+
   const renderInner = () => {
     if (error || !keyStat) {
       return (
@@ -95,7 +97,7 @@ const EditableKeyStat = ({
           }}
         >
           {form => (
-            <Form id={`key-stats-form-${id}`}>
+            <Form id={formId}>
               <h3 className="govuk-heading-s">{name}</h3>
 
               <KeyStatTile
@@ -105,7 +107,7 @@ const EditableKeyStat = ({
                 value={keyStat.value}
               >
                 <FormFieldTextInput<KeyStatsFormValues>
-                  id={`key-stat-dataSummary-${id}`}
+                  id={`${formId}-dataSummary`}
                   name="dataSummary"
                   label={<span className={styles.trendText}>Trend</span>}
                 />
@@ -113,7 +115,7 @@ const EditableKeyStat = ({
 
               <FormFieldTextInput<KeyStatsFormValues>
                 formGroupClass="govuk-!-margin-top-2"
-                id={`key-stat-dataDefinitionTitle-${id}`}
+                id={`${formId}-dataDefinitionTitle`}
                 name="dataDefinitionTitle"
                 label="Guidance title"
               />
@@ -121,7 +123,7 @@ const EditableKeyStat = ({
               <FormFieldEditor<KeyStatsFormValues>
                 name="dataDefinition"
                 toolbarConfig={toolbarConfigs.reduced}
-                id={`key-stat-dataDefinition-${id}`}
+                id={`${formId}-dataDefinition`}
                 label="Guidance text"
               />
 

--- a/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
@@ -7,6 +7,7 @@ import ButtonGroup from '@common/components/ButtonGroup';
 import Details from '@common/components/Details';
 import { Form, FormFieldTextInput } from '@common/components/form';
 import LoadingSpinner from '@common/components/LoadingSpinner';
+import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import {
   KeyStatColumn,
@@ -51,132 +52,149 @@ const EditableKeyStat = ({
     includeGeoJson: false,
   });
 
-  if (error) {
-    return null;
-  }
+  const renderInner = () => {
+    if (error || !keyStat) {
+      return (
+        <>
+          <WarningMessage>Could not load key stat</WarningMessage>
+
+          <ButtonGroup>
+            {onRemove && (
+              <Button
+                disabled={removing}
+                variant="secondary"
+                onClick={() => {
+                  toggleRemoving.on();
+                  onRemove();
+                }}
+              >
+                Remove
+              </Button>
+            )}
+          </ButtonGroup>
+        </>
+      );
+    }
+
+    if (showForm) {
+      return (
+        <Formik<KeyStatsFormValues>
+          initialValues={{
+            dataSummary: summary?.dataSummary?.[0] ?? '',
+            dataDefinitionTitle: summary?.dataDefinitionTitle?.[0] ?? 'Help',
+            dataDefinition: summary?.dataDefinition?.[0]
+              ? toHtml(summary?.dataDefinition?.[0])
+              : '',
+          }}
+          onSubmit={values => {
+            onSubmit({
+              ...values,
+              dataDefinition: toMarkdown(values.dataDefinition),
+            });
+            toggleShowForm.off();
+          }}
+        >
+          {form => (
+            <Form id={`key-stats-form-${id}`}>
+              <h3 className="govuk-heading-s">{name}</h3>
+
+              <KeyStatTile
+                title={keyStat.title}
+                titleTag="h4"
+                testId={testId}
+                value={keyStat.value}
+              >
+                <FormFieldTextInput<KeyStatsFormValues>
+                  id={`key-stat-dataSummary-${id}`}
+                  name="dataSummary"
+                  label={<span className={styles.trendText}>Trend</span>}
+                />
+              </KeyStatTile>
+
+              <FormFieldTextInput<KeyStatsFormValues>
+                formGroupClass="govuk-!-margin-top-2"
+                id={`key-stat-dataDefinitionTitle-${id}`}
+                name="dataDefinitionTitle"
+                label="Guidance title"
+              />
+
+              <FormFieldEditor<KeyStatsFormValues>
+                name="dataDefinition"
+                toolbarConfig={toolbarConfigs.reduced}
+                id={`key-stat-dataDefinition-${id}`}
+                label="Guidance text"
+              />
+
+              <ButtonGroup>
+                <Button
+                  disabled={!form.isValid}
+                  type="submit"
+                  className="govuk-!-margin-right-2"
+                >
+                  Save
+                </Button>
+                <Button variant="secondary" onClick={toggleShowForm.off}>
+                  Cancel
+                </Button>
+              </ButtonGroup>
+            </Form>
+          )}
+        </Formik>
+      );
+    }
+
+    return (
+      <>
+        <KeyStatTile
+          title={keyStat.title}
+          value={keyStat.value}
+          testId={testId}
+        >
+          {summary?.dataSummary[0] && (
+            <p className="govuk-body-s" data-testid={`${testId}-summary`}>
+              {summary.dataSummary[0]}
+            </p>
+          )}
+        </KeyStatTile>
+
+        {summary?.dataDefinition[0] && (
+          <Details
+            summary={summary?.dataDefinitionTitle[0] || 'Help'}
+            className={styles.definition}
+          >
+            <div data-testid={`${testId}-definition`}>
+              {summary.dataDefinition.map(data => (
+                <ReactMarkdown key={data}>{data}</ReactMarkdown>
+              ))}
+            </div>
+          </Details>
+        )}
+
+        {isEditing && (
+          <ButtonGroup className="govuk-!-margin-top-2">
+            <Button onClick={toggleShowForm.on}>Edit</Button>
+
+            {onRemove && (
+              <Button
+                disabled={removing}
+                variant="secondary"
+                onClick={() => {
+                  toggleRemoving.on();
+                  onRemove();
+                }}
+              >
+                Remove
+              </Button>
+            )}
+          </ButtonGroup>
+        )}
+      </>
+    );
+  };
 
   return (
     <KeyStatColumn testId={testId}>
-      <LoadingSpinner loading={isLoading}>
-        {keyStat && (
-          <>
-            {showForm ? (
-              <Formik<KeyStatsFormValues>
-                initialValues={{
-                  dataSummary: summary?.dataSummary?.[0] ?? '',
-                  dataDefinitionTitle:
-                    summary?.dataDefinitionTitle?.[0] ?? 'Help',
-                  dataDefinition: summary?.dataDefinition?.[0]
-                    ? toHtml(summary?.dataDefinition?.[0])
-                    : '',
-                }}
-                onSubmit={values => {
-                  onSubmit({
-                    ...values,
-                    dataDefinition: toMarkdown(values.dataDefinition),
-                  });
-                  toggleShowForm.off();
-                }}
-              >
-                {form => (
-                  <Form id={`key-stats-form-${id}`}>
-                    <h3 className="govuk-heading-s">{name}</h3>
-
-                    <KeyStatTile
-                      title={keyStat.title}
-                      titleTag="h4"
-                      testId={testId}
-                      value={keyStat.value}
-                    >
-                      <FormFieldTextInput<KeyStatsFormValues>
-                        id={`key-stat-dataSummary-${id}`}
-                        name="dataSummary"
-                        label={<span className={styles.trendText}>Trend</span>}
-                      />
-                    </KeyStatTile>
-
-                    <FormFieldTextInput<KeyStatsFormValues>
-                      formGroupClass="govuk-!-margin-top-2"
-                      id={`key-stat-dataDefinitionTitle-${id}`}
-                      name="dataDefinitionTitle"
-                      label="Guidance title"
-                    />
-
-                    <FormFieldEditor<KeyStatsFormValues>
-                      name="dataDefinition"
-                      toolbarConfig={toolbarConfigs.reduced}
-                      id={`key-stat-dataDefinition-${id}`}
-                      label="Guidance text"
-                    />
-
-                    <ButtonGroup>
-                      <Button
-                        disabled={!form.isValid}
-                        type="submit"
-                        className="govuk-!-margin-right-2"
-                      >
-                        Save
-                      </Button>
-                      <Button variant="secondary" onClick={toggleShowForm.off}>
-                        Cancel
-                      </Button>
-                    </ButtonGroup>
-                  </Form>
-                )}
-              </Formik>
-            ) : (
-              <>
-                <KeyStatTile
-                  title={keyStat.title}
-                  value={keyStat.value}
-                  testId={testId}
-                >
-                  {summary?.dataSummary[0] && (
-                    <p
-                      className="govuk-body-s"
-                      data-testid={`${testId}-summary`}
-                    >
-                      {summary.dataSummary[0]}
-                    </p>
-                  )}
-                </KeyStatTile>
-
-                {summary?.dataDefinition[0] && (
-                  <Details
-                    summary={summary?.dataDefinitionTitle[0] || 'Help'}
-                    className={styles.definition}
-                  >
-                    <div data-testid={`${testId}-definition`}>
-                      {summary.dataDefinition.map(data => (
-                        <ReactMarkdown key={data}>{data}</ReactMarkdown>
-                      ))}
-                    </div>
-                  </Details>
-                )}
-
-                {isEditing && (
-                  <ButtonGroup className="govuk-!-margin-top-2">
-                    <Button onClick={toggleShowForm.on}>Edit</Button>
-
-                    {onRemove && (
-                      <Button
-                        disabled={removing}
-                        variant="secondary"
-                        onClick={() => {
-                          toggleRemoving.on();
-                          onRemove();
-                        }}
-                      >
-                        Remove
-                      </Button>
-                    )}
-                  </ButtonGroup>
-                )}
-              </>
-            )}
-          </>
-        )}
-      </LoadingSpinner>
+      <LoadingSpinner loading={isLoading}>{renderInner()}</LoadingSpinner>
     </KeyStatColumn>
   );
 };

--- a/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
@@ -4,6 +4,7 @@ import toHtml from '@admin/utils/markdown/toHtml';
 import toMarkdown from '@admin/utils/markdown/toMarkdown';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
+import Details from '@common/components/Details';
 import { Form, FormFieldTextInput } from '@common/components/form';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import useToggle from '@common/hooks/useToggle';
@@ -16,6 +17,7 @@ import KeyStatTile from '@common/modules/find-statistics/components/KeyStatTile'
 import useKeyStatQuery from '@common/modules/find-statistics/hooks/useKeyStatQuery';
 import { Formik } from 'formik';
 import React from 'react';
+import ReactMarkdown from 'react-markdown';
 
 export interface KeyStatsFormValues {
   dataSummary: string;
@@ -80,7 +82,12 @@ const EditableKeyStat = ({
                   <Form id={`key-stats-form-${id}`}>
                     <h3 className="govuk-heading-s">{name}</h3>
 
-                    <KeyStatTile title={keyStat.title} value={keyStat.value}>
+                    <KeyStatTile
+                      title={keyStat.title}
+                      titleTag="h4"
+                      testId={testId}
+                      value={keyStat.value}
+                    >
                       <FormFieldTextInput<KeyStatsFormValues>
                         id={`key-stat-dataSummary-${id}`}
                         name="dataSummary"
@@ -119,7 +126,33 @@ const EditableKeyStat = ({
               </Formik>
             ) : (
               <>
-                <KeyStatTile title={keyStat.title} value={keyStat.value} />
+                <KeyStatTile
+                  title={keyStat.title}
+                  value={keyStat.value}
+                  testId={testId}
+                >
+                  {summary?.dataSummary[0] && (
+                    <p
+                      className="govuk-body-s"
+                      data-testid={`${testId}-summary`}
+                    >
+                      {summary.dataSummary[0]}
+                    </p>
+                  )}
+                </KeyStatTile>
+
+                {summary?.dataDefinition[0] && (
+                  <Details
+                    summary={summary?.dataDefinitionTitle[0] || 'Help'}
+                    className={styles.definition}
+                  >
+                    <div data-testid={`${testId}-definition`}>
+                      {summary.dataDefinition.map(data => (
+                        <ReactMarkdown key={data}>{data}</ReactMarkdown>
+                      ))}
+                    </div>
+                  </Details>
+                )}
 
                 {isEditing && (
                   <ButtonGroup className="govuk-!-margin-top-2">

--- a/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
@@ -40,7 +40,7 @@ const EditableKeyStat = ({
   name,
   query,
   summary,
-  testId = 'editableKeyStat',
+  testId = 'keyStat',
   onRemove,
   onSubmit,
 }: EditableKeyStatProps) => {

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
@@ -1,0 +1,451 @@
+import EditableKeyStat, {
+  KeyStatsFormValues,
+} from '@admin/components/editable/EditableKeyStat';
+import _tableBuilderService, {
+  TableDataQuery,
+  TableDataResponse,
+} from '@common/services/tableBuilderService';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import React from 'react';
+
+jest.mock('@common/services/tableBuilderService');
+
+const tableBuilderService = _tableBuilderService as jest.Mocked<
+  typeof _tableBuilderService
+>;
+
+describe('EditableKeyStat', () => {
+  const testQuery: TableDataQuery = {
+    filters: ['filter-1'],
+    indicators: ['indicator-1'],
+    subjectId: 'subject-1',
+    timePeriod: {
+      startCode: 'AY',
+      startYear: 2020,
+      endCode: 'AY',
+      endYear: 2020,
+    },
+    locations: {
+      country: ['england'],
+    },
+  };
+
+  const testTableDataResponse: TableDataResponse = {
+    subjectMeta: {
+      publicationName: 'Test publication',
+      subjectName: 'Test subject',
+      geoJsonAvailable: false,
+      filters: {
+        Filter1: {
+          legend: 'Filter 1',
+          name: 'filter1',
+          options: {
+            FilterGroup1: {
+              label: 'Filter group 1',
+              options: [
+                {
+                  label: 'Filter 1',
+                  value: 'filter-1',
+                },
+              ],
+            },
+          },
+        },
+      },
+      locations: [
+        {
+          label: 'England',
+          level: 'country',
+          value: 'england',
+        },
+      ],
+      timePeriodRange: [{ code: 'AY', label: '2020/21', year: 2020 }],
+      indicators: [
+        {
+          label: 'Number of applications received',
+          name: 'applications_received',
+          unit: '',
+          value: 'indicator-1',
+        },
+      ],
+      boundaryLevels: [],
+      footnotes: [],
+    },
+    results: [
+      {
+        filters: ['filter-1'],
+        geographicLevel: 'country',
+        location: {
+          country: {
+            name: 'england',
+            code: 'england',
+          },
+        },
+        timePeriod: '2020_AY',
+        measures: {
+          'indicator-1': '608180',
+        },
+      },
+    ],
+  };
+
+  test('renders correctly with read-only summary', async () => {
+    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+
+    render(
+      <EditableKeyStat
+        id="test-id-1"
+        name="Key Stat 1"
+        onSubmit={noop}
+        query={testQuery}
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: ['What is the number of applications received?'],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+
+      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+
+      expect(screen.getByTestId('editableKeyStat-value')).toHaveTextContent(
+        '608,180',
+      );
+
+      expect(screen.getByTestId('editableKeyStat-summary')).toHaveTextContent(
+        'Down from 620,330 in 2017',
+      );
+
+      expect(
+        screen.getByRole('button', {
+          name: 'What is the number of applications received?',
+        }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByTestId('editableKeyStat-definition'),
+      ).toHaveTextContent(
+        'Total number of applications received for places at primary and secondary schools.',
+      );
+    });
+  });
+
+  test('renders correctly without read-only summary', async () => {
+    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+
+    render(
+      <EditableKeyStat
+        id="test-id-1"
+        name="Key Stat 1"
+        onSubmit={noop}
+        query={testQuery}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+
+      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+
+      expect(screen.getByTestId('editableKeyStat-value')).toHaveTextContent(
+        '608,180',
+      );
+
+      expect(
+        screen.queryByTestId('editableKeyStat-summary'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('editableKeyStat-definition'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('clicking Edit button renders editable summary form with no initial summary', async () => {
+    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+
+    render(
+      <EditableKeyStat
+        isEditing
+        id="test-id-1"
+        name="Key Stat 1"
+        onSubmit={noop}
+        query={testQuery}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(
+      screen.getByText('Key Stat 1', { selector: 'h3' }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+      'Number of applications received',
+    );
+    expect(screen.getByTestId('editableKeyStat-value')).toHaveTextContent(
+      '608,180',
+    );
+    expect(screen.getByLabelText('Trend')).toHaveValue('');
+    expect(screen.getByLabelText('Guidance title')).toHaveValue('Help');
+    expect(screen.getByLabelText('Guidance text')).toHaveTextContent('');
+  });
+
+  test('clicking Edit button renders editable summary form with initial summary', async () => {
+    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+
+    render(
+      <EditableKeyStat
+        isEditing
+        id="test-id-1"
+        name="Key Stat 1"
+        onSubmit={noop}
+        query={testQuery}
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: ['What is the number of applications received?'],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(
+      screen.getByText('Key Stat 1', { selector: 'h3' }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+      'Number of applications received',
+    );
+    expect(screen.getByTestId('editableKeyStat-value')).toHaveTextContent(
+      '608,180',
+    );
+    expect(screen.getByLabelText('Trend')).toHaveValue(
+      'Down from 620,330 in 2017',
+    );
+    expect(screen.getByLabelText('Guidance title')).toHaveValue(
+      'What is the number of applications received?',
+    );
+    expect(screen.getByLabelText('Guidance text')).toHaveTextContent(
+      'Total number of applications received for places at primary and secondary schools.',
+    );
+  });
+
+  test('clicking Cancel button shows read-only summary again', async () => {
+    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+
+    render(
+      <EditableKeyStat
+        isEditing
+        id="test-id-1"
+        name="Key Stat 1"
+        onSubmit={noop}
+        query={testQuery}
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: ['What is the number of applications received?'],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+    });
+
+    // Start editing
+    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    expect(screen.getByLabelText('Trend')).toHaveValue(
+      'Down from 620,330 in 2017',
+    );
+
+    // Cancel editing
+    userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByLabelText('Trend')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Guidance title')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Guidance text')).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+      'Number of applications received',
+    );
+
+    expect(screen.getByTestId('editableKeyStat-value')).toHaveTextContent(
+      '608,180',
+    );
+
+    expect(screen.getByTestId('editableKeyStat-summary')).toHaveTextContent(
+      'Down from 620,330 in 2017',
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: 'What is the number of applications received?',
+      }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('editableKeyStat-definition')).toHaveTextContent(
+      'Total number of applications received for places at primary and secondary schools.',
+    );
+  });
+
+  test('can submit with updated summary field values', async () => {
+    const handleSubmit = jest.fn();
+
+    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+
+    render(
+      <EditableKeyStat
+        isEditing
+        id="test-id-1"
+        name="Key Stat 1"
+        onSubmit={handleSubmit}
+        query={testQuery}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    userEvent.clear(screen.getByLabelText('Trend'));
+    await userEvent.type(screen.getByLabelText('Trend'), 'New trend text');
+
+    userEvent.clear(screen.getByLabelText('Guidance title'));
+    await userEvent.type(
+      screen.getByLabelText('Guidance title'),
+      'New guidance title',
+    );
+
+    // Note that we can't change 'Guidance text' field
+    // as CKEditor doesn't work in Jest
+
+    expect(handleSubmit).not.toBeCalled();
+
+    userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+      expect(handleSubmit).toHaveBeenCalledWith({
+        dataDefinition: '',
+        dataDefinitionTitle: 'New guidance title',
+        dataSummary: 'New trend text',
+      } as KeyStatsFormValues);
+    });
+  });
+
+  test('does not render if there was an error fetching the table data', async () => {
+    tableBuilderService.getTableData.mockRejectedValue(
+      new Error('Something went wrong'),
+    );
+
+    render(
+      <EditableKeyStat
+        id="test-id-1"
+        name="Key Stat 1"
+        onSubmit={noop}
+        query={testQuery}
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: ['What is the number of applications received?'],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('keyStat-value')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('keyStat-summary')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('keyStat-definition'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('does not render if there is no matching result in the response', async () => {
+    tableBuilderService.getTableData.mockResolvedValue({
+      ...testTableDataResponse,
+      subjectMeta: {
+        ...testTableDataResponse.subjectMeta,
+        indicators: [
+          {
+            label: 'Number of applications received',
+            name: 'applications_received',
+            unit: '',
+            value: 'indicator-1',
+          },
+        ],
+      },
+      results: [],
+    });
+
+    render(
+      <EditableKeyStat
+        id="test-id-1"
+        name="Key Stat 1"
+        onSubmit={noop}
+        query={testQuery}
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: ['What is the number of applications received?'],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('keyStat-value')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('keyStat-summary')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('keyStat-definition'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
@@ -256,6 +256,43 @@ describe('EditableKeyStat', () => {
     );
   });
 
+  test('clicking Remove button calls the `onRemove` callback prop', async () => {
+    const handleRemove = jest.fn();
+
+    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+
+    render(
+      <EditableKeyStat
+        isEditing
+        id="test-id-1"
+        name="Key Stat 1"
+        onRemove={handleRemove}
+        onSubmit={noop}
+        query={testQuery}
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: ['What is the number of applications received?'],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+    });
+
+    expect(handleRemove).not.toHaveBeenCalled();
+
+    userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    expect(handleRemove).toHaveBeenCalled();
+  });
+
   test('clicking Cancel button shows read-only summary again', async () => {
     tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
 
@@ -369,7 +406,7 @@ describe('EditableKeyStat', () => {
     });
   });
 
-  test('does not render if there was an error fetching the table data', async () => {
+  test('renders correctly if there was an error fetching the table data', async () => {
     tableBuilderService.getTableData.mockRejectedValue(
       new Error('Something went wrong'),
     );
@@ -378,6 +415,7 @@ describe('EditableKeyStat', () => {
       <EditableKeyStat
         id="test-id-1"
         name="Key Stat 1"
+        onRemove={noop}
         onSubmit={noop}
         query={testQuery}
         summary={{
@@ -393,17 +431,24 @@ describe('EditableKeyStat', () => {
 
     await waitFor(() => {
       expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Could not load key stat')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Remove' }),
+      ).toBeInTheDocument();
+
       expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
       expect(screen.queryByTestId('keyStat-value')).not.toBeInTheDocument();
       expect(screen.queryByTestId('keyStat-summary')).not.toBeInTheDocument();
-      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Edit' }),
+      ).not.toBeInTheDocument();
       expect(
         screen.queryByTestId('keyStat-definition'),
       ).not.toBeInTheDocument();
     });
   });
 
-  test('does not render if there is no matching result in the response', async () => {
+  test('renders correctly if there is no matching result in the response', async () => {
     tableBuilderService.getTableData.mockResolvedValue({
       ...testTableDataResponse,
       subjectMeta: {
@@ -424,6 +469,7 @@ describe('EditableKeyStat', () => {
       <EditableKeyStat
         id="test-id-1"
         name="Key Stat 1"
+        onRemove={noop}
         onSubmit={noop}
         query={testQuery}
         summary={{
@@ -439,13 +485,58 @@ describe('EditableKeyStat', () => {
 
     await waitFor(() => {
       expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Could not load key stat')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Remove' }),
+      ).toBeInTheDocument();
+
       expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
       expect(screen.queryByTestId('keyStat-value')).not.toBeInTheDocument();
       expect(screen.queryByTestId('keyStat-summary')).not.toBeInTheDocument();
-      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Edit' }),
+      ).not.toBeInTheDocument();
       expect(
         screen.queryByTestId('keyStat-definition'),
       ).not.toBeInTheDocument();
     });
+  });
+
+  test('clicking Remove button when there has been an error calls the `onRemove` callback prop', async () => {
+    const handleRemove = jest.fn();
+
+    tableBuilderService.getTableData.mockRejectedValue(
+      new Error('Something went wrong'),
+    );
+
+    render(
+      <EditableKeyStat
+        id="test-id-1"
+        name="Key Stat 1"
+        onRemove={handleRemove}
+        onSubmit={noop}
+        query={testQuery}
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: ['What is the number of applications received?'],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Remove' }),
+      ).toBeInTheDocument();
+    });
+
+    expect(handleRemove).not.toHaveBeenCalled();
+
+    userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    expect(handleRemove).toHaveBeenCalled();
   });
 });

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
@@ -114,15 +114,13 @@ describe('EditableKeyStat', () => {
     await waitFor(() => {
       expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
 
-      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'Number of applications received',
       );
 
-      expect(screen.getByTestId('editableKeyStat-value')).toHaveTextContent(
-        '608,180',
-      );
+      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
 
-      expect(screen.getByTestId('editableKeyStat-summary')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-summary')).toHaveTextContent(
         'Down from 620,330 in 2017',
       );
 
@@ -132,9 +130,7 @@ describe('EditableKeyStat', () => {
         }),
       ).toBeInTheDocument();
 
-      expect(
-        screen.getByTestId('editableKeyStat-definition'),
-      ).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-definition')).toHaveTextContent(
         'Total number of applications received for places at primary and secondary schools.',
       );
     });
@@ -155,19 +151,15 @@ describe('EditableKeyStat', () => {
     await waitFor(() => {
       expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
 
-      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'Number of applications received',
       );
 
-      expect(screen.getByTestId('editableKeyStat-value')).toHaveTextContent(
-        '608,180',
-      );
+      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
 
+      expect(screen.queryByTestId('keyStat-summary')).not.toBeInTheDocument();
       expect(
-        screen.queryByTestId('editableKeyStat-summary'),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByTestId('editableKeyStat-definition'),
+        screen.queryByTestId('keyStat-definition'),
       ).not.toBeInTheDocument();
     });
   });
@@ -186,7 +178,7 @@ describe('EditableKeyStat', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'Number of applications received',
       );
     });
@@ -196,12 +188,10 @@ describe('EditableKeyStat', () => {
     expect(
       screen.getByText('Key Stat 1', { selector: 'h3' }),
     ).toBeInTheDocument();
-    expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+    expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
       'Number of applications received',
     );
-    expect(screen.getByTestId('editableKeyStat-value')).toHaveTextContent(
-      '608,180',
-    );
+    expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
     expect(screen.getByLabelText('Trend')).toHaveValue('');
     expect(screen.getByLabelText('Guidance title')).toHaveValue('Help');
     expect(screen.getByLabelText('Guidance text')).toHaveTextContent('');
@@ -229,7 +219,7 @@ describe('EditableKeyStat', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'Number of applications received',
       );
     });
@@ -239,12 +229,10 @@ describe('EditableKeyStat', () => {
     expect(
       screen.getByText('Key Stat 1', { selector: 'h3' }),
     ).toBeInTheDocument();
-    expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+    expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
       'Number of applications received',
     );
-    expect(screen.getByTestId('editableKeyStat-value')).toHaveTextContent(
-      '608,180',
-    );
+    expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
     expect(screen.getByLabelText('Trend')).toHaveValue(
       'Down from 620,330 in 2017',
     );
@@ -281,7 +269,7 @@ describe('EditableKeyStat', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'Number of applications received',
       );
     });
@@ -315,7 +303,7 @@ describe('EditableKeyStat', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'Number of applications received',
       );
     });
@@ -334,15 +322,13 @@ describe('EditableKeyStat', () => {
     expect(screen.queryByLabelText('Guidance title')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Guidance text')).not.toBeInTheDocument();
 
-    expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+    expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
       'Number of applications received',
     );
 
-    expect(screen.getByTestId('editableKeyStat-value')).toHaveTextContent(
-      '608,180',
-    );
+    expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
 
-    expect(screen.getByTestId('editableKeyStat-summary')).toHaveTextContent(
+    expect(screen.getByTestId('keyStat-summary')).toHaveTextContent(
       'Down from 620,330 in 2017',
     );
 
@@ -352,7 +338,7 @@ describe('EditableKeyStat', () => {
       }),
     ).toBeInTheDocument();
 
-    expect(screen.getByTestId('editableKeyStat-definition')).toHaveTextContent(
+    expect(screen.getByTestId('keyStat-definition')).toHaveTextContent(
       'Total number of applications received for places at primary and secondary schools.',
     );
   });
@@ -373,7 +359,7 @@ describe('EditableKeyStat', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('editableKeyStat-title')).toHaveTextContent(
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'Number of applications received',
       );
     });

--- a/src/explore-education-statistics-admin/src/components/form/FormEditor.module.scss
+++ b/src/explore-education-statistics-admin/src/components/form/FormEditor.module.scss
@@ -5,10 +5,27 @@
   margin-bottom: govuk-spacing(2);
 
   :global(.ck.ck-editor) {
-    border: 2px solid govuk-colour('black');
+    border: $govuk-border-width-form-element solid $govuk-input-border-colour;
   }
 
   :global(.ck-focused) {
     border-color: $govuk-input-border-colour !important;
+  }
+}
+
+.readOnlyEditor {
+  background: govuk-colour('light-grey');
+  border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+  cursor: not-allowed;
+  padding: govuk-spacing(2);
+
+  &:focus {
+    box-shadow: inset 0 0 0 $govuk-border-width-form-element;
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline-offset: 0;
+
+    @include govuk-if-ie8 {
+      border-width: $govuk-border-width-form-element * 2;
+    }
   }
 }

--- a/src/explore-education-statistics-admin/src/components/form/FormEditor.tsx
+++ b/src/explore-education-statistics-admin/src/components/form/FormEditor.tsx
@@ -5,7 +5,7 @@ import ClassicEditor from '@ckeditor/ckeditor5-build-classic';
 // @ts-ignore
 import CKEditor from '@ckeditor/ckeditor5-react';
 import ErrorMessage from '@common/components/ErrorMessage';
-import FormTextArea from '@common/components/form/FormTextArea';
+import SanitizeHtml from '@common/components/SanitizeHtml';
 import isBrowser from '@common/utils/isBrowser';
 import classNames from 'classnames';
 import React, { ChangeEvent, useCallback, useMemo } from 'react';
@@ -17,7 +17,6 @@ export interface FormEditorProps {
   hint?: string;
   id: string;
   label: string;
-  name: string;
   toolbarConfig?: string[];
   value: string;
   onChange: (content: string) => void;
@@ -50,7 +49,6 @@ const FormEditor = ({
   hint,
   id,
   label,
-  name,
   toolbarConfig = toolbarConfigs.full,
   value,
   onChange,
@@ -103,13 +101,12 @@ const FormEditor = ({
     [],
   );
 
-  if (isBrowser('IE')) {
-    return <FormTextArea id={id} name={name} label={label} disabled />;
-  }
+  const isReadOnly = isBrowser('IE');
 
   return (
     <>
       <span
+        id={`${id}-label`}
         className={classNames('govuk-label', {
           'govuk-visually-hidden': hideLabel,
         })}
@@ -125,15 +122,28 @@ const FormEditor = ({
 
       {error && <ErrorMessage id={`${id}-error`}>{error}</ErrorMessage>}
 
-      <div className={styles.editor}>
-        <CKEditor
-          editor={ClassicEditor}
-          config={config}
-          data={value}
-          onChange={handleChange}
-          onInit={handleInit}
-        />
-      </div>
+      {!isReadOnly ? (
+        <div className={styles.editor}>
+          <CKEditor
+            editor={ClassicEditor}
+            config={config}
+            data={value}
+            onChange={handleChange}
+            onInit={handleInit}
+          />
+        </div>
+      ) : (
+        <div
+          aria-readonly
+          aria-labelledby={`${id}-label`}
+          className={styles.readOnlyEditor}
+          role="textbox"
+          id={id}
+          tabIndex={0}
+        >
+          <SanitizeHtml dirtyHtml={value} />
+        </div>
+      )}
     </>
   );
 };

--- a/src/explore-education-statistics-admin/src/components/form/FormEditor.tsx
+++ b/src/explore-education-statistics-admin/src/components/form/FormEditor.tsx
@@ -101,7 +101,7 @@ const FormEditor = ({
     [],
   );
 
-  const isReadOnly = isBrowser('IE');
+  const isReadOnly = isBrowser('IE') || process.env.NODE_ENV === 'test';
 
   return (
     <>

--- a/src/explore-education-statistics-admin/src/prototypes/PrototypeBauGlossary.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/PrototypeBauGlossary.tsx
@@ -94,7 +94,6 @@ const PrototypeBauGlossary = () => {
             </FormGroup>
             <FormEditor
               id="description"
-              name="description"
               label="Item description"
               value={glossaryDescription || ''}
               onChange={() => {

--- a/src/explore-education-statistics-admin/src/prototypes/components/PrototypeMetaForms.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/components/PrototypeMetaForms.tsx
@@ -62,7 +62,6 @@ const PrototypeCreateMetaForms = ({
         <div className="govuk-!-margin-bottom-7">
           <FormEditor
             id="description"
-            name="description"
             label="Public metadata introduction"
             value={formExample.descriptionPlaceholder.text}
             onChange={() => {}}

--- a/src/explore-education-statistics-admin/src/prototypes/components/PrototypePreReleaseCreate.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/components/PrototypePreReleaseCreate.tsx
@@ -79,7 +79,6 @@ const PrototypeCreatePreRelease = () => {
             <div className="govuk-!-margin-bottom-7">
               <FormEditor
                 id="description"
-                name="description"
                 label="Public access list details"
                 value={editPreRelease ? formText : formIntro}
                 onChange={() => setAddNewPreRelease(true)}

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
@@ -36,7 +36,6 @@ export interface KeyStatProps {
   queryOptions?: TableQueryOptions;
   summary?: Summary;
   testId?: string;
-  renderDataSummary?: ReactNode;
 }
 
 const KeyStat = ({
@@ -68,21 +67,23 @@ const KeyStat = ({
               value={keyStat.value}
               testId={testId}
             >
-              {summary?.dataSummary && (
+              {summary?.dataSummary[0] && (
                 <p className="govuk-body-s" data-testid={`${testId}-summary`}>
-                  {summary.dataSummary}
+                  {summary.dataSummary[0]}
                 </p>
               )}
             </KeyStatTile>
 
-            {summary?.dataDefinition?.[0] && (
+            {summary?.dataDefinition[0] && (
               <Details
-                summary={summary?.dataDefinitionTitle || 'Help'}
+                summary={summary?.dataDefinitionTitle[0] || 'Help'}
                 className={styles.definition}
               >
-                {summary.dataDefinition.map(data => (
-                  <ReactMarkdown key={data}>{data}</ReactMarkdown>
-                ))}
+                <div data-testid={`${testId}-definition`}>
+                  {summary.dataDefinition.map(data => (
+                    <ReactMarkdown key={data}>{data}</ReactMarkdown>
+                  ))}
+                </div>
               </Details>
             )}
 

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStatTile.tsx
@@ -5,20 +5,22 @@ interface Props {
   children?: ReactNode;
   testId?: string;
   title: string;
+  titleTag?: 'h3' | 'h4';
   value: string;
 }
 
 const KeyStatTile = ({
   children,
   testId = 'keyStatTile',
+  titleTag: TitleElement = 'h3',
   title,
   value,
 }: Props) => {
   return (
     <div className={styles.tile}>
-      <h3 className="govuk-heading-s" data-testid={`${testId}-title`}>
+      <TitleElement className="govuk-heading-s" data-testid={`${testId}-title`}>
         {title}
-      </h3>
+      </TitleElement>
 
       <p className="govuk-heading-xl" data-testid={`${testId}-value`}>
         {value}

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStat.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStat.test.tsx
@@ -1,0 +1,227 @@
+import KeyStat from '@common/modules/find-statistics/components/KeyStat';
+import _tableBuilderService, {
+  TableDataQuery,
+  TableDataResponse,
+} from '@common/services/tableBuilderService';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('@common/services/tableBuilderService');
+
+const tableBuilderService = _tableBuilderService as jest.Mocked<
+  typeof _tableBuilderService
+>;
+
+describe('KeyStat', () => {
+  const testQuery: TableDataQuery = {
+    filters: ['filter-1'],
+    indicators: ['indicator-1'],
+    subjectId: 'subject-1',
+    timePeriod: {
+      startCode: 'AY',
+      startYear: 2020,
+      endCode: 'AY',
+      endYear: 2020,
+    },
+    locations: {
+      country: ['england'],
+    },
+  };
+
+  const testTableDataResponse: TableDataResponse = {
+    subjectMeta: {
+      publicationName: 'Test publication',
+      subjectName: 'Test subject',
+      geoJsonAvailable: false,
+      filters: {
+        Filter1: {
+          legend: 'Filter 1',
+          name: 'filter1',
+          options: {
+            FilterGroup1: {
+              label: 'Filter group 1',
+              options: [
+                {
+                  label: 'Filter 1',
+                  value: 'filter-1',
+                },
+              ],
+            },
+          },
+        },
+      },
+      locations: [
+        {
+          label: 'England',
+          level: 'country',
+          value: 'england',
+        },
+      ],
+      timePeriodRange: [{ code: 'AY', label: '2020/21', year: 2020 }],
+      indicators: [
+        {
+          label: 'Number of applications received',
+          name: 'applications_received',
+          unit: '',
+          value: 'indicator-1',
+        },
+      ],
+      boundaryLevels: [],
+      footnotes: [],
+    },
+    results: [
+      {
+        filters: ['filter-1'],
+        geographicLevel: 'country',
+        location: {
+          country: {
+            name: 'england',
+            code: 'england',
+          },
+        },
+        timePeriod: '2020_AY',
+        measures: {
+          'indicator-1': '608180',
+        },
+      },
+    ],
+  };
+
+  test('renders correctly with summary', async () => {
+    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+
+    render(
+      <KeyStat
+        query={testQuery}
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: ['What is the number of applications received?'],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+
+      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+
+      expect(screen.getByTestId('keyStat-summary')).toHaveTextContent(
+        'Down from 620,330 in 2017',
+      );
+
+      expect(
+        screen.getByRole('button', {
+          name: 'What is the number of applications received?',
+        }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByTestId('keyStat-definition')).toHaveTextContent(
+        'Total number of applications received for places at primary and secondary schools.',
+      );
+    });
+  });
+
+  test('renders correctly without summary', async () => {
+    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+
+    render(<KeyStat query={testQuery} />);
+
+    await waitFor(() => {
+      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+
+      expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
+        'Number of applications received',
+      );
+
+      expect(screen.getByTestId('keyStat-value')).toHaveTextContent('608,180');
+
+      expect(screen.queryByTestId('keyStat-summary')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('keyStat-definition'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('does not render if there was an error fetching the table data', async () => {
+    tableBuilderService.getTableData.mockRejectedValue(
+      new Error('Something went wrong'),
+    );
+
+    render(
+      <KeyStat
+        query={testQuery}
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: ['What is the number of applications received?'],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('keyStat-value')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('keyStat-summary')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('keyStat-definition'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('does not render if there is no matching result in the response', async () => {
+    tableBuilderService.getTableData.mockResolvedValue({
+      ...testTableDataResponse,
+      subjectMeta: {
+        ...testTableDataResponse.subjectMeta,
+        indicators: [
+          {
+            label: 'Number of applications received',
+            name: 'applications_received',
+            unit: '',
+            value: 'indicator-1',
+          },
+        ],
+      },
+      results: [],
+    });
+
+    render(
+      <KeyStat
+        query={testQuery}
+        summary={{
+          dataSummary: ['Down from 620,330 in 2017'],
+          dataDefinitionTitle: ['What is the number of applications received?'],
+          dataDefinition: [
+            'Total number of applications received for places at primary and secondary schools.',
+          ],
+          dataKeys: [],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('keyStat-value')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('keyStat-summary')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId('keyStat-definition'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useKeyStatQuery.ts
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useKeyStatQuery.ts
@@ -37,10 +37,20 @@ export default function useKeyStatQuery(
     if (tableData) {
       const [indicator] = tableData.subjectMeta.indicators;
 
+      if (!indicator) {
+        return;
+      }
+
+      const indicatorValue = tableData.results[0]?.measures[indicator.value];
+
+      if (!indicatorValue) {
+        return;
+      }
+
       setValue({
         title: indicator.label,
         value: formatPretty(
-          tableData.results[0].measures[indicator.value],
+          indicatorValue,
           indicator.unit,
           indicator.decimalPlaces,
         ),

--- a/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
@@ -61,10 +61,17 @@ Validate Analyst1 can see 'Manage content' page key stats
     [Tags]  HappyPath
     user waits until page contains element  id:releaseHeadlines
     user scrolls to element  id:releaseHeadlines
-    user waits until page contains key stat tile   Overall absence rate        4.7%    60
-    user waits until page contains key stat tile   Authorised absence rate     3.4%
-    user waits until page contains key stat tile   Unauthorised absence rate   1.3%
-    user checks element count is x    css:[data-testid="keyStatTile-title"]   3
+
+    user checks key stat contents    1  Overall absence rate         4.7%   Up from 4.6% in 2015/16   90
+    user checks key stat definition  1  What is overall absence?  Total number of all authorised and unauthorised absences from possible school sessions for all pupils.
+
+    user checks key stat contents    2  Authorised absence rate      3.4%   Similar to previous years
+    user checks key stat definition  2  What is authorized absence rate?  Number of authorised absences as a percentage of the overall school population.
+
+    user checks key stat contents    3  Unauthorised absence rate    1.3%   Up from 1.1% in 2015/16
+    user checks key stat definition  3  What is unauthorized absence rate?  Number of unauthorised absences as a percentage of the overall school population.
+
+    user checks element count is x    css:[data-testid="keyStat"]   3
 
 Validate Analyst1 can see 'Manage content' page accordion sections
     [Tags]  HappyPath

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -91,9 +91,14 @@ Validate absence_in_prus.csv file can be downloaded
 Validate headlines -- Summary tab key stats
     [Documentation]  DFE-915   EES-806   EES-1508
     [Tags]  HappyPath
-    user checks key stat contents   1  Overall absence rate         4.7%   Up from 4.6% in 2015/16
-    user checks key stat contents   2  Authorised absence rate      3.4%   Similar to previous years
-    user checks key stat contents   3  Unauthorised absence rate    1.3%   Up from 1.1% in 2015/16
+    user checks key stat contents    1  Overall absence rate         4.7%   Up from 4.6% in 2015/16   90
+    user checks key stat definition  1  What is overall absence?  Total number of all authorised and unauthorised absences from possible school sessions for all pupils.
+
+    user checks key stat contents    2  Authorised absence rate      3.4%   Similar to previous years
+    user checks key stat definition  2  What is authorized absence rate?  Number of authorised absences as a percentage of the overall school population.
+
+    user checks key stat contents    3  Unauthorised absence rate    1.3%   Up from 1.1% in 2015/16
+    user checks key stat definition  3  What is unauthorized absence rate?  Number of unauthorised absences as a percentage of the overall school population.
 
 Validate headlines -- Summary tab content
     [Documentation]    EES-718

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -440,9 +440,18 @@ user checks publication bullet does not contain link
     [Arguments]   ${publication}   ${link}
     user checks page does not contain element  xpath://details[@open]//*[text()="${publication}"]/..//a[text()="${link}"]
 
-user waits until page contains key stat tile
-    [Arguments]  ${title}   ${value}   ${wait}=${timeout}
-    user waits until page contains element   xpath://*[@data-testid="keyStatTile-title" and text()="${title}"]/../*[@data-testid="keyStatTile-value" and text()="${value}"]    ${wait}
+user checks key stat contents
+    [Arguments]   ${tile}  ${title}  ${value}  ${summary}  ${wait}=${timeout}
+    user waits until element is visible  css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-title"]  ${wait}
+    user waits until element contains  css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-title"]  ${title}
+    user waits until element contains  css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-value"]  ${value}
+    user waits until element contains  css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-summary"]  ${summary}
+
+user checks key stat definition
+    [Arguments]   ${tile}  ${definition_summary}  ${definition}
+    user opens details dropdown  ${definition_summary}  css:[data-testid="keyStat"]:nth-of-type(${tile})
+    user waits until element is visible  css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-definition"]
+    user checks element should contain  css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-definition"]  ${definition}
 
 user clicks radio
     [Arguments]  ${label}

--- a/tests/robot-tests/tests/libs/public-common.robot
+++ b/tests/robot-tests/tests/libs/public-common.robot
@@ -3,13 +3,6 @@ Resource    ./common.robot
 Library     public-utilities.py
 
 *** Keywords ***
-user checks key stat contents
-    [Arguments]   ${tile}  ${title}  ${value}  ${summary}
-    user waits until element is visible  css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-title"]  90
-    user waits until element contains  css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-title"]  ${title}
-    user waits until element contains  css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-value"]  ${value}
-    user waits until element contains  css:[data-testid="keyStat"]:nth-of-type(${tile}) [data-testid="keyStat-summary"]  ${summary}
-
 user checks headline summary contains
     [Arguments]  ${text}
     user waits until element is visible  xpath://*[@id="releaseHeadlines-summary"]//li[text()="${text}"]


### PR DESCRIPTION
This PR primarily fixes the `EditableKeyStat` components not rendering  in the same way that `KeyStat` does, leading to the missing summaries/definitions. This was due to a recent refactoring neglecting to keep both of these components in parity with one another.

## Other changes

- Fixed heading markup semantics for `EditableKeyStat` when toggling between read-only and writeable variants. Now correctly goes from `h3` to `h4`.
- Added better error handling to `EditableKeyStat` so that admin users can more easily see when there is a problem loading the key stat (e.g. there is a backend error). They can also choose to delete the key stat from the content if required.
- Made `EditableKeyStat` form input ids consistent (based on the form id) so that form validation can be applied correctly.
- Adds unit tests and UI tests to cover most parts of the `KeyStat` and `EditableKeyStat` components.
- Fixed `FormEditor` (this is used in `EditableKeyStat`), not rendering its HTML contents in IE11. We've now corrected this so that it will render a read-only textbox (we do this as CKEditor does not work in IE11).