### PR TITLE
EES-372 Filter out subjects that are importing from table tool

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseMetaServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseMetaServicePermissionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -36,13 +37,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             ContentDbContext contentDbContext = null,
             IPersistenceHelper<ContentDbContext> persistenceHelper = null,
             StatisticsDbContext statisticsDbContext = null,
-            IUserService userService = null)
+            IUserService userService = null,
+            IImportStatusService importStatusService = null)
         {
             return new ReleaseMetaService(
                 contentDbContext ?? new Mock<ContentDbContext>().Object,
                 persistenceHelper ?? DefaultPersistenceHelperMock().Object,
                 statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
-                userService ?? new Mock<IUserService>().Object
+                userService ?? new Mock<IUserService>().Object,
+                importStatusService ?? new Mock<IImportStatusService>().Object
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -97,12 +97,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             }
         }
 
-        public static async Task ForEachAsync<T>(this IEnumerable<T> list, Func<T, Task> func)
+        public static async Task ForEachAsync<T>(this IEnumerable<T> source, Func<T, Task> func)
         {
-            foreach (var item in list)
+            foreach (var item in source)
             {
                 await func(item);
             }
+        }
+
+        /// <summary>
+        /// Filter a sequence of elements asynchronously.
+        /// </summary>
+        /// <remarks>
+        /// Do NOT use this in combination with <see cref="IQueryable{T}"/>, as Entity Framework
+        /// contexts are not thread safe. The most likely outcome will be some kind of exception.
+        /// Materialise the <see cref="IQueryable{T}"/> as a list or other collection first.
+        /// </remarks>
+        ///
+        /// <param name="source">Sequence of elements to filter</param>
+        /// <param name="filter">Filtering function that returns true if element should remain in sequence</param>
+        /// <typeparam name="T">Type of elements in the source sequence</typeparam>
+        /// <returns>Filtered sequence of elements</returns>
+        public static IEnumerable<T> WhereAsync<T>(this IEnumerable<T> source, Func<T, Task<bool>> filter)
+        {
+            var tasks = Task.WhenAll<(T item, bool isSuccess)>(
+                source.Select(async item => (item, await filter(item)))
+            );
+
+            return tasks.Result
+                .Where(tuple => tuple.isSuccess)
+                .Select(tuple => tuple.item);
         }
 
         public static IEnumerable<(T item, int index)> WithIndex<T>(this IEnumerable<T> self) =>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -107,15 +107,12 @@ const DataBlockSourceWizardFinalStep = ({
 
 interface DataBlockSourceWizardProps {
   dataBlock?: ReleaseDataBlock;
-  query?: ReleaseTableDataQuery;
-  releaseId?: string;
-  tableToolState?: InitialTableToolState;
+  tableToolState: InitialTableToolState;
   onSave: DataBlockSourceWizardSaveHandler;
 }
 
 const DataBlockSourceWizard = ({
   dataBlock,
-  releaseId,
   tableToolState,
   onSave,
 }: DataBlockSourceWizardProps) => {
@@ -125,17 +122,7 @@ const DataBlockSourceWizard = ({
 
       <TableToolWizard
         themeMeta={[]}
-        initialState={
-          tableToolState ?? {
-            query: {
-              releaseId,
-              subjectId: '',
-              indicators: [],
-              filters: [],
-              locations: {},
-            },
-          }
-        }
+        initialState={tableToolState}
         finalStep={({ response, query }) => (
           <WizardStep>
             {wizardStepProps => (

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ReleaseDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ReleaseDataBlocksPageTabs.tsx
@@ -55,9 +55,22 @@ const ReleaseDataBlocksPageTabs = ({
     setState: setTableState,
     error,
     isLoading,
-  } = useAsyncRetry<InitialTableToolState | undefined>(async () => {
+  } = useAsyncRetry<InitialTableToolState>(async () => {
+    const { subjects } = await tableBuilderService.getReleaseMeta(releaseId);
+
     if (!selectedDataBlock) {
-      return undefined;
+      return {
+        initialStep: 1,
+        subjects,
+        query: {
+          releaseId,
+          subjectId: '',
+          includeGeoJson: false,
+          locations: {},
+          filters: [],
+          indicators: [],
+        },
+      };
     }
 
     const query: ReleaseTableDataQuery = {
@@ -80,6 +93,7 @@ const ReleaseDataBlocksPageTabs = ({
     if (step < 5) {
       return {
         initialStep: step,
+        subjects,
         subjectMeta,
         query,
       };
@@ -95,6 +109,7 @@ const ReleaseDataBlocksPageTabs = ({
 
       return {
         initialStep: step,
+        subjects,
         subjectMeta,
         query,
         response: {
@@ -250,7 +265,7 @@ const ReleaseDataBlocksPageTabs = ({
         />
       )}
 
-      {tableState && tableState?.initialStep < 5 && (
+      {selectedDataBlock && tableState && tableState?.initialStep < 5 && (
         <WarningMessage>
           There is a problem with this data block as we could not render a table
           with the selected options. Please re-check your choices to ensure the
@@ -261,11 +276,10 @@ const ReleaseDataBlocksPageTabs = ({
       {!error ? (
         <Tabs id="manageDataBlocks">
           <TabsSection title="Data source" id="manageDataBlocks-dataSource">
-            {!isLoading && (
+            {!isLoading && tableState && (
               <DataBlockSourceWizard
                 key={saveNumber}
                 dataBlock={selectedDataBlock}
-                releaseId={releaseId}
                 tableToolState={tableState}
                 onSave={handleDataBlockSourceSave}
               />

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -133,18 +133,16 @@ describe('TableToolWizard', () => {
     expect(screen.getAllByRole('listitem')).toHaveLength(1);
   });
 
-  test('renders fetched publication subjects if `initialState.query.publicationId` set', async () => {
-    tableBuilderService.getPublicationMeta.mockResolvedValue({
-      publicationId: 'publication-1',
-      subjects: [{ id: 'subject-1', label: 'Subject 1' }],
-      highlights: [],
-    });
-
+  test('renders `initialState.subjects` on step when it is the current step', async () => {
     render(
       <TableToolWizard
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 2,
+          subjects: [
+            { id: 'subject-1', label: 'Subject 1' },
+            { id: 'subject-2', label: 'Subject 2' },
+          ],
           query: {
             publicationId: 'publication-1',
             subjectId: '',
@@ -157,11 +155,8 @@ describe('TableToolWizard', () => {
     );
 
     await waitFor(() => {
-      expect(tableBuilderService.getPublicationMeta).toHaveBeenCalledWith(
-        'publication-1',
-      );
-
       expect(screen.getByLabelText('Subject 1')).toBeInTheDocument();
+      expect(screen.getByLabelText('Subject 2')).toBeInTheDocument();
     });
   });
 
@@ -197,62 +192,18 @@ describe('TableToolWizard', () => {
     });
   });
 
-  test('renders fetched publication release subjects if `initialState.query.releaseId` is set', async () => {
-    tableBuilderService.getPublicationMeta.mockResolvedValue({
-      publicationId: 'publication-1',
-      subjects: [{ id: 'subject-1', label: 'Subject 1' }],
-      highlights: [],
-    });
-
-    tableBuilderService.getReleaseMeta.mockResolvedValue({
-      releaseId: 'release-1',
-      subjects: [{ id: 'subject-2', label: 'Subject 2' }],
-    });
-
-    render(
-      <TableToolWizard
-        themeMeta={testThemeMeta}
-        initialState={{
-          initialStep: 1,
-          query: {
-            publicationId: 'publication-1',
-            releaseId: 'release-1',
-            subjectId: '',
-            locations: {},
-            filters: [],
-            indicators: [],
-          },
-        }}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(tableBuilderService.getPublicationMeta).not.toHaveBeenCalled();
-      expect(tableBuilderService.getReleaseMeta).toHaveBeenCalledWith(
-        'release-1',
-      );
-
-      expect(screen.queryByText('Subject 1')).not.toBeInTheDocument();
-      expect(screen.getByLabelText('Subject 2')).toBeInTheDocument();
-    });
-  });
-
-  test('renders table highlights on step 2 when it is the current step', async () => {
-    tableBuilderService.getPublicationMeta.mockResolvedValue({
-      publicationId: 'publication-1',
-      subjects: [{ id: 'subject-1', label: 'Subject 1' }],
-      highlights: [
-        { id: 'highlight-1', label: 'Test highlight 1' },
-        { id: 'highlight-2', label: 'Test highlight 2' },
-        { id: 'highlight-3', label: 'Test highlight 3' },
-      ],
-    });
-
+  test('renders `initialState.highlights` on step 2 when it is the current step', async () => {
     render(
       <TableToolWizard
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 2,
+          subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+          highlights: [
+            { id: 'highlight-1', label: 'Test highlight 1' },
+            { id: 'highlight-2', label: 'Test highlight 2' },
+            { id: 'highlight-3', label: 'Test highlight 3' },
+          ],
           query: {
             publicationId: 'publication-1',
             subjectId: '',
@@ -296,22 +247,18 @@ describe('TableToolWizard', () => {
     });
   });
 
-  test('does not render table highlights when step 2 is not the current step', async () => {
-    tableBuilderService.getPublicationMeta.mockResolvedValue({
-      publicationId: 'publication-1',
-      subjects: [{ id: 'subject-1', label: 'Subject 1' }],
-      highlights: [
-        { id: 'highlight-1', label: 'Test highlight 1' },
-        { id: 'highlight-2', label: 'Test highlight 2' },
-        { id: 'highlight-3', label: 'Test highlight 3' },
-      ],
-    });
-
+  test('does not render `initialSate.highlights` when step 2 is not the current step', async () => {
     render(
       <TableToolWizard
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 3,
+          subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+          highlights: [
+            { id: 'highlight-1', label: 'Test highlight 1' },
+            { id: 'highlight-2', label: 'Test highlight 2' },
+            { id: 'highlight-3', label: 'Test highlight 3' },
+          ],
           query: {
             publicationId: 'publication-1',
             subjectId: 'subject-1',
@@ -347,18 +294,14 @@ describe('TableToolWizard', () => {
   });
 
   test('renders all steps correctly when full `initialState` is provided', async () => {
-    tableBuilderService.getPublicationMeta.mockResolvedValue({
-      publicationId: 'publication-1',
-      subjects: [{ id: 'subject-1', label: 'Subject 1' }],
-      highlights: [],
-    });
-
     render(
       <TableToolWizard
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 5,
           subjectMeta: testSubjectMeta,
+          subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+          highlights: [],
           query: {
             publicationId: 'publication-1',
             subjectId: 'subject-1',

--- a/src/explore-education-statistics-common/src/services/fastTrackService.ts
+++ b/src/explore-education-statistics-common/src/services/fastTrackService.ts
@@ -1,7 +1,12 @@
 import { dataApi } from '@common/services/api';
+import { TableDataQuery } from '@common/services/tableBuilderService';
 import { ConfiguredTable } from '@common/services/types/table';
 
-export type FastTrackTable = ConfiguredTable;
+export type FastTrackTable = ConfiguredTable & {
+  query: TableDataQuery & {
+    publicationId: string;
+  };
+};
 
 const fastTrackService = {
   getFastTrackTable(id: string): Promise<FastTrackTable> {

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -7,6 +7,7 @@ import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
 import { FastTrackTable } from '@common/services/fastTrackService';
 import tableBuilderService, {
+  PublicationMeta,
   SubjectMeta,
   ThemeMeta,
 } from '@common/services/tableBuilderService';
@@ -23,60 +24,58 @@ const TableToolFinalStep = dynamic(
 );
 
 export interface TableToolPageProps {
-  publicationSlug?: string;
+  publicationMeta?: PublicationMeta;
   fastTrack?: FastTrackTable;
   subjectMeta?: SubjectMeta;
   themeMeta: ThemeMeta[];
 }
 
 const TableToolPage: NextPage<TableToolPageProps> = ({
-  publicationSlug,
+  publicationMeta,
   fastTrack,
   subjectMeta,
   themeMeta,
 }) => {
-  const initialTableToolState = useMemo<
-    Partial<InitialTableToolState> | undefined
-  >(() => {
-    if (publicationSlug) {
-      const publicationId =
-        themeMeta
-          .flatMap(option => option.topics)
-          .flatMap(option => option.publications)
-          .find(option => option.slug === publicationSlug)?.id ?? '';
+  const initialState = useMemo<InitialTableToolState | undefined>(() => {
+    if (!publicationMeta) {
+      return undefined;
+    }
+
+    const { publicationId, subjects, highlights } = publicationMeta;
+
+    if (fastTrack && subjectMeta) {
+      const fullTable = mapFullTable(fastTrack.fullTable);
+      const tableHeaders = mapTableHeadersConfig(
+        fastTrack.configuration.tableHeaders,
+        fullTable.subjectMeta,
+      );
 
       return {
-        initialStep: 1,
-        query: {
-          publicationId,
-          subjectId: '',
-          indicators: [],
-          filters: [],
-          locations: {},
+        initialStep: 6,
+        subjects,
+        highlights,
+        query: fastTrack.query,
+        subjectMeta,
+        response: {
+          table: fullTable,
+          tableHeaders,
         },
       };
     }
 
-    if (!fastTrack || !subjectMeta) {
-      return undefined;
-    }
-
-    const fullTable = mapFullTable(fastTrack.fullTable);
-    const tableHeaders = mapTableHeadersConfig(
-      fastTrack.configuration.tableHeaders,
-      fullTable.subjectMeta,
-    );
-
     return {
-      initialStep: 6,
-      query: fastTrack.query,
-      subjectMeta,
-      response: {
-        table: fullTable,
-        tableHeaders,
+      initialStep: 2,
+      subjects,
+      highlights,
+      query: {
+        publicationId,
+        subjectId: '',
+        indicators: [],
+        filters: [],
+        locations: {},
       },
     };
-  }, [fastTrack, publicationSlug, subjectMeta, themeMeta]);
+  }, [fastTrack, publicationMeta, subjectMeta]);
 
   return (
     <Page title="Create your own tables online" caption="Table Tool" wide>
@@ -94,7 +93,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
         key={fastTrack?.id}
         scrollOnMount
         themeMeta={themeMeta}
-        initialState={initialTableToolState}
+        initialState={initialState}
         renderHighlights={highlights => (
           <aside>
             <h3>Table highlights</h3>
@@ -149,10 +148,20 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
 
   const themeMeta = await tableBuilderService.getThemes();
 
+  const publicationId =
+    themeMeta
+      .flatMap(option => option.topics)
+      .flatMap(option => option.publications)
+      .find(option => option.slug === publicationSlug)?.id ?? '';
+
+  const publicationMeta = publicationId
+    ? await tableBuilderService.getPublicationMeta(publicationId)
+    : undefined;
+
   return {
     props: {
       themeMeta,
-      publicationSlug,
+      publicationMeta,
     },
   };
 };

--- a/src/explore-education-statistics-frontend/src/pages/data-tables/fast-track/[fastTrackId].tsx
+++ b/src/explore-education-statistics-frontend/src/pages/data-tables/fast-track/[fastTrackId].tsx
@@ -26,14 +26,16 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
     throw new Error('Fast track table does not have `query.subjectId`');
   }
 
-  const subjectMeta = await tableBuilderService.getSubjectMeta(
-    fastTrack.query.subjectId,
-  );
+  const [publicationMeta, subjectMeta] = await Promise.all([
+    tableBuilderService.getPublicationMeta(fastTrack.query.publicationId),
+    tableBuilderService.getSubjectMeta(fastTrack.query.subjectId),
+  ]);
 
   return {
     props: {
       fastTrack,
       subjectMeta,
+      publicationMeta,
       themeMeta,
     },
   };

--- a/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Resource    ../../libs/admin-common.robot
+Resource    ../../libs/public-common.robot
 Library     ../../libs/api_keywords.py
 
 Force Tags  Admin  Local  Dev  AltersData  Footnotes

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Resource    ../../libs/admin-common.robot
+Resource    ../../libs/public-common.robot
 Library     ../../libs/api_keywords.py
 
 Force Tags  Admin  Local  Dev  AltersData

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource    ../../libs/admin-common.robot
 Resource    ../../libs/charts.robot
+Resource    ../../libs/public-common.robot
 Library     ../../libs/api_keywords.py
 
 Force Tags  Admin  Local  Dev  AltersData

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -296,8 +296,6 @@ Clicking "Create tables" takes user to Table Tool page with absence publication 
     user clicks link    Create tables
     user waits until h1 is visible  Create your own tables online   60
     user waits for page to finish loading
-    user checks radio is checked  Pupil absence in schools in England
-    user clicks button  Next step
 
     user waits until page contains  Choose a subject   60
     user checks previous table tool step contains  1   Publication   Pupil absence in schools in England

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -436,9 +436,9 @@ user gets details content element
     [Return]  ${content}
 
 user waits until details contains element
-    [Arguments]  ${text}  ${element}  ${parent}=css:body
+    [Arguments]  ${text}  ${element}  ${parent}=css:body  ${wait}=${timeout}
     ${details}=  user gets details content element  ${text}  ${parent}
-    user waits until parent contains element  ${details}  ${element}
+    user waits until parent contains element  ${details}  ${element}  timeout=${wait}
 
 user waits until details contains link
     [Arguments]  ${text}  ${link}  ${parent}=css:body

--- a/tests/robot-tests/tests/libs/public-common.robot
+++ b/tests/robot-tests/tests/libs/public-common.robot
@@ -16,3 +16,7 @@ user checks release update
     [Arguments]  ${number}  ${date}  ${text}
     user waits until element contains  css:#releaseNotes li:nth-of-type(${number}) time  ${date}
     user waits until element contains  css:#releaseNotes li:nth-of-type(${number}) p     ${text}
+
+user waits until details dropdown contains publication
+    [Arguments]  ${details_heading}  ${publication_name}  ${wait}=3
+    user waits until details contains element  ${details_heading}  xpath:.//*[text()="${publication_name}"]  wait=${wait}

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -256,19 +256,12 @@ def user_checks_selected_list_label(list_locator, label):
             f'Selected label "{selected_label}" didn\'t match label "{label}" for list "{list_locator}"')
 
 
-def user_waits_until_details_dropdown_contains_publication(details_heading, publication_name,
-                                                           timeout=3):
-    sl.wait_until_page_contains_element(f'xpath://details/summary[.="{details_heading}"]',
-                                        timeout=timeout)
-    sl.wait_until_page_contains_element(
-        f'xpath://details/summary[.="{details_heading}"]/../..//*[text()="{publication_name}"]')
-
-
 def remove_substring_from_right_of_string(string, substring):
     if string.endswith(substring):
         return string[:-len(substring)]
     else:
         raise_assertion_error(f'String "{string}" doesn\'t end with substring "{substring}"')
+
 
 def user_clicks_element_if_exists(selector):
     if element_finder.find(selector, required=False) is not None:


### PR DESCRIPTION
This PR filters out subjects that are in the middle of importing from displaying on the 'Data blocks' page table tool. This prevents the user from being able to select them and be presented with the second step in an incorrect state.

## Additional changes

- Refactored all of `TableToolWizard`'s internal state so that it can be passed in via the `initialState` prop. This allows us to completely control the initial state from the parent component and allows us to only render `TableToolWizard` when its initial state has all been fetched. This change has mostly been done to avoid the initial step momentarily showing empty state whilst the meta is still being fetched.