### PR TITLE
EES-372 Fix /data-tables throwing serialization error in development

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -158,10 +158,18 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
     ? await tableBuilderService.getPublicationMeta(publicationId)
     : undefined;
 
+  if (publicationMeta) {
+    return {
+      props: {
+        themeMeta,
+        publicationMeta,
+      },
+    };
+  }
+
   return {
     props: {
       themeMeta,
-      publicationMeta,
     },
   };
 };

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -81,7 +81,7 @@ User waits for table to appear
     [Tags]  HappyPath
     # Extra timeout until EES-234
     user waits until results table appears    180
-    user waits until page contains element   xpath://*[@data-testid="dataTableCaption" and text()="Table showing 'Exclusions by geographic level' from 'Permanent and fixed-period exclusions in England' in Bury, Sheffield and York between 2006/07 and 2008/09"]
+    user waits until page contains element   xpath://*[@data-testid="dataTableCaption" and text()="Table showing 'Exclusions by geographic level' for State-funded secondary from 'Permanent and fixed-period exclusions in England' in Bury, Sheffield and York between 2006/07 and 2008/09"]
 
 Validate results table column headings
     [Tags]  HappyPath


### PR DESCRIPTION
This PR fixes `/data-tables` on the public frontend throwing a JSON serialization error on 'undefined' when running the development server. Notably, it's a bit unfortunate that this only happens in development as it means that the UI tests can't actually catch this kind of problem.