### PR TITLE
EES-1623 EES-1645 Avoid NullReferenceException

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/FootnoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/FootnoteService.cs
@@ -217,6 +217,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
 
             var footnote = _context.Footnote
                 .Include(f => f.Filters)
+                .ThenInclude(f => f.Filter)
                 .Include(f => f.FilterGroups)
                 .ThenInclude(f => f.FilterGroup.Filter)
                 .Include(f => f.FilterItems)


### PR DESCRIPTION
Avoid NullReferenceException in the check `IsFootnoteLinkedToAnotherSubjectForThisRelease` called when deleting footnotes by always including FootnoteFilter.Filter in the query result.

A NullReferenceException was occuring in `Contains(filter.Filter.SubjectId)` if the footnote is linked to other subjects as well as the one being deleted.