### PR TITLE
EES-1293 Add PublishTaxonomy function to update content themes/topics when changed

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
@@ -227,14 +227,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IMapper mapper = null,
             PersistenceHelper<ContentDbContext> persistenceHelper = null,
             IUserService userService = null,
-            ITopicService topicService = null)
+            ITopicService topicService = null,
+            IPublishingService publishingService = null)
         {
             return new ThemeService(
                 context ?? new Mock<ContentDbContext>().Object,
                 mapper ?? AdminMapper(),
                 persistenceHelper ?? MockUtils.MockPersistenceHelper<ContentDbContext, Theme>(_theme.Id, _theme).Object,
                 userService ?? MockUtils.AlwaysTrueUserService().Object,
-                topicService ?? new Mock<ITopicService>().Object
+                topicService ?? new Mock<ITopicService>().Object,
+                publishingService ?? new Mock<IPublishingService>().Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -318,14 +318,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IMapper mapper = null,
             IPersistenceHelper<ContentDbContext> persistenceHelper = null,
             IUserService userService = null,
-            ITopicService topicService = null)
+            ITopicService topicService = null,
+            IPublishingService publishingService = null)
         {
             return new ThemeService(
                 context,
                 mapper ?? AdminMapper(),
                 persistenceHelper ?? new PersistenceHelper<ContentDbContext>(context),
                 userService ?? MockUtils.AlwaysTrueUserService().Object,
-                topicService ?? new Mock<ITopicService>().Object
+                topicService ?? new Mock<ITopicService>().Object,
+                publishingService ?? new Mock<IPublishingService>().Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServicePermissionTests.cs
@@ -102,7 +102,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IMapper mapper = null,
             IUserService userService = null,
             IReleaseSubjectService releaseSubjectService = null,
-            IReleaseFilesService releaseFilesService = null)
+            IReleaseFilesService releaseFilesService = null,
+            IPublishingService publishingService = null)
         {
             return new TopicService(
                 contentContext ?? new Mock<ContentDbContext>().Object,
@@ -111,7 +112,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 mapper ?? AdminMapper(),
                 userService ?? MockUtils.AlwaysTrueUserService().Object,
                 releaseSubjectService ?? new Mock<IReleaseSubjectService>().Object,
-                releaseFilesService ?? new Mock<IReleaseFilesService>().Object
+                releaseFilesService ?? new Mock<IReleaseFilesService>().Object,
+                publishingService ?? new Mock<IPublishingService>().Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
@@ -372,7 +372,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IMapper mapper = null,
             IUserService userService = null,
             IReleaseSubjectService releaseSubjectService = null,
-            IReleaseFilesService releaseFilesService = null)
+            IReleaseFilesService releaseFilesService = null,
+            IPublishingService publishingService = null)
         {
             return new TopicService(
                 contentContext,
@@ -381,7 +382,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 mapper ?? AdminMapper(),
                 userService ?? MockUtils.AlwaysTrueUserService().Object,
                 releaseSubjectService ?? new Mock<IReleaseSubjectService>().Object,
-                releaseFilesService ?? new Mock<IReleaseFilesService>().Object
+                releaseFilesService ?? new Mock<IReleaseFilesService>().Object,
+                publishingService ?? new Mock<IPublishingService>().Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublishingService.cs
@@ -12,5 +12,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, Unit>> ReleaseChanged(Guid id, bool immediate = false);
         Task<Either<ActionResult, Unit>> MethodologyChanged(Guid id);
         Task<Either<ActionResult, Unit>> PublicationChanged(Guid id);
+        Task<Either<ActionResult, Unit>> TaxonomyChanged();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
@@ -136,5 +136,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     return Unit.Instance;
                 });
         }
+
+        /// <summary>
+        /// Notify the Publisher that there has been a change to the
+        /// taxonomy, such as themes and topics.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<Either<ActionResult, Unit>> TaxonomyChanged()
+        {
+            await _storageQueueService.AddMessageAsync(PublishTaxonomyQueue, new PublishTaxonomyMessage());
+
+            _logger.LogTrace($"Sent PublishTaxonomy message");
+
+            return Unit.Instance;
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
@@ -25,19 +25,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
         private readonly IUserService _userService;
         private readonly ITopicService _topicService;
+        private readonly IPublishingService _publishingService;
 
         public ThemeService(
             ContentDbContext context,
             IMapper mapper,
             IPersistenceHelper<ContentDbContext> persistenceHelper,
             IUserService userService,
-            ITopicService topicService)
+            ITopicService topicService,
+            IPublishingService publishingService)
         {
             _context = context;
             _mapper = mapper;
             _persistenceHelper = persistenceHelper;
             _userService = userService;
             _topicService = topicService;
+            _publishingService = publishingService;
         }
 
         public async Task<Either<ActionResult, ThemeViewModel>> CreateTheme(SaveThemeViewModel createdTheme)
@@ -61,6 +64,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         );
 
                         await _context.SaveChangesAsync();
+
+                        await _publishingService.TaxonomyChanged();
+
                         return await GetTheme(saved.Entity.Id);
                     }
                 );
@@ -85,6 +91,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         theme.Summary = updatedTheme.Summary;
 
                         await _context.SaveChangesAsync();
+
+                        await _publishingService.TaxonomyChanged();
+
                         return await GetTheme(theme.Id);
                     }
                 );
@@ -150,6 +159,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                         _context.Themes.Remove(theme);
                         await _context.SaveChangesAsync();
+
+                        await _publishingService.TaxonomyChanged();
                     }
                 );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
@@ -31,6 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IUserService _userService;
         private readonly IReleaseSubjectService _releaseSubjectService;
         private readonly IReleaseFilesService _releaseFilesService;
+        private readonly IPublishingService _publishingService;
 
         public TopicService(
             ContentDbContext contentContext,
@@ -39,7 +40,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IMapper mapper,
             IUserService userService,
             IReleaseSubjectService releaseSubjectService,
-            IReleaseFilesService releaseFilesService)
+            IReleaseFilesService releaseFilesService,
+            IPublishingService publishingService)
         {
             _contentContext = contentContext;
             _statisticsContext = statisticsContext;
@@ -48,6 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _userService = userService;
             _releaseSubjectService = releaseSubjectService;
             _releaseFilesService = releaseFilesService;
+            _publishingService = publishingService;
         }
 
         public async Task<Either<ActionResult, TopicViewModel>> CreateTopic(SaveTopicViewModel createdTopic)
@@ -75,6 +78,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         );
 
                         await _contentContext.SaveChangesAsync();
+
+                        await _publishingService.TaxonomyChanged();
 
                         return await GetTopic(saved.Entity.Id);
                     }
@@ -106,6 +111,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                         _contentContext.Topics.Update(topic);
                         await _contentContext.SaveChangesAsync();
+
+                        await _publishingService.TaxonomyChanged();
 
                         return await GetTopic(topic.Id);
                     }
@@ -176,6 +183,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         );
 
                         await _contentContext.SaveChangesAsync();
+
+                        await _publishingService.TaxonomyChanged();
                     }
                 );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishTaxonomyMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublishTaxonomyMessage.cs
@@ -1,0 +1,6 @@
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
+{
+    public class PublishTaxonomyMessage
+    {
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherQueues.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/PublisherQueues.cs
@@ -9,6 +9,7 @@
         public const string PublishReleaseContentQueue = "publish-release-content";
         public const string PublishReleaseDataQueue = "publish-release-data";
         public const string PublishReleaseFilesQueue = "publish-release-files";
+        public const string PublishTaxonomyQueue = "publish-taxonomy";
         public const string RetryStageQueue = "retry";
         public const string NotifyChangeQueue = "notify";
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishTaxonomyFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishTaxonomyFunction.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
+{
+    // ReSharper disable once UnusedType.Global
+    public class PublishTaxonomyFunction
+    {
+        private readonly IContentService _contentService;
+
+        public PublishTaxonomyFunction(IContentService contentService)
+        {
+            _contentService = contentService;
+        }
+
+        [FunctionName("PublishTaxonomy")]
+        // ReSharper disable once UnusedMember.Global
+        public async Task PublishTaxonomy(
+            [QueueTrigger(PublishTaxonomyQueue)]
+            PublishTaxonomyMessage message,
+            ExecutionContext executionContext,
+            ILogger logger)
+        {
+            logger.LogInformation($"{executionContext.FunctionName} triggered: {message}");
+
+            var context = new PublishContext(DateTime.UtcNow, false);
+
+            await _contentService.UpdateTaxonomy(context);
+
+            logger.LogInformation($"{executionContext.FunctionName} completed");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -158,6 +158,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             }
         }
 
+        public async Task UpdateTaxonomy(PublishContext context)
+        {
+            await CacheTrees(context);
+        }
+
         private async Task DeleteAllContent()
         {
             await _fastTrackService.DeleteAllReleaseFastTracks();

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
@@ -7,7 +7,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
     public interface IContentService
     {
         Task DeletePreviousVersionsDownloadFiles(params Guid[] releaseIds);
-        
+
         Task DeletePreviousVersionsContent(params Guid[] releaseIds);
 
         Task UpdateAllContentAsync();
@@ -17,5 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
         Task UpdateMethodology(PublishContext context, Guid methodologyId);
 
         Task UpdatePublication(PublishContext context, Guid publicationId);
+
+        Task UpdateTaxonomy(PublishContext context);
     }
 }


### PR DESCRIPTION
This PR adds a new `PublishTaxonomyFunction` that is used to update the respective content trees whenever a theme or topic is created, updated or deleted. This should allow users to update the taxonomy without needing to republish a release or update a publication.

## Notes

Identified that the content blob store must be the source of UI test flakiness when run in parallel. UI tests that involve publishing content to the public will typically have intermittent failures when verifying that the correct publication(s) are in the theme trees. This is most likely down to interleaving of publishing tasks that trigger tree regeneration.

In these cases, it's possible for a task to generate a tree using stale content database data and then overwrite a more up-to-date tree (generated by another task). This is a fundamental weakness in using files to represent theme trees, as any change to the tree must overwrite it in its entirety.

Fortunately these issues are intermittent, but it is a fundamental blocker to ensuring tests can be run reliably. Ideally, once we 
are allowed to have a content database connection, we should always be able to display the correct trees as we can just query the content database directly.