### PR TITLE
EES-1587 Alter title to Sign off to match the same label when managing content for Releases

### DIFF
--- a/src/explore-education-statistics-admin/src/routes/methodologyRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/methodologyRoutes.ts
@@ -33,6 +33,6 @@ export const methodologyContentRoute: MethodologyRouteProps = {
 
 export const methodologyStatusRoute: MethodologyRouteProps = {
   path: '/methodologies/:methodologyId/status',
-  title: 'Release status',
+  title: 'Sign off',
   component: MethodologyStatusPage,
 };


### PR DESCRIPTION
There is a UI test failing when approving a newly created methodology because it expects the 'status' tab label to be 'Sign off' rather than 'Release status'. This change updates the label to 'Sign off', matching the terminology used when managing Release content.