### PR TITLE
EES-1459 Unlink a replacement release file reference from the original before trying to delete it

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFilesServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFilesServiceTests.cs
@@ -142,7 +142,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Release = release,
                 Filename = "data.zip",
                 ReleaseFileType = ReleaseFileTypes.DataZip,
-                SubjectId = subject.Id,
+                SubjectId = subject.Id
             };
 
             var dataFile = new ReleaseFileReference
@@ -167,7 +167,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Release = release,
                 Filename = "replacement.zip",
                 ReleaseFileType = ReleaseFileTypes.DataZip,
-                SubjectId = replacementSubject.Id,
+                SubjectId = replacementSubject.Id
             };
 
             var replacementDataFile = new ReleaseFileReference
@@ -187,7 +187,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Filename = "replacement.meta.csv",
                 ReleaseFileType = ReleaseFileTypes.Metadata,
                 Release = release,
-                SubjectId = replacementSubject.Id,
+                SubjectId = replacementSubject.Id
             };
 
             var releaseDataFile = new ReleaseFile
@@ -264,10 +264,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.NotNull(await contentDbContext.ReleaseFileReferences.FindAsync(dataFile.Id));
                 Assert.NotNull(await contentDbContext.ReleaseFileReferences.FindAsync(metaFile.Id));
                 Assert.NotNull(await contentDbContext.ReleaseFileReferences.FindAsync(zipFile.Id));
-                
+
                 Assert.Null(await contentDbContext.ReleaseFileReferences.FindAsync(replacementDataFile.Id));
                 Assert.Null(await contentDbContext.ReleaseFileReferences.FindAsync(replacementMetaFile.Id));
                 Assert.Null(await contentDbContext.ReleaseFileReferences.FindAsync(replacementZipFile.Id));
+
+                Assert.Null((await contentDbContext.ReleaseFileReferences.FindAsync(dataFile.Id)).ReplacedById);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFilesService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFilesService.cs
@@ -294,6 +294,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             AdminReleasePath(releaseId, ReleaseFileTypes.Metadata, metaReleaseFileReference.Filename)
                         );
 
+                        // If this is a replacement then unlink it from the original
+                        if (releaseFileReference.ReplacingId.HasValue)
+                        {
+                            var originalFile = await GetReleaseFileReference(releaseFileReference.ReplacingId.Value);
+                            originalFile.ReplacedById = null;
+                            _context.Update(originalFile);
+                        }
+
                         await DeleteFileLink(releaseId, releaseFileReference.Id);
                         await DeleteFileLink(releaseId, metaReleaseFileReference.Id);
 


### PR DESCRIPTION
There was a referential integrity database exception occuring when cancelling a Data Replacement.

Cancelling the replacement in the UI makes an API call to delete the replacement file id.

The exception was occurring because it is still linked to the original file in its `ReplacedBy` field.

When deleting a file, if it has a `Replacing` file then it's a replacement and we find that file and clear the `ReplacedBy` before removing it.