### PR TITLE
EES-1570 Allow Permalink query's `PublicationId` to be nullable

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -79,11 +79,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             var subject = await _subjectService.Get(permalink.Query.SubjectId);
             var isValid = subject != null && await _subjectService.IsSubjectForLatestPublishedRelease(subject.Id);
 
-            var publication = await _subjectService.GetPublicationForSubject(permalink.Query.SubjectId);
+            var publication = await _subjectService.FindPublicationForSubject(permalink.Query.SubjectId);
 
             var viewModel = _mapper.Map<PermalinkViewModel>(permalink);
 
-            viewModel.Query.PublicationId = publication.Id;
+            viewModel.Query.PublicationId = publication?.Id;
             viewModel.Invalidated = !isValid;
 
             return viewModel;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/ViewModels/TableBuilderQueryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/ViewModels/TableBuilderQueryViewModel.cs
@@ -5,6 +5,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.ViewModels
 {
     public class TableBuilderQueryViewModel : ObservationQueryContext
     {
-        public Guid PublicationId { get; set; }
+        public Guid? PublicationId { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/SubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/SubjectServiceTests.cs
@@ -281,6 +281,56 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
             }
         }
 
+        [Fact]
+        public async Task FindPublicationForSubject()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release
+                {
+                    Publication = new Publication
+                    {
+                        Title = "Test publication"
+                    },
+                },
+                Subject = new Subject
+                {
+                    Name = "Test subject"
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await context.AddAsync(releaseSubject);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildSubjectService(context);
+                var result = await service.FindPublicationForSubject(releaseSubject.SubjectId);
+
+                Assert.Equal(releaseSubject.Release.PublicationId, result.Id);
+                Assert.Equal("Test publication", result.Title);
+            }
+        }
+
+        [Fact]
+        public async Task FindPublicationForSubject_NotFoundReturnsNull()
+        {
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildSubjectService(context);
+                var result = await service.FindPublicationForSubject(Guid.NewGuid());
+
+                Assert.Null(result);
+            }
+        }
+
         private SubjectService BuildSubjectService(
             StatisticsDbContext statisticsDbContext,
             IReleaseService releaseService = null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/ISubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/ISubjectService.cs
@@ -11,6 +11,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfa
 
         Task<Publication> GetPublicationForSubject(Guid subjectId);
 
+        Task<Publication?> FindPublicationForSubject(Guid subjectId);
+
         Task<Subject?> Get(Guid releaseId, string subjectName);
 
         Task<Subject?> Get(Guid subjectId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
@@ -54,13 +54,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
 
         public Task<Publication> GetPublicationForSubject(Guid subjectId)
         {
+            return QueryPublicationForSubject(subjectId).FirstAsync();
+        }
+
+        public async Task<Publication?> FindPublicationForSubject(Guid subjectId)
+        {
+            return await QueryPublicationForSubject(subjectId).FirstOrDefaultAsync();
+        }
+
+        private IQueryable<Publication> QueryPublicationForSubject(Guid subjectId)
+        {
             return _context
                 .ReleaseSubject
                 .Include(r => r.Release)
                 .ThenInclude(r => r.Publication)
                 .Where(r => r.SubjectId == subjectId)
-                .Select(r => r.Release.Publication)
-                .FirstAsync();
+                .Select(r => r.Release.Publication);
         }
 
         public Task<List<Subject>> GetSubjectsForRelease(Guid releaseId)


### PR DESCRIPTION
This PR allows the permalink `Query.PublicationId` to be set to null as there will no longer be any link back to the Publication in the ticket's scenario. To enable this, we have added a `SubjectService.FindPublicationForSubject` method that returns the nullable Publication (instead of throwing when there is none).