### PR TITLE
EES-1416 Use `user enter text into element` for meta guidance editor tests

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -464,10 +464,8 @@ Verify existing meta guidance for amendment
 Update existing meta guidance for amendment
     [Tags]  HappyPath
     user enters text into element  id:metaGuidanceForm-content  Updated test meta guidance content
-
-    ${editor}=  user gets meta guidance data file content editor  Dates test subject
-    user clicks element  ${editor}
-    user presses keys  Updated Dates test subject test meta guidance content  ${editor}
+    user enters text into meta guidance data file content editor  Dates test subject
+    ...  Updated Dates test subject test meta guidance content
 
     user clicks button  Save guidance
 

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -282,4 +282,4 @@ user enters text into meta guidance data file content editor
     user checks page does not contain testid   fileGuidanceContent-focused
     user clicks element  ${editor}
     user waits until page contains testid   fileGuidanceContent-focused
-    user presses keys  ${text}   ${editor}
+    user enters text into element  ${editor}  ${text}


### PR DESCRIPTION
This PR simply updates the meta guidance editor keywords to use the `user enters text into element` keyword internally. This is beneficial as it automatically handles clearing of the editor element before typing the text.