### PR TITLE
EES-1618 - swapped out singleton wiring for transient for new ProcessorService

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Startup.cs
@@ -54,7 +54,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
                 .AddSingleton<IDataArchiveService, DataArchiveService>()
                 .AddSingleton<IFileTypeService, FileTypeService>()
                 .AddSingleton<IGuidGenerator, SequentialGuidGenerator>()
-                .AddSingleton<IProcessorService, ProcessorService>()
+                .AddTransient<IProcessorService, ProcessorService>()
                 .BuildServiceProvider();
 
             ImportRecoveryHandler.CheckIncompleteImports(GetConfigurationValue(serviceProvider, "CoreStorage"));


### PR DESCRIPTION
This PR switches the new ProcessorService to be transient, as some of its dependencies are transient and its prior Singleton wiring was causing these transient dependencies to take on a Singleton lifecycle.