### PR TITLE
EES-1427 Move 'Data replacement in progress' tag to ImporterStatus

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
@@ -160,10 +160,6 @@ const ReleaseDataFilePage = ({
               <section>
                 <h2>Pending data replacement</h2>
 
-                <p>
-                  <Tag>Data replacement in progress</Tag>
-                </p>
-
                 {getReplacementPlanMessage()}
 
                 {replacementDataFile?.status === 'COMPLETE' && (

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFilePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFilePage.test.tsx
@@ -218,7 +218,9 @@ describe('ReleaseDataFilePage', () => {
       );
       expect(screen.getByTestId('Data file size')).toHaveTextContent('200 B');
       expect(screen.getByTestId('Number of rows')).toHaveTextContent('100');
-      expect(screen.getByTestId('Status')).toHaveTextContent('Complete');
+      expect(screen.getByTestId('Status')).toHaveTextContent(
+        'Data replacement in progress',
+      );
       expect(screen.getByTestId('Uploaded by')).toHaveTextContent(
         'original@test.com',
       );
@@ -274,7 +276,9 @@ describe('ReleaseDataFilePage', () => {
       );
       expect(screen.getByTestId('Data file size')).toHaveTextContent('200 B');
       expect(screen.getByTestId('Number of rows')).toHaveTextContent('100');
-      expect(screen.getByTestId('Status')).toHaveTextContent('Complete');
+      expect(screen.getByTestId('Status')).toHaveTextContent(
+        'Data replacement in progress',
+      );
       expect(screen.getByTestId('Uploaded by')).toHaveTextContent(
         'original@test.com',
       );

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
@@ -112,8 +112,17 @@ const ImporterStatus = ({
   return (
     <div>
       <div className="dfe-flex dfe-align-items--center">
-        <Tag colour={getImportStatusColour(currentStatus.status)} strong>
-          {getImportStatusLabel(currentStatus.status)}
+        <Tag
+          colour={
+            dataFile.replacedBy
+              ? 'blue'
+              : getImportStatusColour(currentStatus.status)
+          }
+          strong
+        >
+          {dataFile.replacedBy
+            ? 'Data replacement in progress'
+            : getImportStatusLabel(currentStatus.status)}
         </Tag>
 
         {!terminalImportStatuses.includes(currentStatus.status) && (

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -65,7 +65,7 @@ describe('ReleaseDataUploadsSection', () => {
   test('renders list of uploaded data files', async () => {
     releaseDataFileService.getDataFiles.mockResolvedValue(testDataFiles);
     releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
-      testQueuedImportStatus,
+      testCompleteImportStatus,
     );
 
     render(
@@ -102,7 +102,7 @@ describe('ReleaseDataUploadsSection', () => {
       );
       expect(section1.getByTestId('Data file size')).toHaveTextContent('50 Kb');
       expect(section1.getByTestId('Number of rows')).toHaveTextContent('100');
-      expect(section1.getByTestId('Status')).toHaveTextContent('Queued');
+      expect(section1.getByTestId('Status')).toHaveTextContent('Complete');
       expect(section1.getByTestId('Uploaded by')).toHaveTextContent(
         'user1@test.com',
       );
@@ -128,12 +128,54 @@ describe('ReleaseDataUploadsSection', () => {
         '100 Kb',
       );
       expect(section2.getByTestId('Number of rows')).toHaveTextContent('200');
-      expect(section2.getByTestId('Status')).toHaveTextContent('Queued');
+      expect(section2.getByTestId('Status')).toHaveTextContent('Complete');
       expect(section2.getByTestId('Uploaded by')).toHaveTextContent(
         'user2@test.com',
       );
       expect(section2.getByTestId('Date uploaded')).toHaveTextContent(
         '1 July 2020 12:00',
+      );
+    });
+  });
+
+  test("renders data file details with status of 'Replacement in progress' if being replaced", async () => {
+    releaseDataFileService.getDataFiles.mockResolvedValue([
+      {
+        ...testDataFiles[0],
+        replacedBy: 'data-replacement-1',
+      },
+    ]);
+    releaseDataFileService.getDataFileImportStatus.mockResolvedValue(
+      testCompleteImportStatus,
+    );
+
+    render(
+      <MemoryRouter>
+        <ReleaseDataUploadsSection
+          publicationId="publication-1"
+          releaseId="release-1"
+          canUpdateRelease
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(releaseDataFileService.getDataFiles).toHaveBeenCalledWith(
+        'release-1',
+      );
+
+      const sections = screen.getAllByTestId('accordionSection');
+
+      expect(sections).toHaveLength(1);
+
+      const section1 = within(sections[0]);
+
+      expect(
+        section1.getByRole('button', { name: 'Test data 1' }),
+      ).toBeInTheDocument();
+
+      expect(section1.getByTestId('Status')).toHaveTextContent(
+        'Data replacement in progress',
       );
     });
   });


### PR DESCRIPTION
This PR moves the existing 'Data replacement in progress' tag into the `ImporterStatus` component so that it will be shown anywhere that the data file is in a replacement state i.e.

![image](https://user-images.githubusercontent.com/9917868/94712675-b76c0780-0341-11eb-9956-2672cefbb503.png)
