### PR TITLE
EES-1574, EES-1575, EES-1576 Fixes for meta guidance content

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
@@ -51,7 +51,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                             releaseSubjectsQueryable.Where(rs => subjectIds.Contains(rs.SubjectId));
                     }
 
-                    var releaseSubjects = await releaseSubjectsQueryable.ToListAsync();
+                    var releaseSubjects = await releaseSubjectsQueryable
+                        .OrderBy(rs => rs.Subject.Name)
+                        .ToListAsync();
 
                     var result = new List<MetaGuidanceSubjectViewModel>();
                     await releaseSubjects.ForEachAsync(async releaseSubject =>

--- a/src/explore-education-statistics-common/src/components/SummaryListItem.tsx
+++ b/src/explore-education-statistics-common/src/components/SummaryListItem.tsx
@@ -12,8 +12,13 @@ const SummaryListItem = ({ actions, children, term, testId = term }: Props) => {
     <div className="govuk-summary-list__row" data-testid={testId}>
       <dt className="govuk-summary-list__key">{term}</dt>
 
-      {children && <dd className="govuk-summary-list__value">{children}</dd>}
-      {actions && <dd className="govuk-summary-list__actions">{actions}</dd>}
+      {typeof children !== 'undefined' && (
+        <dd className="govuk-summary-list__value">{children}</dd>
+      )}
+
+      {typeof actions !== 'undefined' && (
+        <dd className="govuk-summary-list__actions">{actions}</dd>
+      )}
     </div>
   );
 };

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseMetaGuidanceDataFile.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseMetaGuidanceDataFile.tsx
@@ -11,7 +11,21 @@ interface Props {
 }
 
 const ReleaseMetaGuidanceDataFile = ({ subject, renderContent }: Props) => {
-  const { filename, geographicLevels, timePeriods, variables } = subject;
+  const { filename, variables } = subject;
+
+  const geographicLevels = useMemo(() => subject.geographicLevels.join('; '), [
+    subject.geographicLevels,
+  ]);
+
+  const timePeriod = useMemo(() => {
+    const { from, to } = subject.timePeriods;
+
+    if (from && to) {
+      return from === to ? from : `${from} to ${to}`;
+    }
+
+    return from || to;
+  }, [subject.timePeriods]);
 
   const contentItem = useMemo(() => {
     if (typeof renderContent === 'function') {
@@ -40,12 +54,14 @@ const ReleaseMetaGuidanceDataFile = ({ subject, renderContent }: Props) => {
     <>
       <SummaryList className="govuk-!-margin-bottom-6">
         <SummaryListItem term="Filename">{filename}</SummaryListItem>
-        <SummaryListItem term="Geographic levels">
-          {geographicLevels.join('; ')}
-        </SummaryListItem>
-        <SummaryListItem term="Time period">
-          {`${timePeriods.from} to ${timePeriods.to}`}
-        </SummaryListItem>
+        {geographicLevels && (
+          <SummaryListItem term="Geographic levels">
+            {geographicLevels}
+          </SummaryListItem>
+        )}
+        {timePeriod && (
+          <SummaryListItem term="Time period">{timePeriod}</SummaryListItem>
+        )}
         {contentItem}
       </SummaryList>
 

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseMetaGuidanceDataFile.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseMetaGuidanceDataFile.tsx
@@ -3,7 +3,7 @@ import SanitizeHtml from '@common/components/SanitizeHtml';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import { SubjectMetaGuidance } from '@common/services/releaseMetaGuidanceService';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 
 interface Props {
   subject: SubjectMetaGuidance;
@@ -11,7 +11,30 @@ interface Props {
 }
 
 const ReleaseMetaGuidanceDataFile = ({ subject, renderContent }: Props) => {
-  const { filename, timePeriods, geographicLevels, variables } = subject;
+  const { filename, geographicLevels, timePeriods, variables } = subject;
+
+  const contentItem = useMemo(() => {
+    if (typeof renderContent === 'function') {
+      return (
+        <SummaryListItem term="Content">
+          {renderContent(subject)}
+        </SummaryListItem>
+      );
+    }
+
+    if (!subject.content) {
+      return null;
+    }
+
+    return (
+      <SummaryListItem term="Content">
+        <SanitizeHtml
+          dirtyHtml={subject.content}
+          testId="fileGuidanceContent"
+        />
+      </SummaryListItem>
+    );
+  }, [renderContent, subject]);
 
   return (
     <>
@@ -23,16 +46,7 @@ const ReleaseMetaGuidanceDataFile = ({ subject, renderContent }: Props) => {
         <SummaryListItem term="Time period">
           {`${timePeriods.from} to ${timePeriods.to}`}
         </SummaryListItem>
-        <SummaryListItem term="Content">
-          {typeof renderContent === 'function' ? (
-            renderContent(subject)
-          ) : (
-            <SanitizeHtml
-              dirtyHtml={subject.content}
-              testId="fileGuidanceContent"
-            />
-          )}
-        </SummaryListItem>
+        {contentItem}
       </SummaryList>
 
       <Details summary="Variable names and descriptions">

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseMetaGuidancePageContent.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseMetaGuidancePageContent.tsx
@@ -27,7 +27,9 @@ const ReleaseMetaGuidancePageContent = ({
         </p>
       )}
 
-      <SanitizeHtml dirtyHtml={metaGuidance} testId="metaGuidance-content" />
+      {metaGuidance && (
+        <SanitizeHtml dirtyHtml={metaGuidance} testId="metaGuidance-content" />
+      )}
 
       {subjects.length > 0 && (
         <>

--- a/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseMetaGuidancePageContent.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseMetaGuidancePageContent.test.tsx
@@ -180,6 +180,75 @@ describe('ReleaseMetaGuidancePageContent', () => {
     expect(section2VariableRow2Cells[1]).toHaveTextContent('Indicator 2');
   });
 
+  test('renders single time period when `from` and `to` are the same', () => {
+    render(
+      <ReleaseMetaGuidancePageContent
+        metaGuidance="Test meta guidance content"
+        subjects={[
+          {
+            ...testSubjectMetaGuidance[0],
+            timePeriods: {
+              from: '2020',
+              to: '2020',
+            },
+          },
+        ]}
+      />,
+    );
+
+    const subjects = screen.getAllByTestId('accordionSection');
+
+    const subject1 = within(subjects[0]);
+
+    expect(subject1.queryByTestId('Time period')).toHaveTextContent('2020');
+    expect(subject1.queryByTestId('Time period')).not.toHaveTextContent(
+      '2020 to 2020',
+    );
+  });
+
+  test('does not render empty geographic levels', () => {
+    render(
+      <ReleaseMetaGuidancePageContent
+        metaGuidance="Test meta guidance content"
+        subjects={[
+          {
+            ...testSubjectMetaGuidance[0],
+            geographicLevels: [],
+          },
+        ]}
+      />,
+    );
+
+    const subjects = screen.getAllByTestId('accordionSection');
+
+    expect(
+      within(subjects[0]).queryByTestId('Geographic levels'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not render empty time periods', () => {
+    render(
+      <ReleaseMetaGuidancePageContent
+        metaGuidance="Test meta guidance content"
+        subjects={[
+          {
+            ...testSubjectMetaGuidance[0],
+            timePeriods: {
+              from: '',
+              to: '',
+            },
+          },
+        ]}
+      />,
+    );
+
+    const subjects = screen.getAllByTestId('accordionSection');
+
+    expect(
+      within(subjects[0]).queryByTestId('Time periods'),
+    ).not.toBeInTheDocument();
+  });
+
   test('does not render empty file content', () => {
     render(
       <ReleaseMetaGuidancePageContent

--- a/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseMetaGuidancePageContent.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseMetaGuidancePageContent.test.tsx
@@ -83,6 +83,14 @@ describe('ReleaseMetaGuidancePageContent', () => {
     ).toBeInTheDocument();
   });
 
+  test('does not render empty meta guidance content', () => {
+    render(<ReleaseMetaGuidancePageContent metaGuidance="" subjects={[]} />);
+
+    expect(
+      screen.queryByTestId('metaGuidance-content'),
+    ).not.toBeInTheDocument();
+  });
+
   test('renders guidance for subjects', async () => {
     render(
       <ReleaseMetaGuidancePageContent
@@ -170,6 +178,26 @@ describe('ReleaseMetaGuidancePageContent', () => {
 
     expect(section2VariableRow2Cells[0]).toHaveTextContent('indicator_2');
     expect(section2VariableRow2Cells[1]).toHaveTextContent('Indicator 2');
+  });
+
+  test('does not render empty file content', () => {
+    render(
+      <ReleaseMetaGuidancePageContent
+        metaGuidance="Test meta guidance content"
+        subjects={[
+          {
+            ...testSubjectMetaGuidance[0],
+            content: '',
+          },
+        ]}
+      />,
+    );
+
+    const subjects = screen.getAllByTestId('accordionSection');
+
+    expect(
+      within(subjects[0]).queryByTestId('Content'),
+    ).not.toBeInTheDocument();
   });
 
   test('renders no subject guidance when empty', () => {


### PR DESCRIPTION
This PR:

- Fixes empty meta guidance content and file content incorrectly rendering (EES-1574)
- Fixes empty subject time periods and geographic levels incorrectly rendering (EES-1575)
- Orders meta guidance subjects alphabetically by name (EES-1576)