### PR TITLE
EES-1691 Rename common FootnoteService to FootnoteRepository

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServicePermissionTests.cs
@@ -137,7 +137,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             Mock<ISubjectService>,
             Mock<IPersistenceHelper<ContentDbContext>>,
             Mock<IUserService>,
-            Mock<IFootnoteService>,
+            Mock<IFootnoteRepository>,
             Mock<IPersistenceHelper<StatisticsDbContext>>) Mocks()
         {
             var contentPersistenceHelper = MockUtils.MockPersistenceHelper<ContentDbContext>();
@@ -152,7 +152,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 new Mock<ISubjectService>(), 
                 contentPersistenceHelper,
                 new Mock<IUserService>(),
-                new Mock<IFootnoteService>(), 
+                new Mock<IFootnoteRepository>(), 
                 MockUtils.MockPersistenceHelper<StatisticsDbContext, Footnote>(footnote.Id, footnote));
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServiceTests.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -279,7 +280,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             ISubjectService subjectService = null,
             IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
             IUserService userService = null,
-            IFootnoteService commonFootnoteService = null,
+            IFootnoteRepository footnoteRepository = null,
             IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper = null)
         {
             var contentContext = contentDbContext ?? new Mock<ContentDbContext>().Object;
@@ -293,9 +294,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 subjectService ?? new Mock<ISubjectService>().Object,
                 contentPersistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentContext),
                 userService ?? MockUtils.AlwaysTrueUserService().Object,
-                commonFootnoteService ?? new Data.Model.Services.FootnoteService(
+                footnoteRepository ?? new FootnoteRepository(
                     statisticsDbContext,
-                    new Mock<ILogger<Data.Model.Services.FootnoteService>>().Object
+                    new Mock<ILogger<FootnoteRepository>>().Object
                 ),
                 statisticsPersistenceHelper ?? new PersistenceHelper<StatisticsDbContext>(statisticsDbContext)
             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseSubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseSubjectServiceTests.cs
@@ -240,11 +240,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
         private ReleaseSubjectService BuildReleaseSubjectService(
             StatisticsDbContext statisticsDbContext,
-            IFootnoteService footnoteService = null)
+            IFootnoteRepository footnoteRepository = null)
         {
             return new ReleaseSubjectService(
                 statisticsDbContext,
-                footnoteService ?? new Mock<IFootnoteService>().Object
+                footnoteRepository ?? new Mock<IFootnoteRepository>().Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -25,7 +25,6 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Val
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 using static GovUk.Education.ExploreEducationStatistics.Data.Model.Database.StatisticsDbUtils;
-using FootnoteService = GovUk.Education.ExploreEducationStatistics.Data.Model.Services.FootnoteService;
 using IReleaseService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseService;
 using Release = GovUk.Education.ExploreEducationStatistics.Data.Model.Release;
 using Unit = GovUk.Education.ExploreEducationStatistics.Common.Model.Unit;
@@ -2320,7 +2319,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 new FilterService(statisticsDbContext, new Mock<ILogger<FilterService>>().Object),
                 new IndicatorService(statisticsDbContext, new Mock<ILogger<IndicatorService>>().Object),
                 locationService.Object,
-                new FootnoteService(statisticsDbContext, new Mock<ILogger<FootnoteService>>().Object),
+                new FootnoteRepository(statisticsDbContext, new Mock<ILogger<FootnoteRepository>>().Object),
                 releaseService.Object,
                 timePeriodService.Object,
                 new PersistenceHelper<ContentDbContext>(contentDbContext),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -25,7 +25,6 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.Validat
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 using static GovUk.Education.ExploreEducationStatistics.Data.Model.Services.LocationService;
-using IFootnoteService = GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces.IFootnoteService;
 using IReleaseService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseService;
 using Unit = GovUk.Education.ExploreEducationStatistics.Common.Model.Unit;
 
@@ -38,7 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IFilterService _filterService;
         private readonly IIndicatorService _indicatorService;
         private readonly ILocationService _locationService;
-        private readonly IFootnoteService _footnoteService;
+        private readonly IFootnoteRepository _footnoteRepository;
         private readonly IReleaseService _releaseService;
         private readonly ITimePeriodService _timePeriodService;
         private readonly IPersistenceHelper<ContentDbContext> _contentPersistenceHelper;
@@ -51,7 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IFilterService filterService,
             IIndicatorService indicatorService,
             ILocationService locationService,
-            IFootnoteService footnoteService,
+            IFootnoteRepository footnoteRepository,
             IReleaseService releaseService,
             ITimePeriodService timePeriodService,
             IPersistenceHelper<ContentDbContext> contentPersistenceHelper,
@@ -62,7 +61,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _filterService = filterService;
             _indicatorService = indicatorService;
             _locationService = locationService;
-            _footnoteService = footnoteService;
+            _footnoteRepository = footnoteRepository;
             _releaseService = releaseService;
             _timePeriodService = timePeriodService;
             _contentPersistenceHelper = contentPersistenceHelper;
@@ -239,7 +238,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private List<FootnoteReplacementPlanViewModel> ValidateFootnotes(Guid releaseId, Guid subjectId,
             ReplacementSubjectMeta replacementSubjectMeta)
         {
-            return _footnoteService.GetFootnotes(releaseId, subjectId)
+            return _footnoteRepository.GetFootnotes(releaseId, subjectId)
                 .Select(footnote => ValidateFootnote(footnote, replacementSubjectMeta))
                 .ToList();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -273,7 +273,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IFilterGroupService, FilterGroupService>();
             services.AddTransient<IFilterItemService, FilterItemService>();
             services.AddTransient<IFootnoteService, FootnoteService>();
-            services.AddTransient<Data.Model.Services.Interfaces.IFootnoteService, Data.Model.Services.FootnoteService>();
+            services.AddTransient<IFootnoteRepository, FootnoteRepository>();
             services.AddTransient<IGeoJsonService, GeoJsonService>();
             services.AddTransient<IIndicatorGroupService, IndicatorGroupService>();
             services.AddTransient<IIndicatorService, IndicatorService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -106,7 +106,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
             services.AddTransient<IFilterGroupService, FilterGroupService>();
             services.AddTransient<IFilterItemService, FilterItemService>();
             services.AddTransient<IFilterService, FilterService>();
-            services.AddTransient<IFootnoteService, FootnoteService>();
+            services.AddTransient<IFootnoteRepository, FootnoteRepository>();
             services.AddTransient<IGeoJsonService, GeoJsonService>();
             services.AddTransient<IIndicatorGroupService, IndicatorGroupService>();
             services.AddTransient<IIndicatorService, IndicatorService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/FootnoteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/FootnoteRepository.cs
@@ -10,10 +10,10 @@ using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
 {
-    public class FootnoteService : AbstractRepository<Footnote, Guid>, IFootnoteService
+    public class FootnoteRepository : AbstractRepository<Footnote, Guid>, IFootnoteRepository
     {
-        public FootnoteService(StatisticsDbContext context,
-            ILogger<FootnoteService> logger) : base(context, logger)
+        public FootnoteRepository(StatisticsDbContext context,
+            ILogger<FootnoteRepository> logger) : base(context, logger)
         {}
 
         public IEnumerable<Footnote> GetFilteredFootnotes(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/IFootnoteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/IFootnoteRepository.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces
 {
-    public interface IFootnoteService
+    public interface IFootnoteRepository
     {
         IEnumerable<Footnote> GetFilteredFootnotes(
             Guid releaseId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/ReleaseSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/ReleaseSubjectService.cs
@@ -11,12 +11,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
     public class ReleaseSubjectService : IReleaseSubjectService
     {
         private readonly StatisticsDbContext _statisticsDbContext;
-        private readonly IFootnoteService _footnoteService;
+        private readonly IFootnoteRepository _footnoteRepository;
 
-        public ReleaseSubjectService(StatisticsDbContext statisticsDbContext, IFootnoteService footnoteService)
+        public ReleaseSubjectService(StatisticsDbContext statisticsDbContext, IFootnoteRepository footnoteRepository)
         {
             _statisticsDbContext = statisticsDbContext;
-            _footnoteService = footnoteService;
+            _footnoteRepository = footnoteRepository;
         }
 
         public async Task SoftDeleteAllReleaseSubjects(Guid releaseId)
@@ -51,7 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
                 .FirstOrDefaultAsync(rs => rs.ReleaseId == releaseId && rs.SubjectId == subjectId);
 
             await DeleteReleaseSubjectIfExists(releaseSubject);
-            await _footnoteService.DeleteAllFootnotesBySubject(releaseId, subjectId);
+            await _footnoteRepository.DeleteAllFootnotesBySubject(releaseId, subjectId);
 
             if (releaseSubject?.Subject != null)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
@@ -24,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
     public class ResultSubjectMetaService : AbstractSubjectMetaService, IResultSubjectMetaService
     {
         private readonly IBoundaryLevelService _boundaryLevelService;
-        private readonly IFootnoteService _footnoteService;
+        private readonly IFootnoteRepository _footnoteRepository;
         private readonly IIndicatorService _indicatorService;
         private readonly ILocationService _locationService;
         private readonly IPersistenceHelper<StatisticsDbContext> _persistenceHelper;
@@ -36,7 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         public ResultSubjectMetaService(IBoundaryLevelService boundaryLevelService,
             IFilterItemService filterItemService,
-            IFootnoteService footnoteService,
+            IFootnoteRepository footnoteRepository,
             IGeoJsonService geoJsonService,
             IIndicatorService indicatorService,
             ILocationService locationService,
@@ -48,7 +48,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             IMapper mapper) : base(boundaryLevelService, filterItemService, geoJsonService)
         {
             _boundaryLevelService = boundaryLevelService;
-            _footnoteService = footnoteService;
+            _footnoteRepository = footnoteRepository;
             _indicatorService = indicatorService;
             _locationService = locationService;
             _persistenceHelper = persistenceHelper;
@@ -162,7 +162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         private IEnumerable<FootnoteViewModel> GetFilteredFootnotes(Guid releaseId, IQueryable<Observation> observations,
             SubjectMetaQueryContext queryContext)
         {
-            return _footnoteService.GetFilteredFootnotes(releaseId, queryContext.SubjectId, observations, queryContext.Indicators)
+            return _footnoteRepository.GetFilteredFootnotes(releaseId, queryContext.SubjectId, observations, queryContext.Indicators)
                 .Select(footnote => new FootnoteViewModel
                 {
                     Id = footnote.Id,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -88,7 +88,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                 .AddScoped<IReleaseStatusService, ReleaseStatusService>()
                 .AddScoped<IValidationService, ValidationService>()
                 .AddScoped<IReleaseSubjectService, ReleaseSubjectService>()
-                .AddScoped<IFootnoteService, FootnoteService>();
+                .AddScoped<IFootnoteRepository, FootnoteRepository>();
         }
 
         private static string GetConfigurationValue(IServiceProvider provider, string key)


### PR DESCRIPTION
This PR renames the common `FootnoteService` (in `Data.Model`) to `FootnoteRepository`. 

This has the benefit of: 
- Removing namespacing issues 
- Simplifying names from things like `commonFootnoteService` to `footnoteRepository`
- Being more semantically correct, as it is more like a repository than a service (most of the common data 'services' are repositories).