### PR TITLE
Ees 1606 create tests project for processor

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MockUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MockUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -44,7 +45,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             where TEntity : class
         {
             helper
-                .Setup(s => s.CheckEntityExists<TEntity>(id,
+                .Setup(s => s.CheckEntityExists(id,
                                 It.IsAny<Func<IQueryable<TEntity>, IQueryable<TEntity>>>()))
                 .ReturnsAsync(new Either<ActionResult, TEntity>(entity));
         }
@@ -55,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             where TEntity : class
         { 
             helper
-                .Setup(s => s.CheckEntityExists<TEntity>(It.IsAny<Guid>(),
+                .Setup(s => s.CheckEntityExists(It.IsAny<Guid>(),
                     It.IsAny<Func<IQueryable<TEntity>, IQueryable<TEntity>>>()))
                 .ReturnsAsync(new Either<ActionResult, TEntity>(Activator.CreateInstance<TEntity>()));
         }
@@ -73,6 +74,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(true);
 
             return userService;
+        }
+        
+        public static void VerifyAllMocks(params object[] mocks)
+        {
+            mocks
+                .ToList()
+                .ForEach(m =>
+                {
+                    m.GetType().GetMethod("VerifyAll", Type.EmptyTypes).Invoke(m, null);
+                    m.GetType().GetMethod("VerifyNoOtherCalls", Type.EmptyTypes).Invoke(m, null);
+                });
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ImportStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ImportStatus.cs
@@ -44,7 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
             return IsAfterStage(IStatus.STAGE_4);
         }
         
-        private bool IsAfterStage(IStatus stage)
+        public bool IsAfterStage(IStatus stage)
         {
             return Status.CompareTo(stage) > 0;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ImportStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ImportStatus.cs
@@ -19,36 +19,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 
         public int NumberOfRows { get; set; }
 
-        public bool IsAfterArchiveProcessing()
-        {
-            return IsAfterStage(IStatus.PROCESSING_ARCHIVE_FILE);
-        }
-
-        public bool IsAfterStage1()
-        {
-            return IsAfterStage(IStatus.STAGE_1);
-        }
-        
-        public bool IsAfterStage2()
-        {
-            return IsAfterStage(IStatus.STAGE_2);
-        }
-        
-        public bool IsAfterStage3()
-        {
-            return IsAfterStage(IStatus.STAGE_3);
-        }
-        
-        public bool IsAfterStage4()
-        {
-            return IsAfterStage(IStatus.STAGE_4);
-        }
-        
-        public bool IsAfterStage(IStatus stage)
-        {
-            return Status.CompareTo(stage) > 0;
-        }
-
         public override string ToString()
         {
             return $"{Status} {PhasePercentageComplete}%, overall {PercentageComplete}%";

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorTests.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Models;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functions
+{
+    public class ProcessorTests
+    {
+        [Fact]
+        public void ProcessUploadsUnpackArchive()
+        {
+            var mocks = Mocks();
+            var (fileStorageService, processorService, importStatusService, batchService, fileImportService) = mocks;
+            var importStagesMessageQueue = new Mock<ICollector<ImportMessage>>();
+            var datafileProcessingMessageQueue = new Mock<ICollector<ImportMessage>>();
+
+            var message = new ImportMessage
+            {
+                ArchiveFileName = "an_archive",
+                Release = new Release
+                {
+                    Id = Guid.NewGuid()
+                },
+                DataFileName = "my_data_file",
+                OrigDataFileName = "my_data_file_original"
+            };
+
+            var processor = new Processor.Functions.Processor(
+                fileImportService.Object,
+                fileStorageService.Object,
+                batchService.Object,
+                importStatusService.Object,
+                processorService.Object,
+                new Mock<ILogger<Processor.Functions.Processor>>().Object);
+
+            processorService
+                .Setup(s => s.ProcessUnpackingArchive(message))
+                .Returns(Task.CompletedTask);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.Release.Id, message.OrigDataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = IStatus.QUEUED
+                });
+
+            importStatusService
+                .Setup(s => s.UpdateStatus(message.Release.Id, message.OrigDataFileName, IStatus.STAGE_1, 0, 0))
+                .Returns(Task.CompletedTask);
+
+            importStagesMessageQueue
+                .Setup(s => s.Add(message));
+
+            processor.ProcessUploads(
+                message,
+                null,
+                importStagesMessageQueue.Object,
+                datafileProcessingMessageQueue.Object
+            );
+
+            MockUtils.VerifyAllMocks(fileStorageService, processorService, importStatusService, batchService,
+                fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
+        }
+
+        [Fact]
+        public void ProcessUploadsUnpackArchiveWithNoArchive()
+        {
+            var mocks = Mocks();
+            var (fileStorageService, processorService, importStatusService, batchService, fileImportService) = mocks;
+            var importStagesMessageQueue = new Mock<ICollector<ImportMessage>>();
+            var datafileProcessingMessageQueue = new Mock<ICollector<ImportMessage>>();
+
+            var message = new ImportMessage
+            {
+                ArchiveFileName = "",
+                Release = new Release
+                {
+                    Id = Guid.NewGuid()
+                },
+                DataFileName = "my_data_file",
+                OrigDataFileName = "my_data_file_original"
+            };
+
+            var processor = new Processor.Functions.Processor(
+                fileImportService.Object,
+                fileStorageService.Object,
+                batchService.Object,
+                importStatusService.Object,
+                processorService.Object,
+                new Mock<ILogger<Processor.Functions.Processor>>().Object);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.Release.Id, message.OrigDataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = IStatus.QUEUED
+                });
+
+            importStatusService
+                .Setup(s => s.UpdateStatus(message.Release.Id, message.OrigDataFileName, IStatus.STAGE_1, 0, 0))
+                .Returns(Task.CompletedTask);
+
+            importStagesMessageQueue
+                .Setup(s => s.Add(message));
+
+            processor.ProcessUploads(
+                message,
+                null,
+                importStagesMessageQueue.Object,
+                datafileProcessingMessageQueue.Object
+            );
+
+            MockUtils.VerifyAllMocks(fileStorageService, processorService, importStatusService, batchService,
+                fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
+        }
+
+        [Fact]
+        public void ProcessUploadsStage1()
+        {
+            var mocks = Mocks();
+            var (fileStorageService, processorService, importStatusService, batchService, fileImportService) = mocks;
+            var importStagesMessageQueue = new Mock<ICollector<ImportMessage>>();
+            var datafileProcessingMessageQueue = new Mock<ICollector<ImportMessage>>();
+
+            var message = new ImportMessage
+            {
+                ArchiveFileName = "",
+                Release = new Release
+                {
+                    Id = Guid.NewGuid()
+                },
+                DataFileName = "my_data_file",
+                OrigDataFileName = "my_data_file_original"
+            };
+            
+            var executionContext = new ExecutionContext();
+            
+            var processor = new Processor.Functions.Processor(
+                fileImportService.Object,
+                fileStorageService.Object,
+                batchService.Object,
+                importStatusService.Object, 
+                processorService.Object,
+                new Mock<ILogger<Processor.Functions.Processor>>().Object);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.Release.Id, message.OrigDataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = IStatus.STAGE_1
+                });
+
+            processorService
+                .Setup(s => s.ProcessStage1(message, executionContext))
+                .Returns(Task.CompletedTask);
+
+            importStatusService
+                .Setup(s => s.UpdateStatus(message.Release.Id, message.OrigDataFileName, IStatus.STAGE_2, 0, 0))
+                .Returns(Task.CompletedTask);
+
+            importStagesMessageQueue
+                .Setup(s => s.Add(message));
+
+            processor.ProcessUploads(
+                message,
+                executionContext,
+                importStagesMessageQueue.Object,
+                datafileProcessingMessageQueue.Object
+            );
+
+            MockUtils.VerifyAllMocks(fileStorageService, processorService, importStatusService, batchService,
+                fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
+        }
+
+        [Fact]
+        public void ProcessUploadsStage2()
+        {
+            var mocks = Mocks();
+            var (fileStorageService, processorService, importStatusService, batchService, fileImportService) = mocks;
+            var importStagesMessageQueue = new Mock<ICollector<ImportMessage>>();
+            var datafileProcessingMessageQueue = new Mock<ICollector<ImportMessage>>();
+
+            var message = new ImportMessage
+            {
+                ArchiveFileName = "",
+                Release = new Release
+                {
+                    Id = Guid.NewGuid()
+                },
+                DataFileName = "my_data_file",
+                OrigDataFileName = "my_data_file_original"
+            };
+            
+            var processor = new Processor.Functions.Processor(
+                fileImportService.Object,
+                fileStorageService.Object,
+                batchService.Object,
+                importStatusService.Object, 
+                processorService.Object,
+                new Mock<ILogger<Processor.Functions.Processor>>().Object);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.Release.Id, message.OrigDataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = IStatus.STAGE_2
+                });
+
+            processorService
+                .Setup(s => s.ProcessStage2(message))
+                .Returns(Task.CompletedTask);
+
+            importStatusService
+                .Setup(s => s.UpdateStatus(message.Release.Id, message.OrigDataFileName, IStatus.STAGE_3, 0, 0))
+                .Returns(Task.CompletedTask);
+
+            importStagesMessageQueue
+                .Setup(s => s.Add(message));
+
+            processor.ProcessUploads(
+                message,
+                null,
+                importStagesMessageQueue.Object,
+                datafileProcessingMessageQueue.Object
+            );
+
+            MockUtils.VerifyAllMocks(fileStorageService, processorService, importStatusService, batchService,
+                fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
+        }
+
+        [Fact]
+        public void ProcessUploadsStage3()
+        {
+            var mocks = Mocks();
+            var (fileStorageService, processorService, importStatusService, batchService, fileImportService) = mocks;
+            var importStagesMessageQueue = new Mock<ICollector<ImportMessage>>();
+            var datafileProcessingMessageQueue = new Mock<ICollector<ImportMessage>>();
+
+            var message = new ImportMessage
+            {
+                ArchiveFileName = "",
+                Release = new Release
+                {
+                    Id = Guid.NewGuid()
+                },
+                DataFileName = "my_data_file",
+                OrigDataFileName = "my_data_file_original"
+            };
+            
+            var processor = new Processor.Functions.Processor(
+                fileImportService.Object,
+                fileStorageService.Object,
+                batchService.Object,
+                importStatusService.Object, 
+                processorService.Object,
+                new Mock<ILogger<Processor.Functions.Processor>>().Object);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.Release.Id, message.OrigDataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = IStatus.STAGE_3
+                });
+
+            processorService
+                .Setup(s => s.ProcessStage3(message))
+                .Returns(Task.CompletedTask);
+
+            importStatusService
+                .Setup(s => s.UpdateStatus(message.Release.Id, message.OrigDataFileName, IStatus.STAGE_4, 0, 0))
+                .Returns(Task.CompletedTask);
+
+            importStagesMessageQueue
+                .Setup(s => s.Add(message));
+
+            processor.ProcessUploads(
+                message,
+                null,
+                importStagesMessageQueue.Object,
+                datafileProcessingMessageQueue.Object
+            );
+
+            MockUtils.VerifyAllMocks(fileStorageService, processorService, importStatusService, batchService,
+                fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
+        }
+        
+        [Fact]
+        public void ProcessUploadsStage4Messages()
+        {
+            var mocks = Mocks();
+            var (fileStorageService, processorService, importStatusService, batchService, fileImportService) = mocks;
+            var importStagesMessageQueue = new Mock<ICollector<ImportMessage>>();
+            var datafileProcessingMessageQueue = new Mock<ICollector<ImportMessage>>();
+
+            var message = new ImportMessage
+            {
+                ArchiveFileName = "",
+                Release = new Release
+                {
+                    Id = Guid.NewGuid()
+                },
+                DataFileName = "my_data_file",
+                OrigDataFileName = "my_data_file_original"
+            };
+            
+            var processor = new Processor.Functions.Processor(
+                fileImportService.Object,
+                fileStorageService.Object,
+                batchService.Object,
+                importStatusService.Object, 
+                processorService.Object,
+                new Mock<ILogger<Processor.Functions.Processor>>().Object);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.Release.Id, message.OrigDataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = IStatus.STAGE_4
+                });
+
+            processorService
+                .Setup(s => s.ProcessStage4Messages(message, datafileProcessingMessageQueue.Object))
+                .Returns(Task.CompletedTask);
+
+            processor.ProcessUploads(
+                message,
+                null,
+                importStagesMessageQueue.Object,
+                datafileProcessingMessageQueue.Object
+            );
+
+            MockUtils.VerifyAllMocks(fileStorageService, processorService, importStatusService, batchService,
+                fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
+        }
+
+        private (
+            Mock<IFileStorageService>,
+            Mock<IProcessorService>,
+            Mock<IImportStatusService>,
+            Mock<IBatchService>,
+            Mock<IFileImportService>
+        ) Mocks() {
+            return (
+                new Mock<IFileStorageService>(),
+                new Mock<IProcessorService>(),
+                new Mock<IImportStatusService>(),
+                new Mock<IBatchService>(),
+                new Mock<IFileImportService>()
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorTests.cs
@@ -5,7 +5,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
-using GovUk.Education.ExploreEducationStatistics.Data.Processor.Models;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
@@ -20,7 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
         public void ProcessUploadsUnpackArchive()
         {
             var mocks = Mocks();
-            var (fileStorageService, processorService, importStatusService, batchService, fileImportService) = mocks;
+            var (processorService, importStatusService, batchService, fileImportService) = mocks;
             var importStagesMessageQueue = new Mock<ICollector<ImportMessage>>();
             var datafileProcessingMessageQueue = new Mock<ICollector<ImportMessage>>();
 
@@ -37,7 +36,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
 
             var processor = new Processor.Functions.Processor(
                 fileImportService.Object,
-                fileStorageService.Object,
                 batchService.Object,
                 importStatusService.Object,
                 processorService.Object,
@@ -68,7 +66,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 datafileProcessingMessageQueue.Object
             );
 
-            MockUtils.VerifyAllMocks(fileStorageService, processorService, importStatusService, batchService,
+            MockUtils.VerifyAllMocks(processorService, importStatusService, batchService,
                 fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
         }
 
@@ -76,7 +74,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
         public void ProcessUploadsUnpackArchiveWithNoArchive()
         {
             var mocks = Mocks();
-            var (fileStorageService, processorService, importStatusService, batchService, fileImportService) = mocks;
+            var (processorService, importStatusService, batchService, fileImportService) = mocks;
             var importStagesMessageQueue = new Mock<ICollector<ImportMessage>>();
             var datafileProcessingMessageQueue = new Mock<ICollector<ImportMessage>>();
 
@@ -93,7 +91,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
 
             var processor = new Processor.Functions.Processor(
                 fileImportService.Object,
-                fileStorageService.Object,
                 batchService.Object,
                 importStatusService.Object,
                 processorService.Object,
@@ -120,7 +117,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 datafileProcessingMessageQueue.Object
             );
 
-            MockUtils.VerifyAllMocks(fileStorageService, processorService, importStatusService, batchService,
+            MockUtils.VerifyAllMocks(processorService, importStatusService, batchService,
                 fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
         }
 
@@ -128,7 +125,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
         public void ProcessUploadsStage1()
         {
             var mocks = Mocks();
-            var (fileStorageService, processorService, importStatusService, batchService, fileImportService) = mocks;
+            var (processorService, importStatusService, batchService, fileImportService) = mocks;
             var importStagesMessageQueue = new Mock<ICollector<ImportMessage>>();
             var datafileProcessingMessageQueue = new Mock<ICollector<ImportMessage>>();
 
@@ -147,7 +144,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
             
             var processor = new Processor.Functions.Processor(
                 fileImportService.Object,
-                fileStorageService.Object,
                 batchService.Object,
                 importStatusService.Object, 
                 processorService.Object,
@@ -178,7 +174,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 datafileProcessingMessageQueue.Object
             );
 
-            MockUtils.VerifyAllMocks(fileStorageService, processorService, importStatusService, batchService,
+            MockUtils.VerifyAllMocks(processorService, importStatusService, batchService,
                 fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
         }
 
@@ -186,7 +182,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
         public void ProcessUploadsStage2()
         {
             var mocks = Mocks();
-            var (fileStorageService, processorService, importStatusService, batchService, fileImportService) = mocks;
+            var (processorService, importStatusService, batchService, fileImportService) = mocks;
             var importStagesMessageQueue = new Mock<ICollector<ImportMessage>>();
             var datafileProcessingMessageQueue = new Mock<ICollector<ImportMessage>>();
 
@@ -203,7 +199,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
             
             var processor = new Processor.Functions.Processor(
                 fileImportService.Object,
-                fileStorageService.Object,
                 batchService.Object,
                 importStatusService.Object, 
                 processorService.Object,
@@ -234,7 +229,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 datafileProcessingMessageQueue.Object
             );
 
-            MockUtils.VerifyAllMocks(fileStorageService, processorService, importStatusService, batchService,
+            MockUtils.VerifyAllMocks(processorService, importStatusService, batchService,
                 fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
         }
 
@@ -242,7 +237,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
         public void ProcessUploadsStage3()
         {
             var mocks = Mocks();
-            var (fileStorageService, processorService, importStatusService, batchService, fileImportService) = mocks;
+            var (processorService, importStatusService, batchService, fileImportService) = mocks;
             var importStagesMessageQueue = new Mock<ICollector<ImportMessage>>();
             var datafileProcessingMessageQueue = new Mock<ICollector<ImportMessage>>();
 
@@ -259,7 +254,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
             
             var processor = new Processor.Functions.Processor(
                 fileImportService.Object,
-                fileStorageService.Object,
                 batchService.Object,
                 importStatusService.Object, 
                 processorService.Object,
@@ -290,7 +284,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 datafileProcessingMessageQueue.Object
             );
 
-            MockUtils.VerifyAllMocks(fileStorageService, processorService, importStatusService, batchService,
+            MockUtils.VerifyAllMocks(processorService, importStatusService, batchService,
                 fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
         }
         
@@ -298,7 +292,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
         public void ProcessUploadsStage4Messages()
         {
             var mocks = Mocks();
-            var (fileStorageService, processorService, importStatusService, batchService, fileImportService) = mocks;
+            var (processorService, importStatusService, batchService, fileImportService) = mocks;
             var importStagesMessageQueue = new Mock<ICollector<ImportMessage>>();
             var datafileProcessingMessageQueue = new Mock<ICollector<ImportMessage>>();
 
@@ -315,7 +309,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
             
             var processor = new Processor.Functions.Processor(
                 fileImportService.Object,
-                fileStorageService.Object,
                 batchService.Object,
                 importStatusService.Object, 
                 processorService.Object,
@@ -339,19 +332,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 datafileProcessingMessageQueue.Object
             );
 
-            MockUtils.VerifyAllMocks(fileStorageService, processorService, importStatusService, batchService,
+            MockUtils.VerifyAllMocks(processorService, importStatusService, batchService,
                 fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
         }
 
         private (
-            Mock<IFileStorageService>,
             Mock<IProcessorService>,
             Mock<IImportStatusService>,
             Mock<IBatchService>,
             Mock<IFileImportService>
         ) Mocks() {
             return (
-                new Mock<IFileStorageService>(),
                 new Mock<IProcessorService>(),
                 new Mock<IImportStatusService>(),
                 new Mock<IBatchService>(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <RootNamespace>GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="Moq" Version="4.13.1" />
+        <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Admin.Tests\GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj" />
+        <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
+        <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Processor\GovUk.Education.ExploreEducationStatistics.Data.Processor.csproj" />
+    </ItemGroup>
+    
+</Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
@@ -17,14 +17,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
     {
         private readonly IBatchService _batchService;
         private readonly IFileImportService _fileImportService;
-        private readonly IFileStorageService _fileStorageService;
         private readonly IImportStatusService _importStatusService;
         private readonly IProcessorService _processorService;
         private readonly ILogger<Processor> _logger;
 
         public Processor(
             IFileImportService fileImportService,
-            IFileStorageService fileStorageService,
             IBatchService batchService,
             IImportStatusService importStatusService,
             IProcessorService processorService,
@@ -32,7 +30,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
         )
         {
             _fileImportService = fileImportService;
-            _fileStorageService = fileStorageService;
             _batchService = batchService;
             _importStatusService = importStatusService;
             _processorService = processorService;
@@ -51,10 +48,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
             {
                 var status = await _importStatusService.GetImportStatus(message.Release.Id, message.OrigDataFileName);
 
+                _logger.LogInformation($"Processor Function processing import message for " +
+                                       $"{message.OrigDataFileName} at stage {status.Status}");
+                
                 if (status.Status == IStatus.QUEUED || status.Status == IStatus.PROCESSING_ARCHIVE_FILE)
                 {
                     if (message.ArchiveFileName != "")
                     {
+                        _logger.LogInformation($"Unpacking archive for {message.OrigDataFileName}");
                         await _processorService.ProcessUnpackingArchive(message);
                     }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IProcessorService.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Models;
+using Microsoft.Azure.WebJobs;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces
+{
+    public interface IProcessorService
+    {
+        Task ProcessUnpackingArchive(ImportMessage message);
+
+        Task ProcessStage1(ImportMessage message, ExecutionContext executionContext);
+
+        Task ProcessStage2(ImportMessage message);
+
+        Task ProcessStage3(ImportMessage message);
+
+        Task ProcessStage4Messages(ImportMessage message, ICollector<ImportMessage> collector);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
@@ -57,7 +57,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             var subjectData = await _fileStorageService.GetSubjectData(message);
 
             await _validatorService.Validate(message.Release.Id, subjectData, executionContext, message)
-                .OnSuccess(async result =>
+                .OnSuccessDo(async result =>
                 {
                     message.RowsPerBatch = result.RowsPerBatch;
                     message.TotalRows = result.FilteredObservationCount;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
@@ -1,0 +1,123 @@
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Importer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Importer.Utils;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Models;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Utils;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
+{
+    public class ProcessorService : IProcessorService
+    {
+        private readonly ILogger<ProcessorService> _logger;
+        private readonly IBatchService _batchService;
+        private readonly IFileImportService _fileImportService;
+        private readonly IFileStorageService _fileStorageService;
+        private readonly IImporterService _importerService;
+        private readonly IReleaseProcessorService _releaseProcessorService;
+        private readonly ISplitFileService _splitFileService;
+        private readonly IValidatorService _validatorService;
+        private readonly IDataArchiveService _dataArchiveService;
+
+        public ProcessorService(
+            ILogger<ProcessorService> logger,
+            IFileImportService fileImportService,
+            IReleaseProcessorService releaseProcessorService,
+            IFileStorageService fileStorageService,
+            ISplitFileService splitFileService,
+            IImporterService importerService,
+            IBatchService batchService,
+            IValidatorService validatorService,
+            IDataArchiveService dataArchiveService)
+        {
+            _logger = logger;
+            _fileImportService = fileImportService;
+            _releaseProcessorService = releaseProcessorService;
+            _fileStorageService = fileStorageService;
+            _splitFileService = splitFileService;
+            _importerService = importerService;
+            _batchService = batchService;
+            _validatorService = validatorService;
+            _dataArchiveService = dataArchiveService;
+        }
+
+        public async Task ProcessUnpackingArchive(ImportMessage message)
+        {
+            await _dataArchiveService.ExtractDataFiles(message.Release.Id, message.ArchiveFileName);
+        }
+
+        public async Task ProcessStage1(ImportMessage message, ExecutionContext executionContext)
+        {
+            var subjectData = await _fileStorageService.GetSubjectData(message);
+
+            await _validatorService.Validate(message.Release.Id, subjectData, executionContext, message)
+                .OnSuccess(async result =>
+                {
+                    message.RowsPerBatch = result.RowsPerBatch;
+                    message.TotalRows = result.FilteredObservationCount;
+                    message.NumBatches = result.NumBatches;
+                    await _batchService.UpdateStoredMessage(message);
+                })
+                .OnFailureDo(async errors =>
+                {
+                    await _batchService.FailImport(message.Release.Id,
+                        message.OrigDataFileName,
+                        errors);
+
+                    _logger.LogError($"Import FAILED for {message.DataFileName}...check log");
+                });
+        }
+
+        public async Task ProcessStage2(ImportMessage message)
+        {
+            var subjectData = await _fileStorageService.GetSubjectData(message);
+
+            await ProcessSubject(message,
+                DbUtils.CreateStatisticsDbContext(),
+                DbUtils.CreateContentDbContext(),
+                subjectData);
+
+        }
+
+        public async Task ProcessStage3(ImportMessage message)
+        {
+            var subjectData = await _fileStorageService.GetSubjectData(message);
+
+            await _splitFileService.SplitDataFile(message, subjectData);
+        }
+
+        public async Task ProcessStage4Messages(ImportMessage message, ICollector<ImportMessage> collector)
+        {
+            await _splitFileService.AddBatchDataFileMessages(collector, message);
+        }
+        
+        private async Task ProcessSubject(
+            ImportMessage message,
+            StatisticsDbContext statisticsDbContext,
+            ContentDbContext contentDbContext,
+            SubjectData subjectData)
+        {
+            var subject = _releaseProcessorService.CreateOrUpdateRelease(subjectData,
+                message,
+                statisticsDbContext,
+                contentDbContext);
+
+            await using var metaFileStream = await _fileStorageService.StreamBlob(subjectData.MetaBlob);
+            var metaFileTable = DataTableUtils.CreateFromStream(metaFileStream);
+
+            _importerService.ImportMeta(metaFileTable, subject, statisticsDbContext);
+
+            await statisticsDbContext.SaveChangesAsync();
+
+            await _fileImportService.ImportFiltersLocationsAndSchools(message, statisticsDbContext);
+
+            await statisticsDbContext.SaveChangesAsync();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
@@ -53,7 +53,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             ImportMessage message,
             SubjectData subjectData)
         {
-            await _importStatusService.UpdateStatus(message.Release.Id, message.OrigDataFileName, IStatus.STAGE_3);
             await using var dataFileStream = await _fileStorageService.StreamBlob(subjectData.DataBlob);
             
             var dataFileTable = DataTableUtils.CreateFromStream(dataFileStream);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
@@ -87,7 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         {
             _logger.LogInformation($"Validating: {message.OrigDataFileName}");
 
-            await _importStatusService.UpdateStatus(message.Release.Id, message.DataFileName, IStatus.STAGE_1);
+            await _importStatusService.UpdateStatus(message.Release.Id, message.OrigDataFileName, IStatus.STAGE_1);
 
             return await ValidateCsvFile(subjectData.DataBlob, false)
                 .OnSuccessDo(async () => await ValidateCsvFile(subjectData.MetaBlob, true))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Startup.cs
@@ -54,6 +54,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
                 .AddSingleton<IDataArchiveService, DataArchiveService>()
                 .AddSingleton<IFileTypeService, FileTypeService>()
                 .AddSingleton<IGuidGenerator, SequentialGuidGenerator>()
+                .AddSingleton<IProcessorService, ProcessorService>()
                 .BuildServiceProvider();
 
             ImportRecoveryHandler.CheckIncompleteImports(GetConfigurationValue(serviceProvider, "CoreStorage"));

--- a/src/GovUk.Education.ExploreEducationStatistics.sln
+++ b/src/GovUk.Education.ExploreEducationStatistics.sln
@@ -47,6 +47,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEduc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEducationStatistics.Data.Model.Tests", "GovUk.Education.ExploreEducationStatistics.Data.Model.Tests\GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.csproj", "{3C5E55E5-D879-43CC-8F8C-C706EE9E63EF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests", "GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests\GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.csproj", "{98E32217-944F-4978-B7AD-6DDA250EF15C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -321,6 +323,18 @@ Global
 		{3C5E55E5-D879-43CC-8F8C-C706EE9E63EF}.Release|x64.Build.0 = Release|Any CPU
 		{3C5E55E5-D879-43CC-8F8C-C706EE9E63EF}.Release|x86.ActiveCfg = Release|Any CPU
 		{3C5E55E5-D879-43CC-8F8C-C706EE9E63EF}.Release|x86.Build.0 = Release|Any CPU
+		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Debug|x64.Build.0 = Debug|Any CPU
+		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Debug|x86.Build.0 = Debug|Any CPU
+		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Release|x64.ActiveCfg = Release|Any CPU
+		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Release|x64.Build.0 = Release|Any CPU
+		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Release|x86.ActiveCfg = Release|Any CPU
+		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR: 
- adds a new "Processor.Tests" project to the EES solution
- refactors Processor.cs to execute stages for an importing file in a more granular way, processing a stage at a time for an importing file (rather than running through multiple consecutive stages in one go), then posting a new Queue message to initiate the next stage.  This makes it easier to test and brings it more in line with the expectations of ImportRecoveryHandler, which expects to be able to simply post a message of an interrupted import to the "imports-pending" queue, and have it pick up on the current stage of import based purely on the ImportStatus record of that file
- adds a ProcessorTests test suite to test the refactored Processor
- fixes a race condition between Processor and BatchService, whereby they were both attempting to update an ImportMessage's status in an inconsistent order, leading to Stage 1 occasionally being executed more than once