### PR TITLE
EES-1544 Deploy triggers in a stopped state.

### DIFF
--- a/infrastructure/templates/datafactory/components/db-maintenance-template.json
+++ b/infrastructure/templates/datafactory/components/db-maintenance-template.json
@@ -319,7 +319,7 @@
       "apiVersion": "2018-06-01",
       "properties": {
         "annotations": [],
-        "runtimeState": "Started",
+        "runtimeState": "Stopped",
         "pipelines": [
           {
             "pipelineReference": {
@@ -362,7 +362,7 @@
       "apiVersion": "2018-06-01",
       "properties": {
         "annotations": [],
-        "runtimeState": "Started",
+        "runtimeState": "Stopped",
         "pipelines": [
           {
             "pipelineReference": {


### PR DESCRIPTION
With the ARM template infrastructure deploy, the triggers triggers can only be deployed in a stopped state.
See MicrosoftDocs/feedback#1583

This PR removes our attempt to start them automatically which is not possible and attempts to stop the deployment failure caused by this if the triggers are already started.

Previously we have been stopping them manually prior to a deploy.

We will still need to remember to re-enable them unless we can add a DevOps plugin to automate this.