### PR TITLE
EES-1615 Prevent cascade delete in one-to-many relationship between Location and Observations.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
@@ -64,6 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
             ConfigureIndicatorFootnote(modelBuilder);
             ConfigureLocation(modelBuilder);
             ConfigureMeasures(modelBuilder);
+            ConfigureObservation(modelBuilder);
             ConfigureObservationFilterItem(modelBuilder);
             ConfigurePublication(modelBuilder);
             ConfigureRelease(modelBuilder);
@@ -100,6 +101,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
             ConfigureSponsor(modelBuilder);
             ConfigureWard(modelBuilder);
             ConfigurePlanningArea(modelBuilder);
+        }
+
+        private static void ConfigureObservation(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Observation>()
+                .HasOne(observation => observation.Location)
+                .WithMany()
+                .HasForeignKey(observation => observation.LocationId)
+                .OnDelete(DeleteBehavior.Restrict);
         }
 
         private static void ConfigureObservationFilterItem(ModelBuilder modelBuilder)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Location.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Location.cs
@@ -20,7 +20,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public Sponsor Sponsor { get; set; }
         public Ward Ward { get; set; }
         public PlanningArea PlanningArea { get; set; }
-        
-        public ICollection<Observation> Observations { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20201120112425_EES1615RemoveCascadeDeleteBetweenLocationAndObservation.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20201120112425_EES1615RemoveCascadeDeleteBetweenLocationAndObservation.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
-    partial class StatisticsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201120112425_EES1615RemoveCascadeDeleteBetweenLocationAndObservation")]
+    partial class EES1615RemoveCascadeDeleteBetweenLocationAndObservation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20201120112425_EES1615RemoveCascadeDeleteBetweenLocationAndObservation.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20201120112425_EES1615RemoveCascadeDeleteBetweenLocationAndObservation.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
+{
+    public partial class EES1615RemoveCascadeDeleteBetweenLocationAndObservation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Observation_Location_LocationId",
+                table: "Observation");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Observation_Location_LocationId",
+                table: "Observation",
+                column: "LocationId",
+                principalTable: "Location",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Observation_Location_LocationId",
+                table: "Observation");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Observation_Location_LocationId",
+                table: "Observation",
+                column: "LocationId",
+                principalTable: "Location",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
This PR removes the cascade delete operation in the one-to-many relationship, `Location-Observation`.

Currently deleting Location (parent) will delete all the associated Observations (children) as the relationship had the default Cascade delete strategy.

This could have had potentially catastrophic consequences if somebody deleted a Location thinking it's either unused by any Observations when it's not, or expected the delete to fail if it's used by any Observations, which it won't.