### PR TITLE
EES-1658 - additional convenience code not relevant to the final fix …

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
+{
+    public class EnumerableExtensionsTests
+    {
+        [Fact]
+        public void DistinctByProperty()
+        {
+            var list = new List<TestClass>
+            {
+                new TestClass(1),
+                new TestClass(1),
+                new TestClass(2),
+            };
+
+            var distinct = list.DistinctByProperty(x => x.Value);
+            
+            Assert.Equal(new List<TestClass>
+            {
+                new TestClass(1),
+                new TestClass(2),
+            }, distinct);
+        }
+
+        private class TestClass
+        {
+            public readonly int Value;
+
+            public TestClass(int value)
+            {
+                Value = value;
+            }
+
+            protected bool Equals(TestClass other)
+            {
+                return Value == other.Value;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != this.GetType()) return false;
+                return Equals((TestClass) obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return Value;
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Xunit;
 
@@ -16,13 +17,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
                 new TestClass(2),
             };
 
-            var distinct = list.DistinctByProperty(x => x.Value);
-            
-            Assert.Equal(new List<TestClass>
-            {
-                new TestClass(1),
-                new TestClass(2),
-            }, distinct);
+            var distinct = list.DistinctByProperty(x => x.Value).ToList();
+
+            Assert.Equal(2, distinct.Count);
+            Assert.Equal(1, distinct[0].Value);
+            Assert.Equal(2, distinct[1].Value);
         }
 
         private class TestClass
@@ -32,24 +31,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             public TestClass(int value)
             {
                 Value = value;
-            }
-
-            protected bool Equals(TestClass other)
-            {
-                return Value == other.Value;
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj)) return false;
-                if (ReferenceEquals(this, obj)) return true;
-                if (obj.GetType() != this.GetType()) return false;
-                return Equals((TestClass) obj);
-            }
-
-            public override int GetHashCode()
-            {
-                return Value;
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/ComparerUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/ComparerUtilsTests.cs
@@ -16,6 +16,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
             Assert.False(comparer.Equals(new TestClass(1), new TestClass(2)));
             Assert.False(comparer.Equals(null, new TestClass(2)));
             Assert.False(comparer.Equals(new TestClass(1), null));
+            
+            Assert.Equal(comparer.GetHashCode(new TestClass(1)), 1.GetHashCode());
         }
 
         private class TestClass

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/ComparerUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/ComparerUtilsTests.cs
@@ -1,0 +1,31 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
+{
+    public class ComparerUtilsTests
+    {
+        [Fact]
+        public void CreateComparerByProperty()
+        {
+            var comparer = ComparerUtils.CreateComparerByProperty<TestClass>(x=> x.Value);
+
+            Assert.True(comparer.Equals(new TestClass(1), new TestClass(1)));
+            Assert.True(comparer.Equals(null, null));
+
+            Assert.False(comparer.Equals(new TestClass(1), new TestClass(2)));
+            Assert.False(comparer.Equals(null, new TestClass(2)));
+            Assert.False(comparer.Equals(new TestClass(1), null));
+        }
+
+        private class TestClass
+        {
+            public readonly int Value;
+
+            public TestClass(int value)
+            {
+                Value = value;
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 {
@@ -144,5 +145,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 
         public static IEnumerable<(T item, int index)> WithIndex<T>(this IEnumerable<T> self) =>
             self.Select((item, index) => (item, index));
+        
+        /// <summary>
+        /// Filter a list down to distinct elements based on a property of the type.
+        /// </summary>
+        ///
+        /// <remarks>
+        /// As IEqualityComparers (as used in Linq's Distinct() method) compare with GetHashCode() rather than with
+        /// Equals(), the property being used to compare distinctions against needs to produce a reliable hash code
+        /// that we can use for equality.  A good property type then could be a Guid Id field, as two identical Guid Ids
+        /// can then represent that 2 or more entities in the list are duplicates as they will have the same hash code.
+        /// </remarks>
+        /// 
+        /// <param name="source">Sequence of elements to filter on a distinct property</param>
+        /// <param name="propertyGetter">A supplier of a property from each entity to check for equality. The property
+        /// chosen must produce the same hash code for any two elements in the source list that are considered
+        /// duplicates.  A good example would be a Guid Id.</param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static IEnumerable<T> DistinctByProperty<T>(
+            this IEnumerable<T> source, 
+            Func<T, object> propertyGetter)
+            where T : class
+        {
+            return source.Distinct(ComparerUtils.CreateComparerByProperty(propertyGetter));
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/ComparerUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/ComparerUtils.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
+{
+    public static class ComparerUtils
+    {
+        public static NullSafePropertyComparer<T> CreateComparerByProperty<T>(Func<T, object> propertyGetter)
+        {
+            return new NullSafePropertyComparer<T>(propertyGetter);    
+        }
+        
+        public class NullSafePropertyComparer<T> : IEqualityComparer<T> 
+        {
+            private readonly Func<T, object> _propertyGetter;
+
+            public NullSafePropertyComparer(Func<T, object> propertyGetter) 
+            {
+                _propertyGetter = propertyGetter;
+            }
+
+            public bool Equals(T x, T y)
+            {
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
+                if (x == null || y == null)
+                {
+                    return false;
+                }
+                
+                return Equals(_propertyGetter.Invoke(x), _propertyGetter.Invoke(y));
+            }
+
+            public int GetHashCode(T obj)
+            {
+                return _propertyGetter.Invoke(obj).GetHashCode();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR:
- contains convenience code that was originally written to fix the issue with EES-1658, but never turned out to be needed.

It's totally optional to bring this into the codebase as it's not yet used anywhere, but the reason it was originally written was that Linq's Distinct() method does not take a lambda but it would be nice to do so.  This ended up as an extension method for IEnumerable that would do a Distinct check on a property by supplying a lambda to look up a property e.g.

``
var distinct = filterItemViewModels
    .DistinctByProperty(item => item.Id)
    .Blah();
``