### PR TITLE
EES-1380 Update apiVersion for all DBs

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1414,7 +1414,7 @@
             "DeploymentRepo": "[parameters('deploymentRepo')]",
             "DeploymentScript": "[parameters('deploymentScript')]"
           },
-          "apiVersion": "2015-01-01",
+          "apiVersion": "2020-08-01-preview",
           "dependsOn": [
             "[variables('sqlserverName')]"
           ],
@@ -1442,7 +1442,7 @@
             "DeploymentRepo": "[parameters('deploymentRepo')]",
             "DeploymentScript": "[parameters('deploymentScript')]"
           },
-          "apiVersion": "2015-01-01",
+          "apiVersion": "2020-08-01-preview",
           "dependsOn": [
             "[variables('sqlserverName')]"
           ],
@@ -1637,7 +1637,7 @@
             "DeploymentRepo": "[parameters('deploymentRepo')]",
             "DeploymentScript": "[parameters('deploymentScript')]"
           },
-          "apiVersion": "2015-01-01",
+          "apiVersion": "2020-08-01-preview",
           "dependsOn": [
             "[variables('publicSqlServerName')]"
           ],


### PR DESCRIPTION
This should fix the "Only a maximum of 15 tags are supported per resource" failure on the deploy of all three DBs.