### PR TITLE
EES-1398 Fix PublicationSummary rendering long external methodology URLs

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
@@ -138,17 +138,9 @@ const PublicationSummary = ({ publication, onChangePublication }: Props) => {
               ) : (
                 <>
                   {externalMethodology?.url ? (
-                    <>
-                      {externalMethodology.title} (
-                      <a
-                        href={externalMethodology.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {externalMethodology.url}
-                      </a>
-                      )
-                    </>
+                    <Link to={externalMethodology.url} unvisited>
+                      {externalMethodology.title} (external methodology)
+                    </Link>
                   ) : (
                     'No methodology assigned'
                   )}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
@@ -45,9 +45,6 @@ const PublicationSummary = ({ publication, onChangePublication }: Props) => {
   const noAmendmentInProgressFilter = (release: Release) =>
     !releases.some(r => r.amendment && r.previousVersionId === release.id);
 
-  // BAU-404 - temporarily hide the Amend Release button completely until Release Versioning Phase 1 is complete
-  const showAmendmentButton = () => true;
-
   return (
     <>
       <table>
@@ -173,9 +170,7 @@ const PublicationSummary = ({ publication, onChangePublication }: Props) => {
                   {releases.filter(noAmendmentInProgressFilter).map(release => (
                     <li key={release.id}>
                       <NonScheduledReleaseSummary
-                        onClickAmendRelease={
-                          showAmendmentButton() ? setAmendReleaseId : undefined
-                        }
+                        onClickAmendRelease={setAmendReleaseId}
                         onClickCancelAmendment={setCancelAmendmentReleaseId}
                         release={release}
                       />


### PR DESCRIPTION
This PR changes `PublicationSummary` so that it no longer renders the external mehodology URL. Long URLs were causing the`SummaryListItem` action column to be pushed out of the page, making it difficult to change the publication details. We've changed this so that it just displays the following:

![image](https://user-images.githubusercontent.com/9917868/95773624-bda1a280-0cb6-11eb-84e3-52e8791b0365.png)
