### PR TITLE
EES-1420 Update amendment content with new fast track links

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ReleaseTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ReleaseTests.cs
@@ -1,123 +1,486 @@
 using System;
+using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
 {
     public class ReleaseTests
     {
         [Fact]
-        public void Release_Not_Live_Published_Null()
+        public void Live_True()
         {
-            var releaseNoPublishedDate = new Release {Published = null};
-            Assert.False(releaseNoPublishedDate.Live);
-        }
+            var releasePublished = new Release
+            {
+                Published = DateTime.Now.AddDays(-1)
+            };
 
-        [Fact]
-        public void Release_Not_Live_Published_In_Future()
-        {
-            // Note that this should not happen, but we test the edge case.
-            var releasePublishedDateInFuture = new Release {Published = DateTime.Now.AddDays(1)};
-            Assert.False(releasePublishedDateInFuture.Live);
-        }
-
-
-        [Fact]
-        public void Release_Live()
-        {
-            var releasePublished = new Release {Published = DateTime.Now.AddDays(-1)};
             Assert.True(releasePublished.Live);
         }
 
         [Fact]
-        public void Release_Name_Ok()
+        public void Live_False_PublishedIsNull()
         {
-            new Release {ReleaseName = "2014"}; // Should not throw
-        }
-
-
-        [Fact]
-        public void Release_Name_Not_Ok()
-        {
-            try
+            var releaseNoPublishedDate = new Release
             {
-                new Release {ReleaseName = "Hello"}; // Not Ok
-                Assert.True(false, "Should have failed validation");
-            }
-            catch
-            {
-                // ignored
-            }
+                Published = null
+            };
+
+            Assert.False(releaseNoPublishedDate.Live);
         }
 
         [Fact]
-        public void Release_NextReleaseDate_Ok()
+        public void Live_False_PublishedInFuture()
         {
-            new Release {NextReleaseDate = new PartialDate {Day = "01"}}; // Should not throw
+            // Note that this should not happen, but we test the edge case.
+            var releasePublishedDateInFuture = new Release
+            {
+                Published = DateTime.Now.AddDays(1)
+            };
+
+            Assert.False(releasePublishedDateInFuture.Live);
         }
 
         [Fact]
-        public void Release_NextReleaseDate_Not_Ok()
+        public void NextReleaseDate_Ok()
         {
-            try
+            var releaseDate = new PartialDate {Day = "01"};
+            var release = new Release
             {
-                new Release {NextReleaseDate = new PartialDate {Day = "45"}}; // Not Ok
-                Assert.True(false, "Should have failed validation");
-            }
-            catch
-            {
-                // ignored
-            }
+                NextReleaseDate = releaseDate
+            };
+
+            Assert.Equal(releaseDate, release.NextReleaseDate);
         }
 
         [Fact]
-        public void Acceptable_ReleaseName()
+        public void NextReleaseDate_InvalidDate()
         {
+            Assert.Throws<FormatException>(
+                () => new Release
+                {
+                    NextReleaseDate = new PartialDate {Day = "45"}
+                }
+            );
+        }
+
+        [Fact]
+        public void ReleaseName_Ok()
+        {
+            // None should throw
             new Release {ReleaseName = "1990"};
             new Release {ReleaseName = "2011"};
             new Release {ReleaseName = "3000"};
             new Release {ReleaseName = ""}; // considered not set
             new Release {ReleaseName = null}; // considered not set
-            // None should throw
         }
-        
+
         [Fact]
-        public void Unacceptable_ReleaseName()
+        public void ReleaseName_InvalidFormats()
         {
-            try
-            {
-                new Release {ReleaseName = "190"};
-                Assert.True(false, "190 is not a year we are interested in");
-            }
-            catch
-            {
-                // ignored
-            }
+            Assert.Throws<FormatException>(
+                () => new Release {ReleaseName = "Hello"}
+            );
 
-            try
-            {
-                new Release {ReleaseName = "ABC123"};
-                Assert.True(false, "Not a year");
-            }
-            catch
-            {
-                // ignored
-            }
+            Assert.Throws<FormatException>(
+                () => new Release {ReleaseName = "190"}
+            );
 
-            try
-            {
-                new Release {ReleaseName = "20000"};
-                Assert.True(false, "20000 is not a year we are interested in");
-            }
-            catch
-            {
-                // ignored
-            }
+            Assert.Throws<FormatException>(
+                () => new Release {ReleaseName = "ABC123"}
+            );
 
-            new Release {ReleaseName = "2011"};
-            new Release {ReleaseName = "3000"};
-            // None should throw
+            Assert.Throws<FormatException>(
+                () => new Release {ReleaseName = "20000"}
+            );
+        }
+
+        [Fact]
+        public void CreateReleaseAmendment_CorrectBasicDetails()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                Version = 1,
+                Published = DateTime.Parse("2020-10-10T13:00:00"),
+                PublishScheduled = DateTime.Parse("2020-10-09T12:00:00")
+            };
+
+            var createdDate = DateTime.Now;
+            var createdById = Guid.NewGuid();
+
+            var amendment = release.CreateReleaseAmendment(createdDate, createdById);
+
+            Assert.NotEqual(release.Id, amendment.Id);
+            Assert.Equal(2, amendment.Version);
+            Assert.Equal(release.Id, amendment.PreviousVersionId);
+
+            Assert.Null(amendment.Published);
+            Assert.Null(amendment.PublishScheduled);
+            Assert.Equal(ReleaseStatus.Draft, amendment.Status);
+
+            Assert.Equal(createdDate, amendment.Created);
+            Assert.Equal(createdById, amendment.CreatedById);
+        }
+
+        [Fact]
+        public void CreateReleaseAmendment_ClonesContent()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+            };
+
+            var section1Id = Guid.NewGuid();
+            var section2Id = Guid.NewGuid();
+
+            release.Content = new List<ReleaseContentSection>
+            {
+                new ReleaseContentSection
+                {
+                    Release = release,
+                    ReleaseId = release.Id,
+                    ContentSectionId = section1Id,
+                    ContentSection = new ContentSection
+                    {
+                        Id = section1Id,
+                        Heading = "Section 1",
+                        Content = new List<ContentBlock>
+                        {
+                            new HtmlBlock
+                            {
+                                Id = Guid.NewGuid(),
+                                Order = 1,
+                                Body = "Block 1 body"
+                            },
+                            new DataBlock
+                            {
+                                Id = Guid.NewGuid(),
+                                Order = 2,
+                                Heading = "Block 2 heading",
+                                Name = "Block 2 name",
+                                Source = "Block 2 source"
+                            }
+                        },
+                    }
+                },
+                new ReleaseContentSection
+                {
+                    Release = release,
+                    ReleaseId = release.Id,
+                    ContentSectionId = section2Id,
+                    ContentSection = new ContentSection
+                    {
+                        Id = section2Id,
+                        Heading = "Section 2",
+                        Content = new List<ContentBlock>
+                        {
+                            new HtmlBlock
+                            {
+                                Id = Guid.NewGuid(),
+                                Order = 1,
+                                Body = "Block 3 body"
+                            },
+                        },
+                    }
+                }
+            };
+
+            var createdDate = DateTime.Now;
+            var createdById = Guid.NewGuid();
+
+            var amendment = release.CreateReleaseAmendment(createdDate, createdById);
+
+            Assert.Equal(2, amendment.Content.Count);
+
+            var section1 = amendment.Content[0];
+            Assert.Equal(amendment, section1.Release);
+            Assert.Equal(amendment.Id, section1.ReleaseId);
+
+            Assert.NotEqual(release.Content[0].ContentSectionId, section1.ContentSectionId);
+            Assert.NotEqual(release.Content[0].ContentSection.Id, section1.ContentSection.Id);
+            Assert.Equal("Section 1", section1.ContentSection.Heading);
+
+            Assert.Equal(2, section1.ContentSection.Content.Count);
+
+            var block1 = Assert.IsType<HtmlBlock>(section1.ContentSection.Content[0]);
+
+            Assert.NotEqual(release.Content[0].ContentSection.Content[0].Id, block1.Id);
+            Assert.Equal(1, block1.Order);
+            Assert.Equal("Block 1 body", block1.Body);
+
+            var block2 = Assert.IsType<DataBlock>(section1.ContentSection.Content[1]);
+            Assert.NotEqual(release.Content[0].ContentSection.Content[1].Id, block2.Id);
+            Assert.Equal(2, block2.Order);
+            Assert.Equal("Block 2 heading", block2.Heading);
+            Assert.Equal("Block 2 name", block2.Name);
+            Assert.Equal("Block 2 source", block2.Source);
+
+            var section2 = amendment.Content[1];
+
+            Assert.Equal(amendment, section2.Release);
+            Assert.Equal(amendment.Id, section2.ReleaseId);
+
+            Assert.NotEqual(release.Content[1].ContentSectionId, section2.ContentSectionId);
+            Assert.NotEqual(release.Content[1].ContentSection.Id, section2.ContentSection.Id);
+            Assert.Equal("Section 2", section2.ContentSection.Heading);
+
+            Assert.Single(section2.ContentSection.Content);
+
+            var block3 = Assert.IsType<HtmlBlock>(section2.ContentSection.Content[0]);
+            Assert.NotEqual(release.Content[1].ContentSection.Content[0].Id, block3.Id);
+            Assert.Equal(1, block3.Order);
+            Assert.Equal("Block 3 body", block3.Body);
+        }
+
+        [Fact]
+        public void CreateReleaseAmendment_ClonesContent_RemovesComments()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+            };
+
+            var section1Id = Guid.NewGuid();
+            var section2Id = Guid.NewGuid();
+
+            release.Content = new List<ReleaseContentSection>
+            {
+                new ReleaseContentSection
+                {
+                    Release = release,
+                    ReleaseId = release.Id,
+                    ContentSectionId = section1Id,
+                    ContentSection = new ContentSection
+                    {
+                        Id = section1Id,
+                        Heading = "Section 1",
+                        Content = new List<ContentBlock>
+                        {
+                            new HtmlBlock
+                            {
+                                Id = Guid.NewGuid(),
+                                Order = 1,
+                                Body = "Block 1 body",
+                                Comments = new List<Comment>
+                                {
+                                    new Comment
+                                    {
+                                        Content = "Comment 1"
+                                    }
+                                }
+                            },
+                        },
+                    }
+                },
+                new ReleaseContentSection
+                {
+                    Release = release,
+                    ReleaseId = release.Id,
+                    ContentSectionId = section2Id,
+                    ContentSection = new ContentSection
+                    {
+                        Id = section2Id,
+                        Heading = "Section 2",
+                        Content = new List<ContentBlock>
+                        {
+                            new HtmlBlock
+                            {
+                                Id = Guid.NewGuid(),
+                                Order = 1,
+                                Body = "Block 2",
+                                Comments = new List<Comment>
+                                {
+                                    new Comment
+                                    {
+                                        Content = "Comment 1"
+                                    }
+                                }
+                            },
+                        },
+                    }
+                }
+            };
+
+            var createdDate = DateTime.Now;
+            var createdById = Guid.NewGuid();
+
+            var amendment = release.CreateReleaseAmendment(createdDate, createdById);
+
+            Assert.Equal(2, amendment.Content.Count);
+
+            var section1 = amendment.Content[0];
+            var section2 = amendment.Content[1];
+
+            var block1 = Assert.IsType<HtmlBlock>(section1.ContentSection.Content[0]);
+            Assert.Empty(block1.Comments);
+
+            var block2 = Assert.IsType<HtmlBlock>(section2.ContentSection.Content[0]);
+            Assert.Empty(block2.Comments);
+        }
+
+        [Fact]
+        public void CreateReleaseAmendment_ClonesRelatedInformation()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+            };
+
+            release.RelatedInformation = new List<Link>
+            {
+                new Link
+                {
+                    Id = Guid.NewGuid(),
+                    Description = "Link 1 description",
+                    Url = "Link 1 url"
+                },
+                new Link
+                {
+                    Id = Guid.NewGuid(),
+                    Description = "Link 2 description",
+                    Url = "Link 2 url"
+                }
+            };
+
+            var createdDate = DateTime.Now;
+            var createdById = Guid.NewGuid();
+
+            var amendment = release.CreateReleaseAmendment(createdDate, createdById);
+
+            Assert.Equal(2, amendment.RelatedInformation.Count);
+
+            var link1 = amendment.RelatedInformation[0];
+
+            Assert.NotEqual(release.RelatedInformation[0].Id, link1.Id);
+            Assert.Equal("Link 1 description", link1.Description);
+            Assert.Equal("Link 1 url", link1.Url);
+
+            var link2 = amendment.RelatedInformation[1];
+
+            Assert.NotEqual(release.RelatedInformation[1].Id, link2.Id);
+            Assert.Equal("Link 2 description", link2.Description);
+            Assert.Equal("Link 2 url", link2.Url);
+        }
+
+        [Fact]
+        public void CreateReleaseAmendment_ClonesUpdates()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+            };
+
+            release.Updates = new List<Update>
+            {
+                new Update
+                {
+                    Id = Guid.NewGuid(),
+                    Reason = "Update 1 reason",
+                    Release = release,
+                    ReleaseId = release.Id
+
+                },
+                new Update
+                {
+                    Id = Guid.NewGuid(),
+                    Reason = "Update 2 reason",
+                    Release = release,
+                    ReleaseId = release.Id
+                }
+            };
+
+            var createdDate = DateTime.Now;
+            var createdById = Guid.NewGuid();
+
+            var amendment = release.CreateReleaseAmendment(createdDate, createdById);
+
+            Assert.Equal(2, amendment.Updates.Count);
+
+            var update1 = amendment.Updates[0];
+
+            Assert.NotEqual(release.Updates[0].Id, update1.Id);
+            Assert.Equal("Update 1 reason", update1.Reason);
+            Assert.Equal(amendment, update1.Release);
+            Assert.Equal(amendment.Id, update1.ReleaseId);
+
+            var update2 = amendment.Updates[1];
+
+            Assert.NotEqual(release.Updates[1].Id, update2.Id);
+            Assert.Equal("Update 2 reason", update2.Reason);
+            Assert.Equal(amendment, update2.Release);
+            Assert.Equal(amendment.Id, update2.ReleaseId);
+        }
+
+        [Fact]
+        public void CreateReleaseAmendment_ClonesContentBlocks()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+            };
+
+            var block1Id = Guid.NewGuid();
+            var block2Id = Guid.NewGuid();
+
+            release.ContentBlocks = new List<ReleaseContentBlock>
+            {
+                new ReleaseContentBlock
+                {
+                    ReleaseId = release.Id,
+                    Release = release,
+                    ContentBlockId = block1Id,
+                    ContentBlock = new HtmlBlock
+                    {
+                        Id = block1Id,
+                        Order = 1,
+                        Body = "Block 1 body"
+                    }
+                },
+                new ReleaseContentBlock
+                {
+                    ReleaseId = release.Id,
+                    Release = release,
+                    ContentBlockId = block2Id,
+                    ContentBlock =  new DataBlock
+                    {
+                        Id = block2Id,
+                        Order = 2,
+                        Heading = "Block 2 heading",
+                        Name = "Block 2 name",
+                        Source = "Block 2 source"
+                    }
+                },
+            };
+
+            var createdDate = DateTime.Now;
+            var createdById = Guid.NewGuid();
+
+            var amendment = release.CreateReleaseAmendment(createdDate, createdById);
+
+            Assert.Equal(2, amendment.ContentBlocks.Count);
+
+            var releaseBlock1 = amendment.ContentBlocks[0];
+            Assert.Equal(amendment, releaseBlock1.Release);
+            Assert.Equal(amendment.Id, releaseBlock1.ReleaseId);
+            Assert.NotEqual(release.ContentBlocks[0].ContentBlockId, releaseBlock1.ContentBlockId);
+
+            var block1 = Assert.IsType<HtmlBlock>(releaseBlock1.ContentBlock);
+            Assert.NotEqual(release.ContentBlocks[0].ContentBlock.Id, block1.Id);
+            Assert.Equal(1, block1.Order);
+            Assert.Equal("Block 1 body", block1.Body);
+
+            var releaseBlock2 = amendment.ContentBlocks[1];
+            Assert.Equal(amendment, releaseBlock2.Release);
+            Assert.Equal(amendment.Id, releaseBlock2.ReleaseId);
+            Assert.NotEqual(release.ContentBlocks[1].ContentBlockId, releaseBlock2.ContentBlockId);
+
+            var block2 = Assert.IsType<DataBlock>(releaseBlock2.ContentBlock);
+            Assert.NotEqual(release.ContentBlocks[1].ContentBlock.Id, block2.Id);
+            Assert.Equal(2, block2.Order);
+            Assert.Equal("Block 2 heading", block2.Heading);
+            Assert.Equal("Block 2 name", block2.Name);
+            Assert.Equal("Block 2 source", block2.Source);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
@@ -27,20 +27,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<Comment> Comments { get; set; }
 
-        public ContentBlock Clone(CreateClonedContext ctx, ContentSection newParent)
+        public ContentBlock Clone(Release.CloneContext context, ContentSection newContentSection)
         {
             var copy = MemberwiseClone() as ContentBlock;
             copy.Id = Guid.NewGuid();
-            ctx.OldToNewIdContentBlockMappings.Add(this, copy);
 
-            if (newParent != null)
+            if (newContentSection != null)
             {
-                copy.ContentSection = newParent;
-                copy.ContentSectionId = newParent.Id;
+                copy.ContentSection = newContentSection;
+                copy.ContentSectionId = newContentSection.Id;
             }
 
             // start a new amendment with no comments
             copy.Comments = new List<Comment>();
+
+            context.ContentBlocks.Add(this, copy);
+
             return copy;
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentSection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentSection.cs
@@ -30,17 +30,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         [JsonIgnore] public ContentSectionType Type { get; set; }
 
-        public ContentSection Clone(CreateClonedContext ctx, ReleaseContentSection newParent)
+        public ContentSection Clone(ReleaseContentSection newReleaseContentSection, Release.CloneContext context)
         {
             var copy = MemberwiseClone() as ContentSection;
             copy.Id = Guid.NewGuid();
-            ctx.OldToNewIdContentSectionMappings.Add(this, copy);
 
-            copy.Release = newParent;
+            copy.Release = newReleaseContentSection;
 
             copy.Content = copy
                 .Content?
-                .Select(content => content.Clone(ctx, copy))
+                .Select(content => content.Clone(context, copy))
                 .ToList();
 
             return copy;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Link.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Link.cs
@@ -10,9 +10,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public string Url { get; set; }
 
-        public Link CreateCopy()
+        public Link Clone()
         {
-            return MemberwiseClone() as Link;
+            var clone = MemberwiseClone() as Link;
+            clone.Id = Guid.NewGuid();
+
+            return clone;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -237,6 +237,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
                 .Select(content => content.Clone(ctx))
                 .ToList();
 
+            amendment.ContentBlocks = amendment
+                .ContentBlocks?
+                .Select(releaseContentBlock => releaseContentBlock.Clone(ctx))
+                .ToList();
+
             amendment.RelatedInformation = amendment
                 .RelatedInformation?
                 .Select(link =>
@@ -250,11 +255,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
             amendment.Updates = amendment
                 .Updates?
                 .Select(update => update.Clone(ctx))
-                .ToList();
-
-            amendment.ContentBlocks = amendment
-                .ContentBlocks?
-                .Select(releaseContentBlock => releaseContentBlock.Clone(ctx))
                 .ToList();
 
             return amendment;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseContentBlock.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseContentBlock.cs
@@ -13,20 +13,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public Guid ContentBlockId { get; set; }
 
-        public ReleaseContentBlock Clone(CreateClonedContext ctx)
+        public ReleaseContentBlock Clone(Release newRelease, Release.CloneContext context)
         {
             var copy = MemberwiseClone() as ReleaseContentBlock;
-            
-            copy.Release = ctx.Target;
-            copy.ReleaseId = ctx.Target.Id;
-            
-            var newVersionOfContentBlock = 
-                ctx.OldToNewIdContentBlockMappings.GetValueOrDefault(ContentBlock) 
-                ?? ContentBlock.Clone(ctx, null);
 
-            copy.ContentBlock = newVersionOfContentBlock;
-            copy.ContentBlockId = newVersionOfContentBlock.Id;
-            
+            copy.Release = newRelease;
+            copy.ReleaseId = newRelease.Id;
+
+            var clonedContentBlock =
+                context.ContentBlocks.GetValueOrDefault(ContentBlock)
+                ?? ContentBlock.Clone(context, null);
+
+            copy.ContentBlock = clonedContentBlock;
+            copy.ContentBlockId = clonedContentBlock.Id;
+
             return copy;
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseContentSection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseContentSection.cs
@@ -17,11 +17,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
             var copy = MemberwiseClone() as ReleaseContentSection;
             copy.Release = ctx.Target;
             copy.ReleaseId = ctx.Target.Id;
-            
-            copy.ContentSection = copy
+
+            var contentSection = copy
                 .ContentSection
                 .Clone(ctx, copy);
-            
+
+            copy.ContentSection = contentSection;
+            copy.ContentSectionId = contentSection.Id;
+
             return copy;
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseContentSection.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseContentSection.cs
@@ -12,15 +12,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public Guid ContentSectionId { get; set; }
 
-        public ReleaseContentSection Clone(CreateClonedContext ctx)
+        public ReleaseContentSection Clone(Release newRelease, Release.CloneContext context)
         {
             var copy = MemberwiseClone() as ReleaseContentSection;
-            copy.Release = ctx.Target;
-            copy.ReleaseId = ctx.Target.Id;
+            copy.Release = newRelease;
+            copy.ReleaseId = newRelease.Id;
 
             var contentSection = copy
                 .ContentSection
-                .Clone(ctx, copy);
+                .Clone(copy, context);
 
             copy.ContentSection = contentSection;
             copy.ContentSectionId = contentSection.Id;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Update.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Update.cs
@@ -8,21 +8,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         [Key] [Required] public Guid Id { get; set; }
 
         public Guid ReleaseId { get; set; }
-        
+
         public Release Release { get; set; }
 
         [Required] public DateTime On { get; set; }
 
         [Required] public string Reason { get; set; }
 
-        public Update Clone(CreateClonedContext ctx)
+        public Update Clone(Release newRelease)
         {
             var copy = MemberwiseClone() as Update;
             copy.Id = Guid.NewGuid();
-            ctx.OldToNewIdUpdateMappings.Add(this, copy);
-            
-            copy.Release = ctx.Target;
-            copy.ReleaseId = ctx.Target.Id;
+            copy.Release = newRelease;
+            copy.ReleaseId = newRelease.Id;
             return copy;
         }
     }


### PR DESCRIPTION
This PR updates content sections with new fast track links when an amendment is created. We have implemented this with a simple search and replace, which should be sufficient for the time being.

## Relevant changes

- Cleaned up `Release.CreateReleaseAmendment` method. This has involved removing any unnecessary parts from the `CloneContext` (now a nested class on `Release`). Ideally we want to be able to remove this completely, but we need to make some adjustments to the content DB schema first to avoid the same data block references being in multiple places.