### PR TITLE
EES-1578 Add logging and alter exception handling when updating import status and progress values

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/ImportStatusServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/ImportStatusServiceTests.cs
@@ -347,7 +347,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             importsTable.Setup(mock => mock.ExecuteAsync(It.Is<TableOperation>(operation =>
                     operation.OperationType == TableOperationType.Replace)))
-                .ThrowsAsync(new StorageException());
+                .ThrowsAsync(new StorageException(new RequestResult
+                {
+                    HttpStatusCode = 412
+                }, "", null));
 
             var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
 
@@ -460,7 +463,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             importsTable.Setup(mock => mock.ExecuteAsync(It.Is<TableOperation>(operation =>
                     operation.OperationType == TableOperationType.Replace)))
-                .ThrowsAsync(new StorageException());
+                .ThrowsAsync(new StorageException(new RequestResult
+                {
+                    HttpStatusCode = 412
+                }, "", null));
 
             var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ImportStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ImportStatus.cs
@@ -18,5 +18,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         public int NumberOfRows { get; set; }
 
         public bool PhaseComplete => PhasePercentageComplete == 100;
+
+        public override string ToString()
+        {
+            return $"{Status} {PhasePercentageComplete}%, overall {PercentageComplete}%";
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/host.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/host.json
@@ -3,14 +3,8 @@
   "functionTimeout": "04:00:00",
   "logging": {
     "logLevel": {
-      "default": "None",
-      "Function.ProcessUploads": "Information",
-      "Function.ProcessUploadsSequentially": "Information",
-      "Function.ImportObservations": "Information",
-      "GovUk.Education.ExploreEducationStatistics.Data.Importer": "Debug",
-      "GovUk.Education.ExploreEducationStatistics.Data.Processor": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      "default": "Information",
+      "Microsoft": "Warning"
     }
   },
   "extensions": {


### PR DESCRIPTION
This PR:

Adds logging so we can see progress updates e.g. `Update: spc_pupils_fsm_eth_lang.csv STAGE_4 (88%) -> STAGE_4 (91%)`

Adds logging so we can see status updates e.g. `spc_pupils_fsm_eth_lang.csv STAGE_4 (97%) -> COMPLETE (100%)`

Adds logging so we can see lost updates e.g. `Precondition failure as expected while updating progress. ETag does not match for update: spc_pupils_fsm_eth_lang.csv STAGE_4 (93%) -> STAGE_4 (97%)`

Throw exceptions occurring for reasons other than optimistic locking when updating status or progress of imports.

Alters logging categories so all services are included by default at Information level.