### PR TITLE
EES-1370 UI tests now allow you to customise time to wait for release…

### DIFF
--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -295,6 +295,9 @@ if args.visual:
 else:
     robotArgs += ["-v", "headless:1"]
 
+if os.getenv('RELEASE_COMPLETE_WAIT'):
+    robotArgs += ["-v", f"release_complete_wait:{os.getenv('RELEASE_COMPLETE_WAIT')}"]
+
 robotArgs += ["-v", "browser:" + args.browser]
 robotArgs += [args.tests]
 

--- a/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
@@ -249,7 +249,7 @@ Verify release is scheduled
 Wait for release process status to be Complete
     [Tags]  HappyPath
     # EES-1007 - Release process status doesn't automatically update
-    user waits for release process status to be  Complete    900
+    user waits for release process status to be  Complete    ${release_complete_wait}
     user checks page does not contain button  Edit release status
 
 User goes to public Find Statistics page

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -55,7 +55,7 @@ Verify release is scheduled
 Wait for release process status to be Complete
     [Tags]  HappyPath
     # EES-1007 - Release process status doesn't automatically update
-    user waits for release process status to be  Complete    900
+    user waits for release process status to be  Complete    ${release_complete_wait}
     user checks page does not contain button  Edit release status
 
 Return to Admin Dashboard
@@ -187,7 +187,7 @@ Wait for release process status for new release to be Complete
     user waits until h2 is visible  Release status
     user checks summary list contains  Current status  Approved
     user checks summary list contains  Scheduled release  ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH_WORD} ${PUBLISH_DATE_YEAR}
-    user waits for release process status to be  Complete    900
+    user waits for release process status to be  Complete    ${release_complete_wait}
     user checks page does not contain button  Edit release status
 
 User goes to public Find Statistics page

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -75,7 +75,7 @@ Verify release is scheduled
 Wait for release process status to be Complete
     [Tags]  HappyPath
     # EES-1007 - Release process status doesn't automatically update
-    user waits for release process status to be  Complete    900
+    user waits for release process status to be  Complete    ${release_complete_wait}
     user checks page does not contain button  Edit release status
 
 User goes to public Find Statistics page
@@ -317,7 +317,7 @@ Wait for release process status to be Complete again
     user waits until h2 is visible  Release status
     user checks summary list contains  Current status  Approved
     user checks summary list contains  Scheduled release  ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH} ${PUBLISH_DATE_YEAR}
-    user waits for release process status to be  Complete    900
+    user waits for release process status to be  Complete    ${release_complete_wait}
     user checks page does not contain button  Edit release status
 
 Go back to public find-statistics page

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -15,6 +15,7 @@ ${headless}   1
 
 ${timeout}          30
 ${implicit_wait}    3
+${release_complete_wait}   900
 
 *** Keywords ***
 do this on failure


### PR DESCRIPTION
… to complete

I've added a default release complete wait time which can be found in common.robot under Variables.

To overwrite this, you can add a `RELEASE_COMPLETE_WAIT` env variable to the relevant `.env` file. So, for example, to overwrite the wait time when I run the tests against my local environment, I added the following to my `.env.local`: `RELEASE_COMPLETE_WAIT="300"`

