### PR TITLE
EES-1632 Historically blob filename has not been forced lowercase.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
@@ -14,7 +14,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainerNames;
 using static GovUk.Education.ExploreEducationStatistics.Common.Extensions.BlobInfoExtensions;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.ReleaseFileTypes;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFileReference.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseFileReference.cs
@@ -32,7 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
                     return Id.ToString();
                 }
 
-                return Filename.ToLower();
+                return Filename;
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileStorageService.cs
@@ -248,7 +248,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
             var name = Path.GetFileName(item.Name);
 
-            // TODO what is this, and is it affected by BlobStorageName being in Lower?
             if (releaseFileReferences.Exists(rfr => rfr.BlobStorageName == name))
             {
                 return true;


### PR DESCRIPTION
Historically the blob storage filename has not always been forced to lowercase,  so rely on the `Filename` field which should be accurate for all files, rather than `Filename.ToLower()` in `BlobStorageName` getter.

Also since Filename is forced to lower case now whenever a `ReleaseFileReference` is created or updated, there was no need to lowercase it again here and removing this won't affect lowercasing newly uploaded files.

The filename of blobs is due to change soon when they will be migrated to use the their database file id, in the same way as chart files now.