### PR TITLE
EES-1653 Refactor ReleaseStatusForm out of ReleaseStatusPage

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -1,74 +1,27 @@
 import ReleaseServiceStatus from '@admin/components/ReleaseServiceStatus';
 import StatusBlock from '@admin/components/StatusBlock';
-import useFormSubmit from '@admin/hooks/useFormSubmit';
+import { useConfig } from '@admin/contexts/ConfigContext';
+import ReleaseStatusForm from '@admin/pages/release/components/ReleaseStatusForm';
 import { useManageReleaseContext } from '@admin/pages/release/contexts/ManageReleaseContext';
 import permissionService, {
   ReleaseStatusPermissions,
 } from '@admin/services/permissionService';
 import releaseService from '@admin/services/releaseService';
 import Button from '@common/components/Button';
-import ButtonGroup from '@common/components/ButtonGroup';
-import ButtonText from '@common/components/ButtonText';
-import { Form, FormFieldRadioGroup } from '@common/components/form';
-import FormFieldDateInput from '@common/components/form/FormFieldDateInput';
-import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
 import FormattedDate from '@common/components/FormattedDate';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import UrlContainer from '@common/components/UrlContainer';
-import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
-import { ReleaseApprovalStatus } from '@common/services/publicationService';
+import useToggle from '@common/hooks/useToggle';
 import {
   formatPartialDate,
-  isPartialDateEmpty,
   isValidPartialDate,
-  parsePartialDateToLocalDate,
-  PartialDate,
 } from '@common/utils/date/partialDate';
-import { mapFieldErrors } from '@common/validation/serverValidations';
-import Yup from '@common/validation/yup';
-import { endOfDay, format, formatISO, isValid, parseISO } from 'date-fns';
-import { Formik } from 'formik';
-import React, { useState } from 'react';
-import { useConfig } from '@admin/contexts/ConfigContext';
-import { StringSchema } from 'yup';
-
-const errorMappings = [
-  mapFieldErrors<FormValues>({
-    target: 'status',
-    messages: {
-      APPROVED_RELEASE_MUST_HAVE_PUBLISH_SCHEDULED_DATE:
-        'Enter a publish scheduled date before approving',
-      ALL_DATAFILES_UPLOADED_MUST_BE_COMPLETE:
-        'Check all uploaded datafiles are complete before approving',
-      PUBLISHED_RELEASE_CANNOT_BE_UNAPPROVED:
-        'Release has already been published and cannot be un-approved',
-      META_GUIDANCE_MUST_BE_POPULATED:
-        'All public metadata guidance must be populated before release can be approved',
-      DATA_REPLACEMENT_IN_PROGRESS:
-        'Pending data file replacements that are in progress must be completed or cancelled before release can be approved',
-      METHODOLOGY_MUST_BE_APPROVED_OR_PUBLISHED:
-        "The publication's methodology must be approved before release can be approved",
-    },
-  }),
-  mapFieldErrors<FormValues>({
-    target: 'nextReleaseDate',
-    messages: {
-      PARTIAL_DATE_NOT_VALID: 'Enter a valid date',
-    },
-  }),
-];
-
-interface FormValues {
-  publishMethod?: 'Scheduled' | 'Immediate';
-  publishScheduled?: Date;
-  nextReleaseDate?: PartialDate;
-  status: ReleaseApprovalStatus;
-  internalReleaseNote: string;
-}
+import { formatISO, parseISO } from 'date-fns';
+import React from 'react';
 
 const statusMap: {
   [keyof: string]: string;
@@ -78,10 +31,8 @@ const statusMap: {
   Approved: 'Approved',
 };
 
-const formId = 'releaseStatusForm';
-
 const ReleaseStatusPage = () => {
-  const [showForm, setShowForm] = useState(false);
+  const [showForm, toggleShowForm] = useToggle(false);
 
   const { releaseId, onChangeReleaseStatus } = useManageReleaseContext();
 
@@ -96,259 +47,87 @@ const ReleaseStatusPage = () => {
 
   const { PublicAppUrl } = useConfig();
 
-  const handleSubmit = useFormSubmit<FormValues>(async values => {
-    if (!release) {
-      throw new Error('Could not update missing release');
-    }
-
-    const nextRelease = await releaseService.updateRelease(releaseId, {
-      ...release,
-      typeId: release.type.id,
-      ...values,
-      publishScheduled:
-        values.status === 'Approved' &&
-        values.publishScheduled &&
-        values.publishMethod === 'Scheduled'
-          ? formatISO(values.publishScheduled, {
-              representation: 'date',
-            })
-          : undefined,
-    });
-
-    setRelease({
-      isLoading: false,
-      value: nextRelease,
-    });
-
-    setShowForm(false);
-
-    onChangeReleaseStatus();
-  }, errorMappings);
-
   if (!release) {
     return <LoadingSpinner />;
   }
 
-  const isEditable = Object.values(statusPermissions ?? {}).some(
-    permission => !!permission,
-  );
+  const isEditable =
+    !!statusPermissions &&
+    Object.values(statusPermissions).some(permission => permission);
+
+  if (showForm && statusPermissions) {
+    return (
+      <ReleaseStatusForm
+        release={release}
+        statusPermissions={statusPermissions}
+        onCancel={toggleShowForm.off}
+        onSubmit={async values => {
+          const nextRelease = await releaseService.updateRelease(releaseId, {
+            ...release,
+            typeId: release.type.id,
+            ...values,
+            publishScheduled: values.publishScheduled
+              ? formatISO(values.publishScheduled, {
+                  representation: 'date',
+                })
+              : undefined,
+          });
+
+          setRelease({ value: nextRelease });
+
+          toggleShowForm.off();
+          onChangeReleaseStatus();
+        }}
+      />
+    );
+  }
 
   return (
     <>
-      {!showForm ? (
-        <>
-          <h2>Sign off</h2>
-          <p>
-            The <strong>public release</strong> will be accessible at:
-          </p>
+      <h2>Sign off</h2>
+      <p>
+        The <strong>public release</strong> will be accessible at:
+      </p>
 
-          <p>
-            <UrlContainer
-              data-testid="public-release-url"
-              url={`${PublicAppUrl}/find-statistics/${release.publicationSlug}/${release.slug}`}
-            />
-          </p>
+      <p>
+        <UrlContainer
+          data-testid="public-release-url"
+          url={`${PublicAppUrl}/find-statistics/${release.publicationSlug}/${release.slug}`}
+        />
+      </p>
 
-          <SummaryList>
-            <SummaryListItem term="Current status">
-              <StatusBlock
-                text={statusMap[release.status]}
-                id={`CurrentReleaseStatus-${statusMap[release.status]}`}
-              />
-            </SummaryListItem>
-            {release.status === 'Approved' && (
-              <SummaryListItem term="Release process status">
-                <ReleaseServiceStatus releaseId={releaseId} />
-              </SummaryListItem>
-            )}
-            <SummaryListItem term="Scheduled release">
-              {release.publishScheduled ? (
-                <FormattedDate>
-                  {parseISO(release.publishScheduled)}
-                </FormattedDate>
-              ) : (
-                'Not scheduled'
-              )}
-            </SummaryListItem>
-            <SummaryListItem term="Next release expected">
-              {isValidPartialDate(release.nextReleaseDate) ? (
-                <time>{formatPartialDate(release.nextReleaseDate)}</time>
-              ) : (
-                'Not set'
-              )}
-            </SummaryListItem>
-          </SummaryList>
-
-          {isEditable && (
-            <Button
-              className="govuk-!-margin-top-2"
-              onClick={() => setShowForm(true)}
-            >
-              Edit release status
-            </Button>
+      <SummaryList>
+        <SummaryListItem term="Current status">
+          <StatusBlock
+            text={statusMap[release.status]}
+            id={`CurrentReleaseStatus-${statusMap[release.status]}`}
+          />
+        </SummaryListItem>
+        {release.status === 'Approved' && (
+          <SummaryListItem term="Release process status">
+            <ReleaseServiceStatus releaseId={releaseId} />
+          </SummaryListItem>
+        )}
+        <SummaryListItem term="Scheduled release">
+          {release.publishScheduled ? (
+            <FormattedDate>{parseISO(release.publishScheduled)}</FormattedDate>
+          ) : (
+            'Not scheduled'
           )}
-        </>
-      ) : (
-        <Formik<FormValues>
-          enableReinitialize
-          initialValues={{
-            status: release.status,
-            internalReleaseNote: release.internalReleaseNote ?? '',
-            publishMethod: release.publishScheduled ? 'Scheduled' : undefined,
-            publishScheduled: release.publishScheduled
-              ? parseISO(release.publishScheduled)
-              : undefined,
-            nextReleaseDate: release.nextReleaseDate,
-          }}
-          onSubmit={handleSubmit}
-          validationSchema={Yup.object<FormValues>({
-            status: Yup.string().required('Choose a status') as StringSchema<
-              FormValues['status']
-            >,
-            internalReleaseNote: Yup.string().when('status', {
-              is: value => ['Approved', 'HigherLevelReview'].includes(value),
-              then: Yup.string().required('Provide an internal release note'),
-            }),
-            publishMethod: Yup.string().when('status', {
-              is: 'Approved',
-              then: Yup.string().required('Choose when to publish'),
-            }) as StringSchema<FormValues['publishMethod']>,
-            publishScheduled: Yup.date().when('publishMethod', {
-              is: 'Scheduled',
-              then: Yup.date()
-                .required('Enter a valid publish date')
-                .test({
-                  name: 'validDateIfAfterToday',
-                  message: `Publish date can't be before ${format(
-                    new Date(),
-                    'do MMMM yyyy',
-                  )}`,
-                  test(value) {
-                    return endOfDay(value) >= endOfDay(new Date());
-                  },
-                }),
-            }),
-            nextReleaseDate: Yup.object<PartialDate>({
-              day: Yup.number().notRequired(),
-              month: Yup.number(),
-              year: Yup.number(),
-            })
-              .notRequired()
-              .test({
-                name: 'validDate',
-                message: 'Enter a valid next release date',
-                test(value: PartialDate) {
-                  if (isPartialDateEmpty(value)) {
-                    return true;
-                  }
+        </SummaryListItem>
+        <SummaryListItem term="Next release expected">
+          {isValidPartialDate(release.nextReleaseDate) ? (
+            <time>{formatPartialDate(release.nextReleaseDate)}</time>
+          ) : (
+            'Not set'
+          )}
+        </SummaryListItem>
+      </SummaryList>
 
-                  if (!isValidPartialDate(value)) {
-                    return false;
-                  }
-
-                  return isValid(parsePartialDateToLocalDate(value));
-                },
-              }),
-          })}
-        >
-          {form => {
-            return (
-              <Form id={formId}>
-                <h2>Edit release status</h2>
-
-                <FormFieldRadioGroup<FormValues>
-                  legend="Status"
-                  name="status"
-                  id={`${formId}-status`}
-                  orderDirection={[]}
-                  options={[
-                    {
-                      label: 'In draft',
-                      value: 'Draft',
-                      disabled: !statusPermissions?.canMarkDraft,
-                    },
-                    {
-                      label: 'Ready for higher review',
-                      value: 'HigherLevelReview',
-                      disabled: !statusPermissions?.canMarkHigherLevelReview,
-                    },
-                    {
-                      label: 'Approved for publication',
-                      value: 'Approved',
-                      disabled: !statusPermissions?.canMarkApproved,
-                    },
-                  ]}
-                />
-                <FormFieldTextArea<FormValues>
-                  name="internalReleaseNote"
-                  className="govuk-!-width-one-half"
-                  id={`${formId}-internalReleaseNote`}
-                  label="Internal release note"
-                  rows={3}
-                />
-
-                {form.values.status === 'Approved' && (
-                  <FormFieldRadioGroup<FormValues>
-                    id={`${formId}-publishMethod`}
-                    name="publishMethod"
-                    legend="When to publish"
-                    legendSize="m"
-                    hint="Do you want to publish this release on a specific date or as soon as possible?"
-                    order={[]}
-                    options={[
-                      {
-                        label: 'On a specific date',
-                        value: 'Scheduled',
-                        conditional: (
-                          <FormFieldDateInput<FormValues>
-                            id={`${formId}-publishScheduled`}
-                            name="publishScheduled"
-                            legend="Publish date"
-                            legendSize="s"
-                          />
-                        ),
-                      },
-                      {
-                        label: 'As soon as possible',
-                        value: 'Immediate',
-                        conditional: (
-                          <WarningMessage className="govuk-!-width-two-thirds">
-                            This will start the release process immediately and
-                            make statistics available to the public. Make sure
-                            this is okay before continuing.
-                          </WarningMessage>
-                        ),
-                      },
-                    ]}
-                  />
-                )}
-
-                <FormFieldDateInput<FormValues>
-                  id={`${formId}-nextReleaseDate`}
-                  name="nextReleaseDate"
-                  legend="Next release expected (optional)"
-                  legendSize="m"
-                  type="partialDate"
-                  partialDateType="monthYear"
-                />
-
-                <ButtonGroup>
-                  <Button type="submit" disabled={form.isSubmitting}>
-                    Update status
-                  </Button>
-                  <ButtonText
-                    onClick={() => {
-                      form.resetForm();
-                      setShowForm(false);
-                    }}
-                  >
-                    Cancel
-                  </ButtonText>
-                </ButtonGroup>
-              </Form>
-            );
-          }}
-        </Formik>
+      {isEditable && (
+        <Button className="govuk-!-margin-top-2" onClick={toggleShowForm.on}>
+          Edit release status
+        </Button>
       )}
     </>
   );

--- a/src/explore-education-statistics-admin/src/pages/release/__tests__/ReleaseStatusPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/__tests__/ReleaseStatusPage.test.tsx
@@ -1,52 +1,56 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
-import _releaseService, { Release } from '@admin/services/releaseService';
+import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
 import ManageReleaseContext, {
   ManageRelease,
 } from '@admin/pages/release/contexts/ManageReleaseContext';
+import _permissionService, {
+  ReleaseStatusPermissions,
+} from '@admin/services/permissionService';
+import _releaseService, { Release } from '@admin/services/releaseService';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import noop from 'lodash/noop';
+import React from 'react';
 import { MemoryRouter } from 'react-router';
-import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
 import ReleaseStatusPage from '../ReleaseStatusPage';
 
+jest.mock('@admin/services/permissionService');
 jest.mock('@admin/services/releaseService');
+
+const permissionService = _permissionService as jest.Mocked<
+  typeof _permissionService
+>;
 const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
 
-const releaseData: Release = {
-  id: 'release-1',
-  slug: 'release-1-slug',
-  status: 'Draft',
-  latestRelease: false,
-  live: false,
-  amendment: false,
-  releaseName: 'Release 1',
-  publicationId: 'publication-1',
-  publicationTitle: 'Publication 1',
-  publicationSlug: 'publication-1-slug',
-  timePeriodCoverage: { value: 'W51', label: 'Week 51' },
-  title: 'Release Title',
-  type: {
-    id: '9d333457-9132-4e55-ae78-c55cb3673d7c',
-    title: 'Official Statistics',
-  },
-  contact: {
-    id: '69416b29-8a20-4de1-11de-08d85fc33fc0',
-    teamName: 'Test name',
-    teamEmail: 'test@test.com',
-    contactName: 'Test contact name',
-    contactTelNo: '1111 1111 1111',
-  },
-  nextReleaseDate: {
-    day: 1,
-    month: 1,
-    year: 2020,
-  },
-  previousVersionId: '',
-  preReleaseAccessList: '',
-};
-
 describe('ReleaseStatusPage', () => {
-  const testRelease: ManageRelease = {
+  const testRelease: Release = {
+    id: 'release-1',
+    slug: 'release-1-slug',
+    status: 'Draft',
+    latestRelease: false,
+    live: false,
+    amendment: false,
+    releaseName: 'Release 1',
+    publicationId: 'publication-1',
+    publicationTitle: 'Publication 1',
+    publicationSlug: 'publication-1-slug',
+    timePeriodCoverage: { value: 'W51', label: 'Week 51' },
+    title: 'Release Title',
+    type: {
+      id: 'type-1',
+      title: 'Official Statistics',
+    },
+    contact: {
+      id: 'contact-1',
+      teamName: 'Test name',
+      teamEmail: 'test@test.com',
+      contactName: 'Test contact name',
+      contactTelNo: '1111 1111 1111',
+    },
+    previousVersionId: '',
+    preReleaseAccessList: '',
+  };
+
+  const testManageRelease: ManageRelease = {
     releaseId: 'release-1',
     onChangeReleaseStatus: noop,
     publication: {
@@ -58,13 +62,19 @@ describe('ReleaseStatusPage', () => {
     },
   };
 
+  const testStatusPermissions: ReleaseStatusPermissions = {
+    canMarkDraft: true,
+    canMarkHigherLevelReview: true,
+    canMarkApproved: true,
+  };
+
   test('renders public release link correctly', async () => {
-    releaseService.getRelease.mockResolvedValue(releaseData);
+    releaseService.getRelease.mockResolvedValue(testRelease);
 
     render(
       <MemoryRouter>
         <TestConfigContextProvider>
-          <ManageReleaseContext.Provider value={testRelease}>
+          <ManageReleaseContext.Provider value={testManageRelease}>
             <ReleaseStatusPage />
           </ManageReleaseContext.Provider>
         </TestConfigContextProvider>
@@ -72,11 +82,139 @@ describe('ReleaseStatusPage', () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByTestId('public-release-url')).toBeInTheDocument();
+      expect(screen.getByText('Sign off')).toBeInTheDocument();
     });
 
     expect(screen.getByTestId('public-release-url')).toHaveTextContent(
       'http://localhost/find-statistics/publication-1-slug/release-1-slug',
     );
+  });
+
+  test('renders Draft status details correctly', async () => {
+    releaseService.getRelease.mockResolvedValue(testRelease);
+
+    render(
+      <MemoryRouter>
+        <TestConfigContextProvider>
+          <ManageReleaseContext.Provider value={testManageRelease}>
+            <ReleaseStatusPage />
+          </ManageReleaseContext.Provider>
+        </TestConfigContextProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign off')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('Current status')).toHaveTextContent('Draft');
+    expect(
+      screen.queryByTestId('Release process status'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('Scheduled release')).toHaveTextContent(
+      'Not scheduled',
+    );
+    expect(screen.getByTestId('Next release expected')).toHaveTextContent(
+      'Not set',
+    );
+  });
+
+  test('renders Approved status details correctly', async () => {
+    releaseService.getReleaseStatus.mockResolvedValue({
+      overallStage: 'Scheduled',
+    });
+    releaseService.getRelease.mockResolvedValue({
+      ...testRelease,
+      status: 'Approved',
+      publishScheduled: '2021-01-15',
+      nextReleaseDate: {
+        month: 10,
+        year: 2022,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <TestConfigContextProvider>
+          <ManageReleaseContext.Provider value={testManageRelease}>
+            <ReleaseStatusPage />
+          </ManageReleaseContext.Provider>
+        </TestConfigContextProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign off')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('Current status')).toHaveTextContent('Approved');
+    expect(screen.getByTestId('Release process status')).toHaveTextContent(
+      'Scheduled',
+    );
+    expect(screen.getByTestId('Scheduled release')).toHaveTextContent(
+      '15 January 2021',
+    );
+    expect(screen.getByTestId('Next release expected')).toHaveTextContent(
+      'October 2022',
+    );
+  });
+
+  test('renders status form when Edit button is clicked', async () => {
+    releaseService.getRelease.mockResolvedValue(testRelease);
+    permissionService.getReleaseStatusPermissions.mockResolvedValue(
+      testStatusPermissions,
+    );
+
+    render(
+      <MemoryRouter>
+        <TestConfigContextProvider>
+          <ManageReleaseContext.Provider value={testManageRelease}>
+            <ReleaseStatusPage />
+          </ManageReleaseContext.Provider>
+        </TestConfigContextProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Edit release status' }),
+      ).toBeInTheDocument();
+    });
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Edit release status' }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit release status')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Update status' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('does not render Edit button if status cannot be changed', async () => {
+    releaseService.getRelease.mockResolvedValue(testRelease);
+    permissionService.getReleaseStatusPermissions.mockResolvedValue({
+      canMarkDraft: false,
+      canMarkHigherLevelReview: false,
+      canMarkApproved: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <TestConfigContextProvider>
+          <ManageReleaseContext.Provider value={testManageRelease}>
+            <ReleaseStatusPage />
+          </ManageReleaseContext.Provider>
+        </TestConfigContextProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign off')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Edit release status')).not.toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -1,0 +1,254 @@
+import useFormSubmit from '@admin/hooks/useFormSubmit';
+import { ReleaseStatusPermissions } from '@admin/services/permissionService';
+import { Release } from '@admin/services/releaseService';
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import ButtonText from '@common/components/ButtonText';
+import { Form, FormFieldRadioGroup } from '@common/components/form';
+import FormFieldDateInput from '@common/components/form/FormFieldDateInput';
+import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
+import WarningMessage from '@common/components/WarningMessage';
+import { ReleaseApprovalStatus } from '@common/services/publicationService';
+import {
+  isPartialDateEmpty,
+  isValidPartialDate,
+  parsePartialDateToLocalDate,
+  PartialDate,
+} from '@common/utils/date/partialDate';
+import { mapFieldErrors } from '@common/validation/serverValidations';
+import Yup from '@common/validation/yup';
+import { endOfDay, format, isValid, parseISO } from 'date-fns';
+import { Formik } from 'formik';
+import React from 'react';
+import { StringSchema } from 'yup';
+
+export interface ReleaseStatusFormValues {
+  publishMethod?: 'Scheduled' | 'Immediate';
+  publishScheduled?: Date;
+  nextReleaseDate?: PartialDate;
+  status: ReleaseApprovalStatus;
+  internalReleaseNote: string;
+}
+
+const formId = 'releaseStatusForm';
+
+const errorMappings = [
+  mapFieldErrors<ReleaseStatusFormValues>({
+    target: 'status',
+    messages: {
+      APPROVED_RELEASE_MUST_HAVE_PUBLISH_SCHEDULED_DATE:
+        'Enter a publish scheduled date before approving',
+      ALL_DATAFILES_UPLOADED_MUST_BE_COMPLETE:
+        'Check all uploaded datafiles are complete before approving',
+      PUBLISHED_RELEASE_CANNOT_BE_UNAPPROVED:
+        'Release has already been published and cannot be un-approved',
+      META_GUIDANCE_MUST_BE_POPULATED:
+        'All public metadata guidance must be populated before release can be approved',
+      DATA_REPLACEMENT_IN_PROGRESS:
+        'Pending data file replacements that are in progress must be completed or cancelled before release can be approved',
+      METHODOLOGY_MUST_BE_APPROVED_OR_PUBLISHED:
+        "The publication's methodology must be approved before release can be approved",
+    },
+  }),
+  mapFieldErrors<ReleaseStatusFormValues>({
+    target: 'nextReleaseDate',
+    messages: {
+      PARTIAL_DATE_NOT_VALID: 'Enter a valid date',
+    },
+  }),
+];
+
+interface Props {
+  release: Release;
+  statusPermissions: ReleaseStatusPermissions;
+  onCancel: () => void;
+  onSubmit: (values: ReleaseStatusFormValues) => void;
+}
+
+const ReleaseStatusForm = ({
+  release,
+  statusPermissions,
+  onCancel,
+  onSubmit,
+}: Props) => {
+  const handleSubmit = useFormSubmit<ReleaseStatusFormValues>(
+    ({ status, publishMethod, publishScheduled, ...values }) => {
+      const isApproved = status === 'Approved';
+
+      onSubmit({
+        ...values,
+        status,
+        publishMethod: isApproved ? publishMethod : undefined,
+        publishScheduled:
+          isApproved && publishScheduled && publishMethod === 'Scheduled'
+            ? publishScheduled
+            : undefined,
+      });
+    },
+    errorMappings,
+  );
+
+  return (
+    <Formik<ReleaseStatusFormValues>
+      enableReinitialize
+      initialValues={{
+        status: release.status,
+        internalReleaseNote: release.internalReleaseNote ?? '',
+        publishMethod: release.publishScheduled ? 'Scheduled' : undefined,
+        publishScheduled: release.publishScheduled
+          ? parseISO(release.publishScheduled)
+          : undefined,
+        nextReleaseDate: release.nextReleaseDate,
+      }}
+      onSubmit={handleSubmit}
+      validationSchema={Yup.object<ReleaseStatusFormValues>({
+        status: Yup.string().required('Choose a status') as StringSchema<
+          ReleaseStatusFormValues['status']
+        >,
+        internalReleaseNote: Yup.string().when('status', {
+          is: value => ['Approved', 'HigherLevelReview'].includes(value),
+          then: Yup.string().required('Enter an internal release note'),
+        }),
+        publishMethod: Yup.string().when('status', {
+          is: 'Approved',
+          then: Yup.string().required('Choose when to publish'),
+        }) as StringSchema<ReleaseStatusFormValues['publishMethod']>,
+        publishScheduled: Yup.date().when('publishMethod', {
+          is: 'Scheduled',
+          then: Yup.date()
+            .required('Enter a valid publish date')
+            .test({
+              name: 'validDateIfAfterToday',
+              message: `Publish date can't be before ${format(
+                new Date(),
+                'do MMMM yyyy',
+              )}`,
+              test(value) {
+                return endOfDay(value) >= endOfDay(new Date());
+              },
+            }),
+        }),
+        nextReleaseDate: Yup.object<PartialDate>({
+          day: Yup.number().notRequired(),
+          month: Yup.number(),
+          year: Yup.number(),
+        })
+          .notRequired()
+          .test({
+            name: 'validDate',
+            message: 'Enter a valid next release date',
+            test(value: PartialDate) {
+              if (isPartialDateEmpty(value)) {
+                return true;
+              }
+
+              if (!isValidPartialDate(value)) {
+                return false;
+              }
+
+              return isValid(parsePartialDateToLocalDate(value));
+            },
+          }),
+      })}
+    >
+      {form => (
+        <Form id={formId}>
+          <h2>Edit release status</h2>
+
+          <FormFieldRadioGroup<ReleaseStatusFormValues>
+            legend="Status"
+            name="status"
+            id={`${formId}-status`}
+            orderDirection={[]}
+            options={[
+              {
+                label: 'In draft',
+                value: 'Draft',
+                disabled: !statusPermissions?.canMarkDraft,
+              },
+              {
+                label: 'Ready for higher review',
+                value: 'HigherLevelReview',
+                disabled: !statusPermissions?.canMarkHigherLevelReview,
+              },
+              {
+                label: 'Approved for publication',
+                value: 'Approved',
+                disabled: !statusPermissions?.canMarkApproved,
+              },
+            ]}
+          />
+
+          <FormFieldTextArea<ReleaseStatusFormValues>
+            name="internalReleaseNote"
+            className="govuk-!-width-one-half"
+            id={`${formId}-internalReleaseNote`}
+            label="Internal release note"
+            rows={3}
+          />
+
+          {form.values.status === 'Approved' && (
+            <FormFieldRadioGroup<ReleaseStatusFormValues>
+              id={`${formId}-publishMethod`}
+              name="publishMethod"
+              legend="When to publish"
+              legendSize="m"
+              hint="Do you want to publish this release on a specific date or as soon as possible?"
+              order={[]}
+              options={[
+                {
+                  label: 'On a specific date',
+                  value: 'Scheduled',
+                  conditional: (
+                    <FormFieldDateInput<ReleaseStatusFormValues>
+                      id={`${formId}-publishScheduled`}
+                      name="publishScheduled"
+                      legend="Publish date"
+                      legendSize="s"
+                    />
+                  ),
+                },
+                {
+                  label: 'As soon as possible',
+                  value: 'Immediate',
+                  conditional: (
+                    <WarningMessage className="govuk-!-width-two-thirds">
+                      This will start the release process immediately and make
+                      statistics available to the public. Make sure this is okay
+                      before continuing.
+                    </WarningMessage>
+                  ),
+                },
+              ]}
+            />
+          )}
+
+          <FormFieldDateInput<ReleaseStatusFormValues>
+            id={`${formId}-nextReleaseDate`}
+            name="nextReleaseDate"
+            legend="Next release expected (optional)"
+            legendSize="m"
+            type="partialDate"
+            partialDateType="monthYear"
+          />
+
+          <ButtonGroup>
+            <Button type="submit" disabled={form.isSubmitting}>
+              Update status
+            </Button>
+            <ButtonText
+              onClick={() => {
+                form.resetForm();
+                onCancel();
+              }}
+            >
+              Cancel
+            </ButtonText>
+          </ButtonGroup>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+export default ReleaseStatusForm;

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -1,0 +1,709 @@
+import { ReleaseStatusPermissions } from '@admin/services/permissionService';
+import { Release } from '@admin/services/releaseService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import ReleaseStatusForm, {
+  ReleaseStatusFormValues,
+} from '@admin/pages/release/components/ReleaseStatusForm';
+import noop from 'lodash/noop';
+import userEvent from '@testing-library/user-event';
+
+describe('ReleaseStatusForm', () => {
+  const testRelease: Release = {
+    id: 'release-1',
+    slug: 'release-1-slug',
+    status: 'Draft',
+    latestRelease: false,
+    live: false,
+    amendment: false,
+    releaseName: 'Release 1',
+    publicationId: 'publication-1',
+    publicationTitle: 'Publication 1',
+    publicationSlug: 'publication-1-slug',
+    timePeriodCoverage: { value: 'W51', label: 'Week 51' },
+    title: 'Release Title',
+    type: {
+      id: 'type-1',
+      title: 'Official Statistics',
+    },
+    contact: {
+      id: 'contact-1',
+      teamName: 'Test name',
+      teamEmail: 'test@test.com',
+      contactName: 'Test contact name',
+      contactTelNo: '1111 1111 1111',
+    },
+    previousVersionId: '',
+    preReleaseAccessList: '',
+  };
+
+  const testStatusPermissions: ReleaseStatusPermissions = {
+    canMarkApproved: true,
+    canMarkDraft: true,
+    canMarkHigherLevelReview: true,
+  };
+
+  test('renders with all status options enabled', () => {
+    render(
+      <ReleaseStatusForm
+        release={testRelease}
+        statusPermissions={testStatusPermissions}
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    const statuses = within(
+      screen.getByRole('group', { name: 'Status' }),
+    ).getAllByRole('radio');
+
+    expect(statuses).toHaveLength(3);
+    expect(statuses[0]).toHaveAttribute('value', 'Draft');
+    expect(statuses[0]).toBeChecked();
+    expect(statuses[0]).toBeEnabled();
+
+    expect(statuses[1]).toHaveAttribute('value', 'HigherLevelReview');
+    expect(statuses[1]).not.toBeChecked();
+    expect(statuses[1]).toBeEnabled();
+
+    expect(statuses[2]).toHaveAttribute('value', 'Approved');
+    expect(statuses[2]).not.toBeChecked();
+    expect(statuses[2]).toBeEnabled();
+  });
+
+  test('renders with Approved status option disabled', () => {
+    render(
+      <ReleaseStatusForm
+        release={testRelease}
+        statusPermissions={{
+          ...testStatusPermissions,
+          canMarkApproved: false,
+        }}
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    const statuses = within(
+      screen.getByRole('group', { name: 'Status' }),
+    ).getAllByRole('radio');
+
+    expect(statuses).toHaveLength(3);
+    expect(statuses[0]).toHaveAttribute('value', 'Draft');
+    expect(statuses[0]).toBeChecked();
+    expect(statuses[0]).toBeEnabled();
+
+    expect(statuses[1]).toHaveAttribute('value', 'HigherLevelReview');
+    expect(statuses[1]).not.toBeChecked();
+    expect(statuses[1]).toBeEnabled();
+
+    expect(statuses[2]).toHaveAttribute('value', 'Approved');
+    expect(statuses[2]).not.toBeChecked();
+    expect(statuses[2]).toBeDisabled();
+  });
+
+  test('renders with HigherLevelReview and Approved status options disabled', () => {
+    render(
+      <ReleaseStatusForm
+        release={testRelease}
+        statusPermissions={{
+          ...testStatusPermissions,
+          canMarkHigherLevelReview: false,
+          canMarkApproved: false,
+        }}
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    const statuses = within(
+      screen.getByRole('group', { name: 'Status' }),
+    ).getAllByRole('radio');
+
+    expect(statuses).toHaveLength(3);
+    expect(statuses[0]).toHaveAttribute('value', 'Draft');
+    expect(statuses[0]).toBeChecked();
+    expect(statuses[0]).toBeEnabled();
+
+    expect(statuses[1]).toHaveAttribute('value', 'HigherLevelReview');
+    expect(statuses[1]).not.toBeChecked();
+    expect(statuses[1]).toBeDisabled();
+
+    expect(statuses[2]).toHaveAttribute('value', 'Approved');
+    expect(statuses[2]).not.toBeChecked();
+    expect(statuses[2]).toBeDisabled();
+  });
+
+  test('renders with all options disabled', () => {
+    render(
+      <ReleaseStatusForm
+        release={testRelease}
+        statusPermissions={{
+          canMarkDraft: false,
+          canMarkHigherLevelReview: false,
+          canMarkApproved: false,
+        }}
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    const statuses = within(
+      screen.getByRole('group', { name: 'Status' }),
+    ).getAllByRole('radio');
+
+    expect(statuses).toHaveLength(3);
+    expect(statuses[0]).toHaveAttribute('value', 'Draft');
+    expect(statuses[0]).toBeChecked();
+    expect(statuses[0]).toBeDisabled();
+
+    expect(statuses[1]).toHaveAttribute('value', 'HigherLevelReview');
+    expect(statuses[1]).not.toBeChecked();
+    expect(statuses[1]).toBeDisabled();
+
+    expect(statuses[2]).toHaveAttribute('value', 'Approved');
+    expect(statuses[2]).not.toBeChecked();
+    expect(statuses[2]).toBeDisabled();
+  });
+
+  test('renders correctly with initial values', () => {
+    render(
+      <ReleaseStatusForm
+        release={{
+          ...testRelease,
+          status: 'HigherLevelReview',
+          nextReleaseDate: {
+            month: 10,
+            year: 2021,
+          },
+          internalReleaseNote: 'Test release note',
+        }}
+        statusPermissions={testStatusPermissions}
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    const statuses = within(screen.getByRole('group', { name: 'Status' }));
+
+    expect(statuses.getByLabelText('In draft')).not.toBeChecked();
+    expect(statuses.getByLabelText('Ready for higher review')).toBeChecked();
+    expect(
+      statuses.getByLabelText('Approved for publication'),
+    ).not.toBeChecked();
+
+    expect(
+      screen.queryByRole('group', { name: 'When to publish' }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByLabelText('Internal release note')).toHaveValue(
+      'Test release note',
+    );
+
+    const nextReleaseDate = within(
+      screen.getByRole('group', { name: 'Next release expected (optional)' }),
+    );
+
+    expect(nextReleaseDate.getByLabelText('Month')).toHaveValue(10);
+    expect(nextReleaseDate.getByLabelText('Year')).toHaveValue(2021);
+  });
+
+  describe('in Draft', () => {
+    test('submits successfully without changing values', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <ReleaseStatusForm
+          release={testRelease}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+      const expectedValues: ReleaseStatusFormValues = {
+        internalReleaseNote: '',
+        status: 'Draft',
+      };
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith(expectedValues);
+      });
+    });
+
+    test('submits successfully with updated values', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <ReleaseStatusForm
+          release={testRelease}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      userEvent.click(screen.getByLabelText('Ready for higher review'));
+      await userEvent.type(
+        screen.getByLabelText('Internal release note'),
+        'Test release note',
+      );
+
+      const nextReleaseDate = within(
+        screen.getByRole('group', { name: 'Next release expected (optional)' }),
+      );
+
+      await userEvent.type(nextReleaseDate.getByLabelText('Month'), '5');
+      await userEvent.type(nextReleaseDate.getByLabelText('Year'), '2021');
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+      const expectedValues: ReleaseStatusFormValues = {
+        internalReleaseNote: 'Test release note',
+        status: 'HigherLevelReview',
+        nextReleaseDate: {
+          month: 5,
+          year: 2021,
+        },
+      };
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith(expectedValues);
+      });
+    });
+  });
+
+  describe('in Higher Level Review', () => {
+    test('shows error message when internal release note is empty', async () => {
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            status: 'HigherLevelReview',
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      userEvent.click(screen.getByLabelText('Internal release note'));
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', { name: 'Enter an internal release note' }),
+        ).toHaveAttribute('href', '#releaseStatusForm-internalReleaseNote');
+      });
+    });
+
+    test('fails to submit with invalid values', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            status: 'HigherLevelReview',
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('There is a problem')).toBeInTheDocument();
+        expect(
+          screen.getByRole('link', { name: 'Enter an internal release note' }),
+        ).toBeInTheDocument();
+
+        expect(handleSubmit).not.toHaveBeenCalled();
+      });
+    });
+
+    test('submits successfully with updated values', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            status: 'HigherLevelReview',
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      userEvent.click(screen.getByLabelText('In draft'));
+      await userEvent.type(
+        screen.getByLabelText('Internal release note'),
+        'Test release note',
+      );
+
+      const nextReleaseDate = within(
+        screen.getByRole('group', { name: 'Next release expected (optional)' }),
+      );
+
+      await userEvent.type(nextReleaseDate.getByLabelText('Month'), '5');
+      await userEvent.type(nextReleaseDate.getByLabelText('Year'), '2021');
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+      const expectedValues: ReleaseStatusFormValues = {
+        internalReleaseNote: 'Test release note',
+        status: 'Draft',
+        nextReleaseDate: {
+          month: 5,
+          year: 2021,
+        },
+      };
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith(expectedValues);
+      });
+    });
+  });
+
+  describe('in Approved', () => {
+    test('renders correctly with no published date', () => {
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            status: 'Approved',
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      const statuses = within(screen.getByRole('group', { name: 'Status' }));
+
+      expect(statuses.getByLabelText('In draft')).not.toBeChecked();
+      expect(
+        statuses.getByLabelText('Ready for higher review'),
+      ).not.toBeChecked();
+      expect(statuses.getByLabelText('Approved for publication')).toBeChecked();
+
+      const whenToPublish = within(
+        screen.getByRole('group', { name: 'When to publish' }),
+      );
+
+      expect(
+        whenToPublish.getByLabelText('On a specific date'),
+      ).not.toBeChecked();
+      expect(
+        whenToPublish.getByLabelText('As soon as possible'),
+      ).not.toBeChecked();
+    });
+
+    test('renders correctly with published date', () => {
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            status: 'Approved',
+            publishScheduled: '2020-12-15',
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      const statuses = within(screen.getByRole('group', { name: 'Status' }));
+
+      expect(statuses.getByLabelText('In draft')).not.toBeChecked();
+      expect(
+        statuses.getByLabelText('Ready for higher review'),
+      ).not.toBeChecked();
+      expect(statuses.getByLabelText('Approved for publication')).toBeChecked();
+
+      const whenToPublish = within(
+        screen.getByRole('group', { name: 'When to publish' }),
+      );
+
+      expect(whenToPublish.getByLabelText('On a specific date')).toBeChecked();
+
+      const publishDate = within(
+        whenToPublish.getByRole('group', {
+          name: 'Publish date',
+        }),
+      );
+
+      expect(publishDate.getByLabelText('Day')).toHaveValue(15);
+      expect(publishDate.getByLabelText('Month')).toHaveValue(12);
+      expect(publishDate.getByLabelText('Year')).toHaveValue(2020);
+    });
+
+    test('shows error message when internal release note is empty', async () => {
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            status: 'Approved',
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      userEvent.click(screen.getByLabelText('Internal release note'));
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', { name: 'Enter an internal release note' }),
+        ).toHaveAttribute('href', '#releaseStatusForm-internalReleaseNote');
+      });
+    });
+
+    test('shows error message when no publishing method selected', async () => {
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            status: 'Approved',
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      // Focus the field above before tabbing through the options
+      userEvent.click(screen.getByLabelText('Internal release note'));
+      userEvent.tab();
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', { name: 'Choose when to publish' }),
+        ).toHaveAttribute('href', '#releaseStatusForm-publishMethod');
+      });
+    });
+
+    test('shows error message when no publish date', async () => {
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            status: 'Approved',
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={noop}
+        />,
+      );
+
+      userEvent.click(screen.getByLabelText('On a specific date'));
+      userEvent.tab();
+      userEvent.tab();
+      userEvent.tab();
+      userEvent.tab();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', { name: 'Enter a valid publish date' }),
+        ).toHaveAttribute('href', '#releaseStatusForm-publishScheduled');
+      });
+    });
+
+    test('fails to submit with invalid values', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            status: 'Approved',
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('There is a problem')).toBeInTheDocument();
+        expect(
+          screen.getByRole('link', { name: 'Enter an internal release note' }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('link', { name: 'Choose when to publish' }),
+        ).toBeInTheDocument();
+
+        expect(handleSubmit).not.toHaveBeenCalled();
+      });
+    });
+
+    test('submits successfully with updated values and Draft status', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            publishScheduled: '2020-12-20',
+            status: 'Approved',
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      userEvent.click(screen.getByLabelText('In draft'));
+      await userEvent.type(
+        screen.getByLabelText('Internal release note'),
+        'Test release note',
+      );
+
+      const nextReleaseDate = within(
+        screen.getByRole('group', { name: 'Next release expected (optional)' }),
+      );
+
+      await userEvent.type(nextReleaseDate.getByLabelText('Month'), '5');
+      await userEvent.type(nextReleaseDate.getByLabelText('Year'), '2021');
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+      const expectedValues: ReleaseStatusFormValues = {
+        internalReleaseNote: 'Test release note',
+        status: 'Draft',
+        nextReleaseDate: {
+          month: 5,
+          year: 2021,
+        },
+      };
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith(expectedValues);
+      });
+    });
+
+    test('submits successfully with updated values and publish date', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            status: 'Approved',
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      await userEvent.type(
+        screen.getByLabelText('Internal release note'),
+        'Test release note',
+      );
+
+      userEvent.click(screen.getByLabelText('On a specific date'));
+
+      const publishDate = within(
+        screen.getByRole('group', { name: 'Publish date' }),
+      );
+
+      await userEvent.type(publishDate.getByLabelText('Day'), '10');
+      await userEvent.type(publishDate.getByLabelText('Month'), '10');
+      await userEvent.type(publishDate.getByLabelText('Year'), '2022');
+
+      const nextReleaseDate = within(
+        screen.getByRole('group', { name: 'Next release expected (optional)' }),
+      );
+
+      await userEvent.type(nextReleaseDate.getByLabelText('Month'), '5');
+      await userEvent.type(nextReleaseDate.getByLabelText('Year'), '2021');
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+      const expectedValues: ReleaseStatusFormValues = {
+        internalReleaseNote: 'Test release note',
+        status: 'Approved',
+        publishScheduled: new Date('2022-10-10'),
+        publishMethod: 'Scheduled',
+        nextReleaseDate: {
+          month: 5,
+          year: 2021,
+        },
+      };
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith(expectedValues);
+      });
+    });
+
+    test('submits successfully with update values and immediate publish', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            status: 'Approved',
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      await userEvent.type(
+        screen.getByLabelText('Internal release note'),
+        'Test release note',
+      );
+
+      userEvent.click(screen.getByLabelText('As soon as possible'));
+
+      const nextReleaseDate = within(
+        screen.getByRole('group', { name: 'Next release expected (optional)' }),
+      );
+
+      await userEvent.type(nextReleaseDate.getByLabelText('Month'), '5');
+      await userEvent.type(nextReleaseDate.getByLabelText('Year'), '2021');
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+      const expectedValues: ReleaseStatusFormValues = {
+        internalReleaseNote: 'Test release note',
+        status: 'Approved',
+        publishMethod: 'Immediate',
+        nextReleaseDate: {
+          month: 5,
+          year: 2021,
+        },
+      };
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith(expectedValues);
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -21,7 +21,7 @@ export interface Release {
   contact: ContactDetails;
   publishScheduled?: string;
   published?: string;
-  nextReleaseDate: PartialDate;
+  nextReleaseDate?: PartialDate;
   internalReleaseNote?: string;
   previousVersionId: string;
   preReleaseAccessList: string;
@@ -68,6 +68,7 @@ export interface UpdateReleaseRequest extends BaseReleaseRequest {
   status: ReleaseApprovalStatus;
   internalReleaseNote?: string;
   publishScheduled?: string;
+  publishMethod?: 'Scheduled' | 'Immediate';
   nextReleaseDate?: PartialDate;
   preReleaseAccessList?: string;
 }


### PR DESCRIPTION
This change also adds a raft of tests to cover `ReleaseStatusPage` and `ReleaseStatusForm`.