### PR TITLE
Task/ees 1552 add percent complete

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFilesServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFilesServiceTests.cs
@@ -1047,7 +1047,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReturnsAsync(
                         new ImportStatus
                         {
-                            Status = IStatus.RUNNING_PHASE_2,
+                            Status = IStatus.STAGE_2,
                         }
                     );
 
@@ -1089,7 +1089,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("test2@test.com", files[1].UserName);
                 Assert.Equal(400, files[1].Rows);
                  Assert.Equal("800 B", files[1].Size);
-                Assert.Equal(IStatus.RUNNING_PHASE_2, files[1].Status);
+                Assert.Equal(IStatus.STAGE_2, files[1].Status);
             }
         }
 
@@ -1353,7 +1353,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReturnsAsync(
                         new ImportStatus
                         {
-                            Status = IStatus.RUNNING_PHASE_2,
+                            Status = IStatus.STAGE_2,
                         }
                     );
 
@@ -1383,7 +1383,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("test2@test.com", files[0].UserName);
                 Assert.Equal(400, files[0].Rows);
                  Assert.Equal("800 B", files[0].Size);
-                Assert.Equal(IStatus.RUNNING_PHASE_2, files[0].Status);
+                Assert.Equal(IStatus.STAGE_2, files[0].Status);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseMetaServiceTests.cs
@@ -359,7 +359,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReturnsAsync(
                         new ImportStatus()
                         {
-                            Status = IStatus.RUNNING_PHASE_1
+                            Status = IStatus.STAGE_1
                         }
                     );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/ImportStatusServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/ImportStatusServiceTests.cs
@@ -1,0 +1,543 @@
+﻿using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using Microsoft.Azure.Cosmos.Table;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.IStatus;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
+{
+    public class ImportStatusServiceTests
+    {
+        private readonly Guid _releaseId = Guid.NewGuid();
+        private const string FileName = "data.csv";
+
+        [Fact]
+        public async Task GetImportStatus_Stage1()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            const int percentageComplete = 50;
+
+            SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_1,
+                percentageComplete: percentageComplete);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            var result = await service.GetImportStatus(_releaseId, FileName);
+
+            Assert.Equal(STAGE_1, result.Status);
+            Assert.Equal(percentageComplete * 0.1, result.PercentageComplete);
+            Assert.Null(result.Errors);
+            Assert.Equal(100, result.NumberOfRows);
+        }
+
+        [Fact]
+        public async Task GetImportStatus_Stage2()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            const int percentageComplete = 50;
+
+            SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_2,
+                percentageComplete: percentageComplete);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            var result = await service.GetImportStatus(_releaseId, FileName);
+
+            Assert.Equal(STAGE_2, result.Status);
+            Assert.Equal(100 * 0.1 + percentageComplete * 0.1, result.PercentageComplete);
+            Assert.Null(result.Errors);
+            Assert.Equal(100, result.NumberOfRows);
+        }
+
+        [Fact]
+        public async Task GetImportStatus_Stage3()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            const int percentageComplete = 50;
+
+            SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_3,
+                percentageComplete: percentageComplete);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            var result = await service.GetImportStatus(_releaseId, FileName);
+
+            Assert.Equal(STAGE_3, result.Status);
+            Assert.Equal(100 * 0.1 + 100 * 0.1 + percentageComplete * 0.1, result.PercentageComplete);
+            Assert.Null(result.Errors);
+            Assert.Equal(100, result.NumberOfRows);
+        }
+
+        [Fact]
+        public async Task GetImportStatus_Stage4()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            const int percentageComplete = 50;
+
+            SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_4,
+                percentageComplete: percentageComplete);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            var result = await service.GetImportStatus(_releaseId, FileName);
+
+            Assert.Equal(STAGE_4, result.Status);
+            Assert.Equal(100 * 0.1 + 100 * 0.1 + 100 * 0.1, result.PercentageComplete);
+            Assert.Null(result.Errors);
+            Assert.Equal(100, result.NumberOfRows);
+        }
+
+        [Fact]
+        public async Task GetImportStatus_Stage5()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            const int percentageComplete = 50;
+
+            SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_5,
+                percentageComplete: percentageComplete);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            var result = await service.GetImportStatus(_releaseId, FileName);
+
+            Assert.Equal(STAGE_5, result.Status);
+            Assert.Equal(100 * 0.1 + 100 * 0.1 + 100 * 0.1 + percentageComplete * 0.7, result.PercentageComplete);
+            Assert.Null(result.Errors);
+            Assert.Equal(100, result.NumberOfRows);
+        }
+
+        [Fact]
+        public async Task GetImportStatus_Complete()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            const int percentageComplete = 50;
+
+            SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: COMPLETE,
+                percentageComplete: percentageComplete);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            var result = await service.GetImportStatus(_releaseId, FileName);
+
+            Assert.Equal(COMPLETE, result.Status);
+            Assert.Equal(100, result.PercentageComplete);
+            Assert.Null(result.Errors);
+            Assert.Equal(100, result.NumberOfRows);
+        }
+
+        [Fact]
+        public async Task GetImportStatus_Failed()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: FAILED,
+                percentageComplete: 50,
+                errors: "Error message");
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            var result = await service.GetImportStatus(_releaseId, FileName);
+
+            Assert.Equal(FAILED, result.Status);
+            Assert.Equal(0, result.PercentageComplete);
+            Assert.Equal("Error message", result.Errors);
+            Assert.Equal(100, result.NumberOfRows);
+        }
+
+        [Fact]
+        public async Task GetImportStatus_NotFound()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            SetupImportsTableMockForDataFileNotFound(tableStorageService);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+
+            var result = await service.GetImportStatus(_releaseId, FileName);
+
+            Assert.Equal(NOT_FOUND, result.Status);
+            Assert.Equal(0, result.PercentageComplete);
+            Assert.Null(result.Errors);
+            Assert.Equal(0, result.NumberOfRows);
+        }
+
+        [Fact]
+        public async Task IsImportFinished_TrueWhenComplete()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: COMPLETE,
+                percentageComplete: 50);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            Assert.True(await service.IsImportFinished(_releaseId, FileName));
+        }
+
+        [Fact]
+        public async Task IsImportFinished_TrueFailed()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: FAILED,
+                percentageComplete: 50,
+                errors: "Error message");
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            Assert.True(await service.IsImportFinished(_releaseId, FileName));
+        }
+
+        [Fact]
+        public async Task IsImportFinished_TrueWhenNotFound()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            SetupImportsTableMockForDataFileNotFound(tableStorageService);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            Assert.True(await service.IsImportFinished(_releaseId, FileName));
+        }
+
+        [Fact]
+        public async Task IsImportFinished_FalseWhenInProgress()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_1,
+                percentageComplete: 50);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            Assert.False(await service.IsImportFinished(_releaseId, FileName));
+        }
+
+        [Fact]
+        public async Task UpdateStatus_AlreadyComplete()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: COMPLETE,
+                percentageComplete: 100);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            
+            Assert.True(await service.UpdateStatus(_releaseId, FileName, STAGE_1));
+
+            importsTable.Verify(mock => 
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                operation.OperationType == TableOperationType.Retrieve)), Times.Once);
+
+            importsTable.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task UpdateStatus_AlreadyFailed()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: FAILED,
+                percentageComplete: 0);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            
+            Assert.False(await service.UpdateStatus(_releaseId, FileName, STAGE_1));
+
+            importsTable.Verify(mock => 
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Retrieve)), Times.Once);
+
+            importsTable.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task UpdateStatus_UpdateToCompleteStatus()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_5,
+                percentageComplete: 0);
+
+            importsTable.Setup(mock => mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Replace)))
+                .ReturnsAsync(new TableResult
+                {
+                    Result = null
+                });
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+
+            Assert.True(await service.UpdateStatus(_releaseId, FileName, COMPLETE));
+
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Retrieve)), Times.Once);
+
+            // TODO ideally we want to verify the percentage complete in the replacement
+            
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Replace)), Times.Once);
+
+            importsTable.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task UpdateStatus_UpdateToOtherStatus()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_1,
+                percentageComplete: 0);
+
+            importsTable.Setup(mock => mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Replace)))
+                .ReturnsAsync(new TableResult
+                {
+                    Result = null
+                });
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+
+            Assert.True(await service.UpdateStatus(_releaseId, FileName, STAGE_2));
+
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Retrieve)), Times.Once);
+
+            // TODO ideally we want to verify the percentage complete in the replacement
+            
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Replace)), Times.Once);
+
+            importsTable.VerifyNoOtherCalls();
+        }
+        
+        [Fact]
+        public async Task UpdateStatus_UpdateAsSameStatus()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_1,
+                percentageComplete: 0);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+            
+            Assert.True(await service.UpdateStatus(_releaseId, FileName, STAGE_1));
+
+            importsTable.Verify(mock => 
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Retrieve)), Times.Once);
+
+            importsTable.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task UpdateStatus_UpdateThrowsException()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_1,
+                percentageComplete: 0);
+
+            importsTable.Setup(mock => mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Replace)))
+                .ThrowsAsync(new StorageException());
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+
+            Assert.True(await service.UpdateStatus(_releaseId, FileName, STAGE_2));
+
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Retrieve)), Times.Once);
+
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Replace)), Times.Once);
+
+            importsTable.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task UpdateProgress()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_1,
+                percentageComplete: 0);
+
+            importsTable.Setup(mock => mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Replace)))
+                .ReturnsAsync(new TableResult
+                {
+                    Result = null
+                });
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+
+            await service.UpdateProgress(_releaseId, FileName, 50.0);
+
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Retrieve)), Times.Once);
+
+            // TODO ideally we want to verify the percentage complete in the replacement
+            
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Replace)), Times.Once);
+
+            importsTable.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task UpdateProgress_PercentageCompleteGreaterThanUpdate()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_1,
+                percentageComplete: 50);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+
+            await service.UpdateProgress(_releaseId, FileName, 25.0);
+
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Retrieve)), Times.Once);
+
+            importsTable.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task UpdateProgress_UpdateExceedsUpperBound()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_1,
+                percentageComplete: 0);
+
+            importsTable.Setup(mock => mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Replace)))
+                .ReturnsAsync(new TableResult
+                {
+                    Result = null
+                });
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+
+            await service.UpdateProgress(_releaseId, FileName, 101.0);
+
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Retrieve)), Times.Once);
+
+            // TODO ideally we want to verify the percentage complete in the replacement
+            
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Replace)), Times.Once);
+            
+            importsTable.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task UpdateProgress_UpdateThrowsException()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_1,
+                percentageComplete: 0);
+
+            importsTable.Setup(mock => mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Replace)))
+                .ThrowsAsync(new StorageException());
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+
+            await service.UpdateProgress(_releaseId, FileName, 50.0);
+
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Retrieve)), Times.Once);
+
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Replace)), Times.Once);
+
+            importsTable.VerifyNoOtherCalls();
+        }
+        
+        private static Mock<CloudTable> SetupImportsTableMockForDataFileImport(Mock<ITableStorageService> tableStorageService,
+            IStatus importStatus,
+            int percentageComplete,
+            string errors = null,
+            int numberOfRows = 100)
+        {
+            return SetupImportsTableMockForDataFileImportResponse(tableStorageService, new DatafileImport
+            {
+                ETag = "*",
+                Errors = errors,
+                NumberOfRows = numberOfRows,
+                PercentageComplete = percentageComplete,
+                Status = importStatus
+            });
+        }
+
+        private static void SetupImportsTableMockForDataFileNotFound(Mock<ITableStorageService> tableStorageService)
+        {
+            SetupImportsTableMockForDataFileImportResponse(tableStorageService, null);
+        }
+
+        private static Mock<CloudTable> SetupImportsTableMockForDataFileImportResponse(Mock<ITableStorageService> tableStorageService,
+            DatafileImport response)
+        {
+            var importsTable = new Mock<CloudTable>(MockBehavior.Strict, new Uri("http://127.0.0.1:10002/devstoreaccount1/imports"),
+                It.IsAny<TableClientConfiguration>());
+
+            tableStorageService.Setup(mock =>
+                mock.GetTableAsync("imports", true)).ReturnsAsync(importsTable.Object);
+
+            importsTable.Setup(mock => mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Retrieve)))
+                .ReturnsAsync(new TableResult
+                {
+                    Result = response
+                });
+
+            return importsTable;
+        }
+
+        private static ImportStatusService BuildImportStatusService(
+            ITableStorageService tableStorageService = null)
+        {
+            return new ImportStatusService(
+                tableStorageService ?? new Mock<ITableStorageService>().Object,
+                new Mock<ILogger<ImportStatusService>>().Object
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/ImportStatusServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/ImportStatusServiceTests.cs
@@ -32,6 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             Assert.Equal(STAGE_1, result.Status);
             Assert.Equal(percentageComplete * 0.1, result.PercentageComplete);
+            Assert.Equal(percentageComplete, result.PhasePercentageComplete);
             Assert.Null(result.Errors);
             Assert.Equal(100, result.NumberOfRows);
         }
@@ -52,6 +53,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             Assert.Equal(STAGE_2, result.Status);
             Assert.Equal(100 * 0.1 + percentageComplete * 0.1, result.PercentageComplete);
+            Assert.Equal(percentageComplete, result.PhasePercentageComplete);
             Assert.Null(result.Errors);
             Assert.Equal(100, result.NumberOfRows);
         }
@@ -72,6 +74,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             Assert.Equal(STAGE_3, result.Status);
             Assert.Equal(100 * 0.1 + 100 * 0.1 + percentageComplete * 0.1, result.PercentageComplete);
+            Assert.Equal(percentageComplete, result.PhasePercentageComplete);
             Assert.Null(result.Errors);
             Assert.Equal(100, result.NumberOfRows);
         }
@@ -91,27 +94,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             var result = await service.GetImportStatus(_releaseId, FileName);
 
             Assert.Equal(STAGE_4, result.Status);
-            Assert.Equal(100 * 0.1 + 100 * 0.1 + 100 * 0.1, result.PercentageComplete);
-            Assert.Null(result.Errors);
-            Assert.Equal(100, result.NumberOfRows);
-        }
-
-        [Fact]
-        public async Task GetImportStatus_Stage5()
-        {
-            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
-
-            const int percentageComplete = 50;
-
-            SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
-                importStatus: STAGE_5,
-                percentageComplete: percentageComplete);
-
-            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
-            var result = await service.GetImportStatus(_releaseId, FileName);
-
-            Assert.Equal(STAGE_5, result.Status);
             Assert.Equal(100 * 0.1 + 100 * 0.1 + 100 * 0.1 + percentageComplete * 0.7, result.PercentageComplete);
+            Assert.Equal(percentageComplete, result.PhasePercentageComplete);
             Assert.Null(result.Errors);
             Assert.Equal(100, result.NumberOfRows);
         }
@@ -132,6 +116,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             Assert.Equal(COMPLETE, result.Status);
             Assert.Equal(100, result.PercentageComplete);
+            Assert.Equal(percentageComplete, result.PhasePercentageComplete);
             Assert.Null(result.Errors);
             Assert.Equal(100, result.NumberOfRows);
         }
@@ -141,9 +126,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         {
             var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
 
+            const int percentageComplete = 50;
+            
             SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
                 importStatus: FAILED,
-                percentageComplete: 50,
+                percentageComplete: percentageComplete,
                 errors: "Error message");
 
             var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
@@ -151,6 +138,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             Assert.Equal(FAILED, result.Status);
             Assert.Equal(0, result.PercentageComplete);
+            Assert.Equal(percentageComplete, result.PhasePercentageComplete);
             Assert.Equal("Error message", result.Errors);
             Assert.Equal(100, result.NumberOfRows);
         }
@@ -168,6 +156,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             Assert.Equal(NOT_FOUND, result.Status);
             Assert.Equal(0, result.PercentageComplete);
+            Assert.Equal(0, result.PhasePercentageComplete);
             Assert.Null(result.Errors);
             Assert.Equal(0, result.NumberOfRows);
         }
@@ -269,7 +258,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
 
             var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
-                importStatus: STAGE_5,
+                importStatus: STAGE_4,
                 percentageComplete: 0);
 
             importsTable.Setup(mock => mock.ExecuteAsync(It.Is<TableOperation>(operation =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/ImportStatusServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/ImportStatusServiceTests.cs
@@ -127,7 +127,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
 
             const int percentageComplete = 50;
-            
+
             SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
                 importStatus: FAILED,
                 percentageComplete: percentageComplete,
@@ -222,12 +222,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
                 percentageComplete: 100);
 
             var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
-            
+
             Assert.True(await service.UpdateStatus(_releaseId, FileName, STAGE_1));
 
-            importsTable.Verify(mock => 
+            importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
-                operation.OperationType == TableOperationType.Retrieve)), Times.Once);
+                    operation.OperationType == TableOperationType.Retrieve)), Times.Once);
 
             importsTable.VerifyNoOtherCalls();
         }
@@ -242,10 +242,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
                 percentageComplete: 0);
 
             var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
-            
+
             Assert.False(await service.UpdateStatus(_releaseId, FileName, STAGE_1));
 
-            importsTable.Verify(mock => 
+            importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
                     operation.OperationType == TableOperationType.Retrieve)), Times.Once);
 
@@ -276,11 +276,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
                     operation.OperationType == TableOperationType.Retrieve)), Times.Once);
 
-            // TODO ideally we want to verify the percentage complete in the replacement
-            
             importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
-                    operation.OperationType == TableOperationType.Replace)), Times.Once);
+                    operation.OperationType == TableOperationType.Replace
+                    && (operation.Entity as DatafileImport).PercentageComplete == 100)), Times.Once);
 
             importsTable.VerifyNoOtherCalls();
         }
@@ -292,7 +291,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
                 importStatus: STAGE_1,
-                percentageComplete: 0);
+                percentageComplete: 100);
 
             importsTable.Setup(mock => mock.ExecuteAsync(It.Is<TableOperation>(operation =>
                     operation.OperationType == TableOperationType.Replace)))
@@ -309,15 +308,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
                     operation.OperationType == TableOperationType.Retrieve)), Times.Once);
 
-            // TODO ideally we want to verify the percentage complete in the replacement
-            
             importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
-                    operation.OperationType == TableOperationType.Replace)), Times.Once);
+                    operation.OperationType == TableOperationType.Replace
+                    && (operation.Entity as DatafileImport).PercentageComplete == 0)), Times.Once);
 
             importsTable.VerifyNoOtherCalls();
         }
-        
+
         [Fact]
         public async Task UpdateStatus_UpdateAsSameStatus()
         {
@@ -328,10 +326,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
                 percentageComplete: 0);
 
             var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
-            
+
             Assert.True(await service.UpdateStatus(_releaseId, FileName, STAGE_1));
 
-            importsTable.Verify(mock => 
+            importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
                     operation.OperationType == TableOperationType.Retrieve)), Times.Once);
 
@@ -345,7 +343,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
                 importStatus: STAGE_1,
-                percentageComplete: 0);
+                percentageComplete: 100);
 
             importsTable.Setup(mock => mock.ExecuteAsync(It.Is<TableOperation>(operation =>
                     operation.OperationType == TableOperationType.Replace)))
@@ -361,7 +359,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
-                    operation.OperationType == TableOperationType.Replace)), Times.Once);
+                    operation.OperationType == TableOperationType.Replace
+                    && (operation.Entity as DatafileImport).PercentageComplete == 0)), Times.Once);
 
             importsTable.VerifyNoOtherCalls();
         }
@@ -390,11 +389,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
                     operation.OperationType == TableOperationType.Retrieve)), Times.Once);
 
-            // TODO ideally we want to verify the percentage complete in the replacement
-            
             importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
-                    operation.OperationType == TableOperationType.Replace)), Times.Once);
+                    operation.OperationType == TableOperationType.Replace
+                    && (operation.Entity as DatafileImport).PercentageComplete == 50)), Times.Once);
 
             importsTable.VerifyNoOtherCalls();
         }
@@ -443,12 +441,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
                     operation.OperationType == TableOperationType.Retrieve)), Times.Once);
 
-            // TODO ideally we want to verify the percentage complete in the replacement
-            
             importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
-                    operation.OperationType == TableOperationType.Replace)), Times.Once);
-            
+                    operation.OperationType == TableOperationType.Replace
+                    && (operation.Entity as DatafileImport).PercentageComplete == 100)), Times.Once);
+
             importsTable.VerifyNoOtherCalls();
         }
 
@@ -475,12 +472,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
-                    operation.OperationType == TableOperationType.Replace)), Times.Once);
+                    operation.OperationType == TableOperationType.Replace
+                    && (operation.Entity as DatafileImport).PercentageComplete == 50)), Times.Once);
 
             importsTable.VerifyNoOtherCalls();
         }
-        
-        private static Mock<CloudTable> SetupImportsTableMockForDataFileImport(Mock<ITableStorageService> tableStorageService,
+
+        private static Mock<CloudTable> SetupImportsTableMockForDataFileImport(
+            Mock<ITableStorageService> tableStorageService,
             IStatus importStatus,
             int percentageComplete,
             string errors = null,
@@ -501,10 +500,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             SetupImportsTableMockForDataFileImportResponse(tableStorageService, null);
         }
 
-        private static Mock<CloudTable> SetupImportsTableMockForDataFileImportResponse(Mock<ITableStorageService> tableStorageService,
+        private static Mock<CloudTable> SetupImportsTableMockForDataFileImportResponse(
+            Mock<ITableStorageService> tableStorageService,
             DatafileImport response)
         {
-            var importsTable = new Mock<CloudTable>(MockBehavior.Strict, new Uri("http://127.0.0.1:10002/devstoreaccount1/imports"),
+            var importsTable = new Mock<CloudTable>(MockBehavior.Strict,
+                new Uri("http://127.0.0.1:10002/devstoreaccount1/imports"),
                 It.IsAny<TableClientConfiguration>());
 
             tableStorageService.Setup(mock =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/DatafileImport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/DatafileImport.cs
@@ -12,6 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
             PartitionKey = releaseId;
             RowKey = dataFileName;
             Status = IStatus.UPLOADING;
+            PercentageComplete = 0;
         }
         
         public DatafileImport(string releaseId, string dataFileName, int numberOfRows, string message, IStatus status, string errors = "")
@@ -22,6 +23,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
             Message = message;
             Status = status;
             Errors = errors;
+            PercentageComplete = 0;
         }
 
         public DatafileImport()
@@ -36,6 +38,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         
         public string Message { get; set; }
 
+        public int PercentageComplete { get; set; }
+        
         public override IDictionary<string, EntityProperty> WriteEntity(OperationContext operationContext)
         {
             var results = base.WriteEntity(operationContext);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ImportStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ImportStatus.cs
@@ -11,8 +11,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 
         public int PercentageComplete { get; set; }
 
+        public int PhasePercentageComplete { get; set; }
+
         public string Errors { get; set; }
 
         public int NumberOfRows { get; set; }
+
+        public bool PhaseComplete => PhasePercentageComplete == 100;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/ImportStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/ImportStatusService.cs
@@ -27,15 +27,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
     public class ImportStatusService : IImportStatusService
     {
         public const int STAGE_1_ROW_CHECK = 1000;
-        public const double STAGE_2_ROW_CHECK = 1000;
-        
-        private static readonly List<IStatus> FinishedImportStatuses = new List<IStatus> {
+        public const int STAGE_2_ROW_CHECK = 1000;
+
+        private static readonly List<IStatus> FinishedImportStatuses = new List<IStatus>
+        {
             IStatus.COMPLETE,
             IStatus.FAILED,
             IStatus.NOT_FOUND
         };
-        
-        private static readonly Dictionary<IStatus, double> ProcessingRatios = new Dictionary<IStatus, double>() {
+
+        private static readonly Dictionary<IStatus, double> ProcessingRatios = new Dictionary<IStatus, double>()
+        {
             {IStatus.STAGE_1, .1},
             {IStatus.STAGE_2, .1},
             {IStatus.STAGE_3, .1},
@@ -69,7 +71,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             var percentageComplete = CalculatePercentageComplete(import.PercentageComplete, import.Status);
 
             _logger.LogInformation($"current status: {import.Status} : {percentageComplete}% complete");
-            
+
             return new ImportStatus
             {
                 Errors = import.Errors,
@@ -118,9 +120,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         public async Task UpdateProgress(Guid releaseId, string origDataFileName, double percentageComplete)
         {
             var import = await GetImport(releaseId, origDataFileName);
-            if (import.PercentageComplete < (int)percentageComplete)
+            if (import.PercentageComplete < (int) percentageComplete)
             {
-                import.PercentageComplete = (int)percentageComplete;
+                import.PercentageComplete = (int) percentageComplete;
                 try
                 {
                     await _table.ExecuteAsync(TableOperation.Replace(import));
@@ -131,7 +133,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
                 }
             }
         }
-        
+
         private async Task<DatafileImport> GetImport(Guid releaseId, string dataFileName)
         {
             // Need to define the extra columns to retrieve
@@ -140,7 +142,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
                 dataFileName,
                 new List<string> {"NumBatches", "Status", "NumberOfRows", "Errors", "Message", "PercentageComplete"}));
 
-            return result.Result != null ? (DatafileImport) result.Result : new DatafileImport {Status = IStatus.NOT_FOUND};
+            return result.Result != null
+                ? (DatafileImport) result.Result
+                : new DatafileImport {Status = IStatus.NOT_FOUND};
         }
 
         private int CalculatePercentageComplete(int percentageComplete, IStatus status)
@@ -149,17 +153,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             {
                 IStatus.STAGE_1 => percentageComplete * ProcessingRatios[IStatus.STAGE_1],
                 IStatus.STAGE_2 => ProcessingRatios[IStatus.STAGE_1] * 100 +
-                                           (percentageComplete * ProcessingRatios[IStatus.STAGE_2]),
+                                   (percentageComplete * ProcessingRatios[IStatus.STAGE_2]),
                 IStatus.STAGE_3 => ProcessingRatios[IStatus.STAGE_1] * 100 +
-                                           ProcessingRatios[IStatus.STAGE_2] * 100 + 
-                                           (percentageComplete * ProcessingRatios[IStatus.STAGE_3]),
+                                   ProcessingRatios[IStatus.STAGE_2] * 100 +
+                                   (percentageComplete * ProcessingRatios[IStatus.STAGE_3]),
                 IStatus.STAGE_4 => ProcessingRatios[IStatus.STAGE_1] * 100 +
-                                           ProcessingRatios[IStatus.STAGE_2] * 100 +
-                                           ProcessingRatios[IStatus.STAGE_3] * 100,
+                                   ProcessingRatios[IStatus.STAGE_2] * 100 +
+                                   ProcessingRatios[IStatus.STAGE_3] * 100,
                 IStatus.STAGE_5 => ProcessingRatios[IStatus.STAGE_1] * 100 +
-                                           ProcessingRatios[IStatus.STAGE_2] * 100 +
-                                           ProcessingRatios[IStatus.STAGE_3] * 100 +
-                                           (percentageComplete * ProcessingRatios[IStatus.STAGE_5]),
+                                   ProcessingRatios[IStatus.STAGE_2] * 100 +
+                                   ProcessingRatios[IStatus.STAGE_3] * 100 +
+                                   (percentageComplete * ProcessingRatios[IStatus.STAGE_5]),
                 IStatus.COMPLETE => ProcessingRatios[IStatus.COMPLETE] * 100,
                 _ => 0
             });

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/ImportStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/ImportStatusService.cs
@@ -17,8 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         STAGE_1, // Basic row validation
         STAGE_2, // Create locations and filters
         STAGE_3, // Split Files
-        STAGE_4, // Split Files complete
-        STAGE_5, // Import observations
+        STAGE_4, // Import observations
         COMPLETE,
         FAILED,
         NOT_FOUND
@@ -41,7 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             {IStatus.STAGE_1, .1},
             {IStatus.STAGE_2, .1},
             {IStatus.STAGE_3, .1},
-            {IStatus.STAGE_5, .7},
+            {IStatus.STAGE_4, .7},
             {IStatus.COMPLETE, 1},
         };
 
@@ -77,7 +76,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
                 Errors = import.Errors,
                 Status = import.Status,
                 NumberOfRows = import.NumberOfRows,
-                PercentageComplete = percentageComplete
+                PercentageComplete = percentageComplete,
+                PhasePercentageComplete = import.PercentageComplete
             };
         }
 
@@ -153,17 +153,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             {
                 IStatus.STAGE_1 => percentageComplete * ProcessingRatios[IStatus.STAGE_1],
                 IStatus.STAGE_2 => ProcessingRatios[IStatus.STAGE_1] * 100 +
-                                   (percentageComplete * ProcessingRatios[IStatus.STAGE_2]),
+                                   percentageComplete * ProcessingRatios[IStatus.STAGE_2],
                 IStatus.STAGE_3 => ProcessingRatios[IStatus.STAGE_1] * 100 +
                                    ProcessingRatios[IStatus.STAGE_2] * 100 +
-                                   (percentageComplete * ProcessingRatios[IStatus.STAGE_3]),
+                                   percentageComplete * ProcessingRatios[IStatus.STAGE_3],
                 IStatus.STAGE_4 => ProcessingRatios[IStatus.STAGE_1] * 100 +
                                    ProcessingRatios[IStatus.STAGE_2] * 100 +
-                                   ProcessingRatios[IStatus.STAGE_3] * 100,
-                IStatus.STAGE_5 => ProcessingRatios[IStatus.STAGE_1] * 100 +
-                                   ProcessingRatios[IStatus.STAGE_2] * 100 +
                                    ProcessingRatios[IStatus.STAGE_3] * 100 +
-                                   (percentageComplete * ProcessingRatios[IStatus.STAGE_5]),
+                                   percentageComplete * ProcessingRatios[IStatus.STAGE_4],
                 IStatus.COMPLETE => ProcessingRatios[IStatus.COMPLETE] * 100,
                 _ => 0
             });

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/ImportStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/ImportStatusService.cs
@@ -70,7 +70,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
             var percentageComplete = CalculatePercentageComplete(import.PercentageComplete, import.Status);
 
-            _logger.LogInformation($"current status: {import.Status} : {percentageComplete}% complete");
+            _logger.LogInformation($"Current status: {import.Status} : {percentageComplete}% complete");
 
             return new ImportStatus
             {
@@ -105,7 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
                 {
                     await _table.ExecuteAsync(TableOperation.Replace(import));
                 }
-                catch (StorageException e)
+                catch (StorageException)
                 {
                     // If the table row has been updated in another thread subsequent
                     // to being read above then an exception will be thrown - ignore and continue.
@@ -122,12 +122,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             var import = await GetImport(releaseId, origDataFileName);
             if (import.PercentageComplete < (int) percentageComplete)
             {
-                import.PercentageComplete = (int) percentageComplete;
+                import.PercentageComplete = (int) Math.Clamp(percentageComplete, 0, 100);
                 try
                 {
                     await _table.ExecuteAsync(TableOperation.Replace(import));
                 }
-                catch (StorageException e)
+                catch (StorageException)
                 {
                     // Ignore - as above
                 }
@@ -147,7 +147,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
                 : new DatafileImport {Status = IStatus.NOT_FOUND};
         }
 
-        private int CalculatePercentageComplete(int percentageComplete, IStatus status)
+        private static int CalculatePercentageComplete(int percentageComplete, IStatus status)
         {
             return (int) (status switch
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IImportStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IImportStatusService.cs
@@ -7,7 +7,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
     public interface IImportStatusService
     {
         Task<ImportStatus> GetImportStatus(Guid releaseId, string dataFileName);
-
         Task<bool> IsImportFinished(Guid releaseId, string dataFileName);
+        Task<bool> UpdateStatus(Guid releaseId, string origDataFileName, IStatus status);
+        Task UpdateProgress(Guid releaseId, string origDataFileName, double percentageComplete);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterService.cs
@@ -140,7 +140,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             
             foreach (DataRow row in rows)
             {
-                if (rowCount % STAGE_1_ROW_CHECK == 0)
+                if (rowCount % STAGE_2_ROW_CHECK == 0)
                 {
                     await _importStatusService.UpdateProgress(releaseId, origDataFileName, (double)rowCount / dataRows * 100);
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterService.cs
@@ -49,52 +49,58 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             new Dictionary<Columns, string[]>
             {
                 {
-                    Columns.SCHOOL_COLS, new[]{"academy_open_date", "academy_type", "estab", "laestab", "school_name", "school_postcode", "urn"}
+                    Columns.SCHOOL_COLS,
+                    new[]
+                    {
+                        "academy_open_date", "academy_type", "estab", "laestab", "school_name", "school_postcode", "urn"
+                    }
                 },
                 {
-                    Columns.COUNTRY_COLS, new[]{"country_code", "country_name"}
+                    Columns.COUNTRY_COLS, new[] {"country_code", "country_name"}
                 },
                 {
-                    Columns.INSTITUTION_COLS, new[]{"institution_id", "institution_name"}
+                    Columns.INSTITUTION_COLS, new[] {"institution_id", "institution_name"}
                 },
                 {
-                    Columns.LOCAL_AUTH_COLS, new[]{"new_la_code", "old_la_code", "la_name"}
+                    Columns.LOCAL_AUTH_COLS, new[] {"new_la_code", "old_la_code", "la_name"}
                 },
                 {
-                    Columns.LOCAL_AUTH_DISTRICT_COLS, new[]{"lad_code", "lad_name"}
+                    Columns.LOCAL_AUTH_DISTRICT_COLS, new[] {"lad_code", "lad_name"}
                 },
                 {
-                    Columns.LOCAL_ENTERPRISE_PARTNERSHIP_COLS, new[]{"local_enterprise_partnership_code", "local_enterprise_partnership_name"}
+                    Columns.LOCAL_ENTERPRISE_PARTNERSHIP_COLS,
+                    new[] {"local_enterprise_partnership_code", "local_enterprise_partnership_name"}
                 },
                 {
-                    Columns.MAYORAL_COMBINED_AUTHORITY_COLS, new[]{"mayoral_combined_authority_code", "mayoral_combined_authority_name"}
+                    Columns.MAYORAL_COMBINED_AUTHORITY_COLS,
+                    new[] {"mayoral_combined_authority_code", "mayoral_combined_authority_name"}
                 },
                 {
-                    Columns.MULTI_ACADEMY_TRUST_COLS, new[]{"trust_id", "trust_name"}
+                    Columns.MULTI_ACADEMY_TRUST_COLS, new[] {"trust_id", "trust_name"}
                 },
                 {
-                    Columns.OPPORTUNITY_AREA_COLS, new[]{"opportunity_area_code", "opportunity_area_name"}
+                    Columns.OPPORTUNITY_AREA_COLS, new[] {"opportunity_area_code", "opportunity_area_name"}
                 },
                 {
-                    Columns.PARLIAMENTARY_CONSTITUENCY_COLS, new[]{"pcon_code", "pcon_name"}
+                    Columns.PARLIAMENTARY_CONSTITUENCY_COLS, new[] {"pcon_code", "pcon_name"}
                 },
                 {
-                    Columns.PROVIDER_COLS, new[]{"provider_urn", "provider_ukprn", "provider_upin", "provider_name"}
+                    Columns.PROVIDER_COLS, new[] {"provider_urn", "provider_ukprn", "provider_upin", "provider_name"}
                 },
                 {
-                    Columns.REGION_COLS, new[]{"region_code", "region_name"}
+                    Columns.REGION_COLS, new[] {"region_code", "region_name"}
                 },
                 {
-                    Columns.SPONSOR_COLS, new[]{"sponsor_id", "sponsor_name"}
+                    Columns.SPONSOR_COLS, new[] {"sponsor_id", "sponsor_name"}
                 },
                 {
-                    Columns.WARD_COLS, new[]{"ward_code", "ward_name"}
+                    Columns.WARD_COLS, new[] {"ward_code", "ward_name"}
                 },
                 {
-                    Columns.PLANNING_AREA_COLS, new[]{"planning_area_code", "planning_area_name"}
+                    Columns.PLANNING_AREA_COLS, new[] {"planning_area_code", "planning_area_name"}
                 },
             };
-                
+
         public static readonly List<GeographicLevel> IgnoredGeographicLevels = new List<GeographicLevel>
         {
             GeographicLevel.Institution,
@@ -102,7 +108,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             GeographicLevel.School,
             GeographicLevel.PlanningArea
         };
-        
+
         public ImporterService(
             IGuidGenerator guidGenerator,
             ImporterFilterService importerFilterService,
@@ -121,7 +127,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
         {
             _importerMetaService.Import(table.Columns, table.Rows, subject, context);
         }
-        
+
         public SubjectMeta GetMeta(DataTable table, Subject subject, StatisticsDbContext context)
         {
             return _importerMetaService.Get(table.Columns, table.Rows, subject, context);
@@ -136,14 +142,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
 
             var headers = CsvUtil.GetColumnValues(cols);
             var rowCount = 1;
-            var dataRows = rows.Count;
-            
+            var totalRows = rows.Count;
+
             foreach (DataRow row in rows)
             {
                 if (rowCount % STAGE_2_ROW_CHECK == 0)
                 {
-                    await _importStatusService.UpdateProgress(releaseId, origDataFileName, (double)rowCount / dataRows * 100);
+                    await _importStatusService.UpdateProgress(releaseId, origDataFileName,
+                        (double) rowCount / totalRows * 100);
                 }
+
                 CreateFiltersAndLocationsFromCsv(context, CsvUtil.GetRowValues(row), headers, subjectMeta.Filters);
                 rowCount++;
             }
@@ -154,7 +162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
         {
             _importerFilterService.ClearCache();
             _importerLocationService.ClearCache();
-            
+
             var observations = GetObservations(
                 context,
                 rows,
@@ -166,7 +174,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
 
             await InsertObservations(context, observations);
         }
-        
+
         public static GeographicLevel GetGeographicLevel(IReadOnlyList<string> line, List<string> headers)
         {
             return GetGeographicLevelFromString(CsvUtil.Value(line, headers, "geographic_level"));
@@ -181,10 +189,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
                     return val;
                 }
             }
-            
+
             throw new InvalidGeographicLevelException(value);
         }
-        
+
         public static TimeIdentifier GetTimeIdentifier(IReadOnlyList<string> line, List<string> headers)
         {
             var timeIdentifier = CsvUtil.Value(line, headers, "time_identifier").ToLower();
@@ -198,14 +206,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
 
             throw new InvalidTimeIdentifierException(timeIdentifier);
         }
-        
+
         public static int GetYear(IReadOnlyList<string> line, List<string> headers)
         {
             var tp = CsvUtil.Value(line, headers, "time_period");
             if (tp == null)
             {
-                throw new InvalidTimePeriodException(null); 
+                throw new InvalidTimePeriodException(null);
             }
+
             return int.Parse(tp.Substring(0, 4));
         }
 
@@ -217,11 +226,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             SubjectMeta subjectMeta,
             int batchNo,
             int rowsPerBatch
-            )
+        )
         {
             var observations = new List<Observation>();
             var i = 0;
-            
+
             foreach (DataRow row in rows)
             {
                 var o = ObservationFromCsv(
@@ -231,16 +240,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
                     subject,
                     subjectMeta,
                     ((batchNo - 1) * rowsPerBatch) + i++ + 2);
-                
+
                 if (!IgnoredGeographicLevels.Contains(o.GeographicLevel))
                 {
-                    observations.Add(o);  
+                    observations.Add(o);
                 }
             }
 
             return observations;
         }
-        
+
         private Observation ObservationFromCsv(
             StatisticsDbContext context,
             string[] line,
@@ -264,7 +273,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
                 CsvRow = csvRowNum
             };
         }
-        
+
         private void CreateFiltersAndLocationsFromCsv(
             StatisticsDbContext context,
             List<string> row,
@@ -285,8 +294,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             {
                 var filterItemLabel = CsvUtil.Value(line, headers, filterMeta.Column);
                 var filterGroupLabel = CsvUtil.Value(line, headers, filterMeta.FilterGroupingColumn);
-                
-                _importerFilterService.Find(filterItemLabel, filterGroupLabel, filterMeta.Filter, context); 
+
+                _importerFilterService.Find(filterItemLabel, filterGroupLabel, filterMeta.Filter, context);
             }
         }
 
@@ -301,11 +310,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             {
                 var filterItemLabel = CsvUtil.Value(line, headers, filterMeta.Column);
                 var filterGroupLabel = CsvUtil.Value(line, headers, filterMeta.FilterGroupingColumn);
-                
+
                 return new ObservationFilterItem
                 {
                     ObservationId = observationId,
-                    FilterItemId = _importerFilterService.Find(filterItemLabel, filterGroupLabel, filterMeta.Filter, context).Id,
+                    FilterItemId = _importerFilterService
+                        .Find(filterItemLabel, filterGroupLabel, filterMeta.Filter, context).Id,
                     FilterId = filterMeta.Filter.Id
                 };
             }).ToList();
@@ -424,7 +434,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             return CsvUtil.BuildType(line, headers, ColumnValues[Columns.WARD_COLS], values =>
                 new Ward(values[0], values[1]));
         }
-        
+
         private static PlanningArea GetPlanningArea(IReadOnlyList<string> line, List<string> headers)
         {
             return CsvUtil.BuildType(line, headers, ColumnValues[Columns.PLANNING_AREA_COLS], values =>
@@ -444,12 +454,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             observationsTable.Columns.Add("TimeIdentifier", typeof(string));
             observationsTable.Columns.Add("Measures", typeof(string));
             observationsTable.Columns.Add("CsvRow", typeof(long));
-            
+
             var observationsFilterItemsTable = new DataTable();
             observationsFilterItemsTable.Columns.Add("ObservationId", typeof(Guid));
             observationsFilterItemsTable.Columns.Add("FilterItemId", typeof(Guid));
             observationsFilterItemsTable.Columns.Add("FilterId", typeof(Guid));
-            
+
             foreach (var o in observations)
             {
                 observationsTable.Rows.Add(
@@ -474,20 +484,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
                     );
                 }
             }
-            
+
             var parameter = new SqlParameter("@Observations", SqlDbType.Structured)
             {
                 Value = observationsTable, TypeName = "[dbo].[ObservationType]"
             };
 
             await context.Database.ExecuteSqlRawAsync("EXEC [dbo].[InsertObservations] @Observations", parameter);
-            
+
             parameter = new SqlParameter("@ObservationFilterItems", SqlDbType.Structured)
             {
                 Value = observationsFilterItemsTable, TypeName = "[dbo].[ObservationFilterItemType]"
             };
 
-            await context.Database.ExecuteSqlRawAsync("EXEC [dbo].[InsertObservationFilterItems] @ObservationFilterItems", parameter);
+            await context.Database.ExecuteSqlRawAsync(
+                "EXEC [dbo].[InsertObservationFilterItems] @ObservationFilterItems", parameter);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/Interfaces/IImporterService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/Interfaces/IImporterService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
@@ -16,6 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services.Inte
         Task ImportObservations(DataColumnCollection cols, DataRowCollection rows, Subject subject,
             SubjectMeta subjectMeta, int batchNo, int rowsPerBatch, StatisticsDbContext context);
 
-        void ImportFiltersLocationsAndSchools(DataColumnCollection cols, DataRowCollection rows, SubjectMeta subjectMeta, StatisticsDbContext context);
+        Task ImportFiltersLocationsAndSchools(DataColumnCollection cols, DataRowCollection rows, SubjectMeta subjectMeta,
+            StatisticsDbContext context, Guid releaseId, string origDataFileName);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/PoisonQueueHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/PoisonQueueHandler.cs
@@ -24,8 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
         )
         {
             await _batchService.FailImport(
-                message.Release.Id.ToString(),
-                message.OrigDataFileName,
+                message.Release.Id, message.OrigDataFileName,
                 new List<ValidationError>
                 {
                     new ValidationError("File failed to import for unknown reason in upload processing stage.")
@@ -40,8 +39,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
             ILogger logger)
         {
             await _batchService.FailImport(
-                message.Release.Id.ToString(),
-                message.OrigDataFileName,
+                message.Release.Id, message.OrigDataFileName,
                 new List<ValidationError>
                 {
                     new ValidationError("File failed to import for unknown reason in upload processing stage.")

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Utils;
@@ -28,6 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
         private readonly ISplitFileService _splitFileService;
         private readonly IValidatorService _validatorService;
         private readonly IDataArchiveService _dataArchiveService;
+        private readonly IImportStatusService _importStatusService;
 
         public Processor(
             IFileImportService fileImportService,
@@ -37,7 +39,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
             IImporterService importerService,
             IBatchService batchService,
             IValidatorService validatorService,
-            IDataArchiveService dataArchiveService
+            IDataArchiveService dataArchiveService,
+            IImportStatusService importStatusService
         )
         {
             _fileImportService = fileImportService;
@@ -48,6 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
             _batchService = batchService;
             _validatorService = validatorService;
             _dataArchiveService = dataArchiveService;
+            _importStatusService = importStatusService;
         }
 
         [FunctionName("ProcessUploads")]
@@ -60,11 +64,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
         {
             if (message.ArchiveFileName != "")
             {
-                await _batchService.UpdateStatus(message.Release.Id.ToString(), message.DataFileName, IStatus.PROCESSING_ARCHIVE_FILE);
+                await _importStatusService.UpdateStatus(message.Release.Id, message.DataFileName, IStatus.PROCESSING_ARCHIVE_FILE);
                 await _dataArchiveService.ExtractDataFiles(message.Release.Id, message.ArchiveFileName);
             }
 
-            await _batchService.UpdateStatus(message.Release.Id.ToString(), message.DataFileName, IStatus.RUNNING_PHASE_1);
+            await _importStatusService.UpdateStatus(message.Release.Id, message.DataFileName, IStatus.STAGE_1);
             var subjectData = await _fileStorageService.GetSubjectData(message);
 
             await _validatorService.Validate(message.Release.Id, subjectData, executionContext, message)
@@ -72,19 +76,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
                 {
                     try
                     {
+                        var status = await _importStatusService.GetImportStatus(message.Release.Id, message.OrigDataFileName);
                         message.RowsPerBatch = result.RowsPerBatch;
                         message.TotalRows = result.FilteredObservationCount;
                         message.NumBatches = result.NumBatches;
 
                         await _batchService.UpdateStoredMessage(message);
-                        
-                        var status = await _batchService.GetStatus(message.Release.Id.ToString(), message.OrigDataFileName);
 
                         // If already reached Phase 4 then don't re-create the subject or split into batches
-                        if ((int) status < (int) IStatus.RUNNING_PHASE_4)
+                        if ((int) status.Status < (int) IStatus.STAGE_4)
                         {
-                            await _batchService.UpdateStatus(message.Release.Id.ToString(), message.OrigDataFileName,
-                                IStatus.RUNNING_PHASE_2);
+                            await _importStatusService.UpdateStatus(message.Release.Id, message.OrigDataFileName,
+                                IStatus.STAGE_2);
                             await ProcessSubject(message, DbUtils.CreateStatisticsDbContext(),
                                 DbUtils.CreateContentDbContext(), subjectData);
                             await _splitFileService.SplitDataFile(collector, message, subjectData);
@@ -94,11 +97,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
                     {
                         var ex = GetInnerException(e);
 
-                        await _batchService.FailImport(
-                            message.Release.Id.ToString(),
-                            message.OrigDataFileName,
-                            new List<ValidationError> {new ValidationError(ex.Message)}
-                        );
+                        await _batchService.FailImport(message.Release.Id, message.OrigDataFileName,
+                            new List<ValidationError> {new ValidationError(ex.Message)});
 
                         logger.LogError(ex,$"{GetType().Name} function FAILED for : Datafile: " +
                                            $"{message.DataFileName} : {ex.Message}");
@@ -109,12 +109,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
                 })
                 .OnFailureDo(async errors =>
                 {
-                    await _batchService.FailImport(
-                        message.Release.Id.ToString(),
-                        message.OrigDataFileName,
-                        errors
-                    );
-
+                    await _batchService.FailImport(message.Release.Id, message.OrigDataFileName, errors);
                     logger.LogError($"Import FAILED for {message.DataFileName}...check log");
                 });
         }
@@ -140,11 +135,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
 
                 var ex = GetInnerException(e);
 
-                await _batchService.FailImport(
-                    message.Release.Id.ToString(),
-                    message.OrigDataFileName,
-                    new List<ValidationError> {new ValidationError(ex.Message)}
-                );
+                await _batchService.FailImport(message.Release.Id, message.OrigDataFileName,new List<ValidationError> {new ValidationError(ex.Message)});
 
                 logger.LogError(ex,$"{GetType().Name} function FAILED for : Datafile: " +
                                 $"{message.DataFileName} : {ex.Message}");

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
@@ -80,18 +80,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
                         
                         var status = await _batchService.GetStatus(message.Release.Id.ToString(), message.OrigDataFileName);
 
-                        // If already reached Phase 2 then don't re-create the subject or split into batches
+                        // If already reached Phase 4 then don't re-create the subject or split into batches
                         if ((int) status < (int) IStatus.RUNNING_PHASE_4)
                         {
                             await _batchService.UpdateStatus(message.Release.Id.ToString(), message.OrigDataFileName,
                                 IStatus.RUNNING_PHASE_2);
                             await ProcessSubject(message, DbUtils.CreateStatisticsDbContext(),
                                 DbUtils.CreateContentDbContext(), subjectData);
-                            await _batchService.UpdateStatus(message.Release.Id.ToString(), message.OrigDataFileName,
-                                IStatus.RUNNING_PHASE_3);
                             await _splitFileService.SplitDataFile(collector, message, subjectData);
-                            await _batchService.UpdateStatus(message.Release.Id.ToString(), message.OrigDataFileName,
-                                IStatus.RUNNING_PHASE_4);
                         }
                     }
                     catch (Exception e)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
@@ -64,7 +64,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
         {
             if (message.ArchiveFileName != "")
             {
-                await _importStatusService.UpdateStatus(message.Release.Id, message.DataFileName, IStatus.PROCESSING_ARCHIVE_FILE);
+                await _importStatusService.UpdateStatus(message.Release.Id,
+                    message.DataFileName,
+                    IStatus.PROCESSING_ARCHIVE_FILE);
+
                 await _dataArchiveService.ExtractDataFiles(message.Release.Id, message.ArchiveFileName);
             }
 
@@ -76,7 +79,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
                 {
                     try
                     {
-                        var status = await _importStatusService.GetImportStatus(message.Release.Id, message.OrigDataFileName);
+                        var status =
+                            await _importStatusService.GetImportStatus(message.Release.Id, message.OrigDataFileName);
+
                         message.RowsPerBatch = result.RowsPerBatch;
                         message.TotalRows = result.FilteredObservationCount;
                         message.NumBatches = result.NumBatches;
@@ -97,11 +102,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
                     {
                         var ex = GetInnerException(e);
 
-                        await _batchService.FailImport(message.Release.Id, message.OrigDataFileName,
-                            new List<ValidationError> {new ValidationError(ex.Message)});
+                        await _batchService.FailImport(message.Release.Id,
+                            message.OrigDataFileName,
+                            new List<ValidationError>
+                            {
+                                new ValidationError(ex.Message)
+                            });
 
-                        logger.LogError(ex,$"{GetType().Name} function FAILED for : Datafile: " +
-                                           $"{message.DataFileName} : {ex.Message}");
+                        logger.LogError(ex, $"{GetType().Name} function FAILED for : Datafile: " +
+                                            $"{message.DataFileName} : {ex.Message}");
                         logger.LogError(ex.StackTrace);
                     }
 
@@ -109,7 +118,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
                 })
                 .OnFailureDo(async errors =>
                 {
-                    await _batchService.FailImport(message.Release.Id, message.OrigDataFileName, errors);
+                    await _batchService.FailImport(message.Release.Id,
+                        message.OrigDataFileName,
+                        errors);
+
                     logger.LogError($"Import FAILED for {message.DataFileName}...check log");
                 });
         }
@@ -129,16 +141,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
                 if (e is SqlException exception && exception.Number == 1205)
                 {
                     logger.LogInformation($"{GetType().Name} : Handling known exception when processing Datafile: " +
-                                       $"{message.DataFileName} : {exception.Message} : transaction will be retried");
+                                          $"{message.DataFileName} : {exception.Message} : transaction will be retried");
                     throw;
                 }
 
                 var ex = GetInnerException(e);
 
-                await _batchService.FailImport(message.Release.Id, message.OrigDataFileName,new List<ValidationError> {new ValidationError(ex.Message)});
+                await _batchService.FailImport(message.Release.Id,
+                    message.OrigDataFileName,
+                    new List<ValidationError>
+                    {
+                        new ValidationError(ex.Message)
+                    });
 
-                logger.LogError(ex,$"{GetType().Name} function FAILED for : Datafile: " +
-                                $"{message.DataFileName} : {ex.Message}");
+                logger.LogError(ex, $"{GetType().Name} function FAILED for : Datafile: " +
+                                    $"{message.DataFileName} : {ex.Message}");
             }
         }
 
@@ -148,7 +165,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
             ContentDbContext contentDbContext,
             SubjectData subjectData)
         {
-            var subject = _releaseProcessorService.CreateOrUpdateRelease(subjectData, message, statisticsDbContext, contentDbContext);
+            var subject = _releaseProcessorService.CreateOrUpdateRelease(subjectData,
+                    message,
+                    statisticsDbContext,
+                    contentDbContext);
 
             await using var metaFileStream = await _fileStorageService.StreamBlob(subjectData.MetaBlob);
             var metaFileTable = DataTableUtils.CreateFromStream(metaFileStream);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
@@ -88,13 +88,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
 
                         await _batchService.UpdateStoredMessage(message);
 
-                        // If already reached Phase 4 then don't re-create the subject or split into batches
-                        if ((int) status.Status < (int) IStatus.STAGE_4)
+                        // If already completed Phase 3 then don't re-create the subject or split into batches
+                        if (IStatus.STAGE_3.CompareTo(status.Status) > 0 ||
+                            status.Status == IStatus.STAGE_3 && !status.PhaseComplete)
                         {
-                            await _importStatusService.UpdateStatus(message.Release.Id, message.OrigDataFileName,
+                            await _importStatusService.UpdateStatus(message.Release.Id,
+                                message.OrigDataFileName,
                                 IStatus.STAGE_2);
-                            await ProcessSubject(message, DbUtils.CreateStatisticsDbContext(),
-                                DbUtils.CreateContentDbContext(), subjectData);
+
+                            await ProcessSubject(message,
+                                DbUtils.CreateStatisticsDbContext(),
+                                DbUtils.CreateContentDbContext(),
+                                subjectData);
+
                             await _splitFileService.SplitDataFile(collector, message, subjectData);
                         }
                     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/ImportRecoveryHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/ImportRecoveryHandler.cs
@@ -96,8 +96,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
                 IStatus.STAGE_1,
                 IStatus.STAGE_2,
                 IStatus.STAGE_3,
-                IStatus.STAGE_4,
-                IStatus.STAGE_5
+                IStatus.STAGE_4
             };
 
             combineFilters = statuses.Aggregate(combineFilters, (current, status) =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/ImportRecoveryHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/ImportRecoveryHandler.cs
@@ -56,7 +56,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
                     Console.Out.WriteLine($"Recovering {entity.PartitionKey} : {entity.RowKey}");
 
                     // If batch was not split then just processing again by adding to pending queue
-                    if (entity.Status.Equals(IStatus.QUEUED) || entity.Status.Equals(IStatus.PROCESSING_ARCHIVE_FILE) || entity.Status.Equals(IStatus.STAGE_1))
+                    if (entity.Status.Equals(IStatus.QUEUED)
+                        || entity.Status.Equals(IStatus.PROCESSING_ARCHIVE_FILE)
+                        || entity.Status.Equals(IStatus.STAGE_1))
                     {
                         Console.WriteLine($"No data imported for {entity.PartitionKey} : {entity.RowKey} - Import will be re-run");
                         pendingQueue.AddMessage(new CloudQueueMessage(entity.Message));
@@ -98,7 +100,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
                 IStatus.STAGE_5
             };
 
-            combineFilters = statuses.Aggregate(combineFilters, (current, status) => TableQuery.CombineFilters(current, TableOperators.Or, TableQuery.GenerateFilterCondition("Status", QueryComparisons.Equal, status.ToString())));
+            combineFilters = statuses.Aggregate(combineFilters, (current, status) =>
+                TableQuery.CombineFilters(current,
+                    TableOperators.Or,
+                    TableQuery.GenerateFilterCondition("Status", QueryComparisons.Equal, status.ToString())));
 
             return new TableQuery<DatafileImport>().Where(combineFilters);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/ImportRecoveryHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/ImportRecoveryHandler.cs
@@ -91,26 +91,38 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
                     QueryComparisons.Equal, IStatus.QUEUED.ToString())
                 , TableOperators.Or,
                 TableQuery.GenerateFilterCondition("Status",
-                    QueryComparisons.Equal, IStatus.RUNNING_PHASE_1.ToString()));
+                    QueryComparisons.Equal, IStatus.PROCESSING_ARCHIVE_FILE.ToString()));
 
+            combineFilters = TableQuery.CombineFilters(
+                combineFilters,
+                TableOperators.Or,
+                TableQuery.GenerateFilterCondition("Status",
+                    QueryComparisons.Equal, IStatus.RUNNING_PHASE_1.ToString()));
+            
             combineFilters = TableQuery.CombineFilters(
                 combineFilters,
                 TableOperators.Or,
                 TableQuery.GenerateFilterCondition("Status",
                     QueryComparisons.Equal, IStatus.RUNNING_PHASE_2.ToString()));
-
+            
             combineFilters = TableQuery.CombineFilters(
                 combineFilters,
                 TableOperators.Or,
                 TableQuery.GenerateFilterCondition("Status",
-                    QueryComparisons.Equal, IStatus.PROCESSING_ARCHIVE_FILE.ToString()));
-
+                    QueryComparisons.Equal, IStatus.RUNNING_PHASE_3.ToString()));
+            
+            combineFilters = TableQuery.CombineFilters(
+                combineFilters,
+                TableOperators.Or,
+                TableQuery.GenerateFilterCondition("Status",
+                    QueryComparisons.Equal, IStatus.RUNNING_PHASE_4.ToString()));
+            
             return new TableQuery<DatafileImport>()
                 .Where(TableQuery.CombineFilters(
                     combineFilters,
                     TableOperators.Or,
                     TableQuery.GenerateFilterCondition("Status",
-                    QueryComparisons.Equal, IStatus.RUNNING_PHASE_3.ToString())));
+                    QueryComparisons.Equal, IStatus.RUNNING_PHASE_5.ToString())));
         }
 
         private static async Task<List<BlobItem>> GetBatchesRemaining(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/ImportRecoveryHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/ImportRecoveryHandler.cs
@@ -56,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
                     Console.Out.WriteLine($"Recovering {entity.PartitionKey} : {entity.RowKey}");
 
                     // If batch was not split then just processing again by adding to pending queue
-                    if (entity.Status.Equals(IStatus.QUEUED) || entity.Status.Equals(IStatus.PROCESSING_ARCHIVE_FILE) || entity.Status.Equals(IStatus.RUNNING_PHASE_1))
+                    if (entity.Status.Equals(IStatus.QUEUED) || entity.Status.Equals(IStatus.PROCESSING_ARCHIVE_FILE) || entity.Status.Equals(IStatus.STAGE_1))
                     {
                         Console.WriteLine($"No data imported for {entity.PartitionKey} : {entity.RowKey} - Import will be re-run");
                         pendingQueue.AddMessage(new CloudQueueMessage(entity.Message));
@@ -86,43 +86,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
 
         private static TableQuery<DatafileImport> BuildQuery()
         {
-            var combineFilters = TableQuery.CombineFilters(
-                TableQuery.GenerateFilterCondition("Status",
-                    QueryComparisons.Equal, IStatus.QUEUED.ToString())
-                , TableOperators.Or,
-                TableQuery.GenerateFilterCondition("Status",
-                    QueryComparisons.Equal, IStatus.PROCESSING_ARCHIVE_FILE.ToString()));
+            var combineFilters = TableQuery.GenerateFilterCondition("Status",
+                    QueryComparisons.Equal, IStatus.QUEUED.ToString());
 
-            combineFilters = TableQuery.CombineFilters(
-                combineFilters,
-                TableOperators.Or,
-                TableQuery.GenerateFilterCondition("Status",
-                    QueryComparisons.Equal, IStatus.RUNNING_PHASE_1.ToString()));
-            
-            combineFilters = TableQuery.CombineFilters(
-                combineFilters,
-                TableOperators.Or,
-                TableQuery.GenerateFilterCondition("Status",
-                    QueryComparisons.Equal, IStatus.RUNNING_PHASE_2.ToString()));
-            
-            combineFilters = TableQuery.CombineFilters(
-                combineFilters,
-                TableOperators.Or,
-                TableQuery.GenerateFilterCondition("Status",
-                    QueryComparisons.Equal, IStatus.RUNNING_PHASE_3.ToString()));
-            
-            combineFilters = TableQuery.CombineFilters(
-                combineFilters,
-                TableOperators.Or,
-                TableQuery.GenerateFilterCondition("Status",
-                    QueryComparisons.Equal, IStatus.RUNNING_PHASE_4.ToString()));
-            
-            return new TableQuery<DatafileImport>()
-                .Where(TableQuery.CombineFilters(
-                    combineFilters,
-                    TableOperators.Or,
-                    TableQuery.GenerateFilterCondition("Status",
-                    QueryComparisons.Equal, IStatus.RUNNING_PHASE_5.ToString())));
+            IStatus[] statuses = {
+                IStatus.PROCESSING_ARCHIVE_FILE,
+                IStatus.STAGE_1,
+                IStatus.STAGE_2,
+                IStatus.STAGE_3,
+                IStatus.STAGE_4,
+                IStatus.STAGE_5
+            };
+
+            combineFilters = statuses.Aggregate(combineFilters, (current, status) => TableQuery.CombineFilters(current, TableOperators.Or, TableQuery.GenerateFilterCondition("Status", QueryComparisons.Equal, status.ToString())));
+
+            return new TableQuery<DatafileImport>().Where(combineFilters);
         }
 
         private static async Task<List<BlobItem>> GetBatchesRemaining(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/BatchService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/BatchService.cs
@@ -1,113 +1,34 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
 using Microsoft.Azure.Cosmos.Table;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using static GovUk.Education.ExploreEducationStatistics.Common.TableStorageTableNames;
-using IFileStorageService = GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces.IFileStorageService;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 {
     public class BatchService : IBatchService
     {
-        private readonly IFileStorageService _fileStorageService;
-        private readonly ILogger<IBatchService> _logger;
         private readonly CloudTable _table;
 
-        public BatchService(
-            ITableStorageService tblStorageService,
-            IFileStorageService fileStorageService,
-            ILogger<IBatchService> logger)
+        public BatchService(ITableStorageService tblStorageService)
         {
             _table = tblStorageService.GetTableAsync(DatafileImportsTableName).Result;
-            _fileStorageService = fileStorageService;
-            _logger = logger;
-        }
-
-        public async Task CheckComplete(string releaseId, ImportMessage message, StatisticsDbContext context)
-        {
-            if (message.NumBatches > 1)
-            {
-                await _fileStorageService.DeleteBatchFile(releaseId, message.DataFileName);
-            }
-
-            var numBatchesRemaining = await _fileStorageService.GetNumBatchesRemaining(releaseId, message.OrigDataFileName);
-            
-            var import = await GetImport(releaseId, message.OrigDataFileName);
-
-            if (import.Status.Equals(IStatus.RUNNING_PHASE_5)
-                && (message.NumBatches == 1 || numBatchesRemaining == 0))
-            {
-                var observationCount = context.Observation.Count(o => o.SubjectId.Equals(message.SubjectId));
-                
-                if (!observationCount.Equals(message.TotalRows))
-                {
-                    await FailImport(releaseId, message.OrigDataFileName,
-                        new List<ValidationError>
-                        {
-                            new ValidationError(
-                                $"Number of observations inserted ({observationCount}) " +
-                                $"does not equal that expected ({message.TotalRows}) : Please delete & retry"
-                            )
-                        }.AsEnumerable());
-                }
-                else
-                {
-                    await UpdateStatus(releaseId, message.OrigDataFileName,
-                        import.Errors.Equals("") ? IStatus.COMPLETE : IStatus.FAILED);
-                }
-
-                _logger.LogInformation(import.Errors.Equals("") && observationCount.Equals(message.TotalRows)
-                    ? $"All batches imported for {releaseId} : {message.OrigDataFileName} with no errors"
-                    : $"All batches imported for {releaseId} : {message.OrigDataFileName} but with errors - check storage log");
-            }
-            else
-            {
-                var percentageComplete = (double)(message.NumBatches - numBatchesRemaining) / message.NumBatches * 100;
-                await UpdateProgress(releaseId, message.OrigDataFileName, percentageComplete);
-            }
-        }
-
-        public async Task<bool> UpdateStatus(string releaseId, string origDataFileName, IStatus status)
-        {
-            var import = await GetImport(releaseId, origDataFileName);
-            if (import.Status == IStatus.FAILED)
-            {
-                return false;
-            }
-
-            if (import.Status != status)
-            {
-                import.PercentageComplete = status == IStatus.COMPLETE ? 100 : 0;
-                import.Status = status;
-                await _table.ExecuteAsync(TableOperation.InsertOrReplace(import));
-            }
-
-            return true;
         }
 
         public async Task UpdateStoredMessage(ImportMessage message)
         {
-            var import = await GetImport(message.Release.Id.ToString(), message.OrigDataFileName);
+            var import = await GetImport(message.Release.Id, message.OrigDataFileName);
             import.Message = JsonConvert.SerializeObject(message);
             await _table.ExecuteAsync(TableOperation.InsertOrReplace(import));
         }
 
-        public async Task<IStatus> GetStatus(string releaseId, string origDataFileName)
-        {
-            var import = await GetImport(releaseId, origDataFileName);
-            return import.Status;
-        }
-
-        public async Task FailImport(string releaseId, string origDataFileName, IEnumerable<ValidationError> errors)
+        public async Task FailImport(Guid releaseId, string origDataFileName, IEnumerable<ValidationError> errors)
         {
             var import = await GetImport(releaseId, origDataFileName);
             if (import.Status != IStatus.COMPLETE && import.Status != IStatus.FAILED)
@@ -118,20 +39,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             }
         }
 
-        public async Task UpdateProgress(string releaseId, string origDataFileName, double percentageComplete)
-        {
-            var import = await GetImport(releaseId, origDataFileName);
-            if (import.PercentageComplete < (int)percentageComplete)
-            {
-                import.PercentageComplete = (int)percentageComplete;
-                await _table.ExecuteAsync(TableOperation.InsertOrReplace(import));  
-            }
-        }
-
-        private async Task<DatafileImport> GetImport(string releaseId, string dataFileName)
+        private async Task<DatafileImport> GetImport(Guid releaseId, string dataFileName)
         {
             var result = await _table.ExecuteAsync(TableOperation.Retrieve<DatafileImport>(
-                releaseId,
+                releaseId.ToString(),
                 dataFileName,
                 new List<string> {"NumBatches", "Status", "NumberOfRows", "Errors", "Message", "PercentageComplete"}));
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataArchiveService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataArchiveService.cs
@@ -15,9 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
     {
         private readonly IBlobStorageService _blobStorageService;
         private readonly IFileStorageService _fileStorageService;
-
-        private const string NameKey = "name";
-
+        
         public DataArchiveService(IBlobStorageService blobStorageService, IFileStorageService fileStorageService)
         {
             _blobStorageService = blobStorageService;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -18,26 +21,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         private readonly IFileStorageService _fileStorageService;
         private readonly IImporterService _importerService;
         private readonly ILogger<IFileImportService> _logger;
+        private readonly IImportStatusService _importStatusService;
 
         public FileImportService(
             IFileStorageService fileStorageService,
             IImporterService importerService,
             IBatchService batchService,
-            ILogger<IFileImportService> logger)
+            ILogger<IFileImportService> logger,
+            IImportStatusService importStatusService)
         {
             _fileStorageService = fileStorageService;
             _importerService = importerService;
             _batchService = batchService;
             _logger = logger;
+            _importStatusService = importStatusService;
         }
 
         public async Task ImportObservations(ImportMessage message, StatisticsDbContext context)
         {
-            var releaseId = message.Release.Id.ToString();
+            var releaseId = message.Release.Id;
 
             // Potentially status could already be failed so don't continue
-            if (await _batchService.UpdateStatus(releaseId, message.OrigDataFileName,
-                IStatus.RUNNING_PHASE_5))
+            if (await _importStatusService.UpdateStatus(releaseId, message.OrigDataFileName, IStatus.STAGE_5))
             {
                 var subjectData = await _fileStorageService.GetSubjectData(message);
                 var releaseSubject = GetReleaseSubjectLink(message, context);
@@ -66,7 +71,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     await context.Database.CloseConnectionAsync();
                 });
 
-                await _batchService.CheckComplete(releaseId, message, context);
+                await CheckComplete(releaseId, message, context);
             }
             else
             {
@@ -85,11 +90,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             await using var metaFileStream = await _fileStorageService.StreamBlob(subjectData.MetaBlob);
             var metaFileTable = DataTableUtils.CreateFromStream(metaFileStream);
 
-            _importerService.ImportFiltersLocationsAndSchools(
+            await _importerService.ImportFiltersLocationsAndSchools(
                 dataFileTable.Columns,
                 dataFileTable.Rows,
                 _importerService.GetMeta(metaFileTable, releaseSubject.Subject, context),
-                context);
+                context,
+                message.Release.Id,
+                message.OrigDataFileName);
         }
 
         private static ReleaseSubject GetReleaseSubjectLink(ImportMessage message, StatisticsDbContext context)
@@ -102,6 +109,49 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 .ThenInclude(p => p.Topic)
                 .ThenInclude(t => t.Theme)
                 .FirstOrDefault(r => r.Subject.Id == message.SubjectId && r.ReleaseId == message.Release.Id);
+        }
+        
+        private async Task CheckComplete(Guid releaseId, ImportMessage message, StatisticsDbContext context)
+        {
+            if (message.NumBatches > 1)
+            {
+                await _fileStorageService.DeleteBatchFile(releaseId.ToString(), message.DataFileName);
+            }
+
+            var numBatchesRemaining = await _fileStorageService.GetNumBatchesRemaining(releaseId.ToString(), message.OrigDataFileName);
+            
+            var import = await _importStatusService.GetImportStatus(releaseId, message.OrigDataFileName);
+
+            if (import.Status.Equals(IStatus.STAGE_5) && (message.NumBatches == 1 || numBatchesRemaining == 0))
+            {
+                var observationCount = context.Observation.Count(o => o.SubjectId.Equals(message.SubjectId));
+                
+                if (!observationCount.Equals(message.TotalRows))
+                {
+                    await _batchService.FailImport(releaseId, message.OrigDataFileName,
+                        new List<ValidationError>
+                        {
+                            new ValidationError(
+                                $"Number of observations inserted ({observationCount}) " +
+                                $"does not equal that expected ({message.TotalRows}) : Please delete & retry"
+                            )
+                        }.AsEnumerable());
+                }
+                else
+                {
+                    await _importStatusService.UpdateStatus(releaseId, message.OrigDataFileName,
+                        import.Errors.Equals("") ? IStatus.COMPLETE : IStatus.FAILED);
+                }
+
+                _logger.LogInformation(import.Errors.Equals("") && observationCount.Equals(message.TotalRows)
+                    ? $"All batches imported for {releaseId} : {message.OrigDataFileName} with no errors"
+                    : $"All batches imported for {releaseId} : {message.OrigDataFileName} but with errors - check storage log");
+            }
+            else
+            {
+                var percentageComplete = (double)(message.NumBatches - numBatchesRemaining) / message.NumBatches * 100;
+                await _importStatusService.UpdateProgress(releaseId, message.OrigDataFileName, percentageComplete);
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -42,7 +42,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             var releaseId = message.Release.Id;
 
             // Potentially status could already be failed so don't continue
-            if (await _importStatusService.UpdateStatus(releaseId, message.OrigDataFileName, IStatus.STAGE_5))
+            if (await _importStatusService.UpdateStatus(releaseId, message.OrigDataFileName, IStatus.STAGE_4))
             {
                 var subjectData = await _fileStorageService.GetSubjectData(message);
                 var releaseSubject = GetReleaseSubjectLink(message, context);
@@ -122,7 +122,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             
             var import = await _importStatusService.GetImportStatus(releaseId, message.OrigDataFileName);
 
-            if (import.Status.Equals(IStatus.STAGE_5) && (message.NumBatches == 1 || numBatchesRemaining == 0))
+            if (import.Status.Equals(IStatus.STAGE_4) && (message.NumBatches == 1 || numBatchesRemaining == 0))
             {
                 var observationCount = context.Observation.Count(o => o.SubjectId.Equals(message.SubjectId));
                 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -37,7 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
             // Potentially status could already be failed so don't continue
             if (await _batchService.UpdateStatus(releaseId, message.OrigDataFileName,
-                IStatus.RUNNING_PHASE_4))
+                IStatus.RUNNING_PHASE_5))
             {
                 var subjectData = await _fileStorageService.GetSubjectData(message);
                 var releaseSubject = GetReleaseSubjectLink(message, context);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -37,7 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
             // Potentially status could already be failed so don't continue
             if (await _batchService.UpdateStatus(releaseId, message.OrigDataFileName,
-                IStatus.RUNNING_PHASE_3))
+                IStatus.RUNNING_PHASE_4))
             {
                 var subjectData = await _fileStorageService.GetSubjectData(message);
                 var releaseSubject = GetReleaseSubjectLink(message, context);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IBatchService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IBatchService.cs
@@ -1,23 +1,13 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
-using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces
 {
     public interface IBatchService
     {
-        Task<bool> UpdateStatus(string releaseId, string dataFileName, IStatus status);
-
-        Task FailImport(string releaseId, string dataFileName, IEnumerable<ValidationError> errors);
-        
-        Task<IStatus> GetStatus(string releaseId, string dataFileName);
-
-        Task CheckComplete(string releaseId, ImportMessage message, StatisticsDbContext context);
-
+        Task FailImport(Guid releaseId, string dataFileName, IEnumerable<ValidationError> errors);
         Task UpdateStoredMessage(ImportMessage message);
-
-        Task UpdateProgress(string releaseId, string origDataFileName, double percentageComplete);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IBatchService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IBatchService.cs
@@ -18,6 +18,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Int
 
         Task UpdateStoredMessage(ImportMessage message);
 
-        Task CreateImport(string releaseId, string dataFileName, int numberOfRows, ImportMessage message);
+        Task UpdateProgress(string releaseId, string origDataFileName, int percentageComplete);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IBatchService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IBatchService.cs
@@ -18,6 +18,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Int
 
         Task UpdateStoredMessage(ImportMessage message);
 
-        Task UpdateProgress(string releaseId, string origDataFileName, int percentageComplete);
+        Task UpdateProgress(string releaseId, string origDataFileName, double percentageComplete);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
@@ -68,7 +68,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             // Else perform any additional validation & pass on file to message queue for import
             else
             {
-                await _importStatusService.UpdateStatus(message.Release.Id, message.OrigDataFileName, IStatus.STAGE_4);
                 collector.Add(message);
             }
         }
@@ -143,8 +142,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
                 batchCount++;
             }
-            
-            await _importStatusService.UpdateStatus(message.Release.Id, message.OrigDataFileName, IStatus.STAGE_4);
 
             // Ensure generated messages are added after batch creation.
             foreach (var m in messages)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
@@ -27,6 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
     {
         private readonly IFileStorageService _fileStorageService;
         private readonly ILogger<ISplitFileService> _logger;
+        private readonly IBatchService _batchService;
 
         private static readonly List<GeographicLevel> IgnoredGeographicLevels = new List<GeographicLevel>
         {
@@ -36,10 +37,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             GeographicLevel.PlanningArea
         };
 
-        public SplitFileService(IFileStorageService fileStorageService, ILogger<ISplitFileService> logger)
+        public SplitFileService(
+            IFileStorageService fileStorageService,
+            ILogger<ISplitFileService> logger,
+            IBatchService batchService)
         {
             _fileStorageService = fileStorageService;
             _logger = logger;
+            _batchService = batchService;
         }
 
         public async Task SplitDataFile(
@@ -61,6 +66,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             {
                 collector.Add(message);
             }
+
+            await _batchService.UpdateProgress(message.Release.Id.ToString(), message.OrigDataFileName, 100);
         }
 
         private async Task SplitFiles(
@@ -126,6 +133,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 };
 
                 messages.Add(iMessage);
+                
+                await _batchService.UpdateProgress(message.Release.Id.ToString(), message.OrigDataFileName, batchCount / batches.Count());
 
                 batchCount++;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
@@ -277,9 +277,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 
                 totalRowCount++;
 
-                if (totalRowCount % 200 == 0)
+                if (totalRowCount % 1000 == 0)
                 {
-                    await _batchService.UpdateProgress(releaseId, origDataFileName, dataRows / totalRowCount);
+                    await _batchService.UpdateProgress(releaseId, origDataFileName, (double)totalRowCount / dataRows * 100);
                 }
             }
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFilePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFilePage.test.tsx
@@ -360,7 +360,7 @@ describe('ReleaseDataFilePage', () => {
       numberOfRows: 100,
     });
     releaseDataFileService.getDataFileImportStatus.mockResolvedValueOnce({
-      status: 'RUNNING_PHASE_1',
+      status: 'STAGE_1',
       numberOfRows: 110,
     });
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
@@ -28,6 +28,10 @@ export const getImportStatusLabel = (
       return 'Importing';
     case 'RUNNING_PHASE_3':
       return 'Importing';
+    case 'RUNNING_PHASE_4':
+      return 'Importing';
+    case 'RUNNING_PHASE_5':
+      return 'Importing';
     case 'COMPLETE':
       return 'Complete';
     case 'FAILED':
@@ -48,6 +52,8 @@ const getImportStatusColour = (
     case 'RUNNING_PHASE_1':
     case 'RUNNING_PHASE_2':
     case 'RUNNING_PHASE_3':
+    case 'RUNNING_PHASE_4':
+    case 'RUNNING_PHASE_5':
       return 'orange';
     case 'COMPLETE':
       return 'green';

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
@@ -22,15 +22,15 @@ export const getImportStatusLabel = (
       return 'Queued';
     case 'PROCESSING_ARCHIVE_FILE':
       return 'Processing archive file';
-    case 'RUNNING_PHASE_1':
+    case 'STAGE_1':
       return 'Validating';
-    case 'RUNNING_PHASE_2':
+    case 'STAGE_2':
       return 'Importing';
-    case 'RUNNING_PHASE_3':
+    case 'STAGE_3':
       return 'Importing';
-    case 'RUNNING_PHASE_4':
+    case 'STAGE_4':
       return 'Importing';
-    case 'RUNNING_PHASE_5':
+    case 'STAGE_5':
       return 'Importing';
     case 'COMPLETE':
       return 'Complete';
@@ -49,11 +49,11 @@ const getImportStatusColour = (
     case 'UPLOADING':
     case 'QUEUED':
     case 'PROCESSING_ARCHIVE_FILE':
-    case 'RUNNING_PHASE_1':
-    case 'RUNNING_PHASE_2':
-    case 'RUNNING_PHASE_3':
-    case 'RUNNING_PHASE_4':
-    case 'RUNNING_PHASE_5':
+    case 'STAGE_1':
+    case 'STAGE_2':
+    case 'STAGE_3':
+    case 'STAGE_4':
+    case 'STAGE_5':
       return 'orange';
     case 'COMPLETE':
       return 'green';

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
@@ -30,8 +30,6 @@ export const getImportStatusLabel = (
       return 'Importing';
     case 'STAGE_4':
       return 'Importing';
-    case 'STAGE_5':
-      return 'Importing';
     case 'COMPLETE':
       return 'Complete';
     case 'FAILED':
@@ -53,7 +51,6 @@ const getImportStatusColour = (
     case 'STAGE_2':
     case 'STAGE_3':
     case 'STAGE_4':
-    case 'STAGE_5':
       return 'orange';
     case 'COMPLETE':
       return 'green';

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ImporterStatus.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ImporterStatus.test.tsx
@@ -53,7 +53,7 @@ describe('ImporterStatus', () => {
 
   test('renders with updated status from service', async () => {
     releaseDataFileService.getDataFileImportStatus.mockResolvedValue({
-      status: 'RUNNING_PHASE_1',
+      status: 'STAGE_1',
       numberOfRows: 100,
     });
 
@@ -82,7 +82,7 @@ describe('ImporterStatus', () => {
 
   test('renders with updated status from service at regular intervals', async () => {
     releaseDataFileService.getDataFileImportStatus.mockResolvedValue({
-      status: 'RUNNING_PHASE_1',
+      status: 'STAGE_1',
       numberOfRows: 100,
     });
 
@@ -107,7 +107,7 @@ describe('ImporterStatus', () => {
     });
 
     releaseDataFileService.getDataFileImportStatus.mockResolvedValue({
-      status: 'RUNNING_PHASE_2',
+      status: 'STAGE_2',
       numberOfRows: 100,
     });
 

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -69,7 +69,6 @@ export type ImportStatusCode =
   | 'STAGE_2'
   | 'STAGE_3'
   | 'STAGE_4'
-  | 'STAGE_5'
   | 'NOT_FOUND'
   | 'FAILED';
 

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -68,6 +68,8 @@ export type ImportStatusCode =
   | 'RUNNING_PHASE_1'
   | 'RUNNING_PHASE_2'
   | 'RUNNING_PHASE_3'
+  | 'RUNNING_PHASE_4'
+  | 'RUNNING_PHASE_5'
   | 'NOT_FOUND'
   | 'FAILED';
 

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -65,11 +65,11 @@ export type ImportStatusCode =
   | 'QUEUED'
   | 'UPLOADING'
   | 'PROCESSING_ARCHIVE_FILE'
-  | 'RUNNING_PHASE_1'
-  | 'RUNNING_PHASE_2'
-  | 'RUNNING_PHASE_3'
-  | 'RUNNING_PHASE_4'
-  | 'RUNNING_PHASE_5'
+  | 'STAGE_1'
+  | 'STAGE_2'
+  | 'STAGE_3'
+  | 'STAGE_4'
+  | 'STAGE_5'
   | 'NOT_FOUND'
   | 'FAILED';
 


### PR DESCRIPTION
This PR provides the PercentageComplete at the backend to be returned with the status request.
We will need to make sure that the importer is stopped & imports are complete when we release this.
I have estimated the duration of the various stages of the import as ratios as follows:

`private static readonly Dictionary<IStatus, double> ProcessingRatios = new Dictionary<IStatus, double>() {
            {IStatus.STAGE_1, .1},
            {IStatus.STAGE_2, .1},
            {IStatus.STAGE_3, .1},
            {IStatus.STAGE_5, .7},
            {IStatus.COMPLETE, 1},
};`
  
Where the various stages are defined as:

`public enum IStatus
{
        UPLOADING,
        QUEUED,
        PROCESSING_ARCHIVE_FILE,
        STAGE_1, // Basic row validation
        STAGE_2, // Create locations and filters
        STAGE_3, // Split Files
        STAGE_4, // Split Files complete
        STAGE_5, // Import observations
        COMPLETE,
        FAILED,
        NOT_FOUND
};`