### PR TITLE
EES-1439, EES-1440 Add replacement completion page and update wording

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -18,6 +18,7 @@ import {
   releaseSummaryRoute,
   releaseFootnotesCreateRoute,
   releaseFootnotesEditRoute,
+  releaseDataFileReplacementCompleteRoute,
 } from '@admin/routes/releaseRoutes';
 import publicationService, {
   BasicPublicationDetails,
@@ -45,6 +46,7 @@ const navRoutes = [
 const routes = [
   ...navRoutes,
   releaseDataFileRoute,
+  releaseDataFileReplacementCompleteRoute,
   releaseSummaryEditRoute,
   releaseFootnotesCreateRoute,
   releaseFootnotesEditRoute,

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
@@ -3,7 +3,7 @@ import DataFileReplacementPlan from '@admin/pages/release/data/components/DataFi
 import DataFileDetailsTable from '@admin/pages/release/data/components/DataFileDetailsTable';
 import DataFileUploadForm from '@admin/pages/release/data/components/DataFileUploadForm';
 import {
-  releaseDataFileRoute,
+  releaseDataFileReplacementCompleteRoute,
   ReleaseDataFileRouteParams,
   releaseDataRoute,
   ReleaseRouteParams,
@@ -176,7 +176,7 @@ const ReleaseDataFilePage = ({
                     onReplacement={() => {
                       history.push(
                         generatePath<ReleaseDataFileRouteParams>(
-                          releaseDataFileRoute.path,
+                          releaseDataFileReplacementCompleteRoute.path,
                           {
                             publicationId,
                             releaseId,

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacementCompletePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacementCompletePage.tsx
@@ -1,0 +1,124 @@
+import Link from '@admin/components/Link';
+import {
+  releaseDataBlocksRoute,
+  ReleaseDataBlocksRouteParams,
+  releaseDataFileRoute,
+  ReleaseDataFileRouteParams,
+  ReleaseFootnoteRouteParams,
+} from '@admin/routes/releaseRoutes';
+import dataReplacementService from '@admin/services/dataReplacementService';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import WarningMessage from '@common/components/WarningMessage';
+import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import React from 'react';
+import { generatePath, RouteComponentProps } from 'react-router';
+
+const ReleaseDataFileReplacementCompletePage = ({
+  match,
+}: RouteComponentProps<ReleaseDataFileRouteParams>) => {
+  const { publicationId, releaseId, fileId } = match.params;
+
+  // Run the replacement plan against itself so we can just get the
+  // data blocks and footnotes in a convenient way.
+  const { value: plan, isLoading } = useAsyncRetry(
+    () => dataReplacementService.getReplacementPlan(fileId, fileId),
+    [fileId],
+  );
+
+  const dataFilePath = generatePath<ReleaseDataFileRouteParams>(
+    releaseDataFileRoute.path,
+    {
+      publicationId,
+      releaseId,
+      fileId,
+    },
+  );
+
+  return (
+    <>
+      <Link back className="govuk-!-margin-bottom-6" to={dataFilePath}>
+        Back
+      </Link>
+
+      <h2>Data replacement complete</h2>
+
+      <WarningMessage>
+        Your data replacement is now complete. Please make sure you review your
+        data blocks and footnotes to ensure that these all remain valid before
+        requesting approval of your release.
+      </WarningMessage>
+
+      <LoadingSpinner loading={isLoading}>
+        {plan && (
+          <>
+            <h3>Data blocks</h3>
+
+            {plan.dataBlocks.length > 0 ? (
+              <>
+                <p>Please check the following data blocks:</p>
+
+                <ul>
+                  {plan.dataBlocks.map(dataBlock => (
+                    <li key={dataBlock.id}>
+                      <Link
+                        unvisited
+                        to={generatePath<ReleaseDataBlocksRouteParams>(
+                          releaseDataBlocksRoute.path,
+                          {
+                            publicationId,
+                            releaseId,
+                            dataBlockId: dataBlock.id,
+                          },
+                        )}
+                      >
+                        {dataBlock.name}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            ) : (
+              <p>There are no data blocks to check.</p>
+            )}
+
+            <h3>Footnotes</h3>
+
+            {plan.footnotes.length > 0 ? (
+              <>
+                <p>Please check the following footnotes:</p>
+
+                <ul className="govuk-list">
+                  {plan.footnotes.map(footnote => (
+                    <li key={footnote.id}>
+                      <Link
+                        unvisited
+                        to={generatePath<ReleaseFootnoteRouteParams>(
+                          releaseDataBlocksRoute.path,
+                          {
+                            publicationId,
+                            releaseId,
+                            footnoteId: footnote.id,
+                          },
+                        )}
+                      >
+                        {footnote.content}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            ) : (
+              <p>There are no footnotes to check.</p>
+            )}
+          </>
+        )}
+      </LoadingSpinner>
+
+      <Link to={dataFilePath} unvisited>
+        Back to data file
+      </Link>
+    </>
+  );
+};
+
+export default ReleaseDataFileReplacementCompletePage;

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
@@ -93,9 +93,9 @@ const DataFileReplacementPlan = ({
       {plan && (
         <>
           <WarningMessage>
-            Before confirming the data replacement please check the information
-            below. Making this change could affect existing data blocks and
-            footnotes.
+            Please check the information below before confirming the data
+            replacement as making this change may affect existing data blocks
+            and footnotes.
           </WarningMessage>
 
           <h3 className="govuk-heading-m">
@@ -113,8 +113,9 @@ const DataFileReplacementPlan = ({
             </p>
           ) : (
             <p>
-              All data blocks will still be valid after this data replacement,
-              no action is required.
+              {plan.dataBlocks.length > 0
+                ? 'All existing data blocks can be replaced by this data replacement.'
+                : 'No data blocks to replace.'}
             </p>
           )}
 
@@ -123,22 +124,18 @@ const DataFileReplacementPlan = ({
               key={dataBlock.id}
               summary={dataBlock.name}
               summaryAfter={
-                <>
-                  <Tag
-                    className="govuk-!-margin-left-2"
-                    colour={dataBlock.valid ? 'green' : 'red'}
-                  >
-                    <VisuallyHidden>:</VisuallyHidden>
+                <Tag
+                  className="govuk-!-margin-left-2"
+                  colour={dataBlock.valid ? 'green' : 'red'}
+                >
+                  <VisuallyHidden>:</VisuallyHidden>
 
-                    {dataBlock.valid ? ' OK' : ' ERROR'}
-                  </Tag>
-                </>
+                  {dataBlock.valid ? ' OK' : ' ERROR'}
+                </Tag>
               }
             >
               {dataBlock.valid ? (
-                <p>
-                  This data block has no conflicts with the replacement data.
-                </p>
+                <p>This data block has no conflicts and can be replaced.</p>
               ) : (
                 <>
                   <SummaryList smallKey>
@@ -258,8 +255,9 @@ const DataFileReplacementPlan = ({
             </p>
           ) : (
             <p>
-              All footnotes will still be valid after this data replacement, no
-              action is required.
+              {plan.footnotes.length > 0
+                ? 'All existing footnotes can be replaced by this data replacement.'
+                : 'No footnotes to replace.'}
             </p>
           )}
 
@@ -271,21 +269,17 @@ const DataFileReplacementPlan = ({
                 key={footnote.id}
                 summary={footnote.content}
                 summaryAfter={
-                  <>
-                    <Tag
-                      className="govuk-!-margin-left-2"
-                      colour={footnote.valid ? 'green' : 'red'}
-                    >
-                      <VisuallyHidden>:</VisuallyHidden>
-                      {footnote.valid ? ' OK' : ' ERROR'}
-                    </Tag>
-                  </>
+                  <Tag
+                    className="govuk-!-margin-left-2"
+                    colour={footnote.valid ? 'green' : 'red'}
+                  >
+                    <VisuallyHidden>:</VisuallyHidden>
+                    {footnote.valid ? ' OK' : ' ERROR'}
+                  </Tag>
                 }
               >
                 {footnote.valid ? (
-                  <p>
-                    This footnote has no conflicts with the replacement data.
-                  </p>
+                  <p>This footnote has no conflicts and can be replaced.</p>
                 ) : (
                   <>
                     <SummaryList smallKey>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
@@ -46,7 +46,9 @@ const DataFileReplacementPlan = ({
   onCancel,
   onReplacement,
 }: Props) => {
+  const [isSubmitting, toggleSubmitting] = useToggle(false);
   const [isCancelling, toggleCancelling] = useToggle(false);
+
   const [deleteDataBlock, setDeleteDataBlock] = useState<
     DataBlockReplacementPlan
   >();
@@ -367,7 +369,10 @@ const DataFileReplacementPlan = ({
           <ButtonGroup className="govuk-!-margin-top-8">
             {plan.valid && (
               <Button
+                disabled={isSubmitting}
                 onClick={async () => {
+                  toggleSubmitting.on();
+
                   await dataReplacementService.replaceData(
                     fileId,
                     replacementFileId,
@@ -376,11 +381,14 @@ const DataFileReplacementPlan = ({
                   if (onReplacement) {
                     onReplacement();
                   }
+
+                  toggleSubmitting.off();
                 }}
               >
                 Confirm data replacement
               </Button>
             )}
+
             <Button variant="secondary" onClick={toggleCancelling.on}>
               Cancel data replacement
             </Button>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
@@ -508,7 +508,7 @@ describe('DataReplacementPlan', () => {
 
       expect(
         dataBlock2.getByText(
-          'This data block has no conflicts with the replacement data.',
+          'This data block has no conflicts and can be replaced.',
         ),
       ).toBeInTheDocument();
 
@@ -573,7 +573,7 @@ describe('DataReplacementPlan', () => {
 
       expect(
         footnote2.getByText(
-          'This footnote has no conflicts with the replacement data.',
+          'This footnote has no conflicts and can be replaced.',
         ),
       ).toBeInTheDocument();
 
@@ -605,12 +605,12 @@ describe('DataReplacementPlan', () => {
 
       expect(
         screen.getByText(
-          /All data blocks will still be valid after this data replacement/,
+          'All existing data blocks can be replaced by this data replacement.',
         ),
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          /All footnotes will still be valid after this data replacement/,
+          'All existing footnotes can be replaced by this data replacement.',
         ),
       ).toBeInTheDocument();
     });
@@ -626,7 +626,7 @@ describe('DataReplacementPlan', () => {
     ).toHaveTextContent('OK');
     expect(
       dataBlock1.getByText(
-        'This data block has no conflicts with the replacement data.',
+        'This data block has no conflicts and can be replaced.',
       ),
     ).toBeInTheDocument();
 
@@ -637,7 +637,7 @@ describe('DataReplacementPlan', () => {
     ).toHaveTextContent('OK');
     expect(
       dataBlock2.getByText(
-        'This data block has no conflicts with the replacement data.',
+        'This data block has no conflicts and can be replaced.',
       ),
     ).toBeInTheDocument();
 
@@ -648,7 +648,7 @@ describe('DataReplacementPlan', () => {
     ).toHaveTextContent('OK');
     expect(
       footnote1.getByText(
-        'This footnote has no conflicts with the replacement data.',
+        'This footnote has no conflicts and can be replaced.',
       ),
     ).toBeInTheDocument();
 
@@ -659,9 +659,44 @@ describe('DataReplacementPlan', () => {
     ).toHaveTextContent('OK');
     expect(
       footnote2.getByText(
-        'This footnote has no conflicts with the replacement data.',
+        'This footnote has no conflicts and can be replaced.',
       ),
     ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Confirm data replacement' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders correctly with valid empty plan', async () => {
+    dataReplacementService.getReplacementPlan.mockResolvedValue({
+      ...testValidReplacementPlan,
+      dataBlocks: [],
+      footnotes: [],
+    });
+
+    render(
+      <MemoryRouter>
+        <DataFileReplacementPlan
+          publicationId="publication-1"
+          releaseId="release-1"
+          fileId="file-1"
+          replacementFileId="file-2"
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Data blocks: OK')).toBeInTheDocument();
+      expect(screen.getByText('Footnotes: OK')).toBeInTheDocument();
+
+      expect(
+        screen.getByText('No data blocks to replace.'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('No footnotes to replace.')).toBeInTheDocument();
+    });
+
+    expect(screen.queryAllByRole('group')).toHaveLength(0);
 
     expect(
       screen.getByRole('button', { name: 'Confirm data replacement' }),

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -1,5 +1,6 @@
 import ReleaseContentPage from '@admin/pages/release/content/ReleaseContentPage';
 import ReleaseDataFilePage from '@admin/pages/release/data/ReleaseDataFilePage';
+import ReleaseDataFileReplacementCompletePage from '@admin/pages/release/data/ReleaseDataFileReplacementCompletePage';
 import ReleaseDataPage from '@admin/pages/release/data/ReleaseDataPage';
 import ReleaseDataBlocksPage from '@admin/pages/release/datablocks/ReleaseDataBlocksPage';
 import ReleaseFootnoteCreatePage from '@admin/pages/release/footnotes/ReleaseFootnoteCreatePage';
@@ -55,6 +56,13 @@ export const releaseDataFileRoute: ReleaseRouteProps = {
   path: '/publication/:publicationId/release/:releaseId/data/:fileId',
   title: 'Data file',
   component: ReleaseDataFilePage,
+};
+
+export const releaseDataFileReplacementCompleteRoute: ReleaseRouteProps = {
+  path:
+    '/publication/:publicationId/release/:releaseId/data/:fileId/replacement-complete',
+  title: 'Replacement complete',
+  component: ReleaseDataFileReplacementCompletePage,
 };
 
 export const releaseFootnotesRoute: ReleaseRouteProps = {


### PR DESCRIPTION
This PR:

- Adds new `ReleaseDataFileReplacementCompletePage` that the user will be redirected to once a data replacement has completed. This shows them the required warning text and lists the data blocks/footnotes that they should check over. Fixes EES-1439.
- Updates wording on the current `DataFileReplacementPlan` to remove mentions of 'valid'. This has been updated to variations of 'replaced by' instead to try prevent setting of false expectations. Fixes EES-1440.