### PR TITLE
EES-711 Fix inconsistent dragging behaviour of table headers

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableList.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableList.tsx
@@ -16,7 +16,7 @@ function FormFieldSortableList<FormValues>(props: Props<FormValues>) {
         return (
           <FormSortableList
             {...props}
-            {...field}
+            value={field.value}
             onChange={value => {
               form.setFieldValue(name as string, value);
             }}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.tsx
@@ -1,4 +1,5 @@
 import { FormFieldset } from '@common/components/form';
+import useToggle from '@common/hooks/useToggle';
 import classNames from 'classnames';
 import { useField } from 'formik';
 import React from 'react';
@@ -20,6 +21,7 @@ function FormFieldSortableListGroup<FormValues>({
   groupLegend,
 }: Props<FormValues>) {
   const [field, meta] = useField(name as string);
+  const [isDragDisabled, toggleDragDisabled] = useToggle(false);
 
   return (
     <Droppable droppableId={name as string} direction="horizontal">
@@ -50,6 +52,7 @@ function FormFieldSortableListGroup<FormValues>({
                   // eslint-disable-next-line react/no-array-index-key
                   key={index}
                   draggableId={`${name}-${index}`}
+                  isDragDisabled={isDragDisabled}
                   index={index}
                 >
                   {(draggableProvided, draggableSnapshot) => (
@@ -68,6 +71,8 @@ function FormFieldSortableListGroup<FormValues>({
                         id={`${id}-${index}`}
                         legend={`${groupLegend} ${index + 1}`}
                         legendSize="s"
+                        onMouseEnter={toggleDragDisabled.on}
+                        onMouseLeave={toggleDragDisabled.off}
                       />
                     </div>
                   )}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormSortableList.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormSortableList.tsx
@@ -3,7 +3,7 @@ import { FormFieldsetProps } from '@common/components/form/FormFieldset';
 import { Filter } from '@common/modules/table-tool/types/filters';
 import reorder from '@common/utils/reorder';
 import classNames from 'classnames';
-import React from 'react';
+import React, { MouseEventHandler } from 'react';
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd';
 import styles from './FormSortableList.module.scss';
 
@@ -11,14 +11,21 @@ type SortableOptionChangeEventHandler = (value: Filter[]) => void;
 
 export type FormSortableListProps = {
   onChange?: SortableOptionChangeEventHandler;
+  onMouseEnter?: MouseEventHandler<HTMLDivElement>;
+  onMouseLeave?: MouseEventHandler<HTMLDivElement>;
   value: Filter[];
 } & FormFieldsetProps;
 
-const FormSortableList = (props: FormSortableListProps) => {
-  const { id, onChange, value } = props;
-
+const FormSortableList = ({
+  id,
+  onChange,
+  onMouseEnter,
+  onMouseLeave,
+  value,
+  ...props
+}: FormSortableListProps) => {
   return (
-    <FormFieldset {...props}>
+    <FormFieldset {...props} id={id}>
       <DragDropContext
         onDragEnd={result => {
           if (!result.destination) {
@@ -45,6 +52,8 @@ const FormSortableList = (props: FormSortableListProps) => {
                 [styles.listDraggingOver]: droppableSnapshot.isDraggingOver,
               })}
               ref={droppableProvided.innerRef}
+              onMouseEnter={onMouseEnter}
+              onMouseLeave={onMouseLeave}
             >
               {value.map((option, index) => (
                 <Draggable


### PR DESCRIPTION
This PR fixes inconsistent behaviour when trying to drag table headers. Roughly half the time, the parent table header group (in `FormFieldSortableListGroup`) would be dragged instead of its child table headers (in `FormSortableList`), leading to a sub-optimal user experience.

We simply disable the table header group from being dragged whilst the user's mouse is over any of the table headers.