### PR TITLE
EES-1409 EES-1410 Add API to get and update Meta Guidance for Release and Subjects

### DIFF
--- a/infrastructure/templates/datafactory/components/template.json
+++ b/infrastructure/templates/datafactory/components/template.json
@@ -2371,6 +2371,16 @@
                                             "name": "ReleaseId",
                                             "type": "Guid"
                                         }
+                                    },
+                                    {
+                                        "source": {
+                                            "name": "MetaGuidance",
+                                            "type": "String"
+                                        },
+                                        "sink": {
+                                            "name": "MetaGuidance",
+                                            "type": "String"
+                                        }
                                     }
                                 ]
                             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServicePermissionTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
+{
+    public class MetaGuidanceServicePermissionTests
+    {
+        private readonly Release _release = new Release
+        {
+            Id = Guid.NewGuid()
+        };
+
+        [Fact]
+        public void Get()
+        {
+            PermissionTestUtil.PolicyCheckBuilder()
+                .ExpectResourceCheckToFail(_release, SecurityPolicies.CanViewSpecificRelease)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = SetupMetaGuidanceService(userService: userService.Object);
+                        return service.Get(_release.Id);
+                    }
+                );
+        }
+
+        [Fact]
+        public void UpdateRelease()
+        {
+            PermissionTestUtil.PolicyCheckBuilder()
+                .ExpectResourceCheckToFail(_release, SecurityPolicies.CanUpdateSpecificRelease)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = SetupMetaGuidanceService(userService: userService.Object);
+                        return service.UpdateRelease(_release.Id, new MetaGuidanceUpdateReleaseViewModel());
+                    }
+                );
+        }
+
+        [Fact]
+        public void UpdateSubject()
+        {
+            PermissionTestUtil.PolicyCheckBuilder()
+                .ExpectResourceCheckToFail(_release, SecurityPolicies.CanUpdateSpecificRelease)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = SetupMetaGuidanceService(userService: userService.Object);
+                        return service.UpdateSubject(_release.Id, Guid.NewGuid(),
+                            new MetaGuidanceUpdateSubjectViewModel());
+                    }
+                );
+        }
+
+        private MetaGuidanceService SetupMetaGuidanceService(
+            ContentDbContext contentDbContext = null,
+            StatisticsDbContext statisticsDbContext = null,
+            IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
+            IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper = null,
+            IUserService userService = null)
+        {
+            return new MetaGuidanceService(
+                contentDbContext ?? new Mock<ContentDbContext>().Object,
+                contentPersistenceHelper ?? DefaultPersistenceHelperMock().Object,
+                statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
+                statisticsPersistenceHelper ?? new PersistenceHelper<StatisticsDbContext>(statisticsDbContext),
+                userService ?? new Mock<IUserService>().Object
+            );
+        }
+
+        private Mock<IPersistenceHelper<ContentDbContext>> DefaultPersistenceHelperMock()
+        {
+            var mock = MockUtils.MockPersistenceHelper<ContentDbContext, Release>();
+            MockUtils.SetupCall(mock, _release.Id, _release);
+            return mock;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServicePermissionTests.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using Moq;
 using Xunit;
 
@@ -66,12 +67,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             ContentDbContext contentDbContext = null,
             StatisticsDbContext statisticsDbContext = null,
             IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
+            IFilterService filterService = null,
+            IIndicatorService indicatorService = null,
             IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper = null,
             IUserService userService = null)
         {
             return new MetaGuidanceService(
                 contentDbContext ?? new Mock<ContentDbContext>().Object,
                 contentPersistenceHelper ?? DefaultPersistenceHelperMock().Object,
+                filterService ?? new Mock<IFilterService>().Object,
+                indicatorService ?? new Mock<IIndicatorService>().Object,
                 statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
                 statisticsPersistenceHelper ?? new PersistenceHelper<StatisticsDbContext>(statisticsDbContext),
                 userService ?? new Mock<IUserService>().Object

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -21,49 +21,71 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task Get()
         {
-            var releaseId = Guid.NewGuid();
-
-            var release = new Release
+            var contentReleaseVersion1 = new Release
             {
-                Id = releaseId,
-                MetaGuidance = "Release Meta Guidance"
+                Id = Guid.NewGuid(),
+                PreviousVersionId = null,
+                MetaGuidance = "Version 1 Release Meta Guidance",
             };
 
-            var statsRelease = new Data.Model.Release
+            var contentReleaseVersion2 = new Release
             {
-                Id = releaseId
+                Id = Guid.NewGuid(),
+                PreviousVersionId = contentReleaseVersion1.Id,
+                MetaGuidance = "Version 2 Release Meta Guidance",
+            };
+
+            var statsReleaseVersion1 = new Data.Model.Release
+            {
+                Id = contentReleaseVersion1.Id,
+                PreviousVersionId = contentReleaseVersion1.PreviousVersionId
+            };
+
+            var statsReleaseVersion2 = new Data.Model.Release
+            {
+                Id = contentReleaseVersion2.Id,
+                PreviousVersionId = contentReleaseVersion2.PreviousVersionId
             };
 
             var subject1 = new Subject
             {
                 Id = Guid.NewGuid(),
-                Name = "Subject 1",
-                MetaGuidance = "Subject 1 Meta Guidance",
+                Name = "Subject 1"
             };
 
             var subject2 = new Subject
             {
                 Id = Guid.NewGuid(),
-                Name = "Subject 2",
-                MetaGuidance = "Subject 2 Meta Guidance"
+                Name = "Subject 2"
             };
 
-            var releaseSubject1 = new ReleaseSubject
+            // Version 1 has one Subject, Version 2 adds another Subject
+
+            var releaseVersion1Subject1 = new ReleaseSubject
             {
-                Release = statsRelease,
-                Subject = subject1
+                Release = statsReleaseVersion1,
+                Subject = subject1,
+                MetaGuidance = "Version 1 Subject 1 Meta Guidance"
             };
 
-            var releaseSubject2 = new ReleaseSubject
+            var releaseVersion2Subject1 = new ReleaseSubject
             {
-                Release = statsRelease,
-                Subject = subject2
+                Release = statsReleaseVersion2,
+                Subject = subject1,
+                MetaGuidance = "Version 2 Subject 1 Meta Guidance"
+            };
+
+            var releaseVersion2Subject2 = new ReleaseSubject
+            {
+                Release = statsReleaseVersion2,
+                Subject = subject2,
+                MetaGuidance = "Version 2 Subject 2 Meta Guidance"
             };
 
             var file1 = new ReleaseFileReference
             {
                 Filename = "file1.csv",
-                Release = release,
+                Release = contentReleaseVersion1,
                 ReleaseFileType = ReleaseFileTypes.Data,
                 SubjectId = subject1.Id
             };
@@ -71,20 +93,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var file2 = new ReleaseFileReference
             {
                 Filename = "file2.csv",
-                Release = release,
+                Release = contentReleaseVersion1,
                 ReleaseFileType = ReleaseFileTypes.Data,
                 SubjectId = subject2.Id
             };
 
-            var releaseFile1 = new ReleaseFile
+            var releaseVersion1File1 = new ReleaseFile
             {
-                Release = release,
+                Release = contentReleaseVersion1,
                 ReleaseFileReference = file1
             };
 
-            var releaseFile2 = new ReleaseFile
+            var releaseVersion2File1 = new ReleaseFile
             {
-                Release = release,
+                Release = contentReleaseVersion2,
+                ReleaseFileReference = file1
+            };
+
+            var releaseVersion2File2 = new ReleaseFile
+            {
+                Release = contentReleaseVersion2,
                 ReleaseFileReference = file2
             };
 
@@ -141,16 +169,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                await contentDbContext.AddAsync(release);
+                await contentDbContext.AddRangeAsync(contentReleaseVersion1, contentReleaseVersion2);
                 await contentDbContext.AddRangeAsync(file1, file2);
-                await contentDbContext.AddRangeAsync(releaseFile1, releaseFile2);
+                await contentDbContext.AddRangeAsync(releaseVersion1File1, releaseVersion2File1, releaseVersion2File2);
                 await contentDbContext.SaveChangesAsync();
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
+                await statisticsDbContext.AddRangeAsync(statsReleaseVersion1, statsReleaseVersion2);
                 await statisticsDbContext.AddRangeAsync(subject1, subject2);
-                await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await statisticsDbContext.AddRangeAsync(releaseVersion1Subject1, releaseVersion2Subject1,
+                    releaseVersion2Subject2);
                 await statisticsDbContext.AddRangeAsync(subject1Observation1, subject1Observation2,
                     subject1Observation3);
                 await statisticsDbContext.AddRangeAsync(subject2Observation1, subject2Observation2,
@@ -164,52 +194,71 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var service = SetupMetaGuidanceService(contentDbContext: contentDbContext,
                     statisticsDbContext: statisticsDbContext);
 
-                var result = await service.Get(release.Id);
+                // Assert version 1 has one Subject with the correct content
+                var version1Result = await service.Get(contentReleaseVersion1.Id);
 
-                Assert.True(result.IsRight);
+                Assert.True(version1Result.IsRight);
 
-                Assert.Equal("Release Meta Guidance", result.Right.Content);
+                Assert.Equal(contentReleaseVersion1.Id, version1Result.Right.Id);
+                Assert.Equal("Version 1 Release Meta Guidance", version1Result.Right.Content);
+                Assert.Single(version1Result.Right.Subjects);
 
-                Assert.Equal(2, result.Right.Subjects.Count);
-
-                Assert.Equal("Subject 1 Meta Guidance", result.Right.Subjects[0].Content);
-                Assert.Equal("file1.csv", result.Right.Subjects[0].Filename);
-                Assert.Equal("Subject 1", result.Right.Subjects[0].Name);
-                Assert.Equal("2020_AYQ3", result.Right.Subjects[0].Start);
-                Assert.Equal("2021_AYQ1", result.Right.Subjects[0].End);
+                Assert.Equal(subject1.Id, version1Result.Right.Subjects[0].Id);
+                Assert.Equal("Version 1 Subject 1 Meta Guidance", version1Result.Right.Subjects[0].Content);
+                Assert.Equal("file1.csv", version1Result.Right.Subjects[0].Filename);
+                Assert.Equal("Subject 1", version1Result.Right.Subjects[0].Name);
+                Assert.Equal("2020_AYQ3", version1Result.Right.Subjects[0].Start);
+                Assert.Equal("2021_AYQ1", version1Result.Right.Subjects[0].End);
                 Assert.Equal(new List<GeographicLevel>
                 {
                     GeographicLevel.Country, GeographicLevel.LocalAuthority, GeographicLevel.LocalAuthorityDistrict
-                }, result.Right.Subjects[0].GeographicLevels);
+                }, version1Result.Right.Subjects[0].GeographicLevels);
 
-                Assert.Equal("Subject 2 Meta Guidance", result.Right.Subjects[1].Content);
-                Assert.Equal("file2.csv", result.Right.Subjects[1].Filename);
-                Assert.Equal("Subject 2", result.Right.Subjects[1].Name);
-                Assert.Equal("2020_T3", result.Right.Subjects[1].Start);
-                Assert.Equal("2021_T2", result.Right.Subjects[1].End);
+                // Assert version 2 has two Subjects with the correct content
+                var version2Result = await service.Get(contentReleaseVersion2.Id);
+
+                Assert.True(version2Result.IsRight);
+
+                Assert.Equal(contentReleaseVersion2.Id, version1Result.Right.Id);
+                Assert.Equal("Version 2 Release Meta Guidance", version2Result.Right.Content);
+                Assert.Equal(2, version2Result.Right.Subjects.Count);
+
+                Assert.Equal(subject1.Id, version2Result.Right.Subjects[0].Id);
+                Assert.Equal("Version 2 Subject 1 Meta Guidance", version2Result.Right.Subjects[0].Content);
+                Assert.Equal("file1.csv", version2Result.Right.Subjects[0].Filename);
+                Assert.Equal("Subject 1", version2Result.Right.Subjects[0].Name);
+                Assert.Equal("2020_AYQ3", version2Result.Right.Subjects[0].Start);
+                Assert.Equal("2021_AYQ1", version2Result.Right.Subjects[0].End);
+                Assert.Equal(new List<GeographicLevel>
+                {
+                    GeographicLevel.Country, GeographicLevel.LocalAuthority, GeographicLevel.LocalAuthorityDistrict
+                }, version1Result.Right.Subjects[0].GeographicLevels);
+
+                Assert.Equal(subject2.Id, version2Result.Right.Subjects[1].Id);
+                Assert.Equal("Version 2 Subject 2 Meta Guidance", version2Result.Right.Subjects[1].Content);
+                Assert.Equal("file2.csv", version2Result.Right.Subjects[1].Filename);
+                Assert.Equal("Subject 2", version2Result.Right.Subjects[1].Name);
+                Assert.Equal("2020_T3", version2Result.Right.Subjects[1].Start);
+                Assert.Equal("2021_T2", version2Result.Right.Subjects[1].End);
                 Assert.Equal(new List<GeographicLevel>
                 {
                     GeographicLevel.Country, GeographicLevel.Region
-                }, result.Right.Subjects[1].GeographicLevels);
+                }, version2Result.Right.Subjects[1].GeographicLevels);
             }
-        }
-
-        [Fact]
-        public async Task Update()
-        {
-            // TODO
         }
 
         private static MetaGuidanceService SetupMetaGuidanceService(
             ContentDbContext contentDbContext,
             StatisticsDbContext statisticsDbContext,
-            IPersistenceHelper<ContentDbContext> persistenceHelper = null,
+            IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
+            IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper = null,
             IUserService userService = null)
         {
             return new MetaGuidanceService(
                 contentDbContext,
-                persistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
+                contentPersistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
                 statisticsDbContext,
+                statisticsPersistenceHelper ?? new PersistenceHelper<StatisticsDbContext>(statisticsDbContext),
                 userService ?? MockUtils.AlwaysTrueUserService().Object
             );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -1,0 +1,217 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
+using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
+{
+    public class MetaGuidanceServiceTests
+    {
+        [Fact]
+        public async Task Get()
+        {
+            var releaseId = Guid.NewGuid();
+
+            var release = new Release
+            {
+                Id = releaseId,
+                MetaGuidance = "Release Meta Guidance"
+            };
+
+            var statsRelease = new Data.Model.Release
+            {
+                Id = releaseId
+            };
+
+            var subject1 = new Subject
+            {
+                Id = Guid.NewGuid(),
+                Name = "Subject 1",
+                MetaGuidance = "Subject 1 Meta Guidance",
+            };
+
+            var subject2 = new Subject
+            {
+                Id = Guid.NewGuid(),
+                Name = "Subject 2",
+                MetaGuidance = "Subject 2 Meta Guidance"
+            };
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = subject1
+            };
+
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = subject2
+            };
+
+            var file1 = new ReleaseFileReference
+            {
+                Filename = "file1.csv",
+                Release = release,
+                ReleaseFileType = ReleaseFileTypes.Data,
+                SubjectId = subject1.Id
+            };
+
+            var file2 = new ReleaseFileReference
+            {
+                Filename = "file2.csv",
+                Release = release,
+                ReleaseFileType = ReleaseFileTypes.Data,
+                SubjectId = subject2.Id
+            };
+
+            var releaseFile1 = new ReleaseFile
+            {
+                Release = release,
+                ReleaseFileReference = file1
+            };
+
+            var releaseFile2 = new ReleaseFile
+            {
+                Release = release,
+                ReleaseFileReference = file2
+            };
+
+            var subject1Observation1 = new Observation
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Subject = subject1,
+                Year = 2020,
+                TimeIdentifier = TimeIdentifier.AcademicYearQ3
+            };
+
+            var subject1Observation2 = new Observation
+            {
+                GeographicLevel = GeographicLevel.LocalAuthority,
+                Subject = subject1,
+                Year = 2020,
+                TimeIdentifier = TimeIdentifier.AcademicYearQ4
+            };
+
+            var subject1Observation3 = new Observation
+            {
+                GeographicLevel = GeographicLevel.LocalAuthorityDistrict,
+                Subject = subject1,
+                Year = 2021,
+                TimeIdentifier = TimeIdentifier.AcademicYearQ1
+            };
+
+            var subject2Observation1 = new Observation
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Subject = subject2,
+                Year = 2020,
+                TimeIdentifier = TimeIdentifier.SummerTerm
+            };
+
+            var subject2Observation2 = new Observation
+            {
+                GeographicLevel = GeographicLevel.Region,
+                Subject = subject2,
+                Year = 2021,
+                TimeIdentifier = TimeIdentifier.AutumnTerm
+            };
+
+            var subject2Observation3 = new Observation
+            {
+                GeographicLevel = GeographicLevel.Region,
+                Subject = subject2,
+                Year = 2021,
+                TimeIdentifier = TimeIdentifier.SpringTerm
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.AddAsync(release);
+                await contentDbContext.AddRangeAsync(file1, file2);
+                await contentDbContext.AddRangeAsync(releaseFile1, releaseFile2);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.AddRangeAsync(subject1, subject2);
+                await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await statisticsDbContext.AddRangeAsync(subject1Observation1, subject1Observation2,
+                    subject1Observation3);
+                await statisticsDbContext.AddRangeAsync(subject2Observation1, subject2Observation2,
+                    subject2Observation3);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = SetupMetaGuidanceService(contentDbContext: contentDbContext,
+                    statisticsDbContext: statisticsDbContext);
+
+                var result = await service.Get(release.Id);
+
+                Assert.True(result.IsRight);
+
+                Assert.Equal("Release Meta Guidance", result.Right.Content);
+
+                Assert.Equal(2, result.Right.Subjects.Count);
+
+                Assert.Equal("Subject 1 Meta Guidance", result.Right.Subjects[0].Content);
+                Assert.Equal("file1.csv", result.Right.Subjects[0].Filename);
+                Assert.Equal("Subject 1", result.Right.Subjects[0].Name);
+                Assert.Equal("2020_AYQ3", result.Right.Subjects[0].Start);
+                Assert.Equal("2021_AYQ1", result.Right.Subjects[0].End);
+                Assert.Equal(new List<GeographicLevel>
+                {
+                    GeographicLevel.Country, GeographicLevel.LocalAuthority, GeographicLevel.LocalAuthorityDistrict
+                }, result.Right.Subjects[0].GeographicLevels);
+
+                Assert.Equal("Subject 2 Meta Guidance", result.Right.Subjects[1].Content);
+                Assert.Equal("file2.csv", result.Right.Subjects[1].Filename);
+                Assert.Equal("Subject 2", result.Right.Subjects[1].Name);
+                Assert.Equal("2020_T3", result.Right.Subjects[1].Start);
+                Assert.Equal("2021_T2", result.Right.Subjects[1].End);
+                Assert.Equal(new List<GeographicLevel>
+                {
+                    GeographicLevel.Country, GeographicLevel.Region
+                }, result.Right.Subjects[1].GeographicLevels);
+            }
+        }
+
+        [Fact]
+        public async Task Update()
+        {
+            // TODO
+        }
+
+        private static MetaGuidanceService SetupMetaGuidanceService(
+            ContentDbContext contentDbContext,
+            StatisticsDbContext statisticsDbContext,
+            IPersistenceHelper<ContentDbContext> persistenceHelper = null,
+            IUserService userService = null)
+        {
+            return new MetaGuidanceService(
+                contentDbContext,
+                persistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
+                statisticsDbContext,
+                userService ?? MockUtils.AlwaysTrueUserService().Object
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -28,30 +28,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public async Task Get()
         {
-            var contentReleaseVersion1 = new Release
+            var contentRelease = new Release
             {
                 Id = Guid.NewGuid(),
-                PreviousVersionId = null,
-                MetaGuidance = "Version 1 Release Meta Guidance"
+                MetaGuidance = "Release Meta Guidance"
             };
 
-            var contentReleaseVersion2 = new Release
+            var statsRelease = new Data.Model.Release
             {
-                Id = Guid.NewGuid(),
-                PreviousVersionId = contentReleaseVersion1.Id,
-                MetaGuidance = "Version 2 Release Meta Guidance"
-            };
-
-            var statsReleaseVersion1 = new Data.Model.Release
-            {
-                Id = contentReleaseVersion1.Id,
-                PreviousVersionId = contentReleaseVersion1.PreviousVersionId
-            };
-
-            var statsReleaseVersion2 = new Data.Model.Release
-            {
-                Id = contentReleaseVersion2.Id,
-                PreviousVersionId = contentReleaseVersion2.PreviousVersionId
+                Id = contentRelease.Id,
             };
 
             var subject1 = new Subject
@@ -106,6 +91,210 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Label = "Subject 2 Indicator"
                     }
                 }
+            };
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = subject1,
+                MetaGuidance = "Subject 1 Meta Guidance"
+            };
+
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = subject2,
+                MetaGuidance = "Subject 2 Meta Guidance"
+            };
+
+            var file1 = new ReleaseFileReference
+            {
+                Filename = "file1.csv",
+                Release = contentRelease,
+                ReleaseFileType = ReleaseFileTypes.Data,
+                SubjectId = subject1.Id
+            };
+
+            var file2 = new ReleaseFileReference
+            {
+                Filename = "file2.csv",
+                Release = contentRelease,
+                ReleaseFileType = ReleaseFileTypes.Data,
+                SubjectId = subject2.Id
+            };
+
+            var releaseFile1 = new ReleaseFile
+            {
+                Release = contentRelease,
+                ReleaseFileReference = file1
+            };
+
+            var releaseFile2 = new ReleaseFile
+            {
+                Release = contentRelease,
+                ReleaseFileReference = file2
+            };
+
+            var subject1Observation1 = new Observation
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Subject = subject1,
+                Year = 2020,
+                TimeIdentifier = TimeIdentifier.AcademicYearQ3
+            };
+
+            var subject1Observation2 = new Observation
+            {
+                GeographicLevel = GeographicLevel.LocalAuthority,
+                Subject = subject1,
+                Year = 2020,
+                TimeIdentifier = TimeIdentifier.AcademicYearQ4
+            };
+
+            var subject1Observation3 = new Observation
+            {
+                GeographicLevel = GeographicLevel.LocalAuthorityDistrict,
+                Subject = subject1,
+                Year = 2021,
+                TimeIdentifier = TimeIdentifier.AcademicYearQ1
+            };
+
+            var subject2Observation1 = new Observation
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Subject = subject2,
+                Year = 2020,
+                TimeIdentifier = TimeIdentifier.SummerTerm
+            };
+
+            var subject2Observation2 = new Observation
+            {
+                GeographicLevel = GeographicLevel.Region,
+                Subject = subject2,
+                Year = 2021,
+                TimeIdentifier = TimeIdentifier.AutumnTerm
+            };
+
+            var subject2Observation3 = new Observation
+            {
+                GeographicLevel = GeographicLevel.Region,
+                Subject = subject2,
+                Year = 2021,
+                TimeIdentifier = TimeIdentifier.SpringTerm
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.AddAsync(contentRelease);
+                await contentDbContext.AddRangeAsync(file1, file2);
+                await contentDbContext.AddRangeAsync(releaseFile1, releaseFile2);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.AddAsync(statsRelease);
+                await statisticsDbContext.AddRangeAsync(subject1, subject2);
+                await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject1,
+                    releaseSubject2);
+                await statisticsDbContext.AddRangeAsync(subject1Filter, subject2Filter);
+                await statisticsDbContext.AddRangeAsync(subject1IndicatorGroup, subject2IndicatorGroup);
+                await statisticsDbContext.AddRangeAsync(subject1Observation1, subject1Observation2,
+                    subject1Observation3, subject2Observation1, subject2Observation2, subject2Observation3);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = SetupMetaGuidanceService(contentDbContext: contentDbContext,
+                    statisticsDbContext: statisticsDbContext);
+
+                var result = await service.Get(contentRelease.Id);
+
+                // Assert there are two Subjects with the correct content
+                Assert.True(result.IsRight);
+
+                Assert.Equal(contentRelease.Id, result.Right.Id);
+                Assert.Equal("Release Meta Guidance", result.Right.Content);
+                Assert.Equal(2, result.Right.Subjects.Count);
+
+                Assert.Equal(subject1.Id, result.Right.Subjects[0].Id);
+                Assert.Equal("Subject 1 Meta Guidance", result.Right.Subjects[0].Content);
+                Assert.Equal("file1.csv", result.Right.Subjects[0].Filename);
+                Assert.Equal("Subject 1", result.Right.Subjects[0].Name);
+                Assert.Equal("2020_AYQ3", result.Right.Subjects[0].TimePeriods.From);
+                Assert.Equal("2021_AYQ1", result.Right.Subjects[0].TimePeriods.To);
+                Assert.Equal(new List<GeographicLevel>
+                {
+                    GeographicLevel.Country, GeographicLevel.LocalAuthority, GeographicLevel.LocalAuthorityDistrict
+                }, result.Right.Subjects[0].GeographicLevels);
+                Assert.Equal(2, result.Right.Subjects[0].Variables.Count);
+                Assert.Equal("Subject 1 Filter - Hint", result.Right.Subjects[0].Variables[0].Label);
+                Assert.Equal("subject1_filter", result.Right.Subjects[0].Variables[0].Value);
+                Assert.Equal("Subject 1 Indicator", result.Right.Subjects[0].Variables[1].Label);
+                Assert.Equal("subject1_indicator", result.Right.Subjects[0].Variables[1].Value);
+
+                Assert.Equal(subject2.Id, result.Right.Subjects[1].Id);
+                Assert.Equal("Subject 2 Meta Guidance", result.Right.Subjects[1].Content);
+                Assert.Equal("file2.csv", result.Right.Subjects[1].Filename);
+                Assert.Equal("Subject 2", result.Right.Subjects[1].Name);
+                Assert.Equal("2020_T3", result.Right.Subjects[1].TimePeriods.From);
+                Assert.Equal("2021_T2", result.Right.Subjects[1].TimePeriods.To);
+                Assert.Equal(new List<GeographicLevel>
+                {
+                    GeographicLevel.Country, GeographicLevel.Region
+                }, result.Right.Subjects[1].GeographicLevels);
+                Assert.Equal(2, result.Right.Subjects[1].Variables.Count);
+                Assert.Equal("Subject 2 Filter", result.Right.Subjects[1].Variables[0].Label);
+                Assert.Equal("subject2_filter", result.Right.Subjects[1].Variables[0].Value);
+                Assert.Equal("Subject 2 Indicator", result.Right.Subjects[1].Variables[1].Label);
+                Assert.Equal("subject2_indicator", result.Right.Subjects[1].Variables[1].Value);
+            }
+        }
+
+        [Fact]
+        public async Task Get_AmendedRelease()
+        {
+            var contentReleaseVersion1 = new Release
+            {
+                Id = Guid.NewGuid(),
+                PreviousVersionId = null,
+                MetaGuidance = "Version 1 Release Meta Guidance"
+            };
+
+            var contentReleaseVersion2 = new Release
+            {
+                Id = Guid.NewGuid(),
+                PreviousVersionId = contentReleaseVersion1.Id,
+                MetaGuidance = "Version 2 Release Meta Guidance"
+            };
+
+            var statsReleaseVersion1 = new Data.Model.Release
+            {
+                Id = contentReleaseVersion1.Id,
+                PreviousVersionId = contentReleaseVersion1.PreviousVersionId
+            };
+
+            var statsReleaseVersion2 = new Data.Model.Release
+            {
+                Id = contentReleaseVersion2.Id,
+                PreviousVersionId = contentReleaseVersion2.PreviousVersionId
+            };
+
+            var subject1 = new Subject
+            {
+                Id = Guid.NewGuid(),
+                Name = "Subject 1"
+            };
+
+            var subject2 = new Subject
+            {
+                Id = Guid.NewGuid(),
+                Name = "Subject 2"
             };
 
             // Version 1 has one Subject, Version 2 adds another Subject
@@ -165,54 +354,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 ReleaseFileReference = file2
             };
 
-            var subject1Observation1 = new Observation
-            {
-                GeographicLevel = GeographicLevel.Country,
-                Subject = subject1,
-                Year = 2020,
-                TimeIdentifier = TimeIdentifier.AcademicYearQ3
-            };
-
-            var subject1Observation2 = new Observation
-            {
-                GeographicLevel = GeographicLevel.LocalAuthority,
-                Subject = subject1,
-                Year = 2020,
-                TimeIdentifier = TimeIdentifier.AcademicYearQ4
-            };
-
-            var subject1Observation3 = new Observation
-            {
-                GeographicLevel = GeographicLevel.LocalAuthorityDistrict,
-                Subject = subject1,
-                Year = 2021,
-                TimeIdentifier = TimeIdentifier.AcademicYearQ1
-            };
-
-            var subject2Observation1 = new Observation
-            {
-                GeographicLevel = GeographicLevel.Country,
-                Subject = subject2,
-                Year = 2020,
-                TimeIdentifier = TimeIdentifier.SummerTerm
-            };
-
-            var subject2Observation2 = new Observation
-            {
-                GeographicLevel = GeographicLevel.Region,
-                Subject = subject2,
-                Year = 2021,
-                TimeIdentifier = TimeIdentifier.AutumnTerm
-            };
-
-            var subject2Observation3 = new Observation
-            {
-                GeographicLevel = GeographicLevel.Region,
-                Subject = subject2,
-                Year = 2021,
-                TimeIdentifier = TimeIdentifier.SpringTerm
-            };
-
             var contentDbContextId = Guid.NewGuid().ToString();
             var statisticsDbContextId = Guid.NewGuid().ToString();
 
@@ -230,10 +371,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await statisticsDbContext.AddRangeAsync(subject1, subject2);
                 await statisticsDbContext.AddRangeAsync(releaseVersion1Subject1, releaseVersion2Subject1,
                     releaseVersion2Subject2);
-                await statisticsDbContext.AddRangeAsync(subject1Filter, subject2Filter);
-                await statisticsDbContext.AddRangeAsync(subject1IndicatorGroup, subject2IndicatorGroup);
-                await statisticsDbContext.AddRangeAsync(subject1Observation1, subject1Observation2,
-                    subject1Observation3, subject2Observation1, subject2Observation2, subject2Observation3);
                 await statisticsDbContext.SaveChangesAsync();
             }
 
@@ -243,9 +380,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var service = SetupMetaGuidanceService(contentDbContext: contentDbContext,
                     statisticsDbContext: statisticsDbContext);
 
-                // Assert version 1 has one Subject with the correct content
                 var version1Result = await service.Get(contentReleaseVersion1.Id);
 
+                // Assert version 1 has one Subject with the correct content
                 Assert.True(version1Result.IsRight);
 
                 Assert.Equal(contentReleaseVersion1.Id, version1Result.Right.Id);
@@ -256,21 +393,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Version 1 Subject 1 Meta Guidance", version1Result.Right.Subjects[0].Content);
                 Assert.Equal("file1.csv", version1Result.Right.Subjects[0].Filename);
                 Assert.Equal("Subject 1", version1Result.Right.Subjects[0].Name);
-                Assert.Equal("2020_AYQ3", version1Result.Right.Subjects[0].TimePeriods.From);
-                Assert.Equal("2021_AYQ1", version1Result.Right.Subjects[0].TimePeriods.To);
-                Assert.Equal(new List<GeographicLevel>
-                {
-                    GeographicLevel.Country, GeographicLevel.LocalAuthority, GeographicLevel.LocalAuthorityDistrict
-                }, version1Result.Right.Subjects[0].GeographicLevels);
-                Assert.Equal(2, version1Result.Right.Subjects[0].Variables.Count);
-                Assert.Equal("Subject 1 Filter - Hint", version1Result.Right.Subjects[0].Variables[0].Label);
-                Assert.Equal("subject1_filter", version1Result.Right.Subjects[0].Variables[0].Value);
-                Assert.Equal("Subject 1 Indicator", version1Result.Right.Subjects[0].Variables[1].Label);
-                Assert.Equal("subject1_indicator", version1Result.Right.Subjects[0].Variables[1].Value);
+                Assert.Null(version1Result.Right.Subjects[0].TimePeriods.From);
+                Assert.Null(version1Result.Right.Subjects[0].TimePeriods.To);
+                Assert.Empty(version1Result.Right.Subjects[0].GeographicLevels);
+                Assert.Empty(version1Result.Right.Subjects[0].Variables);
 
-                // Assert version 2 has two Subjects with the correct content
                 var version2Result = await service.Get(contentReleaseVersion2.Id);
 
+                // Assert version 2 has two Subjects with the correct content
                 Assert.True(version2Result.IsRight);
 
                 Assert.Equal(contentReleaseVersion2.Id, version2Result.Right.Id);
@@ -281,33 +411,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Version 2 Subject 1 Meta Guidance", version2Result.Right.Subjects[0].Content);
                 Assert.Equal("file1.csv", version2Result.Right.Subjects[0].Filename);
                 Assert.Equal("Subject 1", version2Result.Right.Subjects[0].Name);
-                Assert.Equal("2020_AYQ3", version2Result.Right.Subjects[0].TimePeriods.From);
-                Assert.Equal("2021_AYQ1", version2Result.Right.Subjects[0].TimePeriods.To);
-                Assert.Equal(new List<GeographicLevel>
-                {
-                    GeographicLevel.Country, GeographicLevel.LocalAuthority, GeographicLevel.LocalAuthorityDistrict
-                }, version2Result.Right.Subjects[0].GeographicLevels);
-                Assert.Equal(2, version2Result.Right.Subjects[0].Variables.Count);
-                Assert.Equal("Subject 1 Filter - Hint", version2Result.Right.Subjects[0].Variables[0].Label);
-                Assert.Equal("subject1_filter", version2Result.Right.Subjects[0].Variables[0].Value);
-                Assert.Equal("Subject 1 Indicator", version2Result.Right.Subjects[0].Variables[1].Label);
-                Assert.Equal("subject1_indicator", version2Result.Right.Subjects[0].Variables[1].Value);
+                Assert.Null(version2Result.Right.Subjects[0].TimePeriods.From);
+                Assert.Null(version2Result.Right.Subjects[0].TimePeriods.To);
+                Assert.Empty(version2Result.Right.Subjects[0].GeographicLevels);
 
                 Assert.Equal(subject2.Id, version2Result.Right.Subjects[1].Id);
                 Assert.Equal("Version 2 Subject 2 Meta Guidance", version2Result.Right.Subjects[1].Content);
                 Assert.Equal("file2.csv", version2Result.Right.Subjects[1].Filename);
                 Assert.Equal("Subject 2", version2Result.Right.Subjects[1].Name);
-                Assert.Equal("2020_T3", version2Result.Right.Subjects[1].TimePeriods.From);
-                Assert.Equal("2021_T2", version2Result.Right.Subjects[1].TimePeriods.To);
-                Assert.Equal(new List<GeographicLevel>
-                {
-                    GeographicLevel.Country, GeographicLevel.Region
-                }, version2Result.Right.Subjects[1].GeographicLevels);
-                Assert.Equal(2, version2Result.Right.Subjects[1].Variables.Count);
-                Assert.Equal("Subject 2 Filter", version2Result.Right.Subjects[1].Variables[0].Label);
-                Assert.Equal("subject2_filter", version2Result.Right.Subjects[1].Variables[0].Value);
-                Assert.Equal("Subject 2 Indicator", version2Result.Right.Subjects[1].Variables[1].Label);
-                Assert.Equal("subject2_indicator", version2Result.Right.Subjects[1].Variables[1].Value);
+                Assert.Null(version2Result.Right.Subjects[1].TimePeriods.From);
+                Assert.Null(version2Result.Right.Subjects[1].TimePeriods.To);
+                Assert.Empty(version2Result.Right.Subjects[1].GeographicLevels);
+                Assert.Empty(version2Result.Right.Subjects[1].Variables);
             }
         }
 
@@ -357,6 +472,146 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
         [Fact]
         public async Task UpdateSubject()
+        {
+            var contentRelease = new Release
+            {
+                Id = Guid.NewGuid(),
+                MetaGuidance = "Release Meta Guidance"
+            };
+
+            var statsRelease = new Data.Model.Release
+            {
+                Id = contentRelease.Id,
+            };
+
+            var subject1 = new Subject
+            {
+                Id = Guid.NewGuid(),
+                Name = "Subject 1"
+            };
+
+            var subject2 = new Subject
+            {
+                Id = Guid.NewGuid(),
+                Name = "Subject 2"
+            };
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = subject1,
+                MetaGuidance = "Subject 1 Meta Guidance"
+            };
+
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = statsRelease,
+                Subject = subject2,
+                MetaGuidance = "Subject 2 Meta Guidance"
+            };
+
+            var file1 = new ReleaseFileReference
+            {
+                Filename = "file1.csv",
+                Release = contentRelease,
+                ReleaseFileType = ReleaseFileTypes.Data,
+                SubjectId = subject1.Id
+            };
+
+            var file2 = new ReleaseFileReference
+            {
+                Filename = "file2.csv",
+                Release = contentRelease,
+                ReleaseFileType = ReleaseFileTypes.Data,
+                SubjectId = subject2.Id
+            };
+
+            var releaseFile1 = new ReleaseFile
+            {
+                Release = contentRelease,
+                ReleaseFileReference = file1
+            };
+
+            var releaseFile2 = new ReleaseFile
+            {
+                Release = contentRelease,
+                ReleaseFileReference = file2
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.AddAsync(contentRelease);
+                await contentDbContext.AddRangeAsync(file1, file2);
+                await contentDbContext.AddRangeAsync(releaseFile1, releaseFile2);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.AddRangeAsync(statsRelease);
+                await statisticsDbContext.AddRangeAsync(subject1, subject2);
+                await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = SetupMetaGuidanceService(contentDbContext: contentDbContext,
+                    statisticsDbContext: statisticsDbContext);
+
+                // Update Subject 1
+                var result = await service.UpdateSubject(
+                    contentRelease.Id, subject1.Id, new MetaGuidanceUpdateSubjectViewModel
+                    {
+                        Content = "Subject 1 Meta Guidance Updated"
+                    });
+
+                // Assert only one Subject has been updated
+                Assert.True(result.IsRight);
+
+                Assert.Equal(contentRelease.Id, result.Right.Id);
+                Assert.Equal("Release Meta Guidance", result.Right.Content);
+                Assert.Equal(2, result.Right.Subjects.Count);
+
+                Assert.Equal(subject1.Id, result.Right.Subjects[0].Id);
+                Assert.Equal("Subject 1 Meta Guidance Updated", result.Right.Subjects[0].Content);
+                Assert.Equal("file1.csv", result.Right.Subjects[0].Filename);
+                Assert.Equal("Subject 1", result.Right.Subjects[0].Name);
+                Assert.Null(result.Right.Subjects[0].TimePeriods.From);
+                Assert.Null(result.Right.Subjects[0].TimePeriods.To);
+                Assert.Empty(result.Right.Subjects[0].GeographicLevels);
+                Assert.Empty(result.Right.Subjects[0].Variables);
+
+                Assert.Equal(subject2.Id, result.Right.Subjects[1].Id);
+                Assert.Equal("Subject 2 Meta Guidance", result.Right.Subjects[1].Content);
+                Assert.Equal("file2.csv", result.Right.Subjects[1].Filename);
+                Assert.Equal("Subject 2", result.Right.Subjects[1].Name);
+                Assert.Null(result.Right.Subjects[1].TimePeriods.From);
+                Assert.Null(result.Right.Subjects[1].TimePeriods.To);
+                Assert.Empty(result.Right.Subjects[1].GeographicLevels);
+                Assert.Empty(result.Right.Subjects[1].Variables);
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                Assert.Equal("Subject 1 Meta Guidance Updated",
+                    (await statisticsDbContext.ReleaseSubject
+                        .Where(rs => rs.ReleaseId == statsRelease.Id && rs.SubjectId == subject1.Id)
+                        .FirstAsync()).MetaGuidance);
+
+                Assert.Equal("Subject 2 Meta Guidance",
+                    (await statisticsDbContext.ReleaseSubject
+                        .Where(rs => rs.ReleaseId == statsRelease.Id && rs.SubjectId == subject2.Id)
+                        .FirstAsync()).MetaGuidance);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateSubject_AmendedRelease()
         {
             var contentReleaseVersion1 = new Release
             {
@@ -486,8 +741,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Content = "Version 2 Subject 1 Meta Guidance Updated"
                     });
 
-                // Assert only one Subject has been updated
-
+                // Assert only one Subject on version 2 has been updated
                 Assert.True(updateResult.IsRight);
 
                 Assert.Equal(contentReleaseVersion2.Id, updateResult.Right.Id);
@@ -498,15 +752,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Version 2 Subject 1 Meta Guidance Updated", updateResult.Right.Subjects[0].Content);
                 Assert.Equal("file1.csv", updateResult.Right.Subjects[0].Filename);
                 Assert.Equal("Subject 1", updateResult.Right.Subjects[0].Name);
+                Assert.Null(updateResult.Right.Subjects[0].TimePeriods.From);
+                Assert.Null(updateResult.Right.Subjects[0].TimePeriods.To);
+                Assert.Empty(updateResult.Right.Subjects[0].GeographicLevels);
+                Assert.Empty(updateResult.Right.Subjects[0].Variables);
 
                 Assert.Equal(subject2.Id, updateResult.Right.Subjects[1].Id);
                 Assert.Equal("Version 2 Subject 2 Meta Guidance", updateResult.Right.Subjects[1].Content);
                 Assert.Equal("file2.csv", updateResult.Right.Subjects[1].Filename);
                 Assert.Equal("Subject 2", updateResult.Right.Subjects[1].Name);
+                Assert.Null(updateResult.Right.Subjects[1].TimePeriods.From);
+                Assert.Null(updateResult.Right.Subjects[1].TimePeriods.To);
+                Assert.Empty(updateResult.Right.Subjects[1].GeographicLevels);
+                Assert.Empty(updateResult.Right.Subjects[1].Variables);
 
-                // Assert the same Subject on version 1 hasn't been affected
                 var version1Result = await service.Get(contentReleaseVersion1.Id);
 
+                // Assert the same Subject on version 1 hasn't been affected
                 Assert.True(version1Result.IsRight);
 
                 Assert.Equal(contentReleaseVersion1.Id, version1Result.Right.Id);
@@ -517,6 +779,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Version 1 Subject 1 Meta Guidance", version1Result.Right.Subjects[0].Content);
                 Assert.Equal("file1.csv", version1Result.Right.Subjects[0].Filename);
                 Assert.Equal("Subject 1", version1Result.Right.Subjects[0].Name);
+                Assert.Null(version1Result.Right.Subjects[0].TimePeriods.From);
+                Assert.Null(version1Result.Right.Subjects[0].TimePeriods.To);
+                Assert.Empty(version1Result.Right.Subjects[0].GeographicLevels);
+                Assert.Empty(version1Result.Right.Subjects[0].Variables);
             }
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -206,8 +206,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Version 1 Subject 1 Meta Guidance", version1Result.Right.Subjects[0].Content);
                 Assert.Equal("file1.csv", version1Result.Right.Subjects[0].Filename);
                 Assert.Equal("Subject 1", version1Result.Right.Subjects[0].Name);
-                Assert.Equal("2020_AYQ3", version1Result.Right.Subjects[0].Start);
-                Assert.Equal("2021_AYQ1", version1Result.Right.Subjects[0].End);
+                Assert.Equal("2020_AYQ3", version1Result.Right.Subjects[0].TimePeriods.From);
+                Assert.Equal("2021_AYQ1", version1Result.Right.Subjects[0].TimePeriods.To);
                 Assert.Equal(new List<GeographicLevel>
                 {
                     GeographicLevel.Country, GeographicLevel.LocalAuthority, GeographicLevel.LocalAuthorityDistrict
@@ -226,8 +226,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Version 2 Subject 1 Meta Guidance", version2Result.Right.Subjects[0].Content);
                 Assert.Equal("file1.csv", version2Result.Right.Subjects[0].Filename);
                 Assert.Equal("Subject 1", version2Result.Right.Subjects[0].Name);
-                Assert.Equal("2020_AYQ3", version2Result.Right.Subjects[0].Start);
-                Assert.Equal("2021_AYQ1", version2Result.Right.Subjects[0].End);
+                Assert.Equal("2020_AYQ3", version2Result.Right.Subjects[0].TimePeriods.From);
+                Assert.Equal("2021_AYQ1", version2Result.Right.Subjects[0].TimePeriods.To);
                 Assert.Equal(new List<GeographicLevel>
                 {
                     GeographicLevel.Country, GeographicLevel.LocalAuthority, GeographicLevel.LocalAuthorityDistrict
@@ -237,8 +237,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Version 2 Subject 2 Meta Guidance", version2Result.Right.Subjects[1].Content);
                 Assert.Equal("file2.csv", version2Result.Right.Subjects[1].Filename);
                 Assert.Equal("Subject 2", version2Result.Right.Subjects[1].Name);
-                Assert.Equal("2020_T3", version2Result.Right.Subjects[1].Start);
-                Assert.Equal("2021_T2", version2Result.Right.Subjects[1].End);
+                Assert.Equal("2020_T3", version2Result.Right.Subjects[1].TimePeriods.From);
+                Assert.Equal("2021_T2", version2Result.Right.Subjects[1].TimePeriods.To);
                 Assert.Equal(new List<GeographicLevel>
                 {
                     GeographicLevel.Country, GeographicLevel.Region

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/MetaGuidanceController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/MetaGuidanceController.cs
@@ -35,7 +35,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
-        [HttpPut("release/{releaseId}/meta-guidance/subject/{subjectId}")]
+        [HttpPut("release/{releaseId}/subjects/{subjectId}/meta-guidance")]
         public async Task<ActionResult<MetaGuidanceViewModel>> UpdateSubject(Guid releaseId,
             Guid subjectId,
             MetaGuidanceUpdateSubjectViewModel request)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/MetaGuidanceController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/MetaGuidanceController.cs
@@ -8,8 +8,8 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
 {
-    // TODO remove this
-    [AllowAnonymous]
+    [Route("api")]
+    [Authorize]
     [ApiController]
     public class MetaGuidanceController : ControllerBase
     {
@@ -20,17 +20,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             _metaGuidanceService = metaGuidanceService;
         }
 
-        [HttpGet("meta-guidance/{releaseId}")]
+        [HttpGet("release/{releaseId}/meta-guidance")]
         public async Task<ActionResult<MetaGuidanceViewModel>> Get(Guid releaseId)
         {
             return await _metaGuidanceService.Get(releaseId)
                 .HandleFailuresOrOk();
         }
 
-        [HttpPut("meta-guidance/{releaseId}")]
-        public async Task<ActionResult<MetaGuidanceViewModel>> Update(Guid releaseId, MetaGuidanceUpdateViewModel request)
+        [HttpPut("release/{releaseId}/meta-guidance")]
+        public async Task<ActionResult<MetaGuidanceViewModel>> UpdateRelease(Guid releaseId,
+            MetaGuidanceUpdateReleaseViewModel request)
         {
-            return await _metaGuidanceService.Update(releaseId, request)
+            return await _metaGuidanceService.UpdateRelease(releaseId, request)
+                .HandleFailuresOrOk();
+        }
+
+        [HttpPut("release/{releaseId}/meta-guidance/subject/{subjectId}")]
+        public async Task<ActionResult<MetaGuidanceViewModel>> UpdateSubject(Guid releaseId,
+            Guid subjectId,
+            MetaGuidanceUpdateSubjectViewModel request)
+        {
+            return await _metaGuidanceService.UpdateSubject(releaseId, subjectId, request)
                 .HandleFailuresOrOk();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/MetaGuidanceController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/MetaGuidanceController.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
+{
+    // TODO remove this
+    [AllowAnonymous]
+    [ApiController]
+    public class MetaGuidanceController : ControllerBase
+    {
+        private readonly IMetaGuidanceService _metaGuidanceService;
+
+        public MetaGuidanceController(IMetaGuidanceService metaGuidanceService)
+        {
+            _metaGuidanceService = metaGuidanceService;
+        }
+
+        [HttpGet("meta-guidance/{releaseId}")]
+        public async Task<ActionResult<MetaGuidanceViewModel>> Get(Guid releaseId)
+        {
+            return await _metaGuidanceService.Get(releaseId)
+                .HandleFailuresOrOk();
+        }
+
+        [HttpPut("meta-guidance/{releaseId}")]
+        public async Task<ActionResult<MetaGuidanceViewModel>> Update(Guid releaseId, MetaGuidanceUpdateViewModel request)
+        {
+            return await _metaGuidanceService.Update(releaseId, request)
+                .HandleFailuresOrOk();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20201008104504_EES1409AddMetaGuidanceFieldToRelease.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20201008104504_EES1409AddMetaGuidanceFieldToRelease.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201008104504_EES1409AddMetaGuidanceFieldToRelease")]
+    partial class EES1409AddMetaGuidanceFieldToRelease
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20201008104504_EES1409AddMetaGuidanceFieldToRelease.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20201008104504_EES1409AddMetaGuidanceFieldToRelease.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES1409AddMetaGuidanceFieldToRelease : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MetaGuidance",
+                table: "Releases",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MetaGuidance",
+                table: "Releases");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IMetaGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IMetaGuidanceService.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
+{
+    public interface IMetaGuidanceService
+    {
+        public Task<Either<ActionResult, MetaGuidanceViewModel>> Get(Guid releaseId);
+
+        public Task<Either<ActionResult, MetaGuidanceViewModel>> Update(Guid releaseId,
+            MetaGuidanceUpdateViewModel request);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IMetaGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IMetaGuidanceService.cs
@@ -10,7 +10,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     {
         public Task<Either<ActionResult, MetaGuidanceViewModel>> Get(Guid releaseId);
 
-        public Task<Either<ActionResult, MetaGuidanceViewModel>> Update(Guid releaseId,
-            MetaGuidanceUpdateViewModel request);
+        public Task<Either<ActionResult, MetaGuidanceViewModel>> UpdateRelease(Guid releaseId,
+            MetaGuidanceUpdateReleaseViewModel request);
+
+        public Task<Either<ActionResult, MetaGuidanceViewModel>> UpdateSubject(Guid releaseId,
+            Guid subjectId,
+            MetaGuidanceUpdateSubjectViewModel request);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
@@ -132,9 +132,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OrderBy(observation => observation.Year)
                 .ThenBy(observation => observation.TimeIdentifier);
 
-            var first = await orderedObservations.FirstAsync();
-            var last = await orderedObservations.LastAsync();
-            return (first.GetTimePeriod(), last.GetTimePeriod());
+            var first = await orderedObservations.FirstOrDefaultAsync();
+            var last = await orderedObservations.LastOrDefaultAsync();
+            return (first?.GetTimePeriod(), last?.GetTimePeriod());
         }
 
         private async Task<List<GeographicLevel>> GetGeographicLevels(Guid subjectId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
@@ -109,7 +109,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     {
                         var subject = releaseSubject.Subject;
                         var geographicLevels = await GetGeographicLevels(subject.Id);
-                        var (start, end) = await GetSubjectTimePeriods(subject.Id);
+                        var timePeriods = await GetSubjectTimePeriods(subject.Id);
                         return new MetaGuidanceSubjectViewModel
                         {
                             Id = subject.Id,
@@ -117,14 +117,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             Filename = dataFiles[subject.Id].Filename,
                             Name = subject.Name,
                             GeographicLevels = geographicLevels,
-                            Start = start,
-                            End = end
+                            TimePeriods = timePeriods
                         };
                     })
             )).ToList();
         }
 
-        private async Task<(string start, string end)> GetSubjectTimePeriods(Guid subjectId)
+        private async Task<MetaGuidanceSubjectTimePeriodsViewModel> GetSubjectTimePeriods(Guid subjectId)
         {
             var orderedObservations = _statisticsDbContext
                 .Observation
@@ -134,7 +133,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             var first = await orderedObservations.FirstOrDefaultAsync();
             var last = await orderedObservations.LastOrDefaultAsync();
-            return (first?.GetTimePeriod(), last?.GetTimePeriod());
+            return new MetaGuidanceSubjectTimePeriodsViewModel(first?.GetTimePeriod(), last?.GetTimePeriod());
         }
 
         private async Task<List<GeographicLevel>> GetGeographicLevels(Guid subjectId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
@@ -43,6 +43,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, MetaGuidanceViewModel>> Get(Guid releaseId)
         {
             return await _contentPersistenceHelper.CheckEntityExists<Release>(releaseId)
+                .OnSuccessDo(release => _userService.CheckCanViewRelease(release))
                 .OnSuccess(async release => BuildViewModel(release, await GetSubjects(releaseId)));
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
+{
+    public class MetaGuidanceService : IMetaGuidanceService
+    {
+        private readonly ContentDbContext _contentDbContext;
+        private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
+        private readonly StatisticsDbContext _statisticsDbContext;
+        private readonly IUserService _userService;
+
+        public MetaGuidanceService(ContentDbContext contentDbContext,
+            IPersistenceHelper<ContentDbContext> persistenceHelper,
+            StatisticsDbContext statisticsDbContext,
+            IUserService userService)
+        {
+            _contentDbContext = contentDbContext;
+            _persistenceHelper = persistenceHelper;
+            _statisticsDbContext = statisticsDbContext;
+            _userService = userService;
+        }
+
+        public async Task<Either<ActionResult, MetaGuidanceViewModel>> Get(Guid releaseId)
+        {
+            return await _persistenceHelper.CheckEntityExists<Release>(releaseId)
+                .OnSuccess(async release => BuildViewModel(release, await GetSubjects(release.Id)));
+        }
+
+        public async Task<Either<ActionResult, MetaGuidanceViewModel>> Update(Guid releaseId,
+            MetaGuidanceUpdateViewModel request)
+        {
+            return await _persistenceHelper.CheckEntityExists<Release>(releaseId)
+                .OnSuccessDo(release => _userService.CheckCanUpdateRelease(release))
+                .OnSuccess(async release =>
+                {
+                    _contentDbContext.Update(release);
+                    release.MetaGuidance = request.Content;
+                    await _contentDbContext.SaveChangesAsync();
+
+                    return BuildViewModel(release, await GetSubjects(release.Id));
+                });
+        }
+
+        private async Task<List<MetaGuidanceSubjectViewModel>> GetSubjects(Guid releaseId)
+        {
+            var dataFiles = await _contentDbContext
+                .ReleaseFiles
+                .Include(rf => rf.ReleaseFileReference)
+                .Where(rf => rf.ReleaseId == releaseId
+                             && rf.ReleaseFileReference.ReleaseFileType == ReleaseFileTypes.Data
+                             && rf.ReleaseFileReference.SubjectId.HasValue)
+                .Select(rf => rf.ReleaseFileReference)
+                .ToDictionaryAsync(f => f.SubjectId.Value, f => f);
+
+            var subjects = await _statisticsDbContext
+                .ReleaseSubject
+                .Include(s => s.Subject)
+                .Where(s => s.ReleaseId == releaseId)
+                .Select(s => s.Subject)
+                .ToListAsync();
+
+            return (await Task.WhenAll(
+                subjects
+                    .OrderBy(subject => subject.Name)
+                    .Select(async subject =>
+                    {
+                        var geographicLevels = await GetGeographicLevels(subject.Id);
+                        var (start, end) = await GetSubjectTimePeriods(subject.Id);
+                        return new MetaGuidanceSubjectViewModel
+                        {
+                            Content = subject.MetaGuidance,
+                            Filename = dataFiles[subject.Id].Filename,
+                            Name = subject.Name,
+                            GeographicLevels = geographicLevels,
+                            Start = start,
+                            End = end
+                        };
+                    })
+            )).ToList();
+        }
+
+        private async Task<(string start, string end)> GetSubjectTimePeriods(Guid subjectId)
+        {
+            var orderedObservations = _statisticsDbContext
+                .Observation
+                .Where(observation => observation.SubjectId == subjectId)
+                .OrderBy(observation => observation.Year)
+                .ThenBy(observation => observation.TimeIdentifier);
+
+            var first = await orderedObservations.FirstAsync();
+            var last = await orderedObservations.LastAsync();
+            return (first.GetTimePeriod(), last.GetTimePeriod());
+        }
+
+        private async Task<List<GeographicLevel>> GetGeographicLevels(Guid subjectId)
+        {
+            return await _statisticsDbContext
+                .Observation
+                .Where(observation => observation.SubjectId == subjectId)
+                .Select(observation => observation.GeographicLevel)
+                .Distinct()
+                .ToListAsync();
+        }
+
+        private static MetaGuidanceViewModel BuildViewModel(Release release,
+            List<MetaGuidanceSubjectViewModel> subjects)
+        {
+            return new MetaGuidanceViewModel
+            {
+                Content = release.MetaGuidance,
+                Subjects = subjects
+            };
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
@@ -51,7 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             return await _contentPersistenceHelper.CheckEntityExists<Release>(releaseId)
                 .OnSuccessDo(release => _userService.CheckCanViewRelease(release))
-                .OnSuccess(async release => BuildViewModel(release, await GetSubjects(releaseId)));
+                .OnSuccess(BuildViewModel);
         }
 
         public async Task<Either<ActionResult, MetaGuidanceViewModel>> UpdateRelease(Guid releaseId,
@@ -65,7 +65,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     release.MetaGuidance = request.Content;
                     await _contentDbContext.SaveChangesAsync();
 
-                    return BuildViewModel(release, await GetSubjects(releaseId));
+                    return await BuildViewModel(release);
                 });
         }
 
@@ -87,7 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             releaseSubject.MetaGuidance = request.Content;
                             await _statisticsDbContext.SaveChangesAsync();
 
-                            return BuildViewModel(release, await GetSubjects(releaseId));
+                            return await BuildViewModel(release);
                         });
                 });
         }
@@ -172,9 +172,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .ToList();
         }
 
-        private static MetaGuidanceViewModel BuildViewModel(Release release,
-            List<MetaGuidanceSubjectViewModel> subjects)
+        private async Task<MetaGuidanceViewModel> BuildViewModel(Release release)
         {
+            var subjects = await GetSubjects(release.Id);
             return new MetaGuidanceViewModel
             {
                 Id = release.Id,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -276,6 +276,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IIndicatorGroupService, IndicatorGroupService>();
             services.AddTransient<IIndicatorService, IndicatorService>();
             services.AddTransient<ILocationService, LocationService>();
+            services.AddTransient<IMetaGuidanceService, MetaGuidanceService>();
             services.AddTransient<IObservationService, ObservationService>();
             services.AddTransient<IReleaseMetaService, ReleaseMetaService>();
             services.AddTransient<IReleaseNoteService, ReleaseNoteService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MetaGuidanceViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MetaGuidanceViewModel.cs
@@ -19,12 +19,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public string Filename { get; set; }
         public string Name { get; set; }
         public string Content { get; set; }
-        public string Start { get; set; }
-        public string End { get; set; }
+        public MetaGuidanceSubjectTimePeriodsViewModel TimePeriods { get; set; }
         [JsonProperty (ItemConverterType = typeof(EnumToEnumValueJsonConverter<GeographicLevel>))]
         public List<GeographicLevel> GeographicLevels { get; set; }
     }
 
+    public class MetaGuidanceSubjectTimePeriodsViewModel
+    {
+        public string From { get;  }
+        public string To { get; }
+
+        public MetaGuidanceSubjectTimePeriodsViewModel(string from, string to)
+        {
+            From = from;
+            To = to;
+        }
+    }
+    
     public class MetaGuidanceUpdateReleaseViewModel
     {
         public string Content { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MetaGuidanceViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MetaGuidanceViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using Newtonsoft.Json;
 
@@ -22,6 +23,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public MetaGuidanceSubjectTimePeriodsViewModel TimePeriods { get; set; }
         [JsonProperty (ItemConverterType = typeof(EnumToEnumValueJsonConverter<GeographicLevel>))]
         public List<GeographicLevel> GeographicLevels { get; set; }
+        public List<LabelValue> Variables { get; set; }
     }
 
     public class MetaGuidanceSubjectTimePeriodsViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MetaGuidanceViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MetaGuidanceViewModel.cs
@@ -1,16 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
     public class MetaGuidanceViewModel
     {
+        public Guid Id { get; set; }
         public string Content { get; set; }
         public List<MetaGuidanceSubjectViewModel> Subjects { get; set; }
     }
 
     public class MetaGuidanceSubjectViewModel
     {
+        public Guid Id { get; set; }
         public string Filename { get; set; }
         public string Name { get; set; }
         public string Content { get; set; }
@@ -19,7 +22,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public List<GeographicLevel> GeographicLevels { get; set; }
     }
 
-    public class MetaGuidanceUpdateViewModel
+    public class MetaGuidanceUpdateReleaseViewModel
+    {
+        public string Content { get; set; }
+    }
+    
+    public class MetaGuidanceUpdateSubjectViewModel
     {
         public string Content { get; set; }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MetaGuidanceViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MetaGuidanceViewModel.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
+{
+    public class MetaGuidanceViewModel
+    {
+        public string Content { get; set; }
+        public List<MetaGuidanceSubjectViewModel> Subjects { get; set; }
+    }
+
+    public class MetaGuidanceSubjectViewModel
+    {
+        public string Filename { get; set; }
+        public string Name { get; set; }
+        public string Content { get; set; }
+        public string Start { get; set; }
+        public string End { get; set; }
+        public List<GeographicLevel> GeographicLevels { get; set; }
+    }
+
+    public class MetaGuidanceUpdateViewModel
+    {
+        public string Content { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MetaGuidanceViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MetaGuidanceViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
@@ -19,6 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public string Content { get; set; }
         public string Start { get; set; }
         public string End { get; set; }
+        [JsonProperty (ItemConverterType = typeof(EnumToEnumValueJsonConverter<GeographicLevel>))]
         public List<GeographicLevel> GeographicLevels { get; set; }
     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/LabelValue.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/LabelValue.cs
@@ -5,6 +5,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         public string Label { get; set; }
         public string Value { get; set; }
 
+        public LabelValue()
+        {
+        }
+
+        public LabelValue(string label, string value)
+        {
+            Label = label;
+            Value = value;
+        }
+
         protected bool Equals(LabelValue other)
         {
             return Label == other.Label && Value == other.Value;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -71,6 +71,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public string PreReleaseAccessList { get; set; }
 
+        public string MetaGuidance { get; set; }
+
         public Release? PreviousVersion { get; set; }
 
         public bool SoftDeleted { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20201008103731_EES1409AddMetaGuidanceFieldToSubject.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20201008103731_EES1409AddMetaGuidanceFieldToSubject.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
-    partial class StatisticsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201008103731_EES1409AddMetaGuidanceFieldToSubject")]
+    partial class EES1409AddMetaGuidanceFieldToSubject
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20201008103731_EES1409AddMetaGuidanceFieldToSubject.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20201008103731_EES1409AddMetaGuidanceFieldToSubject.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
+{
+    public partial class EES1409AddMetaGuidanceFieldToSubject : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MetaGuidance",
+                table: "Subject",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MetaGuidance",
+                table: "Subject");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20201009100336_EES1409AddMetaGuidanceFieldToReleaseSubject.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20201009100336_EES1409AddMetaGuidanceFieldToReleaseSubject.Designer.cs
@@ -10,8 +10,8 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
-    [Migration("20201008103731_EES1409AddMetaGuidanceFieldToSubject")]
-    partial class EES1409AddMetaGuidanceFieldToSubject
+    [Migration("20201009100336_EES1409AddMetaGuidanceFieldToReleaseSubject")]
+    partial class EES1409AddMetaGuidanceFieldToReleaseSubject
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
@@ -418,6 +418,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
                     b.Property<Guid>("SubjectId")
                         .HasColumnType("uniqueidentifier");
 
+                    b.Property<string>("MetaGuidance")
+                        .HasColumnType("nvarchar(max)");
+
                     b.HasKey("ReleaseId", "SubjectId");
 
                     b.HasIndex("SubjectId");
@@ -458,9 +461,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("MetaGuidance")
-                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
                         .HasColumnType("nvarchar(max)");

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20201009100336_EES1409AddMetaGuidanceFieldToReleaseSubject.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20201009100336_EES1409AddMetaGuidanceFieldToReleaseSubject.cs
@@ -2,13 +2,13 @@
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
-    public partial class EES1409AddMetaGuidanceFieldToSubject : Migration
+    public partial class EES1409AddMetaGuidanceFieldToReleaseSubject : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<string>(
                 name: "MetaGuidance",
-                table: "Subject",
+                table: "ReleaseSubject",
                 nullable: true);
         }
 
@@ -16,7 +16,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
         {
             migrationBuilder.DropColumn(
                 name: "MetaGuidance",
-                table: "Subject");
+                table: "ReleaseSubject");
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/StatisticsDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/StatisticsDbContextModelSnapshot.cs
@@ -416,6 +416,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
                     b.Property<Guid>("SubjectId")
                         .HasColumnType("uniqueidentifier");
 
+                    b.Property<string>("MetaGuidance")
+                        .HasColumnType("nvarchar(max)");
+
                     b.HasKey("ReleaseId", "SubjectId");
 
                     b.HasIndex("SubjectId");
@@ -456,9 +459,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("MetaGuidance")
-                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
                         .HasColumnType("nvarchar(max)");

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ReleaseSubject.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ReleaseSubject.cs
@@ -11,5 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public Release Release { get; set; }
         
         public Guid ReleaseId { get; set; }
+        
+        public string MetaGuidance { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Subject.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Subject.cs
@@ -7,7 +7,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
     {
         public Guid Id { get; set; }
         public string Name { get; set; }
-        public string MetaGuidance { get; set; }
         public IEnumerable<Observation> Observations { get; set; }
         public ICollection<SubjectFootnote> Footnotes { get; set; }
         public bool SoftDeleted { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Subject.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Subject.cs
@@ -7,7 +7,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
     {
         public Guid Id { get; set; }
         public string Name { get; set; }
-
+        public string MetaGuidance { get; set; }
         public IEnumerable<Observation> Observations { get; set; }
         public ICollection<SubjectFootnote> Footnotes { get; set; }
         public bool SoftDeleted { get; set; }


### PR DESCRIPTION
This PR adds the API endpoints to get and update Meta Guidance for Release and Subjects

`GET {{admin_api_url}}/release/{releaseId}/meta-guidance`
`PUT {{admin_api_url}}/release/{releaseId}/meta-guidance`
`PUT {{admin_api_url}}/release/{releaseId}/meta-guidance/subject/{subjectId}`

Each of these requests returns a common Meta Guidance response containing

- Guidance text for the Release
- List of Subjects (sorted by name) containing:
  - Guidance text for the Subject
  - Filename
  - Name
  - Time Periods
  - Geographic Levels
  - List of Filter and Indicator column names with descriptions

```
{
    "id": "ea72ef7a-e357-479d-1fc7-08d86c4b2553",
    "content": "Guidance text for the Release",
    "subjects": [
        {
            "id": "9e8b9d66-bec9-49f5-80a4-08d86c4c75f9",
            "filename": "data.csv",
            "name": "Test Data Subject",
            "content": "Guidance for text for Test Data Subject",
            "timePeriods": {
                "from": "2015_AY",
                "to": "2019_AY"
            },
            "geographicLevels": [
                "NAT", "LA", "LAD"
            ],
            "variables": [
                {
                    "label": "Headcount",
                    "value": "number_of_pupils"
                },
                {
                    "label": "Primary type of need - (ASD, HI, VI)",
                    "value": "primary_need"
                },
                {
                    "label": "Boys",
                    "value": "pupil_gender_boys"
                },
                {
                    "label": "Girls",
                    "value": "pupil_gender_girls"
                },
                {
                    "label": "SEN provision - EHC plan/Statement of SEN or SEN support/School Action/School Action plus",
                    "value": "pupil_sen_status"
                }
            ]
        }
    ]
}
```