### PR TITLE
EES-1541 Retain Subject meta guidance when replacing Subject

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFilesServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFilesServiceTests.cs
@@ -95,7 +95,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var releaseFilesService = SetupReleaseFilesService(context: contentDbContext,
+                var releaseFilesService = SetupReleaseFilesService(
+                    contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object,
                     importService: importService.Object);
 
@@ -237,7 +238,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var releaseFilesService = SetupReleaseFilesService(context: contentDbContext,
+                var releaseFilesService = SetupReleaseFilesService(
+                    contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object,
                     importService: importService.Object);
 
@@ -356,7 +358,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var releaseFilesService = SetupReleaseFilesService(context: contentDbContext,
+                var releaseFilesService = SetupReleaseFilesService(
+                    contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object,
                     importService: importService.Object);
 
@@ -449,8 +452,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     });
 
                 var service = SetupReleaseFilesService(
-                    context,
-                    blobStorageService.Object,
+                    contentDbContext: context,
+                    blobStorageService: blobStorageService.Object,
                     importStatusService: importStatusService.Object
                 );
                 var result = await service.GetDataFile(
@@ -630,8 +633,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReturnsAsync(subject);
 
                 var service = SetupReleaseFilesService(
-                    context,
-                    blobStorageService.Object,
+                    contentDbContext: context,
+                    blobStorageService: blobStorageService.Object,
                     subjectService: subjectService.Object
                 );
                 var result = await service.GetDataFile(
@@ -754,8 +757,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     );
 
                 var service = SetupReleaseFilesService(
-                    context,
-                    blobStorageService.Object,
+                    contentDbContext: context,
+                    blobStorageService: blobStorageService.Object,
                     importStatusService: importStatusService.Object
                 );
                 var result = await service.GetDataFile(
@@ -876,8 +879,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     );
 
                 var service = SetupReleaseFilesService(
-                    context,
-                    blobStorageService.Object,
+                    contentDbContext: context,
+                    blobStorageService: blobStorageService.Object,
                     importStatusService: importStatusService.Object
                 );
                 var result = await service.GetDataFile(
@@ -1049,8 +1052,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     );
 
                 var service = SetupReleaseFilesService(
-                    context,
-                    blobStorageService.Object,
+                    contentDbContext: context,
+                    blobStorageService: blobStorageService.Object,
                     importStatusService: importStatusService.Object
                 );
                 var result = await service.ListDataFiles(release.Id);
@@ -1199,8 +1202,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     );
 
                 var service = SetupReleaseFilesService(
-                    context,
-                    blobStorageService.Object,
+                    contentDbContext: context,
+                    blobStorageService: blobStorageService.Object,
                     importStatusService: importStatusService.Object
                 );
                 var result = await service.ListDataFiles(release.Id);
@@ -1355,8 +1358,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     );
 
                 var service = SetupReleaseFilesService(
-                    context,
-                    blobStorageService.Object,
+                    contentDbContext: context,
+                    blobStorageService: blobStorageService.Object,
                     importStatusService: importStatusService.Object
                 );
                 var result = await service.ListDataFiles(amendedRelease.Id);
@@ -1445,8 +1448,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReturnsAsync(subject);
 
                 var service = SetupReleaseFilesService(
-                    context,
-                    blobStorageService.Object,
+                    contentDbContext: context,
+                    blobStorageService: blobStorageService.Object,
                     subjectService: subjectService.Object
                 );
                 var result = await service.ListDataFiles(release.Id);
@@ -1567,8 +1570,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     );
 
                 var service = SetupReleaseFilesService(
-                    context,
-                    blobStorageService.Object,
+                    contentDbContext: context,
+                    blobStorageService: blobStorageService.Object,
                     importStatusService: importStatusService.Object
                 );
                 var result = await service.ListDataFiles(release.Id);
@@ -1664,8 +1667,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     );
 
                 var service = SetupReleaseFilesService(
-                    context,
-                    blobStorageService.Object,
+                    contentDbContext: context,
+                    blobStorageService: blobStorageService.Object,
                     importService: importService.Object,
                     dataArchiveValidationService: dataArchiveValidationService.Object,
                     fileUploadsValidatorService: fileUploadsValidatorService.Object
@@ -1755,9 +1758,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-            var dataFileName = "test-data.csv";
-            var metaFileName = "test-data.meta.csv";
-            var zipFileName = "test-data-archive.zip";
+            const string dataFileName = "test-data.csv";
+            const string metaFileName = "test-data.meta.csv";
+            const string zipFileName = "test-data-archive.zip";
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
@@ -1787,11 +1790,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .Setup(s => s.ValidateDataArchiveFile(release.Id, zipFormFile.Object))
                     .ReturnsAsync(new Either<ActionResult, IDataArchiveFile>(archiveFile.Object));
 
-                var importService = new Mock<IImportService>();
+                var importService = new Mock<IImportService>(MockBehavior.Strict);
 
                 importService
                     .Setup(s => s.CreateImportTableRow(release.Id, dataFileName))
                     .ReturnsAsync(new Either<ActionResult, Unit>(Unit.Instance));
+
+                importService
+                    .Setup(s => s.Import(release.Id, dataFileName, metaFileName, zipFormFile.Object, true))
+                    .Returns(Task.CompletedTask);
 
                 var blobStorageService = new Mock<IBlobStorageService>();
 
@@ -1816,8 +1823,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     );
 
                 var service = SetupReleaseFilesService(
-                    context,
-                    blobStorageService.Object,
+                    contentDbContext: context,
+                    blobStorageService: blobStorageService.Object,
                     importService: importService.Object,
                     dataArchiveValidationService: dataArchiveValidationService.Object,
                     fileUploadsValidatorService: fileUploadsValidatorService.Object,
@@ -1922,7 +1929,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         private static ReleaseFilesService SetupReleaseFilesService(
-            ContentDbContext context,
+            ContentDbContext contentDbContext,
             IBlobStorageService blobStorageService = null,
             IUserService userService = null,
             IPersistenceHelper<ContentDbContext> persistenceHelper = null,
@@ -1935,8 +1942,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             return new ReleaseFilesService(
                 blobStorageService ?? new Mock<IBlobStorageService>().Object,
                 userService ?? MockUtils.AlwaysTrueUserService().Object,
-                persistenceHelper ?? new PersistenceHelper<ContentDbContext>(context),
-                context,
+                persistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
+                contentDbContext,
                 importService ?? new Mock<IImportService>().Object,
                 fileUploadsValidatorService ?? new Mock<IFileUploadsValidatorService>().Object,
                 subjectService ?? new Mock<ISubjectService>().Object,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -1,10 +1,10 @@
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
@@ -60,7 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Pages.
 
         public async Task OnGetAsync(string returnUrl = null)
         {
-            if (!string.IsNullOrEmpty(ErrorMessage))
+            if (!ErrorMessage.IsNullOrEmpty())
             {
                 ModelState.AddModelError(string.Empty, ErrorMessage);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml.cs
@@ -1,12 +1,10 @@
-using System;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
-using System.Collections.Generic;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -116,7 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Pages.
         {
             // Load the authenticator key & QR code URI to display on the form
             var unformattedKey = await _userManager.GetAuthenticatorKeyAsync(user);
-            if (string.IsNullOrEmpty(unformattedKey))
+            if (unformattedKey.IsNullOrEmpty())
             {
                 await _userManager.ResetAuthenticatorKeyAsync(user);
                 unformattedKey = await _userManager.GetAuthenticatorKeyAsync(user);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Pages/Error.cshtml.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Pages/Error.cshtml.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -11,7 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Pages
     {
         public string RequestId { get; set; }
 
-        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+        public bool ShowRequestId => !RequestId.IsNullOrEmpty();
 
         public void OnGet()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/ErrorViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/ErrorViewModel.cs
@@ -1,9 +1,11 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
 {
     public class ErrorViewModel
     {
         public string RequestId { get; set; }
 
-        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+        public bool ShowRequestId => !RequestId.IsNullOrEmpty();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Pages/Error.cshtml.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Pages/Error.cshtml.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
@@ -17,7 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Pages
 
         public string RequestId { get; set; }
 
-        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+        public bool ShowRequestId => !RequestId.IsNullOrEmpty();
 
         public void OnGet()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ImportService.cs
@@ -47,7 +47,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _guidGenerator = guidGenerator;
         }
 
-        public async Task Import(Guid releaseId, string dataFileName, string metaFileName, IFormFile dataFile, bool isZip)
+        public async Task Import(Guid releaseId,
+            string dataFileName,
+            string metaFileName,
+            IFormFile dataFile,
+            bool isZip)
         {
             var storageAccount = CloudStorageAccount.Parse(_storageConnectionString);
             var client = storageAccount.CreateCloudQueueClient();
@@ -106,7 +110,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     JsonConvert.SerializeObject(message), IStatus.QUEUED));
         }
 
-        private ImportMessage BuildMessage(string dataFileName, string metaFileName, Guid releaseId, string zipFileName)
+        private ImportMessage BuildMessage(string dataFileName,
+            string metaFileName,
+            Guid releaseId,
+            string zipFileName)
         {
             var release = _context.Releases
                 .Where(r => r.Id.Equals(releaseId))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IImportService.cs
@@ -10,8 +10,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     public interface IImportService
     {
         Task Import(Guid releaseId, string dataFileName, string metaFileName, IFormFile dataFile, bool isZip);
+
         Task<Either<ActionResult, Unit>> CreateImportTableRow(Guid releaseId, string dataFileName);
+
         Task FailImport(Guid releaseId, string dataFileName, IEnumerable<ValidationError> errors);
+
         Task RemoveImportTableRowIfExists(Guid releaseId, string dataFileName);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -89,7 +90,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 {
                     var content = contentById.GetValueOrDefault(releaseSubject.SubjectId);
 
-                    if (string.IsNullOrEmpty(content))
+                    if (content.IsNullOrEmpty())
                     {
                         return;
                     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFilesService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFilesService.cs
@@ -14,8 +14,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Secu
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
-using IdentityServer4.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -154,8 +154,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                         await UploadFileToStorage(releaseId, metadataFile, ReleaseFileTypes.Metadata,
                                             metaDataInfo);
 
-                                        await _importService.Import(releaseId, dataFile.FileName.ToLower(),
-                                            metadataFile.FileName.ToLower(), dataFile, false);
+                                        await _importService.Import(
+                                            releaseId: releaseId,
+                                            dataFileName: dataFile.FileName.ToLower(),
+                                            metaFileName: metadataFile.FileName.ToLower(),
+                                            dataFile: dataFile,
+                                            isZip: false);
 
                                         var blob = await _blobStorageService.GetBlob(
                                             PrivateFilesContainerName,
@@ -241,11 +245,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                                 dataInfo);
 
                                             await _importService.Import(
-                                                releaseId,
+                                                releaseId: releaseId,
                                                 dataFileName: archiveFile.DataFileName,
                                                 metaFileName: archiveFile.MetaFileName,
-                                                zipFile,
-                                                true);
+                                                dataFile: zipFile,
+                                                isZip: true);
 
                                             var blob = await _blobStorageService.GetBlob(
                                                 PrivateFilesContainerName,
@@ -703,7 +707,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             // If the file does exist then it could possibly be
             // partially uploaded so make sure meta data exists for it
-            if (blob.GetUserName().IsNullOrEmpty())
+            if (string.IsNullOrEmpty(blob.GetUserName()))
             {
                 return await GetFallbackDataFileInfo(releaseId, dataFileReference);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataReplacementPlanViewModel.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using Newtonsoft.Json;
@@ -252,7 +253,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public string Label { get; }
         public string Target { get; }
 
-        public bool Valid => !string.IsNullOrEmpty(Target);
+        public bool Valid => !Target.IsNullOrEmpty();
 
         public ObservationalUnitReplacementViewModel(string code, string label, string target)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -137,7 +137,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         {
             get
             {
-                if (string.IsNullOrEmpty(PublishScheduled))
+                if (PublishScheduled.IsNullOrEmpty())
                 {
                     return null;
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
@@ -78,6 +78,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             }
         }
 
+        public class IsNullOrEmptyTests
+        {
+            [Fact]
+            public void IsNullOrEmptyIsTrueForNullString()
+            {
+                const string input = null;
+                Assert.True(input.IsNullOrEmpty());
+            }
+            
+            
+            [Fact]
+            public void IsNullOrEmptyIsTrueForEmptyString()
+            {
+                Assert.True("".IsNullOrEmpty());
+            }
+            
+            [Fact]
+            public void IsNullOrEmptyIsFalseForNonEmptyString()
+            {
+                Assert.False("foo".IsNullOrEmpty());
+            }
+        }
+        
         public class PascalCaseTests
         {
             [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
@@ -17,7 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
         
         public static string CamelCase(this string input)
         {
-            if (string.IsNullOrEmpty(input))
+            if (input.IsNullOrEmpty())
             {
                 return input;
             }
@@ -26,9 +26,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return char.ToLowerInvariant(s[0]) + s.Substring(1);
         }
 
+        public static bool IsNullOrEmpty(this string value)
+        {
+            return string.IsNullOrEmpty(value);
+        }
+
         public static string PascalCase(this string input)
         {
-            if (string.IsNullOrEmpty(input))
+            if (input.IsNullOrEmpty())
             {
                 return input;
             }
@@ -43,7 +48,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 
         public static string SnakeCase(this string input)
         {
-            if (string.IsNullOrEmpty(input))
+            if (input.IsNullOrEmpty())
             {
                 return input;
             }
@@ -55,7 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 
         public static string ScreamingSnakeCase(this string input)
         {
-            if (string.IsNullOrEmpty(input))
+            if (input.IsNullOrEmpty())
             {
                 return input;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Functions/ConnectionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Functions/ConnectionUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Functions
 {
@@ -31,7 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Functions
             var connectionString =
                 Environment.GetEnvironmentVariable($"ConnectionStrings:{name}", EnvironmentVariableTarget.Process);
 
-            if (string.IsNullOrEmpty(connectionString))
+            if (connectionString.IsNullOrEmpty())
             {
                 // Get the connection string from the Azure Functions App using the naming convention for type SQLAzure.
                 connectionString = Environment.GetEnvironmentVariable($"{connectionTypeValue}_{name}", EnvironmentVariableTarget.Process);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthority.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthority.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
@@ -26,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 
         public string GetCodeOrOldCodeIfEmpty()
         {
-            return string.IsNullOrEmpty(Code) ? OldCode : Code;
+            return Code.IsNullOrEmpty() ? OldCode : Code;
         }
 
         protected bool Equals(LocalAuthority other)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ReleaseProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ReleaseProcessorService.cs
@@ -35,7 +35,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             var release = CreateOrUpdateRelease(message, statisticsDbContext);
             RemoveSubjectIfExisting(message, statisticsDbContext);
 
-            var subject = CreateSubject(message.SubjectId, subjectData.DataBlob.FileName, subjectData.Name, release,
+            var subject = CreateSubject(message.SubjectId,
+                subjectData.DataBlob.FileName,
+                subjectData.Name,
+                release,
                 statisticsDbContext);
 
             if (!UpdateReleaseFileReferenceLinks(message, contentDbContext, release, subject))


### PR DESCRIPTION
When confirming a Subject replacement we now copy the meta guidance of the original Subject to retain it.

I originally implemented this so that it was retained when importing the replacement but this gave a chance for users to alter the guidance on the original Subject before confirming the replacement, which could have led to lost updates.