### PR TITLE
EES-1616 Fix chart definition defaults not being honoured when type is changed

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
@@ -130,7 +130,7 @@ const ChartBuilder = ({
   >();
 
   const chartProps = useMemo<ChartBuilderChartProps | undefined>(() => {
-    if (!definition) {
+    if (!definition || !options) {
       return undefined;
     }
 
@@ -303,22 +303,24 @@ const ChartBuilder = ({
         >
           {({ forms }) => (
             <Tabs id="chartBuilder-tabs" modifyHash={false}>
-              <TabsSection
-                title="Chart configuration"
-                headingTitle="Chart configuration"
-                id={forms.options.id}
-              >
-                <ChartConfiguration
-                  buttons={deleteButton}
-                  submitError={submitError}
-                  definition={definition}
-                  chartOptions={options}
-                  meta={meta}
-                  onBoundaryLevelChange={handleBoundaryLevelChange}
-                  onChange={handleChartConfigurationChange}
-                  onSubmit={actions.updateChartOptions}
-                />
-              </TabsSection>
+              {options && (
+                <TabsSection
+                  title="Chart configuration"
+                  headingTitle="Chart configuration"
+                  id={forms.options.id}
+                >
+                  <ChartConfiguration
+                    buttons={deleteButton}
+                    submitError={submitError}
+                    definition={definition}
+                    chartOptions={options}
+                    meta={meta}
+                    onBoundaryLevelChange={handleBoundaryLevelChange}
+                    onChange={handleChartConfigurationChange}
+                    onSubmit={actions.updateChartOptions}
+                  />
+                </TabsSection>
+              )}
 
               {forms.dataSets && definition.axes.major && (
                 <TabsSection

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/__tests__/chartBuilderReducer.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/__tests__/chartBuilderReducer.test.ts
@@ -503,12 +503,6 @@ describe('chartBuilderReducer', () => {
 
       expect(nextState).toEqual<ChartBuilderState>({
         axes: {},
-        options: {
-          height: 300,
-          title: '',
-          alt: '',
-        },
-        definition: undefined,
       });
     });
   });
@@ -519,11 +513,6 @@ describe('chartBuilderReducer', () => {
 
       expect(result.current.state).toEqual<ChartBuilderState>({
         axes: {},
-        options: {
-          title: '',
-          alt: '',
-          height: 300,
-        },
       });
     });
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/__tests__/chartBuilderReducer.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/__tests__/chartBuilderReducer.test.ts
@@ -123,7 +123,7 @@ describe('chartBuilderReducer', () => {
       });
     });
 
-    test('does not override `options` or `legend` that already exist ', () => {
+    test('merges correctly with `options` or `legend` that already exist', () => {
       const initialStateWithOptions: ChartBuilderState = {
         ...initialState,
         options: {
@@ -157,7 +157,8 @@ describe('chartBuilderReducer', () => {
       );
 
       expect(nextState.options).toEqual<ChartOptions>({
-        height: 400,
+        // Height is set to the definition default
+        height: 300,
         title: 'Some title',
         alt: 'Some alt',
       });
@@ -214,7 +215,7 @@ describe('chartBuilderReducer', () => {
       });
     });
 
-    test('does not override `axes` options that already exist', () => {
+    test('merges correctly with `axes` options that already exist', () => {
       const initialStateWithAxes: ChartBuilderState = {
         ...initialState,
         axes: {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/chartBuilderReducer.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/chartBuilderReducer.ts
@@ -140,6 +140,13 @@ export const chartBuilderReducer: Reducer<
         ...defaultOptions,
         ...(action.payload.options.defaults ?? {}),
         ...draft.options,
+        // Set height/width to definition defaults
+        // as this seems to surprise users the least.
+        height:
+          action.payload.options.defaults?.height ??
+          draft.options?.height ??
+          defaultOptions.height,
+        width: action.payload.options.defaults?.width ?? draft.options?.width,
       };
 
       if (action.payload.capabilities.hasLegend) {


### PR DESCRIPTION
This PR fixes two issues that have been causing the unexpected behaviour seen in the ticket:

- Incorrect initialisation of initial state (i.e. when user visits chart builder for the first time). For example, this was setting `height` to 300px for every chart regardless of type. We have now modified this so that the state is essentially empty until the user starts using chart builder.
- Chart definition defaults not being set correctly in chart builder state when the definition changes. We now override any height/width with the chart definition's defaults whenever another type has been selected by the user. This should be more in-line with their expectations.