### PR TITLE
EES-1546 Don't allow approval if data replacements are in progress

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -136,6 +136,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         // Release
         ReleaseNotApproved,
         MetaGuidanceMustBePopulated,
+        DataReplacementInProgress,
         ApprovedReleaseMustHavePublishScheduledDate,
         PublishedReleaseCannotBeUnapproved
     }

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -46,6 +46,8 @@ const errorMappings = [
         'Release has already been published and cannot be un-approved',
       META_GUIDANCE_MUST_BE_POPULATED:
         'All public metadata guidance must be populated before release can be approved',
+      DATA_REPLACEMENT_IN_PROGRESS:
+        'Pending data file replacements that are in progress must be completed or cancelled before release can be approved',
       METHODOLOGY_MUST_BE_APPROVED_OR_PUBLISHED:
         "The publication's methodology must be approved before release can be approved",
     },


### PR DESCRIPTION
This PR adds validation to stop a Release being approved if data replacement(s) are in progress. This was previously not checked allowing the temporary replacement file to be published in addition to the original file.

![image](https://user-images.githubusercontent.com/4147126/96852684-553e8800-1451-11eb-9a32-59060f3763c0.png)
