### PR TITLE
Ees 1000 stop insert clashes on parallel imports

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Utils/DbUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Utils/DbUtils.cs
@@ -52,7 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Utils
                 catch (Exception)
                 {
                     await transaction.RollbackAsync();
-                    return default;
+                    throw;
                 }
             });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Utils/DbUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Utils/DbUtils.cs
@@ -29,7 +29,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Utils
 
         /**
          * Obtains an exclusive lock within a new transaction and stops other transactions needing to acquire the
-         * same lock to run until they can obtain the lock.  The lock is released upon a transaction being committed.
+         * same lock to run until they can obtain the lock.  The lock is released upon a transaction being committed
+         * or rolled back.
          */
         public static Task<TResult> ExecuteWithExclusiveLock<TDbContext, TResult>(
             TDbContext dbContext,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Utils/DbUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Importer/Utils/DbUtils.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Data;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Functions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -23,6 +26,37 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Importer.Utils
                 providerOptions => providerOptions.EnableRetryOnFailure());
 
             return new ContentDbContext(optionsBuilder.Options);
+        }
+
+        /**
+         * Obtains an exclusive lock within a new transaction and stops other transactions needing to acquire the
+         * same lock to run until they can obtain the lock.  The lock is released upon a transaction being committed.
+         */
+        public static Task<TResult> ExecuteWithExclusiveLock<TDbContext, TResult>(
+            TDbContext dbContext,
+            string lockName,
+            Func<TDbContext, Task<TResult>> action) 
+            where TDbContext : DbContext
+        {
+            return dbContext.Database.CreateExecutionStrategy().ExecuteAsync(async () =>
+            {
+                using (var transaction = await dbContext.Database.BeginTransactionAsync(IsolationLevel.ReadCommitted))
+                {
+                    await dbContext.Database.ExecuteSqlRawAsync($"exec sp_getapplock '{lockName}', 'exclusive'");
+
+                    try
+                    {
+                        var result = await action(dbContext);
+                        await transaction.CommitAsync();
+                        return result;
+                    }
+                    catch (Exception)
+                    {
+                        await transaction.RollbackAsync();
+                        return default;
+                    }
+                }
+            });
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ReleaseProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ReleaseProcessorService.cs
@@ -142,7 +142,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 statisticsDbContext,
                 message.Release,
                 message.Release.Id,
-                () => new Release
+                new Release
                     {
                         Id = message.Release.Id,
                         Slug = message.Release.Slug,
@@ -161,7 +161,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 statisticsDbContext,
                 message.Release.Publication,
                 message.Release.Publication.Id,
-                () => new Publication
+                new Publication
                     {
                         Id = message.Release.Publication.Id,
                         Title = message.Release.Publication.Title,
@@ -178,7 +178,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 statisticsDbContext,
                 message.Release.Publication.Topic,
                 message.Release.Publication.Topic.Id,
-                () => new Topic
+                new Topic
                     {
                         Id = message.Release.Publication.Topic.Id,
                         Title = message.Release.Publication.Topic.Title,
@@ -194,7 +194,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 statisticsDbContext,
                 message.Release.Publication.Topic.Theme,
                 message.Release.Publication.Topic.Theme.Id,
-                () => new Theme 
+                new Theme 
                 {
                     Id = message.Release.Publication.Topic.Theme.Id,
                     Slug = message.Release.Publication.Topic.Theme.Slug,
@@ -217,7 +217,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             StatisticsDbContext statisticsDbContext,
             TMessageObject objectFromMessage,
             Guid entityId,
-            Func<TEntity> createEntityFn)
+            TEntity entityToCreate)
             where TEntity : class 
             where TMessageObject : class
         {
@@ -236,8 +236,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 if (existing == null)
                 {
                     _logger.LogInformation($"Creating {typeName} \"{entityName}\"");
-                    TEntity newEntity = createEntityFn.Invoke();
-                    TEntity created = (await statisticsDbContext.Set<TEntity>().AddAsync(newEntity)).Entity;
+                    TEntity created = (await statisticsDbContext.Set<TEntity>().AddAsync(entityToCreate)).Entity;
                     await statisticsDbContext.SaveChangesAsync();
                     return created;
                 }


### PR DESCRIPTION
This PR:
- adds concurrency control to the process of creating Themes, Topics, Publications and Releases when multiple data files for the same Release are uploaded close to each other.

It does this by preventing two or more importer threads from attempting to create-or-update any of the above entities by acquiring locks at an "entity type" / "entity id" granularity.

If three threads are trying to create-or-update a "Theme" entity with ID "123478324-37239855-asd0faf-234509845":

- the first thread to acquire the lock will block the others.  It will create a lock called "CreateOrUpdateTheme-123478324-37239855-asd0faf-234509845" and then be free to create the Theme unhindered
- it will then release the lock (after its transaction commits)
- the next thread that tried to acquire the lock will now acquire it and check for the existence of a Theme with ID "123478324-37239855-asd0faf-234509845".  It will find it of course, as the first thread created it.  So it will simply update it and then release the lock again.
- the third and final thread will do the same as the step above!

More details here: https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-getapplock-transact-sql?view=sql-server-ver15