### PR TITLE
EES-1550 Fix Publisher sending notifications when Releases are published

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServiceTests.cs
@@ -43,7 +43,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = publishingService.RetryReleaseStage(release.Id, ContentAndPublishing).Result;
 
                 mocks.StorageQueueService.Verify(
-                    mock => mock.AddMessagesAsync(RetryStageQueue,
+                    mock => mock.AddMessageAsync(RetryStageQueue,
                         It.Is<RetryStageMessage>(message =>
                             message.ReleaseId == release.Id 
                             && message.Stage == ContentAndPublishing)), Times.Once());
@@ -74,7 +74,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = publishingService.ReleaseChanged(release.Id, true).Result;
 
                 mocks.StorageQueueService.Verify(
-                    mock => mock.AddMessagesAsync(NotifyChangeQueue,
+                    mock => mock.AddMessageAsync(NotifyChangeQueue,
                         It.Is<NotifyChangeMessage>(message =>
                             message.ReleaseId == release.Id && message.Immediate)), Times.Once());
 
@@ -104,7 +104,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = publishingService.PublicationChanged(publication.Id).Result;
 
                 mocks.StorageQueueService.Verify(
-                    mock => mock.AddMessagesAsync(PublishPublicationQueue,
+                    mock => mock.AddMessageAsync(PublishPublicationQueue,
                         It.Is<PublishPublicationMessage>(message =>
                             message.PublicationId == publication.Id)), Times.Once());
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
@@ -57,7 +57,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         return ValidationActionResult(ReleaseNotApproved);
                     }
 
-                    await _storageQueueService.AddMessagesAsync(
+                    await _storageQueueService.AddMessageAsync(
                         RetryStageQueue, new RetryStageMessage(releaseId, stage));
 
                     _logger.LogTrace($"Sent retry stage message for Release: {releaseId}");
@@ -90,7 +90,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .CheckEntityExists<Release>(releaseId)
                 .OnSuccess(async release =>
                 {
-                    await _storageQueueService.AddMessagesAsync(
+                    await _storageQueueService.AddMessageAsync(
                         NotifyChangeQueue, new NotifyChangeMessage(immediate, release.Id));
 
                     _logger.LogTrace($"Sent message for Release: {releaseId}");
@@ -109,7 +109,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .CheckEntityExists<Methodology>(id)
                 .OnSuccess(async release =>
                 {
-                    await _storageQueueService.AddMessagesAsync(PublishMethodologyQueue,
+                    await _storageQueueService.AddMessageAsync(PublishMethodologyQueue,
                         new PublishMethodologyMessage(id));
 
                     _logger.LogTrace($"Sent message for Methodology: {id}");
@@ -129,7 +129,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .CheckEntityExists<Publication>(id)
                 .OnSuccess(async release =>
                 {
-                    await _storageQueueService.AddMessagesAsync(
+                    await _storageQueueService.AddMessageAsync(
                         PublishPublicationQueue, new PublishPublicationMessage(id));
 
                     _logger.LogTrace($"Sent message for Publication: {id}");

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IStorageQueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IStorageQueueService.cs
@@ -1,11 +1,16 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 {
     public interface IStorageQueueService
     {
         void AddMessages(string queueName, params object[] values);
-        
+
+        void AddMessages(string queueName, IEnumerable<object> values);
+
         Task AddMessagesAsync(string queueName, params object[] values);
+
+        Task AddMessagesAsync(string queueName, IEnumerable<object> values);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IStorageQueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IStorageQueueService.cs
@@ -5,12 +5,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 {
     public interface IStorageQueueService
     {
-        void AddMessages(string queueName, params object[] values);
+        void AddMessage(string queueName, object value);
 
-        void AddMessages(string queueName, IEnumerable<object> values);
+        Task AddMessageAsync(string queueName, object value);
 
-        Task AddMessagesAsync(string queueName, params object[] values);
-
-        Task AddMessagesAsync(string queueName, IEnumerable<object> values);
+        Task AddMessages(string queueName, IEnumerable<object> values);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/StorageQueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/StorageQueueService.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Queue;
@@ -24,6 +26,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             }
         }
 
+        public void AddMessages(string queueName, IEnumerable<object> values)
+        {
+            AddMessages(queueName, values.ToArray());
+        }
+
         public async Task AddMessagesAsync(string queueName, params object[] values)
         {
             var queue = await GetQueueReferenceAsync(queueName);
@@ -31,6 +38,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             {
                 await queue.AddMessageAsync(ToCloudQueueMessage(value));
             }
+        }
+
+        public async Task AddMessagesAsync(string queueName, IEnumerable<object> values)
+        {
+            await AddMessagesAsync(queueName, values.ToArray());
         }
 
         private CloudQueue GetQueueReference(string queueName)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/StorageQueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/StorageQueueService.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using Microsoft.Azure.Storage;
@@ -17,32 +16,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             _storageConnectionString = storageConnectionString;
         }
 
-        public void AddMessages(string queueName, params object[] values)
+        public void AddMessage(string queueName, object value)
         {
             var queue = GetQueueReference(queueName);
-            foreach (var value in values)
-            {
-                queue.AddMessage(ToCloudQueueMessage(value));
-            }
+            queue.AddMessage(ToCloudQueueMessage(value));
         }
 
-        public void AddMessages(string queueName, IEnumerable<object> values)
+        public async Task AddMessageAsync(string queueName, object value)
         {
-            AddMessages(queueName, values.ToArray());
+            var queue = await GetQueueReferenceAsync(queueName);
+            await queue.AddMessageAsync(ToCloudQueueMessage(value));
         }
 
-        public async Task AddMessagesAsync(string queueName, params object[] values)
+        public async Task AddMessages(string queueName, IEnumerable<object> values)
         {
             var queue = await GetQueueReferenceAsync(queueName);
             foreach (var value in values)
             {
                 await queue.AddMessageAsync(ToCloudQueueMessage(value));
             }
-        }
-
-        public async Task AddMessagesAsync(string queueName, IEnumerable<object> values)
-        {
-            await AddMessagesAsync(queueName, values.ToArray());
         }
 
         private CloudQueue GetQueueReference(string queueName)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -144,7 +144,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             {
                 var publisherConnectionString = Configuration.GetValue<string>("PublisherStorage");
                 var storageQueueService = new StorageQueueService(publisherConnectionString);
-                storageQueueService.AddMessages(queueName, new PublishAllContentMessage());
+                storageQueueService.AddMessage(queueName, new PublishAllContentMessage());
 
                 logger.LogInformation($"Message added to {queueName} queue");
                 logger.LogInformation("Please ensure the Publisher function is running");

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/local.settings.json
@@ -8,7 +8,7 @@
     "PublicationNotificationEmailTemplateId": "change-me",
     "SubscriptionConfirmationEmailTemplateId": "change-me",
     "TokenSecretKey": "change-me",
-    "BaseUrl": "http://localhost:7071/api/publication/",
+    "BaseUrl": "http://localhost:7073/api/publication/",
     "WebApplicationBaseUrl": "http://localhost:3000/",
     "TableStorageConnString": "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;QueueEndpoint=http://data-storage:10001/devstoreaccount1;TableEndpoint=http://data-storage:10002/devstoreaccount1;"
   },

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/NotificationsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/NotificationsService.cs
@@ -28,7 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         {
             var publications = GetPublications(releaseIds);
             var messages = publications.Select(BuildPublicationNotificationMessage);
-            await _storageQueueService.AddMessagesAsync(PublicationQueue, messages);
+            await _storageQueueService.AddMessages(PublicationQueue, messages);
         }
 
         private IEnumerable<Publication> GetPublications(IEnumerable<Guid> releaseIds)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/QueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/QueueService.cs
@@ -31,7 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             var releasesList = releases.ToList();
             _logger.LogInformation(
                 $"Queuing generate content message for releases: {string.Join(", ", releasesList.Select(tuple => tuple.ReleaseId))}");
-            await _storageQueueService.AddMessagesAsync(
+            await _storageQueueService.AddMessageAsync(
                 GenerateReleaseContentQueue, new GenerateReleaseContentMessage(releasesList));
             foreach (var (releaseId, releaseStatusId) in releasesList)
             {
@@ -43,7 +43,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         public async Task QueuePublishReleaseContentMessageAsync(Guid releaseId, Guid releaseStatusId)
         {
             _logger.LogInformation($"Queuing publish content message for release: {releaseId}");
-            await _storageQueueService.AddMessagesAsync(
+            await _storageQueueService.AddMessageAsync(
                 PublishReleaseContentQueue, new PublishReleaseContentMessage(releaseId, releaseStatusId));
             await _releaseStatusService.UpdateContentStageAsync(releaseId, releaseStatusId,
                 ReleaseStatusContentStage.Queued);
@@ -60,7 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             foreach (var (releaseId, releaseStatusId) in releases)
             {
                 _logger.LogInformation($"Queuing data message for release: {releaseId}");
-                await _storageQueueService.AddMessagesAsync(
+                await _storageQueueService.AddMessageAsync(
                     PublishReleaseDataQueue, new PublishReleaseDataMessage(releaseId, releaseStatusId));
                 await _releaseStatusService.UpdateDataStageAsync(releaseId, releaseStatusId,
                     ReleaseStatusDataStage.Queued);
@@ -78,7 +78,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             var releasesList = releases.ToList();
             _logger.LogInformation(
                 $"Queuing files message for releases: {string.Join(", ", releasesList.Select(tuple => tuple.ReleaseId))}");
-            await _storageQueueService.AddMessagesAsync(
+            await _storageQueueService.AddMessageAsync(
                 PublishReleaseFilesQueue, new PublishReleaseFilesMessage(releasesList));
             foreach (var (releaseId, releaseStatusId) in releasesList)
             {


### PR DESCRIPTION
This PR add a `AddMessagesAsync(IEnumerable<object> value)` overload to `StorageQueueService.AddMessagesAsync` to avoid the compiler treating an `IEnumerable<object>` of messages as single valued object array with the existing method `AddMessagesAsync(params object[] values)`.

This was resulting in us serializing the IEnumerable as a single message body, rather than queuing individual messages for each value.

For consistency we also add this to the non-async method `StorageQueueService.AddMessages`.