### PR TITLE
EES-1578 Retry when updating import statuses if an import was changed by a concurrent update

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IImportStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IImportStatusService.cs
@@ -7,8 +7,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
     public interface IImportStatusService
     {
         Task<ImportStatus> GetImportStatus(Guid releaseId, string dataFileName);
+
         Task<bool> IsImportFinished(Guid releaseId, string dataFileName);
-        Task<bool> UpdateStatus(Guid releaseId, string origDataFileName, IStatus status);
-        Task UpdateProgress(Guid releaseId, string origDataFileName, double percentageComplete);
+
+        Task<bool> UpdateStatus(Guid releaseId, string origDataFileName, IStatus status, int retry = 0);
+
+        Task UpdateProgress(Guid releaseId, string origDataFileName, double percentageComplete, int retry = 0);
     }
 }


### PR DESCRIPTION
* Retry up to 5 times when updating status or progress if an import status row has been changed by a concurrent update.

* Ignore status updates to a lesser status than the existing one, for example, `Stage 4 -> Stage 3` and `Complete -> Stage 4` would both be ignored