### PR TITLE
EES-1417 Don't allow deleting a file if a replacement file is still importing

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataBlocksControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/DataBlocksControllerTests.cs
@@ -52,7 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             SetupDataBlockExistsResult(persistenceHelper);
 
             dataBlockService.Setup(s => s.DeleteAsync(_releaseId, _dataBlockId))
-                .Returns(Task.FromResult(new Either<ActionResult, bool>(true)));
+                .ReturnsAsync(Unit.Instance);
 
             var controller = ControllerWithMocks(dataBlockService, persistenceHelper);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -62,24 +62,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
-        public async Task<Either<ActionResult, bool>> DeleteAsync(Guid releaseId, Guid id)
+        public async Task<Either<ActionResult, Unit>> DeleteAsync(Guid releaseId, Guid id)
         {
             return await _persistenceHelper
                 .CheckEntityExists<DataBlock>(id)
                 .OnSuccess(CheckCanUpdateReleaseForDataBlock)
                 .OnSuccess(block => GetDeleteDataBlockPlan(releaseId, id)
-                .OnSuccess(async deletePlan =>
+                .OnSuccessVoid(async deletePlan =>
                 {
                     await DeleteDataBlocks(deletePlan);
-                    return true;
                 }));
         }
 
-        public async Task<Either<ActionResult, bool>> DeleteDataBlocks(DeleteDataBlockPlan deletePlan)
+        public async Task DeleteDataBlocks(DeleteDataBlockPlan deletePlan)
         {
             await DeleteDependentDataBlocks(deletePlan);
             await RemoveChartFileReleaseLinks(deletePlan);
-            return true;
         }
 
         public async Task<Either<ActionResult, Unit>> RemoveChartFile(Guid releaseId, Guid id)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataBlockService.cs
@@ -16,7 +16,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     {
         Task<Either<ActionResult, DataBlockViewModel>> CreateAsync(ReleaseId releaseId, CreateDataBlockViewModel createDataBlock);
 
-        Task<Either<ActionResult, bool>> DeleteAsync(ReleaseId releaseId, DataBlockId id);
+        Task<Either<ActionResult, Unit>> DeleteAsync(ReleaseId releaseId, DataBlockId id);
 
         Task<DataBlockViewModel> GetAsync(DataBlockId id);
 
@@ -24,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, DataBlockViewModel>> UpdateAsync(DataBlockId id, UpdateDataBlockViewModel updateDataBlock);
 
-        Task<Either<ActionResult, bool>> DeleteDataBlocks(DeleteDataBlockPlan deletePlan);
+        Task DeleteDataBlocks(DeleteDataBlockPlan deletePlan);
 
         Task<Either<ActionResult, DeleteDataBlockPlan>> GetDeleteDataBlockPlan(Guid releaseId, Guid id);
 


### PR DESCRIPTION
This PR:

- Returns the result for removing a replacement data file if it's a failure. This was previously ignored so if the replacement file was still importing the original file continued to be deleted without an error.
- Adds unit tests for removing a data file that is importing
- Adds a unit test for removing a data file with a replacement file that is importing
- Cleans up other unit tests in `ReleaseServiceTests`.