### PR TITLE
EES-1457 Delete any replacement file that might exist when deleting an amendment.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -222,7 +222,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void DeleteReleaseAsync()
+        public void DeleteRelease()
         {
             PermissionTestUtil.PolicyCheckBuilder()
                 .ExpectResourceCheckToFail(_release, CanDeleteSpecificRelease)
@@ -230,7 +230,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService =>
                     {
                         var service = BuildReleaseService(userService: userService.Object);
-                        return service.DeleteReleaseAsync(_release.Id);
+                        return service.DeleteRelease(_release.Id);
                     }
                 );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -1420,11 +1420,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
+            var releaseFilesService = new Mock<IReleaseFilesService>(MockBehavior.Strict);
+
+            releaseFilesService.Setup(mock => mock.DeleteAllFiles(release.Id, false)).ReturnsAsync(Unit.Instance);
+
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                var releaseService = BuildReleaseService(context);
+                var releaseService = BuildReleaseService(context,
+                    fileStorageService: releaseFilesService.Object);
 
                 var result = await releaseService.DeleteRelease(release.Id);
+
+                releaseFilesService.Verify(mock =>
+                    mock.DeleteAllFiles(release.Id, false), Times.Once);
+
                 Assert.True(result.IsRight);
 
                 // assert that soft-deleted entities are no longer discoverable by default
@@ -1504,135 +1513,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .First(r => r.Id == anotherUserReleaseInvite.Id);
 
                 Assert.False(retrievedAnotherReleaseInvite.SoftDeleted);
-            }
-        }
-
-        [Fact]
-        public async Task DeleteRelease_DeleteReplacements()
-        {
-            var subject1 = new Subject
-            {
-                Id = Guid.NewGuid()
-            };
-
-            var subject2 = new Subject
-            {
-                Id = Guid.NewGuid()
-            };
-
-            var replacementSubject1 = new Subject
-            {
-                Id = Guid.NewGuid()
-            };
-
-            var replacementSubject2 = new Subject
-            {
-                Id = Guid.NewGuid()
-            };
-
-            var release = new Release();
-
-            var file1 = new ReleaseFileReference
-            {
-                Filename = "data1.csv",
-                ReleaseFileType = ReleaseFileTypes.Data,
-                Release = release,
-                SubjectId = subject1.Id
-            };
-
-            var file2 = new ReleaseFileReference
-            {
-                Filename = "data2.csv",
-                ReleaseFileType = ReleaseFileTypes.Data,
-                Release = release,
-                SubjectId = subject2.Id
-            };
-
-            var replacementFile1 = new ReleaseFileReference
-            {
-                Filename = "replacement1.csv",
-                ReleaseFileType = ReleaseFileTypes.Data,
-                Release = release,
-                SubjectId = replacementSubject1.Id,
-                Replacing = file1
-            };
-
-            file1.ReplacedBy = replacementFile1;
-
-            var replacementFile2 = new ReleaseFileReference
-            {
-                Filename = "replacement2.csv",
-                ReleaseFileType = ReleaseFileTypes.Data,
-                Release = release,
-                SubjectId = replacementSubject2.Id,
-                Replacing = file2
-            };
-
-            file2.ReplacedBy = replacementFile2;
-
-            var releaseFile1 = new ReleaseFile
-            {
-                Release = release,
-                ReleaseFileReference = file1
-            };
-
-            var releaseFile2 = new ReleaseFile
-            {
-                Release = release,
-                ReleaseFileReference = file2
-            };
-
-            var replacementReleaseFile1 = new ReleaseFile
-            {
-                Release = release,
-                ReleaseFileReference = replacementFile1
-            };
-
-            var replacementReleaseFile2 = new ReleaseFile
-            {
-                Release = release,
-                ReleaseFileReference = replacementFile2
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.AddAsync(release);
-                await context.AddRangeAsync(file1, file2, replacementFile1, replacementFile2);
-                await context.AddRangeAsync(releaseFile1, releaseFile2, replacementReleaseFile1,
-                    replacementReleaseFile2);
-                await context.SaveChangesAsync();
-            }
-
-            var releaseFilesService = new Mock<IReleaseFilesService>(MockBehavior.Strict);
-
-            releaseFilesService
-                .Setup(mock =>
-                    mock.DeleteDataFiles(release.Id, It.IsIn(replacementFile1.Id, replacementFile2.Id), false))
-                .ReturnsAsync(Unit.Instance);
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var releaseService = BuildReleaseService(contentDbContext: context,
-                    fileStorageService: releaseFilesService.Object);
-
-                var result = await releaseService.DeleteRelease(release.Id);
-
-                releaseFilesService.Verify(mock =>
-                    mock.DeleteDataFiles(release.Id, replacementFile1.Id, false), Times.Once);
-
-                releaseFilesService.Verify(mock =>
-                    mock.DeleteDataFiles(release.Id, replacementFile2.Id, false), Times.Once);
-
-                Assert.True(result.IsRight);
-
-                Assert.Null(await context.Releases.FirstOrDefaultAsync(r => r.Id == release.Id));
-
-                Assert.True((await context
-                    .Releases
-                    .IgnoreQueryFilters()
-                    .FirstAsync(r => r.Id == release.Id)).SoftDeleted);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -63,11 +63,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpDelete("release/{releaseId}")]
-        public async Task<ActionResult<ReleaseViewModel>> DeleteReleaseAsync(Guid releaseId)
+        public async Task<ActionResult<ReleaseViewModel>> DeleteRelease(Guid releaseId)
         {
             return await _releaseService
-                .DeleteReleaseAsync(releaseId)
-                .HandleFailuresOr(_ => NoContent());
+                .DeleteRelease(releaseId)
+                .HandleFailuresOrNoContent();
         }
 
         [HttpPost("release/{releaseId}/amendment")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -13,7 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     {
         Task<Either<ActionResult, ReleaseViewModel>> CreateReleaseAsync(CreateReleaseViewModel release);
 
-        Task<Either<ActionResult, bool>> DeleteReleaseAsync(Guid releaseId);
+        Task<Either<ActionResult, Unit>> DeleteRelease(Guid releaseId);
 
         Task<Either<ActionResult, ReleaseViewModel>> CreateReleaseAmendmentAsync(Guid releaseId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -142,26 +142,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return _persistenceHelper
                 .CheckEntityExists<Release>(releaseId)
                 .OnSuccess(_userService.CheckCanDeleteRelease)
-                .OnSuccessDo(async () =>
-                {
-                    // Delete any replacements that might exist
-                    var filesWithReplacements = await _context.ReleaseFiles
-                        .Include(f => f.ReleaseFileReference)
-                        .Where(f => f.ReleaseId == releaseId && f.ReleaseFileReference.ReplacedById.HasValue)
-                        .ToListAsync();
-
-                    foreach (var file in filesWithReplacements)
-                    {
-                        var result = await _releaseFilesService.DeleteDataFiles(releaseId,
-                            file.ReleaseFileReference.ReplacedById.Value);
-                        if (!result.IsRight)
-                        {
-                            return result;
-                        }
-                    }
-
-                    return Unit.Instance;
-                })
+                .OnSuccessDo(async () => await _releaseFilesService.DeleteAllFiles(releaseId))
                 .OnSuccessVoid(async release =>
                 {
                     var roles = await _context


### PR DESCRIPTION
When an amendment is deleted, delete any files including those belonging to incomplete replacements.

Without doing this, the replacement files would still be tracked as replacing their original files.

If the previous Release was amended again the files would show up as having replacements in progress.

We've also been retaining files unnecessarily when cancelling amendments and a new issue has been opened to clean these up and physically delete Releases rather than soft deleting them.