### PR TITLE
EES-92 Fix map tooltips becoming too wide for map container

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.module.scss
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlock.module.scss
@@ -21,15 +21,22 @@
   }
 }
 
+.tooltip {
+  white-space: normal;
+  width: 100%;
+}
+
 .tooltipList {
   list-style: none;
   margin-bottom: 0;
   padding-left: 0;
 
   li {
-    align-items: center;
-    display: flex;
     font-size: 0.9rem;
+    margin-bottom: govuk-spacing(2);
+  }
+
+  li:last-of-type {
     margin-bottom: 0;
   }
 }

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -368,11 +368,20 @@ export const MapBlockInternal = ({
             },
           );
 
+          const mapWidth = mapRef.current?.container?.clientWidth;
+
+          // Not ideal, we would want to use `max-width` instead.
+          // Unfortunately it doesn't seem to work with the tooltip
+          // for some reason (maybe due to the pane styling).
+          const tooltipStyle = mapWidth ? `width: ${mapWidth / 2}px` : '';
+
           return (
+            `<div class="${styles.tooltip}" style="${tooltipStyle}">` +
             `<p><strong data-testid="chartTooltip-label">${feature.properties.name}</strong></p>` +
             `<ul class="${
               styles.tooltipList
-            }" data-testid="chartTooltip-items">${items.join('')}</ul>`
+            }" data-testid="chartTooltip-items">${items.join()}</ul>` +
+            `</div>`
           );
         }
 


### PR DESCRIPTION
This change prevents map tooltips with lots of content from becoming toowide for the map container. This bug would typically make it really hardto use the map as most of the tooltip content could be shifted out of the map pane.