### PR TITLE
EES-1293 Sync content DB taxonomy with stats DB on change

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DbUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DbUtils.cs
@@ -11,14 +11,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
     {
         public static ContentDbContext InMemoryApplicationDbContext(string dbName)
         {
-            var builder = new DbContextOptionsBuilder<ContentDbContext>();
-            builder.UseInMemoryDatabase(databaseName: dbName);
-            return new ContentDbContext(builder.Options);
+            return ContentDbUtils.InMemoryContentDbContext(dbName);
         }
 
         public static ContentDbContext InMemoryApplicationDbContext()
         {
-            return InMemoryApplicationDbContext(Guid.NewGuid().ToString());
+            return ContentDbUtils.InMemoryContentDbContext();
         }
 
         public static UsersAndRolesDbContext InMemoryUserAndRolesDbContext(string dbName)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbUtils.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
+{
+    public static class ContentDbUtils
+    {
+        public static ContentDbContext InMemoryContentDbContext(string dbName)
+        {
+            var builder = new DbContextOptionsBuilder<ContentDbContext>();
+            builder.UseInMemoryDatabase(databaseName: dbName);
+            return new ContentDbContext(builder.Options);
+        }
+
+        public static ContentDbContext InMemoryContentDbContext()
+        {
+            return InMemoryContentDbContext(Guid.NewGuid().ToString());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/GovUk.Education.ExploreEducationStatistics.Content.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/GovUk.Education.ExploreEducationStatistics.Content.Model.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="JsonKnownTypes" Version="0.4.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
     </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Theme.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Theme.cs
@@ -8,6 +8,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public Guid Id { get; set; }
         public string Title { get; set; }
         public string Slug { get; set; }
-        public IEnumerable<Topic> Topics { get; set; }
+        public ISet<Topic> Topics { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/TaxonomyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/TaxonomyServiceTests.cs
@@ -1,0 +1,672 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
+{
+    public class TaxonomyServiceTests
+    {
+        [Fact]
+        public async Task SyncStatisticsTaxonomy_AddsNewTheme()
+        {
+            var theme1 = new Theme
+            {
+                Title = "Theme 1",
+                Slug = "theme-1",
+                Topics = new List<Topic>
+                {
+                    new Topic
+                    {
+                        Title = "Topic 1",
+                        Slug = "topic-1",
+                    },
+                    new Topic
+                    {
+                        Title = "Topic 2",
+                        Slug = "topic-2",
+                    }
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(theme1);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildTaxonomyService(contentDbContext, statisticsDbContext);
+
+                await service.SyncTaxonomy();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var themes = statisticsDbContext.Theme
+                    .Include(t => t.Topics)
+                    .ToList();
+
+                Assert.Single(themes);
+
+                Assert.Equal(theme1.Id, themes[0].Id);
+                Assert.Equal("Theme 1", themes[0].Title);
+                Assert.Equal("theme-1", themes[0].Slug);
+
+                var topics = themes[0].Topics.ToList();
+                Assert.Equal(2, topics.Count);
+
+                Assert.Equal(theme1.Topics[0].Id, topics[0].Id);
+                Assert.Equal("Topic 1", topics[0].Title);
+                Assert.Equal("topic-1", topics[0].Slug);
+
+                Assert.Equal(theme1.Topics[1].Id, topics[1].Id);
+                Assert.Equal("Topic 2", topics[1].Title);
+                Assert.Equal("topic-2", topics[1].Slug);
+            }
+        }
+
+        [Fact]
+        public async Task SyncStatisticsTaxonomy_RemovesTheme()
+        {
+            var theme1 = new Theme
+            {
+                Title = "Theme 1",
+                Slug = "theme-1",
+                Topics = new List<Topic>()
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(theme1);
+                await contentDbContext.SaveChangesAsync();
+
+                await statisticsDbContext.AddAsync(new Data.Model.Theme
+                {
+                    Title = "Theme 2",
+                    Slug = "theme-2",
+                    Topics = new HashSet<Data.Model.Topic>()
+                });
+
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildTaxonomyService(contentDbContext, statisticsDbContext);
+
+                await service.SyncTaxonomy();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var themes = statisticsDbContext.Theme
+                    .Include(t => t.Topics)
+                    .ToList();
+
+                Assert.Single(themes);
+
+                Assert.Equal(theme1.Id, themes[0].Id);
+                Assert.Equal("Theme 1", themes[0].Title);
+                Assert.Equal("theme-1", themes[0].Slug);
+
+                Assert.Empty(themes[0].Topics);
+            }
+        }
+
+        [Fact]
+        public async Task SyncStatisticsTaxonomy_UpdatesTheme()
+        {
+            var theme1 = new Theme
+            {
+                Title = "Updated Theme 1",
+                Slug = "updated-theme-1",
+                Topics = new List<Topic>()
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(theme1);
+                await contentDbContext.SaveChangesAsync();
+
+                await statisticsDbContext.AddAsync(new Data.Model.Theme
+                {
+                    Id = theme1.Id,
+                    Title = "Old Theme 1",
+                    Slug = "old-theme-1",
+                    Topics = new HashSet<Data.Model.Topic>()
+                });
+
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildTaxonomyService(contentDbContext, statisticsDbContext);
+
+                await service.SyncTaxonomy();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var themes = statisticsDbContext.Theme
+                    .Include(t => t.Topics)
+                    .ToList();
+
+                Assert.Single(themes);
+
+                Assert.Equal(theme1.Id, themes[0].Id);
+                Assert.Equal("Updated Theme 1", themes[0].Title);
+                Assert.Equal("updated-theme-1", themes[0].Slug);
+
+                Assert.Empty(themes[0].Topics);
+            }
+        }
+
+        [Fact]
+        public async Task SyncStatisticsTaxonomy_UpdatesThemeAndTopic()
+        {
+            var theme1 = new Theme
+            {
+                Title = "Updated Theme 1",
+                Slug = "updated-theme-1",
+                Topics = new List<Topic>
+                {
+                    new Topic
+                    {
+                        Title = "Updated Topic 1",
+                        Slug = "updated-topic-1",
+                    }
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(theme1);
+                await contentDbContext.SaveChangesAsync();
+
+                await statisticsDbContext.AddAsync(new Data.Model.Theme
+                {
+                    Id = theme1.Id,
+                    Title = "Old Theme 1",
+                    Slug = "old-theme-1",
+                    Topics = new HashSet<Data.Model.Topic>
+                    {
+                        new Data.Model.Topic
+                        {
+                            Id = theme1.Topics[0].Id,
+                            Title = "Old Topic 1",
+                            Slug = "old-topic-1"
+                        }
+                    }
+                });
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildTaxonomyService(contentDbContext, statisticsDbContext);
+
+                await service.SyncTaxonomy();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var themes = statisticsDbContext.Theme
+                    .Include(theme => theme.Topics)
+                    .ToList();
+
+                Assert.Single(themes);
+
+                Assert.Equal(theme1.Id, themes[0].Id);
+                Assert.Equal("Updated Theme 1", themes[0].Title);
+                Assert.Equal("updated-theme-1", themes[0].Slug);
+
+                var topics = themes[0].Topics.ToList();
+                Assert.Single(topics);
+
+                Assert.Equal(theme1.Topics[0].Id, topics[0].Id);
+                Assert.Equal("Updated Topic 1", topics[0].Title);
+                Assert.Equal("updated-topic-1", topics[0].Slug);
+            }
+        }
+
+        [Fact]
+        public async Task SyncStatisticsTaxonomy_UpdatesThemeAndAddsNewTopic()
+        {
+            var theme1 = new Theme
+            {
+                Title = "Updated Theme 1",
+                Slug = "updated-theme-1",
+                Topics = new List<Topic>
+                {
+                    new Topic
+                    {
+                        Title = "Updated Topic 1",
+                        Slug = "updated-topic-1",
+                    },
+                    new Topic
+                    {
+                        Title = "Topic 2",
+                        Slug = "topic-2",
+                    },
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(theme1);
+                await contentDbContext.SaveChangesAsync();
+
+                await statisticsDbContext.AddAsync(new Data.Model.Theme
+                {
+                    Id = theme1.Id,
+                    Title = "Old Theme 1",
+                    Slug = "old-theme-1",
+                    Topics = new HashSet<Data.Model.Topic>
+                    {
+                        new Data.Model.Topic
+                        {
+                            Id = theme1.Topics[0].Id,
+                            Title = "Old Topic 1",
+                            Slug = "old-topic-1"
+                        },
+                    }
+                });
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildTaxonomyService(contentDbContext, statisticsDbContext);
+
+                await service.SyncTaxonomy();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var themes = statisticsDbContext.Theme
+                    .Include(theme => theme.Topics)
+                    .ToList();
+
+                Assert.Single(themes);
+
+                Assert.Equal(theme1.Id, themes[0].Id);
+                Assert.Equal("Updated Theme 1", themes[0].Title);
+                Assert.Equal("updated-theme-1", themes[0].Slug);
+
+                var topics = themes[0].Topics.ToList();
+                Assert.Equal(2, topics.Count);
+
+                Assert.Equal(theme1.Topics[0].Id, topics[0].Id);
+                Assert.Equal("Updated Topic 1", topics[0].Title);
+                Assert.Equal("updated-topic-1", topics[0].Slug);
+
+                Assert.Equal(theme1.Topics[1].Id, topics[1].Id);
+                Assert.Equal("Topic 2", topics[1].Title);
+                Assert.Equal("topic-2", topics[1].Slug);
+            }
+        }
+
+        [Fact]
+        public async Task SyncStatisticsTaxonomy_UpdatesThemeAndRemovesTopic()
+        {
+            var theme1 = new Theme
+            {
+                Title = "Updated Theme 1",
+                Slug = "updated-theme-1",
+                Topics = new List<Topic>
+                {
+                    new Topic
+                    {
+                        Title = "Topic 1",
+                        Slug = "topic-1",
+                    }
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(theme1);
+                await contentDbContext.SaveChangesAsync();
+
+                await statisticsDbContext.AddAsync(new Data.Model.Theme
+                {
+                    Id = theme1.Id,
+                    Title = "Old Theme 1",
+                    Slug = "old-theme-1",
+                    Topics = new HashSet<Data.Model.Topic>
+                    {
+                        new Data.Model.Topic
+                        {
+                            Id = theme1.Topics[0].Id,
+                            Title = "Topic 1",
+                            Slug = "topic-1"
+                        },
+                        new Data.Model.Topic
+                        {
+                            Title = "Topic 2",
+                            Slug = "topic-2"
+                        },
+                    }
+                });
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildTaxonomyService(contentDbContext, statisticsDbContext);
+
+                await service.SyncTaxonomy();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var themes = statisticsDbContext.Theme
+                    .Include(theme => theme.Topics)
+                    .ToList();
+
+                Assert.Single(themes);
+
+                Assert.Equal(theme1.Id, themes[0].Id);
+                Assert.Equal("Updated Theme 1", themes[0].Title);
+                Assert.Equal("updated-theme-1", themes[0].Slug);
+
+                var topics = themes[0].Topics.ToList();
+                Assert.Single(topics);
+
+                Assert.Equal(theme1.Topics[0].Id, topics[0].Id);
+                Assert.Equal("Topic 1", topics[0].Title);
+                Assert.Equal("topic-1", topics[0].Slug);
+            }
+        }
+
+        [Fact]
+        public async Task SyncStatisticsTaxonomy_DoesNotAddTopicPublication()
+        {
+            var theme1 = new Theme
+            {
+                Title = "Theme 1",
+                Slug = "theme-1",
+                Topics = new List<Topic>
+                {
+                    new Topic
+                    {
+                        Title = "Updated Topic 1",
+                        Slug = "updated-topic-1",
+                        Publications = new List<Publication>
+                        {
+                            new Publication
+                            {
+                                Title = "Publication 1"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(theme1);
+                await contentDbContext.SaveChangesAsync();
+
+                await statisticsDbContext.AddAsync(new Data.Model.Theme
+                {
+                    Id = theme1.Id,
+                    Title = "Theme 1",
+                    Slug = "theme-1",
+                    Topics = new HashSet<Data.Model.Topic>
+                    {
+                        new Data.Model.Topic
+                        {
+                            Id = theme1.Topics[0].Id,
+                            Title = "Old Topic 1",
+                            Slug = "old-topic-1",
+                            Publications = new List<Data.Model.Publication>()
+                        }
+                    }
+                });
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildTaxonomyService(contentDbContext, statisticsDbContext);
+
+                await service.SyncTaxonomy();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var themes = statisticsDbContext.Theme
+                    .Include(theme => theme.Topics)
+                    .ThenInclude(topic => topic.Publications)
+                    .ToList();
+
+                Assert.Single(themes);
+
+                var topics = themes[0].Topics.ToList();
+                Assert.Single(topics);
+
+                Assert.Equal(theme1.Topics[0].Id, topics[0].Id);
+                Assert.Equal("Updated Topic 1", topics[0].Title);
+                Assert.Equal("updated-topic-1", topics[0].Slug);
+
+                Assert.Empty(topics[0].Publications);
+            }
+        }
+
+        [Fact]
+        public async Task SyncStatisticsTaxonomy_DoesNotUpdateTopicPublication()
+        {
+            var theme1 = new Theme
+            {
+                Title = "Theme 1",
+                Slug = "theme-1",
+                Topics = new List<Topic>
+                {
+                    new Topic
+                    {
+                        Title = "Updated Topic 1",
+                        Slug = "updated-topic-1",
+                        Publications = new List<Publication>
+                        {
+                            new Publication
+                            {
+                                Title = "Updated publication 1"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(theme1);
+                await contentDbContext.SaveChangesAsync();
+
+                await statisticsDbContext.AddAsync(new Data.Model.Theme
+                {
+                    Id = theme1.Id,
+                    Title = "Theme 1",
+                    Slug = "theme-1",
+                    Topics = new HashSet<Data.Model.Topic>
+                    {
+                        new Data.Model.Topic
+                        {
+                            Id = theme1.Topics[0].Id,
+                            Title = "Old Topic 1",
+                            Slug = "old-topic-1",
+                            Publications = new List<Data.Model.Publication>
+                            {
+                                new Data.Model.Publication
+                                {
+                                    Title = "Publication 1"
+                                }
+                            }
+                        }
+                    }
+                });
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildTaxonomyService(contentDbContext, statisticsDbContext);
+
+                await service.SyncTaxonomy();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var themes = statisticsDbContext.Theme
+                    .Include(theme => theme.Topics)
+                    .ThenInclude(topic => topic.Publications)
+                    .ToList();
+
+                Assert.Single(themes);
+
+                var topics = themes[0].Topics.ToList();
+                Assert.Single(topics);
+
+                Assert.Equal(theme1.Topics[0].Id, topics[0].Id);
+                Assert.Equal("Updated Topic 1", topics[0].Title);
+                Assert.Equal("updated-topic-1", topics[0].Slug);
+
+                Assert.Single(topics[0].Publications);
+                Assert.Equal("Publication 1", topics[0].Publications.First().Title);
+            }
+        }
+
+        [Fact]
+        public async Task SyncStatisticsTaxonomy_DoesNotRemoveTopicPublication()
+        {
+            var theme1 = new Theme
+            {
+                Title = "Theme 1",
+                Slug = "theme-1",
+                Topics = new List<Topic>
+                {
+                    new Topic
+                    {
+                        Title = "Updated Topic 1",
+                        Slug = "updated-topic-1",
+                    }
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(theme1);
+                await contentDbContext.SaveChangesAsync();
+
+                await statisticsDbContext.AddAsync(
+                    new Data.Model.Theme
+                    {
+                        Id = theme1.Id,
+                        Title = "Theme 1",
+                        Slug = "theme-1",
+                        Topics = new HashSet<Data.Model.Topic>
+                        {
+                            new Data.Model.Topic
+                            {
+                                Id = theme1.Topics[0].Id,
+                                Title = "Old Topic 1",
+                                Slug = "old-topic-1",
+                                Publications = new List<Data.Model.Publication>
+                                {
+                                    new Data.Model.Publication
+                                    {
+                                        Title = "Publication 1"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                );
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildTaxonomyService(contentDbContext, statisticsDbContext);
+
+                await service.SyncTaxonomy();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var themes = statisticsDbContext.Theme
+                    .Include(theme => theme.Topics)
+                    .ThenInclude(topic => topic.Publications)
+                    .ToList();
+
+                Assert.Single(themes);
+
+                var topics = themes[0].Topics.ToList();
+                Assert.Single(topics);
+
+                Assert.Equal(theme1.Topics[0].Id, topics[0].Id);
+                Assert.Equal("Updated Topic 1", topics[0].Title);
+                Assert.Equal("updated-topic-1", topics[0].Slug);
+
+                Assert.Single(topics[0].Publications);
+                Assert.Equal("Publication 1", topics[0].Publications.First().Title);
+            }
+        }
+
+        private TaxonomyService BuildTaxonomyService(
+            ContentDbContext contentDbContext,
+            StatisticsDbContext statisticsDbContext)
+        {
+            return new TaxonomyService(
+                contentDbContext: contentDbContext,
+                statisticsDbContext: statisticsDbContext,
+                mapper: MapperUtils.MapperForProfile<MappingProfiles>()
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishTaxonomyFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishTaxonomyFunction.cs
@@ -13,10 +13,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
     public class PublishTaxonomyFunction
     {
         private readonly IContentService _contentService;
+        private readonly ITaxonomyService _taxonomyService;
 
-        public PublishTaxonomyFunction(IContentService contentService)
+        public PublishTaxonomyFunction(IContentService contentService, ITaxonomyService taxonomyService)
         {
             _contentService = contentService;
+            _taxonomyService = taxonomyService;
         }
 
         [FunctionName("PublishTaxonomy")]
@@ -32,6 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             var context = new PublishContext(DateTime.UtcNow, false);
 
             await _contentService.UpdateTaxonomy(context);
+            await _taxonomyService.SyncTaxonomy();
 
             logger.LogInformation($"{executionContext.FunctionName} completed");
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/MappingProfiles.cs
@@ -41,6 +41,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                     m => m.MapFrom(p => p.LegacyReleases.OrderByDescending(l => l.Order)))
                 .ForMember(dest => dest.Releases, m => m.Ignore());
 
+            CreateMap<Publication, Data.Model.Publication>()
+                .ForMember(dest => dest.Releases, m => m.Ignore())
+                .ForMember(dest => dest.Topic, m => m.Ignore());
+
             CreateMap<Release, CachedReleaseViewModel>()
                 .ForMember(dest => dest.CoverageTitle,
                     m => m.MapFrom(release => release.TimePeriodCoverage.GetEnumLabel()))

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/MappingProfiles.cs
@@ -54,7 +54,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
 
             CreateMap<Theme, ThemeViewModel>();
 
+            CreateMap<Theme, Data.Model.Theme>()
+                .ForMember(dest => dest.Topics, m => m.Ignore());
+
             CreateMap<Topic, TopicViewModel>();
+
+            CreateMap<Topic, Data.Model.Topic>()
+                .ForMember(dest => dest.Publications, m => m.Ignore())
+                .ForMember(dest => dest.Theme, m => m.Ignore());
 
             CreateMap<Update, ReleaseNoteViewModel>();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/ITaxonomyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/ITaxonomyService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces
+{
+    public interface ITaxonomyService
+    {
+        Task SyncTaxonomy();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/TaxonomyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/TaxonomyService.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
+{
+    public class TaxonomyService : ITaxonomyService
+    {
+        private readonly ContentDbContext _contentDbContext;
+        private readonly StatisticsDbContext _statisticsDbContext;
+        private readonly IMapper _mapper;
+
+        public TaxonomyService(
+            ContentDbContext contentDbContext,
+            StatisticsDbContext statisticsDbContext,
+            IMapper mapper)
+        {
+            _contentDbContext = contentDbContext;
+            _statisticsDbContext = statisticsDbContext;
+            _mapper = mapper;
+        }
+
+        public async Task SyncTaxonomy()
+        {
+            await SyncThemes();
+            await _statisticsDbContext.SaveChangesAsync();
+
+            await SyncTopics();
+            await _statisticsDbContext.SaveChangesAsync();
+        }
+
+        private async Task SyncThemes()
+        {
+            var themes = await _contentDbContext.Themes
+                .ToListAsync();
+
+            var themeIds = themes.Select(theme => theme.Id).ToList();
+
+            var statisticsThemes = await _statisticsDbContext.Theme
+                .Where(theme => themeIds.Contains(theme.Id))
+                .ToDictionaryAsync(theme => theme.Id);
+
+            foreach (var theme in themes)
+            {
+                await SyncTheme(theme, statisticsThemes);
+            }
+
+            _statisticsDbContext.Theme.RemoveRange(
+                _statisticsDbContext.Theme.Where(theme => !themeIds.Contains(theme.Id))
+            );
+        }
+
+        private async Task SyncTheme(Theme theme, IReadOnlyDictionary<Guid, Data.Model.Theme> statisticsThemes)
+        {
+            var matchingStatsTheme = statisticsThemes.GetValueOrDefault(theme.Id);
+
+            if (matchingStatsTheme == null)
+            {
+                var newStatsTheme = _mapper.Map(theme, new Data.Model.Theme());
+                await _statisticsDbContext.Theme.AddAsync(newStatsTheme);
+            }
+            else
+            {
+                _mapper.Map(theme, matchingStatsTheme);
+                _statisticsDbContext.Theme.Update(matchingStatsTheme);
+            }
+        }
+
+        private async Task SyncTopics()
+        {
+            var topics = await _contentDbContext.Topics
+                .ToListAsync();
+
+            var topicIds = topics.Select(topic => topic.Id).ToList();
+
+            var statisticsTopics = await _statisticsDbContext.Topic
+                .Where(topic => topicIds.Contains(topic.Id))
+                .ToDictionaryAsync(topic => topic.Id);
+
+            foreach (var topic in topics)
+            {
+                await SyncTopic(topic, statisticsTopics);
+            }
+
+            _statisticsDbContext.Topic.RemoveRange(
+                _statisticsDbContext.Topic.Where(topic => !topicIds.Contains(topic.Id))
+            );
+        }
+
+        private async Task SyncTopic(Topic topic, IReadOnlyDictionary<Guid, Data.Model.Topic> statsTopics)
+        {
+            var matchingStatsTopic = statsTopics.GetValueOrDefault(topic.Id);
+
+            if (matchingStatsTopic == null)
+            {
+                var newStatsTopic = _mapper.Map(topic, new Data.Model.Topic());
+                await _statisticsDbContext.Topic.AddAsync(newStatsTopic);
+            }
+            else
+            {
+                _mapper.Map(topic, matchingStatsTopic);
+                _statisticsDbContext.Topic.Update(matchingStatsTopic);
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -67,6 +67,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                     })
                 .AddScoped<IPublishingService, PublishingService>()
                 .AddScoped<IContentService, ContentService>()
+                .AddScoped<ITaxonomyService, TaxonomyService>()
                 .AddScoped<IReleaseService, ReleaseService>()
                 .AddScoped<ITableStorageService, TableStorageService>(provider =>
                     new TableStorageService(GetConfigurationValue(provider, "PublisherStorage")))


### PR DESCRIPTION
This PR:

- Adds additional syncing functionality to ensure that changes to the content DB taxonomy also updates the statistics DB taxonomy as well. Synchronization means that we add, update and remove themes/topics as required to ensure that they match each other.
- Fixes changes to content DB's publication also not being synced to the statistics DB.

## Notes

- As part of the synchronization, we remove themes/topics that are no longer in the content DB. This unlikely to happen unless you delete a theme/topic in the admin (via API), however, it could theoretically happen if you manually modify the database tables (definitely not advised).
- If themes/topics were removed during synchronization, to make sure everything was cleaned up properly we would also need to delete relevant subjects/files across the entire service (admin and public). For the time being, we don't do this but the issue is described by EES-1295 in more detail.