### PR TITLE
EES-169 Filter instances where no rows in Releases or ReleaseFileRefe…

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/bau/BauImportsPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/bau/BauImportsPage.tsx
@@ -32,7 +32,7 @@ const BauImportsPage = () => {
               <th scope="col">Data file name</th>
               <th scope="col">Data file rows</th>
               <th scope="col">Status</th>
-              <th scope="col">Stage Percentage Complete</th>
+              <th scope="col">Stage percentage complete</th>
               <th scope="col">Go to release data files</th>
             </tr>
           </thead>


### PR DESCRIPTION
…rences

Things I'm unsure about:
- I'm currently having to make some queries twice in both the Where and Select in `ImportStatusBauService`. I think I could avoid this if I used a for loop. Is there a way to avoid this with linq?
- The two new unit tests I wrote could check that the output logging messages are correct. I tried looking for other unit tests that did such a check, but couldn't find them - but my intuition says I've seen them before?