### PR TITLE
EES-1446 Meta file download links need to use the meta file id

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileDetailsTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileDetailsTable.tsx
@@ -86,7 +86,7 @@ const DataFileDetailsTable = ({
               onClick={() =>
                 releaseDataFileService.downloadFile(
                   releaseId,
-                  dataFile.id,
+                  dataFile.metaFileId,
                   dataFile.metaFileName,
                 )
               }
@@ -100,7 +100,7 @@ const DataFileDetailsTable = ({
                 onClick={() =>
                   releaseDataFileService.downloadFile(
                     releaseId,
-                    replacementDataFile.id,
+                    replacementDataFile.metaFileId,
                     replacementDataFile.metaFileName,
                   )
                 }


### PR DESCRIPTION
There was a change in https://github.com/dfe-analytical-services/explore-education-statistics/pull/2013 to remove dedicated endpoints for downloading types of files, replaced by a common endpoint to download any file by its file id.

This PR updates the meta file download links to use the meta file id rather than the corresponding data file id.