### PR TITLE
EES-1605 Revert decimal place formatting and calculate default map legend decimals from data

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlock.test.tsx
@@ -45,11 +45,11 @@ describe('MapBlock', () => {
     const legendItems = screen.getAllByTestId('mapBlock-legend-item');
 
     expect(legendItems).toHaveLength(5);
-    expect(legendItems[0]).toHaveTextContent('3.00% to 3.20%');
-    expect(legendItems[1]).toHaveTextContent('3.21% to 3.40%');
-    expect(legendItems[2]).toHaveTextContent('3.41% to 3.60%');
-    expect(legendItems[3]).toHaveTextContent('3.61% to 3.80%');
-    expect(legendItems[4]).toHaveTextContent('3.81% to 4.00%');
+    expect(legendItems[0]).toHaveTextContent('3.0% to 3.2%');
+    expect(legendItems[1]).toHaveTextContent('3.3% to 3.4%');
+    expect(legendItems[2]).toHaveTextContent('3.5% to 3.6%');
+    expect(legendItems[3]).toHaveTextContent('3.7% to 3.8%');
+    expect(legendItems[4]).toHaveTextContent('3.9% to 4.0%');
 
     const legendColours = screen.getAllByTestId('mapBlock-legend-colour');
 
@@ -214,7 +214,7 @@ describe('MapBlock', () => {
       'Authorised absence rate (2016/17)',
     );
     expect(tile1.getByTestId('mapBlock-indicatorTile-value')).toHaveTextContent(
-      '3.50%',
+      '3.5%',
     );
 
     const tile2 = within(indicators[1]);
@@ -223,7 +223,7 @@ describe('MapBlock', () => {
       'Overall absence rate (2016/17)',
     );
     expect(tile2.getByTestId('mapBlock-indicatorTile-value')).toHaveTextContent(
-      '4.80%',
+      '4.8%',
     );
   });
 

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
@@ -83,21 +83,18 @@ export const testMapTableData: TableDataResponse = {
         unit: '%',
         value: 'authorised-absence-rate',
         name: 'sess_authorised_percent',
-        decimalPlaces: 2,
       },
       {
         label: 'Unauthorised absence rate',
         unit: '%',
         value: 'unauthorised-absence-rate',
         name: 'sess_unauthorised_percent',
-        decimalPlaces: 2,
       },
       {
         label: 'Overall absence rate',
         unit: '%',
         value: 'overall-absence-rate',
         name: 'sess_overall_percent',
-        decimalPlaces: 2,
       },
     ],
     locations: [

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/TimePeriodDataTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/TimePeriodDataTable.test.tsx.snap
@@ -530,7 +530,7 @@ exports[`TimePeriodDataTable renders table with only one of each option and no f
       England
     </th>
     <td class="govuk-table__cell--numeric borderBottom">
-      18.30%
+      18.3%
     </td>
   </tr>
 </tbody>

--- a/src/explore-education-statistics-common/src/utils/number/__tests__/countDecimals.test.ts
+++ b/src/explore-education-statistics-common/src/utils/number/__tests__/countDecimals.test.ts
@@ -8,10 +8,36 @@ describe('countDecimals', () => {
     expect(countDecimals(100)).toBe(0);
   });
 
-  test('returns correct number of decimals places when there are some', () => {
+  test('returns 0 when there are no decimal places for numeric strings', () => {
+    expect(countDecimals('0')).toBe(0);
+    expect(countDecimals('1')).toBe(0);
+    expect(countDecimals('10')).toBe(0);
+    expect(countDecimals('100')).toBe(0);
+  });
+
+  test('returns 0 when there are no decimal places for non-numeric strings', () => {
+    expect(countDecimals('0.')).toBe(0);
+    expect(countDecimals('0.ABC')).toBe(0);
+    expect(countDecimals('0.123.234')).toBe(0);
+    expect(countDecimals('')).toBe(0);
+    expect(countDecimals('not a number')).toBe(0);
+  });
+
+  test('returns correct non-zero decimals places', () => {
     expect(countDecimals(0.1)).toBe(1);
     expect(countDecimals(0.02)).toBe(2);
     expect(countDecimals(0.003)).toBe(3);
     expect(countDecimals(0.0004)).toBe(4);
+  });
+
+  test('returns correct non-zero decimals places for numeric strings', () => {
+    expect(countDecimals('0.1')).toBe(1);
+    expect(countDecimals('0.02')).toBe(2);
+    expect(countDecimals('0.003')).toBe(3);
+    expect(countDecimals('0.0004')).toBe(4);
+
+    expect(countDecimals('1.0')).toBe(1);
+    expect(countDecimals('1.00')).toBe(2);
+    expect(countDecimals('1.000')).toBe(3);
   });
 });

--- a/src/explore-education-statistics-common/src/utils/number/__tests__/formatPretty.test.ts
+++ b/src/explore-education-statistics-common/src/utils/number/__tests__/formatPretty.test.ts
@@ -2,12 +2,18 @@ import formatPretty from '../formatPretty';
 
 describe('formatPretty', () => {
   test('returns formatted string from integer', () => {
-    expect(formatPretty(150000000)).toBe('150,000,000.00');
+    expect(formatPretty(150000000)).toBe('150,000,000');
     expect(formatPretty(150000000, '', 1)).toBe('150,000,000.0');
     expect(formatPretty(150000000, '', 2)).toBe('150,000,000.00');
   });
 
   test('returns formatted string rounded down from float', () => {
+    expect(formatPretty(150000000.1)).toBe('150,000,000.1');
+    expect(formatPretty(150000000.101)).toBe('150,000,000.10');
+    expect(formatPretty(150000000.12)).toBe('150,000,000.12');
+    expect(formatPretty(150000000.123)).toBe('150,000,000.12');
+    expect(formatPretty(150000000.1234)).toBe('150,000,000.12');
+
     expect(formatPretty(150000000.1234, '', 2)).toBe('150,000,000.12');
     expect(formatPretty(150000000.1234, '', 3)).toBe('150,000,000.123');
     expect(formatPretty(150000000.1234, '', 4)).toBe('150,000,000.1234');
@@ -16,6 +22,11 @@ describe('formatPretty', () => {
   });
 
   test('returns formatted string rounded up from float', () => {
+    expect(formatPretty(150000000.2)).toBe('150,000,000.2');
+    expect(formatPretty(150000000.25)).toBe('150,000,000.25');
+    expect(formatPretty(150000000.256)).toBe('150,000,000.26');
+    expect(formatPretty(150000000.2567)).toBe('150,000,000.26');
+
     expect(formatPretty(150000000.2567, '', 2)).toBe('150,000,000.26');
     expect(formatPretty(150000000.2567, '', 3)).toBe('150,000,000.257');
     expect(formatPretty(150000000.2567, '', 4)).toBe('150,000,000.2567');
@@ -23,7 +34,7 @@ describe('formatPretty', () => {
   });
 
   test('returns formatted string from string containing integer', () => {
-    expect(formatPretty('150000000')).toBe('150,000,000.00');
+    expect(formatPretty('150000000')).toBe('150,000,000');
     expect(formatPretty('150000000', '', 1)).toBe('150,000,000.0');
     expect(formatPretty('150000000', '', 2)).toBe('150,000,000.00');
   });
@@ -44,6 +55,10 @@ describe('formatPretty', () => {
   });
 
   test('returns formatted string from string containing trailing zeroes', () => {
+    expect(formatPretty('150000000.0', '')).toBe('150,000,000.0');
+    expect(formatPretty('150000000.00', '')).toBe('150,000,000.00');
+    expect(formatPretty('150000000.000', '')).toBe('150,000,000.00');
+
     expect(formatPretty('150000000.0', '', 2)).toBe('150,000,000.00');
     expect(formatPretty('150000000.00', '', 2)).toBe('150,000,000.00');
     expect(formatPretty('150000000.000', '', 2)).toBe('150,000,000.00');
@@ -63,5 +78,21 @@ describe('formatPretty', () => {
     expect(formatPretty(15.1234, '£m', 2)).toBe('£15.12m');
     expect(formatPretty(15.1234, '%', 2)).toBe('15.12%');
     expect(formatPretty(150000000.1234, '', 4)).toBe('150,000,000.1234');
+  });
+
+  test('returns NaN string if number value is not a number', () => {
+    expect(formatPretty(Number.NaN)).toBe('NaN');
+  });
+
+  test('returns infinity string if number is infinite', () => {
+    expect(formatPretty(1 / 0)).toBe('∞');
+    expect(formatPretty(Number.NEGATIVE_INFINITY)).toBe('-∞');
+    expect(formatPretty(Number.POSITIVE_INFINITY)).toBe('∞');
+  });
+
+  test('returns string value as-is if it is not a number', () => {
+    expect(formatPretty('not a number')).toBe('not a number');
+    expect(formatPretty('n/a')).toBe('n/a');
+    expect(formatPretty('')).toBe('');
   });
 });

--- a/src/explore-education-statistics-common/src/utils/number/__tests__/getMinMax.test.ts
+++ b/src/explore-education-statistics-common/src/utils/number/__tests__/getMinMax.test.ts
@@ -8,6 +8,22 @@ describe('getMinMax', () => {
     expect(max).toBe(80);
   });
 
+  test('returns the correct min/max for multiple values with non-numeric values', () => {
+    const { min, max } = getMinMax([
+      null as never,
+      5,
+      2,
+      80,
+      undefined as never,
+      -44,
+      12,
+      'not a number' as never,
+    ]);
+
+    expect(min).toBe(-44);
+    expect(max).toBe(80);
+  });
+
   test('returns a single min/max for a single value', () => {
     const { min, max } = getMinMax([5]);
 

--- a/src/explore-education-statistics-common/src/utils/number/countDecimals.ts
+++ b/src/explore-education-statistics-common/src/utils/number/countDecimals.ts
@@ -1,7 +1,20 @@
 /**
+ * This is unsafe as we don't do any further parsing
+ * of the {@param value} to ensure it is a number,
+ * but will be slightly more performant.
+ */
+export function unsafeCountDecimals(value: string) {
+  const decimals = value.split('.')[1];
+  return decimals ? decimals.length : 0;
+}
+
+/**
  * Count the number of decimal places in a {@param value}.
  */
-export default function countDecimals(value: number): number {
-  const decimals = value.toString().split('.')[1];
-  return decimals ? decimals.length : 0;
+export default function countDecimals(value: number | string): number {
+  if (Number.isNaN(Number(value))) {
+    return 0;
+  }
+
+  return unsafeCountDecimals(value.toString());
 }

--- a/src/explore-education-statistics-common/src/utils/number/formatPretty.ts
+++ b/src/explore-education-statistics-common/src/utils/number/formatPretty.ts
@@ -1,4 +1,7 @@
-export const defaultDecimalPlaces = 2;
+import { unsafeCountDecimals } from '@common/utils/number/countDecimals';
+import clamp from 'lodash/clamp';
+
+export const defaultMaxDecimalPlaces = 2;
 
 /**
  * Return a formatted {@param value} in a pretty format
@@ -10,31 +13,40 @@ export const defaultDecimalPlaces = 2;
  *
  * {@param decimalPlaces} can be optionally used
  * determine the number of decimal places that
- * the formatted number can have.
- *
- * This also accepts strings and preserves their
- * decimal places, even if there are trailing zeros.
+ * the formatted number should have.
  */
 export default function formatPretty(
   value: string | number,
   unit?: string,
-  decimalPlaces = defaultDecimalPlaces,
+  decimalPlaces?: number,
 ): string {
-  let formattedValue;
+  let numberValue: number;
 
   if (typeof value === 'string') {
-    const numberValue = Number(value);
+    numberValue = Number(value);
 
-    if (Number.isNaN(numberValue)) {
+    if (Number.isNaN(numberValue) || value === '') {
       return value;
     }
+  } else {
+    numberValue = value;
+  }
+
+  let formattedValue: string;
+
+  if (typeof decimalPlaces === 'undefined') {
+    const minDecimalPlaces = clamp(
+      unsafeCountDecimals(value.toString()),
+      0,
+      defaultMaxDecimalPlaces,
+    );
 
     formattedValue = numberValue.toLocaleString('en-GB', {
-      maximumFractionDigits: decimalPlaces,
-      minimumFractionDigits: decimalPlaces,
+      maximumFractionDigits: defaultMaxDecimalPlaces,
+      minimumFractionDigits: minDecimalPlaces,
     });
   } else {
-    formattedValue = value.toLocaleString('en-GB', {
+    formattedValue = numberValue.toLocaleString('en-GB', {
       maximumFractionDigits: decimalPlaces,
       minimumFractionDigits: decimalPlaces,
     });

--- a/src/explore-education-statistics-common/src/utils/number/getMinMax.ts
+++ b/src/explore-education-statistics-common/src/utils/number/getMinMax.ts
@@ -6,6 +6,10 @@ export default function getMinMax(
 ): { min?: number; max?: number } {
   const { min, max } = values.reduce<{ min: number; max: number }>(
     (acc, value) => {
+      if (typeof value !== 'number') {
+        return acc;
+      }
+
       if (value < acc.min) {
         acc.min = value;
       }


### PR DESCRIPTION
This PR:

- Mostly reverts decimal place formatting changes made to `formatPretty`. If no decimal places are specified, it will default to having a maximum of 2 decimal places and a minimum based on the decimals in the input value.
- Adjusts the `MapBlock` legend to calculate the decimal places to use in its group boundaries based on the data values. We try and find the maximum number of decimal places in the values (up to a max of 2), then re-adjust if necessary to prevent the boundaries from overlapping.