### PR TITLE
EES-1578 Allow updating Status and Percentage Complete together

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/ImportStatusServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/ImportStatusServiceTests.cs
@@ -228,7 +228,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateStatus_AlreadyComplete()
+        public async Task UpdateStatus_UpdateWhenAlreadyCompleteIsIgnored()
         {
             var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
 
@@ -248,7 +248,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateStatus_AlreadyFailed()
+        public async Task UpdateStatus_UpdateWhenAlreadyFailedIsIgnored()
         {
             var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
 
@@ -300,7 +300,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateStatus_UpdateToLesserStatus()
+        public async Task UpdateStatus_UpdateToLesserStatusIsIgnored()
         {
             var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
 
@@ -352,7 +352,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateStatus_UpdateAsSameStatus()
+        public async Task UpdateStatus_UpdateAsSameStatusIsIgnored()
         {
             var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
 
@@ -454,7 +454,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
 
-            await service.UpdateProgress(_releaseId, FileName, 50.0);
+            await service.UpdateProgress(_releaseId, FileName, STAGE_1, 50.0);
 
             importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
@@ -469,7 +469,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateProgress_PercentageCompleteGreaterThanUpdate()
+        public async Task UpdateProgress_IntendedStatusDifferentFromActualStatusIsIgnored()
+        {
+            var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
+
+            var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
+                importStatus: STAGE_3,
+                percentageComplete: 0);
+
+            var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
+
+            await service.UpdateProgress(_releaseId, FileName, STAGE_2, 50.0);
+
+            importsTable.Verify(mock =>
+                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
+                    operation.OperationType == TableOperationType.Retrieve)), Times.Once);
+
+            importsTable.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task UpdateProgress_PercentageCompleteGreaterThanUpdateIsIgnored()
         {
             var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
 
@@ -479,7 +499,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
 
-            await service.UpdateProgress(_releaseId, FileName, 25.0);
+            await service.UpdateProgress(_releaseId, FileName, STAGE_1, 25.0);
 
             importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
@@ -505,7 +525,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
 
-            await service.UpdateProgress(_releaseId, FileName, 101.0);
+            await service.UpdateProgress(_releaseId, FileName, STAGE_1, 101.0);
 
             importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
@@ -533,7 +553,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
 
-            await Assert.ThrowsAsync<StorageException>(() => service.UpdateProgress(_releaseId, FileName, 50.0));
+            await Assert.ThrowsAsync<StorageException>(
+                () => service.UpdateProgress(_releaseId, FileName, STAGE_1, 50.0));
 
             importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
@@ -569,7 +590,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
 
             var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
 
-            await service.UpdateProgress(_releaseId, FileName, 50.0);
+            await service.UpdateProgress(_releaseId, FileName, STAGE_1, 50.0);
 
             importsTable.Verify(mock =>
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/ImportStatusServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/ImportStatusServiceTests.cs
@@ -340,19 +340,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateStatus_UpdateToSameStatus()
+        public async Task UpdateStatus_UpdateToSamePercentageCompleteAtSameStatusIsIgnored()
         {
             var tableStorageService = new Mock<ITableStorageService>(MockBehavior.Strict);
 
             var importsTable = SetupImportsTableMockForDataFileImport(tableStorageService: tableStorageService,
                 importStatus: STAGE_2,
                 percentageComplete: 50);
-
-            importsTable.Setup(mock => mock.ExecuteAsync(It.Is(_tableReplaceExpression)))
-                .ReturnsAsync(new TableResult
-                {
-                    Result = null
-                });
 
             var service = BuildImportStatusService(tableStorageService: tableStorageService.Object);
 
@@ -362,15 +356,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
                 mock.ExecuteAsync(It.Is<TableOperation>(operation =>
                     operation.OperationType == TableOperationType.Retrieve)), Times.Once);
 
-            importsTable.Verify(mock =>
-                mock.ExecuteAsync(It.Is<TableOperation>(operation =>
-                    operation.OperationType == TableOperationType.Replace
-                    && (operation.Entity as DatafileImport).PercentageComplete == 50
-                    && (operation.Entity as DatafileImport).Status == STAGE_2)), Times.Once);
-
             importsTable.VerifyNoOtherCalls();
         }
-        
+
         [Fact]
         public async Task UpdateStatus_UpdateToGreaterStatus()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
@@ -207,7 +207,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             var blobContainer = await GetBlobContainer(containerName);
             var blob = blobContainer.GetBlockBlobClient(path);
 
-            _logger.LogInformation($"Uploading stream to blob {containerName}/{path}");
+            _logger.LogInformation($"Uploading {containerName}/{path}");
 
             if (stream.CanSeek)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/ImportStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/ImportStatusService.cs
@@ -89,27 +89,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return FinishedImportStatuses.Contains(importStatus.Status);
         }
 
-        public async Task<bool> UpdateStatus(Guid releaseId, string origDataFileName, IStatus status, int retry = 0)
+        public async Task UpdateStatus(Guid releaseId, string origDataFileName, IStatus status, double percentageComplete = 0, int retry = 0)
         {
             var import = await GetImport(releaseId, origDataFileName);
 
-            // Ignore updating when already failed
-            if (import.Status == IStatus.FAILED)
-            {
-                _logger.LogWarning($"Update: {origDataFileName} {import.Status} -> {status} ignored");
-                return false;
-            }
-
-            // Ignore updating to a lesser or equal status 
-            if (import.Status.CompareTo(status) >= 0)
-            {
-                _logger.LogWarning($"Update: {origDataFileName} {import.Status} -> {status} ignored");
-                return true;
-            }
-
             var percentageCompleteBefore = import.PercentageComplete;
-            var percentageCompleteAfter = status == IStatus.COMPLETE ? 100 : 0;
+            var percentageCompleteAfter = (int) Math.Clamp(percentageComplete, 0, 100);
             var statusBefore = import.Status;
+
+            // Ignore updating when already failed
+            // Ignore updating to a lower status
+            // Ignore updating to a lower percentage complete at the same status
+            if (statusBefore == IStatus.FAILED
+                || statusBefore.CompareTo(status) > 0
+                || statusBefore == status && percentageCompleteBefore > percentageCompleteAfter)
+            {
+                _logger.LogWarning(
+                    $"Update: {origDataFileName} {statusBefore} ({percentageCompleteBefore}%) -> {status} ({percentageCompleteAfter}%) ignored");
+                return;
+            }
 
             _logger.LogInformation(
                 $"Update: {origDataFileName} {statusBefore} ({percentageCompleteBefore}%) -> {status} ({percentageCompleteAfter}%)");
@@ -134,7 +132,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
                         $"Precondition failure as expected while updating progress. ETag does not match for update: {origDataFileName} {statusBefore} ({percentageCompleteBefore}%) -> {status} ({percentageCompleteAfter}%)");
                     if (retry++ < 5)
                     {
-                        await UpdateStatus(releaseId, origDataFileName, status, retry);
+                        await UpdateStatus(releaseId, origDataFileName, status, percentageComplete, retry);
                     }
                     else
                     {
@@ -145,61 +143,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
                 {
                     throw;
                 }
-            }
-
-            return true;
-        }
-
-        public async Task UpdateProgress(Guid releaseId, string origDataFileName, IStatus status,
-            double percentageComplete, int retry = 0)
-        {
-            var import = await GetImport(releaseId, origDataFileName);
-
-            var before = import.PercentageComplete;
-            var after = (int) Math.Clamp(percentageComplete, 0, 100);
-
-            // Ensure that the intended phase progress is being updated by comparing the status
-            if (import.Status != status)
-            {
-                _logger.LogWarning(
-                    $"Update: {origDataFileName} {import.Status} ({before}%) -> {status} ({after}%) ignored due to status mismatch");
-                return;
-            }
-
-            if (before < after)
-            {
-                _logger.LogInformation(
-                    $"Update: {origDataFileName} {import.Status} ({before}%) -> {import.Status} ({after}%)");
-                import.PercentageComplete = after;
-                try
-                {
-                    await _table.ExecuteAsync(TableOperation.Replace(import));
-                }
-                catch (StorageException e)
-                {
-                    if (e.RequestInformation.HttpStatusCode == (int) HttpStatusCode.PreconditionFailed)
-                    {
-                        _logger.LogWarning(e,
-                            $"Precondition failure as expected while updating progress. ETag does not match for update: {origDataFileName} {import.Status} ({before}%) -> {import.Status} ({after}%)");
-                        if (retry++ < 5)
-                        {
-                            await UpdateProgress(releaseId, origDataFileName, status, percentageComplete, retry);
-                        }
-                        else
-                        {
-                            throw;
-                        }
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
-            }
-            else if (before != after)
-            {
-                _logger.LogWarning(
-                    $"Ignoring attempt for {origDataFileName} {import.Status} to replace {before}% with lower value {after}%");
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IImportStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IImportStatusService.cs
@@ -10,8 +10,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 
         Task<bool> IsImportFinished(Guid releaseId, string dataFileName);
 
-        Task<bool> UpdateStatus(Guid releaseId, string origDataFileName, IStatus status, int retry = 0);
-
-        Task UpdateProgress(Guid releaseId, string origDataFileName, IStatus status, double percentageComplete, int retry = 0);
+        Task UpdateStatus(Guid releaseId, string origDataFileName, IStatus status, double percentageComplete = 0, int retry = 0);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IImportStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IImportStatusService.cs
@@ -12,6 +12,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 
         Task<bool> UpdateStatus(Guid releaseId, string origDataFileName, IStatus status, int retry = 0);
 
-        Task UpdateProgress(Guid releaseId, string origDataFileName, double percentageComplete, int retry = 0);
+        Task UpdateProgress(Guid releaseId, string origDataFileName, IStatus status, double percentageComplete, int retry = 0);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Exceptions;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Models;
@@ -148,7 +149,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             {
                 if (rowCount % STAGE_2_ROW_CHECK == 0)
                 {
-                    await _importStatusService.UpdateProgress(releaseId, origDataFileName,
+                    await _importStatusService.UpdateProgress(releaseId,
+                        origDataFileName,
+                        IStatus.STAGE_2,
                         (double) rowCount / totalRows * 100);
                 }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Services/ImporterService.cs
@@ -149,7 +149,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Services
             {
                 if (rowCount % STAGE_2_ROW_CHECK == 0)
                 {
-                    await _importStatusService.UpdateProgress(releaseId,
+                    await _importStatusService.UpdateStatus(releaseId,
                         origDataFileName,
                         IStatus.STAGE_2,
                         (double) rowCount / totalRows * 100);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -50,7 +50,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 return;
             }
 
-            await _importStatusService.UpdateStatus(releaseId, message.OrigDataFileName, IStatus.STAGE_4);
+            if (status.Status != IStatus.STAGE_4)
+            {
+                await _importStatusService.UpdateStatus(releaseId, message.OrigDataFileName, IStatus.STAGE_4);                
+            }
 
             var subjectData = await _fileStorageService.GetSubjectData(message);
             var releaseSubject = GetReleaseSubjectLink(message, context);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Services.Interfaces;
@@ -42,41 +43,43 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             var releaseId = message.Release.Id;
 
             // Potentially status could already be failed so don't continue
-            if (await _importStatusService.UpdateStatus(releaseId, message.OrigDataFileName, IStatus.STAGE_4))
-            {
-                var subjectData = await _fileStorageService.GetSubjectData(message);
-                var releaseSubject = GetReleaseSubjectLink(message, context);
-
-                await using var datafileStream = await _fileStorageService.StreamBlob(subjectData.DataBlob);
-                var dataFileTable = DataTableUtils.CreateFromStream(datafileStream);
-
-                await using var metaFileStream = await _fileStorageService.StreamBlob(subjectData.MetaBlob);
-                var metaFileTable = DataTableUtils.CreateFromStream(metaFileStream);
-
-                await context.Database.CreateExecutionStrategy().Execute(async () =>
-                {
-                    await using var transaction = await context.Database.BeginTransactionAsync();
-
-                    await _importerService.ImportObservations(
-                        dataFileTable.Columns,
-                        dataFileTable.Rows,
-                        releaseSubject.Subject,
-                        _importerService.GetMeta(metaFileTable, releaseSubject.Subject, context),
-                        message.BatchNo,
-                        message.RowsPerBatch,
-                        context
-                    );
-
-                    await transaction.CommitAsync();
-                    await context.Database.CloseConnectionAsync();
-                });
-
-                await CheckComplete(releaseId, message, context);
-            }
-            else
+            var status = await _importStatusService.GetImportStatus(releaseId, message.OrigDataFileName);
+            if (status.Status == IStatus.FAILED)
             {
                 _logger.LogInformation($"{message.DataFileName} already failed...skipping");
+                return;
             }
+
+            await _importStatusService.UpdateStatus(releaseId, message.OrigDataFileName, IStatus.STAGE_4);
+
+            var subjectData = await _fileStorageService.GetSubjectData(message);
+            var releaseSubject = GetReleaseSubjectLink(message, context);
+
+            await using var datafileStream = await _fileStorageService.StreamBlob(subjectData.DataBlob);
+            var dataFileTable = DataTableUtils.CreateFromStream(datafileStream);
+
+            await using var metaFileStream = await _fileStorageService.StreamBlob(subjectData.MetaBlob);
+            var metaFileTable = DataTableUtils.CreateFromStream(metaFileStream);
+
+            await context.Database.CreateExecutionStrategy().Execute(async () =>
+            {
+                await using var transaction = await context.Database.BeginTransactionAsync();
+
+                await _importerService.ImportObservations(
+                    dataFileTable.Columns,
+                    dataFileTable.Rows,
+                    releaseSubject.Subject,
+                    _importerService.GetMeta(metaFileTable, releaseSubject.Subject, context),
+                    message.BatchNo,
+                    message.RowsPerBatch,
+                    context
+                );
+
+                await transaction.CommitAsync();
+                await context.Database.CloseConnectionAsync();
+            });
+
+            await CheckComplete(releaseId, message, context);
         }
 
         public async Task ImportFiltersLocationsAndSchools(ImportMessage message, StatisticsDbContext context)
@@ -125,7 +128,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             if (message.NumBatches == 1 || numBatchesRemaining == 0)
             {
                 var observationCount = context.Observation.Count(o => o.SubjectId.Equals(message.SubjectId));
-                
+
                 if (!observationCount.Equals(message.TotalRows))
                 {
                     await _batchService.FailImport(releaseId, message.OrigDataFileName,
@@ -139,19 +142,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 }
                 else
                 {
-                    await _importStatusService.UpdateStatus(releaseId, message.OrigDataFileName,
-                        import.Errors.Equals("") ? IStatus.COMPLETE : IStatus.FAILED);
+                    if (import.Errors.IsNullOrEmpty())
+                    {
+                        await _importStatusService.UpdateStatus(releaseId, message.OrigDataFileName, IStatus.COMPLETE, 100);
+                    }
+                    else
+                    {
+                        await _importStatusService.UpdateStatus(releaseId, message.OrigDataFileName, IStatus.FAILED);
+                    }
                 }
-
-                _logger.LogInformation(import.Errors.Equals("") && observationCount.Equals(message.TotalRows)
-                    ? $"All batches imported for {releaseId} : {message.OrigDataFileName} with no errors"
-                    : $"All batches imported for {releaseId} : {message.OrigDataFileName} but with errors - check storage log");
             }
             else
             {
                 var percentageComplete = (double) (message.NumBatches - numBatchesRemaining) / message.NumBatches * 100;
 
-                await _importStatusService.UpdateProgress(releaseId,
+                await _importStatusService.UpdateStatus(releaseId,
                     message.OrigDataFileName,
                     IStatus.STAGE_4,
                     percentageComplete);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -122,7 +122,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             
             var import = await _importStatusService.GetImportStatus(releaseId, message.OrigDataFileName);
 
-            if (import.Status.Equals(IStatus.STAGE_4) && (message.NumBatches == 1 || numBatchesRemaining == 0))
+            if (message.NumBatches == 1 || numBatchesRemaining == 0)
             {
                 var observationCount = context.Observation.Count(o => o.SubjectId.Equals(message.SubjectId));
                 
@@ -149,8 +149,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             }
             else
             {
-                var percentageComplete = (double)(message.NumBatches - numBatchesRemaining) / message.NumBatches * 100;
-                await _importStatusService.UpdateProgress(releaseId, message.OrigDataFileName, percentageComplete);
+                var percentageComplete = (double) (message.NumBatches - numBatchesRemaining) / message.NumBatches * 100;
+
+                await _importStatusService.UpdateProgress(releaseId,
+                    message.OrigDataFileName,
+                    IStatus.STAGE_4,
+                    percentageComplete);
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
@@ -95,10 +95,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 var table = new DataTable();
                 CopyColumns(dataFileTable, table);
                 CopyRows(table, batch.ToList(), headerList);
-                
-                var percentageComplete = (double)batchCount / numBatches * 100;
-                await _importStatusService.UpdateProgress(message.Release.Id, message.OrigDataFileName, percentageComplete);
-                
+
+                var percentageComplete = (double) batchCount / numBatches * 100;
+
+                await _importStatusService.UpdateProgress(message.Release.Id,
+                    message.OrigDataFileName,
+                    IStatus.STAGE_3,
+                    percentageComplete);
+
                 // If no lines then don't create a batch or message unless it's the last one & there are zero
                 // lines in total in which case create a zero lines batch
                 if (table.Rows.Count == 0 && batchCount != numBatches || table.Rows.Count == 0 && messages.Count != 0)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
@@ -98,7 +98,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
                 var percentageComplete = (double) batchCount / numBatches * 100;
 
-                await _importStatusService.UpdateProgress(message.Release.Id,
+                await _importStatusService.UpdateStatus(message.Release.Id,
                     message.OrigDataFileName,
                     IStatus.STAGE_3,
                     percentageComplete);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
@@ -279,7 +279,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
                 if (totalRowCount % STAGE_1_ROW_CHECK == 0)
                 {
-                    await _importStatusService.UpdateProgress(releaseId,
+                    await _importStatusService.UpdateStatus(releaseId,
                         origDataFileName,
                         IStatus.STAGE_1,
                         (double) totalRowCount / dataRows * 100);
@@ -291,7 +291,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 return errors;
             }
 
-            await _importStatusService.UpdateProgress(releaseId,
+            await _importStatusService.UpdateStatus(releaseId,
                 origDataFileName,
                 IStatus.STAGE_1,
                 100);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
@@ -85,7 +85,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         public async Task<Either<IEnumerable<ValidationError>, ProcessorStatistics>>
             Validate(Guid releaseId, SubjectData subjectData, ExecutionContext executionContext, ImportMessage message)
         {
-            _logger.LogInformation($"Validating Datafile: {message.OrigDataFileName}");
+            _logger.LogInformation($"Validating: {message.OrigDataFileName}");
 
             await _importStatusService.UpdateStatus(message.Release.Id, message.DataFileName, IStatus.STAGE_1);
 
@@ -111,8 +111,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                                             result =>
                                             {
                                                 _logger.LogInformation(
-                                                    $"Validation of Datafile: {message.OrigDataFileName} complete"
-                                                );
+                                                    $"Validating: {message.OrigDataFileName} complete");
                                                 return result;
                                             }
                                         )
@@ -280,7 +279,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
                 if (totalRowCount % STAGE_1_ROW_CHECK == 0)
                 {
-                    await _importStatusService.UpdateProgress(releaseId, origDataFileName, (double)totalRowCount / dataRows * 100);
+                    await _importStatusService.UpdateProgress(releaseId,
+                        origDataFileName,
+                        IStatus.STAGE_1,
+                        (double) totalRowCount / dataRows * 100);
                 }
             }
 
@@ -288,8 +290,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             {
                 return errors;
             }
-            
-            await _importStatusService.UpdateProgress(releaseId, origDataFileName, 100);
+
+            await _importStatusService.UpdateProgress(releaseId,
+                origDataFileName,
+                IStatus.STAGE_1,
+                100);
 
             var rowsPerBatch = Convert.ToInt32(LoadAppSettings(executionContext).GetValue<string>("RowsPerBatch"));
 


### PR DESCRIPTION
Previously there were two different methods for `UpdateStatus` and `UpdateProgress`, and `UpdateProgress` did not check the existing status matched the intended status of the calling code doing the update.

When updating the Percentage Complete value in a `DatafileImport` row in Azure Table Storage, always set Status and Percentage Complete together so that there is no chance of to inadvertently writing a percentage value for a different phase and corrupting it.

![image](https://user-images.githubusercontent.com/4147126/98407671-f3446c00-2067-11eb-9e13-379d5d08866e.png)
