### PR TITLE
EES-221 Filters and Filter Groups are valid only if their children are all valid

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -724,6 +724,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(originalFilter.Id, dataBlockFilterPlan.Value.Id);
                 Assert.Equal(originalFilter.Label, dataBlockFilterPlan.Value.Label);
                 Assert.Equal(originalFilter.Name, dataBlockFilterPlan.Value.Name);
+                Assert.False(dataBlockFilterPlan.Value.Valid);
 
                 Assert.Single(dataBlockFilterPlan.Value.Groups);
 
@@ -732,7 +733,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(originalFilterGroup.Id, dataBlockFilterGroupPlan.Key);
                 Assert.Equal(originalFilterGroup.Id, dataBlockFilterGroupPlan.Value.Id);
                 Assert.Equal(originalFilterGroup.Label, dataBlockFilterGroupPlan.Value.Label);
-                Assert.Null(dataBlockFilterGroupPlan.Value.Target);
                 Assert.False(dataBlockFilterGroupPlan.Value.Valid);
 
                 Assert.Single(dataBlockFilterGroupPlan.Value.Filters);
@@ -743,9 +743,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(originalFilterItem.Label, dataBlockFilterItemPlan.Label);
                 Assert.Null(dataBlockFilterItemPlan.Target);
                 Assert.False(dataBlockFilterItemPlan.Valid);
-
-                Assert.Null(dataBlockFilterPlan.Value.Target);
-                Assert.False(dataBlockFilterPlan.Value.Valid);
 
                 Assert.NotNull(dataBlockPlan.Locations);
                 Assert.Single(dataBlockPlan.Locations);
@@ -850,7 +847,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Single(footnoteForIndicatorPlan.IndicatorGroups);
 
                 var footnoteForIndicatorIndicatorGroupPlan = footnoteForIndicatorPlan.IndicatorGroups.First();
-
 
                 Assert.Equal(originalIndicator.IndicatorGroup.Id,  footnoteForIndicatorIndicatorGroupPlan.Key);
                 Assert.Equal(originalIndicator.IndicatorGroup.Label, footnoteForIndicatorIndicatorGroupPlan.Value.Label);
@@ -1295,7 +1291,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(originalFilter1.Id, dataBlockFilterPlan.Value.Id);
                 Assert.Equal(originalFilter1.Label, dataBlockFilterPlan.Value.Label);
                 Assert.Equal(originalFilter1.Name, dataBlockFilterPlan.Value.Name);
-                Assert.Equal(replacementFilter1.Id, dataBlockFilterPlan.Value.Target);
                 Assert.True(dataBlockFilterPlan.Value.Valid);
 
                 Assert.Single(dataBlockFilterPlan.Value.Groups);
@@ -1305,17 +1300,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(originalFilterGroup1.Id, dataBlockFilterGroupPlan.Key);
                 Assert.Equal(originalFilterGroup1.Id, dataBlockFilterGroupPlan.Value.Id);
                 Assert.Equal(originalFilterGroup1.Label, dataBlockFilterGroupPlan.Value.Label);
-                Assert.Equal(replacementFilterGroup1.Id, dataBlockFilterGroupPlan.Value.Target);
-                Assert.True(dataBlockFilterGroupPlan.Value.Valid);
-
                 Assert.Single(dataBlockFilterGroupPlan.Value.Filters);
+                Assert.True(dataBlockFilterGroupPlan.Value.Valid);
 
                 var dataBlockFilterItemPlan = dataBlockFilterGroupPlan.Value.Filters.First();
 
-                Assert.True(dataBlockFilterItemPlan.Valid);
                 Assert.Equal(originalFilterItem1.Id, dataBlockFilterItemPlan.Id);
                 Assert.Equal(originalFilterItem1.Label, dataBlockFilterItemPlan.Label);
                 Assert.Equal(replacementFilterItem1.Id, dataBlockFilterItemPlan.Target);
+                Assert.True(dataBlockFilterItemPlan.Valid);
 
                 Assert.NotNull(dataBlockPlan.Locations);
                 Assert.Single(dataBlockPlan.Locations);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -353,7 +353,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             id: filter.Key.Id,
                             name: filter.Key.Name,
                             label: filter.Key.Label,
-                            target: FindReplacementFilter(replacementSubjectMeta, filter.Key.Name)?.Id,
                             groups: filter
                                 .GroupBy(filterItem => filterItem.FilterGroup)
                                 .OrderBy(group => group.Key.Label, LabelComparer)
@@ -438,10 +437,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return new FilterGroupReplacementViewModel(
                 id: filterGroup.Id,
                 label: filterGroup.Label,
-                target: FindReplacementFilterGroup(
-                    replacementSubjectMeta,
-                    filterGroup.Filter.Name,
-                    filterGroup.Label)?.Id,
                 filters: filterGroup.FilterItems
                     .Select(item => ValidateFilterItemForReplacement(item, replacementSubjectMeta))
                     .OrderBy(item => item.Label, LabelComparer)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -169,33 +169,43 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         }
     }
 
-    public class FilterReplacementViewModel : TargetableReplacementViewModel
+    public class FilterReplacementViewModel
     {
+        public Guid Id { get; }
+        public string Label { get; }
         public string Name { get; }
         public Dictionary<Guid, FilterGroupReplacementViewModel> Groups { get; }
 
+        public bool Valid => Groups.All(group => group.Value.Valid);
+        
         public FilterReplacementViewModel(
             Guid id,
             string label,
-            Guid? target,
             string name,
-            Dictionary<Guid, FilterGroupReplacementViewModel> groups) : base(id, label, target)
+            Dictionary<Guid, FilterGroupReplacementViewModel> groups)
         {
+            Id = id;
+            Label = label;
             Name = name;
             Groups = groups;
         }
     }
 
-    public class FilterGroupReplacementViewModel : TargetableReplacementViewModel
+    public class FilterGroupReplacementViewModel
     {
+        public Guid Id { get; }
+        public string Label { get; }
         public IEnumerable<FilterItemReplacementViewModel> Filters { get; }
+
+        public bool Valid => Filters.All(filter => filter.Valid);
 
         public FilterGroupReplacementViewModel(
             Guid id,
             string label,
-            Guid? target,
-            IEnumerable<FilterItemReplacementViewModel> filters) : base(id, label, target)
+            IEnumerable<FilterItemReplacementViewModel> filters)
         {
+            Id = id;
+            Label = label;
             Filters = filters;
         }
     }


### PR DESCRIPTION
Remove the `target` field from the DataBlock Filters and FilterGroup replacement response models which isn't needed.

Presence of a target value was previously used to check if the Filter / Filter Group are valid but this should have been checking whether the child Filter Groups / Filter Items are also valid.

New valid field added to both response models which checks that their children are valid.