### PR TITLE
EES-1605 Re-add 2 d.p as default for map legend groups and indicators

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -24,8 +24,9 @@ import {
 import { Dictionary } from '@common/types';
 import generateHslColour from '@common/utils/colour/generateHslColour';
 import lighten from '@common/utils/colour/lighten';
-import countDecimals from '@common/utils/number/countDecimals';
-import formatPretty from '@common/utils/number/formatPretty';
+import formatPretty, {
+  defaultDecimalPlaces,
+} from '@common/utils/number/formatPretty';
 import getMinMax from '@common/utils/number/getMinMax';
 import { roundDownToNearest } from '@common/utils/number/roundNearest';
 import classNames from 'classnames';
@@ -88,7 +89,7 @@ function generateGeometryAndLegend(
 
   const {
     unit,
-    decimalPlaces,
+    decimalPlaces = defaultDecimalPlaces,
   } = selectedDataSetConfiguration.dataSet.indicator;
 
   const { min = 0, max = 0 } = getMinMax(
@@ -109,8 +110,7 @@ function generateGeometryAndLegend(
   // Calculate the increment between values by using
   // decimal places expressed as a proportion of 1 e.g.
   // 1 decimal place is 0.1, 2 decimal places is 0.01, etc.
-  const valueIncrement =
-    1 / 10 ** (decimalPlaces ?? countDecimals(range * groupSize));
+  const valueIncrement = 1 / 10 ** decimalPlaces;
 
   const legend: LegendEntry[] =
     range > 0

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlock.test.tsx
@@ -45,11 +45,11 @@ describe('MapBlock', () => {
     const legendItems = screen.getAllByTestId('mapBlock-legend-item');
 
     expect(legendItems).toHaveLength(5);
-    expect(legendItems[0]).toHaveTextContent('3% to 3.2%');
-    expect(legendItems[1]).toHaveTextContent('3.3% to 3.4%');
-    expect(legendItems[2]).toHaveTextContent('3.5% to 3.6%');
-    expect(legendItems[3]).toHaveTextContent('3.7% to 3.8%');
-    expect(legendItems[4]).toHaveTextContent('3.9% to 4%');
+    expect(legendItems[0]).toHaveTextContent('3.00% to 3.20%');
+    expect(legendItems[1]).toHaveTextContent('3.21% to 3.40%');
+    expect(legendItems[2]).toHaveTextContent('3.41% to 3.60%');
+    expect(legendItems[3]).toHaveTextContent('3.61% to 3.80%');
+    expect(legendItems[4]).toHaveTextContent('3.81% to 4.00%');
 
     const legendColours = screen.getAllByTestId('mapBlock-legend-colour');
 
@@ -67,7 +67,7 @@ describe('MapBlock', () => {
         draft.results[0].measures['authorised-absence-rate'] = '3.5123';
         draft.results[1].measures['authorised-absence-rate'] = '3.012';
         draft.results[2].measures['authorised-absence-rate'] = '4.009';
-        draft.subjectMeta.indicators[0].decimalPlaces = 2;
+        draft.subjectMeta.indicators[0].decimalPlaces = 1;
       }),
     );
 
@@ -83,11 +83,11 @@ describe('MapBlock', () => {
       const legendItems = screen.getAllByTestId('mapBlock-legend-item');
 
       expect(legendItems).toHaveLength(5);
-      expect(legendItems[0]).toHaveTextContent('3.01% to 3.21%');
-      expect(legendItems[1]).toHaveTextContent('3.22% to 3.41%');
-      expect(legendItems[2]).toHaveTextContent('3.42% to 3.61%');
-      expect(legendItems[3]).toHaveTextContent('3.62% to 3.81%');
-      expect(legendItems[4]).toHaveTextContent('3.82% to 4.01%');
+      expect(legendItems[0]).toHaveTextContent('3.0% to 3.2%');
+      expect(legendItems[1]).toHaveTextContent('3.3% to 3.4%');
+      expect(legendItems[2]).toHaveTextContent('3.5% to 3.6%');
+      expect(legendItems[3]).toHaveTextContent('3.7% to 3.8%');
+      expect(legendItems[4]).toHaveTextContent('3.9% to 4.0%');
     });
   });
 
@@ -152,11 +152,11 @@ describe('MapBlock', () => {
 
     const legendItems = screen.getAllByTestId('mapBlock-legend-item');
 
-    expect(legendItems[0]).toHaveTextContent('4.7% to 4.78%');
-    expect(legendItems[1]).toHaveTextContent('4.78% to 4.86%');
-    expect(legendItems[2]).toHaveTextContent('4.86% to 4.94%');
-    expect(legendItems[3]).toHaveTextContent('4.94% to 5.02%');
-    expect(legendItems[4]).toHaveTextContent('5.02% to 5.1%');
+    expect(legendItems[0]).toHaveTextContent('4.70% to 4.78%');
+    expect(legendItems[1]).toHaveTextContent('4.79% to 4.86%');
+    expect(legendItems[2]).toHaveTextContent('4.87% to 4.94%');
+    expect(legendItems[3]).toHaveTextContent('4.95% to 5.02%');
+    expect(legendItems[4]).toHaveTextContent('5.03% to 5.10%');
 
     const legendColours = screen.getAllByTestId('mapBlock-legend-colour');
 
@@ -214,7 +214,7 @@ describe('MapBlock', () => {
       'Authorised absence rate (2016/17)',
     );
     expect(tile1.getByTestId('mapBlock-indicatorTile-value')).toHaveTextContent(
-      '3.5%',
+      '3.50%',
     );
 
     const tile2 = within(indicators[1]);
@@ -223,7 +223,7 @@ describe('MapBlock', () => {
       'Overall absence rate (2016/17)',
     );
     expect(tile2.getByTestId('mapBlock-indicatorTile-value')).toHaveTextContent(
-      '4.8%',
+      '4.80%',
     );
   });
 

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
@@ -83,18 +83,21 @@ export const testMapTableData: TableDataResponse = {
         unit: '%',
         value: 'authorised-absence-rate',
         name: 'sess_authorised_percent',
+        decimalPlaces: 2,
       },
       {
         label: 'Unauthorised absence rate',
         unit: '%',
         value: 'unauthorised-absence-rate',
         name: 'sess_unauthorised_percent',
+        decimalPlaces: 2,
       },
       {
         label: 'Overall absence rate',
         unit: '%',
         value: 'overall-absence-rate',
         name: 'sess_overall_percent',
+        decimalPlaces: 2,
       },
     ],
     locations: [

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/TimePeriodDataTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/TimePeriodDataTable.test.tsx.snap
@@ -530,7 +530,7 @@ exports[`TimePeriodDataTable renders table with only one of each option and no f
       England
     </th>
     <td class="govuk-table__cell--numeric borderBottom">
-      18.3%
+      18.30%
     </td>
   </tr>
 </tbody>

--- a/src/explore-education-statistics-common/src/utils/number/__tests__/formatPretty.test.ts
+++ b/src/explore-education-statistics-common/src/utils/number/__tests__/formatPretty.test.ts
@@ -2,7 +2,7 @@ import formatPretty from '../formatPretty';
 
 describe('formatPretty', () => {
   test('returns formatted string from integer', () => {
-    expect(formatPretty(150000000)).toBe('150,000,000');
+    expect(formatPretty(150000000)).toBe('150,000,000.00');
     expect(formatPretty(150000000, '', 1)).toBe('150,000,000.0');
     expect(formatPretty(150000000, '', 2)).toBe('150,000,000.00');
   });
@@ -23,7 +23,7 @@ describe('formatPretty', () => {
   });
 
   test('returns formatted string from string containing integer', () => {
-    expect(formatPretty('150000000')).toBe('150,000,000');
+    expect(formatPretty('150000000')).toBe('150,000,000.00');
     expect(formatPretty('150000000', '', 1)).toBe('150,000,000.0');
     expect(formatPretty('150000000', '', 2)).toBe('150,000,000.00');
   });

--- a/src/explore-education-statistics-common/src/utils/number/formatPretty.ts
+++ b/src/explore-education-statistics-common/src/utils/number/formatPretty.ts
@@ -1,3 +1,5 @@
+export const defaultDecimalPlaces = 2;
+
 /**
  * Return a formatted {@param value} in a pretty format
  * i.e. 10,000,000.000.
@@ -16,7 +18,7 @@
 export default function formatPretty(
   value: string | number,
   unit?: string,
-  decimalPlaces?: number,
+  decimalPlaces = defaultDecimalPlaces,
 ): string {
   let formattedValue;
 


### PR DESCRIPTION
This change reinstates 2 decimal places as the default for `formatPretty` (and consequently all indicator formatting). This will have implications for any indicators where analysts have not specified decimal places e.g. indicators that are actually integers will be 'incorrectly' formatted to 2 decimal places. The advice there is to ensure that decimal places are explicitly specified in the metadata.