### PR TITLE
EES-1636 Fix admin release files not specifying correct file name

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -137,17 +137,16 @@ const ReleaseContent = () => {
               <Details summary="Download associated files">
                 <ul className="govuk-list govuk-list--bullet">
                   {release.downloadFiles.map(
-                    ({ id, extension, name, path, size }) => (
+                    ({ id, extension, name, fileName, path, size }) => (
                       <li key={path}>
                         <ButtonText
                           onClick={() =>
                             releaseDataFileService.downloadFile(
                               release.id,
                               id,
-                              name,
+                              fileName,
                             )
                           }
-                          className="govuk-link"
                         >
                           {name}
                         </ButtonText>


### PR DESCRIPTION
This bug was causing the causing browser to infer the file type based on the blob returned from the API. It seems like most files seem to have been uploaded with Excel content types, so it would incorrectly infer file types as xls.

By setting the filename correctly, we provide the file with a .csv extension, which is enough to make sure the file downloads correctly.
