### PR TITLE
EES-1426 Fix uploaded zip data file returning incorrect details

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileUploadsValidatorServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileUploadsValidatorServiceTests.cs
@@ -32,7 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var result = await service.ValidateFileForUpload(Guid.NewGuid(),
                 file, ReleaseFileTypes.Ancillary, true);
-            
+
             Assert.True(result.IsLeft);
             AssertValidationProblem(result.Left, FileCannotBeEmpty);
         }
@@ -163,7 +163,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 AssertValidationProblem(result.Left, SubjectTitleCannotContainSpecialCharacters);
             }
         }
-        
+
         [Fact]
         public async Task ValidateSubjectName_SubjectNameNotUnique()
         {
@@ -276,7 +276,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 fileTypeService
                     .Setup(s => s.HasMatchingEncodingType(metaFile, It.IsAny<IEnumerable<string>>()))
                     .Returns(() => true);
-                
+
                 var result = await service.ValidateDataFilesForUpload(Guid.NewGuid(), dataFile, metaFile);
 
                 Assert.True(result.IsLeft);
@@ -308,7 +308,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 fileTypeService
                     .Setup(s => s.HasMatchingEncodingType(metaFile, It.IsAny<IEnumerable<string>>()))
                     .Returns(() => true);
-                
+
                 var result = await service.ValidateDataFilesForUpload(Guid.NewGuid(), dataFile, metaFile);
 
                 Assert.True(result.IsLeft);
@@ -325,7 +325,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var service = new FileUploadsValidatorService(subjectService.Object, fileTypeService.Object, context);
 
-                var (dataFile, metaFile) = GetArchiveEntries("data-zip-valid.zip");
+                var archiveFile = GetArchiveFile("data-zip-valid.zip");
 
                 fileTypeService
                     .Setup(s => s.HasMatchingMimeType(It.IsAny<Stream>(),
@@ -333,7 +333,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReturnsAsync(() => true);
 
                 var result = await service.ValidateDataArchiveEntriesForUpload(Guid.NewGuid(),
-                    dataFile, metaFile);
+                    archiveFile);
 
                 Assert.True(result.IsRight);
             }
@@ -348,7 +348,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var service = new FileUploadsValidatorService(subjectService.Object, fileTypeService.Object, context);
 
-                var (dataFile, metaFile) = GetArchiveEntries("data-zip-invalid.zip");
+                var archiveFile = GetArchiveFile("data-zip-invalid.zip");
 
                 fileTypeService
                     .Setup(s => s.HasMatchingMimeType(It.IsAny<Stream>(),
@@ -356,7 +356,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReturnsAsync(() => true);
 
                 var result = await service.ValidateDataArchiveEntriesForUpload(Guid.NewGuid(),
-                    dataFile,metaFile);
+                    archiveFile);
 
                 Assert.True(result.IsLeft);
                 AssertValidationProblem(result.Left, DataFileMustBeCsvFile);
@@ -375,7 +375,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             return CreateFormFile(fileName, name, "line1");
         }
-        
+
         private static IFormFile CreateFormFile(string fileName, string name, params string[] lines)
         {
             var mStream = new MemoryStream();
@@ -396,7 +396,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             return f;
         }
 
-        private static Tuple<ZipArchiveEntry, ZipArchiveEntry> GetArchiveEntries(string archiveFileName)
+        private static DataArchiveFile GetArchiveFile(string archiveFileName)
         {
             var archiveFile = CreateFormFileFromResource(archiveFileName);
 
@@ -409,7 +409,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var dataFile = file1.Name.Contains(".meta.") ? file2 : file1;
             var metaFile = file1.Name.Contains(".meta.") ? file1 : file2;
 
-            return new Tuple<ZipArchiveEntry, ZipArchiveEntry>(dataFile, metaFile);
+            return new DataArchiveFile(dataFile, metaFile);
         }
 
         private static IFormFile CreateFormFileFromResource(string fileName)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataArchiveValidationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataArchiveValidationService.cs
@@ -33,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _fileTypeService = fileTypeService;
         }
 
-        public async Task<Either<ActionResult, Tuple<ZipArchiveEntry, ZipArchiveEntry>>> ValidateDataArchiveFile(
+        public async Task<Either<ActionResult, IDataArchiveFile>> ValidateDataArchiveFile(
             Guid releaseId,
             IFormFile zipFile)
         {
@@ -49,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 return ValidationActionResult(DataZipFileAlreadyExists);
             }
 
-            using var stream = zipFile.OpenReadStream();
+            await using var stream = zipFile.OpenReadStream();
             using var archive = new ZipArchive(stream);
 
             if (archive.Entries.Count != 2)
@@ -68,7 +68,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             var dataFile = file1.Name.Contains(".meta.") ? file2 : file1;
             var metaFile = file1.Name.Contains(".meta.") ? file1 : file2;
 
-            return new Tuple<ZipArchiveEntry, ZipArchiveEntry>(dataFile, metaFile);
+            return new DataArchiveFile(dataFile: dataFile, metaFile: metaFile);
         }
 
         private async Task<bool> IsZipFile(IFormFile file)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataArchiveValidationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataArchiveValidationService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO.Compression;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Http;
@@ -9,7 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IDataArchiveValidationService
     {
-        Task<Either<ActionResult, Tuple<ZipArchiveEntry, ZipArchiveEntry>>> ValidateDataArchiveFile(
+        Task<Either<ActionResult, IDataArchiveFile>> ValidateDataArchiveFile(
             Guid releaseId,
             IFormFile zipFile);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileUploadsValidatorService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO.Compression;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Http;
@@ -17,8 +16,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, Unit>> ValidateDataFilesForUpload(Guid releaseId, IFormFile dataFile,
             IFormFile metaFile);
 
-        Task<Either<ActionResult, Unit>> ValidateDataArchiveEntriesForUpload(Guid releaseId, ZipArchiveEntry dataFile,
-            ZipArchiveEntry metaFile);
+        Task<Either<ActionResult, Unit>> ValidateDataArchiveEntriesForUpload(Guid releaseId, IDataArchiveFile archiveFile);
 
         Task<Either<ActionResult, Unit>> ValidateSubjectName(Guid releaseId, string name);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IImportService.cs
@@ -10,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     public interface IImportService
     {
         Task Import(Guid releaseId, string dataFileName, string metaFileName, IFormFile dataFile, bool isZip);
-        Task<Either<ActionResult, bool>> CreateImportTableRow(Guid releaseId, string dataFileName);
+        Task<Either<ActionResult, Unit>> CreateImportTableRow(Guid releaseId, string dataFileName);
         Task FailImport(Guid releaseId, string dataFileName, IEnumerable<ValidationError> errors);
         Task RemoveImportTableRowIfExists(Guid releaseId, string dataFileName);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/BlobInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/BlobInfo.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using IOPath = System.IO.Path;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 {
@@ -40,6 +40,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 
         public string FileName => Path.Substring(Path.LastIndexOf('/') + 1);
 
-        public string Extension => IOPath.GetExtension(FileName)?.TrimStart('.') ?? string.Empty;
+        public string Extension => FileStorageUtils.GetExtension(FileName);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/DataArchiveFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/DataArchiveFile.cs
@@ -1,0 +1,35 @@
+using System.IO.Compression;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+{
+    public interface IDataArchiveFile
+    {
+        public string DataFileName { get; }
+        public string MetaFileName { get; }
+
+        public long DataFileSize { get; }
+        public long MetaFileSize { get; }
+    }
+
+    public class DataArchiveFile : IDataArchiveFile
+    {
+        private readonly ZipArchiveEntry _dataFile;
+        private readonly ZipArchiveEntry _metaFile;
+
+        public DataArchiveFile()
+        {
+        }
+
+        public DataArchiveFile(ZipArchiveEntry dataFile, ZipArchiveEntry metaFile)
+        {
+            _dataFile = dataFile;
+            _metaFile = metaFile;
+        }
+
+        public string DataFileName => _dataFile.Name.ToLower();
+        public string MetaFileName => _metaFile.Name.ToLower();
+
+        public long DataFileSize => _dataFile.Length;
+        public long MetaFileSize => _metaFile.Length;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStorageUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStorageUtils.cs
@@ -48,6 +48,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             };
         }
 
+        public static string GetExtension(string fileName)
+        {
+            return Path.GetExtension(fileName)?.TrimStart('.') ?? string.Empty;
+        }
+
         public static string GetSize(long contentLength)
         {
             var fileSize = contentLength;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFileReference.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFileReference.cs
@@ -1,5 +1,6 @@
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
@@ -43,5 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public Guid? SourceId { get; set; }
         public ReleaseFileReference? Source { get; set; }
+
+        public string Extension => FileStorageUtils.GetExtension(Filename);
     }
 }


### PR DESCRIPTION
This PR fixes the `ReleaseFilesService.UploadDataFilesAsZip` method returning incorrect `DataFileInfo`. We have now adjusted this to return details of the zipped data file instead of the ZIP file itself. This includes the correct subject name and the import status (so 'Not found' will no longer be displayed).

As part of this, we have refactored other service APIs involving `ZipArchiveEntry` parameters to take a `DataArchiveFile` instead. This allows us to more easily mock things for unit tests.