### PR TITLE
EES-1481 Allow no Release to exist when databases are not in sync.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/MetaGuidanceSubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/MetaGuidanceSubjectServiceTests.cs
@@ -8,7 +8,6 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -212,8 +211,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var result = await service.GetSubjects(Guid.NewGuid());
 
-                Assert.True(result.IsLeft);
-                Assert.IsType<NotFoundResult>(result.Left);
+                Assert.True(result.IsRight);
+                Assert.Empty(result.Right);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
@@ -52,7 +52,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     });
 
                     return result;
-                });
+                })
+                // Currently we expect a failure checking the Release exists and succeed with an empty list.
+                // StatisticsDb Releases are not always in sync with ContentDb Releases.
+                // Until the first Subject is imported, no StatisticsDb Release exists.
+                .OnFailureSucceedWith(result => Task.FromResult(new List<MetaGuidanceSubjectViewModel>()));
         }
 
         private async Task<MetaGuidanceSubjectTimePeriodsViewModel> GetTimePeriods(Guid subjectId)


### PR DESCRIPTION
When getting the meta guidance Subject view models for a Release we are checking first that the Release exists before executing the body of the code.

This PR makes a change to not execute the body but instead handle a failure when the Release doesn't exist and succeed with an empty list.

This is because the Statistics database Releases are not always in sync with Content database Releases.

For example until the first Subject is imported, no StatisticsDb Release exists.

When used by the Public Content API, the only database available is the Statistics database.

It might be possible to improve this in future if the Public Content API using this service is granted access to both databases.