### PR TITLE
EES-1362 Add API to upload a Replacement Subject

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleaseControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleaseControllerTests.cs
@@ -116,7 +116,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             };
 
             mocks.FileStorageService
-                .Setup(service => service.UploadDataFilesAsync(_releaseId, dataFile, metaFile, "Subject name", "test user"))
+                .Setup(service => service.UploadDataFilesAsync(_releaseId, dataFile, metaFile, "test user", "Subject name", null))
                 .ReturnsAsync(dataFileInfo);
 
             // Call the method under test
@@ -135,8 +135,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var metaFile = MockFile("metafile.csv");
 
             mocks.FileStorageService
-                .Setup(service => service.UploadDataFilesAsync(_releaseId, dataFile, metaFile, "Subject name",
-                    "test user"))
+                .Setup(service => service.UploadDataFilesAsync(_releaseId, dataFile, metaFile, "test user", "Subject name", null))
                 .ReturnsAsync(new BadRequestObjectResult(CannotOverwriteFile));
 
             var controller = ReleasesControllerWithMocks(mocks);
@@ -185,13 +184,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         {
             var mocks = Mocks();
 
+            var releaseFileReferenceId = Guid.NewGuid();
+
             mocks.ReleaseService
-                .Setup(service => service.RemoveDataFilesAsync(_releaseId, "datafilename", "subject title"))
+                .Setup(service => service.RemoveDataFilesAsync(_releaseId, releaseFileReferenceId))
                 .ReturnsAsync(Unit.Instance);
             var controller = ReleasesControllerWithMocks(mocks);
 
             // Call the method under test
-            var result = await controller.DeleteDataFiles(_releaseId, "datafilename", "subject title");
+            var result = await controller.DeleteDataFiles(_releaseId, releaseFileReferenceId);
             Assert.IsAssignableFrom<NoContentResult>(result);
         }
 
@@ -200,13 +201,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         {
             var mocks = Mocks();
 
+            var releaseFileReferenceId = Guid.NewGuid();
+
             mocks.ReleaseService
-                .Setup(service => service.RemoveDataFilesAsync(_releaseId, "datafilename", "subject title"))
+                .Setup(service => service.RemoveDataFilesAsync(_releaseId, releaseFileReferenceId))
                 .ReturnsAsync(ValidationActionResult(UnableToFindMetadataFileToDelete));
             var controller = ReleasesControllerWithMocks(mocks);
 
             // Call the method under test
-            var result = await controller.DeleteDataFiles(_releaseId, "datafilename", "subject title");
+            var result = await controller.DeleteDataFiles(_releaseId, releaseFileReferenceId);
             AssertValidationProblem(result, UnableToFindMetadataFileToDelete);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -60,7 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var ancillaryFile = MockFile("ancillaryFile.doc");
             mocks.FileStorageService
                 .Setup(service =>
-                    service.UploadFileAsync(_releaseId, ancillaryFile, "File name",
+                    service.UploadFile(_releaseId, ancillaryFile, "File name",
                         ReleaseFileTypes.Ancillary, false))
                 .ReturnsAsync(new Either<ActionResult, FileInfo>(testFile));
             var controller = ReleasesControllerWithMocks(mocks);
@@ -91,7 +91,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 }
             };
             var mocks = Mocks();
-            mocks.FileStorageService.Setup(s => s.ListFilesAsync(_releaseId, ReleaseFileTypes.Ancillary))
+            mocks.FileStorageService.Setup(s => s.ListFiles(_releaseId, ReleaseFileTypes.Ancillary))
                 .ReturnsAsync(new Either<ActionResult, IEnumerable<FileInfo>>(testFiles));
             var controller = ReleasesControllerWithMocks(mocks);
 
@@ -114,7 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             };
 
             mocks.FileStorageService
-                .Setup(service => service.UploadDataFilesAsync(_releaseId, dataFile, metaFile, ApplicationUser.Email, "Subject name", null))
+                .Setup(service => service.UploadDataFiles(_releaseId, dataFile, metaFile, ApplicationUser.Email, "Subject name", null))
                 .ReturnsAsync(dataFileInfo);
 
             // Call the method under test
@@ -133,7 +133,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var metaFile = MockFile("metafile.csv");
 
             mocks.FileStorageService
-                .Setup(service => service.UploadDataFilesAsync(_releaseId, dataFile, metaFile, ApplicationUser.Email, "Subject name", null))
+                .Setup(service => service.UploadDataFiles(_releaseId, dataFile, metaFile, ApplicationUser.Email, "Subject name", null))
                 .ReturnsAsync(ValidationActionResult(CannotOverwriteFile));
 
             var controller = ReleasesControllerWithMocks(mocks);
@@ -166,7 +166,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var mocks = Mocks();
 
-            mocks.FileStorageService.Setup(s => s.ListDataFilesAsync(_releaseId))
+            mocks.FileStorageService.Setup(s => s.ListDataFiles(_releaseId))
                 .ReturnsAsync(new Either<ActionResult, IEnumerable<DataFileInfo>>(testFiles));
             var controller = ReleasesControllerWithMocks(mocks);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -114,12 +114,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             };
 
             mocks.FileStorageService
-                .Setup(service => service.UploadDataFiles(_releaseId, dataFile, metaFile, ApplicationUser.Email, "Subject name", null))
+                .Setup(service => service.UploadDataFiles(_releaseId,
+                    dataFile,
+                    metaFile,
+                    ApplicationUser.Email, 
+                    null,
+                    "Subject name"))
                 .ReturnsAsync(dataFileInfo);
 
             // Call the method under test
             var controller = ReleasesControllerWithMocks(mocks);
-            var result = await controller.AddDataFilesAsync(_releaseId, "Subject name", dataFile, metaFile);
+            var result = await controller.AddDataFilesAsync(releaseId: _releaseId,
+                replacingFileId: null,
+                subjectName: "Subject name",
+                file: dataFile,
+                metaFile: metaFile);
             var dataFileInfoResult = AssertOkResult(result);
             Assert.Equal("Subject name", dataFileInfoResult.Name);
             Assert.Equal("datafile.csv", dataFileInfoResult.Path);
@@ -133,13 +142,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var metaFile = MockFile("metafile.csv");
 
             mocks.FileStorageService
-                .Setup(service => service.UploadDataFiles(_releaseId, dataFile, metaFile, ApplicationUser.Email, "Subject name", null))
+                .Setup(service => service.UploadDataFiles(_releaseId,
+                    dataFile,
+                    metaFile,
+                    ApplicationUser.Email,
+                    null,
+                    "Subject name"))
                 .ReturnsAsync(ValidationActionResult(CannotOverwriteFile));
 
             var controller = ReleasesControllerWithMocks(mocks);
 
             // Call the method under test
-            var result = await controller.AddDataFilesAsync(_releaseId, "Subject name", dataFile, metaFile);
+            var result = await controller.AddDataFilesAsync(releaseId: _releaseId,
+                replacingFileId: null,
+                subjectName: "Subject name",
+                file: dataFile,
+                metaFile: metaFile);
             AssertValidationProblem(result, CannotOverwriteFile);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileStorageServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileStorageServicePermissionTests.cs
@@ -13,7 +13,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
@@ -73,7 +72,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             AssertSecurityPoliciesChecked(service =>
                     service.DeleteDataFilesAsync(
                         _release.Id,
-                        ""
+                        Guid.NewGuid()
                         ),
                 CanUpdateSpecificRelease);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileStorageServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileStorageServicePermissionTests.cs
@@ -30,7 +30,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void UploadFilesAsync()
         {
             AssertSecurityPoliciesChecked(service =>
-                service.UploadFileAsync(
+                service.UploadFile(
                     _release.Id,
                     new Mock<IFormFile>().Object,
                     "",
@@ -44,7 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void DeleteFileAsync()
         {
             AssertSecurityPoliciesChecked(service =>
-                    service.DeleteNonDataFileAsync(
+                    service.DeleteNonDataFile(
                         _release.Id,
                         ReleaseFileTypes.Ancillary,
                         ""
@@ -56,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void UploadDataFilesAsync()
         {
             AssertSecurityPoliciesChecked(service =>
-                    service.UploadDataFilesAsync(
+                    service.UploadDataFiles(
                         _release.Id,
                         new Mock<IFormFile>().Object,
                         new Mock<IFormFile>().Object,
@@ -70,7 +70,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void DeleteDataFileAsync()
         {
             AssertSecurityPoliciesChecked(service =>
-                    service.DeleteDataFilesAsync(
+                    service.DeleteDataFiles(
                         _release.Id,
                         Guid.NewGuid()
                         ),
@@ -81,7 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void ListFilesAsync()
         {
             AssertSecurityPoliciesChecked(service =>
-                    service.ListFilesAsync(
+                    service.ListFiles(
                         _release.Id,
                         ReleaseFileTypes.Ancillary
                     ),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileStorageServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileStorageServicePermissionTests.cs
@@ -57,12 +57,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             AssertSecurityPoliciesChecked(service =>
                     service.UploadDataFiles(
-                        _release.Id,
-                        new Mock<IFormFile>().Object,
-                        new Mock<IFormFile>().Object,
-                        "",
-                        ""
-                        ),
+                        releaseId: _release.Id,
+                        dataFile: new Mock<IFormFile>().Object,
+                        metadataFile: new Mock<IFormFile>().Object,
+                        userName: "",
+                        subjectName: ""),
                 CanUpdateSpecificRelease);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileUploadsValidatorServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileUploadsValidatorServiceTests.cs
@@ -363,7 +363,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             }
         }
 
-        private (Mock<ISubjectService>, Mock<IFileTypeService>) Mocks()
+        private static (Mock<ISubjectService>, Mock<IFileTypeService>) Mocks()
         {
             return (
                 new Mock<ISubjectService>(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -340,7 +340,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     async userService =>
                     {
                         var service = BuildReleaseService(userService: userService.Object);
-                        return await service.RemoveDataFilesAsync(_release.Id, "", "");
+                        return await service.RemoveDataFilesAsync(_release.Id, Guid.NewGuid());
                     }
                 );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -1770,7 +1770,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             mocks.ReleaseService.Setup(service => service.RemoveDataFilesAsync(
-                    contentReleaseVersion2.Id, originalReleaseFileReference.Filename, originalSubject.Name))
+                    contentReleaseVersion2.Id, originalReleaseFileReference.Id))
                 .ReturnsAsync(Unit.Instance);
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
@@ -1815,8 +1815,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     replacementReleaseFileReference.Id);
 
                 mocks.ReleaseService.Verify(
-                    mock => mock.RemoveDataFilesAsync(contentReleaseVersion2.Id, originalReleaseFileReference.Filename,
-                        originalSubject.Name), Times.Once());
+                    mock => mock.RemoveDataFilesAsync(contentReleaseVersion2.Id, originalReleaseFileReference.Id), Times.Once());
 
                 mocks.ReleaseService.VerifyNoOtherCalls();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -1769,10 +1769,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }
                 });
 
-            mocks.ReleaseService.Setup(service => service.RemoveDataFilesAsync(
-                    contentReleaseVersion2.Id, originalReleaseFileReference.Id))
-                .ReturnsAsync(Unit.Instance);
-
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
                 .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>
                 {
@@ -1805,6 +1801,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     footnoteForFilterItem, footnoteForIndicator, footnoteForSubject);
                 await statisticsDbContext.SaveChangesAsync();
             }
+
+            mocks.ReleaseService.Setup(service => service.RemoveDataFilesAsync(
+                    contentReleaseVersion2.Id, originalReleaseFileReference.Id))
+                .ReturnsAsync(Unit.Instance);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -112,7 +112,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         public async Task<ActionResult<IEnumerable<DataFileInfo>>> GetDataFilesAsync(Guid releaseId)
         {
             return await _releaseFilesService
-                .ListDataFilesAsync(releaseId)
+                .ListDataFiles(releaseId)
                 .HandleFailuresOrOk();
         }
 
@@ -123,7 +123,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         public async Task<ActionResult<IEnumerable<FileInfo>>> GetAncillaryFilesAsync(Guid releaseId)
         {
             return await _releaseFilesService
-                .ListFilesAsync(releaseId, ReleaseFileTypes.Ancillary)
+                .ListFiles(releaseId, ReleaseFileTypes.Ancillary)
                 .HandleFailuresOrOk();
         }
 
@@ -137,7 +137,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             [FromQuery(Name = "name"), Required] string name, IFormFile file)
         {
             return await _releaseFilesService
-                .UploadFileAsync(releaseId, file, name, ReleaseFileTypes.Ancillary, false)
+                .UploadFile(releaseId, file, name, ReleaseFileTypes.Ancillary, false)
                 .HandleFailuresOrOk();
         }
 
@@ -150,7 +150,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         public async Task<ActionResult<FileInfo>> AddChartFileAsync(Guid releaseId, IFormFile file)
         {
             return await _releaseFilesService
-                .UploadChartFileAsync(releaseId, file)
+                .UploadChartFile(releaseId, file)
                 .HandleFailuresOrOk();
         }
 
@@ -163,7 +163,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         public async Task<ActionResult<FileInfo>> UpdateChartFileAsync(Guid releaseId, Guid id, IFormFile file)
         {
             return await _releaseFilesService
-                .UploadChartFileAsync(releaseId, file, id)
+                .UploadChartFile(releaseId, file, id)
                 .HandleFailuresOrOk();
         }
 
@@ -179,7 +179,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             var user = await _userManager.GetUserAsync(User);
 
             return await _releaseFilesService
-                .UploadDataFilesAsync(releaseId: releaseId,
+                .UploadDataFiles(releaseId: releaseId,
                     dataFile: file,
                     metaFile: metaFile,
                     userName: user.Email,
@@ -194,18 +194,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [RequestSizeLimit(int.MaxValue)]
         [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
         public async Task<ActionResult<DataFileInfo>> AddReplacementDataFilesAsync(Guid releaseId,
-            Guid replacingId,
+            Guid replacingFileId,
             IFormFile file,
             IFormFile metaFile)
         {
             var user = await _userManager.GetUserAsync(User);
 
             return await _releaseFilesService
-                .UploadDataFilesAsync(releaseId: releaseId,
+                .UploadDataFiles(releaseId: releaseId,
                     dataFile: file,
                     metaFile: metaFile,
                     userName: user.Email,
-                    replacingId: replacingId)
+                    replacingFileId: replacingFileId)
                 .HandleFailuresOrOk();
         }
 
@@ -221,7 +221,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             var user = await _userManager.GetUserAsync(User);
 
             return await _releaseFilesService
-                .UploadDataFilesAsZipAsync(releaseId: releaseId,
+                .UploadDataFilesAsZip(releaseId: releaseId,
                     zipFile: zipFile,
                     userName: user.Email,
                     subjectName: name)
@@ -235,16 +235,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [RequestSizeLimit(int.MaxValue)]
         [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
         public async Task<ActionResult<DataFileInfo>> AddReplacementDataZipFileAsync(Guid releaseId,
-            Guid replacingId,
+            Guid replacingFileId,
             IFormFile zipFile)
         {
             var user = await _userManager.GetUserAsync(User);
 
             return await _releaseFilesService
-                .UploadDataFilesAsZipAsync(releaseId: releaseId,
+                .UploadDataFilesAsZip(releaseId: releaseId,
                     zipFile: zipFile, 
                     userName: user.Email,
-                    replacingId: replacingId)
+                    replacingFileId: replacingFileId)
                 .HandleFailuresOrOk();
         }
 
@@ -306,12 +306,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
-        [HttpGet("release/{releaseId}/data/{releaseFileReferenceId}/delete-plan")]
-        public async Task<ActionResult<DeleteDataFilePlan>> GetDeleteDataFilePlan(Guid releaseId,
-            Guid releaseFileReferenceId)
+        [HttpGet("release/{releaseId}/data/{fileId}/delete-plan")]
+        public async Task<ActionResult<DeleteDataFilePlan>> GetDeleteDataFilePlan(Guid releaseId, Guid fileId)
         {
             return await _releaseService
-                .GetDeleteDataFilePlan(releaseId, releaseFileReferenceId)
+                .GetDeleteDataFilePlan(releaseId, fileId)
                 .HandleFailuresOrOk();
         }
 
@@ -347,7 +346,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             Guid releaseId, string fileName)
         {
             return await _releaseFilesService
-                .DeleteNonDataFileAsync(releaseId, ReleaseFileTypes.Ancillary, fileName)
+                .DeleteNonDataFile(releaseId, ReleaseFileTypes.Ancillary, fileName)
                 .HandleFailuresOrNoContent();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -174,27 +174,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [RequestSizeLimit(int.MaxValue)]
         [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
         public async Task<ActionResult<DataFileInfo>> AddDataFilesAsync(Guid releaseId,
-            [FromQuery(Name = "name"), Required] string subjectName, IFormFile file, IFormFile metaFile)
-        {
-            var user = await _userManager.GetUserAsync(User);
-
-            return await _releaseFilesService
-                .UploadDataFiles(releaseId: releaseId,
-                    dataFile: file,
-                    metaFile: metaFile,
-                    userName: user.Email,
-                    subjectName: subjectName)
-                .HandleFailuresOrOk();
-        }
-
-        [HttpPost("release/{releaseId}/data/replacing/{replacingId}")]
-        [Produces("application/json")]
-        [ProducesResponseType(200)]
-        [ProducesResponseType(404)]
-        [RequestSizeLimit(int.MaxValue)]
-        [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
-        public async Task<ActionResult<DataFileInfo>> AddReplacementDataFilesAsync(Guid releaseId,
-            Guid replacingFileId,
+            [FromQuery(Name = "replacingFileId")] Guid? replacingFileId,
+            [FromQuery(Name = "name")] string subjectName,
             IFormFile file,
             IFormFile metaFile)
         {
@@ -205,7 +186,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                     dataFile: file,
                     metaFile: metaFile,
                     userName: user.Email,
-                    replacingFileId: replacingFileId)
+                    replacingFileId: replacingFileId,
+                    subjectName: subjectName)
                 .HandleFailuresOrOk();
         }
 
@@ -216,7 +198,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         [RequestSizeLimit(int.MaxValue)]
         [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
         public async Task<ActionResult<DataFileInfo>> AddDataZipFileAsync(Guid releaseId,
-            [FromQuery(Name = "name"), Required] string name, IFormFile zipFile)
+            [FromQuery(Name = "replacingFileId")] Guid? replacingFileId,
+            [FromQuery(Name = "name")] string subjectName,
+            IFormFile zipFile)
         {
             var user = await _userManager.GetUserAsync(User);
 
@@ -224,27 +208,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .UploadDataFilesAsZip(releaseId: releaseId,
                     zipFile: zipFile,
                     userName: user.Email,
-                    subjectName: name)
-                .HandleFailuresOrOk();
-        }
-
-        [HttpPost("release/{releaseId}/zip-data/replacing/{replacingId}")]
-        [Produces("application/json")]
-        [ProducesResponseType(200)]
-        [ProducesResponseType(404)]
-        [RequestSizeLimit(int.MaxValue)]
-        [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
-        public async Task<ActionResult<DataFileInfo>> AddReplacementDataZipFileAsync(Guid releaseId,
-            Guid replacingFileId,
-            IFormFile zipFile)
-        {
-            var user = await _userManager.GetUserAsync(User);
-
-            return await _releaseFilesService
-                .UploadDataFilesAsZip(releaseId: releaseId,
-                    zipFile: zipFile, 
-                    userName: user.Email,
-                    replacingFileId: replacingFileId)
+                    replacingFileId: replacingFileId,
+                    subjectName: subjectName)
                 .HandleFailuresOrOk();
         }
 
@@ -332,12 +297,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
-        [HttpDelete("release/{releaseId}/data/{releaseFileReferenceId}")]
+        [HttpDelete("release/{releaseId}/data/{fileId}")]
         public async Task<ActionResult> DeleteDataFiles(Guid releaseId,
-            Guid releaseFileReferenceId)
+            Guid fileId)
         {
             return await _releaseService
-                .RemoveDataFilesAsync(releaseId, releaseFileReferenceId)
+                .RemoveDataFilesAsync(releaseId, fileId)
                 .HandleFailuresOrNoContent();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -179,8 +179,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             var user = await _userManager.GetUserAsync(User);
 
             return await _releaseFilesService
-                .UploadDataFilesAsync(
-                    releaseId: releaseId,
+                .UploadDataFilesAsync(releaseId: releaseId,
                     dataFile: file,
                     metaFile: metaFile,
                     userName: user.Email,
@@ -222,7 +221,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             var user = await _userManager.GetUserAsync(User);
 
             return await _releaseFilesService
-                .UploadDataFilesAsZipAsync(releaseId, zipFile, name, user.Email)
+                .UploadDataFilesAsZipAsync(releaseId: releaseId,
+                    zipFile: zipFile,
+                    userName: user.Email,
+                    subjectName: name)
+                .HandleFailuresOrOk();
+        }
+
+        [HttpPost("release/{releaseId}/zip-data/replacing/{replacingId}")]
+        [Produces("application/json")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(404)]
+        [RequestSizeLimit(int.MaxValue)]
+        [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
+        public async Task<ActionResult<DataFileInfo>> AddReplacementDataZipFileAsync(Guid releaseId,
+            Guid replacingId,
+            IFormFile zipFile)
+        {
+            var user = await _userManager.GetUserAsync(User);
+
+            return await _releaseFilesService
+                .UploadDataFilesAsZipAsync(releaseId: releaseId,
+                    zipFile: zipFile, 
+                    userName: user.Email,
+                    replacingId: replacingId)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200921084042_EES1362AddReplacingId.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200921084042_EES1362AddReplacingId.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200921084042_EES1362AddReplacingId")]
+    partial class EES1362AddReplacingId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200921084042_EES1362AddReplacingId.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200921084042_EES1362AddReplacingId.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES1362AddReplacingId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ReplacingId",
+                table: "ReleaseFileReferences",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReleaseFileReferences_ReplacingId",
+                table: "ReleaseFileReferences",
+                column: "ReplacingId",
+                unique: true,
+                filter: "[ReplacingId] IS NOT NULL");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ReleaseFileReferences_ReleaseFileReferences_ReplacingId",
+                table: "ReleaseFileReferences",
+                column: "ReplacingId",
+                principalTable: "ReleaseFileReferences",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ReleaseFileReferences_ReleaseFileReferences_ReplacingId",
+                table: "ReleaseFileReferences");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ReleaseFileReferences_ReplacingId",
+                table: "ReleaseFileReferences");
+
+            migrationBuilder.DropColumn(
+                name: "ReplacingId",
+                table: "ReleaseFileReferences");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200922103259_EES1362AddReplacingId.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200922103259_EES1362AddReplacingId.Designer.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    [Migration("20200921084042_EES1362AddReplacingId")]
+    [Migration("20200922103259_EES1362AddReplacingId")]
     partial class EES1362AddReplacingId
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -534,6 +534,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<Guid>("ReleaseId")
                         .HasColumnType("uniqueidentifier");
 
+                    b.Property<Guid?>("ReplacedById")
+                        .HasColumnType("uniqueidentifier");
+
                     b.Property<Guid?>("ReplacingId")
                         .HasColumnType("uniqueidentifier");
 
@@ -546,6 +549,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasKey("Id");
 
                     b.HasIndex("ReleaseId");
+
+                    b.HasIndex("ReplacedById")
+                        .IsUnique()
+                        .HasFilter("[ReplacedById] IS NOT NULL");
 
                     b.HasIndex("ReplacingId")
                         .IsUnique()
@@ -1080,6 +1087,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .HasForeignKey("ReleaseId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseFileReference", "ReplacedBy")
+                        .WithOne()
+                        .HasForeignKey("GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseFileReference", "ReplacedById");
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseFileReference", "Replacing")
                         .WithOne()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200922103259_EES1362AddReplacingId.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20200922103259_EES1362AddReplacingId.cs
@@ -8,9 +8,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<Guid>(
+                name: "ReplacedById",
+                table: "ReleaseFileReferences",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
                 name: "ReplacingId",
                 table: "ReleaseFileReferences",
                 nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ReleaseFileReferences_ReplacedById",
+                table: "ReleaseFileReferences",
+                column: "ReplacedById",
+                unique: true,
+                filter: "[ReplacedById] IS NOT NULL");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ReleaseFileReferences_ReplacingId",
@@ -18,6 +30,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                 column: "ReplacingId",
                 unique: true,
                 filter: "[ReplacingId] IS NOT NULL");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ReleaseFileReferences_ReleaseFileReferences_ReplacedById",
+                table: "ReleaseFileReferences",
+                column: "ReplacedById",
+                principalTable: "ReleaseFileReferences",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
 
             migrationBuilder.AddForeignKey(
                 name: "FK_ReleaseFileReferences_ReleaseFileReferences_ReplacingId",
@@ -31,11 +51,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropForeignKey(
+                name: "FK_ReleaseFileReferences_ReleaseFileReferences_ReplacedById",
+                table: "ReleaseFileReferences");
+
+            migrationBuilder.DropForeignKey(
                 name: "FK_ReleaseFileReferences_ReleaseFileReferences_ReplacingId",
                 table: "ReleaseFileReferences");
 
             migrationBuilder.DropIndex(
+                name: "IX_ReleaseFileReferences_ReplacedById",
+                table: "ReleaseFileReferences");
+
+            migrationBuilder.DropIndex(
                 name: "IX_ReleaseFileReferences_ReplacingId",
+                table: "ReleaseFileReferences");
+
+            migrationBuilder.DropColumn(
+                name: "ReplacedById",
                 table: "ReleaseFileReferences");
 
             migrationBuilder.DropColumn(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
@@ -532,6 +532,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<Guid>("ReleaseId")
                         .HasColumnType("uniqueidentifier");
 
+                    b.Property<Guid?>("ReplacedById")
+                        .HasColumnType("uniqueidentifier");
+
                     b.Property<Guid?>("ReplacingId")
                         .HasColumnType("uniqueidentifier");
 
@@ -544,6 +547,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasKey("Id");
 
                     b.HasIndex("ReleaseId");
+
+                    b.HasIndex("ReplacedById")
+                        .IsUnique()
+                        .HasFilter("[ReplacedById] IS NOT NULL");
 
                     b.HasIndex("ReplacingId")
                         .IsUnique()
@@ -1078,6 +1085,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .HasForeignKey("ReleaseId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseFileReference", "ReplacedBy")
+                        .WithOne()
+                        .HasForeignKey("GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseFileReference", "ReplacedById");
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseFileReference", "Replacing")
                         .WithOne()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/DataFileInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/DataFileInfo.cs
@@ -9,5 +9,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
         public int Rows { get; set; }
         public string UserName { get; set; }
         public DateTimeOffset? Created { get; set; }
+        public Guid? ReplacedBy { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -84,7 +84,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, bool>> RemoveChartFile(Guid releaseId, Guid id)
         {
             return await RemoveInfographicChartFromDataBlock(releaseId, id)
-                .OnSuccess(async () => await _releaseFilesService.DeleteChartFileAsync(releaseId, id));
+                .OnSuccess(async () => await _releaseFilesService.DeleteChartFile(releaseId, id));
         }
 
         public async Task<DataBlockViewModel> GetAsync(Guid id)
@@ -121,7 +121,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     if (infographicChart != null && infographicChart.FileId != updatedInfographicChart?.FileId)
                     {
                         var release = GetReleaseForDataBlock(existing.Id);
-                        await _releaseFilesService.DeleteChartFileAsync(
+                        await _releaseFilesService.DeleteChartFile(
                             release.Id,
                             new Guid(infographicChart.FileId)
                         );
@@ -240,7 +240,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             var chartFileIds = deletePlan.DependentDataBlocks.SelectMany(
                 block => block.InfographicFilesInfo.Select((f => f.Id)));
 
-            await _releaseFilesService.DeleteChartFilesAsync(deletePlan.ReleaseId, chartFileIds);
+            await _releaseFilesService.DeleteChartFiles(deletePlan.ReleaseId, chartFileIds);
         }
 
         private async Task DeleteDependentDataBlocks(DeleteDataBlockPlan deletePlan)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
@@ -14,7 +14,6 @@ using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Validators.FileTypeValidationUtils;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 using static System.StringComparison;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
@@ -33,19 +32,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         // We cannot rely on the normal upload validation as we want this to be an atomic operation for both files.
-        public async Task<Either<ActionResult, Unit>> ValidateDataFilesForUpload(Guid releaseId, IFormFile dataFile, IFormFile metaFile, string name)
+        public async Task<Either<ActionResult, Unit>> ValidateDataFilesForUpload(Guid releaseId,
+            IFormFile dataFile,
+            IFormFile metaFile)
         {
             return await ValidateDataFileNames(releaseId, dataFile.FileName, metaFile.FileName)
                 .OnSuccess(async _ => await ValidateDataFileSizes(dataFile.Length, metaFile.Length))
-                .OnSuccess(async _ => await ValidateSubjectName(releaseId, name))
-                .OnSuccess(async _ => await ValidateDataFileTypes(releaseId, dataFile, metaFile));
+                .OnSuccess(async _ => await ValidateDataFileTypes(dataFile, metaFile));
         }
 
-        public async Task<Either<ActionResult, Unit>> ValidateDataArchiveEntriesForUpload(Guid releaseId, ZipArchiveEntry dataFile, ZipArchiveEntry metaFile, string name)
+        public async Task<Either<ActionResult, Unit>> ValidateDataArchiveEntriesForUpload(Guid releaseId,
+            ZipArchiveEntry dataFile,
+            ZipArchiveEntry metaFile)
         {
             return await ValidateDataFileNames(releaseId, dataFile.Name, metaFile.Name)
-                .OnSuccess(async _ => await ValidateDataFileSizes(dataFile.Length, metaFile.Length))
-                .OnSuccess(async _ => await ValidateSubjectName(releaseId, name));
+                .OnSuccess(async _ => await ValidateDataFileSizes(dataFile.Length, metaFile.Length));
         }
 
         public async Task<Either<ActionResult, Unit>> ValidateFileForUpload(Guid releaseId, IFormFile file,
@@ -80,6 +81,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return Unit.Instance;
         }
 
+        public async Task<Either<ActionResult, Unit>> ValidateSubjectName(Guid releaseId, string name)
+        {
+            if (FileContainsSpecialChars(name))
+            {
+                return ValidationActionResult(SubjectTitleCannotContainSpecialCharacters);
+            }
+            
+            if (await _subjectService.GetAsync(releaseId, name) != null)
+            {
+                return ValidationActionResult(SubjectTitleMustBeUnique);
+            }
+
+            return Unit.Instance;
+        }
+
         // We cannot rely on the normal upload validation as we want this to be an atomic operation for both files.
         public async Task<Either<ActionResult, Unit>> ValidateUploadFileType(
             IFormFile file, ReleaseFileTypes type)
@@ -99,7 +115,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return Unit.Instance;
         }
 
-        private async Task<bool> IsCsvFile(string filePath, IFormFile file)
+        private async Task<bool> IsCsvFile(IFormFile file)
         {
             return await _fileTypeService.HasMatchingMimeType(file, AllowedMimeTypesByFileType[ReleaseFileTypes.Data]) 
                    && _fileTypeService.HasMatchingEncodingType(file, CsvEncodingTypes);
@@ -173,7 +189,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return Unit.Instance;
         }
 
-        private async Task<Either<ActionResult, Unit>> ValidateDataFileSizes(long dataFileLength, long metaFileLength)
+        private static async Task<Either<ActionResult, Unit>> ValidateDataFileSizes(long dataFileLength,
+            long metaFileLength)
         {
             if (dataFileLength == 0)
             {
@@ -188,17 +205,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return Unit.Instance;
         }
         
-        private async Task<Either<ActionResult, Unit>> ValidateDataFileTypes(Guid releaseId, IFormFile dataFile, IFormFile metaFile)
+        private async Task<Either<ActionResult, Unit>> ValidateDataFileTypes(IFormFile dataFile, IFormFile metaFile)
         {
-            var dataFilePath = AdminReleasePath(releaseId, ReleaseFileTypes.Data, dataFile.FileName.ToLower());
-            var metadataFilePath = AdminReleasePath(releaseId, ReleaseFileTypes.Data, metaFile.FileName.ToLower());
-
-            if (!await IsCsvFile(dataFilePath, dataFile))
+            if (!await IsCsvFile(dataFile))
             {
                 return ValidationActionResult(DataFileMustBeCsvFile);
             }
 
-            if (!await IsCsvFile(metadataFilePath, metaFile))
+            if (!await IsCsvFile(metaFile))
             {
                 return ValidationActionResult(MetaFileMustBeCsvFile);
             }
@@ -206,24 +220,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return Unit.Instance;
         }
         
-        private bool ValidateFileExtension(string fileName, string requiredExtension)
+        private static bool ValidateFileExtension(string fileName, string requiredExtension)
         {
             return fileName.EndsWith(requiredExtension);
-        }
-        
-        private async Task<Either<ActionResult, Unit>> ValidateSubjectName(Guid releaseId, string name)
-        {
-            if (FileContainsSpecialChars(name))
-            {
-                return ValidationActionResult(SubjectTitleCannotContainSpecialCharacters);
-            }
-            
-            if (await _subjectService.GetAsync(releaseId, name) != null)
-            {
-                return ValidationActionResult(SubjectTitleMustBeUnique);
-            }
-
-            return Unit.Instance;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileUploadsValidatorService.cs
@@ -9,11 +9,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IFileUploadsValidatorService
     {
-        Task<Either<ActionResult, Unit>> ValidateFileForUpload(Guid releaseId, IFormFile file, ReleaseFileTypes type, bool overwrite);
+        Task<Either<ActionResult, Unit>> ValidateFileForUpload(Guid releaseId, IFormFile file, ReleaseFileTypes type,
+            bool overwrite);
+
         Task<Either<ActionResult, Unit>> ValidateFileUploadName(string name);
-        Task<Either<ActionResult, Unit>> ValidateDataFilesForUpload(Guid releaseId, IFormFile dataFile, IFormFile metaFile, string name);
+
+        Task<Either<ActionResult, Unit>> ValidateDataFilesForUpload(Guid releaseId, IFormFile dataFile,
+            IFormFile metaFile);
+
         Task<Either<ActionResult, Unit>> ValidateDataArchiveEntriesForUpload(Guid releaseId, ZipArchiveEntry dataFile,
-            ZipArchiveEntry metaFile, string name);
+            ZipArchiveEntry metaFile);
+
+        Task<Either<ActionResult, Unit>> ValidateSubjectName(Guid releaseId, string name);
+
         Task<Either<ActionResult, Unit>> ValidateUploadFileType(IFormFile file, ReleaseFileTypes type);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFilesService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFilesService.cs
@@ -11,9 +11,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     public interface IReleaseFilesService
     {
         Task<Either<ActionResult, DataFileInfo>> UploadDataFilesAsync(Guid releaseId,
-            IFormFile dataFile, IFormFile metaFile, string name, string userName);
+            IFormFile dataFile, IFormFile metaFile, string userName, string subjectName = null, Guid? replacingId = null);
 
-        Task<Either<ActionResult, DataFileInfo>>  UploadDataFilesAsZipAsync(Guid releaseId, IFormFile zipFile, string name, string userEmail);
+        Task<Either<ActionResult, DataFileInfo>>  UploadDataFilesAsZipAsync(Guid releaseId, IFormFile zipFile, string subjectName, string userEmail);
 
         Task<Either<ActionResult, IEnumerable<FileInfo>>> ListFilesAsync(Guid releaseId, params ReleaseFileTypes[] types);
 
@@ -33,14 +33,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, bool>> DeleteChartFilesAsync(Guid releaseId, IEnumerable<Guid> fileIds);
 
-        Task<Either<ActionResult, bool>> DeleteDataFilesAsync(Guid releaseId, string dataFileName);
+        Task<Either<ActionResult, Unit>> DeleteDataFilesAsync(Guid releaseId, Guid releaseFileReferenceId);
 
         Task<Either<ActionResult, Unit>> DeleteAllFiles(Guid releaseId);
 
         Task<Either<ActionResult, FileStreamResult>> StreamFile(Guid releaseId, ReleaseFileTypes type,
             string fileName);
 
-        Task<Either<ActionResult, FileStreamResult>> StreamFile(Guid releaseId, ReleaseFileTypes type,
-            Guid id);
+        Task<Either<ActionResult, FileStreamResult>> StreamFile(Guid releaseId, Guid id);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFilesService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFilesService.cs
@@ -11,10 +11,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     public interface IReleaseFilesService
     {
         Task<Either<ActionResult, DataFileInfo>> UploadDataFiles(Guid releaseId, IFormFile dataFile,
-            IFormFile metaFile, string userName, string subjectName = null, Guid? replacingFileId = null);
+            IFormFile metaFile, string userName, Guid? replacingFileId = null, string subjectName = null);
 
         Task<Either<ActionResult, DataFileInfo>> UploadDataFilesAsZip(Guid releaseId, IFormFile zipFile,
-            string userName, string subjectName = null, Guid? replacingFileId = null);
+            string userName, Guid? replacingFileId = null, string subjectName = null);
 
         Task<Either<ActionResult, IEnumerable<FileInfo>>> ListFiles(Guid releaseId,
             params ReleaseFileTypes[] types);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFilesService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFilesService.cs
@@ -10,32 +10,32 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IReleaseFilesService
     {
-        Task<Either<ActionResult, DataFileInfo>> UploadDataFilesAsync(Guid releaseId, IFormFile dataFile,
-            IFormFile metaFile, string userName, string subjectName = null, Guid? replacingId = null);
+        Task<Either<ActionResult, DataFileInfo>> UploadDataFiles(Guid releaseId, IFormFile dataFile,
+            IFormFile metaFile, string userName, string subjectName = null, Guid? replacingFileId = null);
 
-        Task<Either<ActionResult, DataFileInfo>> UploadDataFilesAsZipAsync(Guid releaseId, IFormFile zipFile,
-            string userName, string subjectName = null, Guid? replacingId = null);
+        Task<Either<ActionResult, DataFileInfo>> UploadDataFilesAsZip(Guid releaseId, IFormFile zipFile,
+            string userName, string subjectName = null, Guid? replacingFileId = null);
 
-        Task<Either<ActionResult, IEnumerable<FileInfo>>> ListFilesAsync(Guid releaseId,
+        Task<Either<ActionResult, IEnumerable<FileInfo>>> ListFiles(Guid releaseId,
             params ReleaseFileTypes[] types);
 
-        Task<Either<ActionResult, IEnumerable<DataFileInfo>>> ListDataFilesAsync(Guid releaseId);
+        Task<Either<ActionResult, IEnumerable<DataFileInfo>>> ListDataFiles(Guid releaseId);
 
         Task<Either<ActionResult, IEnumerable<FileInfo>>> ListPublicFilesPreview(Guid releaseId,
             IEnumerable<Guid> referencedReleaseVersions);
 
-        Task<Either<ActionResult, FileInfo>> UploadFileAsync(Guid releaseId, IFormFile file, string name,
+        Task<Either<ActionResult, FileInfo>> UploadFile(Guid releaseId, IFormFile file, string name,
             ReleaseFileTypes type, bool overwrite);
 
-        Task<Either<ActionResult, FileInfo>> UploadChartFileAsync(Guid releaseId, IFormFile file, Guid? id = null);
+        Task<Either<ActionResult, FileInfo>> UploadChartFile(Guid releaseId, IFormFile file, Guid? id = null);
 
-        Task<Either<ActionResult, bool>> DeleteNonDataFileAsync(Guid releaseId, ReleaseFileTypes type, string fileName);
+        Task<Either<ActionResult, bool>> DeleteNonDataFile(Guid releaseId, ReleaseFileTypes type, string fileName);
 
-        Task<Either<ActionResult, bool>> DeleteChartFileAsync(Guid releaseId, Guid id);
+        Task<Either<ActionResult, bool>> DeleteChartFile(Guid releaseId, Guid id);
 
-        Task<Either<ActionResult, bool>> DeleteChartFilesAsync(Guid releaseId, IEnumerable<Guid> fileIds);
+        Task<Either<ActionResult, bool>> DeleteChartFiles(Guid releaseId, IEnumerable<Guid> fileIds);
 
-        Task<Either<ActionResult, Unit>> DeleteDataFilesAsync(Guid releaseId, Guid releaseFileReferenceId);
+        Task<Either<ActionResult, Unit>> DeleteDataFiles(Guid releaseId, Guid fileId);
 
         Task<Either<ActionResult, Unit>> DeleteAllFiles(Guid releaseId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFilesService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFilesService.cs
@@ -10,24 +10,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IReleaseFilesService
     {
-        Task<Either<ActionResult, DataFileInfo>> UploadDataFilesAsync(Guid releaseId,
-            IFormFile dataFile, IFormFile metaFile, string userName, string subjectName = null, Guid? replacingId = null);
+        Task<Either<ActionResult, DataFileInfo>> UploadDataFilesAsync(Guid releaseId, IFormFile dataFile,
+            IFormFile metaFile, string userName, string subjectName = null, Guid? replacingId = null);
 
-        Task<Either<ActionResult, DataFileInfo>>  UploadDataFilesAsZipAsync(Guid releaseId, IFormFile zipFile, string subjectName, string userEmail);
+        Task<Either<ActionResult, DataFileInfo>> UploadDataFilesAsZipAsync(Guid releaseId, IFormFile zipFile,
+            string userName, string subjectName = null, Guid? replacingId = null);
 
-        Task<Either<ActionResult, IEnumerable<FileInfo>>> ListFilesAsync(Guid releaseId, params ReleaseFileTypes[] types);
+        Task<Either<ActionResult, IEnumerable<FileInfo>>> ListFilesAsync(Guid releaseId,
+            params ReleaseFileTypes[] types);
 
         Task<Either<ActionResult, IEnumerable<DataFileInfo>>> ListDataFilesAsync(Guid releaseId);
 
-        Task<Either<ActionResult, IEnumerable<FileInfo>>> ListPublicFilesPreview(Guid releaseId, IEnumerable<Guid> referencedReleaseVersions);
+        Task<Either<ActionResult, IEnumerable<FileInfo>>> ListPublicFilesPreview(Guid releaseId,
+            IEnumerable<Guid> referencedReleaseVersions);
 
-        Task<Either<ActionResult, FileInfo>> UploadFileAsync(Guid releaseId, IFormFile file,
-            string name, ReleaseFileTypes type, bool overwrite);
+        Task<Either<ActionResult, FileInfo>> UploadFileAsync(Guid releaseId, IFormFile file, string name,
+            ReleaseFileTypes type, bool overwrite);
 
         Task<Either<ActionResult, FileInfo>> UploadChartFileAsync(Guid releaseId, IFormFile file, Guid? id = null);
 
-        Task<Either<ActionResult, bool>> DeleteNonDataFileAsync(Guid releaseId, ReleaseFileTypes type,
-            string fileName);
+        Task<Either<ActionResult, bool>> DeleteNonDataFileAsync(Guid releaseId, ReleaseFileTypes type, string fileName);
 
         Task<Either<ActionResult, bool>> DeleteChartFileAsync(Guid releaseId, Guid id);
 
@@ -37,8 +39,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, Unit>> DeleteAllFiles(Guid releaseId);
 
-        Task<Either<ActionResult, FileStreamResult>> StreamFile(Guid releaseId, ReleaseFileTypes type,
-            string fileName);
+        Task<Either<ActionResult, FileStreamResult>> StreamFile(Guid releaseId, ReleaseFileTypes type, string fileName);
 
         Task<Either<ActionResult, FileStreamResult>> StreamFile(Guid releaseId, Guid id);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -29,9 +29,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, List<MyReleaseViewModel>>> GetMyScheduledReleasesAsync();
 
-        Task<Either<ActionResult, DeleteDataFilePlan>> GetDeleteDataFilePlan(Guid releaseId, string dataFileName, string subjectTitle);
+        Task<Either<ActionResult, DeleteDataFilePlan>> GetDeleteDataFilePlan(Guid releaseId, Guid releaseFileReferenceId);
 
-        Task<Either<ActionResult, Unit>> RemoveDataFilesAsync(Guid releaseId, string fileName, string subjectTitle);
+        Task<Either<ActionResult, Unit>> RemoveDataFilesAsync(Guid releaseId, Guid releaseFileReferenceId);
 
         Task<Either<ActionResult, ImportStatus>> GetDataFileImportStatus(Guid releaseId, string dataFileName);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -29,9 +29,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, List<MyReleaseViewModel>>> GetMyScheduledReleasesAsync();
 
-        Task<Either<ActionResult, DeleteDataFilePlan>> GetDeleteDataFilePlan(Guid releaseId, Guid releaseFileReferenceId);
+        Task<Either<ActionResult, DeleteDataFilePlan>> GetDeleteDataFilePlan(Guid releaseId, Guid fileId);
 
-        Task<Either<ActionResult, Unit>> RemoveDataFilesAsync(Guid releaseId, Guid releaseFileReferenceId);
+        Task<Either<ActionResult, Unit>> RemoveDataFilesAsync(Guid releaseId, Guid fileId);
 
         Task<Either<ActionResult, ImportStatus>> GetDataFileImportStatus(Guid releaseId, string dataFileName);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFilesService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFilesService.cs
@@ -99,8 +99,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IFormFile dataFile,
             IFormFile metadataFile,
             string userName,
-            string subjectName = null,
-            Guid? replacingFileId = null)
+            Guid? replacingFileId = null,
+            string subjectName = null)
         {
             return _persistenceHelper
                 .CheckEntityExists<Release>(releaseId)
@@ -173,8 +173,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public Task<Either<ActionResult, DataFileInfo>> UploadDataFilesAsZip(Guid releaseId,
             IFormFile zipFile,
             string userName,
-            string subjectName = null,
-            Guid? replacingFileId = null)
+            Guid? replacingFileId = null,
+            string subjectName = null)
         {
             return _persistenceHelper
                 .CheckEntityExists<Release>(releaseId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -392,6 +392,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .Select(rfr => rfr.ReleaseId).Distinct();
         }
 
+        private async Task<Either<ActionResult, ReleaseFileReference>> CheckReleaseFileReferenceExists(Guid id)
+        {
+            return await _persistenceHelper.CheckEntityExists<ReleaseFileReference>(id)
+                .OnSuccess(releaseFileReference => releaseFileReference.ReleaseFileType != ReleaseFileTypes.Data
+                    ? new Either<ActionResult, ReleaseFileReference>(
+                        ValidationActionResult(FileTypeMustBeData))
+                    : releaseFileReference);
+        }
+
         private async Task<Either<ActionResult, bool>> ValidateReleaseSlugUniqueToPublication(string slug,
             Guid publicationId, Guid? releaseId = null)
         {
@@ -421,41 +430,47 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         public async Task<Either<ActionResult, DeleteDataFilePlan>> GetDeleteDataFilePlan(Guid releaseId,
-            string dataFileName, string subjectTitle)
+            Guid releaseFileReferenceId)
         {
-            return await _persistenceHelper
-                .CheckEntityExists<Release>(releaseId)
+            return await _persistenceHelper.CheckEntityExists<Release>(releaseId)
                 .OnSuccess(_userService.CheckCanUpdateRelease)
-                .OnSuccess(async _ =>
+                .OnSuccess(() => CheckReleaseFileReferenceExists(releaseFileReferenceId))
+                .OnSuccess(async releaseFileReference =>
                 {
-                    var subject = await _subjectService.GetAsync(releaseId, subjectTitle);
-                    var footnotes = subject == null ? new List<Footnote>() : _footnoteService.GetFootnotes(releaseId, subject.Id);
+                    var subject = releaseFileReference.SubjectId.HasValue
+                        ? await _subjectService.GetAsync(releaseFileReference.SubjectId.Value)
+                        : null;
+
+                    var footnotes = subject == null
+                        ? new List<Footnote>()
+                        : _footnoteService.GetFootnotes(releaseId, subject.Id);
 
                     return new DeleteDataFilePlan
                     {
                         ReleaseId = releaseId,
                         SubjectId = subject?.Id ?? Guid.Empty,
-                        TableStorageItem = new DatafileImport(releaseId.ToString(), dataFileName),
+                        TableStorageItem = new DatafileImport(releaseId.ToString(), releaseFileReference.Filename),
                         DeleteDataBlockPlan = await _dataBlockService.GetDeleteDataBlockPlan(releaseId, subject),
-                        FootnoteIds = footnotes.Select(footnote => footnote.Id).ToList(),
+                        FootnoteIds = footnotes.Select(footnote => footnote.Id).ToList()
                     };
                 });
         }
 
-        public async Task<Either<ActionResult, Unit>> RemoveDataFilesAsync(Guid releaseId, string fileName, string subjectTitle)
+        public async Task<Either<ActionResult, Unit>> RemoveDataFilesAsync(Guid releaseId, Guid releaseFileReferenceId)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Release>(releaseId)
                 .OnSuccess(_userService.CheckCanUpdateRelease)
-                .OnSuccess(() => CheckCanDeleteDataFiles(releaseId, fileName))
-                .OnSuccess(_ => GetDeleteDataFilePlan(releaseId, fileName, subjectTitle))
+                .OnSuccess(() => CheckReleaseFileReferenceExists(releaseFileReferenceId))
+                .OnSuccess(releaseFileReference => CheckCanDeleteDataFiles(releaseId, releaseFileReference))
+                .OnSuccess(_ => GetDeleteDataFilePlan(releaseId, releaseFileReferenceId))
                 .OnSuccess(async deletePlan =>
                 {
                     await _dataBlockService.DeleteDataBlocks(deletePlan.DeleteDataBlockPlan);
                     await _releaseSubjectService.SoftDeleteSubjectOrBreakReleaseLink(releaseId, deletePlan.SubjectId);
 
                     return await _releaseFilesService
-                        .DeleteDataFilesAsync(releaseId, fileName)
+                        .DeleteDataFilesAsync(releaseId, releaseFileReferenceId)
                         .OnSuccess(async () => await RemoveFileImportEntryIfOrphaned(deletePlan));
                 });
         }
@@ -500,16 +515,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return release.Status != ReleaseStatus.Approved;
         }
 
-        private async Task<Either<ActionResult, bool>> CheckCanDeleteDataFiles(Guid releaseId, string dataFileName)
+        private async Task<Either<ActionResult, Unit>> CheckCanDeleteDataFiles(Guid releaseId,
+            ReleaseFileReference releaseFileReference)
         {
-            var releaseFileReference = _context
-                .ReleaseFiles
-                .Include(rf => rf.ReleaseFileReference)
-                .Where(rf => rf.ReleaseId == releaseId && rf.ReleaseFileReference.Filename == dataFileName)
-                .Select(rf => rf.ReleaseFileReference)
-                .First();
-
-            var importFinished = await _importStatusService.IsImportFinished(releaseFileReference.ReleaseId.ToString(), dataFileName);
+            var importFinished = await _importStatusService.IsImportFinished(releaseFileReference.ReleaseId.ToString(),
+                releaseFileReference.Filename);
 
             if (!importFinished)
             {
@@ -521,7 +531,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 return ValidationActionResult(CannotRemoveDataFilesOnceReleaseApproved);
             }
 
-            return true;
+            return Unit.Instance;
         }
 
         private async Task<Either<ActionResult, bool>> CheckMethodologyHasBeenApproved(Release release, ReleaseStatus status)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -113,8 +113,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     var releaseId = (await _contentDbContext.ReleaseFileReferences
                         .FindAsync(replacementReleaseFileReferenceId)).ReleaseId;
 
-                    return await RemoveSubjectAndFileFromRelease(releaseId, replacementPlan.OriginalSubjectId,
-                        originalReleaseFileReferenceId);
+                    return await RemoveSubjectAndFileFromRelease(releaseId, originalReleaseFileReferenceId);
                 });
         }
 
@@ -623,17 +622,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         private async Task<Either<ActionResult, Unit>> RemoveSubjectAndFileFromRelease(Guid releaseId,
-            Guid subjectId,
             Guid releaseFileReferenceId)
         {
-            var releaseFileReference = await _contentDbContext.ReleaseFileReferences
-                .FindAsync(releaseFileReferenceId);
-
-            var subject =
-                await _statisticsDbContext.Subject.FindAsync(subjectId);
-
-            return await _releaseService.RemoveDataFilesAsync(releaseId,
-                releaseFileReference.Filename, subject.Name);
+            return await _releaseService.RemoveDataFilesAsync(releaseId, releaseFileReferenceId);
         }
 
         private class ReplacementSubjectMeta

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -107,6 +107,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         FileUploadNameCannotContainSpecialCharacters,
 
         // Data file
+        SubjectTitleCannotContainSpecialCharacters,
         SubjectTitleMustBeUnique,
         CannotUseGenericFunctionToDeleteDataFile,
         CannotUseGenericFunctionToAddDataFile,
@@ -119,6 +120,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         CannotRemoveDataFilesUntilImportComplete,
         CannotRemoveDataFilesOnceReleaseApproved,
         AllDatafilesUploadedMustBeComplete,
+        FileTypeMustBeData,
         
         // Data zip file
         DataFileMustBeZipFile,
@@ -141,9 +143,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         // Release
         ReleaseNotApproved,
         ApprovedReleaseMustHavePublishScheduledDate,
-        PublishedReleaseCannotBeUnapproved,
-        
-        // Subject
-        SubjectTitleCannotContainSpecialCharacters,
+        PublishedReleaseCannotBeUnapproved
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/IPersistenceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/IPersistenceHelper.cs
@@ -18,5 +18,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
             Guid id,
             Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null)
             where TEntity : class;
+
+        Task<Either<ActionResult, TEntity>> CheckOptionalEntityExists<TEntity>(
+            Guid? id,
+            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null)
+            where TEntity : class;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/PersistenceHelper.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/PersistenceHelper.cs
@@ -12,16 +12,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
         where TDbContext : DbContext
     {
         private readonly TDbContext _context;
-            
+
         public PersistenceHelper(
             TDbContext context)
         {
             _context = context;
         }
-        
+
         public async Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity, TEntityId>(
-            TEntityId id, 
-            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null) 
+            TEntityId id,
+            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null)
             where TEntity : class
         {
             var queryableEntities = _context.Set<TEntity>()
@@ -30,21 +30,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
             var hydratedEntities = hydrateEntityFn != null
                 ? hydrateEntityFn.Invoke(queryableEntities)
                 : queryableEntities;
-            
+
             var entity = await hydratedEntities
                 .FirstOrDefaultAsync();
 
             return entity == null
                 ? new NotFoundResult()
                 : new Either<ActionResult, TEntity>(entity);
-        }        
-        
+        }
+
         public Task<Either<ActionResult, TEntity>> CheckEntityExists<TEntity>(
-            Guid id, 
-            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null) 
+            Guid id,
+            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null)
             where TEntity : class
         {
             return CheckEntityExists<TEntity, Guid>(id, hydrateEntityFn);
+        }
+
+        public async Task<Either<ActionResult, TEntity>> CheckOptionalEntityExists<TEntity>(Guid? id,
+            Func<IQueryable<TEntity>, IQueryable<TEntity>> hydrateEntityFn = null) where TEntity : class
+        {
+            return id.HasValue
+                ? await CheckEntityExists(id.Value, hydrateEntityFn)
+                : (TEntity) null;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -187,6 +187,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .Property(b => b.ReleaseFileType)
                 .HasConversion(new EnumToStringConverter<ReleaseFileTypes>());
 
+            modelBuilder.Entity<ReleaseFileReference>()
+                .HasOne(b => b.Replacing)
+                .WithOne()
+                .HasForeignKey<ReleaseFileReference>(b => b.ReplacingId)
+                .IsRequired(false);
+
             modelBuilder.Entity<Release>()
                 .HasOne(r => r.PreviousVersion)
                 .WithMany()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -193,6 +193,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .HasForeignKey<ReleaseFileReference>(b => b.ReplacingId)
                 .IsRequired(false);
 
+            modelBuilder.Entity<ReleaseFileReference>()
+                .HasOne(b => b.ReplacedBy)
+                .WithOne()
+                .HasForeignKey<ReleaseFileReference>(b => b.ReplacedById)
+                .IsRequired(false);
+
             modelBuilder.Entity<Release>()
                 .HasOne(r => r.PreviousVersion)
                 .WithMany()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFileReference.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFileReference.cs
@@ -34,6 +34,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
                 return Filename;
             }
         }
+
+        public Guid? ReplacingId { get; set; }
+        public ReleaseFileReference Replacing { get; set; }
+
         public Guid? SourceId { get; set; }
         public ReleaseFileReference? Source { get; set; }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFileReference.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFileReference.cs
@@ -35,6 +35,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
             }
         }
 
+        public Guid? ReplacedById { get; set; }
+        public ReleaseFileReference ReplacedBy { get; set; }
+
         public Guid? ReplacingId { get; set; }
         public ReleaseFileReference Replacing { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Model/ImportMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Model/ImportMessage.cs
@@ -12,15 +12,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Model
         public int NumBatches { get; set; }
         public int BatchNo { get; set; }
         public int RowsPerBatch { get; set; }
-        public bool Seeding{ get; set; }
+        public bool Seeding { get; set; }
         public int TotalRows { get; set; }
         public string ArchiveFileName { get; set; }
+
         public override string ToString()
         {
-            return
-                $"{nameof(SubjectId)}: {SubjectId}, {nameof(DataFileName)}: {DataFileName}, {nameof(OrigDataFileName)}: {OrigDataFileName}, {nameof(Release)}: {Release}, " +
-                $"{nameof(NumBatches)}: {NumBatches}, {nameof(BatchNo)}: {BatchNo}, {nameof(RowsPerBatch)}: {RowsPerBatch}, " +
-                $"{nameof(Seeding)}: {Seeding}, {nameof(TotalRows)}: {TotalRows}, {nameof(ArchiveFileName)}: {ArchiveFileName}";
+            return $"{nameof(SubjectId)}: {SubjectId}, " +
+                   $"{nameof(DataFileName)}: {DataFileName}, " +
+                   $"{nameof(OrigDataFileName)}: {OrigDataFileName}, " +
+                   $"{nameof(MetaFileName)}: {MetaFileName}, " +
+                   $"{nameof(Release)}: {Release}, " +
+                   $"{nameof(NumBatches)}: {NumBatches}, " +
+                   $"{nameof(BatchNo)}: {BatchNo}, " +
+                   $"{nameof(RowsPerBatch)}: {RowsPerBatch}, " +
+                   $"{nameof(Seeding)}: {Seeding}, " +
+                   $"{nameof(TotalRows)}: {TotalRows}, " +
+                   $"{nameof(ArchiveFileName)}: {ArchiveFileName}";
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -40,7 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 IStatus.RUNNING_PHASE_3))
             {
                 var subjectData = await _fileStorageService.GetSubjectData(message);
-                var releaseSubject = GetReleaseSubjectLink(message, subjectData.Name, context);
+                var releaseSubject = GetReleaseSubjectLink(message, context);
 
                 await using var datafileStream = await _fileStorageService.StreamBlob(subjectData.DataBlob);
                 var dataFileTable = DataTableUtils.CreateFromStream(datafileStream);
@@ -76,7 +76,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         public async Task ImportFiltersLocationsAndSchools(ImportMessage message, StatisticsDbContext context)
         {
             var subjectData = _fileStorageService.GetSubjectData(message).Result;
-            var releaseSubject = GetReleaseSubjectLink(message, subjectData.Name, context);
+            var releaseSubject = GetReleaseSubjectLink(message, context);
 
             await using var dataFileStream = await _fileStorageService.StreamBlob(subjectData.DataBlob);
             var dataFileTable = DataTableUtils.CreateFromStream(dataFileStream);
@@ -91,7 +91,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 context);
         }
 
-        private static ReleaseSubject GetReleaseSubjectLink(ImportMessage message, string subjectName, StatisticsDbContext context)
+        private static ReleaseSubject GetReleaseSubjectLink(ImportMessage message, StatisticsDbContext context)
         {
             return context
                 .ReleaseSubject
@@ -100,7 +100,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 .ThenInclude(r => r.Publication)
                 .ThenInclude(p => p.Topic)
                 .ThenInclude(t => t.Theme)
-                .FirstOrDefault(r => r.Subject.Name.Equals(subjectName) && r.ReleaseId == message.Release.Id);
+                .FirstOrDefault(r => r.Subject.Id == message.SubjectId && r.ReleaseId == message.Release.Id);
         }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -24,7 +24,7 @@ const releaseDataFileService = _releaseDataFileService as jest.Mocked<
 describe('ReleaseDataUploadsSection', () => {
   const testDataFiles: DataFile[] = [
     {
-      id: '52d30125-6381-455a-abc6-eab82c943fc9',
+      id: 'data-1',
       title: 'Test data 1',
       userName: 'user1@test.com',
       filename: 'data-1.csv',
@@ -37,7 +37,7 @@ describe('ReleaseDataUploadsSection', () => {
       created: new Date('2020-06-12T12:00:00'),
     },
     {
-      id: '538a6f3f-5d84-449e-ae19-80788768e8d6',
+      id: 'data-2',
       title: 'Test data 2',
       userName: 'user2@test.com',
       filename: 'data-2.csv',
@@ -329,7 +329,7 @@ describe('ReleaseDataUploadsSection', () => {
 
   describe('uploading data file', () => {
     const testUploadedDataFile: DataFile = {
-      id: '4c96b8cf-140b-47cb-9774-83668c432578',
+      id: 'file-1',
       title: 'Test title',
       userName: 'user1@test.com',
       filename: 'test-data.csv',

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -24,6 +24,7 @@ const releaseDataFileService = _releaseDataFileService as jest.Mocked<
 describe('ReleaseDataUploadsSection', () => {
   const testDataFiles: DataFile[] = [
     {
+      id: '52d30125-6381-455a-abc6-eab82c943fc9',
       title: 'Test data 1',
       userName: 'user1@test.com',
       filename: 'data-1.csv',
@@ -36,6 +37,7 @@ describe('ReleaseDataUploadsSection', () => {
       created: new Date('2020-06-12T12:00:00'),
     },
     {
+      id: '538a6f3f-5d84-449e-ae19-80788768e8d6',
       title: 'Test data 2',
       userName: 'user2@test.com',
       filename: 'data-2.csv',
@@ -327,6 +329,7 @@ describe('ReleaseDataUploadsSection', () => {
 
   describe('uploading data file', () => {
     const testUploadedDataFile: DataFile = {
+      id: '4c96b8cf-140b-47cb-9774-83668c432578',
       title: 'Test title',
       userName: 'user1@test.com',
       filename: 'test-data.csv',

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -18,6 +18,7 @@ export interface DeleteDataFilePlan {
 }
 
 export interface DataFile {
+  id: string;
   title: string;
   filename: string;
   fileSize: {
@@ -69,6 +70,7 @@ function mapFile(file: DataFileInfo): DataFile {
   const [size, unit] = file.size.split(' ');
 
   return {
+    id: file.id,
     title: file.name,
     filename: file.fileName,
     rows: file.rows || 0,
@@ -159,23 +161,11 @@ const releaseDataFileService = {
     dataFile: DataFile,
   ): Promise<DeleteDataFilePlan> {
     return client.get<DeleteDataFilePlan>(
-      `/release/${releaseId}/data/${dataFile.filename}/delete-plan`,
-      {
-        params: {
-          name: dataFile.title,
-        },
-      },
+      `/release/${releaseId}/data/${dataFile.id}/delete-plan`,
     );
   },
   deleteDataFiles(releaseId: string, dataFile: DataFile): Promise<void> {
-    return client.delete<void>(
-      `/release/${releaseId}/data/${dataFile.filename}`,
-      {
-        params: {
-          name: dataFile.title,
-        },
-      },
-    );
+    return client.delete<void>(`/release/${releaseId}/data/${dataFile.id}`);
   },
   downloadDataFile(releaseId: string, fileName: string): Promise<void> {
     return client

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -67,6 +67,7 @@ Return to Admin Dashboard
 Create another release for the same publication
     [Tags]  HappyPath
     user selects theme "Test theme" and topic "${TOPIC_NAME}" from the admin dashboard
+    user waits until page contains link    Create new publication
     user opens accordion section   ${PUBLICATION_NAME}
     user clicks testid element   Create new release link for ${PUBLICATION_NAME}
     user creates release for publication  ${PUBLICATION_NAME}  Financial Year  3001


### PR DESCRIPTION
This PR:

- Adds a new Admin API route `/api/release/{releaseId}/data/replacing/{replacingId}` to upload Subject data files in the context of another Subject being replaced where `replacingId` is the ReleaseFileReference of the data file being replaced. When processed, the replacement will use the same Subject name as that linked to the `ReleaseFileReference` that it's replacing.

- Avoids using Subject name as an identifier around the codebase to lookup Subjects / ReleaseSubjects/ ReleaseFileReferences since Subject name is now temporarily not unique until the replacement is in completed and the original is soft deleted.

- Excludes replacement Subject data files in the list of data files returned in the call `/api/release/{releaseId}/data`.

- Includes a new field `ReplacedBy` on data files in the call  `/api/release/{releaseId}/data` when a file has a replacement in progress. This is the Id of the ReleaseFileReference data file that is replacing it.

![image](https://user-images.githubusercontent.com/4147126/94134492-fc7fcd80-fe59-11ea-8593-7bf70556966a.png)
