### PR TITLE
EES-1412 Prevent approval if meta guidance isn't populated.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -531,6 +532,32 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task Validate_NoDataFiles()
+        {
+            var release = new Release();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.AddAsync(release);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>(MockBehavior.Strict);
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMetaGuidanceService(contentDbContext: contentDbContext,
+                    metaGuidanceSubjectService: metaGuidanceSubjectService.Object);
+
+                var result = await service.Validate(release.Id);
+
+                Assert.True(result.IsRight);
+            }
+        }
+
+        [Fact]
         public async Task Validate_MetaGuidancePopulated()
         {
             var release = new Release
@@ -538,11 +565,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 MetaGuidance = "Release Meta Guidance"
             };
 
+            var releaseFile = new ReleaseFile
+            {
+                Release = release,
+                ReleaseFileReference = new ReleaseFileReference
+                {
+                    Filename = "file1.csv",
+                    Release = release,
+                    ReleaseFileType = ReleaseFileTypes.Data,
+                    SubjectId = Guid.NewGuid()
+                }
+            };
+
             var contentDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 await contentDbContext.AddAsync(release);
+                await contentDbContext.AddAsync(releaseFile);
                 await contentDbContext.SaveChangesAsync();
             }
 
@@ -572,11 +612,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 MetaGuidance = null
             };
 
+            var releaseFile = new ReleaseFile
+            {
+                Release = release,
+                ReleaseFileReference = new ReleaseFileReference
+                {
+                    Filename = "file1.csv",
+                    Release = release,
+                    ReleaseFileType = ReleaseFileTypes.Data,
+                    SubjectId = Guid.NewGuid()
+                }
+            };
+
             var contentDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 await contentDbContext.AddAsync(release);
+                await contentDbContext.AddAsync(releaseFile);
                 await contentDbContext.SaveChangesAsync();
             }
 
@@ -602,11 +655,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 MetaGuidance = "Release Meta Guidance"
             };
 
+            var releaseFile = new ReleaseFile
+            {
+                Release = release,
+                ReleaseFileReference = new ReleaseFileReference
+                {
+                    Filename = "file1.csv",
+                    Release = release,
+                    ReleaseFileType = ReleaseFileTypes.Data,
+                    SubjectId = Guid.NewGuid()
+                }
+            };
+
             var contentDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 await contentDbContext.AddAsync(release);
+                await contentDbContext.AddAsync(releaseFile);
                 await contentDbContext.SaveChangesAsync();
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
@@ -34,7 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void CreateReleaseAmendmentAsync()
         {
             var (userService, _, publishingService, repository, subjectService, tableStorageService,
-                    fileStorageService, importStatusService, footnoteService, _, dataBlockService, releaseSubjectService) = Mocks();
+                    fileStorageService, importStatusService, footnoteService, _, metaGuidanceService, dataBlockService, releaseSubjectService) = Mocks();
 
             var releaseId = Guid.NewGuid();
             var releaseType = new ReleaseType
@@ -389,13 +389,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 using (var statisticsDbContext = InMemoryStatisticsDbContext("CreateReleaseAmendment"))
                 {
-                    var releaseService = new ReleaseService(contentDbContext, AdminMapper(),
-                        publishingService.Object, new PersistenceHelper<ContentDbContext>(contentDbContext),
-                        userService.Object,
-                        repository.Object,
-                        subjectService.Object, tableStorageService.Object, fileStorageService.Object,
-                        importStatusService.Object, footnoteService.Object, statisticsDbContext,
-                        dataBlockService.Object, releaseSubjectService.Object, new SequentialGuidGenerator());
+                    var releaseService = new ReleaseService(context: contentDbContext,
+                        mapper: AdminMapper(),
+                        publishingService: publishingService.Object,
+                        persistenceHelper: new PersistenceHelper<ContentDbContext>(contentDbContext),
+                        userService: userService.Object,
+                        repository: repository.Object,
+                        subjectService: subjectService.Object,
+                        coreTableStorageService: tableStorageService.Object,
+                        releaseFilesService: fileStorageService.Object,
+                        importStatusService: importStatusService.Object,
+                        footnoteService: footnoteService.Object,
+                        statisticsDbContext: statisticsDbContext,
+                        dataBlockService: dataBlockService.Object,
+                        metaGuidanceService: metaGuidanceService.Object,
+                        releaseSubjectService: releaseSubjectService.Object,
+                        guidGenerator: new SequentialGuidGenerator());
 
                     // Method under test
                     var amendmentViewModel = releaseService.CreateReleaseAmendmentAsync(releaseId).Result.Right;
@@ -625,6 +634,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             Mock<IImportStatusService>,
             Mock<IFootnoteService>,
             Mock<StatisticsDbContext>,
+            Mock<IMetaGuidanceService>,
             Mock<IDataBlockService>,
             Mock<IReleaseSubjectService>) Mocks()
         {
@@ -649,6 +659,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 new Mock<IImportStatusService>(),
                 new Mock<IFootnoteService>(),
                 new Mock<StatisticsDbContext>(),
+                new Mock<IMetaGuidanceService>(),
                 new Mock<IDataBlockService>(),
                 new Mock<IReleaseSubjectService>());
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -359,6 +359,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IFootnoteService footnoteService = null,
             StatisticsDbContext statisticsDbContext = null,
             IDataBlockService dataBlockService = null,
+            IMetaGuidanceService metaGuidanceService = null,
             IReleaseSubjectService releaseSubjectService = null)
         {
             return new ReleaseService(
@@ -375,6 +376,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 footnoteService ?? new Mock<IFootnoteService>().Object,
                 statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
                 dataBlockService ?? new Mock<IDataBlockService>().Object,
+                metaGuidanceService ?? new Mock<IMetaGuidanceService>().Object,
                 releaseSubjectService ?? new Mock<IReleaseSubjectService>().Object,
                 new SequentialGuidGenerator()
             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IMetaGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IMetaGuidanceService.cs
@@ -12,5 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         public Task<Either<ActionResult, MetaGuidanceViewModel>> Update(Guid releaseId,
             MetaGuidanceUpdateViewModel request);
+
+        public Task<Either<ActionResult, Unit>> Validate(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -75,22 +75,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         UserDoesNotExist,
         UserAlreadyHasReleaseRole,
 
-        // Role
-        RoleDoesNotExist,
-
         // Invite
         UnableToCancelInvite,
         InvalidEmailAddress,
 
         // Publication
         PublicationDoesNotExist,
-        PublicationHasMethodologyAssigned,
 
         // Methodology
         MethodologyDoesNotExist,
         MethodologyMustBeApprovedOrPublished,
         CannotSpecifyMethodologyAndExternalMethodology,
-        MethodologyOrExternalMethodologyLinkMustBeDefined,
 
         // Theme
         ThemeDoesNotExist,
@@ -100,7 +95,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
 
         // File
         CannotOverwriteFile,
-        FileNotFound,
         FileCannotBeEmpty,
         FileTypeInvalid,
         FilenameCannotContainSpacesOrSpecialCharacters,
@@ -141,6 +135,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
 
         // Release
         ReleaseNotApproved,
+        MetaGuidanceMustBePopulated,
         ApprovedReleaseMustHavePublishScheduledDate,
         PublishedReleaseCannotBeUnapproved
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IMetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IMetaGuidanceSubjectService.cs
@@ -10,5 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
     public interface IMetaGuidanceSubjectService
     {
         Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(Guid releaseId);
+
+        Task<Either<ActionResult, bool>> Validate(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
@@ -59,6 +59,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 .OnFailureSucceedWith(result => Task.FromResult(new List<MetaGuidanceSubjectViewModel>()));
         }
 
+        public async Task<Either<ActionResult, bool>> Validate(Guid releaseId)
+        {
+            var releaseSubjects = _context
+                        .ReleaseSubject
+                        .Where(rs => rs.ReleaseId == releaseId);
+
+            return !await releaseSubjects.AnyAsync() || !await releaseSubjects.AnyAsync(
+                rs => string.IsNullOrWhiteSpace(rs.MetaGuidance));
+        }
+
         private async Task<MetaGuidanceSubjectTimePeriodsViewModel> GetTimePeriods(Guid subjectId)
         {
             var orderedTimePeriods = _context

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -44,6 +44,8 @@ const errorMappings = [
         'Check all uploaded datafiles are complete before approving',
       PUBLISHED_RELEASE_CANNOT_BE_UNAPPROVED:
         'Release has already been published and cannot be un-approved',
+      META_GUIDANCE_MUST_BE_POPULATED:
+        'All public metadata guidance must be populated before release can be approved',
       METHODOLOGY_MUST_BE_APPROVED_OR_PUBLISHED:
         "The publication's methodology must be approved before release can be approved",
     },


### PR DESCRIPTION
This alters the approval validation when changing the status of a Release to check that the public meta guidance document has been populated with content for the Release and content for every Subject.

If there are no data files the validation is skipped completely as the user is not asked to enter the Release level guidance.