### PR TITLE
EES-1417 When removing a Subject also remove any replacement Subject that might exist

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -202,7 +202,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             var fileId = Guid.NewGuid();
 
-            mocks.ReleaseService.Setup(service => service.RemoveDataFiles(_releaseId, fileId, false))
+            mocks.ReleaseService.Setup(service => service.RemoveDataFiles(_releaseId, fileId))
                 .ReturnsAsync(Unit.Instance);
             var controller = ReleasesControllerWithMocks(mocks);
 
@@ -218,7 +218,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var fileId = Guid.NewGuid();
 
             mocks.ReleaseService
-                .Setup(service => service.RemoveDataFiles(_releaseId, fileId, false))
+                .Setup(service => service.RemoveDataFiles(_releaseId, fileId))
                 .ReturnsAsync(ValidationActionResult(UnableToFindMetadataFileToDelete));
             var controller = ReleasesControllerWithMocks(mocks);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -200,15 +200,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         {
             var mocks = Mocks();
 
-            var releaseFileReferenceId = Guid.NewGuid();
+            var fileId = Guid.NewGuid();
 
-            mocks.ReleaseService
-                .Setup(service => service.RemoveDataFilesAsync(_releaseId, releaseFileReferenceId))
+            mocks.ReleaseService.Setup(service => service.RemoveDataFiles(_releaseId, fileId, false))
                 .ReturnsAsync(Unit.Instance);
             var controller = ReleasesControllerWithMocks(mocks);
 
-            // Call the method under test
-            var result = await controller.DeleteDataFiles(_releaseId, releaseFileReferenceId);
+            var result = await controller.DeleteDataFiles(_releaseId, fileId);
             Assert.IsAssignableFrom<NoContentResult>(result);
         }
 
@@ -217,15 +215,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         {
             var mocks = Mocks();
 
-            var releaseFileReferenceId = Guid.NewGuid();
+            var fileId = Guid.NewGuid();
 
             mocks.ReleaseService
-                .Setup(service => service.RemoveDataFilesAsync(_releaseId, releaseFileReferenceId))
+                .Setup(service => service.RemoveDataFiles(_releaseId, fileId, false))
                 .ReturnsAsync(ValidationActionResult(UnableToFindMetadataFileToDelete));
             var controller = ReleasesControllerWithMocks(mocks);
 
-            // Call the method under test
-            var result = await controller.DeleteDataFiles(_releaseId, releaseFileReferenceId);
+            var result = await controller.DeleteDataFiles(_releaseId, fileId);
             AssertValidationProblem(result, UnableToFindMetadataFileToDelete);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -332,7 +332,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void DeleteDataFilesAsync()
+        public void RemoveDataFiles()
         {
             PermissionTestUtil.PolicyCheckBuilder()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
@@ -340,7 +340,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     async userService =>
                     {
                         var service = BuildReleaseService(userService: userService.Object);
-                        return await service.RemoveDataFilesAsync(_release.Id, Guid.NewGuid());
+                        return await service.RemoveDataFiles(_release.Id, Guid.NewGuid());
                     }
                 );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -1953,8 +1953,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await statisticsDbContext.SaveChangesAsync();
             }
 
-            mocks.ReleaseService.Setup(service => service.RemoveDataFilesAsync(
-                    contentReleaseVersion2.Id, originalReleaseFileReference.Id))
+            mocks.ReleaseService.Setup(service => service.RemoveDataFiles(
+                    contentReleaseVersion2.Id, originalReleaseFileReference.Id, true))
                 .ReturnsAsync(Unit.Instance);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -1966,7 +1966,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     replacementReleaseFileReference.Id);
 
                 mocks.ReleaseService.Verify(
-                    mock => mock.RemoveDataFilesAsync(contentReleaseVersion2.Id, originalReleaseFileReference.Id), Times.Once());
+                    mock => mock.RemoveDataFiles(contentReleaseVersion2.Id, originalReleaseFileReference.Id, true),
+                    Times.Once());
 
                 mocks.ReleaseService.VerifyNoOtherCalls();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -1483,8 +1483,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Filename = "replacement.csv",
                 ReleaseFileType = ReleaseFileTypes.Data,
                 Release = contentRelease,
-                SubjectId = replacementSubject.Id
+                SubjectId = replacementSubject.Id,
+                Replacing = originalReleaseFileReference
             };
+
+            originalReleaseFileReference.ReplacedBy = replacementReleaseFileReference;
 
             var originalReleaseFile = new ReleaseFile
             {
@@ -1645,8 +1648,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Filename = "replacement.csv",
                 ReleaseFileType = ReleaseFileTypes.Data,
                 Release = contentReleaseVersion2,
-                SubjectId = replacementSubject.Id
+                SubjectId = replacementSubject.Id,
+                Replacing = originalReleaseFileReference
             };
+
+            originalReleaseFileReference.ReplacedBy = replacementReleaseFileReference;
 
             var originalReleaseFile1 = new ReleaseFile
             {
@@ -1954,8 +1960,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             }
 
             mocks.ReleaseService.Setup(service => service.RemoveDataFiles(
-                    contentReleaseVersion2.Id, originalReleaseFileReference.Id, true))
-                .ReturnsAsync(Unit.Instance);
+                    contentReleaseVersion2.Id, originalReleaseFileReference.Id)).ReturnsAsync(Unit.Instance);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -1966,12 +1971,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     replacementReleaseFileReference.Id);
 
                 mocks.ReleaseService.Verify(
-                    mock => mock.RemoveDataFiles(contentReleaseVersion2.Id, originalReleaseFileReference.Id, true),
+                    mock => mock.RemoveDataFiles(contentReleaseVersion2.Id, originalReleaseFileReference.Id),
                     Times.Once());
 
                 mocks.ReleaseService.VerifyNoOtherCalls();
 
                 Assert.True(result.IsRight);
+
+                // Check that the original file was unlinked from the replacement before the mock call to remove it.
+                Assert.Null((await contentDbContext.ReleaseFileReferences.FindAsync(originalReleaseFileReference.Id))
+                    .ReplacedBy);
 
                 var replacedDataBlock = await contentDbContext.DataBlocks.FindAsync(dataBlock.Id);
                 Assert.NotNull(replacedDataBlock);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -269,7 +269,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             Guid fileId)
         {
             return await _releaseService
-                .RemoveDataFilesAsync(releaseId, fileId)
+                .RemoveDataFiles(releaseId, fileId)
                 .HandleFailuresOrNoContent();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -31,9 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, DeleteDataFilePlan>> GetDeleteDataFilePlan(Guid releaseId, Guid fileId);
 
-        Task<Either<ActionResult, Unit>> RemoveDataFiles(Guid releaseId,
-            Guid fileId,
-            bool removingReplacedSubject = false);
+        Task<Either<ActionResult, Unit>> RemoveDataFiles(Guid releaseId, Guid fileId);
 
         Task<Either<ActionResult, ImportStatus>> GetDataFileImportStatus(Guid releaseId, string dataFileName);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -31,7 +31,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, DeleteDataFilePlan>> GetDeleteDataFilePlan(Guid releaseId, Guid fileId);
 
-        Task<Either<ActionResult, Unit>> RemoveDataFilesAsync(Guid releaseId, Guid fileId);
+        Task<Either<ActionResult, Unit>> RemoveDataFiles(Guid releaseId,
+            Guid fileId,
+            bool removingReplacedSubject = false);
 
         Task<Either<ActionResult, ImportStatus>> GetDataFileImportStatus(Guid releaseId, string dataFileName);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -455,9 +455,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
-        public async Task<Either<ActionResult, Unit>> RemoveDataFiles(Guid releaseId,
-            Guid fileId,
-            bool removingReplacedSubject = false)
+        public async Task<Either<ActionResult, Unit>> RemoveDataFiles(Guid releaseId, Guid fileId)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Release>(releaseId)
@@ -469,15 +467,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .OnSuccess(_ => GetDeleteDataFilePlan(releaseId, fileId))
                         .OnSuccess(async deletePlan =>
                         {
-                            // Unless removing a Subject after completing a replacement
-                            // Delete any replacement Subject that might exist
-                            if (!removingReplacedSubject)
+                            // Delete any replacement that might exist
+                            var replacementInProgress = releaseFileReference.ReplacedById;
+                            if (replacementInProgress.HasValue)
                             {
-                                var replacementInProgress = releaseFileReference.ReplacedById;
-                                if (replacementInProgress.HasValue)
-                                {
-                                    await RemoveDataFiles(releaseId, replacementInProgress.Value);
-                                }
+                                await RemoveDataFiles(releaseId, replacementInProgress.Value);
                             }
 
                             await _dataBlockService.DeleteDataBlocks(deletePlan.DeleteDataBlockPlan);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -761,9 +761,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         private async Task<Either<ActionResult, Unit>> RemoveSubjectAndFileFromRelease(Guid releaseId,
-            Guid releaseFileReferenceId)
+            Guid fileId)
         {
-            return await _releaseService.RemoveDataFilesAsync(releaseId, releaseFileReferenceId);
+            return await _releaseService.RemoveDataFiles(releaseId, fileId, true);
         }
 
         private class ReplacementSubjectMeta


### PR DESCRIPTION
Although a user won't be given the option to remove a Subject when it's already entered the process of being replaced, it's possible that a user might have a view on the remove option for that Subject before the replacement process started.

This PR makes sure that if a Subject is removed and it's associated with an incomplete replacement, that the replacement Subject is also removed.