### PR TITLE
EES-1416 Add metadata guidance page to public frontend

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/MetaGuidanceController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/MetaGuidanceController.cs
@@ -17,11 +17,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
             _metaGuidanceService = metaGuidanceService;
         }
 
-        [HttpGet("publications/{publicationSlug}/release/{releaseSlug}/meta-guidance")]
-        public async Task<ActionResult<MetaGuidanceViewModel>> Get(string publicationSlug,
+        [HttpGet("publications/{publicationSlug}/releases/latest/meta-guidance")]
+        public async Task<ActionResult<MetaGuidanceViewModel>> GetLatest(string publicationSlug)
+        {
+            return await _metaGuidanceService.Get(
+                    publicationPath: PublicContentPublicationPath(publicationSlug),
+                    releasePath: PublicContentLatestReleasePath(publicationSlug)
+                )
+                .HandleFailuresOrOk();
+        }
+
+        [HttpGet("publications/{publicationSlug}/releases/{releaseSlug}/meta-guidance")]
+        public async Task<ActionResult<MetaGuidanceViewModel>> Get(
+            string publicationSlug,
             string releaseSlug)
         {
-            return await _metaGuidanceService.Get(PublicContentReleasePath(publicationSlug, releaseSlug))
+            return await _metaGuidanceService.Get(
+                    publicationPath: PublicContentPublicationPath(publicationSlug),
+                    releasePath: PublicContentReleasePath(publicationSlug, releaseSlug)
+                )
                 .HandleFailuresOrOk();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PreReleaseAccessListController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/PreReleaseAccessListController.cs
@@ -45,19 +45,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
             var publicationTask = _fileStorageService.GetDeserialized<CachedPublicationViewModel>(publicationPath);
             var releaseTask = _fileStorageService.GetDeserialized<CachedReleaseViewModel>(releasePath);
 
-            var continuation = Task.WhenAll(publicationTask, releaseTask);
+            await Task.WhenAll(publicationTask, releaseTask);
 
-            try
-            {
-                continuation.Wait();
-            }
-            catch (AggregateException)
-            {
-            }
-
-            if (continuation.Status == TaskStatus.RanToCompletion
-                && releaseTask.Result.IsRight
-                && publicationTask.Result.IsRight)
+            if (releaseTask.Result.IsRight && publicationTask.Result.IsRight)
             {
                 return new PreReleaseAccessListViewModel(releaseTask.Result.Right, publicationTask.Result.Right);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseController.cs
@@ -45,19 +45,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
             var publicationTask = _fileStorageService.GetDeserialized<CachedPublicationViewModel>(publicationPath);
             var releaseTask = _fileStorageService.GetDeserialized<CachedReleaseViewModel>(releasePath);
 
-            var continuation = Task.WhenAll(publicationTask, releaseTask);
+            await Task.WhenAll(publicationTask, releaseTask);
 
-            try
-            {
-                continuation.Wait();
-            }
-            catch (AggregateException)
-            {
-            }
-
-            if (continuation.Status == TaskStatus.RanToCompletion
-                && releaseTask.Result.IsRight
-                && publicationTask.Result.IsRight)
+            if (releaseTask.Result.IsRight && publicationTask.Result.IsRight)
             {
                 return new ReleaseViewModel(releaseTask.Result.Right, publicationTask.Result.Right);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/Interfaces/IMetaGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/Interfaces/IMetaGuidanceService.cs
@@ -7,6 +7,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interf
 {
     public interface IMetaGuidanceService
     {
-        public Task<Either<ActionResult, MetaGuidanceViewModel>> Get(string releasePath);
+        public Task<Either<ActionResult, MetaGuidanceViewModel>> Get(string publicationPath, string releasePath);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/ViewModels/MetaGuidanceViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/ViewModels/MetaGuidanceViewModel.cs
@@ -1,13 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels
 {
-    public class MetaGuidanceViewModel
+    public class MetaGuidanceViewModel : ReleaseSummaryViewModel
     {
-        public Guid Id { get; set; }
-        public string Content { get; set; }
-        public List<MetaGuidanceSubjectViewModel> Subjects { get; set; }
+        public string MetaGuidance { get;  }
+
+        public List<MetaGuidanceSubjectViewModel> Subjects { get; }
+
+        public MetaGuidanceViewModel(
+            CachedReleaseViewModel release,
+            CachedPublicationViewModel publication,
+            List<MetaGuidanceSubjectViewModel> subjects) : base(release, publication)
+        {
+            MetaGuidance = release.MetaGuidance;
+            Subjects = subjects;
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ReleaseSubject.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ReleaseSubject.cs
@@ -5,13 +5,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
     public class ReleaseSubject
     {
         public Subject Subject { get; set; }
-        
+
         public Guid SubjectId { get; set; }
-        
+
         public Release Release { get; set; }
-        
+
         public Guid ReleaseId { get; set; }
-        
+
         public string MetaGuidance { get; set; }
+
+        public ReleaseSubject CopyForRelease(Release release)
+        {
+            var releaseSubject = MemberwiseClone() as ReleaseSubject;
+
+            releaseSubject.Release = release;
+            releaseSubject.ReleaseId = release.Id;
+
+            return releaseSubject;
+        }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseMetaGuidancePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseMetaGuidancePage.tsx
@@ -1,18 +1,14 @@
 import Page from '@admin/components/Page';
 import PageTitle from '@admin/components/PageTitle';
 import { useAuthContext } from '@admin/contexts/AuthContext';
-import ReleaseMetaGuidanceDataFile from '@admin/pages/release/components/ReleaseMetaGuidanceDataFile';
 import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
 import releaseMetaGuidanceService, {
   ReleaseMetaGuidance,
 } from '@admin/services/releaseMetaGuidanceService';
 import releaseService, { Release } from '@admin/services/releaseService';
-import Accordion from '@common/components/Accordion';
-import AccordionSection from '@common/components/AccordionSection';
-import FormattedDate from '@common/components/FormattedDate';
 import LoadingSpinner from '@common/components/LoadingSpinner';
-import SanitizeHtml from '@common/components/SanitizeHtml';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import ReleaseMetaGuidancePageContent from '@common/modules/release/components/ReleaseMetaGuidancePageContent';
 import React from 'react';
 import { RouteComponentProps, StaticContext } from 'react-router';
 
@@ -66,33 +62,11 @@ const ReleaseMetaGuidancePage = ({
 
             <h2>Metadata guidance document</h2>
 
-            {model.release.published && (
-              <p>
-                <strong>
-                  Published{' '}
-                  <FormattedDate>{model.release.published}</FormattedDate>
-                </strong>
-              </p>
-            )}
-
-            <SanitizeHtml dirtyHtml={model.metaGuidance.content} />
-
-            {model.metaGuidance.subjects.length > 0 && (
-              <>
-                <h3 className="govuk-!-margin-top-6">Data files</h3>
-
-                <Accordion id="dataFiles">
-                  {model.metaGuidance.subjects.map(subject => (
-                    <AccordionSection heading={subject.name} key={subject.id}>
-                      <ReleaseMetaGuidanceDataFile
-                        key={subject.id}
-                        subject={subject}
-                      />
-                    </AccordionSection>
-                  ))}
-                </Accordion>
-              </>
-            )}
+            <ReleaseMetaGuidancePageContent
+              published={model.release.published}
+              metaGuidance={model.metaGuidance.content}
+              subjects={model.metaGuidance.subjects}
+            />
           </>
         )}
       </LoadingSpinner>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseMetaGuidanceSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseMetaGuidanceSection.tsx
@@ -1,7 +1,6 @@
 import { toolbarConfigs } from '@admin/components/form/FormEditor';
 import FormFieldEditor from '@admin/components/form/FormFieldEditor';
 import useFormSubmit from '@admin/hooks/useFormSubmit';
-import ReleaseMetaGuidanceDataFile from '@admin/pages/release/components/ReleaseMetaGuidanceDataFile';
 import releaseMetaGuidanceService from '@admin/services/releaseMetaGuidanceService';
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
@@ -14,6 +13,7 @@ import SanitizeHtml from '@common/components/SanitizeHtml';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import useToggle from '@common/hooks/useToggle';
+import ReleaseMetaGuidanceDataFile from '@common/modules/release/components/ReleaseMetaGuidanceDataFile';
 import minDelay from '@common/utils/minDelay';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';

--- a/src/explore-education-statistics-admin/src/services/releaseMetaGuidanceService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseMetaGuidanceService.ts
@@ -1,25 +1,10 @@
 import client from '@admin/services/utils/service';
+import { SubjectMetaGuidance } from '@common/services/releaseMetaGuidanceService';
 
 export interface ReleaseMetaGuidance {
   id: string;
   content: string;
   subjects: SubjectMetaGuidance[];
-}
-
-export interface SubjectMetaGuidance {
-  id: string;
-  filename: string;
-  name: string;
-  content: string;
-  timePeriods: {
-    from: string;
-    to: string;
-  };
-  geographicLevels: string[];
-  variables: {
-    label: string;
-    value: string;
-  }[];
 }
 
 const releaseMetaGuidanceService = {

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseMetaGuidanceDataFile.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseMetaGuidanceDataFile.tsx
@@ -1,8 +1,8 @@
-import { SubjectMetaGuidance } from '@admin/services/releaseMetaGuidanceService';
 import Details from '@common/components/Details';
 import SanitizeHtml from '@common/components/SanitizeHtml';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
+import { SubjectMetaGuidance } from '@common/services/releaseMetaGuidanceService';
 import React, { ReactNode } from 'react';
 
 interface Props {

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseMetaGuidancePageContent.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseMetaGuidancePageContent.tsx
@@ -1,0 +1,52 @@
+import Accordion from '@common/components/Accordion';
+import AccordionSection from '@common/components/AccordionSection';
+import FormattedDate from '@common/components/FormattedDate';
+import SanitizeHtml from '@common/components/SanitizeHtml';
+import ReleaseMetaGuidanceDataFile from '@common/modules/release/components/ReleaseMetaGuidanceDataFile';
+import { SubjectMetaGuidance } from '@common/services/releaseMetaGuidanceService';
+import React from 'react';
+
+interface Props {
+  published?: string;
+  metaGuidance: string;
+  subjects: SubjectMetaGuidance[];
+}
+
+const ReleaseMetaGuidancePageContent = ({
+  published,
+  metaGuidance,
+  subjects,
+}: Props) => {
+  return (
+    <>
+      {published && (
+        <p className="govuk-!-margin-bottom-8" data-testid="published-date">
+          <strong>
+            Published <FormattedDate>{published}</FormattedDate>
+          </strong>
+        </p>
+      )}
+
+      <SanitizeHtml dirtyHtml={metaGuidance} testId="metaGuidance-content" />
+
+      {subjects.length > 0 && (
+        <>
+          <h3 className="govuk-!-margin-top-6">Data files</h3>
+
+          <Accordion id="dataFiles">
+            {subjects.map(subject => (
+              <AccordionSection heading={subject.name} key={subject.id}>
+                <ReleaseMetaGuidanceDataFile
+                  key={subject.id}
+                  subject={subject}
+                />
+              </AccordionSection>
+            ))}
+          </Accordion>
+        </>
+      )}
+    </>
+  );
+};
+
+export default ReleaseMetaGuidancePageContent;

--- a/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseMetaGuidancePageContent.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseMetaGuidancePageContent.test.tsx
@@ -1,0 +1,185 @@
+import ReleaseMetaGuidancePageContent from '@common/modules/release/components/ReleaseMetaGuidancePageContent';
+import { SubjectMetaGuidance } from '@common/services/releaseMetaGuidanceService';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+describe('ReleaseMetaGuidancePageContent', () => {
+  const testSubjectMetaGuidance: SubjectMetaGuidance[] = [
+    {
+      id: 'subject-1',
+      name: 'Subject 1',
+      filename: 'subject-1.csv',
+      content: '<p>Test subject 1 content</p>',
+      geographicLevels: ['Local Authority', 'National'],
+      timePeriods: {
+        from: '2018',
+        to: '2019',
+      },
+      variables: [
+        { value: 'filter_1', label: 'Filter 1' },
+        { value: 'indicator_1', label: 'Indicator 1' },
+      ],
+    },
+    {
+      id: 'subject-2',
+      name: 'Subject 2',
+      filename: 'subject-2.csv',
+      content: '<p>Test subject 2 content</p>',
+      geographicLevels: ['Regional', 'Ward'],
+      timePeriods: {
+        from: '2020',
+        to: '2021',
+      },
+      variables: [
+        { value: 'filter_2', label: 'Filter 2' },
+        { value: 'indicator_2', label: 'Indicator 2' },
+      ],
+    },
+  ];
+
+  test('renders published date if present', () => {
+    render(
+      <ReleaseMetaGuidancePageContent
+        published="2020-10-22T12:00:00"
+        metaGuidance="Test meta guidance content"
+        subjects={[]}
+      />,
+    );
+
+    expect(screen.getByTestId('published-date')).toHaveTextContent(
+      'Published 22 October 2020',
+    );
+  });
+
+  test('does not render published date if not present', () => {
+    render(
+      <ReleaseMetaGuidancePageContent
+        metaGuidance="Test meta guidance content"
+        subjects={[]}
+      />,
+    );
+
+    expect(screen.queryByTestId('published-date')).not.toBeInTheDocument();
+  });
+
+  test('renders meta guidance content as HTML', () => {
+    const metaGuidance = `
+      <h2>Description</h2>
+      <p>Test meta guidance content</p>`;
+
+    render(
+      <ReleaseMetaGuidancePageContent
+        metaGuidance={metaGuidance}
+        subjects={[]}
+      />,
+    );
+
+    expect(
+      screen.getByText('Description', { selector: 'h2' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Test meta guidance content', { selector: 'p' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders guidance for subjects', async () => {
+    render(
+      <ReleaseMetaGuidancePageContent
+        metaGuidance="Test meta guidance content"
+        subjects={testSubjectMetaGuidance}
+      />,
+    );
+
+    const subjects = screen.getAllByTestId('accordionSection');
+
+    // Subject 1
+
+    const subject1 = within(subjects[0]);
+
+    expect(subject1.getByTestId('Filename')).toHaveTextContent('subject-1.csv');
+    expect(subject1.getByTestId('Geographic levels')).toHaveTextContent(
+      'Local Authority; National',
+    );
+    expect(subject1.getByTestId('Time period')).toHaveTextContent(
+      '2018 to 2019',
+    );
+    expect(
+      within(
+        subject1.getByTestId('Content'),
+      ).getByText('Test subject 1 content', { selector: 'p' }),
+    ).toBeInTheDocument();
+
+    userEvent.click(
+      subject1.getByRole('button', {
+        name: 'Variable names and descriptions',
+      }),
+    );
+
+    const section1VariableRows = subject1.getAllByRole('row');
+
+    const section1VariableRow1Cells = within(
+      section1VariableRows[1],
+    ).getAllByRole('cell');
+
+    expect(section1VariableRow1Cells[0]).toHaveTextContent('filter_1');
+    expect(section1VariableRow1Cells[1]).toHaveTextContent('Filter 1');
+
+    const section1VariableRow2Cells = within(
+      section1VariableRows[2],
+    ).getAllByRole('cell');
+
+    expect(section1VariableRow2Cells[0]).toHaveTextContent('indicator_1');
+    expect(section1VariableRow2Cells[1]).toHaveTextContent('Indicator 1');
+
+    // Subject 2
+
+    const subject2 = within(subjects[1]);
+
+    expect(subject2.getByTestId('Filename')).toHaveTextContent('subject-2.csv');
+    expect(subject2.getByTestId('Geographic levels')).toHaveTextContent(
+      'Regional; Ward',
+    );
+    expect(subject2.getByTestId('Time period')).toHaveTextContent(
+      '2020 to 2021',
+    );
+    expect(
+      within(
+        subject2.getByTestId('Content'),
+      ).getByText('Test subject 2 content', { selector: 'p' }),
+    ).toBeInTheDocument();
+
+    userEvent.click(
+      subject2.getByRole('button', {
+        name: 'Variable names and descriptions',
+      }),
+    );
+
+    const section2VariableRows = subject2.getAllByRole('row');
+
+    const section2VariableRow1Cells = within(
+      section2VariableRows[1],
+    ).getAllByRole('cell');
+
+    expect(section2VariableRow1Cells[0]).toHaveTextContent('filter_2');
+    expect(section2VariableRow1Cells[1]).toHaveTextContent('Filter 2');
+
+    const section2VariableRow2Cells = within(
+      section2VariableRows[2],
+    ).getAllByRole('cell');
+
+    expect(section2VariableRow2Cells[0]).toHaveTextContent('indicator_2');
+    expect(section2VariableRow2Cells[1]).toHaveTextContent('Indicator 2');
+  });
+
+  test('renders no subject guidance when empty', () => {
+    render(
+      <ReleaseMetaGuidancePageContent
+        metaGuidance="Test meta guidance content"
+        subjects={[]}
+      />,
+    );
+
+    expect(screen.queryAllByTestId('accordionSection')).toHaveLength(0);
+  });
+});

--- a/src/explore-education-statistics-common/src/services/releaseMetaGuidanceService.ts
+++ b/src/explore-education-statistics-common/src/services/releaseMetaGuidanceService.ts
@@ -1,0 +1,43 @@
+import { contentApi } from '@common/services/api';
+import { ReleaseSummary } from '@common/services/publicationService';
+
+export interface SubjectMetaGuidance {
+  id: string;
+  filename: string;
+  name: string;
+  content: string;
+  timePeriods: {
+    from: string;
+    to: string;
+  };
+  geographicLevels: string[];
+  variables: {
+    label: string;
+    value: string;
+  }[];
+}
+
+export interface ReleaseMetaGuidanceSummary extends ReleaseSummary {
+  metaGuidance: string;
+  subjects: SubjectMetaGuidance[];
+}
+
+const releaseMetaGuidanceService = {
+  getLatestReleaseMetaGuidance(
+    publicationSlug: string,
+  ): Promise<ReleaseMetaGuidanceSummary> {
+    return contentApi.get(
+      `/publications/${publicationSlug}/releases/latest/meta-guidance`,
+    );
+  },
+  getReleaseMetaGuidance(
+    publicationSlug: string,
+    releaseSlug: string,
+  ): Promise<ReleaseMetaGuidanceSummary> {
+    return contentApi.get(
+      `/publications/${publicationSlug}/releases/${releaseSlug}/meta-guidance`,
+    );
+  },
+};
+
+export default releaseMetaGuidanceService;

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PreReleaseAccessListPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PreReleaseAccessListPage.tsx
@@ -30,7 +30,7 @@ const PreReleaseAccessListPage = ({ release }: Props) => {
       <h2>Pre-release access list</h2>
 
       {release.published && (
-        <p>
+        <p className="govuk-!-margin-bottom-8">
           <strong>
             Published <FormattedDate>{release.published}</FormattedDate>
           </strong>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -156,6 +156,24 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                     {` (${extension}, ${size})`}
                   </li>
                 ))}
+                {data.hasMetaGuidance && (
+                  <li>
+                    <Link
+                      to={
+                        data.latestRelease
+                          ? '/find-statistics/[publication]/meta-guidance'
+                          : '/find-statistics/[publication]/[release]/meta-guidance'
+                      }
+                      as={
+                        data.latestRelease
+                          ? `/find-statistics/${data.publication.slug}/meta-guidance`
+                          : `/find-statistics/${data.publication.slug}/${data.slug}/meta-guidance`
+                      }
+                    >
+                      Metadata guidance document
+                    </Link>
+                  </li>
+                )}
                 {data.hasPreReleaseAccessList && (
                   <li>
                     <Link

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/ReleaseMetaGuidancePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/ReleaseMetaGuidancePage.tsx
@@ -1,0 +1,59 @@
+import ReleaseMetaGuidancePageContent from '@common/modules/release/components/ReleaseMetaGuidancePageContent';
+import releaseMetaGuidanceService, {
+  ReleaseMetaGuidanceSummary,
+} from '@common/services/releaseMetaGuidanceService';
+import Page from '@frontend/components/Page';
+import { GetServerSideProps } from 'next';
+import React from 'react';
+
+interface Props {
+  release: ReleaseMetaGuidanceSummary;
+}
+
+const ReleaseMetaGuidancePage = ({ release }: Props) => {
+  return (
+    <Page
+      title={release.publication.title}
+      caption={release.title}
+      breadcrumbs={[
+        { name: 'Find statistics and data', link: '/find-statistics' },
+        {
+          name: release.publication.title,
+          link: release.latestRelease
+            ? `/find-statistics/${release.publication.slug}`
+            : `/find-statistics/${release.publication.slug}/${release.slug}`,
+        },
+      ]}
+      breadcrumbLabel="Metadata guidance document"
+    >
+      <h2>Metadata guidance document</h2>
+
+      <ReleaseMetaGuidancePageContent
+        published={release.published}
+        metaGuidance={release.metaGuidance}
+        subjects={release.subjects}
+      />
+    </Page>
+  );
+};
+
+export default ReleaseMetaGuidancePage;
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({
+  query,
+}) => {
+  const { publication, release } = query as {
+    publication: string;
+    release: string;
+  };
+
+  const data = await (release
+    ? releaseMetaGuidanceService.getReleaseMetaGuidance(publication, release)
+    : releaseMetaGuidanceService.getLatestReleaseMetaGuidance(publication));
+
+  return {
+    props: {
+      release: data,
+    },
+  };
+};

--- a/src/explore-education-statistics-frontend/src/pages/find-statistics/[publication]/[release]/meta-guidance.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/find-statistics/[publication]/[release]/meta-guidance.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  getServerSideProps,
+} from '@frontend/modules/find-statistics/ReleaseMetaGuidancePage';

--- a/src/explore-education-statistics-frontend/src/pages/find-statistics/[publication]/meta-guidance.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/find-statistics/[publication]/meta-guidance.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  getServerSideProps,
+} from '@frontend/modules/find-statistics/ReleaseMetaGuidancePage';

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -14,6 +14,7 @@ ${RUN_IDENTIFIER}    %{RUN_IDENTIFIER}
 ${THEME_NAME}        %{TEST_THEME_NAME}
 ${TOPIC_NAME}        %{TEST_TOPIC_NAME}
 ${PUBLICATION_NAME}  UI tests - publish release %{RUN_IDENTIFIER}
+${RELEASE_NAME}      Financial Year 3000-01
 ${DATABLOCK_NAME}    Dates data block name
 
 *** Test Cases ***
@@ -24,7 +25,7 @@ Create new publication for "UI tests topic" topic
 
 Go to "Release summary" page
     [Tags]  HappyPath
-    user navigates to release summary from admin dashboard  ${PUBLICATION_NAME}   Financial Year 3000-01 (not Live)
+    user navigates to release summary from admin dashboard  ${PUBLICATION_NAME}   ${RELEASE_NAME} (not Live)
 
 Verify release summary
     [Tags]  HappyPath
@@ -53,16 +54,22 @@ Upload subject
     user checks headed table body row contains  Data file size   17 Kb  ${section}
     user checks headed table body row contains  Status           Complete  ${section}  180
 
-Add meta guidance to subject
+Add meta guidance
     [Tags]  HappyPath
     user clicks link  Metadata guidance
     user waits until h2 is visible  Public metadata guidance document
 
+    user enters text into element  id:metaGuidanceForm-content  Test meta guidance content
     user waits until page contains accordion section  Dates test subject
-    user opens accordion section  Dates test subject
+
+    user checks summary list contains  Filename             dates.csv
+    user checks summary list contains  Geographic levels    National
+    user checks summary list contains  Time period          2020 Week 13 to 2021 Week 24
+
     ${editor}=  user gets meta guidance data file content editor  Dates test subject
     user clicks element  ${editor}
-    user presses keys  Dates test subject test meta guidance content
+    user presses keys  Dates test subject test meta guidance content  ${editor}
+
     user clicks button  Save guidance
 
 # TODO: Add footnotes
@@ -249,7 +256,7 @@ Navigate to newly published release page
 Verify release URL and page caption
     [Tags]  HappyPath
     user checks url contains  %{PUBLIC_URL}/find-statistics/ui-tests-publish-release-${RUN_IDENTIFIER}
-    user waits until page contains title caption  Financial Year 3000-01
+    user waits until page contains title caption  ${RELEASE_NAME}
 
 Verify publish and update dates
     [Tags]  HappyPath
@@ -272,8 +279,51 @@ Verify release associated files
     user waits until element contains link  ${downloads}  test ancillary file 1
     user checks link has url  test ancillary file 1  %{DATA_API_URL}/download/ui-tests-publish-release-${RUN_IDENTIFIER}/3000-01/ancillary/test-file-1.txt   ${downloads}
 
+Verify public metadata guidance document
+    [Tags]  HappyPath
+    user clicks link  Metadata guidance document
+
+    user checks breadcrumb count should be   4
+    user checks nth breadcrumb contains   1    Home
+    user checks nth breadcrumb contains   2    Find statistics and data
+    user checks nth breadcrumb contains   3    ${PUBLICATION_NAME}
+    user checks nth breadcrumb contains   4    Metadata guidance document
+    user waits until h2 is visible  Metadata guidance document
+
+    user waits until page contains title caption  ${RELEASE_NAME}
+    user waits until h1 is visible  ${PUBLICATION_NAME}
+
+    user waits until h2 is visible  Metadata guidance document
+    user waits until page contains  Test meta guidance content
+
+    user waits until page contains accordion section  Dates test subject
+    user checks there are x accordion sections  1
+
+    user opens accordion section  Dates test subject
+    user checks summary list contains  Filename             dates.csv
+    user checks summary list contains  Geographic levels    National
+    user checks summary list contains  Time period          2020 Week 13 to 2021 Week 24
+    user checks summary list contains  Content              Dates test subject test meta guidance content
+
+    user opens details dropdown  Variable names and descriptions
+
+    user checks table column heading contains  1  1  Variable name
+    user checks table column heading contains  1  2  Variable description
+
+    user checks results table cell contains  1  1   children_attending
+    user checks results table cell contains  1  2   Number of children attending
+
+    user checks results table cell contains  6  1   date
+    user checks results table cell contains  6  2   Date
+
+    user checks results table cell contains  10  1   otherwise_vulnerable_children_attending
+    user checks results table cell contains  10  2   Number of otherwise vulnerable children attending
+
+    user goes to release page via breadcrumb  ${PUBLICATION_NAME}  ${RELEASE_NAME}
+
 Verify public pre-release access list
     [Tags]  HappyPath
+    user opens details dropdown     Download associated files
     user clicks link  Pre-release access list
 
     user checks breadcrumb count should be   4
@@ -282,23 +332,14 @@ Verify public pre-release access list
     user checks nth breadcrumb contains   3    ${PUBLICATION_NAME}
     user checks nth breadcrumb contains   4    Pre-release access list
 
-    user waits until page contains title caption  Financial Year 3000-01
+    user waits until page contains title caption  ${RELEASE_NAME}
     user waits until h1 is visible  ${PUBLICATION_NAME}
 
     user waits until h2 is visible  Pre-release access list
     user waits until page contains  Published ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH} ${PUBLISH_DATE_YEAR}
     user waits until page contains  Test public access list
 
-Navigate back to release page
-    user clicks link  ${PUBLICATION_NAME}
-
-    user checks breadcrumb count should be   3
-    user checks nth breadcrumb contains   1    Home
-    user checks nth breadcrumb contains   2    Find statistics and data
-    user checks nth breadcrumb contains   3    ${PUBLICATION_NAME}
-
-    user waits until h1 is visible  ${PUBLICATION_NAME}
-    user waits until page contains title caption  Financial Year 3000-01
+    user goes to release page via breadcrumb  ${PUBLICATION_NAME}  ${RELEASE_NAME}
 
 Verify accordions are correct
     [Tags]  HappyPath
@@ -349,8 +390,8 @@ Create amendment
     user opens accordion section  ${PUBLICATION_NAME}
     ${accordion_section}=  user gets accordion section content element  ${PUBLICATION_NAME}
 
-    user opens details dropdown  Financial Year 3000-01 (Live - Latest release)  ${accordion_section}
-    ${details_elem}=  user gets details content element  Financial Year 3000-01 (Live - Latest release)  ${accordion_section}
+    user opens details dropdown  ${RELEASE_NAME}  ${accordion_section}
+    ${details_elem}=  user gets details content element  ${RELEASE_NAME} (Live - Latest release)  ${accordion_section}
 
     user clicks button  Amend this release  ${details_elem}
     user waits until h1 is visible  Confirm you want to amend this live release
@@ -406,6 +447,33 @@ Confirm data replacement
     user waits until page contains  Footnotes: OK
     user clicks button  Confirm data replacement
     user waits until h2 is visible  Data replacement complete
+
+Verify existing meta guidance for amendment
+    [Tags]  HappyPath
+    user clicks link  Data and files
+    user clicks link  Metadata guidance
+    user waits until h2 is visible  Public metadata guidance document
+
+    user waits until element contains  id:metaGuidanceForm-content  Test meta guidance content
+
+    user waits until page contains accordion section  Dates test subject
+
+    user checks summary list contains  Filename             dates-replacement.csv
+    user checks summary list contains  Geographic levels    National
+    user checks summary list contains  Time period          2020 Week 13 to 2021 Week 24
+
+    ${editor}=  user gets meta guidance data file content editor  Dates test subject
+    user waits until element contains  ${editor}    Dates test subject test meta guidance content
+
+Update existing meta guidance for amendment
+    [Tags]  HappyPath
+    user enters text into element  id:metaGuidanceForm-content  Updated test meta guidance content
+
+    ${editor}=  user gets meta guidance data file content editor  Dates test subject
+    user clicks element  ${editor}
+    user presses keys  Updated Dates test subject test meta guidance content  ${editor}
+
+    user clicks button  Save guidance
 
 # TODO: Add footnotes
 
@@ -548,7 +616,7 @@ Navigate to amendment release page
     user clicks testid element  View stats link for ${PUBLICATION_NAME}
 
     user waits until h1 is visible  ${PUBLICATION_NAME}  90
-    user waits until page contains title caption  Financial Year 3000-01
+    user waits until page contains title caption  ${RELEASE_NAME}
 
     user checks url contains  %{PUBLIC_URL}/find-statistics/ui-tests-publish-release-${RUN_IDENTIFIER}
 
@@ -588,8 +656,51 @@ Verify amendment files
     user waits until element contains link  ${downloads}  test ancillary file 2
     user checks link has url  test ancillary file 2  %{DATA_API_URL}/download/ui-tests-publish-release-${RUN_IDENTIFIER}/3000-01/ancillary/test-file-2.txt   ${downloads}
 
+Verify amendment public metadata guidance document
+    [Tags]  HappyPath
+    user clicks link  Metadata guidance document
+
+    user checks breadcrumb count should be   4
+    user checks nth breadcrumb contains   1    Home
+    user checks nth breadcrumb contains   2    Find statistics and data
+    user checks nth breadcrumb contains   3    ${PUBLICATION_NAME}
+    user checks nth breadcrumb contains   4    Metadata guidance document
+    user waits until h2 is visible  Metadata guidance document
+
+    user waits until page contains title caption  ${RELEASE_NAME}
+    user waits until h1 is visible  ${PUBLICATION_NAME}
+
+    user waits until h2 is visible  Metadata guidance document
+    user waits until page contains  Updated test meta guidance content
+
+    user waits until page contains accordion section  Dates test subject
+    user checks there are x accordion sections  1
+
+    user opens accordion section  Dates test subject
+    user checks summary list contains  Filename             dates-replacement.csv
+    user checks summary list contains  Geographic levels    National
+    user checks summary list contains  Time period          2020 Week 13 to 2021 Week 24
+    user checks summary list contains  Content              Updated Dates test subject test meta guidance content
+
+    user opens details dropdown  Variable names and descriptions
+
+    user checks table column heading contains  1  1  Variable name
+    user checks table column heading contains  1  2  Variable description
+
+    user checks results table cell contains  1  1   children_attending
+    user checks results table cell contains  1  2   Number of children attending
+
+    user checks results table cell contains  6  1   date
+    user checks results table cell contains  6  2   Date
+
+    user checks results table cell contains  10  1   otherwise_vulnerable_children_attending
+    user checks results table cell contains  10  2   Number of otherwise vulnerable children attending
+
+    user goes to release page via breadcrumb  ${PUBLICATION_NAME}  ${RELEASE_NAME}
+
 Verify amendment public pre-release access list
     [Tags]  HappyPath
+    user opens details dropdown     Download associated files
     user clicks link  Pre-release access list
 
     user checks breadcrumb count should be   4
@@ -598,23 +709,14 @@ Verify amendment public pre-release access list
     user checks nth breadcrumb contains   3    ${PUBLICATION_NAME}
     user checks nth breadcrumb contains   4    Pre-release access list
 
-    user waits until page contains title caption  Financial Year 3000-01
+    user waits until page contains title caption  ${RELEASE_NAME}
     user waits until h1 is visible  ${PUBLICATION_NAME}
 
     user waits until h2 is visible  Pre-release access list
     user waits until page contains  Published ${PUBLISH_DATE_DAY} ${PUBLISH_DATE_MONTH} ${PUBLISH_DATE_YEAR}
     user waits until page contains  Updated public access list
 
-Navigate back to amendment release page
-    user clicks link  ${PUBLICATION_NAME}
-
-    user checks breadcrumb count should be   3
-    user checks nth breadcrumb contains   1    Home
-    user checks nth breadcrumb contains   2    Find statistics and data
-    user checks nth breadcrumb contains   3    ${PUBLICATION_NAME}
-
-    user waits until h1 is visible  ${PUBLICATION_NAME}
-    user waits until page contains title caption  Financial Year 3000-01
+    user goes to release page via breadcrumb  ${PUBLICATION_NAME}  ${RELEASE_NAME}
 
 Verify amendment accordions are correct
     [Tags]  HappyPath

--- a/tests/robot-tests/tests/libs/public-common.robot
+++ b/tests/robot-tests/tests/libs/public-common.robot
@@ -20,3 +20,15 @@ user checks release update
 user waits until details dropdown contains publication
     [Arguments]  ${details_heading}  ${publication_name}  ${wait}=3
     user waits until details contains element  ${details_heading}  xpath:.//*[text()="${publication_name}"]  wait=${wait}
+
+user goes to release page via breadcrumb
+    [Arguments]  ${publication}  ${release}
+    user clicks link  ${publication}
+
+    user checks breadcrumb count should be   3
+    user checks nth breadcrumb contains   1    Home
+    user checks nth breadcrumb contains   2    Find statistics and data
+    user checks nth breadcrumb contains   3    ${publication}
+
+    user waits until h1 is visible  ${publication}
+    user waits until page contains title caption  ${release}


### PR DESCRIPTION
This PR adds the public metadata guidance page, completing the end-to-end journey. Users can access it in the same place as the Pre-release access list in the 'Download associated files' details dropdown on a release.

## Relevant changes

- Modifies meta guidance endpoints to include the publication slug as we need this to be able to fetch the correct publication details to include in the `MetaGuidanceViewModel`. This just extends `ReleaseSummaryViewModel` so that the frontend can conveniently display all of its requirements using a single request.
- Adds new endpoint for getting the latest release's meta guidance from `/publications/{publicationSlug}/releases/latest/meta-guidance`. This is used by the `ReleaseMetaGuidancePage` when no release slug is specified.

## Other changes

- Fixes `ReleaseSubjects` for amendments having missing `MetaGuidance` fields as they were not being fully cloned during the amendment creation process.