### PR TITLE
EES-1532 Exclude subjects that are uploaded while a replacement is in progress from Meta guidance

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -56,18 +56,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 MetaGuidance = "Release Meta Guidance"
             };
 
+            var releaseFile = new ReleaseFile
+            {
+                Release = release,
+                ReleaseFileReference = new ReleaseFileReference
+                {
+                    Filename = "file1.csv",
+                    Release = release,
+                    ReleaseFileType = ReleaseFileTypes.Data,
+                    SubjectId = Guid.NewGuid()
+                }
+            };
+
             var contentDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 await contentDbContext.AddAsync(release);
+                await contentDbContext.AddAsync(releaseFile);
                 await contentDbContext.SaveChangesAsync();
             }
 
             var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>(MockBehavior.Strict);
 
             metaGuidanceSubjectService.Setup(mock =>
-                mock.GetSubjects(release.Id)).ReturnsAsync(SubjectMetaGuidance);
+                mock.GetSubjects(release.Id, new List<Guid>
+                {
+                    releaseFile.ReleaseFileReference.SubjectId.Value
+                })).ReturnsAsync(SubjectMetaGuidance);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -79,7 +95,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(result.IsRight);
 
                 metaGuidanceSubjectService.Verify(mock =>
-                    mock.GetSubjects(release.Id), Times.Once);
+                    mock.GetSubjects(release.Id, new List<Guid>
+                    {
+                        releaseFile.ReleaseFileReference.SubjectId.Value
+                    }), Times.Once);
 
                 Assert.Equal(release.Id, result.Right.Id);
                 Assert.Equal("Release Meta Guidance", result.Right.Content);
@@ -147,7 +166,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>(MockBehavior.Strict);
 
             metaGuidanceSubjectService.Setup(mock =>
-                mock.GetSubjects(release.Id)).ReturnsAsync(new List<MetaGuidanceSubjectViewModel>());
+                mock.GetSubjects(release.Id, new List<Guid>())).ReturnsAsync(new List<MetaGuidanceSubjectViewModel>());
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -167,7 +186,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(result.IsRight);
 
                 metaGuidanceSubjectService.Verify(mock =>
-                    mock.GetSubjects(release.Id), Times.Once);
+                    mock.GetSubjects(release.Id, new List<Guid>()), Times.Once);
 
                 Assert.Equal(release.Id, result.Right.Id);
                 Assert.Equal("Updated Release Meta Guidance", result.Right.Content);
@@ -191,19 +210,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 MetaGuidance = "Release Meta Guidance"
             };
 
+            var releaseFile = new ReleaseFile
+            {
+                Release = release,
+                ReleaseFileReference = new ReleaseFileReference
+                {
+                    Filename = "file1.csv",
+                    Release = release,
+                    ReleaseFileType = ReleaseFileTypes.Data,
+                    SubjectId = Guid.NewGuid()
+                }
+            };
+
             var contentDbContextId = Guid.NewGuid().ToString();
             var statisticsDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 await contentDbContext.AddAsync(release);
+                await contentDbContext.AddAsync(releaseFile);
                 await contentDbContext.SaveChangesAsync();
             }
 
             var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>(MockBehavior.Strict);
 
             metaGuidanceSubjectService.Setup(mock =>
-                mock.GetSubjects(release.Id)).ReturnsAsync(SubjectMetaGuidance);
+                mock.GetSubjects(release.Id, new List<Guid>
+                {
+                    releaseFile.ReleaseFileReference.SubjectId.Value
+                })).ReturnsAsync(SubjectMetaGuidance);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -230,7 +265,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(result.IsRight);
 
                 metaGuidanceSubjectService.Verify(mock =>
-                    mock.GetSubjects(release.Id), Times.Once);
+                    mock.GetSubjects(release.Id, new List<Guid>
+                    {
+                        releaseFile.ReleaseFileReference.SubjectId.Value
+                    }), Times.Once);
 
                 Assert.Equal(release.Id, result.Right.Id);
                 Assert.Equal("Updated Release Meta Guidance", result.Right.Content);
@@ -258,27 +296,55 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Id = contentRelease.Id,
             };
 
+            var subject1 = new Subject
+            {
+                Id = Guid.NewGuid(),
+                Filename = "file1.csv",
+                Name = "Subject 1"
+            };
+
+            var subject2 = new Subject
+            {
+                Id = Guid.NewGuid(),
+                Filename = "file2.csv",
+                Name = "Subject 2"
+            };
+
+            var releaseFile1 = new ReleaseFile
+            {
+                Release = contentRelease,
+                ReleaseFileReference = new ReleaseFileReference
+                {
+                    Filename = "file1.csv",
+                    Release = contentRelease,
+                    ReleaseFileType = ReleaseFileTypes.Data,
+                    SubjectId = subject1.Id
+                }
+            };
+
+            var releaseFile2 = new ReleaseFile
+            {
+                Release = contentRelease,
+                ReleaseFileReference = new ReleaseFileReference
+                {
+                    Filename = "file2.csv",
+                    Release = contentRelease,
+                    ReleaseFileType = ReleaseFileTypes.Data,
+                    SubjectId = subject2.Id
+                }
+            };
+
             var releaseSubject1 = new ReleaseSubject
             {
                 Release = statsRelease,
-                Subject = new Subject
-                {
-                    Id = Guid.NewGuid(),
-                    Filename = "file1.csv",
-                    Name = "Subject 1"
-                },
+                Subject = subject1,
                 MetaGuidance = "Subject 1 Meta Guidance"
             };
 
             var releaseSubject2 = new ReleaseSubject
             {
                 Release = statsRelease,
-                Subject = new Subject
-                {
-                    Id = Guid.NewGuid(),
-                    Filename = "file2.csv",
-                    Name = "Subject 2"
-                },
+                Subject = subject2,
                 MetaGuidance = "Subject 2 Meta Guidance"
             };
 
@@ -288,6 +354,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 await contentDbContext.AddAsync(contentRelease);
+                await contentDbContext.AddRangeAsync(releaseFile1, releaseFile2);
                 await contentDbContext.SaveChangesAsync();
             }
 
@@ -301,7 +368,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>(MockBehavior.Strict);
 
             metaGuidanceSubjectService.Setup(mock =>
-                mock.GetSubjects(statsRelease.Id)).ReturnsAsync(SubjectMetaGuidance);
+                mock.GetSubjects(statsRelease.Id, new List<Guid>
+                {
+                    subject1.Id, subject2.Id
+                })).ReturnsAsync(SubjectMetaGuidance);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -330,7 +400,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(result.IsRight);
 
                 metaGuidanceSubjectService.Verify(mock =>
-                    mock.GetSubjects(statsRelease.Id), Times.Once);
+                    mock.GetSubjects(statsRelease.Id, new List<Guid>
+                    {
+                        subject1.Id, subject2.Id
+                    }), Times.Once);
 
                 Assert.Equal(contentRelease.Id, result.Right.Id);
                 Assert.Equal("Release Meta Guidance Updated", result.Right.Content);
@@ -404,6 +477,42 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             // Version 1 has one Subject, version 2 adds another Subject
 
+            var releaseVersion1File1 = new ReleaseFile
+            {
+                Release = contentReleaseVersion1,
+                ReleaseFileReference = new ReleaseFileReference
+                {
+                    Filename = "file1.csv",
+                    Release = contentReleaseVersion1,
+                    ReleaseFileType = ReleaseFileTypes.Data,
+                    SubjectId = subject1.Id
+                }
+            };
+
+            var releaseVersion2File1 = new ReleaseFile
+            {
+                Release = contentReleaseVersion2,
+                ReleaseFileReference = new ReleaseFileReference
+                {
+                    Filename = "file1.csv",
+                    Release = contentReleaseVersion2,
+                    ReleaseFileType = ReleaseFileTypes.Data,
+                    SubjectId = subject1.Id
+                }
+            };
+
+            var releaseVersion2File2 = new ReleaseFile
+            {
+                Release = contentReleaseVersion2,
+                ReleaseFileReference = new ReleaseFileReference
+                {
+                    Filename = "file2.csv",
+                    Release = contentReleaseVersion2,
+                    ReleaseFileType = ReleaseFileTypes.Data,
+                    SubjectId = subject2.Id
+                }
+            };
+
             var releaseVersion1Subject1 = new ReleaseSubject
             {
                 Release = statsReleaseVersion1,
@@ -431,6 +540,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
                 await contentDbContext.AddRangeAsync(contentReleaseVersion1, contentReleaseVersion2);
+                await contentDbContext.AddRangeAsync(releaseVersion1File1, releaseVersion2File1,
+                    releaseVersion2File2);
                 await contentDbContext.SaveChangesAsync();
             }
 
@@ -446,7 +557,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>(MockBehavior.Strict);
 
             metaGuidanceSubjectService.Setup(mock =>
-                mock.GetSubjects(statsReleaseVersion2.Id)).ReturnsAsync(SubjectMetaGuidance);
+                mock.GetSubjects(statsReleaseVersion2.Id, new List<Guid>
+                {
+                    subject1.Id, subject2.Id
+                })).ReturnsAsync(SubjectMetaGuidance);
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -475,7 +589,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.True(result.IsRight);
 
                 metaGuidanceSubjectService.Verify(mock =>
-                    mock.GetSubjects(statsReleaseVersion2.Id), Times.Once);
+                    mock.GetSubjects(statsReleaseVersion2.Id, new List<Guid>
+                    {
+                        subject1.Id, subject2.Id
+                    }), Times.Once);
 
                 Assert.Equal(contentReleaseVersion2.Id, result.Right.Id);
                 Assert.Equal("Version 2 Release Meta Guidance Updated", result.Right.Content);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MetaGuidanceServiceTests.cs
@@ -56,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
                 .ReturnsAsync(ReleaseJson);
 
             metaGuidanceSubjectService.Setup(
-                    mock => mock.GetSubjects(releaseId))
+                    mock => mock.GetSubjects(releaseId, null))
                 .ReturnsAsync(SubjectMetaGuidance);
 
             var result = await service.Get(releasePath);
@@ -65,7 +65,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
                 mock => mock.DownloadBlobText(PublicContentContainerName, releasePath), Times.Once);
 
             metaGuidanceSubjectService.Verify(
-                mock => mock.GetSubjects(releaseId), Times.Once);
+                mock => mock.GetSubjects(releaseId, null), Times.Once);
 
             Assert.True(result.IsRight);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IMetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IMetaGuidanceSubjectService.cs
@@ -9,7 +9,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
 {
     public interface IMetaGuidanceSubjectService
     {
-        Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(Guid releaseId);
+        Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(Guid releaseId,
+            List<Guid> subjectIds = null);
 
         Task<Either<ActionResult, bool>> Validate(Guid releaseId);
     }


### PR DESCRIPTION
This PR excludes subjects that are uploaded while a replacement is in progress from the Meta guidance tab and Admin Meta guidance content preview.

The Public Content API continues to retrieve meta guidance for all subjects belonging to the Release.