### PR TITLE
EES-1186 Add styles to ensure AccordionSection contents lazy load

### DIFF
--- a/src/explore-education-statistics-common/src/components/AccordionSection.module.scss
+++ b/src/explore-education-statistics-common/src/components/AccordionSection.module.scss
@@ -1,0 +1,21 @@
+.section {
+  @media print {
+    display: block !important;
+    page-break-inside: avoid;
+  }
+}
+
+.sectionContentCollapsed {
+  display: block !important;
+  height: 0;
+  overflow: hidden;
+  padding: 0 !important;
+  visibility: hidden;
+
+  @media print {
+    height: auto;
+    overflow: visible;
+    padding: 15px 0 !important;
+    visibility: visible;
+  }
+}

--- a/src/explore-education-statistics-common/src/components/AccordionSection.tsx
+++ b/src/explore-education-statistics-common/src/components/AccordionSection.tsx
@@ -2,6 +2,7 @@ import useMounted from '@common/hooks/useMounted';
 import findAllParents from '@common/utils/dom/findAllParents';
 import classNames from 'classnames';
 import React, { createElement, memo, ReactNode } from 'react';
+import styles from './AccordionSection.module.scss';
 import GoToTopLink from './GoToTopLink';
 
 export type ToggleHandler = (open: boolean, id: string) => void;
@@ -52,14 +53,14 @@ const AccordionSection = ({
   open = false,
   onToggle,
 }: AccordionSectionProps) => {
-  const { isMounted } = useMounted();
+  const { isMounted, onMounted } = useMounted();
 
   const headingId = `${id}-heading`;
   const contentId = `${id}-content`;
 
   return (
     <div
-      className={classNames(classes.section, className, {
+      className={classNames(classes.section, styles.section, className, {
         [classes.expanded]: open,
       })}
       data-testid="accordionSection"
@@ -103,7 +104,10 @@ const AccordionSection = ({
       </div>
       <div
         aria-labelledby={headingId}
-        className={classNames(classes.sectionContent)}
+        className={classNames(
+          classes.sectionContent,
+          onMounted({ [styles.sectionContentCollapsed]: !open }),
+        )}
         id={contentId}
       >
         {typeof children === 'function'

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Accordion.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/Accordion.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`Accordion renders with hidden content by default 1`] = `
       </button>
     </div>
     <div
-      class="govuk-accordion__section"
+      class="govuk-accordion__section section"
       data-testid="accordionSection"
       id="test-sections-1"
       role="presentation"
@@ -52,7 +52,7 @@ exports[`Accordion renders with hidden content by default 1`] = `
       </div>
       <div
         aria-labelledby="test-sections-1-heading"
-        class="govuk-accordion__section-content"
+        class="govuk-accordion__section-content sectionContentCollapsed"
         id="test-sections-1-content"
       >
         <p>
@@ -99,7 +99,7 @@ exports[`Accordion renders with visible content when \`open\` is true 1`] = `
       </button>
     </div>
     <div
-      class="govuk-accordion__section govuk-accordion__section--expanded"
+      class="govuk-accordion__section section govuk-accordion__section--expanded"
       data-testid="accordionSection"
       id="test-sections-1"
       role="presentation"

--- a/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/__tests__/__snapshots__/AccordionSection.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AccordionSection renders correctly with required props 1`] = `
-<div class="govuk-accordion__section"
+<div class="govuk-accordion__section section"
      data-testid="accordionSection"
      id="accordionSection"
      role="presentation"
@@ -22,7 +22,7 @@ exports[`AccordionSection renders correctly with required props 1`] = `
     </h2>
   </div>
   <div aria-labelledby="accordionSection-heading"
-       class="govuk-accordion__section-content"
+       class="govuk-accordion__section-content sectionContentCollapsed"
        id="accordionSection-content"
   >
     <p>
@@ -40,7 +40,7 @@ exports[`AccordionSection renders correctly with required props 1`] = `
 `;
 
 exports[`AccordionSection renders with caption 1`] = `
-<div class="govuk-accordion__section"
+<div class="govuk-accordion__section section"
      data-testid="accordionSection"
      id="accordionSection"
      role="presentation"
@@ -64,7 +64,7 @@ exports[`AccordionSection renders with caption 1`] = `
     </div>
   </div>
   <div aria-labelledby="accordionSection-heading"
-       class="govuk-accordion__section-content"
+       class="govuk-accordion__section-content sectionContentCollapsed"
        id="accordionSection-content"
   >
     <p>
@@ -82,7 +82,7 @@ exports[`AccordionSection renders with caption 1`] = `
 `;
 
 exports[`AccordionSection renders with different heading size 1`] = `
-<div class="govuk-accordion__section"
+<div class="govuk-accordion__section section"
      data-testid="accordionSection"
      id="accordionSection"
      role="presentation"
@@ -103,7 +103,7 @@ exports[`AccordionSection renders with different heading size 1`] = `
     </h3>
   </div>
   <div aria-labelledby="accordionSection-heading"
-       class="govuk-accordion__section-content"
+       class="govuk-accordion__section-content sectionContentCollapsed"
        id="accordionSection-content"
   >
     <p>


### PR DESCRIPTION
When using the govuk styles alone, content inside the AccordionSection
wouldn't lazy load until the user had interacted with the page - specifically tables and charts. This meant tables and charts would load forever until the user scrolled down the page a little. Using these additional AccordionSection
styles resolves this issue.