### PR TITLE
EES-1292 API to allow replacing a Subject on DataBlocks and Footnotes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -31,6 +31,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
     public class ReplacementServiceTests
     {
+        private const string CountryCodeEngland = "E92000001";
+
         [Fact]
         public async Task GetReplacementPlan_OriginalSubjectBelongsToDifferentRelease()
         {
@@ -379,7 +381,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 TableHeaders = new TableHeaders
                 {
-                    ColumnGroups = new List<List<TableHeader>>(),
+                    ColumnGroups = new List<List<TableHeader>>
+                    {
+                        new List<TableHeader>
+                        {
+                            TableHeader.NewLocationHeader(GeographicLevel.Country, CountryCodeEngland)
+                        }
+                    },
                     Columns = new List<TableHeader>
                     {
                         new TableHeader("2019_CY", TableHeaderType.TimePeriod),
@@ -390,8 +398,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new List<TableHeader>
                         {
                             new TableHeader(originalFilterItem.Id.ToString(), TableHeaderType.Filter)
-                            // TODO can this be a col group?
-                            //TableHeader.NewLocationHeader(GeographicLevel.Country, "E92000001")
                         }
                     },
                     Rows = new List<TableHeader>
@@ -412,7 +418,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Indicators = new[] {originalIndicator.Id},
                     Locations = new LocationQuery
                     {
-                        Country = new[] {"E92000001"}
+                        Country = new[] {CountryCodeEngland}
                     },
                     TimePeriod = timePeriod
                 },
@@ -759,31 +765,51 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 }
             };
 
-            var originalFilter = new Filter
+            var originalFilter1 = new Filter
             {
                 Id = Guid.NewGuid(),
-                Label = "Test filter - not changing",
-                Name = "test_filter_not_changing",
+                Label = "Test filter 1 - not changing",
+                Name = "test_filter_1_not_changing",
                 Subject = originalSubject,
                 FilterGroups = new List<FilterGroup>
                 {
-                    originalFilterGroup1,
-                    // TODO
-                    //originalFilterGroup2
+                    originalFilterGroup1
                 }
             };
 
-            var replacementFilter = new Filter
+            var originalFilter2 = new Filter
             {
                 Id = Guid.NewGuid(),
-                Label = "Test filter - not changing",
-                Name = "test_filter_not_changing",
+                Label = "Test filter 2 - not changing",
+                Name = "test_filter_2_not_changing",
+                Subject = originalSubject,
+                FilterGroups = new List<FilterGroup>
+                {
+                    originalFilterGroup2
+                }
+            };
+
+            var replacementFilter1 = new Filter
+            {
+                Id = Guid.NewGuid(),
+                Label = "Test filter 1 - not changing",
+                Name = "test_filter_1_not_changing",
                 Subject = replacementSubject,
                 FilterGroups = new List<FilterGroup>
                 {
-                    replacementFilterGroup1,
-                    // TODO
-                    //replacementFilterGroup2
+                    replacementFilterGroup1
+                }
+            };
+
+            var replacementFilter2 = new Filter
+            {
+                Id = Guid.NewGuid(),
+                Label = "Test filter 2 - not changing",
+                Name = "test_filter_2_not_changing",
+                Subject = replacementSubject,
+                FilterGroups = new List<FilterGroup>
+                {
+                    replacementFilterGroup2
                 }
             };
 
@@ -835,7 +861,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 TableHeaders = new TableHeaders
                 {
-                    ColumnGroups = new List<List<TableHeader>>(),
+                    ColumnGroups = new List<List<TableHeader>>
+                    {
+                        new List<TableHeader>
+                        {
+                            TableHeader.NewLocationHeader(GeographicLevel.Country, CountryCodeEngland)
+                        }
+                    },
                     Columns = new List<TableHeader>
                     {
                         new TableHeader("2019_CY", TableHeaderType.TimePeriod),
@@ -847,8 +879,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         {
                             new TableHeader(originalFilterItem1.Id.ToString(), TableHeaderType.Filter)
                             // TODO include more than 1 filter here?
-                            // TODO can this be a col group?
-                            //TableHeader.NewLocationHeader(GeographicLevel.Country, "E92000001")
                         }
                     },
                     Rows = new List<TableHeader>
@@ -869,7 +899,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Indicators = new[] {originalIndicator.Id},
                     Locations = new LocationQuery
                     {
-                        Country = new[] {"E92000001"}
+                        Country = new[] {CountryCodeEngland}
                     },
                     TimePeriod = timePeriod
                 },
@@ -888,7 +918,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     new FilterFootnote
                     {
-                        Filter = originalFilter
+                        Filter = originalFilter1
                     }
                 });
 
@@ -935,7 +965,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         GeographicLevel.Country,
                         new List<Country>
                         {
-                            new Country("E92000001", "England")
+                            new Country(CountryCodeEngland, "England")
                         }
                     }
                 });
@@ -964,7 +994,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await statisticsDbContext.AddRangeAsync(originalSubject, replacementSubject);
                 await statisticsDbContext.AddRangeAsync(originalReleaseSubject1, originalReleaseSubject2,
                     replacementReleaseSubject);
-                await statisticsDbContext.AddRangeAsync(originalFilter, replacementFilter);
+                await statisticsDbContext.AddRangeAsync(originalFilter1, originalFilter2,
+                    replacementFilter1, replacementFilter2);
                 await statisticsDbContext.AddRangeAsync(originalIndicatorGroup, replacementIndicatorGroup);
                 await statisticsDbContext.AddRangeAsync(footnoteForFilter, footnoteForFilterGroup,
                     footnoteForFilterItem, footnoteForIndicator, footnoteForSubject);
@@ -1039,10 +1070,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Empty(footnoteForFilterPlan.Indicators);
 
                 var footnoteForFilterFilterPlan = footnoteForFilterPlan.Filters.First();
-                Assert.Equal(originalFilter.Id, footnoteForFilterFilterPlan.Id);
-                Assert.Equal(originalFilter.Label, footnoteForFilterFilterPlan.Label);
-                Assert.Equal(originalFilter.Name, footnoteForFilterFilterPlan.Name);
-                Assert.Equal(replacementFilter.Id, footnoteForFilterFilterPlan.Target);
+                Assert.Equal(originalFilter1.Id, footnoteForFilterFilterPlan.Id);
+                Assert.Equal(originalFilter1.Label, footnoteForFilterFilterPlan.Label);
+                Assert.Equal(originalFilter1.Name, footnoteForFilterFilterPlan.Name);
+                Assert.Equal(replacementFilter1.Id, footnoteForFilterFilterPlan.Target);
                 Assert.True(footnoteForFilterFilterPlan.Valid);
 
                 Assert.True(footnoteForFilterPlan.Valid);
@@ -1215,7 +1246,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         new List<TableHeader>
                         {
-                            TableHeader.NewLocationHeader(GeographicLevel.Country, "E92000001")
+                            TableHeader.NewLocationHeader(GeographicLevel.Country, CountryCodeEngland)
                         }
                     },
                     Rows = new List<TableHeader>()
@@ -1233,7 +1264,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Indicators = new Guid[] { },
                     Locations = new LocationQuery
                     {
-                        Country = new[] {"E92000001"}
+                        Country = new[] {CountryCodeEngland}
                     },
                     TimePeriod = timePeriod
                 },
@@ -1406,31 +1437,51 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 }
             };
 
-            var originalFilter = new Filter
+            var originalFilter1 = new Filter
             {
                 Id = Guid.NewGuid(),
-                Label = "Test filter - not changing",
-                Name = "test_filter_not_changing",
+                Label = "Test filter 1 - not changing",
+                Name = "test_filter_1_not_changing",
                 Subject = originalSubject,
                 FilterGroups = new List<FilterGroup>
                 {
-                    originalFilterGroup1,
-                    // TODO
-                    //originalFilterGroup2
+                    originalFilterGroup1
                 }
             };
 
-            var replacementFilter = new Filter
+            var originalFilter2 = new Filter
             {
                 Id = Guid.NewGuid(),
-                Label = "Test filter - not changing",
-                Name = "test_filter_not_changing",
+                Label = "Test filter 2 - not changing",
+                Name = "test_filter_2_not_changing",
+                Subject = originalSubject,
+                FilterGroups = new List<FilterGroup>
+                {
+                    originalFilterGroup2
+                }
+            };
+
+            var replacementFilter1 = new Filter
+            {
+                Id = Guid.NewGuid(),
+                Label = "Test filter 1 - not changing",
+                Name = "test_filter_1_not_changing",
                 Subject = replacementSubject,
                 FilterGroups = new List<FilterGroup>
                 {
-                    replacementFilterGroup1,
-                    // TODO
-                    //replacementFilterGroup2
+                    replacementFilterGroup1
+                }
+            };
+
+            var replacementFilter2 = new Filter
+            {
+                Id = Guid.NewGuid(),
+                Label = "Test filter 2 - not changing",
+                Name = "test_filter_2_not_changing",
+                Subject = replacementSubject,
+                FilterGroups = new List<FilterGroup>
+                {
+                    replacementFilterGroup2
                 }
             };
 
@@ -1482,7 +1533,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 TableHeaders = new TableHeaders
                 {
-                    ColumnGroups = new List<List<TableHeader>>(),
+                    ColumnGroups = new List<List<TableHeader>>
+                    {
+                        new List<TableHeader>
+                        {
+                            TableHeader.NewLocationHeader(GeographicLevel.Country, CountryCodeEngland)
+                        }
+                    },
                     Columns = new List<TableHeader>
                     {
                         new TableHeader("2019_CY", TableHeaderType.TimePeriod),
@@ -1494,8 +1551,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         {
                             new TableHeader(originalFilterItem1.Id.ToString(), TableHeaderType.Filter)
                             // TODO include more than 1 filter here?
-                            // TODO can this be a col group?
-                            //TableHeader.NewLocationHeader(GeographicLevel.Country, "E92000001")
                         }
                     },
                     Rows = new List<TableHeader>
@@ -1516,7 +1571,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Indicators = new[] {originalIndicator.Id},
                     Locations = new LocationQuery
                     {
-                        Country = new[] {"E92000001"}
+                        Country = new[] {CountryCodeEngland}
                     },
                     TimePeriod = timePeriod
                 },
@@ -1535,7 +1590,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     new FilterFootnote
                     {
-                        Filter = originalFilter
+                        Filter = originalFilter1
                     }
                 });
 
@@ -1582,7 +1637,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         GeographicLevel.Country,
                         new List<Country>
                         {
-                            new Country("E92000001", "England")
+                            new Country(CountryCodeEngland, "England")
                         }
                     }
                 });
@@ -1611,7 +1666,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await statisticsDbContext.AddRangeAsync(originalSubject, replacementSubject);
                 await statisticsDbContext.AddRangeAsync(originalReleaseSubject1, originalReleaseSubject2,
                     replacementReleaseSubject);
-                await statisticsDbContext.AddRangeAsync(originalFilter, replacementFilter);
+                await statisticsDbContext.AddRangeAsync(originalFilter1, originalFilter2,
+                    replacementFilter1, replacementFilter2);
                 await statisticsDbContext.AddRangeAsync(originalIndicatorGroup, replacementIndicatorGroup);
                 await statisticsDbContext.AddRangeAsync(footnoteForFilter, footnoteForFilterGroup,
                     footnoteForFilterItem, footnoteForIndicator, footnoteForSubject);
@@ -1647,16 +1703,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(2, replacedDataBlock.Table.TableHeaders.Columns.Count());
                 Assert.Equal(TableHeaderType.TimePeriod, replacedDataBlock.Table.TableHeaders.Columns.First().Type);
                 Assert.Equal("2019_CY", replacedDataBlock.Table.TableHeaders.Columns.First().Value);
-                Assert.Equal(TableHeaderType.TimePeriod, replacedDataBlock.Table.TableHeaders.Columns.ElementAt(1).Type);
+                Assert.Equal(TableHeaderType.TimePeriod,
+                    replacedDataBlock.Table.TableHeaders.Columns.ElementAt(1).Type);
                 Assert.Equal("2020_CY", replacedDataBlock.Table.TableHeaders.Columns.ElementAt(1).Value);
-                Assert.Empty(replacedDataBlock.Table.TableHeaders.ColumnGroups);
+                Assert.Single(replacedDataBlock.Table.TableHeaders.ColumnGroups);
+                Assert.Single(replacedDataBlock.Table.TableHeaders.ColumnGroups.First());
+                Assert.Equal(TableHeaderType.Location,
+                    replacedDataBlock.Table.TableHeaders.ColumnGroups.First().First().Type);
+                Assert.Equal(CountryCodeEngland,
+                    replacedDataBlock.Table.TableHeaders.ColumnGroups.First().First().Value);
                 Assert.Single(replacedDataBlock.Table.TableHeaders.Rows);
                 Assert.Equal(TableHeaderType.Indicator, replacedDataBlock.Table.TableHeaders.Rows.First().Type);
-                Assert.Equal(replacementIndicator.Id.ToString(), replacedDataBlock.Table.TableHeaders.Rows.First().Value);
+                Assert.Equal(replacementIndicator.Id.ToString(),
+                    replacedDataBlock.Table.TableHeaders.Rows.First().Value);
                 Assert.Single(replacedDataBlock.Table.TableHeaders.RowGroups);
                 Assert.Single(replacedDataBlock.Table.TableHeaders.RowGroups.First());
-                Assert.Equal(TableHeaderType.Filter, replacedDataBlock.Table.TableHeaders.RowGroups.First().First().Type);
-                Assert.Equal(replacementFilterItem1.Id.ToString(), replacedDataBlock.Table.TableHeaders.RowGroups.First().First().Value);
+                Assert.Equal(TableHeaderType.Filter,
+                    replacedDataBlock.Table.TableHeaders.RowGroups.First().First().Type);
+                Assert.Equal(replacementFilterItem1.Id.ToString(),
+                    replacedDataBlock.Table.TableHeaders.RowGroups.First().First().Value);
 
                 var replacedFootnoteForFilter = await GetFootnoteById(statisticsDbContext, footnoteForFilter.Id);
                 Assert.NotNull(replacedFootnoteForFilter);
@@ -1667,9 +1732,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Empty(replacedFootnoteForFilter.Indicators);
                 Assert.Empty(replacedFootnoteForFilter.Subjects);
 
-                Assert.Equal(replacementFilter.Id, replacedFootnoteForFilter.Filters.First().Filter.Id);
-                Assert.Equal(replacementFilter.Label, replacedFootnoteForFilter.Filters.First().Filter.Label);
-                Assert.Equal(replacementFilter.Name, replacedFootnoteForFilter.Filters.First().Filter.Name);
+                Assert.Equal(replacementFilter1.Id, replacedFootnoteForFilter.Filters.First().Filter.Id);
+                Assert.Equal(replacementFilter1.Label, replacedFootnoteForFilter.Filters.First().Filter.Label);
+                Assert.Equal(replacementFilter1.Name, replacedFootnoteForFilter.Filters.First().Filter.Name);
 
                 var replacedFootnoteForFilterGroup =
                     await GetFootnoteById(statisticsDbContext, footnoteForFilterGroup.Id);
@@ -1724,7 +1789,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Empty(replacedFootnoteForSubject.FilterItems);
                 Assert.Empty(replacedFootnoteForSubject.Indicators);
                 Assert.Single(replacedFootnoteForSubject.Subjects);
-                
+
                 Assert.Equal(replacementSubject.Id, replacedFootnoteForSubject.Subjects.First().Subject.Id);
             }
         }
@@ -1745,13 +1810,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 FilterGroups = filterGroupFootnotes,
                 FilterItems = filterItemFootnotes,
                 Indicators = indicatorFootnotes,
-                Subjects = subject != null ? new List<SubjectFootnote>
-                {
-                   new SubjectFootnote
-                   {
-                       Subject = subject
-                   }
-                } : new List<SubjectFootnote>(),
+                Subjects = subject != null
+                    ? new List<SubjectFootnote>
+                    {
+                        new SubjectFootnote
+                        {
+                            Subject = subject
+                        }
+                    }
+                    : new List<SubjectFootnote>(),
                 Releases = new List<ReleaseFootnote>
                 {
                     new ReleaseFootnote

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -14,6 +14,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -54,7 +55,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Id = Guid.NewGuid(),
                 PreviousVersionId = contentRelease1Version1.Id
             };
-            
+
             var contentRelease2 = new Content.Model.Release
             {
                 Id = Guid.NewGuid(),
@@ -112,7 +113,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 await statisticsDbContext.AddRangeAsync(statsRelease1Version1, statsRelease1Version2, statsRelease2);
                 await statisticsDbContext.AddRangeAsync(originalSubject, replacementSubject);
-                await statisticsDbContext.AddRangeAsync(originalReleaseSubject1, originalReleaseSubject2, replacementReleaseSubject);
+                await statisticsDbContext.AddRangeAsync(originalReleaseSubject1, originalReleaseSubject2,
+                    replacementReleaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
             }
 
@@ -146,7 +148,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Id = Guid.NewGuid(),
                 PreviousVersionId = null
             };
-            
+
             var contentReleaseVersion2 = new Content.Model.Release
             {
                 Id = Guid.NewGuid(),
@@ -158,7 +160,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Id = contentReleaseVersion1.Id,
                 PreviousVersionId = contentReleaseVersion1.PreviousVersionId
             };
-            
+
             var statsReleaseVersion2 = new Release
             {
                 Id = contentReleaseVersion2.Id,
@@ -176,7 +178,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Release = statsReleaseVersion2,
                 Subject = originalSubject
             };
-            
+
             var replacementReleaseSubject = new ReleaseSubject
             {
                 Release = statsReleaseVersion2,
@@ -198,7 +200,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 await statisticsDbContext.AddRangeAsync(statsReleaseVersion1, statsReleaseVersion2);
                 await statisticsDbContext.AddRangeAsync(originalSubject, replacementSubject);
-                await statisticsDbContext.AddRangeAsync(originalReleaseSubject1, originalReleaseSubject2, replacementReleaseSubject);
+                await statisticsDbContext.AddRangeAsync(originalReleaseSubject1, originalReleaseSubject2,
+                    replacementReleaseSubject);
                 await statisticsDbContext.SaveChangesAsync();
             }
 
@@ -235,7 +238,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Id = Guid.NewGuid(),
                 PreviousVersionId = null
             };
-            
+
             var contentReleaseVersion2 = new Content.Model.Release
             {
                 Id = Guid.NewGuid(),
@@ -247,7 +250,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Id = contentReleaseVersion1.Id,
                 PreviousVersionId = contentReleaseVersion1.PreviousVersionId
             };
-            
+
             var statsReleaseVersion2 = new Release
             {
                 Id = contentReleaseVersion2.Id,
@@ -271,7 +274,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Release = statsReleaseVersion2,
                 Subject = replacementSubject
             };
-            
+
             var originalFilterItem = new FilterItem
             {
                 Id = Guid.NewGuid(),
@@ -372,6 +375,32 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 EndCode = CalendarYear
             };
 
+            var table = new TableBuilderConfiguration
+            {
+                TableHeaders = new TableHeaders
+                {
+                    ColumnGroups = new List<List<TableHeader>>(),
+                    Columns = new List<TableHeader>
+                    {
+                        new TableHeader("2019_CY", TableHeaderType.TimePeriod),
+                        new TableHeader("2020_CY", TableHeaderType.TimePeriod)
+                    },
+                    RowGroups = new List<List<TableHeader>>
+                    {
+                        new List<TableHeader>
+                        {
+                            new TableHeader(originalFilterItem.Id.ToString(), TableHeaderType.Filter)
+                            // TODO can this be a col group?
+                            //TableHeader.NewLocationHeader(GeographicLevel.Country, "E92000001")
+                        }
+                    },
+                    Rows = new List<TableHeader>
+                    {
+                        new TableHeader(originalIndicator.Id.ToString(), TableHeaderType.Indicator)
+                    }
+                }
+            };
+
             var dataBlock = new DataBlock
             {
                 Id = Guid.NewGuid(),
@@ -386,7 +415,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Country = new[] {"E92000001"}
                     },
                     TimePeriod = timePeriod
-                }
+                },
+                Table = table
             };
 
             var releaseContentBlock = new ReleaseContentBlock
@@ -395,7 +425,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 ContentBlock = dataBlock
             };
 
-            var originalFootnoteForFilter = CreateFootnote(statsReleaseVersion2,
+            var footnoteForSubject = CreateFootnote(statsReleaseVersion2,
+                "Test footnote for Subject",
+                subject: originalSubject);
+
+            var footnoteForFilter = CreateFootnote(statsReleaseVersion2,
                 "Test footnote for Filter",
                 filterFootnotes: new List<FilterFootnote>
                 {
@@ -405,7 +439,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }
                 });
 
-            var originalFootnoteForFilterGroup = CreateFootnote(statsReleaseVersion2,
+            var footnoteForFilterGroup = CreateFootnote(statsReleaseVersion2,
                 "Test footnote for Filter group",
                 filterGroupFootnotes: new List<FilterGroupFootnote>
                 {
@@ -415,7 +449,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }
                 });
 
-            var originalFootnoteForFilterItem = CreateFootnote(statsReleaseVersion2,
+            var footnoteForFilterItem = CreateFootnote(statsReleaseVersion2,
                 "Test footnote for Filter item",
                 filterItemFootnotes: new List<FilterItemFootnote>
                 {
@@ -425,7 +459,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }
                 });
 
-            var originalFootnoteForIndicator = CreateFootnote(statsReleaseVersion2,
+            var footnoteForIndicator = CreateFootnote(statsReleaseVersion2,
                 "Test footnote for Filter item",
                 indicatorFootnotes: new List<IndicatorFootnote>
                 {
@@ -458,11 +492,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 await statisticsDbContext.AddRangeAsync(statsReleaseVersion1, statsReleaseVersion2);
                 await statisticsDbContext.AddRangeAsync(originalSubject, replacementSubject);
-                await statisticsDbContext.AddRangeAsync(originalReleaseSubject1, originalReleaseSubject2, replacementReleaseSubject);
+                await statisticsDbContext.AddRangeAsync(originalReleaseSubject1, originalReleaseSubject2,
+                    replacementReleaseSubject);
                 await statisticsDbContext.AddRangeAsync(originalFilter, replacementFilter);
                 await statisticsDbContext.AddRangeAsync(originalIndicatorGroup, replacementIndicatorGroup);
-                await statisticsDbContext.AddRangeAsync(originalFootnoteForFilter, originalFootnoteForFilterGroup,
-                    originalFootnoteForFilterItem, originalFootnoteForIndicator);
+                await statisticsDbContext.AddRangeAsync(footnoteForFilter, footnoteForFilterGroup,
+                    footnoteForFilterItem, footnoteForIndicator, footnoteForSubject);
                 await statisticsDbContext.SaveChangesAsync();
             }
 
@@ -522,12 +557,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.False(dataBlockPlan.TimePeriods.Valid);
 
                 Assert.False(dataBlockPlan.Valid);
-                
-                Assert.Equal(4, replacementPlan.Footnotes.Count());
+
+                Assert.Equal(5, replacementPlan.Footnotes.Count());
 
                 var footnoteForFilterPlan =
-                    replacementPlan.Footnotes.Single(plan => plan.Id == originalFootnoteForFilter.Id);
-                Assert.Equal(originalFootnoteForFilter.Content, footnoteForFilterPlan.Content);
+                    replacementPlan.Footnotes.Single(plan => plan.Id == footnoteForFilter.Id);
+                Assert.Equal(footnoteForFilter.Content, footnoteForFilterPlan.Content);
                 Assert.Single(footnoteForFilterPlan.Filters);
                 Assert.Empty(footnoteForFilterPlan.FilterGroups);
                 Assert.Empty(footnoteForFilterPlan.FilterItems);
@@ -541,10 +576,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.False(footnoteForFilterFilterPlan.Valid);
 
                 Assert.False(footnoteForFilterPlan.Valid);
-                
+
                 var footnoteForFilterGroupPlan =
-                    replacementPlan.Footnotes.Single(plan => plan.Id == originalFootnoteForFilterGroup.Id);
-                Assert.Equal(originalFootnoteForFilterGroup.Content, footnoteForFilterGroupPlan.Content);
+                    replacementPlan.Footnotes.Single(plan => plan.Id == footnoteForFilterGroup.Id);
+                Assert.Equal(footnoteForFilterGroup.Content, footnoteForFilterGroupPlan.Content);
                 Assert.Empty(footnoteForFilterGroupPlan.Filters);
                 Assert.Single(footnoteForFilterGroupPlan.FilterGroups);
                 Assert.Empty(footnoteForFilterGroupPlan.FilterItems);
@@ -555,12 +590,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(originalFilterGroup.Label, footnoteForFilterGroupFilterGroupPlan.Label);
                 Assert.Null(footnoteForFilterGroupFilterGroupPlan.Target);
                 Assert.False(footnoteForFilterGroupFilterGroupPlan.Valid);
-                
+
                 Assert.False(footnoteForFilterGroupPlan.Valid);
 
                 var footnoteForFilterItemPlan =
-                    replacementPlan.Footnotes.Single(plan => plan.Id == originalFootnoteForFilterItem.Id);
-                Assert.Equal(originalFootnoteForFilterItem.Content, footnoteForFilterItemPlan.Content);
+                    replacementPlan.Footnotes.Single(plan => plan.Id == footnoteForFilterItem.Id);
+                Assert.Equal(footnoteForFilterItem.Content, footnoteForFilterItemPlan.Content);
                 Assert.Empty(footnoteForFilterItemPlan.Filters);
                 Assert.Empty(footnoteForFilterItemPlan.FilterGroups);
                 Assert.Single(footnoteForFilterItemPlan.FilterItems);
@@ -571,12 +606,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(originalFilterItem.Label, footnoteForFilterItemFilterItemPlan.Label);
                 Assert.Null(footnoteForFilterItemFilterItemPlan.Target);
                 Assert.False(footnoteForFilterItemFilterItemPlan.Valid);
-                
+
                 Assert.False(footnoteForFilterItemPlan.Valid);
 
                 var footnoteForIndicatorPlan =
-                    replacementPlan.Footnotes.Single(plan => plan.Id == originalFootnoteForIndicator.Id);
-                Assert.Equal(originalFootnoteForIndicator.Content, footnoteForIndicatorPlan.Content);
+                    replacementPlan.Footnotes.Single(plan => plan.Id == footnoteForIndicator.Id);
+                Assert.Equal(footnoteForIndicator.Content, footnoteForIndicatorPlan.Content);
                 Assert.Empty(footnoteForIndicatorPlan.Filters);
                 Assert.Empty(footnoteForIndicatorPlan.FilterGroups);
                 Assert.Empty(footnoteForIndicatorPlan.FilterItems);
@@ -588,9 +623,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(originalIndicator.Name, footnoteForIndicatorIndicatorPlan.Name);
                 Assert.Null(footnoteForIndicatorIndicatorPlan.Target);
                 Assert.False(footnoteForIndicatorIndicatorPlan.Valid);
-                
+
                 Assert.False(footnoteForIndicatorPlan.Valid);
-                
+
+                var footnoteForSubjectPlan =
+                    replacementPlan.Footnotes.Single(plan => plan.Id == footnoteForSubject.Id);
+                Assert.Equal(footnoteForSubject.Content, footnoteForSubjectPlan.Content);
+                Assert.Empty(footnoteForSubjectPlan.Filters);
+                Assert.Empty(footnoteForSubjectPlan.FilterGroups);
+                Assert.Empty(footnoteForSubjectPlan.FilterItems);
+                Assert.Empty(footnoteForSubjectPlan.Indicators);
+
+                Assert.True(footnoteForSubjectPlan.Valid);
+
                 Assert.False(replacementPlan.Valid);
             }
         }
@@ -613,7 +658,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Id = Guid.NewGuid(),
                 PreviousVersionId = null
             };
-            
+
             var contentReleaseVersion2 = new Content.Model.Release
             {
                 Id = Guid.NewGuid(),
@@ -625,7 +670,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Id = contentReleaseVersion1.Id,
                 PreviousVersionId = contentReleaseVersion1.PreviousVersionId
             };
-            
+
             var statsReleaseVersion2 = new Release
             {
                 Id = contentReleaseVersion2.Id,
@@ -650,35 +695,67 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Subject = replacementSubject
             };
 
-            var originalFilterItem = new FilterItem
+            var originalFilterItem1 = new FilterItem
             {
                 Id = Guid.NewGuid(),
                 Label = "Test filter item - not changing"
             };
 
-            var replacementFilterItem = new FilterItem
+            var originalFilterItem2 = new FilterItem
             {
                 Id = Guid.NewGuid(),
                 Label = "Test filter item - not changing"
             };
 
-            var originalFilterGroup = new FilterGroup
+            var replacementFilterItem1 = new FilterItem
+            {
+                Id = Guid.NewGuid(),
+                Label = "Test filter item - not changing"
+            };
+
+            var replacementFilterItem2 = new FilterItem
+            {
+                Id = Guid.NewGuid(),
+                Label = "Test filter item - not changing"
+            };
+
+            var originalFilterGroup1 = new FilterGroup
             {
                 Id = Guid.NewGuid(),
                 Label = "Default group - not changing",
                 FilterItems = new List<FilterItem>
                 {
-                    originalFilterItem
+                    originalFilterItem1
                 }
             };
 
-            var replacementFilterGroup = new FilterGroup
+            var originalFilterGroup2 = new FilterGroup
             {
                 Id = Guid.NewGuid(),
                 Label = "Default group - not changing",
                 FilterItems = new List<FilterItem>
                 {
-                    replacementFilterItem
+                    originalFilterItem2
+                }
+            };
+
+            var replacementFilterGroup1 = new FilterGroup
+            {
+                Id = Guid.NewGuid(),
+                Label = "Default group - not changing",
+                FilterItems = new List<FilterItem>
+                {
+                    replacementFilterItem1
+                }
+            };
+
+            var replacementFilterGroup2 = new FilterGroup
+            {
+                Id = Guid.NewGuid(),
+                Label = "Default group - not changing",
+                FilterItems = new List<FilterItem>
+                {
+                    replacementFilterItem2
                 }
             };
 
@@ -690,7 +767,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Subject = originalSubject,
                 FilterGroups = new List<FilterGroup>
                 {
-                    originalFilterGroup
+                    originalFilterGroup1,
+                    // TODO
+                    //originalFilterGroup2
                 }
             };
 
@@ -702,7 +781,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Subject = replacementSubject,
                 FilterGroups = new List<FilterGroup>
                 {
-                    replacementFilterGroup
+                    replacementFilterGroup1,
+                    // TODO
+                    //replacementFilterGroup2
                 }
             };
 
@@ -750,6 +831,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 EndCode = CalendarYear
             };
 
+            var table = new TableBuilderConfiguration
+            {
+                TableHeaders = new TableHeaders
+                {
+                    ColumnGroups = new List<List<TableHeader>>(),
+                    Columns = new List<TableHeader>
+                    {
+                        new TableHeader("2019_CY", TableHeaderType.TimePeriod),
+                        new TableHeader("2020_CY", TableHeaderType.TimePeriod)
+                    },
+                    RowGroups = new List<List<TableHeader>>
+                    {
+                        new List<TableHeader>
+                        {
+                            new TableHeader(originalFilterItem1.Id.ToString(), TableHeaderType.Filter)
+                            // TODO include more than 1 filter here?
+                            // TODO can this be a col group?
+                            //TableHeader.NewLocationHeader(GeographicLevel.Country, "E92000001")
+                        }
+                    },
+                    Rows = new List<TableHeader>
+                    {
+                        new TableHeader(originalIndicator.Id.ToString(), TableHeaderType.Indicator)
+                    }
+                }
+            };
+
             var dataBlock = new DataBlock
             {
                 Id = Guid.NewGuid(),
@@ -757,14 +865,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Query = new ObservationQueryContext
                 {
                     SubjectId = originalSubject.Id,
-                    Filters = new[] {originalFilterItem.Id},
+                    Filters = new[] {originalFilterItem1.Id},
                     Indicators = new[] {originalIndicator.Id},
                     Locations = new LocationQuery
                     {
                         Country = new[] {"E92000001"}
                     },
                     TimePeriod = timePeriod
-                }
+                },
+                Table = table
             };
 
             var releaseContentBlock = new ReleaseContentBlock
@@ -773,7 +882,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 ContentBlock = dataBlock
             };
 
-            var originalFootnoteForFilter = CreateFootnote(statsReleaseVersion2,
+            var footnoteForFilter = CreateFootnote(statsReleaseVersion2,
                 "Test footnote for Filter",
                 filterFootnotes: new List<FilterFootnote>
                 {
@@ -783,27 +892,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }
                 });
 
-            var originalFootnoteForFilterGroup = CreateFootnote(statsReleaseVersion2,
+            var footnoteForFilterGroup = CreateFootnote(statsReleaseVersion2,
                 "Test footnote for Filter group",
                 filterGroupFootnotes: new List<FilterGroupFootnote>
                 {
                     new FilterGroupFootnote
                     {
-                        FilterGroup = originalFilterGroup
+                        FilterGroup = originalFilterGroup1
                     }
                 });
 
-            var originalFootnoteForFilterItem = CreateFootnote(statsReleaseVersion2,
+            var footnoteForFilterItem = CreateFootnote(statsReleaseVersion2,
                 "Test footnote for Filter item",
                 filterItemFootnotes: new List<FilterItemFootnote>
                 {
                     new FilterItemFootnote
                     {
-                        FilterItem = originalFilterItem
+                        FilterItem = originalFilterItem1
                     }
                 });
 
-            var originalFootnoteForIndicator = CreateFootnote(statsReleaseVersion2,
+            var footnoteForIndicator = CreateFootnote(statsReleaseVersion2,
                 "Test footnote for Filter item",
                 indicatorFootnotes: new List<IndicatorFootnote>
                 {
@@ -812,6 +921,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Indicator = originalIndicator
                     }
                 });
+
+            var footnoteForSubject = CreateFootnote(statsReleaseVersion2,
+                "Test footnote for Subject",
+                subject: originalSubject);
 
             var mocks = Mocks();
 
@@ -849,11 +962,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 await statisticsDbContext.AddRangeAsync(statsReleaseVersion1, statsReleaseVersion2);
                 await statisticsDbContext.AddRangeAsync(originalSubject, replacementSubject);
-                await statisticsDbContext.AddRangeAsync(originalReleaseSubject1, originalReleaseSubject2, replacementReleaseSubject);
+                await statisticsDbContext.AddRangeAsync(originalReleaseSubject1, originalReleaseSubject2,
+                    replacementReleaseSubject);
                 await statisticsDbContext.AddRangeAsync(originalFilter, replacementFilter);
                 await statisticsDbContext.AddRangeAsync(originalIndicatorGroup, replacementIndicatorGroup);
-                await statisticsDbContext.AddRangeAsync(originalFootnoteForFilter, originalFootnoteForFilterGroup,
-                    originalFootnoteForFilterItem, originalFootnoteForIndicator);
+                await statisticsDbContext.AddRangeAsync(footnoteForFilter, footnoteForFilterGroup,
+                    footnoteForFilterItem, footnoteForIndicator, footnoteForSubject);
                 await statisticsDbContext.SaveChangesAsync();
             }
 
@@ -884,7 +998,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var dataBlockFilterItemPlan = dataBlockPlan.FilterItems.First();
                 Assert.Equal(dataBlockFilterItemPlan.Id, dataBlockFilterItemPlan.Id);
                 Assert.Equal(dataBlockFilterItemPlan.Label, dataBlockFilterItemPlan.Label);
-                Assert.Equal(replacementFilterItem.Id, dataBlockFilterItemPlan.Target);
+                Assert.Equal(replacementFilterItem1.Id, dataBlockFilterItemPlan.Target);
                 Assert.True(dataBlockFilterItemPlan.Valid);
 
                 Assert.NotNull(dataBlockPlan.ObservationalUnits);
@@ -913,12 +1027,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(dataBlockPlan.TimePeriods.Valid);
 
                 Assert.True(dataBlockPlan.Valid);
-                
-                Assert.Equal(4, replacementPlan.Footnotes.Count());
+
+                Assert.Equal(5, replacementPlan.Footnotes.Count());
 
                 var footnoteForFilterPlan =
-                    replacementPlan.Footnotes.Single(plan => plan.Id == originalFootnoteForFilter.Id);
-                Assert.Equal(originalFootnoteForFilter.Content, footnoteForFilterPlan.Content);
+                    replacementPlan.Footnotes.Single(plan => plan.Id == footnoteForFilter.Id);
+                Assert.Equal(footnoteForFilter.Content, footnoteForFilterPlan.Content);
                 Assert.Single(footnoteForFilterPlan.Filters);
                 Assert.Empty(footnoteForFilterPlan.FilterGroups);
                 Assert.Empty(footnoteForFilterPlan.FilterItems);
@@ -930,44 +1044,44 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(originalFilter.Name, footnoteForFilterFilterPlan.Name);
                 Assert.Equal(replacementFilter.Id, footnoteForFilterFilterPlan.Target);
                 Assert.True(footnoteForFilterFilterPlan.Valid);
-                
+
                 Assert.True(footnoteForFilterPlan.Valid);
 
                 var footnoteForFilterGroupPlan =
-                    replacementPlan.Footnotes.Single(plan => plan.Id == originalFootnoteForFilterGroup.Id);
-                Assert.Equal(originalFootnoteForFilterGroup.Content, footnoteForFilterGroupPlan.Content);
+                    replacementPlan.Footnotes.Single(plan => plan.Id == footnoteForFilterGroup.Id);
+                Assert.Equal(footnoteForFilterGroup.Content, footnoteForFilterGroupPlan.Content);
                 Assert.Empty(footnoteForFilterGroupPlan.Filters);
                 Assert.Single(footnoteForFilterGroupPlan.FilterGroups);
                 Assert.Empty(footnoteForFilterGroupPlan.FilterItems);
                 Assert.Empty(footnoteForFilterGroupPlan.Indicators);
 
                 var footnoteForFilterGroupFilterGroupPlan = footnoteForFilterGroupPlan.FilterGroups.First();
-                Assert.Equal(originalFilterGroup.Id, footnoteForFilterGroupFilterGroupPlan.Id);
-                Assert.Equal(originalFilterGroup.Label, footnoteForFilterGroupFilterGroupPlan.Label);
-                Assert.Equal(replacementFilterGroup.Id, footnoteForFilterGroupFilterGroupPlan.Target);
+                Assert.Equal(originalFilterGroup1.Id, footnoteForFilterGroupFilterGroupPlan.Id);
+                Assert.Equal(originalFilterGroup1.Label, footnoteForFilterGroupFilterGroupPlan.Label);
+                Assert.Equal(replacementFilterGroup1.Id, footnoteForFilterGroupFilterGroupPlan.Target);
                 Assert.True(footnoteForFilterGroupFilterGroupPlan.Valid);
 
                 Assert.True(footnoteForFilterGroupPlan.Valid);
-                
+
                 var footnoteForFilterItemPlan =
-                    replacementPlan.Footnotes.Single(plan => plan.Id == originalFootnoteForFilterItem.Id);
-                Assert.Equal(originalFootnoteForFilterItem.Content, footnoteForFilterItemPlan.Content);
+                    replacementPlan.Footnotes.Single(plan => plan.Id == footnoteForFilterItem.Id);
+                Assert.Equal(footnoteForFilterItem.Content, footnoteForFilterItemPlan.Content);
                 Assert.Empty(footnoteForFilterItemPlan.Filters);
                 Assert.Empty(footnoteForFilterItemPlan.FilterGroups);
                 Assert.Single(footnoteForFilterItemPlan.FilterItems);
                 Assert.Empty(footnoteForFilterItemPlan.Indicators);
 
                 var footnoteForFilterItemFilterItemPlan = footnoteForFilterItemPlan.FilterItems.First();
-                Assert.Equal(originalFilterItem.Id, footnoteForFilterItemFilterItemPlan.Id);
-                Assert.Equal(originalFilterItem.Label, footnoteForFilterItemFilterItemPlan.Label);
-                Assert.Equal(replacementFilterItem.Id, footnoteForFilterItemFilterItemPlan.Target);
+                Assert.Equal(originalFilterItem1.Id, footnoteForFilterItemFilterItemPlan.Id);
+                Assert.Equal(originalFilterItem1.Label, footnoteForFilterItemFilterItemPlan.Label);
+                Assert.Equal(replacementFilterItem1.Id, footnoteForFilterItemFilterItemPlan.Target);
                 Assert.True(footnoteForFilterItemFilterItemPlan.Valid);
-                
+
                 Assert.True(footnoteForFilterItemPlan.Valid);
 
                 var footnoteForIndicatorPlan =
-                    replacementPlan.Footnotes.Single(plan => plan.Id == originalFootnoteForIndicator.Id);
-                Assert.Equal(originalFootnoteForIndicator.Content, footnoteForIndicatorPlan.Content);
+                    replacementPlan.Footnotes.Single(plan => plan.Id == footnoteForIndicator.Id);
+                Assert.Equal(footnoteForIndicator.Content, footnoteForIndicatorPlan.Content);
                 Assert.Empty(footnoteForIndicatorPlan.Filters);
                 Assert.Empty(footnoteForIndicatorPlan.FilterGroups);
                 Assert.Empty(footnoteForIndicatorPlan.FilterItems);
@@ -979,10 +1093,639 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(originalIndicator.Name, footnoteForIndicatorIndicatorPlan.Name);
                 Assert.Equal(replacementIndicator.Id, footnoteForIndicatorIndicatorPlan.Target);
                 Assert.True(footnoteForIndicatorIndicatorPlan.Valid);
-                
+
                 Assert.True(footnoteForIndicatorPlan.Valid);
-                
+
+                var footnoteForSubjectPlan =
+                    replacementPlan.Footnotes.Single(plan => plan.Id == footnoteForSubject.Id);
+                Assert.Equal(footnoteForSubject.Content, footnoteForSubjectPlan.Content);
+                Assert.Empty(footnoteForSubjectPlan.Filters);
+                Assert.Empty(footnoteForSubjectPlan.FilterGroups);
+                Assert.Empty(footnoteForSubjectPlan.FilterItems);
+                Assert.Empty(footnoteForSubjectPlan.Indicators);
+
+                Assert.True(footnoteForSubjectPlan.Valid);
+
                 Assert.True(replacementPlan.Valid);
+            }
+        }
+
+        [Fact]
+        public async Task Replace_ReplacementPlanInvalid()
+        {
+            var originalSubject = new Subject
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var replacementSubject = new Subject
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var contentRelease = new Content.Model.Release
+            {
+                Id = Guid.NewGuid(),
+                PreviousVersionId = null
+            };
+
+            var statsRelease = new Release
+            {
+                Id = contentRelease.Id,
+                PreviousVersionId = contentRelease.PreviousVersionId
+            };
+
+            var originalReleaseSubject = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = originalSubject
+            };
+
+            var replacementReleaseSubject = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = replacementSubject
+            };
+
+            var originalFilterItem = new FilterItem
+            {
+                Id = Guid.NewGuid(),
+                Label = "Original Test filter item"
+            };
+
+            var originalFilterGroup = new FilterGroup
+            {
+                Id = Guid.NewGuid(),
+                Label = "Original Default group",
+                FilterItems = new List<FilterItem>
+                {
+                    originalFilterItem
+                }
+            };
+
+            var originalFilter = new Filter
+            {
+                Id = Guid.NewGuid(),
+                Label = "Original Test filter",
+                Name = "original_test_filter",
+                Subject = originalSubject,
+                FilterGroups = new List<FilterGroup>
+                {
+                    originalFilterGroup
+                }
+            };
+
+            var originalIndicator = new Indicator
+            {
+                Id = Guid.NewGuid(),
+                Label = "Original Indicator",
+                Name = "original_indicator"
+            };
+
+            var originalIndicatorGroup = new IndicatorGroup
+            {
+                Id = Guid.NewGuid(),
+                Label = "Original Default group",
+                Subject = originalSubject,
+                Indicators = new List<Indicator>
+                {
+                    originalIndicator
+                }
+            };
+
+            var timePeriod = new TimePeriodQuery
+            {
+                StartYear = 2019,
+                StartCode = CalendarYear,
+                EndYear = 2020,
+                EndCode = CalendarYear
+            };
+
+            var table = new TableBuilderConfiguration
+            {
+                TableHeaders = new TableHeaders
+                {
+                    ColumnGroups = new List<List<TableHeader>>(),
+                    Columns = new List<TableHeader>
+                    {
+                        new TableHeader("2019_CY", TableHeaderType.TimePeriod),
+                        new TableHeader("2020_CY", TableHeaderType.TimePeriod)
+                    },
+                    RowGroups = new List<List<TableHeader>>
+                    {
+                        new List<TableHeader>
+                        {
+                            TableHeader.NewLocationHeader(GeographicLevel.Country, "E92000001")
+                        }
+                    },
+                    Rows = new List<TableHeader>()
+                }
+            };
+
+            var dataBlock = new DataBlock
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test DataBlock",
+                Query = new ObservationQueryContext
+                {
+                    SubjectId = originalSubject.Id,
+                    Filters = new Guid[] { },
+                    Indicators = new Guid[] { },
+                    Locations = new LocationQuery
+                    {
+                        Country = new[] {"E92000001"}
+                    },
+                    TimePeriod = timePeriod
+                },
+                Table = table
+            };
+
+            var releaseContentBlock = new ReleaseContentBlock
+            {
+                Release = contentRelease,
+                ContentBlock = dataBlock
+            };
+
+            var mocks = Mocks();
+
+            mocks.LocationService.Setup(service => service.GetObservationalUnits(replacementSubject.Id))
+                .Returns(new Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>>());
+
+            mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
+                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.AddAsync(contentRelease);
+                await contentDbContext.AddAsync(dataBlock);
+                await contentDbContext.AddRangeAsync(releaseContentBlock);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.AddRangeAsync(statsRelease);
+                await statisticsDbContext.AddRangeAsync(originalSubject, replacementSubject);
+                await statisticsDbContext.AddRangeAsync(originalReleaseSubject, replacementReleaseSubject);
+                await statisticsDbContext.AddRangeAsync(originalFilter);
+                await statisticsDbContext.AddRangeAsync(originalIndicatorGroup);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var replacementService = BuildReplacementService(contentDbContext, statisticsDbContext, mocks);
+
+                var result = await replacementService.Replace(originalSubject.Id, replacementSubject.Id);
+
+                Assert.True(result.IsLeft);
+                AssertValidationProblem(result.Left, ReplacementMustBeValid);
+            }
+        }
+
+        [Fact]
+        public async Task Replace()
+        {
+            var originalSubject = new Subject
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var replacementSubject = new Subject
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var contentReleaseVersion1 = new Content.Model.Release
+            {
+                Id = Guid.NewGuid(),
+                PreviousVersionId = null
+            };
+
+            var contentReleaseVersion2 = new Content.Model.Release
+            {
+                Id = Guid.NewGuid(),
+                PreviousVersionId = contentReleaseVersion1.Id
+            };
+
+            var statsReleaseVersion1 = new Release
+            {
+                Id = contentReleaseVersion1.Id,
+                PreviousVersionId = contentReleaseVersion1.PreviousVersionId
+            };
+
+            var statsReleaseVersion2 = new Release
+            {
+                Id = contentReleaseVersion2.Id,
+                PreviousVersionId = contentReleaseVersion2.PreviousVersionId
+            };
+
+            var originalReleaseSubject1 = new ReleaseSubject
+            {
+                Release = statsReleaseVersion1,
+                Subject = originalSubject
+            };
+
+            var originalReleaseSubject2 = new ReleaseSubject
+            {
+                Release = statsReleaseVersion2,
+                Subject = originalSubject
+            };
+
+            var replacementReleaseSubject = new ReleaseSubject
+            {
+                Release = statsReleaseVersion2,
+                Subject = replacementSubject
+            };
+
+            var originalFilterItem1 = new FilterItem
+            {
+                Id = Guid.NewGuid(),
+                Label = "Test filter item - not changing"
+            };
+
+            var originalFilterItem2 = new FilterItem
+            {
+                Id = Guid.NewGuid(),
+                Label = "Test filter item - not changing"
+            };
+
+            var replacementFilterItem1 = new FilterItem
+            {
+                Id = Guid.NewGuid(),
+                Label = "Test filter item - not changing"
+            };
+
+            var replacementFilterItem2 = new FilterItem
+            {
+                Id = Guid.NewGuid(),
+                Label = "Test filter item - not changing"
+            };
+
+            var originalFilterGroup1 = new FilterGroup
+            {
+                Id = Guid.NewGuid(),
+                Label = "Default group - not changing",
+                FilterItems = new List<FilterItem>
+                {
+                    originalFilterItem1
+                }
+            };
+
+            var originalFilterGroup2 = new FilterGroup
+            {
+                Id = Guid.NewGuid(),
+                Label = "Default group - not changing",
+                FilterItems = new List<FilterItem>
+                {
+                    originalFilterItem2
+                }
+            };
+
+            var replacementFilterGroup1 = new FilterGroup
+            {
+                Id = Guid.NewGuid(),
+                Label = "Default group - not changing",
+                FilterItems = new List<FilterItem>
+                {
+                    replacementFilterItem1
+                }
+            };
+
+            var replacementFilterGroup2 = new FilterGroup
+            {
+                Id = Guid.NewGuid(),
+                Label = "Default group - not changing",
+                FilterItems = new List<FilterItem>
+                {
+                    replacementFilterItem2
+                }
+            };
+
+            var originalFilter = new Filter
+            {
+                Id = Guid.NewGuid(),
+                Label = "Test filter - not changing",
+                Name = "test_filter_not_changing",
+                Subject = originalSubject,
+                FilterGroups = new List<FilterGroup>
+                {
+                    originalFilterGroup1,
+                    // TODO
+                    //originalFilterGroup2
+                }
+            };
+
+            var replacementFilter = new Filter
+            {
+                Id = Guid.NewGuid(),
+                Label = "Test filter - not changing",
+                Name = "test_filter_not_changing",
+                Subject = replacementSubject,
+                FilterGroups = new List<FilterGroup>
+                {
+                    replacementFilterGroup1,
+                    // TODO
+                    //replacementFilterGroup2
+                }
+            };
+
+            var originalIndicator = new Indicator
+            {
+                Id = Guid.NewGuid(),
+                Label = "Indicator - not changing",
+                Name = "indicator_not_changing"
+            };
+
+            var replacementIndicator = new Indicator
+            {
+                Id = Guid.NewGuid(),
+                Label = "Indicator - not changing",
+                Name = "indicator_not_changing"
+            };
+
+            var originalIndicatorGroup = new IndicatorGroup
+            {
+                Id = Guid.NewGuid(),
+                Label = "Default group - not changing",
+                Subject = originalSubject,
+                Indicators = new List<Indicator>
+                {
+                    originalIndicator
+                }
+            };
+
+            var replacementIndicatorGroup = new IndicatorGroup
+            {
+                Id = Guid.NewGuid(),
+                Label = "Default group - not changing",
+                Subject = replacementSubject,
+                Indicators = new List<Indicator>
+                {
+                    replacementIndicator
+                }
+            };
+
+            var timePeriod = new TimePeriodQuery
+            {
+                StartYear = 2019,
+                StartCode = CalendarYear,
+                EndYear = 2020,
+                EndCode = CalendarYear
+            };
+
+            var table = new TableBuilderConfiguration
+            {
+                TableHeaders = new TableHeaders
+                {
+                    ColumnGroups = new List<List<TableHeader>>(),
+                    Columns = new List<TableHeader>
+                    {
+                        new TableHeader("2019_CY", TableHeaderType.TimePeriod),
+                        new TableHeader("2020_CY", TableHeaderType.TimePeriod)
+                    },
+                    RowGroups = new List<List<TableHeader>>
+                    {
+                        new List<TableHeader>
+                        {
+                            new TableHeader(originalFilterItem1.Id.ToString(), TableHeaderType.Filter)
+                            // TODO include more than 1 filter here?
+                            // TODO can this be a col group?
+                            //TableHeader.NewLocationHeader(GeographicLevel.Country, "E92000001")
+                        }
+                    },
+                    Rows = new List<TableHeader>
+                    {
+                        new TableHeader(originalIndicator.Id.ToString(), TableHeaderType.Indicator)
+                    }
+                }
+            };
+
+            var dataBlock = new DataBlock
+            {
+                Id = Guid.NewGuid(),
+                Name = "Test DataBlock",
+                Query = new ObservationQueryContext
+                {
+                    SubjectId = originalSubject.Id,
+                    Filters = new[] {originalFilterItem1.Id},
+                    Indicators = new[] {originalIndicator.Id},
+                    Locations = new LocationQuery
+                    {
+                        Country = new[] {"E92000001"}
+                    },
+                    TimePeriod = timePeriod
+                },
+                Table = table
+            };
+
+            var releaseContentBlock = new ReleaseContentBlock
+            {
+                Release = contentReleaseVersion2,
+                ContentBlock = dataBlock
+            };
+
+            var footnoteForFilter = CreateFootnote(statsReleaseVersion2,
+                "Test footnote for Filter",
+                filterFootnotes: new List<FilterFootnote>
+                {
+                    new FilterFootnote
+                    {
+                        Filter = originalFilter
+                    }
+                });
+
+            var footnoteForFilterGroup = CreateFootnote(statsReleaseVersion2,
+                "Test footnote for Filter group",
+                filterGroupFootnotes: new List<FilterGroupFootnote>
+                {
+                    new FilterGroupFootnote
+                    {
+                        FilterGroup = originalFilterGroup1
+                    }
+                });
+
+            var footnoteForFilterItem = CreateFootnote(statsReleaseVersion2,
+                "Test footnote for Filter item",
+                filterItemFootnotes: new List<FilterItemFootnote>
+                {
+                    new FilterItemFootnote
+                    {
+                        FilterItem = originalFilterItem1
+                    }
+                });
+
+            var footnoteForIndicator = CreateFootnote(statsReleaseVersion2,
+                "Test footnote for Filter item",
+                indicatorFootnotes: new List<IndicatorFootnote>
+                {
+                    new IndicatorFootnote
+                    {
+                        Indicator = originalIndicator
+                    }
+                });
+
+            var footnoteForSubject = CreateFootnote(statsReleaseVersion2,
+                "Test footnote for Subject",
+                subject: originalSubject);
+
+            var mocks = Mocks();
+
+            mocks.LocationService.Setup(service => service.GetObservationalUnits(replacementSubject.Id))
+                .Returns(new Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>>
+                {
+                    {
+                        GeographicLevel.Country,
+                        new List<Country>
+                        {
+                            new Country("E92000001", "England")
+                        }
+                    }
+                });
+
+            mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
+                .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>
+                {
+                    (2019, CalendarYear),
+                    (2020, CalendarYear)
+                });
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.AddRangeAsync(contentReleaseVersion1, contentReleaseVersion2);
+                await contentDbContext.AddAsync(dataBlock);
+                await contentDbContext.AddRangeAsync(releaseContentBlock);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.AddRangeAsync(statsReleaseVersion1, statsReleaseVersion2);
+                await statisticsDbContext.AddRangeAsync(originalSubject, replacementSubject);
+                await statisticsDbContext.AddRangeAsync(originalReleaseSubject1, originalReleaseSubject2,
+                    replacementReleaseSubject);
+                await statisticsDbContext.AddRangeAsync(originalFilter, replacementFilter);
+                await statisticsDbContext.AddRangeAsync(originalIndicatorGroup, replacementIndicatorGroup);
+                await statisticsDbContext.AddRangeAsync(footnoteForFilter, footnoteForFilterGroup,
+                    footnoteForFilterItem, footnoteForIndicator, footnoteForSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var replacementService = BuildReplacementService(contentDbContext, statisticsDbContext, mocks);
+
+                var result = await replacementService.Replace(originalSubject.Id, replacementSubject.Id);
+
+                Assert.True(result.IsRight);
+
+                var replacedDataBlock = await contentDbContext.DataBlocks.FindAsync(dataBlock.Id);
+                Assert.NotNull(replacedDataBlock);
+                Assert.Equal(dataBlock.Name, replacedDataBlock.Name);
+                Assert.Equal(replacementSubject.Id, replacedDataBlock.Query.SubjectId);
+
+                Assert.Single(replacedDataBlock.Query.Indicators);
+                Assert.Equal(replacementIndicator.Id, replacedDataBlock.Query.Indicators.First());
+
+                Assert.Single(replacedDataBlock.Query.Filters);
+                Assert.Equal(replacementFilterItem1.Id, replacedDataBlock.Query.Filters.First());
+
+                Assert.NotNull(replacedDataBlock.Query.Locations);
+                Assert.Equal(dataBlock.Query.Locations, replacedDataBlock.Query.Locations);
+
+                Assert.NotNull(replacedDataBlock.Query.TimePeriod);
+                Assert.Equal(timePeriod, replacedDataBlock.Query.TimePeriod);
+
+                Assert.Equal(2, replacedDataBlock.Table.TableHeaders.Columns.Count());
+                Assert.Equal(TableHeaderType.TimePeriod, replacedDataBlock.Table.TableHeaders.Columns.First().Type);
+                Assert.Equal("2019_CY", replacedDataBlock.Table.TableHeaders.Columns.First().Value);
+                Assert.Equal(TableHeaderType.TimePeriod, replacedDataBlock.Table.TableHeaders.Columns.ElementAt(1).Type);
+                Assert.Equal("2020_CY", replacedDataBlock.Table.TableHeaders.Columns.ElementAt(1).Value);
+                Assert.Empty(replacedDataBlock.Table.TableHeaders.ColumnGroups);
+                Assert.Single(replacedDataBlock.Table.TableHeaders.Rows);
+                Assert.Equal(TableHeaderType.Indicator, replacedDataBlock.Table.TableHeaders.Rows.First().Type);
+                Assert.Equal(replacementIndicator.Id.ToString(), replacedDataBlock.Table.TableHeaders.Rows.First().Value);
+                Assert.Single(replacedDataBlock.Table.TableHeaders.RowGroups);
+                Assert.Single(replacedDataBlock.Table.TableHeaders.RowGroups.First());
+                Assert.Equal(TableHeaderType.Filter, replacedDataBlock.Table.TableHeaders.RowGroups.First().First().Type);
+                Assert.Equal(replacementFilterItem1.Id.ToString(), replacedDataBlock.Table.TableHeaders.RowGroups.First().First().Value);
+
+                var replacedFootnoteForFilter = await GetFootnoteById(statisticsDbContext, footnoteForFilter.Id);
+                Assert.NotNull(replacedFootnoteForFilter);
+                Assert.Equal(footnoteForFilter.Content, replacedFootnoteForFilter.Content);
+                Assert.Single(replacedFootnoteForFilter.Filters);
+                Assert.Empty(replacedFootnoteForFilter.FilterGroups);
+                Assert.Empty(replacedFootnoteForFilter.FilterItems);
+                Assert.Empty(replacedFootnoteForFilter.Indicators);
+                Assert.Empty(replacedFootnoteForFilter.Subjects);
+
+                Assert.Equal(replacementFilter.Id, replacedFootnoteForFilter.Filters.First().Filter.Id);
+                Assert.Equal(replacementFilter.Label, replacedFootnoteForFilter.Filters.First().Filter.Label);
+                Assert.Equal(replacementFilter.Name, replacedFootnoteForFilter.Filters.First().Filter.Name);
+
+                var replacedFootnoteForFilterGroup =
+                    await GetFootnoteById(statisticsDbContext, footnoteForFilterGroup.Id);
+                Assert.NotNull(replacedFootnoteForFilterGroup);
+                Assert.Equal(footnoteForFilterGroup.Content, replacedFootnoteForFilterGroup.Content);
+                Assert.Single(replacedFootnoteForFilterGroup.FilterGroups);
+                Assert.Empty(replacedFootnoteForFilterGroup.Filters);
+                Assert.Single(replacedFootnoteForFilterGroup.FilterGroups);
+                Assert.Empty(replacedFootnoteForFilterGroup.FilterItems);
+                Assert.Empty(replacedFootnoteForFilterGroup.Indicators);
+                Assert.Empty(replacedFootnoteForFilterGroup.Subjects);
+
+                Assert.Equal(replacementFilterGroup1.Id,
+                    replacedFootnoteForFilterGroup.FilterGroups.First().FilterGroup.Id);
+                Assert.Equal(replacementFilterGroup1.Label,
+                    replacedFootnoteForFilterGroup.FilterGroups.First().FilterGroup.Label);
+
+                var replacedFootnoteForFilterItem =
+                    await GetFootnoteById(statisticsDbContext, footnoteForFilterItem.Id);
+                Assert.NotNull(replacedFootnoteForFilterItem);
+                Assert.Equal(footnoteForFilterItem.Content, replacedFootnoteForFilterItem.Content);
+                Assert.Empty(replacedFootnoteForFilterItem.Filters);
+                Assert.Empty(replacedFootnoteForFilterItem.FilterGroups);
+                Assert.Single(replacedFootnoteForFilterItem.FilterItems);
+                Assert.Empty(replacedFootnoteForFilterItem.Indicators);
+                Assert.Empty(replacedFootnoteForFilterItem.Subjects);
+
+                Assert.Equal(replacementFilterItem1.Id,
+                    replacedFootnoteForFilterItem.FilterItems.First().FilterItem.Id);
+                Assert.Equal(replacementFilterItem1.Label,
+                    replacedFootnoteForFilterItem.FilterItems.First().FilterItem.Label);
+
+                var replacedFootnoteForIndicator = await GetFootnoteById(statisticsDbContext, footnoteForIndicator.Id);
+                Assert.NotNull(replacedFootnoteForIndicator);
+                Assert.Equal(footnoteForIndicator.Content, replacedFootnoteForIndicator.Content);
+                Assert.Empty(replacedFootnoteForIndicator.Filters);
+                Assert.Empty(replacedFootnoteForIndicator.FilterGroups);
+                Assert.Empty(replacedFootnoteForIndicator.FilterItems);
+                Assert.Single(replacedFootnoteForIndicator.Indicators);
+                Assert.Empty(replacedFootnoteForIndicator.Subjects);
+
+                Assert.Equal(replacementIndicator.Id, replacedFootnoteForIndicator.Indicators.First().Indicator.Id);
+                Assert.Equal(replacementIndicator.Label,
+                    replacedFootnoteForIndicator.Indicators.First().Indicator.Label);
+                Assert.Equal(replacementIndicator.Name, replacedFootnoteForIndicator.Indicators.First().Indicator.Name);
+
+                var replacedFootnoteForSubject = await GetFootnoteById(statisticsDbContext, footnoteForSubject.Id);
+                Assert.NotNull(replacedFootnoteForSubject);
+                Assert.Equal(footnoteForSubject.Content, replacedFootnoteForSubject.Content);
+                Assert.Empty(replacedFootnoteForSubject.Filters);
+                Assert.Empty(replacedFootnoteForSubject.FilterGroups);
+                Assert.Empty(replacedFootnoteForSubject.FilterItems);
+                Assert.Empty(replacedFootnoteForSubject.Indicators);
+                Assert.Single(replacedFootnoteForSubject.Subjects);
+                
+                Assert.Equal(replacementSubject.Id, replacedFootnoteForSubject.Subjects.First().Subject.Id);
             }
         }
 
@@ -991,7 +1734,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             ICollection<FilterFootnote> filterFootnotes = null,
             ICollection<FilterGroupFootnote> filterGroupFootnotes = null,
             ICollection<FilterItemFootnote> filterItemFootnotes = null,
-            ICollection<IndicatorFootnote> indicatorFootnotes = null)
+            ICollection<IndicatorFootnote> indicatorFootnotes = null,
+            Subject subject = null)
         {
             return new Footnote
             {
@@ -1001,6 +1745,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 FilterGroups = filterGroupFootnotes,
                 FilterItems = filterItemFootnotes,
                 Indicators = indicatorFootnotes,
+                Subjects = subject != null ? new List<SubjectFootnote>
+                {
+                   new SubjectFootnote
+                   {
+                       Subject = subject
+                   }
+                } : new List<SubjectFootnote>(),
                 Releases = new List<ReleaseFootnote>
                 {
                     new ReleaseFootnote
@@ -1009,6 +1760,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }
                 }
             };
+        }
+
+        private static async Task<Footnote> GetFootnoteById(StatisticsDbContext context, Guid id)
+        {
+            return await context.Footnote
+                .Include(footnote => footnote.Filters)
+                .ThenInclude(filterFootnote => filterFootnote.Filter)
+                .Include(footnote => footnote.FilterGroups)
+                .ThenInclude(filterGroupFootnote => filterGroupFootnote.FilterGroup)
+                .Include(footnote => footnote.FilterItems)
+                .ThenInclude(filterItemFootnote => filterItemFootnote.FilterItem)
+                .Include(footnote => footnote.Indicators)
+                .ThenInclude(indicatorFootnote => indicatorFootnote.Indicator)
+                .Include(footnote => footnote.Subjects)
+                .ThenInclude(subjectFootnote => subjectFootnote.Subject)
+                .SingleAsync(footnote => footnote.Id == id);
         }
 
         private static List<string> GetGeographicLevelsAsStrings()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -531,24 +531,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Null(dataBlockFilterItemPlan.Target);
                 Assert.False(dataBlockFilterItemPlan.Valid);
 
-                Assert.NotNull(dataBlockPlan.ObservationalUnits);
+                Assert.NotNull(dataBlockPlan.Locations);
                 var allGeographicLevels = GetGeographicLevelsAsStrings();
-                Assert.Equal(allGeographicLevels.Count, dataBlockPlan.ObservationalUnits.Count);
-                Assert.False(allGeographicLevels.Except(dataBlockPlan.ObservationalUnits.Keys).Any());
+                Assert.Equal(allGeographicLevels.Count, dataBlockPlan.Locations.Count);
+                Assert.False(allGeographicLevels.Except(dataBlockPlan.Locations.Keys).Any());
 
-                Assert.Empty(dataBlockPlan.ObservationalUnits[GeographicLevel.Country.ToString()].Matched);
-                Assert.Single(dataBlockPlan.ObservationalUnits[GeographicLevel.Country.ToString()].Unmatched);
+                Assert.Empty(dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Matched);
+                Assert.Single(dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Unmatched);
                 Assert.Equal(dataBlock.Query.Locations.Country,
-                    dataBlockPlan.ObservationalUnits[GeographicLevel.Country.ToString()].Unmatched);
-                Assert.False(dataBlockPlan.ObservationalUnits[GeographicLevel.Country.ToString()].Valid);
+                    dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Unmatched);
+                Assert.False(dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Valid);
 
                 allGeographicLevels.ForEach(level =>
                 {
                     if (level != GeographicLevel.Country.ToString())
                     {
-                        Assert.Empty(dataBlockPlan.ObservationalUnits[level].Matched);
-                        Assert.Empty(dataBlockPlan.ObservationalUnits[level].Unmatched);
-                        Assert.True(dataBlockPlan.ObservationalUnits[level].Valid);
+                        Assert.Empty(dataBlockPlan.Locations[level].Matched);
+                        Assert.Empty(dataBlockPlan.Locations[level].Unmatched);
+                        Assert.True(dataBlockPlan.Locations[level].Valid);
                     }
                 });
 
@@ -1001,24 +1001,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(replacementFilterItem1.Id, dataBlockFilterItemPlan.Target);
                 Assert.True(dataBlockFilterItemPlan.Valid);
 
-                Assert.NotNull(dataBlockPlan.ObservationalUnits);
+                Assert.NotNull(dataBlockPlan.Locations);
                 var allGeographicLevels = GetGeographicLevelsAsStrings();
-                Assert.Equal(allGeographicLevels.Count, dataBlockPlan.ObservationalUnits.Count);
-                Assert.False(allGeographicLevels.Except(dataBlockPlan.ObservationalUnits.Keys).Any());
+                Assert.Equal(allGeographicLevels.Count, dataBlockPlan.Locations.Count);
+                Assert.False(allGeographicLevels.Except(dataBlockPlan.Locations.Keys).Any());
 
-                Assert.Single(dataBlockPlan.ObservationalUnits[GeographicLevel.Country.ToString()].Matched);
+                Assert.Single(dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Matched);
                 Assert.Equal(dataBlock.Query.Locations.Country,
-                    dataBlockPlan.ObservationalUnits[GeographicLevel.Country.ToString()].Matched);
-                Assert.Empty(dataBlockPlan.ObservationalUnits[GeographicLevel.Country.ToString()].Unmatched);
-                Assert.True(dataBlockPlan.ObservationalUnits[GeographicLevel.Country.ToString()].Valid);
+                    dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Matched);
+                Assert.Empty(dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Unmatched);
+                Assert.True(dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Valid);
 
                 allGeographicLevels.ForEach(level =>
                 {
                     if (level != GeographicLevel.Country.ToString())
                     {
-                        Assert.Empty(dataBlockPlan.ObservationalUnits[level].Matched);
-                        Assert.Empty(dataBlockPlan.ObservationalUnits[level].Unmatched);
-                        Assert.True(dataBlockPlan.ObservationalUnits[level].Valid);
+                        Assert.Empty(dataBlockPlan.Locations[level].Matched);
+                        Assert.Empty(dataBlockPlan.Locations[level].Unmatched);
+                        Assert.True(dataBlockPlan.Locations[level].Valid);
                     }
                 });
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -22,8 +22,6 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbU
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.ValidationTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
-using static GovUk.Education.ExploreEducationStatistics.Data.Model.Services.LocationService;
 using FootnoteService = GovUk.Education.ExploreEducationStatistics.Data.Model.Services.FootnoteService;
 using Release = GovUk.Education.ExploreEducationStatistics.Data.Model.Release;
 
@@ -538,25 +536,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.False(dataBlockFilterItemPlan.Valid);
 
                 Assert.NotNull(dataBlockPlan.Locations);
-                var allGeographicLevels = GetGeographicLevelsAsStrings();
-                Assert.Equal(allGeographicLevels.Count, dataBlockPlan.Locations.Count);
-                Assert.False(allGeographicLevels.Except(dataBlockPlan.Locations.Keys).Any());
-
+                Assert.Single(dataBlockPlan.Locations);
+                Assert.True(dataBlockPlan.Locations.ContainsKey(GeographicLevel.Country.ToString()));
                 Assert.Empty(dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Matched);
                 Assert.Single(dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Unmatched);
                 Assert.Equal(dataBlock.Query.Locations.Country,
                     dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Unmatched);
                 Assert.False(dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Valid);
-
-                allGeographicLevels.ForEach(level =>
-                {
-                    if (level != GeographicLevel.Country.ToString())
-                    {
-                        Assert.Empty(dataBlockPlan.Locations[level].Matched);
-                        Assert.Empty(dataBlockPlan.Locations[level].Unmatched);
-                        Assert.True(dataBlockPlan.Locations[level].Valid);
-                    }
-                });
 
                 Assert.NotNull(dataBlockPlan.TimePeriods);
                 Assert.Equal(timePeriod, dataBlockPlan.TimePeriods.Query);
@@ -878,7 +864,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new List<TableHeader>
                         {
                             new TableHeader(originalFilterItem1.Id.ToString(), TableHeaderType.Filter)
-                            // TODO include more than 1 filter here?
                         }
                     },
                     Rows = new List<TableHeader>
@@ -1033,25 +1018,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(dataBlockFilterItemPlan.Valid);
 
                 Assert.NotNull(dataBlockPlan.Locations);
-                var allGeographicLevels = GetGeographicLevelsAsStrings();
-                Assert.Equal(allGeographicLevels.Count, dataBlockPlan.Locations.Count);
-                Assert.False(allGeographicLevels.Except(dataBlockPlan.Locations.Keys).Any());
-
+                Assert.Single(dataBlockPlan.Locations);
+                Assert.True(dataBlockPlan.Locations.ContainsKey(GeographicLevel.Country.ToString()));
                 Assert.Single(dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Matched);
                 Assert.Equal(dataBlock.Query.Locations.Country,
                     dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Matched);
                 Assert.Empty(dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Unmatched);
                 Assert.True(dataBlockPlan.Locations[GeographicLevel.Country.ToString()].Valid);
-
-                allGeographicLevels.ForEach(level =>
-                {
-                    if (level != GeographicLevel.Country.ToString())
-                    {
-                        Assert.Empty(dataBlockPlan.Locations[level].Matched);
-                        Assert.Empty(dataBlockPlan.Locations[level].Unmatched);
-                        Assert.True(dataBlockPlan.Locations[level].Valid);
-                    }
-                });
 
                 Assert.NotNull(dataBlockPlan.TimePeriods);
                 Assert.Equal(timePeriod, dataBlockPlan.TimePeriods.Query);
@@ -1550,7 +1523,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new List<TableHeader>
                         {
                             new TableHeader(originalFilterItem1.Id.ToString(), TableHeaderType.Filter)
-                            // TODO include more than 1 filter here?
                         }
                     },
                     Rows = new List<TableHeader>
@@ -1843,14 +1815,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Include(footnote => footnote.Subjects)
                 .ThenInclude(subjectFootnote => subjectFootnote.Subject)
                 .SingleAsync(footnote => footnote.Id == id);
-        }
-
-        private static List<string> GetGeographicLevelsAsStrings()
-        {
-            return GetEnumValues<GeographicLevel>()
-                .Where(geographicLevel => !IgnoredLevels.Contains(geographicLevel))
-                .Select(level => level.ToString())
-                .ToList();
         }
 
         private static ReplacementService BuildReplacementService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -283,6 +283,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
+        [HttpPost("release/data/replace")]
+        public async Task<ActionResult<Unit>> Replace(ReplacementPlanRequest request)
+        {
+            return await _replacementService
+                .Replace(request.OriginalSubjectId.Value, request.ReplacementSubjectId.Value)
+                .HandleFailuresOrOk();
+        }
+
         [HttpDelete("release/{releaseId}/data/{fileName}")]
         public async Task<ActionResult> DeleteDataFiles(Guid releaseId,
             string fileName,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReplacementService.cs
@@ -11,5 +11,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, ReplacementPlanViewModel>> GetReplacementPlan(
             Guid originalSubjectId,
             Guid replacementSubjectId);
+        
+        Task<Either<ActionResult, Unit>> Replace(
+            Guid originalSubjectId,
+            Guid replacementSubjectId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -267,8 +267,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     geographicLevel =>
                         ValidateLocationsForReplacement(dataBlock.Query.Locations,
                             geographicLevel,
-                            replacementSubjectMeta)
-                );
+                            replacementSubjectMeta))
+                .Filter(pair => pair.Value.Any);
         }
 
         private static TimePeriodReplacementViewModel ValidateTimePeriodsForDataBlock(DataBlock dataBlock,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -504,23 +504,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 f.FootnoteId == footnoteId && f.FilterId == plan.Id
             );
 
-            _statisticsDbContext.Update(filterFootnote);
-            filterFootnote.FilterId = plan.TargetValue;
+            _statisticsDbContext.Remove(filterFootnote);
+            await _statisticsDbContext.FilterFootnote.AddAsync(new FilterFootnote
+            {
+                FootnoteId = footnoteId,
+                FilterId = plan.TargetValue
+            });
         }
 
         private async Task ReplaceFootnoteFilterGroup(Guid footnoteId, TargetableReplacementViewModel plan)
         {
-            if (!plan.Target.HasValue)
-            {
-                throw new ArgumentException($"{nameof(plan)} does not have a target replacement value");
-            }
-
             var filterGroupFootnote = await _statisticsDbContext.FilterGroupFootnote.SingleAsync(f =>
                 f.FootnoteId == footnoteId && f.FilterGroupId == plan.Id
             );
 
-            _statisticsDbContext.Update(filterGroupFootnote);
-            filterGroupFootnote.FilterGroupId = plan.TargetValue;
+            _statisticsDbContext.Remove(filterGroupFootnote);
+            await _statisticsDbContext.FilterGroupFootnote.AddAsync(new FilterGroupFootnote
+            {
+                FootnoteId = footnoteId,
+                FilterGroupId = plan.TargetValue
+            });
         }
 
         private async Task ReplaceFootnoteFilterItem(Guid footnoteId, TargetableReplacementViewModel plan)
@@ -529,8 +532,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 f.FootnoteId == footnoteId && f.FilterItemId == plan.Id
             );
 
-            _statisticsDbContext.Update(filterItemFootnote);
-            filterItemFootnote.FilterItemId = plan.TargetValue;
+            _statisticsDbContext.Remove(filterItemFootnote);
+            await _statisticsDbContext.FilterItemFootnote.AddAsync(new FilterItemFootnote
+            {
+                FootnoteId = footnoteId,
+                FilterItemId = plan.TargetValue
+            });
         }
 
         private async Task ReplaceIndicatorFootnote(Guid footnoteId, TargetableReplacementViewModel plan)
@@ -539,8 +546,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 f.FootnoteId == footnoteId && f.IndicatorId == plan.Id
             );
 
-            _statisticsDbContext.Update(indicatorFootnote);
-            indicatorFootnote.IndicatorId = plan.TargetValue;
+            _statisticsDbContext.Remove(indicatorFootnote);
+            await _statisticsDbContext.IndicatorFootnote.AddAsync(new IndicatorFootnote
+            {
+                FootnoteId = footnoteId,
+                IndicatorId = plan.TargetValue
+            });
         }
 
         private class ReplacementSubjectMeta

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -418,26 +418,37 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             DataBlock dataBlock)
         {
             var tableHeaders = dataBlock.Table.TableHeaders;
-            var tableHeaderColumns = tableHeaders.Columns.ToList();
-            var tableHeaderRows = tableHeaders.Rows.ToList();
 
             var filterItemTargets = replacementPlan.FilterItems.ToDictionary(plan => plan.Id, plan => plan.TargetValue);
             var indicatorTargets = replacementPlan.Indicators.ToDictionary(plan => plan.Id, plan => plan.TargetValue);
 
             ReplaceDataBlockTableHeaders(
-                tableHeaderColumns.FilterByType(TableHeaderType.Filter), dataBlock, filterItemTargets);
+                tableHeaders.Columns.FilterByType(TableHeaderType.Filter), dataBlock, filterItemTargets);
             ReplaceDataBlockTableHeaders(
-                tableHeaderRows.FilterByType(TableHeaderType.Filter), dataBlock, filterItemTargets);
-            ReplaceDataBlockTableHeaders(
-                tableHeaderColumns.FilterByType(TableHeaderType.Indicator), dataBlock, indicatorTargets);
-            ReplaceDataBlockTableHeaders(
-                tableHeaderRows.FilterByType(TableHeaderType.Indicator), dataBlock, indicatorTargets);
+                tableHeaders.Columns.FilterByType(TableHeaderType.Indicator), dataBlock, indicatorTargets);
 
-            dataBlock.Table.TableHeaders.Columns = tableHeaderColumns;
-            dataBlock.Table.TableHeaders.Rows = tableHeaderRows;
+            ReplaceDataBlockTableHeaders(
+                tableHeaders.Rows.FilterByType(TableHeaderType.Filter), dataBlock, filterItemTargets);
+            ReplaceDataBlockTableHeaders(
+                tableHeaders.Rows.FilterByType(TableHeaderType.Indicator), dataBlock, indicatorTargets);
 
-            // TODO EES-1292 ColGroups
-            // TODO EES-1292 RowGroups
+            foreach (var group in tableHeaders.ColumnGroups)
+            {
+                ReplaceDataBlockTableHeaders(
+                    group.FilterByType(TableHeaderType.Filter), dataBlock, filterItemTargets);
+
+                ReplaceDataBlockTableHeaders(
+                    group.FilterByType(TableHeaderType.Indicator), dataBlock, indicatorTargets);
+            }
+
+            foreach (var group in tableHeaders.RowGroups)
+            {
+                ReplaceDataBlockTableHeaders(
+                    group.FilterByType(TableHeaderType.Filter), dataBlock, filterItemTargets);
+
+                ReplaceDataBlockTableHeaders(
+                    group.FilterByType(TableHeaderType.Indicator), dataBlock, indicatorTargets);
+            }
         }
 
         private static void ReplaceDataBlockTableHeaders(List<TableHeader> tableHeaders, DataBlock dataBlock,
@@ -454,13 +465,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     else
                     {
                         throw new InvalidOperationException(
-                            $"Expected target replacement value for dataBlock ${dataBlock.Id} ${tableHeader.Type} table header value: ${idAsGuid}");
+                            $"Expected target replacement value for dataBlock {dataBlock.Id} {tableHeader.Type} table header value: {idAsGuid}");
                     }
                 }
                 else
                 {
                     throw new InvalidOperationException(
-                        $"Expected Guid for dataBlock ${dataBlock.Id} ${tableHeader.Type} table header value but found: ${tableHeader.Value}");
+                        $"Expected Guid for dataBlock {dataBlock.Id} {tableHeader.Type} table header value but found: {tableHeader.Value}");
                 }
             }
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -175,14 +175,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             var filterItems = ValidateFilterItemsForDataBlock(dataBlock, replacementSubjectMeta);
             var indicators = ValidateIndicatorsForDataBlock(dataBlock, replacementSubjectMeta);
-            var observationalUnits = ValidateObservationalUnitsForDataBlock(dataBlock, replacementSubjectMeta);
+            var locations = ValidateLocationsForDataBlock(dataBlock, replacementSubjectMeta);
             var timePeriods = ValidateTimePeriodsForDataBlock(dataBlock, replacementSubjectMeta);
 
             return new DataBlockReplacementPlanViewModel(dataBlock.Id,
                 dataBlock.Name,
                 filterItems,
                 indicators,
-                observationalUnits,
+                locations,
                 timePeriods);
         }
 
@@ -264,7 +264,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .ToList();
         }
 
-        private static Dictionary<string, ObservationalUnitReplacementViewModel> ValidateObservationalUnitsForDataBlock(
+        private static Dictionary<string, LocationReplacementViewModel> ValidateLocationsForDataBlock(
             DataBlock dataBlock,
             ReplacementSubjectMeta replacementSubjectMeta)
         {
@@ -272,7 +272,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .Where(geographicLevel => !IgnoredLevels.Contains(geographicLevel))
                 .ToDictionary(geographicLevel => geographicLevel.ToString(),
                     geographicLevel =>
-                        ValidateObservationalUnitsForReplacement(dataBlock.Query.Locations,
+                        ValidateLocationsForReplacement(dataBlock.Query.Locations,
                             geographicLevel,
                             replacementSubjectMeta)
                 );
@@ -344,7 +344,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             };
         }
 
-        private static ObservationalUnitReplacementViewModel ValidateObservationalUnitsForReplacement(
+        private static LocationReplacementViewModel ValidateLocationsForReplacement(
             LocationQuery locationQuery,
             GeographicLevel geographicLevel,
             ReplacementSubjectMeta replacementSubjectMeta)
@@ -364,7 +364,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 ?.Select(unit => unit.Code)
                 .ToList() ?? new List<string>();
 
-            return new ObservationalUnitReplacementViewModel
+            return new LocationReplacementViewModel
             {
                 Matched = originalCodes.Intersect(replacementCodes),
                 Unmatched = originalCodes.Except(replacementCodes),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -127,6 +127,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         DataZipFileAlreadyExists,
         
         ReplacementDataFileMustBeForSameRelease,
+        ReplacementMustBeValid,
 
         // Meta file
         CannotOverwriteMetadataFile,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReplacementPlanViewModel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
@@ -118,6 +119,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public string Label { get; set; }
         public Guid? Target { get; set; }
         public bool Valid => Target.HasValue;
+
+        [JsonIgnore]
+        public Guid TargetValue
+        {
+            get
+            {
+                if (!Target.HasValue)
+                {
+                    throw new InvalidOperationException ($"{nameof(Target)} does not have a value");
+                }
+                return Target.Value;
+            }
+        }
     }
 
     public abstract class ReplacementViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReplacementPlanViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using Newtonsoft.Json;
 
@@ -104,11 +103,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
     public class LocationReplacementViewModel : ReplacementViewModel
     {
-        [JsonIgnore]
-        public GeographicLevel GeographicLevel { get; set; }
         public IEnumerable<string> Matched { get; set; }
         public IEnumerable<string> Unmatched { get; set; }
         public new bool Valid => !Unmatched.Any();
+
+        [JsonIgnore]
+        public bool Any => Matched.Any() || Unmatched.Any();
     }
 
     public class TimePeriodReplacementViewModel : ReplacementViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReplacementPlanViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using Newtonsoft.Json;
 
@@ -28,27 +29,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public string Name { get; }
         public IEnumerable<FilterItemReplacementViewModel> FilterItems { get; }
         public IEnumerable<IndicatorReplacementViewModel> Indicators { get; }
-        public Dictionary<string, ObservationalUnitReplacementViewModel> ObservationalUnits { get; }
+        public Dictionary<string, LocationReplacementViewModel> Locations { get; }
         public TimePeriodReplacementViewModel TimePeriods { get; }
 
         public DataBlockReplacementPlanViewModel(Guid id,
             string name,
             IEnumerable<FilterItemReplacementViewModel> filterItems,
             IEnumerable<IndicatorReplacementViewModel> indicators,
-            Dictionary<string, ObservationalUnitReplacementViewModel> observationalUnits,
+            Dictionary<string, LocationReplacementViewModel> locations,
             TimePeriodReplacementViewModel timePeriods)
         {
             Id = id;
             Name = name;
             FilterItems = filterItems;
             Indicators = indicators;
-            ObservationalUnits = observationalUnits;
+            Locations = locations;
             TimePeriods = timePeriods;
         }
 
         public bool Valid => FilterItems.All(model => model.Valid)
                              && Indicators.All(model => model.Valid)
-                             && ObservationalUnits.Values.All((model => model.Valid))
+                             && Locations.Values.All((model => model.Valid))
                              && TimePeriods.Valid;
     }
 
@@ -101,8 +102,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public string Name { get; set; }
     }
 
-    public class ObservationalUnitReplacementViewModel : ReplacementViewModel
+    public class LocationReplacementViewModel : ReplacementViewModel
     {
+        [JsonIgnore]
+        public GeographicLevel GeographicLevel { get; set; }
         public IEnumerable<string> Matched { get; set; }
         public IEnumerable<string> Unmatched { get; set; }
         public new bool Valid => !Unmatched.Any();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DictionaryExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+{
+    public static class DictionaryExtensions
+    {
+        public static Dictionary<TKey, TValue> Filter<TKey, TValue>(this Dictionary<TKey, TValue> dictionary,
+            Predicate<KeyValuePair<TKey, TValue>> predicate)
+        {
+            return dictionary
+                .Where(pair => predicate(pair))
+                .ToDictionary(pair => pair.Key, pair => pair.Value);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -20,6 +20,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 {
@@ -93,6 +94,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
                     Array.Resize(ref bucket, count);
                     yield return resultSelector(bucket);
                 }
+            }
+        }
+
+        public static async Task ForEachAsync<T>(this IEnumerable<T> list, Func<T, Task> func)
+        {
+            foreach (var item in list)
+            {
+                await func(item);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -99,10 +99,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 
         public static async Task ForEachAsync<T>(this IEnumerable<T> list, Func<T, Task> func)
         {
-            foreach (var item in list)
-            {
-                await func(item);
-            }
+            await Task.WhenAll(list.Select(func));
         }
 
         public static IEnumerable<(T item, int index)> WithIndex<T>(this IEnumerable<T> self) =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/TableHeadersExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/TableHeadersExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+{
+    public static class TableHeadersExtensions
+    {
+        public static List<TableHeader> FilterByType(this IEnumerable<TableHeader> tableHeaders, TableHeaderType type)
+        {
+            return tableHeaders.Where(header => header.Type.HasValue && header.Type.Value == type).ToList();
+        }
+    }
+}


### PR DESCRIPTION
Allows changing the Subject of DataBlocks or Footnotes on a Release.

For DataBlocks as well as changing the Subject this includes changing the Filter Items and Indicators of the data block query and the table header configuration.

For Footnotes as well as changing any linked Subject this includes changing any linked Filter Items, Filter Groups, Filters and Indicators.

A replacement plan is generated immediately before updating and this must be valid.