### PR TITLE
EES-1409 Multiple Subject Guidance API bug fixes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -228,9 +228,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Subject 1", result.Right.Subjects[0].Name);
                 Assert.Equal("2020_AYQ3", result.Right.Subjects[0].TimePeriods.From);
                 Assert.Equal("2021_AYQ1", result.Right.Subjects[0].TimePeriods.To);
-                Assert.Equal(new List<GeographicLevel>
+                Assert.Equal(new List<string>
                 {
-                    GeographicLevel.Country, GeographicLevel.LocalAuthority, GeographicLevel.LocalAuthorityDistrict
+                    "National", "Local Authority", "Local Authority District"
                 }, result.Right.Subjects[0].GeographicLevels);
                 Assert.Equal(2, result.Right.Subjects[0].Variables.Count);
                 Assert.Equal("Subject 1 Filter - Hint", result.Right.Subjects[0].Variables[0].Label);
@@ -244,9 +244,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Subject 2", result.Right.Subjects[1].Name);
                 Assert.Equal("2020_T3", result.Right.Subjects[1].TimePeriods.From);
                 Assert.Equal("2021_T2", result.Right.Subjects[1].TimePeriods.To);
-                Assert.Equal(new List<GeographicLevel>
+                Assert.Equal(new List<string>
                 {
-                    GeographicLevel.Country, GeographicLevel.Region
+                    "National", "Regional"
                 }, result.Right.Subjects[1].GeographicLevels);
                 Assert.Equal(2, result.Right.Subjects[1].Variables.Count);
                 Assert.Equal("Subject 2 Filter", result.Right.Subjects[1].Variables[0].Label);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MetaGuidanceViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MetaGuidanceViewModel.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
-using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
@@ -21,15 +18,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public string Name { get; set; }
         public string Content { get; set; }
         public MetaGuidanceSubjectTimePeriodsViewModel TimePeriods { get; set; }
-        [JsonProperty (ItemConverterType = typeof(EnumToEnumValueJsonConverter<GeographicLevel>))]
-        public List<GeographicLevel> GeographicLevels { get; set; }
+        public List<string> GeographicLevels { get; set; }
         public List<LabelValue> Variables { get; set; }
     }
 
     public class MetaGuidanceSubjectTimePeriodsViewModel
     {
-        public string From { get;  }
+        public string From { get; }
         public string To { get; }
+
+        public MetaGuidanceSubjectTimePeriodsViewModel()
+        {
+        }
 
         public MetaGuidanceSubjectTimePeriodsViewModel(string from, string to)
         {
@@ -37,12 +37,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
             To = to;
         }
     }
-    
+
     public class MetaGuidanceUpdateReleaseViewModel
     {
         public string Content { get; set; }
     }
-    
+
     public class MetaGuidanceUpdateSubjectViewModel
     {
         public string Content { get; set; }


### PR DESCRIPTION
- Don't await multiple tasks when building Subject view models since this involves multiple database calls and DbContext is not thread safe and results in an error getting the Subject Guidance for a Release with multiple Subjects.
- Fix a performance issue getting Subject time period of large subjects by limiting the database query to the time period fields.
- Serialize GeographicLevel as String label in the view model response.