### PR TITLE
EES-1570 Fix permalink throwing error when subject has been replaced in amendment

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileUploadsValidatorServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FileUploadsValidatorServiceTests.cs
@@ -169,7 +169,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var (subjectService, fileTypeService) = Mocks();
 
-            subjectService.Setup(service => service.GetAsync(It.IsAny<Guid>(), "Subject Title"))
+            subjectService.Setup(service => service.Get(It.IsAny<Guid>(), "Subject Title"))
                 .ReturnsAsync(new Subject());
 
             await using (var context = InMemoryApplicationDbContext())

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTest.cs
@@ -953,7 +953,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var subjectService = new Mock<ISubjectService>();
 
                 subjectService
-                    .Setup(s => s.GetAsync(subject.Id))
+                    .Setup(s => s.Get(subject.Id))
                     .ReturnsAsync(subject);
 
                 var service = SetupReleaseDataFileService(
@@ -1772,7 +1772,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var subjectService = new Mock<ISubjectService>();
 
                 subjectService
-                    .Setup(s => s.GetAsync(subject.Id))
+                    .Setup(s => s.Get(subject.Id))
                     .ReturnsAsync(subject);
 
                 var service = SetupReleaseDataFileService(
@@ -2115,7 +2115,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 subjectService
-                    .Setup(s => s.GetAsync(originalDataFileReference.SubjectId.Value))
+                    .Setup(s => s.Get(originalDataFileReference.SubjectId.Value))
                     .ReturnsAsync(
                         new Subject
                         {
@@ -2445,7 +2445,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 subjectService
-                    .Setup(s => s.GetAsync(originalDataFileReference.SubjectId.Value))
+                    .Setup(s => s.Get(originalDataFileReference.SubjectId.Value))
                     .ReturnsAsync(
                         new Subject
                         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -355,7 +355,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             releaseDataFileService.Setup(service => service.Delete(release.Id, file.Id, false))
                 .ReturnsAsync(Unit.Instance);
 
-            releaseSubjectService.Setup(service => service.SoftDeleteSubjectOrBreakReleaseLink(release.Id, subject.Id))
+            releaseSubjectService.Setup(service => service.SoftDeleteReleaseSubject(release.Id, subject.Id))
                 .Returns(Task.CompletedTask);
 
                 await using (var context = InMemoryApplicationDbContext(contentDbContextId))
@@ -382,7 +382,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Times.Once());
 
                 releaseSubjectService.Verify(
-                    mock => mock.SoftDeleteSubjectOrBreakReleaseLink(release.Id, subject.Id),
+                    mock => mock.SoftDeleteReleaseSubject(release.Id, subject.Id),
                     Times.Once());
 
                 Assert.True(result.IsRight);
@@ -525,7 +525,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(Unit.Instance);
 
             releaseSubjectService.Setup(service =>
-                    service.SoftDeleteSubjectOrBreakReleaseLink(release.Id, It.IsIn(subject.Id, replacementSubject.Id)))
+                    service.SoftDeleteReleaseSubject(release.Id, It.IsIn(subject.Id, replacementSubject.Id)))
                 .Returns(Task.CompletedTask);
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
@@ -559,7 +559,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         It.IsIn(file.Filename, replacementFile.Filename)), Times.Exactly(2));
 
                 releaseSubjectService.Verify(
-                    mock => mock.SoftDeleteSubjectOrBreakReleaseLink(release.Id,
+                    mock => mock.SoftDeleteReleaseSubject(release.Id,
                         It.IsIn(subject.Id, replacementSubject.Id)), Times.Exactly(2));
 
                 Assert.True(result.IsRight);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -350,7 +350,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     service.IsImportFinished(file.ReleaseId, file.Filename))
                 .ReturnsAsync(true);
 
-            subjectService.Setup(service => service.GetAsync(subject.Id)).ReturnsAsync(subject);
+            subjectService.Setup(service => service.Get(subject.Id)).ReturnsAsync(subject);
 
             releaseDataFileService.Setup(service => service.Delete(release.Id, file.Id, false))
                 .ReturnsAsync(Unit.Instance);
@@ -430,7 +430,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     service.IsImportFinished(file.ReleaseId, file.Filename))
                 .ReturnsAsync(false);
 
-            subjectService.Setup(service => service.GetAsync(subject.Id)).ReturnsAsync(subject);
+            subjectService.Setup(service => service.Get(subject.Id)).ReturnsAsync(subject);
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -517,8 +517,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         It.IsIn(file.Filename, replacementFile.Filename)))
                 .ReturnsAsync(true);
 
-            subjectService.Setup(service => service.GetAsync(subject.Id)).ReturnsAsync(subject);
-            subjectService.Setup(service => service.GetAsync(replacementSubject.Id)).ReturnsAsync(replacementSubject);
+            subjectService.Setup(service => service.Get(subject.Id)).ReturnsAsync(subject);
+            subjectService.Setup(service => service.Get(replacementSubject.Id)).ReturnsAsync(replacementSubject);
 
             releaseDataFileService
                 .Setup(service => service.Delete(release.Id, It.IsIn(file.Id, replacementFile.Id), false))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseSubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseSubjectServiceTests.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
+{
+    public class ReleaseSubjectServiceTests
+    {
+        [Fact]
+        public async Task DeleteReleaseSubject()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject(),
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildReleaseSubjectService(statisticsDbContext);
+                await service.DeleteReleaseSubject(releaseSubject.ReleaseId, releaseSubject.SubjectId);
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                Assert.Empty(statisticsDbContext.ReleaseSubject.ToList());
+                Assert.Empty(statisticsDbContext.Subject.IgnoreQueryFilters().ToList());
+            }
+        }
+
+        [Fact]
+        public async Task DeleteReleaseSubject_SoftDeleteOrphanedSubject()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject(),
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildReleaseSubjectService(statisticsDbContext);
+                await service.DeleteReleaseSubject(releaseSubject.ReleaseId, releaseSubject.SubjectId, true);
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                Assert.Empty(statisticsDbContext.ReleaseSubject.ToList());
+
+                var subjects = statisticsDbContext.Subject.IgnoreQueryFilters().ToList();
+                Assert.Single(subjects);
+                Assert.Equal(releaseSubject.Subject.Id, subjects[0].Id);
+                Assert.True(subjects[0].SoftDeleted);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteReleaseSubject_NonOrphanedSubject()
+        {
+            var subject = new Subject();
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = subject,
+            };
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = subject
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildReleaseSubjectService(statisticsDbContext);
+                await service.DeleteReleaseSubject(releaseSubject2.ReleaseId, releaseSubject2.SubjectId);
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var releaseSubjects = statisticsDbContext.ReleaseSubject.ToList();
+                Assert.Single(releaseSubjects);
+                Assert.Equal(subject.Id, releaseSubjects[0].SubjectId);
+
+                var subjects = statisticsDbContext.Subject.ToList();
+                Assert.Single(subjects);
+                Assert.Equal(subject.Id, subjects[0].Id);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteAllReleaseSubjects()
+        {
+            var release = new Release();
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject(),
+            };
+
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject(),
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildReleaseSubjectService(statisticsDbContext);
+                await service.DeleteAllReleaseSubjects(release.Id);
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                Assert.Empty(statisticsDbContext.ReleaseSubject.ToList());
+                Assert.Empty(statisticsDbContext.Subject.IgnoreQueryFilters().ToList());
+            }
+        }
+
+        [Fact]
+        public async Task DeleteAllReleaseSubjects_SoftDeleteOrphanedSubjects()
+        {
+            var release = new Release();
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject(),
+            };
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject(),
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildReleaseSubjectService(statisticsDbContext);
+                await service.DeleteAllReleaseSubjects(release.Id, true);
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                Assert.Empty(statisticsDbContext.ReleaseSubject.ToList());
+
+                var subjects = statisticsDbContext.Subject.IgnoreQueryFilters().ToList();
+                Assert.Equal(2, subjects.Count);
+                Assert.Equal(releaseSubject1.SubjectId, subjects[0].Id);
+                Assert.True(subjects[0].SoftDeleted);
+
+                Assert.Equal(releaseSubject2.SubjectId, subjects[1].Id);
+                Assert.True(subjects[1].SoftDeleted);
+            }
+        }
+
+        private ReleaseSubjectService BuildReleaseSubjectService(
+            StatisticsDbContext statisticsDbContext,
+            IFootnoteService footnoteService = null)
+        {
+            return new ReleaseSubjectService(
+                statisticsDbContext,
+                footnoteService ?? new Mock<IFootnoteService>().Object
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileUploadsValidatorService.cs
@@ -87,7 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 return ValidationActionResult(SubjectTitleCannotContainSpecialCharacters);
             }
 
-            if (await _subjectService.GetAsync(releaseId, name) != null)
+            if (await _subjectService.Get(releaseId, name) != null)
             {
                 return ValidationActionResult(SubjectTitleMustBeUnique);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
@@ -472,7 +472,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             if (file.SubjectId.HasValue)
             {
-                var subject = await _subjectService.GetAsync(file.SubjectId.Value);
+                var subject = await _subjectService.Get(file.SubjectId.Value);
                 return subject.Name;
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -426,7 +426,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(async releaseFileReference =>
                 {
                     var subject = releaseFileReference.SubjectId.HasValue
-                        ? await _subjectService.GetAsync(releaseFileReference.SubjectId.Value)
+                        ? await _subjectService.Get(releaseFileReference.SubjectId.Value)
                         : null;
 
                     var footnotes = subject == null
@@ -478,7 +478,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         private async Task RemoveFileImportEntryIfOrphaned(DeleteDataFilePlan deletePlan)
         {
-            if (await _subjectService.GetAsync(deletePlan.SubjectId) == null)
+            if (await _subjectService.Get(deletePlan.SubjectId) == null)
             {
                 await _coreTableStorageService.DeleteEntityAsync(DatafileImportsTableName, deletePlan.TableStorageItem);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -172,7 +172,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     await _context.SaveChangesAsync();
 
-                    await _releaseSubjectService.SoftDeleteAllSubjectsOrBreakReleaseLinks(releaseId);
+                    await _releaseSubjectService.SoftDeleteAllReleaseSubjects(releaseId);
                 });
         }
 
@@ -466,7 +466,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .OnSuccess(async deletePlan =>
                         {
                             await _dataBlockService.DeleteDataBlocks(deletePlan.DeleteDataBlockPlan);
-                            await _releaseSubjectService.SoftDeleteSubjectOrBreakReleaseLink(releaseId,
+                            await _releaseSubjectService.SoftDeleteReleaseSubject(releaseId,
                                 deletePlan.SubjectId);
 
                             return await _releaseDataFileService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
@@ -169,7 +169,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         {
                             await _releaseDataFileService.DeleteAll(release.Id, forceDelete: true);
                             await _releaseFileService.DeleteAll(release.Id, forceDelete: true);
-                            await _releaseSubjectService.DeleteAllSubjectsOrBreakReleaseLinks(release.Id);
+                            await _releaseSubjectService.DeleteAllReleaseSubjects(release.Id);
                         }
 
                         _statisticsContext.Release.RemoveRange(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/FastTrackService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/FastTrackService.cs
@@ -64,7 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
                 var viewModel = _mapper.Map<FastTrackViewModel>(fastTrack);
                 viewModel.FullTable = result;
                 viewModel.Query.PublicationId =
-                    _subjectService.GetPublicationForSubjectAsync(fastTrack.Query.SubjectId).Result.Id;
+                    _subjectService.GetPublicationForSubject(fastTrack.Query.SubjectId).Result.Id;
                 return viewModel;
             });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -55,7 +55,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
 
         public async Task<Either<ActionResult, PermalinkViewModel>> CreateAsync(CreatePermalinkRequest request)
         {
-            var publicationId = _subjectService.GetPublicationForSubjectAsync(request.Query.SubjectId).Result.Id;
+            var publicationId = _subjectService.GetPublicationForSubject(request.Query.SubjectId).Result.Id;
             var releaseId = _releaseService.GetLatestPublishedRelease(publicationId);
 
             return await CreateAsync(releaseId.Value, request);
@@ -77,7 +77,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
         private async Task<PermalinkViewModel> BuildViewModel(Permalink permalink)
         {
             var isSubjectForLatestRelease = _subjectService.IsSubjectForLatestPublishedRelease(permalink.Query.SubjectId);
-            var publication = await _subjectService.GetPublicationForSubjectAsync(permalink.Query.SubjectId);
+            var publication = await _subjectService.GetPublicationForSubject(permalink.Query.SubjectId);
 
             var viewModel = _mapper.Map<PermalinkViewModel>(permalink);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -76,13 +76,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
 
         private async Task<PermalinkViewModel> BuildViewModel(Permalink permalink)
         {
-            var isSubjectForLatestRelease = await _subjectService.IsSubjectForLatestPublishedRelease(permalink.Query.SubjectId);
+            var subject = await _subjectService.Get(permalink.Query.SubjectId);
+            var isValid = subject != null && await _subjectService.IsSubjectForLatestPublishedRelease(subject.Id);
+
             var publication = await _subjectService.GetPublicationForSubject(permalink.Query.SubjectId);
 
             var viewModel = _mapper.Map<PermalinkViewModel>(permalink);
 
             viewModel.Query.PublicationId = publication.Id;
-            viewModel.Invalidated = !isSubjectForLatestRelease;
+            viewModel.Invalidated = !isValid;
 
             return viewModel;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -76,7 +76,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
 
         private async Task<PermalinkViewModel> BuildViewModel(Permalink permalink)
         {
-            var isSubjectForLatestRelease = _subjectService.IsSubjectForLatestPublishedRelease(permalink.Query.SubjectId);
+            var isSubjectForLatestRelease = await _subjectService.IsSubjectForLatestPublishedRelease(permalink.Query.SubjectId);
             var publication = await _subjectService.GetPublicationForSubject(permalink.Query.SubjectId);
 
             var viewModel = _mapper.Map<PermalinkViewModel>(permalink);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/FootnoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/FootnoteService.cs
@@ -56,6 +56,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
 
                 await DeleteFootnote(releaseId, footnote, canRemoveReleaseFootnote, canRemoveFootnote);
             }
+
+            await _context.SaveChangesAsync();
         }
 
         public async Task DeleteFootnote(Guid releaseId, Guid id)
@@ -66,6 +68,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
             {
                 await DeleteFootnote(releaseId, footnote, true, true);
             }
+
+            await _context.SaveChangesAsync();
         }
 
         private async Task DeleteFootnote(Guid releaseId, Footnote footnote, bool canRemoveReleaseFootnote, bool canRemoveFootnote)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/IReleaseSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/IReleaseSubjectService.cs
@@ -5,12 +5,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfa
 {
     public interface IReleaseSubjectService
     {
-        Task SoftDeleteAllSubjectsOrBreakReleaseLinks(Guid releaseId);
+        Task SoftDeleteAllReleaseSubjects(Guid releaseId);
 
-        Task SoftDeleteSubjectOrBreakReleaseLink(Guid releaseId, Guid subjectId);
+        Task SoftDeleteReleaseSubject(Guid releaseId, Guid subjectId);
 
-        Task DeleteAllSubjectsOrBreakReleaseLinks(Guid releaseId, bool isSoftDelete = false);
+        Task DeleteAllReleaseSubjects(Guid releaseId, bool softDeleteOrphanedSubjects = false);
 
-        Task DeleteSubjectOrBreakReleaseLink(Guid releaseId, Guid subjectId, bool isSoftDelete = false);
+        Task DeleteReleaseSubject(Guid releaseId, Guid subjectId, bool softDeleteOrphanedSubject = false);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/ISubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/ISubjectService.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -10,9 +11,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfa
 
         Task<Publication> GetPublicationForSubject(Guid subjectId);
 
-        Task<Subject> Get(Guid releaseId, string name);
+        Task<Subject?> Get(Guid releaseId, string subjectName);
 
-        Task<Subject> Get(Guid subjectId);
+        Task<Subject?> Get(Guid subjectId);
 
         Task<List<Subject>> GetSubjectsForRelease(Guid releaseId);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/ISubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/ISubjectService.cs
@@ -6,7 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfa
 {
     public interface ISubjectService : IRepository<Subject, Guid>
     {
-        bool IsSubjectForLatestPublishedRelease(Guid subjectId);
+        Task<bool> IsSubjectForLatestPublishedRelease(Guid subjectId);
 
         Task<Publication> GetPublicationForSubject(Guid subjectId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/ISubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/ISubjectService.cs
@@ -8,12 +8,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfa
     {
         bool IsSubjectForLatestPublishedRelease(Guid subjectId);
 
-        Task<Publication> GetPublicationForSubjectAsync(Guid subjectId);
-        
-        Task<Subject> GetAsync(Guid releaseId, string name);
-        
-        Task<Subject> GetAsync(Guid subjectId);
+        Task<Publication> GetPublicationForSubject(Guid subjectId);
 
-        Task<List<Subject>> GetSubjectsForReleaseAsync(Guid releaseId);
+        Task<Subject> Get(Guid releaseId, string name);
+
+        Task<Subject> Get(Guid subjectId);
+
+        Task<List<Subject>> GetSubjectsForRelease(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/ReleaseSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/ReleaseSubjectService.cs
@@ -59,6 +59,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
             if (releaseSubject != null)
             {
                 _statisticsDbContext.ReleaseSubject.Remove(releaseSubject);
+                // Immediately save context as we will need to re-check
+                // how many ReleaseSubjects are attached to the Subject
+                // later when determining if the Subject has been orphaned.
+                await _statisticsDbContext.SaveChangesAsync();
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
 
         public bool IsSubjectForLatestPublishedRelease(Guid subjectId)
         {
-            var publicationId = GetPublicationForSubjectAsync(subjectId).Result.Id;
+            var publicationId = GetPublicationForSubject(subjectId).Result.Id;
             var latestRelease = _releaseService.GetLatestPublishedRelease(publicationId);
 
             if (!latestRelease.HasValue)
@@ -34,14 +34,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
                 .Any(r => r.ReleaseId == latestRelease.Value && r.SubjectId == subjectId);
         }
 
-        public async Task<Subject> GetAsync(Guid subjectId)
+        public async Task<Subject> Get(Guid subjectId)
         {
             return await _context
                 .Subject
                 .Where(s => s.Id == subjectId).FirstOrDefaultAsync();
         }
         
-        public async Task<Subject> GetAsync(Guid releaseId, string name)
+        public async Task<Subject> Get(Guid releaseId, string name)
         {
             return await _context
                 .ReleaseSubject
@@ -51,7 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
                 .FirstOrDefaultAsync();
         }
 
-        public Task<Publication> GetPublicationForSubjectAsync(Guid subjectId)
+        public Task<Publication> GetPublicationForSubject(Guid subjectId)
         {
             return _context
                 .ReleaseSubject
@@ -62,7 +62,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
                 .FirstAsync();
         }
 
-        public Task<List<Subject>> GetSubjectsForReleaseAsync(Guid releaseId)
+        public Task<List<Subject>> GetSubjectsForRelease(Guid releaseId)
         {
             return _context
                 .ReleaseSubject

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,19 +35,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
                 .Any(r => r.ReleaseId == latestRelease.Value && r.SubjectId == subjectId);
         }
 
-        public async Task<Subject> Get(Guid subjectId)
+        public async Task<Subject?> Get(Guid subjectId)
         {
             return await _context
                 .Subject
-                .Where(s => s.Id == subjectId).FirstOrDefaultAsync();
+                .FindAsync(subjectId);
         }
 
-        public async Task<Subject> Get(Guid releaseId, string name)
+        public async Task<Subject?> Get(Guid releaseId, string subjectName)
         {
             return await _context
                 .ReleaseSubject
                 .Include(r => r.Subject)
-                .Where(r => r.ReleaseId == releaseId && r.Subject.Name == name)
+                .Where(r => r.ReleaseId == releaseId && r.Subject.Name == subjectName)
                 .Select(r => r.Subject)
                 .FirstOrDefaultAsync();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
@@ -19,16 +19,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
             _releaseService = releaseService;
         }
 
-        public bool IsSubjectForLatestPublishedRelease(Guid subjectId)
+        public async Task<bool> IsSubjectForLatestPublishedRelease(Guid subjectId)
         {
-            var publicationId = GetPublicationForSubject(subjectId).Result.Id;
-            var latestRelease = _releaseService.GetLatestPublishedRelease(publicationId);
+            var publication = await GetPublicationForSubject(subjectId);
+            var latestRelease = _releaseService.GetLatestPublishedRelease(publication.Id);
 
             if (!latestRelease.HasValue)
             {
                 return false;
             }
-            
+
             return _context
                 .ReleaseSubject
                 .Any(r => r.ReleaseId == latestRelease.Value && r.SubjectId == subjectId);
@@ -40,7 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
                 .Subject
                 .Where(s => s.Id == subjectId).FirstOrDefaultAsync();
         }
-        
+
         public async Task<Subject> Get(Guid releaseId, string name)
         {
             return await _context
@@ -70,6 +70,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
                 .Where(s => s.ReleaseId == releaseId)
                 .Select(s => s.Subject)
                 .ToListAsync();
-        } 
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/PublicationMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/PublicationMetaService.cs
@@ -67,7 +67,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         private async Task<IEnumerable<IdLabel>> GetSubjects(Guid releaseId)
         {
-            var subjects = await _subjectService.GetSubjectsForReleaseAsync(releaseId);
+            var subjects = await _subjectService.GetSubjectsForRelease(releaseId);
             return _mapper.Map<IEnumerable<IdLabel>>(subjects);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
@@ -100,7 +100,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     _logger.LogTrace("Got Time Periods in {Time} ms", stopwatch.Elapsed.TotalMilliseconds);
                     stopwatch.Stop();
 
-                    var publication = await _subjectService.GetPublicationForSubjectAsync(subject.Id);
+                    var publication = await _subjectService.GetPublicationForSubject(subject.Id);
                     
                     return new ResultSubjectMetaViewModel
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
@@ -26,7 +26,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         private readonly ISubjectService _subjectService;
         private readonly IUserService _userService;
         private readonly IReleaseService _releaseService;
-        
+
         public TableBuilderService(IObservationService observationService,
             IPersistenceHelper<StatisticsDbContext> persistenceHelper,
             IResultSubjectMetaService resultSubjectMetaService,
@@ -48,10 +48,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         {
             var publicationId = _subjectService.GetPublicationForSubject(queryContext.SubjectId).Result.Id;
             var releaseId = _releaseService.GetLatestPublishedRelease(publicationId);
-            
+
             return Query(releaseId.Value, queryContext);
         }
-        
+
         public Task<Either<ActionResult, TableBuilderResultViewModel>> Query(Guid releaseId, ObservationQueryContext queryContext)
         {
             return _persistenceHelper.CheckEntityExists<Subject>(queryContext.SubjectId)
@@ -81,7 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         private async Task<Either<ActionResult, Subject>> CheckCanViewSubjectData(Subject subject)
         {
-            if (_subjectService.IsSubjectForLatestPublishedRelease(subject.Id) ||
+            if (await _subjectService.IsSubjectForLatestPublishedRelease(subject.Id) ||
                 await _userService.MatchesPolicy(subject, CanViewSubjectData))
             {
                 return subject;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
@@ -46,7 +46,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         public Task<Either<ActionResult, TableBuilderResultViewModel>> Query(ObservationQueryContext queryContext)
         {
-            var publicationId = _subjectService.GetPublicationForSubjectAsync(queryContext.SubjectId).Result.Id;
+            var publicationId = _subjectService.GetPublicationForSubject(queryContext.SubjectId).Result.Id;
             var releaseId = _releaseService.GetLatestPublishedRelease(publicationId);
             
             return Query(releaseId.Value, queryContext);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -178,7 +178,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
             foreach (var previousVersion in previousVersions)
             {
-                await _releaseSubjectService.SoftDeleteAllSubjectsOrBreakReleaseLinks(previousVersion);
+                await _releaseSubjectService.SoftDeleteAllReleaseSubjects(previousVersion);
             }
 
             // Remove Statistical Releases for each of the Content Releases

--- a/tests/robot-tests/tests/admin_and_public/bau/create_amendment_check_permalink.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/create_amendment_check_permalink.robot
@@ -129,12 +129,12 @@ Generate the peramlink
     [Tags]  HappyPath
     user clicks button  Generate permanent link
     user waits until page contains testid  permalink-generated-url
-    ${PERMA_LOCATION_URL}=  Get Text  xpath://*[@data-testid="permalink-generated-url"]
-    Set Suite Variable  ${PERMA_LOCATION_URL}
+    ${PERMALINK_URL}=  Get Text  xpath://*[@data-testid="permalink-generated-url"]
+    Set Suite Variable  ${PERMALINK_URL}
 
 Go to permalink
     [Tags]  HappyPath
-    user goes to url  ${PERMA_LOCATION_URL}
+    user goes to url  ${PERMALINK_URL}
     user waits until h1 is visible  '${SUBJECT_NAME}' from '${PUBLICATION_NAME}'
     user checks page does not contain   WARNING - The data used in this permalink may be out-of-date.
 
@@ -156,7 +156,7 @@ Create amendment
     user clicks button  Amend this release  ${details}
     user clicks button  Confirm
 
-replace data files for amendment
+Replace data files for amendment
     [Tags]  HappyPath
     user clicks link  Data and files
     user waits until page contains element  id:dataFileUploadForm-subjectTitle
@@ -176,7 +176,6 @@ Confirm data replacement
     user waits until page contains  Footnotes: OK
     user clicks button  Confirm data replacement
     user waits until h2 is visible  Data replacement complete
-
 
 Go to "Sign off" page for amendment
     [Tags]  HappyPath
@@ -201,5 +200,5 @@ Wait for release amendment process status to be Complete
 
 Go to permalink page & check for error element to be present
     [Tags]  HappyPath
-    user goes to url  ${PERMA_LOCATION_URL}
+    user goes to url  ${PERMALINK_URL}
     user waits until page contains  WARNING - The data used in this permalink may be out-of-date.


### PR DESCRIPTION
This PR fixes permalinks throwing error when a subject has been replaced. When building the permalink view model, we now do an additional check to ensure that the subject actually exists before calling the `SubjectService.IsSubjectForLatestPublishedRelease` method (was previously throwing as the subject could not be found).

Interestingly, this was only happening on non-local environments. I'm not 100% why this occurs, but it's probably because of the specific interaction between data factory and the public stats DB.

## Relevant changes

- Cleaned up `ReleaseSubjectService`, simplfying methods and their names, and updating the orphaned subject check to use the most up-to-date `ReleaseSubjects`.