### PR TITLE
EES-214 Add warning message when permalinks are invalidated

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/ViewModels/PermalinkViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/ViewModels/PermalinkViewModel.cs
@@ -10,6 +10,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.ViewModels
 
         public DateTime Created { get; set; }
 
+        public bool Invalidated { get; set; }
+
         public TableBuilderConfiguration Configuration { get; set; }
 
         public TableBuilderResultViewModel FullTable { get; set; }

--- a/src/explore-education-statistics-common/src/components/WarningMessage.module.scss
+++ b/src/explore-education-statistics-common/src/components/WarningMessage.module.scss
@@ -15,3 +15,17 @@
 .text {
   padding-left: govuk-spacing(3);
 }
+
+.error {
+  border: 5px solid $govuk-error-colour;
+  padding: govuk-spacing(4);
+
+  .text {
+    color: $govuk-error-colour;
+  }
+
+  .icon {
+    background: $govuk-error-colour;
+    border-color: $govuk-error-colour;
+  }
+}

--- a/src/explore-education-statistics-common/src/components/WarningMessage.tsx
+++ b/src/explore-education-statistics-common/src/components/WarningMessage.tsx
@@ -5,13 +5,16 @@ import styles from './WarningMessage.module.scss';
 interface Props {
   children: ReactNode;
   className?: string;
+  error?: boolean;
   icon?: string;
 }
 
-const WarningMessage = ({ children, className, icon = '!' }: Props) => {
+const WarningMessage = ({ children, className, error, icon = '!' }: Props) => {
   return (
     <div
-      className={classNames('govuk-warning-text', styles.warning, className)}
+      className={classNames('govuk-warning-text', styles.warning, className, {
+        [styles.error]: error,
+      })}
     >
       <span
         className={classNames('govuk-warning-text__icon', styles.icon)}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.module.scss
@@ -12,6 +12,7 @@
   @include govuk-media-query($from: desktop) {
     figcaption {
       max-width: 66.6%;
+
       @media print {
         max-width: 100%;
       }
@@ -28,31 +29,5 @@
 
   &:focus {
     outline: none;
-  }
-
-  @media print {
-    max-height: none;
-    overflow: visible !important;
-    padding-right: 0;
-    width: auto;
-
-    thead {
-      display: table-row-group;
-    }
-
-    table {
-      break-inside: auto;
-    }
-
-    tr,
-    td {
-      break-after: auto;
-      break-inside: avoid;
-    }
-
-    thead th,
-    thead td {
-      transform: none !important;
-    }
   }
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.module.scss
@@ -9,10 +9,6 @@ $border-width: 1px;
 .table {
   border-collapse: separate;
 
-  @media print {
-    font-size: 0.8rem;
-  }
-
   th:last-child,
   td:last-child {
     padding-right: govuk-spacing(2);
@@ -23,6 +19,33 @@ $border-width: 1px;
     position: relative;
     text-align: left !important;
     z-index: 1;
+  }
+
+  @media print {
+    font-size: 0.8rem;
+    max-height: none;
+    overflow: visible !important;
+    padding-right: 0;
+    width: auto;
+
+    thead {
+      display: table-row-group;
+    }
+
+    table {
+      break-inside: auto;
+    }
+
+    tr,
+    td {
+      break-after: auto;
+      break-inside: avoid;
+    }
+
+    thead th,
+    thead td {
+      transform: none !important;
+    }
   }
 }
 

--- a/src/explore-education-statistics-common/src/services/permalinkService.ts
+++ b/src/explore-education-statistics-common/src/services/permalinkService.ts
@@ -2,7 +2,9 @@ import { dataApi } from '@common/services/api';
 import { TableDataQuery } from '@common/services/tableBuilderService';
 import { ConfiguredTable } from '@common/services/types/table';
 
-export type Permalink = ConfiguredTable;
+export type Permalink = ConfiguredTable & {
+  invalidated: boolean;
+};
 
 export type TableHeader =
   | {

--- a/src/explore-education-statistics-common/src/styles/_layout.scss
+++ b/src/explore-education-statistics-common/src/styles/_layout.scss
@@ -2,9 +2,9 @@
 
 .dfe-width-container--wide {
   max-width: $dfe-page-width-wide;
+
   @media print {
     max-width: none;
-    width: 100%;
   }
 }
 

--- a/src/explore-education-statistics-common/src/styles/utils/_flex.scss
+++ b/src/explore-education-statistics-common/src/styles/utils/_flex.scss
@@ -10,6 +10,10 @@
   justify-content: center;
 }
 
+.dfe-justify-content--space-between {
+  justify-content: space-between;
+}
+
 .dfe-align-items--center {
   align-items: center;
 }

--- a/src/explore-education-statistics-frontend/src/components/PageTitle.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageTitle.tsx
@@ -8,12 +8,13 @@ interface Props {
 const PageTitle = ({ caption, title }: Props) => {
   return (
     <>
+      {caption && (
+        <span className="govuk-caption-xl" data-testid="page-title-caption">
+          {caption}
+        </span>
+      )}
+
       <h1 className="govuk-heading-xl" data-testid={`page-title ${title}`}>
-        {caption && (
-          <span className="govuk-caption-xl" data-testid="page-title-caption">
-            {caption}
-          </span>
-        )}
         {title}
       </h1>
     </>

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -38,26 +38,22 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
         { name: 'Permanent link', link: '/data-tables' },
       ]}
     >
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-two-thirds">
-          <dl className="dfe-meta-content govuk-!-margin-bottom-9">
-            <dt className="govuk-caption-m">Created: </dt>
-            <dd data-testid="created-date">
-              <strong>
-                <FormattedDate>{data.created}</FormattedDate>
-              </strong>
-            </dd>
-          </dl>
-        </div>
-        <div className="govuk-grid-column-one-third">
-          <PrintThisPage
-            className="dfe-align--centre govuk-!-margin-top-0"
-            analytics={{
-              category: 'Page print',
-              action: 'Print this page link selected',
-            }}
-          />
-        </div>
+      <div className="dfe-flex dfe-justify-content--space-between">
+        <dl className="dfe-meta-content">
+          <dt className="govuk-caption-m">Created: </dt>
+          <dd data-testid="created-date">
+            <strong>
+              <FormattedDate>{data.created}</FormattedDate>
+            </strong>
+          </dd>
+        </dl>
+
+        <PrintThisPage
+          analytics={{
+            category: 'Page print',
+            action: 'Print this page link selected',
+          }}
+        />
       </div>
 
       {data.invalidated && (

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -1,4 +1,5 @@
 import FormattedDate from '@common/components/FormattedDate';
+import WarningMessage from '@common/components/WarningMessage';
 import DownloadCsvButton from '@common/modules/table-tool/components/DownloadCsvButton';
 import DownloadExcelButton from '@common/modules/table-tool/components/DownloadExcelButton';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
@@ -58,6 +59,13 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
           />
         </div>
       </div>
+
+      {data.invalidated && (
+        <WarningMessage error>
+          WARNING - The data used in this permalink may be out-of-date.
+        </WarningMessage>
+      )}
+
       <div ref={tableRef}>
         <TimePeriodDataTable
           fullTable={fullTable}

--- a/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/PermalinkPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/PermalinkPage.test.tsx
@@ -1,0 +1,152 @@
+import { Permalink } from '@common/services/permalinkService';
+import PermalinkPage from '@frontend/modules/permalink/PermalinkPage';
+import { render, screen, within } from '@testing-library/react';
+import React from 'react';
+
+describe('PermalinkPage', () => {
+  const testPermalink: Permalink = {
+    id: 'permalink-1',
+    invalidated: false,
+    created: '2020-10-07T12:00:00.00Z',
+    configuration: {
+      tableHeaders: {
+        columnGroups: [[{ type: 'TimePeriod', value: '2020_AY' }]],
+        columns: [{ type: 'Filter', value: 'gender-female' }],
+        rowGroups: [
+          [{ type: 'Location', value: 'barnet', level: 'localAuthority' }],
+        ],
+        rows: [{ type: 'Indicator', value: 'authorised-absence-sessions' }],
+      },
+    },
+    query: {
+      includeGeoJson: false,
+      subjectId: 'subject-1',
+      locations: {
+        localAuthority: ['barnet'],
+      },
+      timePeriod: {
+        startYear: 2020,
+        startCode: 'AY',
+        endYear: 2020,
+        endCode: 'AY',
+      },
+      filters: ['gender-female'],
+      indicators: ['authorised-absence-sessions'],
+    },
+    fullTable: {
+      subjectMeta: {
+        publicationName: 'Test publication',
+        boundaryLevels: [],
+        footnotes: [],
+        subjectName: 'Subject 1',
+        geoJsonAvailable: false,
+        locations: [
+          {
+            level: 'localAuthority',
+            label: 'Barnet',
+            value: 'barnet',
+          },
+        ],
+        timePeriodRange: [{ code: 'AY', year: 2020, label: '2020/21' }],
+        indicators: [
+          {
+            value: 'authorised-absence-sessions',
+            label: 'Number of authorised absence sessions',
+            unit: '',
+            name: 'sess_authorised',
+            decimalPlaces: 2,
+          },
+        ],
+        filters: {
+          Characteristic: {
+            totalValue: '',
+            hint: 'Filter by pupil characteristic',
+            legend: 'Characteristic',
+            name: 'characteristic',
+            options: {
+              Gender: {
+                label: 'Gender',
+                options: [
+                  {
+                    label: 'Gender female',
+                    value: 'gender-female',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      results: [
+        {
+          timePeriod: '2020_AY',
+          measures: {
+            'authorised-absence-sessions': '123',
+          },
+          location: {
+            localAuthority: {
+              name: 'Barnet',
+              code: 'barnet',
+            },
+          },
+          geographicLevel: 'localAuthority',
+          filters: ['gender-female'],
+        },
+      ],
+    },
+  };
+
+  test('renders correctly with permalink', () => {
+    render(<PermalinkPage data={testPermalink} />);
+
+    expect(
+      screen.getByText("'Subject 1' from 'Test publication'", {
+        selector: 'h1',
+      }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('created-date')).toHaveTextContent(
+      '7 October 2020',
+    );
+
+    expect(screen.getByRole('figure')).toHaveTextContent(
+      "Table showing Number of authorised absence sessions for 'Subject 1' from 'Test publication' in Barnet for 2020/21",
+    );
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+
+    const rows = screen.getAllByRole('row');
+
+    expect(rows).toHaveLength(2);
+    expect(within(rows[0]).getByRole('columnheader')).toHaveTextContent(
+      '2020/21',
+    );
+    expect(within(rows[1]).getByRole('rowheader')).toHaveTextContent('Barnet');
+    expect(within(rows[1]).getByRole('cell')).toHaveTextContent('123');
+
+    expect(
+      screen.getByText('Source: Test publication, Subject 1'),
+    ).toBeInTheDocument();
+  });
+
+  test('renders warning message with invalidated permalink', () => {
+    render(
+      <PermalinkPage
+        data={{
+          ...testPermalink,
+          invalidated: true,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        'WARNING - The data used in this permalink may be out-of-date.',
+      ),
+    ).toBeInTheDocument();
+
+    // Table still renders
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getAllByRole('row')).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
This PR adds the following warning message to permalinks when they are invalidated by a data replacement or file deletion in an amendment:

![image](https://user-images.githubusercontent.com/9917868/95445001-6322e200-0956-11eb-8644-6ff6a63b8af4.png)

## Other changes

- Cleaned up various markup and styling across `PermalinkPage`.
- Fixed wide pages being too wide for printing.