### PR TITLE
EES-1557 Allow glossary links to have `target` and `rel` attributes

### DIFF
--- a/src/explore-education-statistics-common/src/components/SanitizeHtml.tsx
+++ b/src/explore-education-statistics-common/src/components/SanitizeHtml.tsx
@@ -1,16 +1,22 @@
+import sanitizeHtml, { SanitizeHtmlOptions } from '@common/utils/sanitizeHtml';
 import React, { useMemo } from 'react';
-import sanitizeHtml from '@common/utils/sanitizeHtml';
 
 export interface SanitizeHtmlProps {
   className?: string;
   dirtyHtml: string;
+  options?: SanitizeHtmlOptions;
   testId?: string;
 }
 
-const SanitizeHtml = ({ className, dirtyHtml, testId }: SanitizeHtmlProps) => {
+const SanitizeHtml = ({
+  className,
+  dirtyHtml,
+  options,
+  testId,
+}: SanitizeHtmlProps) => {
   const cleanHtml = useMemo(() => {
-    return sanitizeHtml(dirtyHtml);
-  }, [dirtyHtml]);
+    return sanitizeHtml(dirtyHtml, options);
+  }, [dirtyHtml, options]);
 
   return (
     <div

--- a/src/explore-education-statistics-common/src/utils/sanitizeHtml.ts
+++ b/src/explore-education-statistics-common/src/utils/sanitizeHtml.ts
@@ -1,6 +1,12 @@
+import { Dictionary } from '@common/types';
 import sanitize from 'sanitize-html';
 
-const config: sanitize.IOptions = {
+export type SanitizeHtmlOptions = {
+  allowedTags?: string[];
+  allowedAttributes?: Dictionary<string[]>;
+};
+
+export const defaultSanitizeOptions: SanitizeHtmlOptions = {
   allowedTags: [
     'p',
     'h2',
@@ -35,6 +41,9 @@ const config: sanitize.IOptions = {
   },
 };
 
-export default function sanitizeHtml(dirtyHtml: string): string {
-  return sanitize(dirtyHtml, config);
+export default function sanitizeHtml(
+  dirtyHtml: string,
+  options: SanitizeHtmlOptions = defaultSanitizeOptions,
+): string {
+  return sanitize(dirtyHtml, options);
 }

--- a/src/explore-education-statistics-frontend/src/modules/glossary/GlossaryPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/glossary/GlossaryPage.tsx
@@ -2,11 +2,23 @@ import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
 import RelatedInformation from '@common/components/RelatedInformation';
 import SanitizeHtml from '@common/components/SanitizeHtml';
+import {
+  defaultSanitizeOptions,
+  SanitizeHtmlOptions,
+} from '@common/utils/sanitizeHtml';
 import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
 import PageSearchFormWithAnalytics from '@frontend/components/PageSearchFormWithAnalytics';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
 import React from 'react';
+
+const sanitizeHtmlOptions: SanitizeHtmlOptions = {
+  ...defaultSanitizeOptions,
+  allowedAttributes: {
+    ...defaultSanitizeOptions.allowedAttributes,
+    a: ['href', 'rel', 'target'],
+  },
+};
 
 export interface GlossaryEntry {
   heading: string;
@@ -59,7 +71,10 @@ function GlossaryPage({ entries }: GlossaryPageProps) {
             id={`glossary-${entry.heading}`}
           >
             {entry.content ? (
-              <SanitizeHtml dirtyHtml={entry.content} />
+              <SanitizeHtml
+                dirtyHtml={entry.content}
+                options={sanitizeHtmlOptions}
+              />
             ) : (
               <p className="govuk-inset-text">
                 There are currently no entries under this section


### PR DESCRIPTION
This PR allows links in the Glossary to have `target` and `rel` attributes so that they can open up in a new browser tab (particularly useful for external links).