### PR TITLE
EES-1557 Optimize glossary page bundle size

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/glossary/GlossaryPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/glossary/GlossaryPage.tsx
@@ -1,24 +1,11 @@
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
 import RelatedInformation from '@common/components/RelatedInformation';
-import SanitizeHtml from '@common/components/SanitizeHtml';
-import {
-  defaultSanitizeOptions,
-  SanitizeHtmlOptions,
-} from '@common/utils/sanitizeHtml';
 import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
 import PageSearchFormWithAnalytics from '@frontend/components/PageSearchFormWithAnalytics';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
 import React from 'react';
-
-const sanitizeHtmlOptions: SanitizeHtmlOptions = {
-  ...defaultSanitizeOptions,
-  allowedAttributes: {
-    ...defaultSanitizeOptions.allowedAttributes,
-    a: ['href', 'rel', 'target'],
-  },
-};
 
 export interface GlossaryEntry {
   heading: string;
@@ -71,9 +58,11 @@ function GlossaryPage({ entries }: GlossaryPageProps) {
             id={`glossary-${entry.heading}`}
           >
             {entry.content ? (
-              <SanitizeHtml
-                dirtyHtml={entry.content}
-                options={sanitizeHtmlOptions}
+              <div
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{
+                  __html: entry.content,
+                }}
               />
             ) : (
               <p className="govuk-inset-text">

--- a/src/explore-education-statistics-frontend/src/pages/glossary.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/glossary.tsx
@@ -1,3 +1,7 @@
+import sanitizeHtml, {
+  defaultSanitizeOptions,
+  SanitizeHtmlOptions,
+} from '@common/utils/sanitizeHtml';
 import {
   GlossaryEntry,
   GlossaryPageProps,
@@ -5,6 +9,14 @@ import {
 import fs from 'fs';
 import { GetStaticProps } from 'next';
 import path from 'path';
+
+const sanitizeHtmlOptions: SanitizeHtmlOptions = {
+  ...defaultSanitizeOptions,
+  allowedAttributes: {
+    ...defaultSanitizeOptions.allowedAttributes,
+    a: ['href', 'rel', 'target'],
+  },
+};
 
 export { default } from '@frontend/modules/glossary/GlossaryPage';
 
@@ -22,7 +34,7 @@ export const getStaticProps: GetStaticProps<GlossaryPageProps> = async () => {
 
     return {
       heading,
-      content,
+      content: sanitizeHtml(content, sanitizeHtmlOptions),
     };
   });
 


### PR DESCRIPTION
This PR re-jigs the glossary page so that the entries are sanitized at build time (using the `sanitizeHtml` function), rather than at run time (using the `SanitizeHtml` component). 

This allows for a decent ~25% reduction in JS bundle size:

Before: 226 kB 
After: 170 kB