### PR TITLE
EES-1434 Filter group should only have filter items of data block

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -358,7 +358,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                 .OrderBy(group => group.Key.Label, LabelComparer)
                                 .ToDictionary(
                                     group => group.Key.Id,
-                                    group => ValidateFilterGroupForReplacement(group.Key, replacementSubjectMeta)
+                                    group => ValidateFilterGroupForReplacement(
+                                        new FilterGroup
+                                        {
+                                            Id = group.Key.Id,
+                                            Label = group.Key.Label,
+                                            FilterItems = filter.ToList()
+                                        },
+                                        replacementSubjectMeta)
                                 )
                         );
                     }


### PR DESCRIPTION
There was a bug in method `ReplacementService.ValidateFiltersForDataBlock` since a groups filter items aren’t necessarily the same filter items from the data block query.

They will be, the first time the filter group is accessed from a new database context, but they are susceptible to be altered by other database access, for example by getting all the footnotes in a later call, where the FootnotesService.GetBaseFootnoteQuery results in a FilterGroup being populated with FilterItems appearing in footnotes.

This explains why this bug doesn’t happen when there are no footnotes for the original subject.