### PR TITLE
EES-1429 Allow initialisation of data block table tool when table cannot be rendered

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ChartBuilderTabSection.tsx
@@ -14,15 +14,17 @@ import isEqual from 'lodash/isEqual';
 import React, { useCallback, useMemo } from 'react';
 import { useParams } from 'react-router';
 
+export type ChartBuilderTableUpdateHandler = (params: {
+  table: FullTable;
+  query: ReleaseTableDataQuery;
+}) => void;
+
 interface Props {
   dataBlock: ReleaseDataBlock;
   query: ReleaseTableDataQuery;
   table: FullTable;
   onDataBlockSave: (dataBlock: SavedDataBlock) => void;
-  onTableUpdate: (params: {
-    table: FullTable;
-    query: ReleaseTableDataQuery;
-  }) => void;
+  onTableUpdate: ChartBuilderTableUpdateHandler;
 }
 
 const ChartBuilderTabSection = ({

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ChartBuilderTabSection.tsx
@@ -8,11 +8,11 @@ import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import tableBuilderService, {
   ReleaseTableDataQuery,
+  TableDataQuery,
 } from '@common/services/tableBuilderService';
 import { Chart } from '@common/services/types/blocks';
 import isEqual from 'lodash/isEqual';
 import React, { useCallback, useMemo } from 'react';
-import { useParams } from 'react-router';
 
 export type ChartBuilderTableUpdateHandler = (params: {
   table: FullTable;
@@ -21,7 +21,8 @@ export type ChartBuilderTableUpdateHandler = (params: {
 
 interface Props {
   dataBlock: ReleaseDataBlock;
-  query: ReleaseTableDataQuery;
+  query: TableDataQuery;
+  releaseId: string;
   table: FullTable;
   onDataBlockSave: (dataBlock: SavedDataBlock) => void;
   onTableUpdate: ChartBuilderTableUpdateHandler;
@@ -30,12 +31,11 @@ interface Props {
 const ChartBuilderTabSection = ({
   dataBlock,
   query,
+  releaseId,
   table,
   onDataBlockSave,
   onTableUpdate,
 }: Props) => {
-  const { releaseId } = useParams<{ releaseId: string }>();
-
   const meta = useMemo(
     () => ({
       ...table.subjectMeta,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -13,7 +13,7 @@ import WizardStepHeading from '@common/modules/table-tool/components/WizardStepH
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 import {
-  PublicationSubjectMeta,
+  SubjectMeta,
   ReleaseTableDataQuery,
 } from '@common/services/tableBuilderService';
 import React, {
@@ -118,7 +118,7 @@ interface DataBlockSourceWizardProps {
   dataBlock?: ReleaseDataBlock;
   query?: ReleaseTableDataQuery;
   releaseId?: string;
-  subjectMeta?: PublicationSubjectMeta;
+  subjectMeta?: SubjectMeta;
   table?: FullTable;
   tableHeaders?: TableHeadersConfig;
   onSave: DataBlockSourceWizardSaveHandler;

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -5,24 +5,15 @@ import { ReleaseDataBlock } from '@admin/services/dataBlockService';
 import { generateTableTitle } from '@common/modules/table-tool/components/DataTableCaption';
 import TableHeadersForm from '@common/modules/table-tool/components/TableHeadersForm';
 import TableToolWizard, {
-  TableToolState,
+  InitialTableToolState,
 } from '@common/modules/table-tool/components/TableToolWizard';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
 import WizardStep from '@common/modules/table-tool/components/WizardStep';
 import WizardStepHeading from '@common/modules/table-tool/components/WizardStepHeading';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
-import {
-  SubjectMeta,
-  ReleaseTableDataQuery,
-} from '@common/services/tableBuilderService';
-import React, {
-  createRef,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { ReleaseTableDataQuery } from '@common/services/tableBuilderService';
+import React, { createRef, useCallback, useEffect, useState } from 'react';
 
 export type DataBlockSourceWizardSaveHandler = (params: {
   details: DataBlockDetailsFormValues;
@@ -118,37 +109,16 @@ interface DataBlockSourceWizardProps {
   dataBlock?: ReleaseDataBlock;
   query?: ReleaseTableDataQuery;
   releaseId?: string;
-  subjectMeta?: SubjectMeta;
-  table?: FullTable;
-  tableHeaders?: TableHeadersConfig;
+  tableToolState?: InitialTableToolState;
   onSave: DataBlockSourceWizardSaveHandler;
 }
 
 const DataBlockSourceWizard = ({
   dataBlock,
-  query: initialQuery,
   releaseId,
-  subjectMeta,
-  table,
-  tableHeaders,
+  tableToolState,
   onSave,
 }: DataBlockSourceWizardProps) => {
-  const initialTableToolState = useMemo<TableToolState | undefined>(() => {
-    if (!initialQuery || !table || !tableHeaders || !subjectMeta) {
-      return undefined;
-    }
-
-    return {
-      initialStep: 5,
-      query: initialQuery,
-      subjectMeta,
-      response: {
-        table,
-        tableHeaders,
-      },
-    };
-  }, [initialQuery, subjectMeta, table, tableHeaders]);
-
   return (
     <div className="govuk-!-margin-bottom-8">
       <p>Configure data source for the data block</p>
@@ -156,7 +126,7 @@ const DataBlockSourceWizard = ({
       <TableToolWizard
         themeMeta={[]}
         initialState={
-          initialTableToolState ?? {
+          tableToolState ?? {
             query: {
               releaseId,
               subjectId: '',

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ReleaseDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ReleaseDataBlocksPageTabs.tsx
@@ -20,7 +20,7 @@ import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
 import mapUnmappedTableHeaders from '@common/modules/table-tool/utils/mapUnmappedTableHeaders';
 import tableBuilderService, {
-  PublicationSubjectMeta,
+  SubjectMeta,
   ReleaseTableDataQuery,
 } from '@common/services/tableBuilderService';
 import minDelay from '@common/utils/minDelay';
@@ -53,7 +53,7 @@ const ReleaseDataBlocksPageTabs = ({
   const [saveNumber, setSaveNumber] = useState(0);
   const [isSaving, setIsSaving] = useState(false);
 
-  const [subjectMeta, setSubjectMeta] = useState<PublicationSubjectMeta>();
+  const [subjectMeta, setSubjectMeta] = useState<SubjectMeta>();
 
   const {
     value: tableState,
@@ -74,7 +74,7 @@ const ReleaseDataBlocksPageTabs = ({
     };
 
     const tableData = await tableBuilderService.getTableData(query);
-    const nextSubjectMeta = await tableBuilderService.getPublicationSubjectMeta(
+    const nextSubjectMeta = await tableBuilderService.getSubjectMeta(
       query.subjectId,
     );
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ReleaseDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ReleaseDataBlocksPageTabs.tsx
@@ -23,10 +23,12 @@ import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHead
 import mapUnmappedTableHeaders from '@common/modules/table-tool/utils/mapUnmappedTableHeaders';
 import tableBuilderService, {
   ReleaseTableDataQuery,
+  TableDataQuery,
 } from '@common/services/tableBuilderService';
 import minDelay from '@common/utils/minDelay';
 import produce from 'immer';
 import React, { useCallback, useState } from 'react';
+import omit from 'lodash/omit';
 
 export type SavedDataBlock = CreateReleaseDataBlock & {
   id?: string;
@@ -105,20 +107,20 @@ const ReleaseDataBlocksPageTabs = ({
       const dataBlockToSave: SavedDataBlock = {
         ...dataBlock,
         query: {
-          ...dataBlock.query,
+          ...(omit(dataBlock.query, ['releaseId']) as SavedDataBlock['query']),
           includeGeoJson: dataBlock.charts[0]?.type === 'map',
         },
       };
 
       const newDataBlock = await minDelay(() => {
         if (dataBlockToSave.id) {
-          return dataBlocksService.putDataBlock(
+          return dataBlocksService.updateDataBlock(
             dataBlockToSave.id,
             dataBlockToSave as ReleaseDataBlock,
           );
         }
 
-        return dataBlocksService.postDataBlock(releaseId, dataBlockToSave);
+        return dataBlocksService.createDataBlock(releaseId, dataBlockToSave);
       }, 500);
 
       onDataBlockSave(newDataBlock);
@@ -278,6 +280,7 @@ const ReleaseDataBlocksPageTabs = ({
                   key={saveNumber}
                   dataBlock={selectedDataBlock}
                   query={query}
+                  releaseId={releaseId}
                   table={response.table}
                   onDataBlockSave={handleDataBlockSave}
                   onTableUpdate={handleChartTableUpdate}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ReleaseDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ReleaseDataBlocksPageTabs.tsx
@@ -1,4 +1,6 @@
-import ChartBuilderTabSection from '@admin/pages/release/datablocks/components/ChartBuilderTabSection';
+import ChartBuilderTabSection, {
+  ChartBuilderTableUpdateHandler,
+} from '@admin/pages/release/datablocks/components/ChartBuilderTabSection';
 import DataBlockSourceWizard, {
   DataBlockSourceWizardSaveHandler,
 } from '@admin/pages/release/datablocks/components/DataBlockSourceWizard';
@@ -13,14 +15,13 @@ import TabsSection from '@common/components/TabsSection';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import filterOrphanedDataSets from '@common/modules/charts/util/filterOrphanedDataSets';
-import { FullTable } from '@common/modules/table-tool/types/fullTable';
+import { InitialTableToolState } from '@common/modules/table-tool/components/TableToolWizard';
+import getInitialStepSubjectMeta from '@common/modules/table-tool/components/utils/getInitialStepSubjectMeta';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
-import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/getDefaultTableHeadersConfig';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
 import mapUnmappedTableHeaders from '@common/modules/table-tool/utils/mapUnmappedTableHeaders';
 import tableBuilderService, {
-  SubjectMeta,
   ReleaseTableDataQuery,
 } from '@common/services/tableBuilderService';
 import minDelay from '@common/utils/minDelay';
@@ -30,12 +31,6 @@ import React, { useCallback, useState } from 'react';
 export type SavedDataBlock = CreateReleaseDataBlock & {
   id?: string;
 };
-
-interface TableState {
-  table: FullTable;
-  tableHeaders: TableHeadersConfig;
-  query: ReleaseTableDataQuery;
-}
 
 interface Props {
   releaseId: string;
@@ -53,14 +48,12 @@ const ReleaseDataBlocksPageTabs = ({
   const [saveNumber, setSaveNumber] = useState(0);
   const [isSaving, setIsSaving] = useState(false);
 
-  const [subjectMeta, setSubjectMeta] = useState<SubjectMeta>();
-
   const {
     value: tableState,
     setState: setTableState,
     error,
     isLoading,
-  } = useAsyncRetry<TableState | undefined>(async () => {
+  } = useAsyncRetry<InitialTableToolState | undefined>(async () => {
     if (!selectedDataBlock) {
       return undefined;
     }
@@ -73,45 +66,37 @@ const ReleaseDataBlocksPageTabs = ({
       ),
     };
 
+    const { initialStep, subjectMeta } = await getInitialStepSubjectMeta(query);
+
+    // Reduce step by 1 as there is no publication step
+    const step = initialStep - 1;
+
+    if (step < 5) {
+      return {
+        initialStep: step,
+        subjectMeta,
+        query,
+      };
+    }
+
     const tableData = await tableBuilderService.getTableData(query);
-    const nextSubjectMeta = await tableBuilderService.getSubjectMeta(
-      query.subjectId,
-    );
 
     const table = mapFullTable(tableData);
-
-    setSubjectMeta(nextSubjectMeta);
-
-    const tableHeaders = selectedDataBlock
-      ? mapTableHeadersConfig(
-          selectedDataBlock.table.tableHeaders,
-          table.subjectMeta,
-        )
-      : getDefaultTableHeaderConfig(table.subjectMeta);
+    const tableHeaders = mapTableHeadersConfig(
+      selectedDataBlock.table.tableHeaders,
+      table.subjectMeta,
+    );
 
     return {
-      table,
-      tableHeaders,
+      initialStep: step,
+      subjectMeta,
       query,
+      response: {
+        table,
+        tableHeaders,
+      },
     };
   }, []);
-
-  const updateTableState = useCallback(
-    (nextTableState: Partial<TableState>) => {
-      if (!tableState) {
-        throw new Error('Cannot update undefined table state');
-      }
-
-      setTableState({
-        isLoading: false,
-        value: {
-          ...tableState,
-          ...nextTableState,
-        },
-      });
-    },
-    [setTableState, tableState],
-  );
 
   const handleDataBlockSave = useCallback(
     async (dataBlock: SavedDataBlock) => {
@@ -158,11 +143,13 @@ const ReleaseDataBlocksPageTabs = ({
       });
 
       setTableState({
-        isLoading: false,
         value: {
+          initialStep: 5,
           query,
-          table,
-          tableHeaders,
+          response: {
+            table,
+            tableHeaders,
+          },
         },
       });
 
@@ -188,7 +175,21 @@ const ReleaseDataBlocksPageTabs = ({
         );
       }
 
-      updateTableState({ tableHeaders });
+      if (!tableState?.response) {
+        throw new Error(
+          'Cannot save table headers when table has not been created',
+        );
+      }
+
+      setTableState({
+        value: {
+          ...tableState,
+          response: {
+            ...tableState?.response,
+            tableHeaders,
+          },
+        },
+      });
 
       await handleDataBlockSave({
         ...selectedDataBlock,
@@ -198,10 +199,30 @@ const ReleaseDataBlocksPageTabs = ({
         },
       });
     },
-    [handleDataBlockSave, selectedDataBlock, updateTableState],
+    [handleDataBlockSave, selectedDataBlock, setTableState, tableState],
   );
 
-  const { query, table, tableHeaders } = tableState ?? {};
+  const handleChartTableUpdate: ChartBuilderTableUpdateHandler = useCallback(
+    ({ table, query }) => {
+      if (!tableState?.response) {
+        throw new Error('Cannot update uninitialised table state');
+      }
+
+      setTableState({
+        value: {
+          ...tableState,
+          query,
+          response: {
+            ...tableState?.response,
+            table,
+          },
+        },
+      });
+    },
+    [setTableState, tableState],
+  );
+
+  const { query, response } = tableState ?? {};
 
   return (
     <div style={{ position: 'relative' }} className="govuk-!-padding-top-2">
@@ -212,6 +233,14 @@ const ReleaseDataBlocksPageTabs = ({
         />
       )}
 
+      {tableState && tableState?.initialStep < 5 && (
+        <WarningMessage>
+          There is a problem with this data block as some of the selected
+          options are invalid. Please re-check your choices to ensure the
+          correct table can be produced.
+        </WarningMessage>
+      )}
+
       {!error ? (
         <Tabs id="manageDataBlocks">
           <TabsSection title="Data source" id="manageDataBlocks-dataSource">
@@ -220,38 +249,41 @@ const ReleaseDataBlocksPageTabs = ({
                 key={saveNumber}
                 dataBlock={selectedDataBlock}
                 releaseId={releaseId}
-                query={query}
-                subjectMeta={subjectMeta}
-                table={table}
-                tableHeaders={tableHeaders}
+                tableToolState={tableState}
                 onSave={handleDataBlockSourceSave}
               />
             )}
           </TabsSection>
 
-          {selectedDataBlock && [
-            <TabsSection title="Table" key="table" id="manageDataBlocks-table">
-              {table && tableHeaders && (
+          {selectedDataBlock &&
+            query &&
+            response && [
+              <TabsSection
+                title="Table"
+                key="table"
+                id="manageDataBlocks-table"
+              >
                 <TableTabSection
-                  table={table}
-                  tableHeaders={tableHeaders}
+                  table={response.table}
+                  tableHeaders={response.tableHeaders}
                   onSave={handleTableHeadersSave}
                 />
-              )}
-            </TabsSection>,
-            <TabsSection title="Chart" key="chart" id="manageDataBlocks-chart">
-              {query && table && (
+              </TabsSection>,
+              <TabsSection
+                title="Chart"
+                key="chart"
+                id="manageDataBlocks-chart"
+              >
                 <ChartBuilderTabSection
                   key={saveNumber}
                   dataBlock={selectedDataBlock}
                   query={query}
-                  table={table}
+                  table={response.table}
                   onDataBlockSave={handleDataBlockSave}
-                  onTableUpdate={updateTableState}
+                  onTableUpdate={handleChartTableUpdate}
                 />
-              )}
-            </TabsSection>,
-          ]}
+              </TabsSection>,
+            ]}
         </Tabs>
       ) : (
         <WarningMessage>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/ReleaseDataBlocksPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/ReleaseDataBlocksPageTabs.test.tsx
@@ -1,0 +1,490 @@
+import ReleaseDataBlocksPageTabs from '@admin/pages/release/datablocks/components/ReleaseDataBlocksPageTabs';
+import _dataBlockService, {
+  ReleaseDataBlock,
+} from '@admin/services/dataBlockService';
+import _tableBuilderService, {
+  SubjectMeta,
+  TableDataResponse,
+  TimePeriodQuery,
+} from '@common/services/tableBuilderService';
+import { render, screen, waitFor } from '@testing-library/react';
+import noop from 'lodash/noop';
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@admin/services/dataBlockService');
+jest.mock('@common/services/tableBuilderService');
+
+const dataBlockService = _dataBlockService as jest.Mocked<
+  typeof _dataBlockService
+>;
+const tableBuilderService = _tableBuilderService as jest.Mocked<
+  typeof _tableBuilderService
+>;
+
+describe('ReleaseDataBlocksPageTabs', () => {
+  const testSubjectMeta: SubjectMeta = {
+    filters: {
+      Characteristic: {
+        totalValue: '',
+        hint: 'Filter by pupil characteristic',
+        legend: 'Characteristic',
+        name: 'characteristic',
+        options: {
+          Gender: {
+            label: 'Gender',
+            options: [
+              {
+                label: 'Gender female',
+                value: 'gender-female',
+              },
+            ],
+          },
+        },
+      },
+    },
+    indicators: {
+      AbsenceFields: {
+        label: 'Absence fields',
+        options: [
+          {
+            value: 'authorised-absence-sessions',
+            label: 'Number of authorised absence sessions',
+            unit: '',
+            name: 'sess_authorised',
+            decimalPlaces: 2,
+          },
+        ],
+      },
+    },
+    locations: {
+      localAuthority: {
+        legend: 'Local authority',
+        options: [{ value: 'barnet', label: 'Barnet' }],
+      },
+    },
+    timePeriod: {
+      legend: 'Time period',
+      options: [{ label: '2020/21', code: 'AY', year: 2020 }],
+    },
+  };
+
+  const testTableData: TableDataResponse = {
+    subjectMeta: {
+      publicationName: '',
+      boundaryLevels: [],
+      footnotes: [],
+      subjectName: 'Subject 1',
+      geoJsonAvailable: false,
+      locations: [
+        {
+          level: 'localAuthority',
+          label: 'Barnet',
+          value: 'barnet',
+        },
+      ],
+      timePeriodRange: [{ code: 'AY', year: 2020, label: '2020/21' }],
+      indicators: [
+        {
+          value: 'authorised-absence-sessions',
+          label: 'Number of authorised absence sessions',
+          unit: '',
+          name: 'sess_authorised',
+          decimalPlaces: 2,
+        },
+      ],
+      filters: {
+        Characteristic: {
+          totalValue: '',
+          hint: 'Filter by pupil characteristic',
+          legend: 'Characteristic',
+          name: 'characteristic',
+          options: {
+            Gender: {
+              label: 'Gender',
+              options: [
+                {
+                  label: 'Gender female',
+                  value: 'gender-female',
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    results: [],
+  };
+
+  const testDataBlock: ReleaseDataBlock = {
+    name: 'Test data block',
+    heading: 'Test title',
+    id: 'block-1',
+    source: 'Test source',
+    highlightName: '',
+    query: {
+      includeGeoJson: false,
+      subjectId: 'subject-1',
+      locations: {
+        localAuthority: ['barnet'],
+      },
+      timePeriod: {
+        startYear: 2020,
+        startCode: 'AY',
+        endYear: 2020,
+        endCode: 'AY',
+      },
+      filters: ['gender-female'],
+      indicators: ['authorised-absence-sessions'],
+    },
+    table: {
+      indicators: [],
+      tableHeaders: {
+        columnGroups: [],
+        columns: [],
+        rowGroups: [],
+        rows: [],
+      },
+    },
+    charts: [],
+  };
+
+  test('renders uninitialised table tool when no data block is selected', async () => {
+    tableBuilderService.getReleaseMeta.mockResolvedValue({
+      releaseId: 'release-1',
+      subjects: [],
+    });
+
+    render(
+      <ReleaseDataBlocksPageTabs
+        releaseId="release-1"
+        onDataBlockSave={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
+
+      expect(stepHeadings).toHaveLength(1);
+      expect(stepHeadings[0]).toHaveTextContent(
+        'Step 1 (current): Choose a subject',
+      );
+
+      expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    });
+  });
+
+  test('does not render table or chart tabs when no data block is selected', async () => {
+    tableBuilderService.getReleaseMeta.mockResolvedValue({
+      releaseId: 'release-1',
+      subjects: [],
+    });
+
+    render(
+      <ReleaseDataBlocksPageTabs
+        releaseId="release-1"
+        onDataBlockSave={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      const tabs = screen.getAllByRole('tab');
+
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0]).toHaveTextContent('Data source');
+    });
+  });
+
+  test('renders fully initialised table tool when data block is selected', async () => {
+    tableBuilderService.getReleaseMeta.mockResolvedValue({
+      releaseId: 'release-1',
+      subjects: [],
+    });
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.getTableData.mockResolvedValue(testTableData);
+
+    render(
+      <ReleaseDataBlocksPageTabs
+        releaseId="release-1"
+        selectedDataBlock={testDataBlock}
+        onDataBlockSave={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
+
+      expect(stepHeadings).toHaveLength(5);
+      expect(stepHeadings[0]).toHaveTextContent('Step 1: Choose a subject');
+      expect(stepHeadings[1]).toHaveTextContent('Step 2: Choose locations');
+      expect(stepHeadings[2]).toHaveTextContent('Step 3: Choose time period');
+      expect(stepHeadings[3]).toHaveTextContent('Step 4: Choose your filters');
+      expect(stepHeadings[4]).toHaveTextContent(
+        'Step 5 (current): Update data block',
+      );
+
+      expect(screen.getByLabelText('Name')).toHaveValue('Test data block');
+      expect(screen.getByLabelText('Table title')).toHaveValue('Test title');
+      expect(screen.getByLabelText('Source')).toHaveValue('Test source');
+    });
+  });
+
+  test('renders table and chart tabs when data block is selected', async () => {
+    tableBuilderService.getReleaseMeta.mockResolvedValue({
+      releaseId: 'release-1',
+      subjects: [],
+    });
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.getTableData.mockResolvedValue(testTableData);
+
+    render(
+      <ReleaseDataBlocksPageTabs
+        releaseId="release-1"
+        selectedDataBlock={testDataBlock}
+        onDataBlockSave={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      const tabs = screen.getAllByRole('tab');
+
+      expect(tabs).toHaveLength(3);
+      expect(tabs[0]).toHaveTextContent('Data source');
+      expect(tabs[1]).toHaveTextContent('Table');
+      expect(tabs[2]).toHaveTextContent('Chart');
+    });
+  });
+
+  test('renders partially initialised table tool when there are invalid locations in query', async () => {
+    tableBuilderService.getReleaseMeta.mockResolvedValue({
+      releaseId: 'release-1',
+      subjects: [],
+    });
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.getTableData.mockResolvedValue(testTableData);
+
+    render(
+      <ReleaseDataBlocksPageTabs
+        releaseId="release-1"
+        selectedDataBlock={{
+          ...testDataBlock,
+          query: {
+            ...testDataBlock.query,
+            locations: {
+              localAuthority: ['barnet', 'invalid-location'],
+            },
+          },
+        }}
+        onDataBlockSave={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /There is a problem with this data block as some of the selected options are invalid/,
+        ),
+      ).toBeInTheDocument();
+
+      const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
+
+      expect(stepHeadings).toHaveLength(2);
+      expect(stepHeadings[0]).toHaveTextContent('Step 1: Choose a subject');
+      expect(stepHeadings[1]).toHaveTextContent(
+        'Step 2 (current): Choose locations',
+      );
+    });
+  });
+
+  test('renders partially initialised table tool when there are invalid time periods in query', async () => {
+    tableBuilderService.getReleaseMeta.mockResolvedValue({
+      releaseId: 'release-1',
+      subjects: [],
+    });
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.getTableData.mockResolvedValue(testTableData);
+
+    render(
+      <ReleaseDataBlocksPageTabs
+        releaseId="release-1"
+        selectedDataBlock={{
+          ...testDataBlock,
+          query: {
+            ...testDataBlock.query,
+            timePeriod: {
+              ...(testDataBlock.query.timePeriod as TimePeriodQuery),
+              endCode: 'AY',
+              endYear: 2021,
+            },
+          },
+        }}
+        onDataBlockSave={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /There is a problem with this data block as some of the selected options are invalid/,
+        ),
+      ).toBeInTheDocument();
+
+      const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
+
+      expect(stepHeadings).toHaveLength(3);
+      expect(stepHeadings[0]).toHaveTextContent('Step 1: Choose a subject');
+      expect(stepHeadings[1]).toHaveTextContent('Step 2: Choose locations');
+      expect(stepHeadings[2]).toHaveTextContent(
+        'Step 3 (current): Choose time period',
+      );
+    });
+  });
+
+  test('renders partially initialised table tool when there are invalid filters in query', async () => {
+    tableBuilderService.getReleaseMeta.mockResolvedValue({
+      releaseId: 'release-1',
+      subjects: [],
+    });
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.getTableData.mockResolvedValue(testTableData);
+
+    render(
+      <ReleaseDataBlocksPageTabs
+        releaseId="release-1"
+        selectedDataBlock={{
+          ...testDataBlock,
+          query: {
+            ...testDataBlock.query,
+            filters: ['gender-female', 'invalid-filter'],
+          },
+        }}
+        onDataBlockSave={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /There is a problem with this data block as some of the selected options are invalid/,
+        ),
+      ).toBeInTheDocument();
+
+      const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
+
+      expect(stepHeadings).toHaveLength(4);
+      expect(stepHeadings[0]).toHaveTextContent('Step 1: Choose a subject');
+      expect(stepHeadings[1]).toHaveTextContent('Step 2: Choose locations');
+      expect(stepHeadings[2]).toHaveTextContent('Step 3: Choose time period');
+      expect(stepHeadings[3]).toHaveTextContent(
+        'Step 4 (current): Choose your filters',
+      );
+    });
+  });
+
+  test('renders partially initialised table tool when there are invalid indicators in query', async () => {
+    tableBuilderService.getReleaseMeta.mockResolvedValue({
+      releaseId: 'release-1',
+      subjects: [],
+    });
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.getTableData.mockResolvedValue(testTableData);
+
+    render(
+      <ReleaseDataBlocksPageTabs
+        releaseId="release-1"
+        selectedDataBlock={{
+          ...testDataBlock,
+          query: {
+            ...testDataBlock.query,
+            indicators: ['authorised-absence-sessions', 'invalid-indicator'],
+          },
+        }}
+        onDataBlockSave={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /There is a problem with this data block as some of the selected options are invalid/,
+        ),
+      ).toBeInTheDocument();
+
+      const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
+
+      expect(stepHeadings).toHaveLength(4);
+      expect(stepHeadings[0]).toHaveTextContent('Step 1: Choose a subject');
+      expect(stepHeadings[1]).toHaveTextContent('Step 2: Choose locations');
+      expect(stepHeadings[2]).toHaveTextContent('Step 3: Choose time period');
+      expect(stepHeadings[3]).toHaveTextContent(
+        'Step 4 (current): Choose your filters',
+      );
+    });
+  });
+
+  describe('updating data block', () => {
+    test('submitting data source form calls correct service to update data block', async () => {
+      tableBuilderService.getReleaseMeta.mockResolvedValue({
+        releaseId: 'release-1',
+        subjects: [],
+      });
+
+      tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+      tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+      tableBuilderService.getTableData.mockResolvedValue(testTableData);
+
+      render(
+        <ReleaseDataBlocksPageTabs
+          releaseId="release-1"
+          selectedDataBlock={testDataBlock}
+          onDataBlockSave={noop}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Name')).toHaveValue('Test data block');
+        expect(screen.getByLabelText('Table title')).toHaveValue('Test title');
+        expect(screen.getByLabelText('Source')).toHaveValue('Test source');
+      });
+
+      const nameInput = screen.getByLabelText('Name');
+      const titleInput = screen.getByLabelText('Table title');
+      const sourceInput = screen.getByLabelText('Source');
+
+      userEvent.clear(nameInput);
+      await userEvent.type(nameInput, 'Updated test data block');
+
+      userEvent.clear(titleInput);
+      await userEvent.type(titleInput, 'Updated test title');
+
+      userEvent.clear(sourceInput);
+      await userEvent.type(sourceInput, 'Updated test source');
+
+      expect(dataBlockService.updateDataBlock).not.toBeCalled();
+
+      userEvent.click(screen.getByRole('button', { name: 'Save data block' }));
+
+      await waitFor(() => {
+        expect(dataBlockService.updateDataBlock).toBeCalledTimes(1);
+        expect(dataBlockService.updateDataBlock).toBeCalledWith('block-1', {
+          ...testDataBlock,
+          name: 'Updated test data block',
+          heading: 'Updated test title',
+          source: 'Updated test source',
+        } as ReleaseDataBlock);
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/services/dataBlockService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataBlockService.ts
@@ -33,14 +33,17 @@ const dataBlockService = {
     );
   },
 
-  async postDataBlock(releaseId: string, dataBlock: CreateReleaseDataBlock) {
+  async createDataBlock(releaseId: string, dataBlock: CreateReleaseDataBlock) {
     return client.post<ReleaseDataBlock>(
       `/release/${releaseId}/datablocks`,
       dataBlock,
     );
   },
 
-  async putDataBlock(dataBlockId: string, dataBlock: UpdateReleaseDataBlock) {
+  async updateDataBlock(
+    dataBlockId: string,
+    dataBlock: UpdateReleaseDataBlock,
+  ) {
     return client.put<ReleaseDataBlock>(
       `/datablocks/${dataBlockId}`,
       dataBlock,

--- a/src/explore-education-statistics-common/src/components/Tabs.tsx
+++ b/src/explore-education-statistics-common/src/components/Tabs.tsx
@@ -25,7 +25,6 @@ interface Props {
 }
 
 const Tabs = ({ children, id, modifyHash = true, testId, onToggle }: Props) => {
-  const [loadedSections, setLoadedSections] = useState(new Set<number>());
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
 
   const { onMedia } = useDesktopMedia();
@@ -38,7 +37,6 @@ const Tabs = ({ children, id, modifyHash = true, testId, onToggle }: Props) => {
   ) as ReactElement<TabsSectionProps>[];
 
   const sections = filteredChildren.map((section, index) => {
-    const { lazy } = section.props;
     const sectionId = section.props.id || `${id}-${index + 1}`;
 
     return cloneElement<
@@ -54,7 +52,7 @@ const Tabs = ({ children, id, modifyHash = true, testId, onToggle }: Props) => {
         key: sectionId,
         ref: (element: HTMLElement) => sectionElements.current.push(element),
       },
-      lazy && !loadedSections.has(index) ? null : section.props.children,
+      section.props.children,
     );
   });
 
@@ -72,10 +70,9 @@ const Tabs = ({ children, id, modifyHash = true, testId, onToggle }: Props) => {
         }
       }
 
-      setLoadedSections(loadedSections.add(index));
       setSelectedTabIndex(index);
     },
-    [loadedSections, modifyHash],
+    [modifyHash],
   );
 
   useEffect(() => {

--- a/src/explore-education-statistics-common/src/components/TabsSection.tsx
+++ b/src/explore-education-statistics-common/src/components/TabsSection.tsx
@@ -7,7 +7,6 @@ import React, {
   HTMLAttributes,
   ReactNode,
   useEffect,
-  useRef,
   useState,
 } from 'react';
 import styles from './TabsSection.module.scss';

--- a/src/explore-education-statistics-common/src/components/TabsSection.tsx
+++ b/src/explore-education-statistics-common/src/components/TabsSection.tsx
@@ -6,6 +6,9 @@ import React, {
   forwardRef,
   HTMLAttributes,
   ReactNode,
+  useEffect,
+  useRef,
+  useState,
 } from 'react';
 import styles from './TabsSection.module.scss';
 
@@ -33,18 +36,26 @@ const TabsSection = forwardRef<HTMLElement, TabsSectionProps>(
       id,
       headingTitle = '',
       headingTag = 'h3',
+      lazy,
       ...restProps
     }: TabsSectionProps,
     ref,
   ) => {
-    const { onMedia } = useDesktopMedia();
-
     // Hide additional props from the component's public API to
     // avoid any confusion over this component's usage as
     // it should only be used in combination with Tabs.
     const { hidden, ...tabProps } = restProps as HTMLAttributes<HTMLElement>;
 
-    return (
+    const { onMedia } = useDesktopMedia();
+    const [hasRendered, setRendered] = useState(!lazy);
+
+    useEffect(() => {
+      if (lazy && !hasRendered && !hidden) {
+        setRendered(true);
+      }
+    }, [hasRendered, hidden, lazy]);
+
+    return hasRendered ? (
       <section
         aria-labelledby={onMedia(tabProps['aria-labelledby'])}
         hidden={hidden}
@@ -59,7 +70,7 @@ const TabsSection = forwardRef<HTMLElement, TabsSectionProps>(
         {headingTitle && createElement(headingTag, { children: headingTitle })}
         {children}
       </section>
-    );
+    ) : null;
   },
 );
 

--- a/src/explore-education-statistics-common/src/components/__tests__/Tabs.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/Tabs.test.tsx
@@ -352,6 +352,89 @@ describe('Tabs', () => {
     expect(queryByText('Test section 2 content')).not.toBeNull();
   });
 
+  test('can re-render with new tab and the active tab will still be active', () => {
+    const { rerender } = render(
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1">
+          <p>Test section 1 content</p>
+        </TabsSection>
+        <TabsSection title="Tab 2">
+          <p>Test section 2 content</p>
+        </TabsSection>
+      </Tabs>,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Tab 2' }));
+
+    rerender(
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1">
+          <p>Test section 1 content</p>
+        </TabsSection>
+        <TabsSection title="Tab 2">
+          <p>Test section 2 content</p>
+        </TabsSection>
+        <TabsSection title="Tab 3">
+          <p>Test section 3 content</p>
+        </TabsSection>
+      </Tabs>,
+    );
+
+    const tabs = screen.getAllByRole('tab');
+    const sections = screen.getAllByRole('tabpanel', { hidden: true });
+
+    expect(tabs).toHaveLength(3);
+    expect(sections).toHaveLength(3);
+
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
+    expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
+    expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
+
+    expect(sections[0]).not.toBeVisible();
+    expect(sections[1]).toBeVisible();
+    expect(sections[1]).toHaveTextContent('Test section 2 content');
+    expect(sections[2]).not.toBeVisible();
+
+    expect(window.location.hash).toBe('#test-tabs-2');
+  });
+
+  test('can re-render without active tab and another other tab will become active', () => {
+    const { rerender } = render(
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1">
+          <p>Test section 1 content</p>
+        </TabsSection>
+        <TabsSection title="Tab 2">
+          <p>Test section 2 content</p>
+        </TabsSection>
+      </Tabs>,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Tab 2' }));
+
+    rerender(
+      <Tabs id="test-tabs">
+        <TabsSection title="Tab 1">
+          <p>Test section 1 content</p>
+        </TabsSection>
+      </Tabs>,
+    );
+
+    const tabs = screen.getAllByRole('tab');
+    const sections = screen.getAllByRole('tabpanel', { hidden: true });
+
+    expect(tabs).toHaveLength(1);
+    expect(sections).toHaveLength(1);
+
+    expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
+    expect(tabs[0]).toHaveTextContent('Tab 1');
+
+    expect(sections[0]).toBeVisible();
+    expect(sections[0]).toHaveTextContent('Test section 1 content');
+
+    expect(window.location.hash).toBe('#test-tabs-1');
+  });
+
   describe('keyboard interactions', () => {
     let tab1: HTMLAnchorElement;
     let tab2: HTMLAnchorElement;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -8,7 +8,7 @@ import {
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import FormCheckboxSelectedCount from '@common/modules/table-tool/components/FormCheckboxSelectedCount';
-import { PublicationSubjectMeta } from '@common/services/tableBuilderService';
+import { SubjectMeta } from '@common/services/tableBuilderService';
 import { Dictionary } from '@common/types';
 import createErrorHelper from '@common/validation/createErrorHelper';
 import Yup from '@common/validation/yup';
@@ -34,7 +34,7 @@ interface Props {
     indicators: string[];
     filters: string[];
   };
-  subjectMeta: PublicationSubjectMeta;
+  subjectMeta: SubjectMeta;
   onSubmit: FilterFormSubmitHandler;
 }
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -5,7 +5,7 @@ import SummaryListItem from '@common/components/SummaryListItem';
 import ResetFormOnPreviousStep from '@common/modules/table-tool/components/ResetFormOnPreviousStep';
 import {
   FilterOption,
-  PublicationSubjectMeta,
+  SubjectMeta,
 } from '@common/services/tableBuilderService';
 import { Dictionary } from '@common/types/util';
 import Yup from '@common/validation/yup';
@@ -27,7 +27,7 @@ export type LocationFiltersFormSubmitHandler = (values: {
 }) => void;
 
 interface Props {
-  options: PublicationSubjectMeta['locations'];
+  options: SubjectMeta['locations'];
   initialValues?: Dictionary<string[]>;
   onSubmit: LocationFiltersFormSubmitHandler;
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -25,7 +25,7 @@ import parseYearCodeTuple from '@common/modules/table-tool/utils/parseYearCodeTu
 import logger from '@common/services/logger';
 import tableBuilderService, {
   PublicationSubject,
-  PublicationSubjectMeta,
+  SubjectMeta,
   ReleaseTableDataQuery,
   TableHighlight,
   ThemeMeta,
@@ -49,7 +49,7 @@ interface Publication {
 
 export interface TableToolState {
   initialStep: number;
-  subjectMeta: PublicationSubjectMeta;
+  subjectMeta: SubjectMeta;
   query: ReleaseTableDataQuery;
   response?: {
     table: FullTable;
@@ -162,7 +162,7 @@ const TableToolWizard = ({
   const handlePublicationSubjectFormSubmit: PublicationSubjectFormSubmitHandler = async ({
     subjectId: selectedSubjectId,
   }) => {
-    const nextSubjectMeta = await tableBuilderService.getPublicationSubjectMeta(
+    const nextSubjectMeta = await tableBuilderService.getSubjectMeta(
       selectedSubjectId,
     );
 
@@ -176,9 +176,7 @@ const TableToolWizard = ({
   const handleLocationStepBack = async () => {
     const { subjectId } = state.query;
 
-    const nextSubjectMeta = await tableBuilderService.getPublicationSubjectMeta(
-      subjectId,
-    );
+    const nextSubjectMeta = await tableBuilderService.getSubjectMeta(subjectId);
 
     updateState(draft => {
       draft.subjectMeta = nextSubjectMeta;
@@ -188,12 +186,10 @@ const TableToolWizard = ({
   const handleLocationFiltersFormSubmit: LocationFiltersFormSubmitHandler = async ({
     locations,
   }) => {
-    const nextSubjectMeta = await tableBuilderService.filterPublicationSubjectMeta(
-      {
-        locations,
-        subjectId: state.query.subjectId,
-      },
-    );
+    const nextSubjectMeta = await tableBuilderService.filterSubjectMeta({
+      locations,
+      subjectId: state.query.subjectId,
+    });
 
     updateState(draft => {
       draft.subjectMeta.timePeriod = nextSubjectMeta.timePeriod;
@@ -205,12 +201,10 @@ const TableToolWizard = ({
   const handleTimePeriodStepBack = async () => {
     const { subjectId, locations } = state.query;
 
-    const nextSubjectMeta = await tableBuilderService.filterPublicationSubjectMeta(
-      {
-        subjectId,
-        locations,
-      },
-    );
+    const nextSubjectMeta = await tableBuilderService.filterSubjectMeta({
+      subjectId,
+      locations,
+    });
 
     updateState(draft => {
       draft.subjectMeta.timePeriod = nextSubjectMeta.timePeriod;
@@ -221,18 +215,16 @@ const TableToolWizard = ({
     const [startYear, startCode] = parseYearCodeTuple(values.start);
     const [endYear, endCode] = parseYearCodeTuple(values.end);
 
-    const nextSubjectMeta = await tableBuilderService.filterPublicationSubjectMeta(
-      {
-        ...state.query,
-        subjectId: state.query.subjectId,
-        timePeriod: {
-          startYear,
-          startCode,
-          endYear,
-          endCode,
-        },
+    const nextSubjectMeta = await tableBuilderService.filterSubjectMeta({
+      ...state.query,
+      subjectId: state.query.subjectId,
+      timePeriod: {
+        startYear,
+        startCode,
+        endYear,
+        endCode,
       },
-    );
+    });
 
     updateState(draft => {
       draft.subjectMeta.indicators = nextSubjectMeta.indicators;
@@ -250,13 +242,11 @@ const TableToolWizard = ({
   const handleFiltersStepBack = async () => {
     const { subjectId, locations, timePeriod } = state.query;
 
-    const nextSubjectMeta = await tableBuilderService.filterPublicationSubjectMeta(
-      {
-        subjectId,
-        locations,
-        timePeriod,
-      },
-    );
+    const nextSubjectMeta = await tableBuilderService.filterSubjectMeta({
+      subjectId,
+      locations,
+      timePeriod,
+    });
 
     updateState(draft => {
       draft.subjectMeta.indicators = nextSubjectMeta.indicators;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -1,4 +1,5 @@
 import { ConfirmContextProvider } from '@common/contexts/ConfirmContext';
+import useMounted from '@common/hooks/useMounted';
 import FiltersForm, {
   FilterFormSubmitHandler,
 } from '@common/modules/table-tool/components/FiltersForm';
@@ -25,20 +26,14 @@ import parseYearCodeTuple from '@common/modules/table-tool/utils/parseYearCodeTu
 import logger from '@common/services/logger';
 import tableBuilderService, {
   PublicationSubject,
-  SubjectMeta,
   ReleaseTableDataQuery,
+  SubjectMeta,
   TableHighlight,
   ThemeMeta,
 } from '@common/services/tableBuilderService';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
-import React, {
-  ReactElement,
-  ReactNode,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { ReactElement, ReactNode, useMemo, useState } from 'react';
 import { useImmer } from 'use-immer';
 
 interface Publication {
@@ -112,8 +107,12 @@ const TableToolWizard = ({
       .find(option => option.id === state.query.publicationId);
   }, [state.query.publicationId, themeMeta]);
 
-  useEffect(() => {
-    const { releaseId, publicationId } = state.query;
+  useMounted(() => {
+    if (!initialState?.query) {
+      return;
+    }
+
+    const { releaseId, publicationId } = initialState.query;
 
     if (releaseId) {
       tableBuilderService
@@ -143,7 +142,7 @@ const TableToolWizard = ({
           }
         });
     }
-  }, [state.query]);
+  });
 
   const handlePublicationFormSubmit: PublicationFormSubmitHandler = async ({
     publicationId: selectedPublicationId,
@@ -153,6 +152,7 @@ const TableToolWizard = ({
     );
 
     setSubjects(publicationMeta.subjects);
+    setHighlights(publicationMeta.highlights);
 
     updateState(draft => {
       draft.query.publicationId = selectedPublicationId;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -42,14 +42,19 @@ interface Publication {
   slug: string;
 }
 
-export interface TableToolState {
+export interface InitialTableToolState {
   initialStep: number;
-  subjectMeta: SubjectMeta;
-  query: ReleaseTableDataQuery;
+  subjectMeta?: SubjectMeta;
+  query?: ReleaseTableDataQuery;
   response?: {
     table: FullTable;
     tableHeaders: TableHeadersConfig;
   };
+}
+
+interface TableToolState extends InitialTableToolState {
+  subjectMeta: SubjectMeta;
+  query: ReleaseTableDataQuery;
 }
 
 export interface FinalStepRenderProps {
@@ -63,7 +68,7 @@ export interface FinalStepRenderProps {
 
 export interface TableToolWizardProps {
   themeMeta: ThemeMeta[];
-  initialState?: Partial<TableToolState>;
+  initialState?: Partial<InitialTableToolState>;
   finalStep?: (props: FinalStepRenderProps) => ReactElement;
   renderHighlights?: (highlights: TableHighlight[]) => ReactNode;
   scrollOnMount?: boolean;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
@@ -4,7 +4,7 @@ import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import ResetFormOnPreviousStep from '@common/modules/table-tool/components/ResetFormOnPreviousStep';
 import {
-  PublicationSubjectMeta,
+  SubjectMeta,
   TimePeriodQuery,
 } from '@common/services/tableBuilderService';
 import Yup from '@common/validation/yup';
@@ -22,7 +22,7 @@ interface FormValues {
 export type TimePeriodFormSubmitHandler = (values: FormValues) => void;
 
 interface Props {
-  options: PublicationSubjectMeta['timePeriod']['options'];
+  options: SubjectMeta['timePeriod']['options'];
   initialValues?: { timePeriod?: TimePeriodQuery };
   onSubmit: TimePeriodFormSubmitHandler;
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FiltersForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FiltersForm.test.tsx
@@ -1,6 +1,6 @@
 import FiltersForm from '@common/modules/table-tool/components/FiltersForm';
 import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
-import { PublicationSubjectMeta } from '@common/services/tableBuilderService';
+import { SubjectMeta } from '@common/services/tableBuilderService';
 import { waitFor } from '@testing-library/dom';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -8,7 +8,7 @@ import noop from 'lodash/noop';
 import React from 'react';
 
 describe('FiltersForm', () => {
-  const testSubjectMeta: PublicationSubjectMeta = {
+  const testSubjectMeta: SubjectMeta = {
     filters: {
       SchoolType: {
         totalValue: '',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -1,8 +1,6 @@
 import TableToolWizard from '@common/modules/table-tool/components/TableToolWizard';
 import _tableBuilderService, {
-  PublicationMeta,
   SubjectMeta,
-  ReleaseMeta,
   ThemeMeta,
 } from '@common/services/tableBuilderService';
 import { within } from '@testing-library/dom';
@@ -136,20 +134,17 @@ describe('TableToolWizard', () => {
   });
 
   test('renders fetched publication subjects if `initialState.query.publicationId` set', async () => {
-    tableBuilderService.getPublicationMeta.mockImplementation(() =>
-      Promise.resolve<PublicationMeta>({
-        publicationId: 'publication-1',
-        subjects: [{ id: 'subject-1', label: 'Subject 1' }],
-        highlights: [],
-      }),
-    );
+    tableBuilderService.getPublicationMeta.mockResolvedValue({
+      publicationId: 'publication-1',
+      subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+      highlights: [],
+    });
 
     render(
       <TableToolWizard
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 2,
-          subjectMeta: testSubjectMeta,
           query: {
             publicationId: 'publication-1',
             subjectId: '',
@@ -171,19 +166,16 @@ describe('TableToolWizard', () => {
   });
 
   test('does not render publication step if `initialState.query.releaseId` is set', async () => {
-    tableBuilderService.getReleaseMeta.mockImplementation(() =>
-      Promise.resolve<ReleaseMeta>({
-        releaseId: 'release-1',
-        subjects: [{ id: 'subject-2', label: 'Subject 2' }],
-      }),
-    );
+    tableBuilderService.getReleaseMeta.mockResolvedValue({
+      releaseId: 'release-1',
+      subjects: [{ id: 'subject-2', label: 'Subject 2' }],
+    });
 
     render(
       <TableToolWizard
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 1,
-          subjectMeta: testSubjectMeta,
           query: {
             subjectId: '',
             releaseId: 'release-1',
@@ -206,27 +198,22 @@ describe('TableToolWizard', () => {
   });
 
   test('renders fetched publication release subjects if `initialState.query.releaseId` is set', async () => {
-    tableBuilderService.getPublicationMeta.mockImplementation(() =>
-      Promise.resolve<PublicationMeta>({
-        publicationId: 'publication-1',
-        subjects: [{ id: 'subject-1', label: 'Subject 1' }],
-        highlights: [],
-      }),
-    );
+    tableBuilderService.getPublicationMeta.mockResolvedValue({
+      publicationId: 'publication-1',
+      subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+      highlights: [],
+    });
 
-    tableBuilderService.getReleaseMeta.mockImplementation(() =>
-      Promise.resolve<ReleaseMeta>({
-        releaseId: 'release-1',
-        subjects: [{ id: 'subject-2', label: 'Subject 2' }],
-      }),
-    );
+    tableBuilderService.getReleaseMeta.mockResolvedValue({
+      releaseId: 'release-1',
+      subjects: [{ id: 'subject-2', label: 'Subject 2' }],
+    });
 
     render(
       <TableToolWizard
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 1,
-          subjectMeta: testSubjectMeta,
           query: {
             publicationId: 'publication-1',
             releaseId: 'release-1',
@@ -251,24 +238,21 @@ describe('TableToolWizard', () => {
   });
 
   test('renders table highlights on step 2 when it is the current step', async () => {
-    tableBuilderService.getPublicationMeta.mockImplementation(() =>
-      Promise.resolve<PublicationMeta>({
-        publicationId: 'publication-1',
-        subjects: [{ id: 'subject-1', label: 'Subject 1' }],
-        highlights: [
-          { id: 'highlight-1', label: 'Test highlight 1' },
-          { id: 'highlight-2', label: 'Test highlight 2' },
-          { id: 'highlight-3', label: 'Test highlight 3' },
-        ],
-      }),
-    );
+    tableBuilderService.getPublicationMeta.mockResolvedValue({
+      publicationId: 'publication-1',
+      subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+      highlights: [
+        { id: 'highlight-1', label: 'Test highlight 1' },
+        { id: 'highlight-2', label: 'Test highlight 2' },
+        { id: 'highlight-3', label: 'Test highlight 3' },
+      ],
+    });
 
     render(
       <TableToolWizard
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 2,
-          subjectMeta: testSubjectMeta,
           query: {
             publicationId: 'publication-1',
             subjectId: '',
@@ -313,24 +297,21 @@ describe('TableToolWizard', () => {
   });
 
   test('does not render table highlights when step 2 is not the current step', async () => {
-    tableBuilderService.getPublicationMeta.mockImplementation(() =>
-      Promise.resolve<PublicationMeta>({
-        publicationId: 'publication-1',
-        subjects: [{ id: 'subject-1', label: 'Subject 1' }],
-        highlights: [
-          { id: 'highlight-1', label: 'Test highlight 1' },
-          { id: 'highlight-2', label: 'Test highlight 2' },
-          { id: 'highlight-3', label: 'Test highlight 3' },
-        ],
-      }),
-    );
+    tableBuilderService.getPublicationMeta.mockResolvedValue({
+      publicationId: 'publication-1',
+      subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+      highlights: [
+        { id: 'highlight-1', label: 'Test highlight 1' },
+        { id: 'highlight-2', label: 'Test highlight 2' },
+        { id: 'highlight-3', label: 'Test highlight 3' },
+      ],
+    });
 
     render(
       <TableToolWizard
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 3,
-          subjectMeta: testSubjectMeta,
           query: {
             publicationId: 'publication-1',
             subjectId: 'subject-1',
@@ -366,13 +347,11 @@ describe('TableToolWizard', () => {
   });
 
   test('renders all steps correctly when full `initialState` is provided', async () => {
-    tableBuilderService.getPublicationMeta.mockImplementation(() =>
-      Promise.resolve<PublicationMeta>({
-        publicationId: 'publication-1',
-        subjects: [{ id: 'subject-1', label: 'Subject 1' }],
-        highlights: [],
-      }),
-    );
+    tableBuilderService.getPublicationMeta.mockResolvedValue({
+      publicationId: 'publication-1',
+      subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+      highlights: [],
+    });
 
     render(
       <TableToolWizard

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -1,7 +1,7 @@
 import TableToolWizard from '@common/modules/table-tool/components/TableToolWizard';
 import _tableBuilderService, {
   PublicationMeta,
-  PublicationSubjectMeta,
+  SubjectMeta,
   ReleaseMeta,
   ThemeMeta,
 } from '@common/services/tableBuilderService';
@@ -38,7 +38,7 @@ describe('TableToolWizard', () => {
     },
   ];
 
-  const testSubjectMeta: PublicationSubjectMeta = {
+  const testSubjectMeta: SubjectMeta = {
     filters: {
       Characteristic: {
         totalValue: '',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/getInitialStepSubjectMeta.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/getInitialStepSubjectMeta.test.ts
@@ -1,0 +1,675 @@
+import getInitialStepSubjectMeta, {
+  InitialStepSubjectMeta,
+} from '@common/modules/table-tool/components/utils/getInitialStepSubjectMeta';
+import _tableBuilderService, {
+  ReleaseTableDataQuery,
+  SubjectMeta,
+} from '@common/services/tableBuilderService';
+
+jest.mock('@common/services/tableBuilderService');
+
+const tableBuilderService = _tableBuilderService as jest.Mocked<
+  typeof _tableBuilderService
+>;
+
+describe('getInitialStepSubjectMeta', () => {
+  test('returns `initialStep` of 1 when query does not have a `releaseId`', async () => {
+    const query: ReleaseTableDataQuery = {
+      subjectId: '',
+      filters: [],
+      indicators: [],
+      locations: {},
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 1,
+    });
+  });
+
+  test('returns `initialStep` of 2 when query does not have a `subjectId`', async () => {
+    const query: ReleaseTableDataQuery = {
+      releaseId: 'release-1',
+      subjectId: '',
+      filters: [],
+      indicators: [],
+      locations: {},
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 2,
+    });
+  });
+
+  test('returns `initialStep` of 3 when query has no locations', async () => {
+    const subjectMeta: SubjectMeta = {
+      locations: {
+        country: {
+          legend: 'Country',
+          options: [{ value: 'england', label: 'England' }],
+        },
+        localAuthority: {
+          legend: 'Local authority',
+          options: [{ value: 'sheffield', label: 'Sheffield' }],
+        },
+      },
+      timePeriod: {
+        legend: 'Time period',
+        hint: '',
+        options: [],
+      },
+      indicators: {},
+      filters: {},
+    };
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
+
+    const query: ReleaseTableDataQuery = {
+      releaseId: 'release-1',
+      subjectId: 'subject-1',
+      locations: {},
+      indicators: [],
+      filters: [],
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 3,
+      subjectMeta,
+    });
+
+    expect(tableBuilderService.getSubjectMeta).toHaveBeenCalledWith(
+      'subject-1',
+    );
+  });
+
+  test('returns `initialStep` of 3 when query has locations and there are none in subject meta', async () => {
+    const subjectMeta: SubjectMeta = {
+      locations: {},
+      timePeriod: {
+        legend: 'Time period',
+        hint: '',
+        options: [],
+      },
+      indicators: {},
+      filters: {},
+    };
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
+
+    const query: ReleaseTableDataQuery = {
+      releaseId: 'release-1',
+      subjectId: 'subject-1',
+      locations: {
+        country: ['england'],
+      },
+      indicators: [],
+      filters: [],
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 3,
+      subjectMeta,
+    });
+
+    expect(tableBuilderService.getSubjectMeta).toHaveBeenCalledWith(
+      'subject-1',
+    );
+  });
+
+  test('returns `initialStep` of 3 when query has locations and some are missing from subject meta', async () => {
+    const subjectMeta: SubjectMeta = {
+      locations: {
+        country: {
+          legend: 'Country',
+          options: [{ value: 'england', label: 'England' }],
+        },
+        localAuthority: {
+          legend: 'Local authority',
+          options: [{ value: 'sheffield', label: 'Sheffield' }],
+        },
+      },
+      timePeriod: {
+        legend: 'Time period',
+        hint: '',
+        options: [],
+      },
+      indicators: {},
+      filters: {},
+    };
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
+
+    const query: ReleaseTableDataQuery = {
+      releaseId: 'release-1',
+      subjectId: 'subject-1',
+      locations: {
+        country: ['england'],
+        localAuthority: ['sheffield', 'barnsley'],
+      },
+      indicators: [],
+      filters: [],
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 3,
+      subjectMeta,
+    });
+
+    expect(tableBuilderService.getSubjectMeta).toHaveBeenCalledWith(
+      'subject-1',
+    );
+  });
+
+  test('returns `initialStep` of 4 when query has no time periods', async () => {
+    const subjectMeta: SubjectMeta = {
+      locations: {
+        country: {
+          legend: 'Country',
+          options: [{ value: 'england', label: 'England' }],
+        },
+      },
+      timePeriod: {
+        legend: 'Time period',
+        hint: '',
+        options: [],
+      },
+      indicators: {},
+      filters: {},
+    };
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
+
+    const query: ReleaseTableDataQuery = {
+      releaseId: 'release-1',
+      subjectId: 'subject-1',
+      locations: {
+        country: ['england'],
+      },
+      indicators: [],
+      filters: [],
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 4,
+      subjectMeta,
+    });
+
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(1);
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
+      subjectId: 'subject-1',
+      locations: query.locations,
+    });
+  });
+
+  test('returns `initialStep` of 4 when query has time periods and there are none in subject meta', async () => {
+    const subjectMeta: SubjectMeta = {
+      locations: {
+        country: {
+          legend: 'Country',
+          options: [{ value: 'england', label: 'England' }],
+        },
+      },
+      timePeriod: {
+        legend: 'Time period',
+        hint: '',
+        options: [],
+      },
+      indicators: {},
+      filters: {},
+    };
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
+
+    const query: ReleaseTableDataQuery = {
+      releaseId: 'release-1',
+      subjectId: 'subject-1',
+      locations: {
+        country: ['england'],
+      },
+      timePeriod: {
+        startYear: 2016,
+        startCode: 'AY',
+        endYear: 2020,
+        endCode: 'AY',
+      },
+      indicators: [],
+      filters: [],
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 4,
+      subjectMeta,
+    });
+
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(1);
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
+      subjectId: 'subject-1',
+      locations: query.locations,
+    });
+  });
+
+  test('returns `initialStep` of 4 when query has time periods and some are missing from subject meta', async () => {
+    const subjectMeta: SubjectMeta = {
+      locations: {
+        country: {
+          legend: 'Country',
+          options: [{ value: 'england', label: 'England' }],
+        },
+      },
+      timePeriod: {
+        legend: 'Time period',
+        hint: '',
+        options: [
+          { year: 2018, code: 'AY', label: '2018' },
+          { year: 2019, code: 'AY', label: '2019' },
+          { year: 2020, code: 'AY', label: '2020' },
+        ],
+      },
+      indicators: {},
+      filters: {},
+    };
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
+
+    const query: ReleaseTableDataQuery = {
+      releaseId: 'release-1',
+      subjectId: 'subject-1',
+      locations: {
+        country: ['england'],
+      },
+      timePeriod: {
+        startYear: 2016,
+        startCode: 'AY',
+        endYear: 2020,
+        endCode: 'AY',
+      },
+      indicators: [],
+      filters: [],
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 4,
+      subjectMeta,
+    });
+
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(1);
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
+      subjectId: 'subject-1',
+      locations: query.locations,
+    });
+  });
+
+  test('returns `initialStep` of 5 when query has indicators and there are none in subject meta', async () => {
+    const subjectMeta: SubjectMeta = {
+      locations: {
+        country: {
+          legend: 'Country',
+          options: [{ value: 'england', label: 'England' }],
+        },
+      },
+      timePeriod: {
+        legend: 'Time period',
+        hint: '',
+        options: [
+          { year: 2018, code: 'AY', label: '2018' },
+          { year: 2019, code: 'AY', label: '2019' },
+          { year: 2020, code: 'AY', label: '2020' },
+        ],
+      },
+      indicators: {},
+      filters: {},
+    };
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
+
+    const query: ReleaseTableDataQuery = {
+      releaseId: 'release-1',
+      subjectId: 'subject-1',
+      locations: {
+        country: ['england'],
+      },
+      timePeriod: {
+        startYear: 2018,
+        startCode: 'AY',
+        endYear: 2020,
+        endCode: 'AY',
+      },
+      indicators: ['indicator-1', 'indicator-2'],
+      filters: [],
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 5,
+      subjectMeta,
+    });
+
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(2);
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
+      subjectId: 'subject-1',
+      locations: query.locations,
+    });
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
+      subjectId: 'subject-1',
+      locations: query.locations,
+      timePeriod: query.timePeriod,
+    });
+  });
+
+  test('returns `initialStep` of 5 when query has indicators and some are missing from subject meta', async () => {
+    const subjectMeta: SubjectMeta = {
+      locations: {
+        country: {
+          legend: 'Country',
+          options: [{ value: 'england', label: 'England' }],
+        },
+      },
+      timePeriod: {
+        legend: 'Time period',
+        hint: '',
+        options: [
+          { year: 2018, code: 'AY', label: '2018' },
+          { year: 2019, code: 'AY', label: '2019' },
+          { year: 2020, code: 'AY', label: '2020' },
+        ],
+      },
+      indicators: {
+        indicatorGroup1: {
+          label: 'Indicator group 1',
+          options: [
+            {
+              label: 'Indicator 1',
+              value: 'indicator-1',
+              unit: '',
+              name: 'indicator_1',
+            },
+          ],
+        },
+      },
+      filters: {},
+    };
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
+
+    const query: ReleaseTableDataQuery = {
+      releaseId: 'release-1',
+      subjectId: 'subject-1',
+      locations: {
+        country: ['england'],
+      },
+      timePeriod: {
+        startYear: 2018,
+        startCode: 'AY',
+        endYear: 2020,
+        endCode: 'AY',
+      },
+      indicators: ['indicator-1', 'indicator-2'],
+      filters: [],
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 5,
+      subjectMeta,
+    });
+
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(2);
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
+      subjectId: 'subject-1',
+      locations: query.locations,
+    });
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
+      subjectId: 'subject-1',
+      locations: query.locations,
+      timePeriod: query.timePeriod,
+    });
+  });
+
+  test('returns `initialStep` of 5 when query has filters and there are none in subject meta', async () => {
+    const subjectMeta: SubjectMeta = {
+      locations: {
+        country: {
+          legend: 'Country',
+          options: [{ value: 'england', label: 'England' }],
+        },
+      },
+      timePeriod: {
+        legend: 'Time period',
+        hint: '',
+        options: [
+          { year: 2018, code: 'AY', label: '2018' },
+          { year: 2019, code: 'AY', label: '2019' },
+          { year: 2020, code: 'AY', label: '2020' },
+        ],
+      },
+      indicators: {
+        indicatorGroup1: {
+          label: 'Indicator group 1',
+          options: [
+            {
+              label: 'Indicator 1',
+              value: 'indicator-1',
+              unit: '',
+              name: 'indicator_1',
+            },
+          ],
+        },
+      },
+      filters: {},
+    };
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
+
+    const query: ReleaseTableDataQuery = {
+      releaseId: 'release-1',
+      subjectId: 'subject-1',
+      locations: {
+        country: ['england'],
+      },
+      timePeriod: {
+        startYear: 2018,
+        startCode: 'AY',
+        endYear: 2020,
+        endCode: 'AY',
+      },
+      indicators: ['indicator-1'],
+      filters: ['filter-1', 'filter-2'],
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 5,
+      subjectMeta,
+    });
+
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(2);
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
+      subjectId: 'subject-1',
+      locations: query.locations,
+    });
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
+      subjectId: 'subject-1',
+      locations: query.locations,
+      timePeriod: query.timePeriod,
+    });
+  });
+
+  test('returns `initialStep` of 5 when query has filters and some are missing from subject meta', async () => {
+    const subjectMeta: SubjectMeta = {
+      locations: {
+        country: {
+          legend: 'Country',
+          options: [{ value: 'england', label: 'England' }],
+        },
+      },
+      timePeriod: {
+        legend: 'Time period',
+        hint: '',
+        options: [
+          { year: 2018, code: 'AY', label: '2018' },
+          { year: 2019, code: 'AY', label: '2019' },
+          { year: 2020, code: 'AY', label: '2020' },
+        ],
+      },
+      indicators: {
+        indicatorGroup1: {
+          label: 'Indicator group 1',
+          options: [
+            {
+              label: 'Indicator 1',
+              value: 'indicator-1',
+              unit: '',
+              name: 'indicator_1',
+            },
+          ],
+        },
+      },
+      filters: {
+        filter1: {
+          legend: 'Filter 1',
+          hint: '',
+          name: 'filter_1',
+          options: {
+            filterGroup1: {
+              label: 'Filter Group 1',
+              options: [{ value: 'filter-item-1', label: 'Filter item 1' }],
+            },
+          },
+        },
+      },
+    };
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
+
+    const query: ReleaseTableDataQuery = {
+      releaseId: 'release-1',
+      subjectId: 'subject-1',
+      locations: {
+        country: ['england'],
+      },
+      timePeriod: {
+        startYear: 2018,
+        startCode: 'AY',
+        endYear: 2020,
+        endCode: 'AY',
+      },
+      indicators: ['indicator-1'],
+      filters: ['filter-item-1', 'filter-item-2'],
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 5,
+      subjectMeta,
+    });
+
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(2);
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
+      subjectId: 'subject-1',
+      locations: query.locations,
+    });
+    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
+      subjectId: 'subject-1',
+      locations: query.locations,
+      timePeriod: query.timePeriod,
+    });
+  });
+
+  test('returns `initialStep` of 6 when entire query is valid', async () => {
+    const subjectMeta: SubjectMeta = {
+      locations: {
+        country: {
+          legend: 'Country',
+          options: [{ value: 'england', label: 'England' }],
+        },
+      },
+      timePeriod: {
+        legend: 'Time period',
+        hint: '',
+        options: [
+          { year: 2018, code: 'AY', label: '2018' },
+          { year: 2019, code: 'AY', label: '2019' },
+          { year: 2020, code: 'AY', label: '2020' },
+        ],
+      },
+      indicators: {
+        indicatorGroup1: {
+          label: 'Indicator group 1',
+          options: [
+            {
+              label: 'Indicator 1',
+              value: 'indicator-1',
+              unit: '',
+              name: 'indicator_1',
+            },
+          ],
+        },
+      },
+      filters: {
+        filter1: {
+          legend: 'Filter 1',
+          hint: '',
+          name: 'filter_1',
+          options: {
+            filterGroup1: {
+              label: 'Filter Group 1',
+              options: [{ value: 'filter-item-1', label: 'Filter item 1' }],
+            },
+          },
+        },
+      },
+    };
+
+    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
+
+    const query: ReleaseTableDataQuery = {
+      releaseId: 'release-1',
+      subjectId: 'subject-1',
+      locations: {
+        country: ['england'],
+      },
+      timePeriod: {
+        startYear: 2018,
+        startCode: 'AY',
+        endYear: 2020,
+        endCode: 'AY',
+      },
+      indicators: ['indicator-1'],
+      filters: ['filter-item-1'],
+    };
+
+    expect(await getInitialStepSubjectMeta(query)).toEqual<
+      InitialStepSubjectMeta
+    >({
+      initialStep: 6,
+      subjectMeta,
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/getInitialStepSubjectMeta.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/getInitialStepSubjectMeta.test.ts
@@ -4,6 +4,7 @@ import getInitialStepSubjectMeta, {
 import _tableBuilderService, {
   ReleaseTableDataQuery,
   SubjectMeta,
+  TableDataResponse,
 } from '@common/services/tableBuilderService';
 
 jest.mock('@common/services/tableBuilderService');
@@ -87,7 +88,7 @@ describe('getInitialStepSubjectMeta', () => {
     );
   });
 
-  test('returns `initialStep` of 3 when query has locations and there are none in subject meta', async () => {
+  test('returns `initialStep` of 3 when table data has not been provided', async () => {
     const subjectMeta: SubjectMeta = {
       locations: {},
       timePeriod: {
@@ -123,7 +124,7 @@ describe('getInitialStepSubjectMeta', () => {
     );
   });
 
-  test('returns `initialStep` of 3 when query has locations and some are missing from subject meta', async () => {
+  test('returns `initialStep` of 3 when table data does not have any results', async () => {
     const subjectMeta: SubjectMeta = {
       locations: {
         country: {
@@ -157,7 +158,22 @@ describe('getInitialStepSubjectMeta', () => {
       filters: [],
     };
 
-    expect(await getInitialStepSubjectMeta(query)).toEqual<
+    const tableData: TableDataResponse = {
+      results: [],
+      subjectMeta: {
+        publicationName: 'Test publication',
+        subjectName: 'Test subject',
+        geoJsonAvailable: false,
+        footnotes: [],
+        boundaryLevels: [],
+        locations: [],
+        timePeriodRange: [],
+        indicators: [],
+        filters: {},
+      },
+    };
+
+    expect(await getInitialStepSubjectMeta(query, tableData)).toEqual<
       InitialStepSubjectMeta
     >({
       initialStep: 3,
@@ -169,356 +185,7 @@ describe('getInitialStepSubjectMeta', () => {
     );
   });
 
-  test('returns `initialStep` of 4 when query has no time periods', async () => {
-    const subjectMeta: SubjectMeta = {
-      locations: {
-        country: {
-          legend: 'Country',
-          options: [{ value: 'england', label: 'England' }],
-        },
-      },
-      timePeriod: {
-        legend: 'Time period',
-        hint: '',
-        options: [],
-      },
-      indicators: {},
-      filters: {},
-    };
-
-    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
-    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
-
-    const query: ReleaseTableDataQuery = {
-      releaseId: 'release-1',
-      subjectId: 'subject-1',
-      locations: {
-        country: ['england'],
-      },
-      indicators: [],
-      filters: [],
-    };
-
-    expect(await getInitialStepSubjectMeta(query)).toEqual<
-      InitialStepSubjectMeta
-    >({
-      initialStep: 4,
-      subjectMeta,
-    });
-
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(1);
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
-      subjectId: 'subject-1',
-      locations: query.locations,
-    });
-  });
-
-  test('returns `initialStep` of 4 when query has time periods and there are none in subject meta', async () => {
-    const subjectMeta: SubjectMeta = {
-      locations: {
-        country: {
-          legend: 'Country',
-          options: [{ value: 'england', label: 'England' }],
-        },
-      },
-      timePeriod: {
-        legend: 'Time period',
-        hint: '',
-        options: [],
-      },
-      indicators: {},
-      filters: {},
-    };
-
-    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
-    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
-
-    const query: ReleaseTableDataQuery = {
-      releaseId: 'release-1',
-      subjectId: 'subject-1',
-      locations: {
-        country: ['england'],
-      },
-      timePeriod: {
-        startYear: 2016,
-        startCode: 'AY',
-        endYear: 2020,
-        endCode: 'AY',
-      },
-      indicators: [],
-      filters: [],
-    };
-
-    expect(await getInitialStepSubjectMeta(query)).toEqual<
-      InitialStepSubjectMeta
-    >({
-      initialStep: 4,
-      subjectMeta,
-    });
-
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(1);
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
-      subjectId: 'subject-1',
-      locations: query.locations,
-    });
-  });
-
-  test('returns `initialStep` of 4 when query has time periods and some are missing from subject meta', async () => {
-    const subjectMeta: SubjectMeta = {
-      locations: {
-        country: {
-          legend: 'Country',
-          options: [{ value: 'england', label: 'England' }],
-        },
-      },
-      timePeriod: {
-        legend: 'Time period',
-        hint: '',
-        options: [
-          { year: 2018, code: 'AY', label: '2018' },
-          { year: 2019, code: 'AY', label: '2019' },
-          { year: 2020, code: 'AY', label: '2020' },
-        ],
-      },
-      indicators: {},
-      filters: {},
-    };
-
-    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
-    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
-
-    const query: ReleaseTableDataQuery = {
-      releaseId: 'release-1',
-      subjectId: 'subject-1',
-      locations: {
-        country: ['england'],
-      },
-      timePeriod: {
-        startYear: 2016,
-        startCode: 'AY',
-        endYear: 2020,
-        endCode: 'AY',
-      },
-      indicators: [],
-      filters: [],
-    };
-
-    expect(await getInitialStepSubjectMeta(query)).toEqual<
-      InitialStepSubjectMeta
-    >({
-      initialStep: 4,
-      subjectMeta,
-    });
-
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(1);
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
-      subjectId: 'subject-1',
-      locations: query.locations,
-    });
-  });
-
-  test('returns `initialStep` of 5 when query has indicators and there are none in subject meta', async () => {
-    const subjectMeta: SubjectMeta = {
-      locations: {
-        country: {
-          legend: 'Country',
-          options: [{ value: 'england', label: 'England' }],
-        },
-      },
-      timePeriod: {
-        legend: 'Time period',
-        hint: '',
-        options: [
-          { year: 2018, code: 'AY', label: '2018' },
-          { year: 2019, code: 'AY', label: '2019' },
-          { year: 2020, code: 'AY', label: '2020' },
-        ],
-      },
-      indicators: {},
-      filters: {},
-    };
-
-    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
-    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
-
-    const query: ReleaseTableDataQuery = {
-      releaseId: 'release-1',
-      subjectId: 'subject-1',
-      locations: {
-        country: ['england'],
-      },
-      timePeriod: {
-        startYear: 2018,
-        startCode: 'AY',
-        endYear: 2020,
-        endCode: 'AY',
-      },
-      indicators: ['indicator-1', 'indicator-2'],
-      filters: [],
-    };
-
-    expect(await getInitialStepSubjectMeta(query)).toEqual<
-      InitialStepSubjectMeta
-    >({
-      initialStep: 5,
-      subjectMeta,
-    });
-
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(2);
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
-      subjectId: 'subject-1',
-      locations: query.locations,
-    });
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
-      subjectId: 'subject-1',
-      locations: query.locations,
-      timePeriod: query.timePeriod,
-    });
-  });
-
-  test('returns `initialStep` of 5 when query has indicators and some are missing from subject meta', async () => {
-    const subjectMeta: SubjectMeta = {
-      locations: {
-        country: {
-          legend: 'Country',
-          options: [{ value: 'england', label: 'England' }],
-        },
-      },
-      timePeriod: {
-        legend: 'Time period',
-        hint: '',
-        options: [
-          { year: 2018, code: 'AY', label: '2018' },
-          { year: 2019, code: 'AY', label: '2019' },
-          { year: 2020, code: 'AY', label: '2020' },
-        ],
-      },
-      indicators: {
-        indicatorGroup1: {
-          label: 'Indicator group 1',
-          options: [
-            {
-              label: 'Indicator 1',
-              value: 'indicator-1',
-              unit: '',
-              name: 'indicator_1',
-            },
-          ],
-        },
-      },
-      filters: {},
-    };
-
-    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
-    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
-
-    const query: ReleaseTableDataQuery = {
-      releaseId: 'release-1',
-      subjectId: 'subject-1',
-      locations: {
-        country: ['england'],
-      },
-      timePeriod: {
-        startYear: 2018,
-        startCode: 'AY',
-        endYear: 2020,
-        endCode: 'AY',
-      },
-      indicators: ['indicator-1', 'indicator-2'],
-      filters: [],
-    };
-
-    expect(await getInitialStepSubjectMeta(query)).toEqual<
-      InitialStepSubjectMeta
-    >({
-      initialStep: 5,
-      subjectMeta,
-    });
-
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(2);
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
-      subjectId: 'subject-1',
-      locations: query.locations,
-    });
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
-      subjectId: 'subject-1',
-      locations: query.locations,
-      timePeriod: query.timePeriod,
-    });
-  });
-
-  test('returns `initialStep` of 5 when query has filters and there are none in subject meta', async () => {
-    const subjectMeta: SubjectMeta = {
-      locations: {
-        country: {
-          legend: 'Country',
-          options: [{ value: 'england', label: 'England' }],
-        },
-      },
-      timePeriod: {
-        legend: 'Time period',
-        hint: '',
-        options: [
-          { year: 2018, code: 'AY', label: '2018' },
-          { year: 2019, code: 'AY', label: '2019' },
-          { year: 2020, code: 'AY', label: '2020' },
-        ],
-      },
-      indicators: {
-        indicatorGroup1: {
-          label: 'Indicator group 1',
-          options: [
-            {
-              label: 'Indicator 1',
-              value: 'indicator-1',
-              unit: '',
-              name: 'indicator_1',
-            },
-          ],
-        },
-      },
-      filters: {},
-    };
-
-    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
-    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
-
-    const query: ReleaseTableDataQuery = {
-      releaseId: 'release-1',
-      subjectId: 'subject-1',
-      locations: {
-        country: ['england'],
-      },
-      timePeriod: {
-        startYear: 2018,
-        startCode: 'AY',
-        endYear: 2020,
-        endCode: 'AY',
-      },
-      indicators: ['indicator-1'],
-      filters: ['filter-1', 'filter-2'],
-    };
-
-    expect(await getInitialStepSubjectMeta(query)).toEqual<
-      InitialStepSubjectMeta
-    >({
-      initialStep: 5,
-      subjectMeta,
-    });
-
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(2);
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
-      subjectId: 'subject-1',
-      locations: query.locations,
-    });
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
-      subjectId: 'subject-1',
-      locations: query.locations,
-      timePeriod: query.timePeriod,
-    });
-  });
-
-  test('returns `initialStep` of 5 when query has filters and some are missing from subject meta', async () => {
+  test('returns `initialStep` of 6 when table can be rendered', async () => {
     const subjectMeta: SubjectMeta = {
       locations: {
         country: {
@@ -564,90 +231,6 @@ describe('getInitialStepSubjectMeta', () => {
     };
 
     tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
-    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
-
-    const query: ReleaseTableDataQuery = {
-      releaseId: 'release-1',
-      subjectId: 'subject-1',
-      locations: {
-        country: ['england'],
-      },
-      timePeriod: {
-        startYear: 2018,
-        startCode: 'AY',
-        endYear: 2020,
-        endCode: 'AY',
-      },
-      indicators: ['indicator-1'],
-      filters: ['filter-item-1', 'filter-item-2'],
-    };
-
-    expect(await getInitialStepSubjectMeta(query)).toEqual<
-      InitialStepSubjectMeta
-    >({
-      initialStep: 5,
-      subjectMeta,
-    });
-
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledTimes(2);
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
-      subjectId: 'subject-1',
-      locations: query.locations,
-    });
-    expect(tableBuilderService.filterSubjectMeta).toHaveBeenCalledWith({
-      subjectId: 'subject-1',
-      locations: query.locations,
-      timePeriod: query.timePeriod,
-    });
-  });
-
-  test('returns `initialStep` of 6 when entire query is valid', async () => {
-    const subjectMeta: SubjectMeta = {
-      locations: {
-        country: {
-          legend: 'Country',
-          options: [{ value: 'england', label: 'England' }],
-        },
-      },
-      timePeriod: {
-        legend: 'Time period',
-        hint: '',
-        options: [
-          { year: 2018, code: 'AY', label: '2018' },
-          { year: 2019, code: 'AY', label: '2019' },
-          { year: 2020, code: 'AY', label: '2020' },
-        ],
-      },
-      indicators: {
-        indicatorGroup1: {
-          label: 'Indicator group 1',
-          options: [
-            {
-              label: 'Indicator 1',
-              value: 'indicator-1',
-              unit: '',
-              name: 'indicator_1',
-            },
-          ],
-        },
-      },
-      filters: {
-        filter1: {
-          legend: 'Filter 1',
-          hint: '',
-          name: 'filter_1',
-          options: {
-            filterGroup1: {
-              label: 'Filter Group 1',
-              options: [{ value: 'filter-item-1', label: 'Filter item 1' }],
-            },
-          },
-        },
-      },
-    };
-
-    tableBuilderService.getSubjectMeta.mockResolvedValue(subjectMeta);
-    tableBuilderService.filterSubjectMeta.mockResolvedValue(subjectMeta);
 
     const query: ReleaseTableDataQuery = {
       releaseId: 'release-1',
@@ -665,7 +248,56 @@ describe('getInitialStepSubjectMeta', () => {
       filters: ['filter-item-1'],
     };
 
-    expect(await getInitialStepSubjectMeta(query)).toEqual<
+    const tableData: TableDataResponse = {
+      results: [
+        {
+          timePeriod: '2018',
+          measures: {
+            'indicator-1': '123',
+          },
+          location: {
+            country: {
+              name: 'England',
+              code: 'england',
+            },
+          },
+          geographicLevel: 'country',
+          filters: ['filter-item-1'],
+        },
+      ],
+      subjectMeta: {
+        publicationName: 'Test publication',
+        subjectName: 'Test subject',
+        geoJsonAvailable: false,
+        footnotes: [],
+        boundaryLevels: [],
+        locations: [{ value: 'england', level: 'country', label: 'England' }],
+        timePeriodRange: [{ year: 2018, code: 'AY', label: '2018' }],
+        indicators: [
+          {
+            label: 'Indicator 1',
+            value: 'indicator-1',
+            unit: '',
+            name: 'indicator_1',
+          },
+        ],
+        filters: {
+          filter1: {
+            legend: 'Filter 1',
+            hint: '',
+            name: 'filter_1',
+            options: {
+              filterGroup1: {
+                label: 'Filter Group 1',
+                options: [{ value: 'filter-item-1', label: 'Filter item 1' }],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(await getInitialStepSubjectMeta(query, tableData)).toEqual<
       InitialStepSubjectMeta
     >({
       initialStep: 6,

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/getInitialStepSubjectMeta.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/getInitialStepSubjectMeta.ts
@@ -1,0 +1,138 @@
+import tableBuilderService, {
+  ReleaseTableDataQuery,
+  SubjectMeta,
+} from '@common/services/tableBuilderService';
+import pick from 'lodash/pick';
+
+function hasAllLocations(
+  query: ReleaseTableDataQuery,
+  subjectMeta: SubjectMeta,
+) {
+  const locationEntries = Object.entries(query.locations);
+
+  if (locationEntries.length === 0) {
+    return false;
+  }
+
+  return locationEntries.every(([locationLevel, locations]) => {
+    if (locations.length === 0) {
+      return false;
+    }
+
+    return locations.every(locationCode =>
+      subjectMeta.locations[locationLevel]?.options?.find(
+        metaLocation => metaLocation.value === locationCode,
+      ),
+    );
+  });
+}
+
+function hasAllTimePeriods(
+  query: ReleaseTableDataQuery,
+  subjectMeta: SubjectMeta,
+) {
+  if (!query.timePeriod) {
+    return false;
+  }
+
+  return (
+    subjectMeta.timePeriod.options.some(
+      timePeriod =>
+        timePeriod.year === query.timePeriod?.startYear &&
+        timePeriod.code === query.timePeriod?.startCode,
+    ) &&
+    subjectMeta.timePeriod.options.some(
+      timePeriod =>
+        timePeriod.year === query.timePeriod?.endYear &&
+        timePeriod.code === query.timePeriod?.endCode,
+    )
+  );
+}
+
+function hasAllFilters(query: ReleaseTableDataQuery, subjectMeta: SubjectMeta) {
+  const metaFilters = Object.values(subjectMeta.filters)
+    .flatMap(filter => Object.values(filter.options))
+    .flatMap(filterGroup => filterGroup.options)
+    .flatMap(filterItem => filterItem.value);
+
+  return query.filters.every(filter => metaFilters.includes(filter));
+}
+
+function hasAllIndicators(
+  query: ReleaseTableDataQuery,
+  subjectMeta: SubjectMeta,
+) {
+  const metaIndicators = Object.values(subjectMeta.indicators)
+    .flatMap(indicatorGroup => indicatorGroup.options)
+    .map(indicator => indicator.value);
+
+  return query.indicators.every(indicator =>
+    metaIndicators.includes(indicator),
+  );
+}
+
+export interface InitialStepSubjectMeta {
+  initialStep: number;
+  subjectMeta?: SubjectMeta;
+}
+
+/**
+ * Get the initial state for table tool given a {@param query}.
+ * This allows us to partially setup table tool, even when
+ * some of the query options are invalid. The user can then
+ * go back through table tool and pick valid options.
+ */
+export default async function getInitialStepSubjectMeta(
+  query: ReleaseTableDataQuery,
+): Promise<InitialStepSubjectMeta> {
+  if (!query.releaseId) {
+    return {
+      initialStep: 1,
+    };
+  }
+
+  if (!query.subjectId) {
+    return {
+      initialStep: 2,
+    };
+  }
+
+  const subjectMeta = await tableBuilderService.getSubjectMeta(query.subjectId);
+
+  if (!hasAllLocations(query, subjectMeta)) {
+    return {
+      initialStep: 3,
+      subjectMeta,
+    };
+  }
+
+  let filteredSubjectMeta = await tableBuilderService.filterSubjectMeta(
+    pick(query, ['subjectId', 'locations']),
+  );
+
+  if (!hasAllTimePeriods(query, filteredSubjectMeta)) {
+    return {
+      initialStep: 4,
+      subjectMeta,
+    };
+  }
+
+  filteredSubjectMeta = await tableBuilderService.filterSubjectMeta(
+    pick(query, ['subjectId', 'locations', 'timePeriod']),
+  );
+
+  if (
+    !hasAllIndicators(query, filteredSubjectMeta) ||
+    !hasAllFilters(query, filteredSubjectMeta)
+  ) {
+    return {
+      initialStep: 5,
+      subjectMeta,
+    };
+  }
+
+  return {
+    initialStep: 6,
+    subjectMeta,
+  };
+}

--- a/src/explore-education-statistics-common/src/services/logger.ts
+++ b/src/explore-education-statistics-common/src/services/logger.ts
@@ -19,6 +19,10 @@ const logger = {
     }
   },
   info(message: string) {
+    if (process.env.NODE_ENV === 'test') {
+      return;
+    }
+
     console.info(message);
 
     getApplicationInsights().trackTrace({
@@ -27,6 +31,10 @@ const logger = {
     });
   },
   warn(message: string) {
+    if (process.env.NODE_ENV === 'test') {
+      return;
+    }
+
     console.warn(message);
 
     getApplicationInsights().trackTrace({
@@ -35,6 +43,10 @@ const logger = {
     });
   },
   error(error: Error) {
+    if (process.env.NODE_ENV === 'test') {
+      return;
+    }
+
     console.error(error);
 
     getApplicationInsights().trackException({

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -95,7 +95,7 @@ export interface ReleaseMeta {
   subjects: PublicationSubject[];
 }
 
-export interface PublicationSubjectMeta {
+export interface SubjectMeta {
   filters: Dictionary<{
     legend: string;
     hint?: string;
@@ -189,17 +189,15 @@ const tableBuilderService = {
   getReleaseMeta(releaseId: string): Promise<ReleaseMeta> {
     return dataApi.get(`/meta/release/${releaseId}`);
   },
-  getPublicationSubjectMeta(
-    subjectId: string,
-  ): Promise<PublicationSubjectMeta> {
+  getSubjectMeta(subjectId: string): Promise<SubjectMeta> {
     return dataApi.get(`/meta/subject/${subjectId}`);
   },
-  filterPublicationSubjectMeta(query: {
+  filterSubjectMeta(query: {
     subjectId: string;
     timePeriod?: TimePeriodQuery;
     geographicLevel?: string;
     locations?: Dictionary<string[]>;
-  }): Promise<PublicationSubjectMeta> {
+  }): Promise<SubjectMeta> {
     return dataApi.post('/meta/subject', query);
   },
   getTableData(query: ReleaseTableDataQuery): Promise<TableDataResponse> {

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseHelpAndSupportSection.tsx
@@ -17,18 +17,16 @@ interface Props {
   methodologyUrl?: string;
   methodologySummary?: string;
   releaseType?: string;
-  themeTitle: string;
   publicationContact: PublicationContact;
 }
 
-const HelpAndSupport = ({
+const PublicationReleaseHelpAndSupportSection = ({
   accordionId,
   includeAnalytics = false,
   publicationTitle,
   methodologyUrl = '',
   methodologySummary,
   releaseType,
-  themeTitle,
   publicationContact,
 }: Props) => {
   return (
@@ -102,4 +100,4 @@ const AccordionComponent = ({
   );
 };
 
-export default HelpAndSupport;
+export default PublicationReleaseHelpAndSupportSection;

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -18,7 +18,7 @@ import Page from '@frontend/components/Page';
 import PageSearchFormWithAnalytics from '@frontend/components/PageSearchFormWithAnalytics';
 import PrintThisPage from '@frontend/components/PrintThisPage';
 import PublicationSectionBlocks from '@frontend/modules/find-statistics/components/PublicationSectionBlocks';
-import HelpAndSupport from '@frontend/modules/find-statistics/PublicationReleaseHelpAndSupportSection';
+import PublicationReleaseHelpAndSupportSection from '@frontend/modules/find-statistics/PublicationReleaseHelpAndSupportSection';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
 import classNames from 'classnames';
 import { GetServerSideProps, NextPage } from 'next';
@@ -350,12 +350,11 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
         </Accordion>
       )}
 
-      <HelpAndSupport
+      <PublicationReleaseHelpAndSupportSection
         accordionId="help-and-support"
         publicationTitle={data.publication.title}
         methodologyUrl={methodologyUrl}
         methodologySummary={methodologySummary}
-        themeTitle={data.publication.topic.theme.title}
         publicationContact={data.publication.contact}
         releaseType={data.type.title}
       />

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -1,5 +1,5 @@
 import TableToolWizard, {
-  TableToolState,
+  InitialTableToolState,
 } from '@common/modules/table-tool/components/TableToolWizard';
 import WizardStep from '@common/modules/table-tool/components/WizardStep';
 import WizardStepHeading from '@common/modules/table-tool/components/WizardStepHeading';
@@ -36,7 +36,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
   themeMeta,
 }) => {
   const initialTableToolState = useMemo<
-    Partial<TableToolState> | undefined
+    Partial<InitialTableToolState> | undefined
   >(() => {
     if (publicationSlug) {
       const publicationId =

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -7,7 +7,7 @@ import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
 import { FastTrackTable } from '@common/services/fastTrackService';
 import tableBuilderService, {
-  PublicationSubjectMeta,
+  SubjectMeta,
   ThemeMeta,
 } from '@common/services/tableBuilderService';
 import { Dictionary } from '@common/types';
@@ -25,7 +25,7 @@ const TableToolFinalStep = dynamic(() =>
 export interface TableToolPageProps {
   publicationSlug?: string;
   fastTrack?: FastTrackTable;
-  subjectMeta?: PublicationSubjectMeta;
+  subjectMeta?: SubjectMeta;
   themeMeta: ThemeMeta[];
 }
 

--- a/src/explore-education-statistics-frontend/src/pages/data-tables/fast-track/[fastTrackId].tsx
+++ b/src/explore-education-statistics-frontend/src/pages/data-tables/fast-track/[fastTrackId].tsx
@@ -26,7 +26,7 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
     throw new Error('Fast track table does not have `query.subjectId`');
   }
 
-  const subjectMeta = await tableBuilderService.getPublicationSubjectMeta(
+  const subjectMeta = await tableBuilderService.getSubjectMeta(
     fastTrack.query.subjectId,
   );
 


### PR DESCRIPTION
This PR adds the ability for the 'Data blocks' page table tool to initialise from an earlier step when we determine that an empty table could be rendered or the table headers may throw an error. Typically, we will send the user back to the locations step (step 2) when there is such a failure.

This isn't the most optimum solution as it doesn't really tell the user what the problem is, and it doesn't take them to the specific step in table tool to rectify the issue. Unfortunately this solution is quite involved and would require a lot more work. We have decided not to go with this for the time being.

## Other changes

- Fixed `Tabs` not being able to conditionally render its tab sections. This previously meant that all of its child sections would need to be rendered as soon as the parent `Tabs` was. We have now changed this to that we add/remove tabs (and their sections) after the initial render.