### PR TITLE
EES-1449 Delete meta data blob by the correct filename

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFilesServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFilesServiceTests.cs
@@ -114,8 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(result.IsRight);
 
                 Assert.Null(await contentDbContext.ReleaseFiles.FindAsync(releaseDataFile.Id));
-                // TODO not sure why this is failing?
-                //Assert.Null(await contentDbContext.ReleaseFiles.FindAsync(releaseMetaFile.Id));
+                Assert.Null(await contentDbContext.ReleaseFiles.FindAsync(releaseMetaFile.Id));
 
                 Assert.Null(await contentDbContext.ReleaseFileReferences.FindAsync(dataFile.Id));
                 Assert.Null(await contentDbContext.ReleaseFileReferences.FindAsync(metaFile.Id));

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFilesService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFilesService.cs
@@ -278,11 +278,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .CheckEntityExists<Release>(releaseId)
                 .OnSuccess(async release => await CheckCanDeleteReleaseFile(release, forceDelete))
                 .OnSuccess(() => CheckReleaseFileReferenceExists(fileId))
-                .OnSuccess(async releaseFileReference =>
+                .OnSuccessVoid(async releaseFileReference =>
                 {
                     var metaReleaseFileReference = await GetAssociatedReleaseFileReference(releaseFileReference, ReleaseFileTypes.Metadata);
 
-                    if (await DeletionWillOrphanFileAsync(releaseId, releaseFileReference.Filename, ReleaseFileTypes.Data))
+                    if (await DeletionWillOrphanFileAsync(releaseId, fileId))
                     {
                         await _importService.RemoveImportTableRowIfExists(releaseId, releaseFileReference.Filename);
                         await _blobStorageService.DeleteBlob(
@@ -291,7 +291,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         );
                         await _blobStorageService.DeleteBlob(
                             PrivateFilesContainerName,
-                            AdminReleasePath(releaseId, ReleaseFileTypes.Metadata, releaseFileReference.Filename)
+                            AdminReleasePath(releaseId, ReleaseFileTypes.Metadata, metaReleaseFileReference.Filename)
                         );
 
                         _context.ReleaseFileReferences.Remove(releaseFileReference);
@@ -304,7 +304,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                 PrivateFilesContainerName,
                                 AdminReleasePath(releaseId, ReleaseFileTypes.DataZip, sourceRef.Filename)
                             );
-                            // N.B. Not ReleaseFies row for source links
+                            // N.B. No ReleaseFiles row for source links
                             _context.ReleaseFileReferences.Remove(sourceRef);
                         }
                     }
@@ -315,7 +315,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     }
 
                     await _context.SaveChangesAsync();
-                    return Unit.Instance;
                 });
         }
 
@@ -896,22 +895,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             var fileLink = await GetReleaseFileLinkAsync(releaseId, filename, type);
 
-            var otherFileReferences = await _context
-                .ReleaseFiles
-                .CountAsync(f => f.ReleaseFileReferenceId == fileLink.ReleaseFileReferenceId && f.Id != fileLink.Id);
-
-            return otherFileReferences == 0;
+            return !await _context.ReleaseFiles.AnyAsync(f => 
+                f.ReleaseFileReferenceId == fileLink.ReleaseFileReferenceId && f.Id != fileLink.Id);
         }
 
         private async Task<bool> DeletionWillOrphanFileAsync(Guid releaseId, Guid id)
         {
             var fileLink = await GetReleaseFileLink(releaseId, id);
 
-            var otherFileReferences = await _context
-                .ReleaseFiles
-                .CountAsync(f => f.ReleaseFileReferenceId == fileLink.ReleaseFileReferenceId && f.Id != fileLink.Id);
-
-            return otherFileReferences == 0;
+            return !await _context.ReleaseFiles.AnyAsync(f =>
+                f.ReleaseFileReferenceId == fileLink.ReleaseFileReferenceId && f.Id != fileLink.Id);
         }
 
         private string AdminReleasePathWithFileReference(ReleaseFileReference fileReference)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFilesService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFilesService.cs
@@ -294,6 +294,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             AdminReleasePath(releaseId, ReleaseFileTypes.Metadata, metaReleaseFileReference.Filename)
                         );
 
+                        await DeleteFileLink(releaseId, releaseFileReference.Id);
+                        await DeleteFileLink(releaseId, metaReleaseFileReference.Id);
+
                         _context.ReleaseFileReferences.Remove(releaseFileReference);
                         _context.ReleaseFileReferences.Remove(metaReleaseFileReference);
 


### PR DESCRIPTION
This PR:

Corrects the file name that we delete the meta data blob with
Adds unit tests for deleting a Subjects set of files and deleting a Subjects set of files that exist on a previous version.