### PR TITLE
EES-1531 Add checklist to release status page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -285,6 +285,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             Mock<IReleaseFileService> ReleaseFileService,
             Mock<IReleaseDataFileService> ReleaseDataFilesService,
             Mock<IReleaseStatusService> ReleaseStatusService,
+            Mock<IReleaseChecklistService> ReleaseChecklistService,
             Mock<UserManager<ApplicationUser>> UserManager,
             Mock<IDataBlockService> DataBlockService) Mocks()
         {
@@ -292,6 +293,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                     new Mock<IReleaseFileService>(),
                     new Mock<IReleaseDataFileService>(),
                     new Mock<IReleaseStatusService>(),
+                    new Mock<IReleaseChecklistService>(),
                     MockUserManager(),
                     new Mock<IDataBlockService>()
                 );
@@ -302,6 +304,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             Mock<IReleaseFileService> ReleaseFileService,
             Mock<IReleaseDataFileService> ReleaseDataFileService,
             Mock<IReleaseStatusService> ReleaseStatusService,
+            Mock<IReleaseChecklistService> ReleaseChecklistService,
             Mock<UserManager<ApplicationUser>> UserManager,
             Mock<IDataBlockService> DataBlockService
             ) mocks)
@@ -311,6 +314,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 mocks.ReleaseFileService.Object,
                 mocks.ReleaseDataFileService.Object,
                 mocks.ReleaseStatusService.Object,
+                mocks.ReleaseChecklistService.Object,
                 mocks.UserManager.Object,
                 mocks.DataBlockService.Object);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServicePermissionTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -54,14 +55,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             StatisticsDbContext statisticsDbContext = null,
             IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
             IMetaGuidanceSubjectService metaGuidanceSubjectService = null,
-            IUserService userService = null)
+            IUserService userService = null,
+            IFileRepository fileRepository = null)
         {
             return new MetaGuidanceService(
                 contentDbContext ?? new Mock<ContentDbContext>().Object,
                 contentPersistenceHelper ?? DefaultPersistenceHelperMock().Object,
                 metaGuidanceSubjectService ?? new Mock<IMetaGuidanceSubjectService>().Object,
                 statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
-                userService ?? new Mock<IUserService>().Object
+                userService ?? new Mock<IUserService>().Object,
+                fileRepository ?? new FileRepository(contentDbContext)
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -893,14 +894,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             StatisticsDbContext statisticsDbContext = null,
             IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
             IMetaGuidanceSubjectService metaGuidanceSubjectService = null,
-            IUserService userService = null)
+            IUserService userService = null,
+            IFileRepository fileRepository = null)
         {
             return new MetaGuidanceService(
                 contentDbContext,
                 contentPersistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
                 metaGuidanceSubjectService ?? new Mock<IMetaGuidanceSubjectService>().Object,
                 statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
-                userService ?? MockUtils.AlwaysTrueUserService().Object
+                userService ?? MockUtils.AlwaysTrueUserService().Object,
+                fileRepository ?? new FileRepository(contentDbContext)
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -836,7 +836,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.Validate(release.Id);
 
                 Assert.True(result.IsLeft);
-                ValidationTestUtil.AssertValidationProblem(result.Left, MetaGuidanceMustBePopulated);
+                ValidationTestUtil.AssertValidationProblem(result.Left, PublicMetaGuidanceRequired);
             }
         }
 
@@ -885,7 +885,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 metaGuidanceSubjectService.Verify(mock => mock.Validate(release.Id), Times.Once);
 
-                ValidationTestUtil.AssertValidationProblem(result.Left, MetaGuidanceMustBePopulated);
+                ValidationTestUtil.AssertValidationProblem(result.Left, PublicMetaGuidanceRequired);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
@@ -8,11 +7,12 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Secu
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.ValidationTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -110,11 +110,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 });
 
             Assert.True(result.IsLeft);
-
-            var badRequestObjectResult = Assert.IsType<BadRequestObjectResult>(result.Left);
-            var details = Assert.IsType<ValidationProblemDetails>(badRequestObjectResult.Value);
-
-            Assert.Equal("TOPIC_DOES_NOT_EXIST", details.Errors[""].First());
+            AssertValidationProblem(result.Left, TopicDoesNotExist);
         }
 
         [Fact]
@@ -148,11 +144,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 );
 
                 Assert.True(result.IsLeft);
-
-                var badRequestObjectResult = Assert.IsType<BadRequestObjectResult>(result.Left);
-                var details = Assert.IsType<ValidationProblemDetails>(badRequestObjectResult.Value);
-
-                Assert.Equal("METHODOLOGY_DOES_NOT_EXIST", details.Errors[""].First());
+                AssertValidationProblem(result.Left, MethodologyDoesNotExist);
             }
         }
 
@@ -198,11 +190,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 );
 
                 Assert.True(result.IsLeft);
-
-                var badRequestObjectResult = Assert.IsType<BadRequestObjectResult>(result.Left);
-                var details = Assert.IsType<ValidationProblemDetails>(badRequestObjectResult.Value);
-
-                Assert.Equal("CANNOT_SPECIFY_METHODOLOGY_AND_EXTERNAL_METHODOLOGY", details.Errors[""].First());
+                AssertValidationProblem(result.Left, CannotSpecifyMethodologyAndExternalMethodology);
             }
         }
 
@@ -244,11 +232,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 );
 
                 Assert.True(result.IsLeft);
-
-                var badRequestObjectResult = Assert.IsType<BadRequestObjectResult>(result.Left);
-                var details = Assert.IsType<ValidationProblemDetails>(badRequestObjectResult.Value);
-
-                Assert.Equal("METHODOLOGY_MUST_BE_APPROVED_OR_PUBLISHED", details.Errors[""].First());
+                AssertValidationProblem(result.Left, MethodologyMustBeApproved);
             }
         }
 
@@ -291,11 +275,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 );
 
                 Assert.True(result.IsLeft);
-
-                var badRequestObjectResult = Assert.IsType<BadRequestObjectResult>(result.Left);
-                var details = Assert.IsType<ValidationProblemDetails>(badRequestObjectResult.Value);
-
-                Assert.Equal("SLUG_NOT_UNIQUE", details.Errors[""].First());
+                AssertValidationProblem(result.Left, SlugNotUnique);
             }
         }
 
@@ -396,7 +376,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("New methodology", updatedPublication.Methodology.Title);
             }
         }
-        
+
         [Fact]
         public async void UpdatePublication_AlreadyPublished()
         {
@@ -614,7 +594,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         MethodologyId = publication.MethodologyId,
                     }
                 );
-                
+
                 var updatedPublication = await context.Publications.FindAsync(result.Right.Id);
 
                 Assert.NotEqual(sharedContact.Id, updatedPublication.Contact.Id);
@@ -664,11 +644,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 );
 
                 Assert.True(result.IsLeft);
-
-                var badRequestObjectResult = Assert.IsType<BadRequestObjectResult>(result.Left);
-                var details = Assert.IsType<ValidationProblemDetails>(badRequestObjectResult.Value);
-
-                Assert.Equal("TOPIC_DOES_NOT_EXIST", details.Errors[""].First());
+                AssertValidationProblem(result.Left, TopicDoesNotExist);
             }
         }
 
@@ -707,11 +683,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 );
 
                 Assert.True(result.IsLeft);
-
-                var badRequestObjectResult = Assert.IsType<BadRequestObjectResult>(result.Left);
-                var details = Assert.IsType<ValidationProblemDetails>(badRequestObjectResult.Value);
-
-                Assert.Equal("METHODOLOGY_DOES_NOT_EXIST", details.Errors[""].First());
+                AssertValidationProblem(result.Left, MethodologyDoesNotExist);
             }
         }
 
@@ -755,11 +727,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 );
 
                 Assert.True(result.IsLeft);
-
-                var badRequestObjectResult = Assert.IsType<BadRequestObjectResult>(result.Left);
-                var details = Assert.IsType<ValidationProblemDetails>(badRequestObjectResult.Value);
-
-                Assert.Equal("CANNOT_SPECIFY_METHODOLOGY_AND_EXTERNAL_METHODOLOGY", details.Errors[""].First());
+                AssertValidationProblem(result.Left, CannotSpecifyMethodologyAndExternalMethodology);
             }
         }
 
@@ -805,11 +773,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 );
 
                 Assert.True(result.IsLeft);
-
-                var badRequestObjectResult = Assert.IsType<BadRequestObjectResult>(result.Left);
-                var details = Assert.IsType<ValidationProblemDetails>(badRequestObjectResult.Value);
-
-                Assert.Equal("METHODOLOGY_MUST_BE_APPROVED_OR_PUBLISHED", details.Errors[""].First());
+                AssertValidationProblem(result.Left, MethodologyMustBeApproved);
             }
         }
 
@@ -857,11 +821,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 );
 
                 Assert.True(result.IsLeft);
-
-                var badRequestObjectResult = Assert.IsType<BadRequestObjectResult>(result.Left);
-                var details = Assert.IsType<ValidationProblemDetails>(badRequestObjectResult.Value);
-
-                Assert.Equal("SLUG_NOT_UNIQUE", details.Errors[""].First());
+                AssertValidationProblem(result.Left, SlugNotUnique);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServicePermissionTests.cs
@@ -1,0 +1,67 @@
+using System;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.PermissionTestUtil;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
+{
+    public class ReleaseChecklistPermissionServiceTests
+    {
+        private readonly Release _release = new Release
+        {
+            Id = Guid.NewGuid()
+        };
+
+
+        [Fact]
+        public void GetChecklist()
+        {
+            PolicyCheckBuilder()
+                .ExpectResourceCheckToFail(_release, SecurityPolicies.CanViewSpecificRelease)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = BuildReleaseChecklistService(userService: userService.Object);
+                        return service.GetChecklist(_release.Id);
+                    }
+                );
+        }
+
+        private ReleaseChecklistService BuildReleaseChecklistService(
+            IPersistenceHelper<ContentDbContext> persistenceHelper = null,
+            ITableStorageService tableStorageService = null,
+            IUserService userService = null,
+            IMetaGuidanceService metaGuidanceService = null,
+            IFileRepository fileRepository = null,
+            IFootnoteRepository footnoteRepository = null,
+            IDataBlockService dataBlockService = null)
+        {
+
+            return new ReleaseChecklistService(
+                persistenceHelper ?? DefaultPersistenceHelperMock().Object,
+                tableStorageService ?? new Mock<ITableStorageService>().Object,
+                userService ?? MockUtils.AlwaysTrueUserService().Object,
+                metaGuidanceService ?? new Mock<IMetaGuidanceService>().Object,
+                fileRepository ?? new Mock<IFileRepository>().Object,
+                footnoteRepository ?? new Mock<IFootnoteRepository>().Object,
+                dataBlockService ?? new Mock<IDataBlockService>().Object
+            );
+        }
+
+        private Mock<IPersistenceHelper<ContentDbContext>> DefaultPersistenceHelperMock()
+        {
+            var mock = MockUtils.MockPersistenceHelper<ContentDbContext, Release>();
+            MockUtils.SetupCall(mock, _release.Id, _release);
+            return mock;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
@@ -1,0 +1,469 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Cosmos.Table;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Utils.TableStorageTestUtils;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
+using Publication = GovUk.Education.ExploreEducationStatistics.Content.Model.Publication;
+using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
+using Unit = GovUk.Education.ExploreEducationStatistics.Common.Model.Unit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
+{
+    public class ReleaseChecklistServiceTests
+    {
+        [Fact]
+        public async Task GetChecklist_AllErrors()
+        {
+            var publication = new Publication
+            {
+                Methodology = new Methodology()
+            };
+            var originalRelease = new Release
+            {
+                Publication = publication,
+                Version = 0
+            };
+            var release = new Release
+            {
+                Publication = publication,
+                PreviousVersion = originalRelease,
+                Version = 1,
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.AddRangeAsync(release, originalRelease);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var fileRepository = new Mock<IFileRepository>();
+
+                fileRepository
+                    .Setup(r => r.ListDataFiles(release.Id))
+                    .ReturnsAsync(new List<ReleaseFileReference>());
+
+                fileRepository
+                    .Setup(r => r.ListReplacementDataFiles(release.Id))
+                    .ReturnsAsync(
+                        new List<ReleaseFileReference>
+                        {
+                            new ReleaseFileReference()
+                        }
+                    );
+
+                var metaGuidanceService = new Mock<IMetaGuidanceService>();
+
+                metaGuidanceService
+                    .Setup(s => s.Validate(release.Id))
+                    .ReturnsAsync(ValidationActionResult(PublicMetaGuidanceRequired));
+
+                var tableStorageService = MockTableStorageService(
+                    new List<DatafileImport>
+                    {
+                        new DatafileImport()
+                    }
+                );
+
+                var service = BuildReleaseChecklistService(
+                    context,
+                    fileRepository: fileRepository.Object,
+                    metaGuidanceService: metaGuidanceService.Object,
+                    tableStorageService: tableStorageService.Object
+                );
+                var checklist = await service.GetChecklist(release.Id);
+
+                Assert.True(checklist.IsRight);
+
+                Assert.False(checklist.Right.Valid);
+
+                Assert.Equal(6, checklist.Right.Errors.Count);
+
+                Assert.Equal(DataFileImportsMustBeCompleted, checklist.Right.Errors[0].Code);
+                Assert.Equal(DataFileReplacementsMustBeCompleted, checklist.Right.Errors[1].Code);
+
+                var methodologyMustBeApprovedError =
+                    Assert.IsType<MethodologyMustBeApprovedError>(checklist.Right.Errors[2]);
+                Assert.Equal(MethodologyMustBeApproved, methodologyMustBeApprovedError.Code);
+                Assert.Equal(publication.MethodologyId, methodologyMustBeApprovedError.MethodologyId);
+
+                Assert.Equal(PublicMetaGuidanceRequired, checklist.Right.Errors[3].Code);
+                Assert.Equal(PublicPreReleaseAccessListRequired, checklist.Right.Errors[4].Code);
+                Assert.Equal(ReleaseNoteRequired, checklist.Right.Errors[5].Code);
+            }
+        }
+
+        [Fact]
+        public async Task GetChecklist_AllWarningsWithNoDataFiles()
+        {
+            var publication = new Publication();
+            var release = new Release
+            {
+                Publication = publication,
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.AddRangeAsync(release);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var fileRepository = new Mock<IFileRepository>();
+
+                fileRepository
+                    .Setup(r => r.ListDataFiles(release.Id))
+                    .ReturnsAsync(new List<ReleaseFileReference>());
+
+                fileRepository
+                    .Setup(r => r.ListReplacementDataFiles(release.Id))
+                    .ReturnsAsync(new List<ReleaseFileReference>());
+
+                var metaGuidanceService = new Mock<IMetaGuidanceService>();
+
+                metaGuidanceService
+                    .Setup(s => s.Validate(release.Id))
+                    .ReturnsAsync(ValidationActionResult(PublicMetaGuidanceRequired));
+
+                var service = BuildReleaseChecklistService(
+                    context,
+                    fileRepository: fileRepository.Object,
+                    metaGuidanceService: metaGuidanceService.Object
+                );
+                var checklist = await service.GetChecklist(release.Id);
+
+                Assert.True(checklist.IsRight);
+
+                Assert.False(checklist.Right.Valid);
+
+                Assert.Equal(3, checklist.Right.Warnings.Count);
+                Assert.Equal(NoMethodology, checklist.Right.Warnings[0].Code);
+                Assert.Equal(NoNextReleaseDate, checklist.Right.Warnings[1].Code);
+                Assert.Equal(NoDataFiles, checklist.Right.Warnings[2].Code);
+            }
+        }
+
+        [Fact]
+        public async Task GetChecklist_AllWarningsWithDataFiles()
+        {
+            var publication = new Publication();
+            var release = new Release
+            {
+                Publication = publication,
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.AddRangeAsync(release);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var subject = new Subject
+                {
+                    Id = Guid.NewGuid()
+                };
+                var otherSubject = new Subject
+                {
+                    Id = Guid.NewGuid(),
+                };
+
+                var fileRepository = new Mock<IFileRepository>();
+
+                fileRepository
+                    .Setup(r => r.ListDataFiles(release.Id))
+                    .ReturnsAsync(
+                        new List<ReleaseFileReference>
+                        {
+                            new ReleaseFileReference
+                            {
+                                Id = Guid.NewGuid(),
+                                Filename = "test-file-1.csv",
+                                ReleaseFileType = ReleaseFileTypes.Data,
+                                Release = release,
+                                ReleaseId = release.Id,
+                                SubjectId = subject.Id
+                            },
+                            new ReleaseFileReference
+                            {
+                                Id = Guid.NewGuid(),
+                                Filename = "test-file-2.csv",
+                                ReleaseFileType = ReleaseFileTypes.Data,
+                                Release = release,
+                                ReleaseId = release.Id,
+                                SubjectId = otherSubject.Id
+                            }
+                        }
+                    );
+
+                var metaGuidanceService = new Mock<IMetaGuidanceService>();
+
+                metaGuidanceService
+                    .Setup(s => s.Validate(release.Id))
+                    .ReturnsAsync(ValidationActionResult(PublicMetaGuidanceRequired));
+
+                var footnoteRepository = new Mock<IFootnoteRepository>();
+
+                footnoteRepository
+                    .Setup(r => r.GetSubjectsWithNoFootnotes(release.Id))
+                    .ReturnsAsync(
+                        new List<Subject>
+                        {
+                            subject,
+                        }
+                    );
+
+                fileRepository
+                    .Setup(r => r.ListReplacementDataFiles(release.Id))
+                    .ReturnsAsync(new List<ReleaseFileReference>());
+
+                var dataBlockService = new Mock<IDataBlockService>();
+
+                dataBlockService
+                    .Setup(s => s.List(release.Id))
+                    .ReturnsAsync(
+                        new List<DataBlockViewModel>
+                        {
+                            new DataBlockViewModel(),
+                            new DataBlockViewModel(),
+                        }
+                    );
+
+                var service = BuildReleaseChecklistService(
+                    context,
+                    fileRepository: fileRepository.Object,
+                    metaGuidanceService: metaGuidanceService.Object,
+                    footnoteRepository: footnoteRepository.Object,
+                    dataBlockService: dataBlockService.Object
+                );
+                var checklist = await service.GetChecklist(release.Id);
+
+                Assert.True(checklist.IsRight);
+
+                Assert.False(checklist.Right.Valid);
+
+                Assert.Equal(4, checklist.Right.Warnings.Count);
+                Assert.Equal(NoMethodology, checklist.Right.Warnings[0].Code);
+                Assert.Equal(NoNextReleaseDate, checklist.Right.Warnings[1].Code);
+
+                var noFootnotesWarning = Assert.IsType<NoFootnotesOnSubjectsWarning>(checklist.Right.Warnings[2]);
+                Assert.Equal(NoFootnotesOnSubjects, noFootnotesWarning.Code);
+                Assert.Equal(1, noFootnotesWarning.TotalSubjects);
+
+                Assert.Equal(NoTableHighlights, checklist.Right.Warnings[3].Code);
+            }
+        }
+
+        [Fact]
+        public async Task GetChecklist_FullyValid()
+        {
+            var publication = new Publication
+            {
+                Methodology = new Methodology
+                {
+                    Status = MethodologyStatus.Approved
+                }
+            };
+
+            var originalRelease = new Release
+            {
+                Publication = publication,
+                Version = 0
+            };
+            var release = new Release
+            {
+                Publication = publication,
+                PreviousVersion = originalRelease,
+                Version = 1,
+                MetaGuidance = "Test meta guidance",
+                PreReleaseAccessList = "Test access list",
+                NextReleaseDate = new PartialDate
+                {
+                    Month = "12",
+                    Year = "2021"
+                },
+                Updates = new List<Update>
+                {
+                    new Update
+                    {
+                        Reason = "Test reason 1",
+                        Release = originalRelease
+                    },
+                    new Update
+                    {
+                        Reason = "Test reason 2"
+                    }
+                },
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.AddRangeAsync(release, originalRelease);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var subject = new Subject
+                {
+                    Id = Guid.NewGuid()
+                };
+
+                var fileRepository = new Mock<IFileRepository>();
+
+                fileRepository
+                    .Setup(r => r.ListDataFiles(release.Id))
+                    .ReturnsAsync(
+                        new List<ReleaseFileReference>
+                        {
+                            new ReleaseFileReference
+                            {
+                                Id = Guid.NewGuid(),
+                                Filename = "test-file-1.csv",
+                                ReleaseFileType = ReleaseFileTypes.Data,
+                                Release = release,
+                                ReleaseId = release.Id,
+                                SubjectId = subject.Id,
+                            },
+                        }
+                    );
+
+                fileRepository
+                    .Setup(r => r.ListReplacementDataFiles(release.Id))
+                    .ReturnsAsync(new List<ReleaseFileReference>());
+
+                var metaGuidanceService = new Mock<IMetaGuidanceService>();
+
+                metaGuidanceService
+                    .Setup(s => s.Validate(release.Id))
+                    .ReturnsAsync(Unit.Instance);
+
+                var footnoteRepository = new Mock<IFootnoteRepository>();
+
+                footnoteRepository
+                    .Setup(r => r.GetSubjectsWithNoFootnotes(release.Id))
+                    .ReturnsAsync(new List<Subject>());
+
+                var dataBlockService = new Mock<IDataBlockService>();
+
+                dataBlockService
+                    .Setup(s => s.List(release.Id))
+                    .ReturnsAsync(
+                        new List<DataBlockViewModel>
+                        {
+                            new DataBlockViewModel
+                            {
+                                HighlightName = "Test highlight name"
+                            },
+                        }
+                    );
+
+                var service = BuildReleaseChecklistService(
+                    context,
+                    metaGuidanceService: metaGuidanceService.Object,
+                    fileRepository: fileRepository.Object,
+                    footnoteRepository: footnoteRepository.Object,
+                    dataBlockService: dataBlockService.Object
+                );
+                var checklist = await service.GetChecklist(release.Id);
+
+                Assert.True(checklist.IsRight);
+
+                Assert.Empty(checklist.Right.Errors);
+                Assert.Empty(checklist.Right.Warnings);
+                Assert.True(checklist.Right.Valid);
+            }
+        }
+
+        [Fact]
+        public async Task GetChecklist_NotFound()
+        {
+            var release = new Release();
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.AddAsync(release);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var service = BuildReleaseChecklistService(context);
+                var checklist = await service.GetChecklist(Guid.NewGuid());
+
+                Assert.True(checklist.IsLeft);
+
+                Assert.IsType<NotFoundResult>(checklist.Left);
+            }
+        }
+
+        private Mock<ITableStorageService> MockTableStorageService(List<DatafileImport> expectedResults)
+        {
+            var cloudTable = MockCloudTable();
+
+            cloudTable
+                .Setup(
+                    t => t.ExecuteQuerySegmentedAsync(It.IsAny<TableQuery<DatafileImport>>(), null)
+                )
+                .ReturnsAsync(CreateTableQuerySegment(expectedResults));
+
+            var tableStorageService = new Mock<ITableStorageService>();
+
+            tableStorageService
+                .Setup(s => s.GetTableAsync(It.IsAny<string>(), true))
+                .ReturnsAsync(cloudTable.Object);
+
+            return tableStorageService;
+        }
+
+        private ReleaseChecklistService BuildReleaseChecklistService(
+            ContentDbContext contentDbContext,
+            ITableStorageService tableStorageService = null,
+            IUserService userService = null,
+            IMetaGuidanceService metaGuidanceService = null,
+            IFileRepository fileRepository = null,
+            IFootnoteRepository footnoteRepository = null,
+            IDataBlockService dataBlockService = null)
+        {
+            return new ReleaseChecklistService(
+                new PersistenceHelper<ContentDbContext>(contentDbContext),
+                tableStorageService ?? MockTableStorageService(new List<DatafileImport>()).Object,
+                userService ?? MockUtils.AlwaysTrueUserService().Object,
+                metaGuidanceService ?? new Mock<IMetaGuidanceService>().Object,
+                fileRepository ?? new Mock<IFileRepository>().Object,
+                footnoteRepository ?? new Mock<IFootnoteRepository>().Object,
+                dataBlockService ?? new Mock<IDataBlockService>().Object
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -319,7 +319,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IFootnoteService footnoteService = null,
             StatisticsDbContext statisticsDbContext = null,
             IDataBlockService dataBlockService = null,
-            IMetaGuidanceService metaGuidanceService = null,
+            IReleaseChecklistService releaseChecklistService = null,
             IReleaseSubjectService releaseSubjectService = null)
         {
             return new ReleaseService(
@@ -337,7 +337,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 footnoteService ?? new Mock<IFootnoteService>().Object,
                 statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
                 dataBlockService ?? new Mock<IDataBlockService>().Object,
-                metaGuidanceService ?? new Mock<IMetaGuidanceService>().Object,
+                releaseChecklistService ?? new Mock<IReleaseChecklistService>().Object,
                 releaseSubjectService ?? new Mock<IReleaseSubjectService>().Object,
                 new SequentialGuidGenerator()
             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -941,7 +941,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     );
 
                 Assert.True(result.IsLeft);
-                AssertValidationProblem(result.Left, AllDatafilesUploadedMustBeComplete);
+                AssertValidationProblem(result.Left, DataFileImportsMustBeCompleted);
             }
         }
 
@@ -1033,7 +1033,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.True(result.IsLeft);
 
-                AssertValidationProblem(result.Left, DataReplacementInProgress);
+                AssertValidationProblem(result.Left, DataFileReplacementsMustBeCompleted);
             }
         }
 
@@ -1076,7 +1076,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .ReturnsAsync(TableStorageTestUtils.CreateTableQuerySegment(new List<DatafileImport>()));
 
                 metaGuidanceService.Setup(service => service.Validate(release.Id))
-                    .ReturnsAsync(ValidationActionResult(MetaGuidanceMustBePopulated));
+                    .ReturnsAsync(ValidationActionResult(PublicMetaGuidanceRequired));
 
                 tableStorageService.Setup(service => service.GetTableAsync(DatafileImportsTableName, true))
                     .ReturnsAsync(cloudTableMock.Object);
@@ -1102,7 +1102,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 metaGuidanceService.Verify(mock => mock.Validate(release.Id), Times.Once);
 
-                AssertValidationProblem(result.Left, MetaGuidanceMustBePopulated);
+                AssertValidationProblem(result.Left, PublicMetaGuidanceRequired);
             }
         }
 
@@ -1176,7 +1176,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 metaGuidanceService.Verify(mock => mock.Validate(release.Id), Times.Once);
 
-                AssertValidationProblem(result.Left, MethodologyMustBeApprovedOrPublished);
+                AssertValidationProblem(result.Left, MethodologyMustBeApproved);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Utils;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
@@ -16,7 +15,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
-using Microsoft.Azure.Cosmos.Table;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
@@ -24,8 +22,6 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbU
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.ValidationTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
-using static GovUk.Education.ExploreEducationStatistics.Common.TableStorageTableNames;
 using IFootnoteService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IFootnoteService;
 using Publication = GovUk.Education.ExploreEducationStatistics.Content.Model.Publication;
 using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
@@ -876,7 +872,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateRelease_Approved_FailsDataFilesNotUploaded()
+        public async Task UpdateRelease_Approved_FailsOnChecklistErrors()
         {
             var release = new Release
             {
@@ -902,30 +898,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-            var metaGuidanceService = new Mock<IMetaGuidanceService>(MockBehavior.Strict);
-            var tableStorageService = new Mock<ITableStorageService>();
-
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                var cloudTableMock = TableStorageTestUtils.MockCloudTable();
+                var releaseChecklistService = new Mock<IReleaseChecklistService>(MockBehavior.Strict);
 
-                cloudTableMock
-                    .Setup(table => table.ExecuteQuerySegmentedAsync(It.IsAny<TableQuery<DatafileImport>>(), null))
+                releaseChecklistService
+                    .Setup(s =>
+                            s.GetErrors(It.Is<Release>(r => r.Id == release.Id)))
                     .ReturnsAsync(
-                        TableStorageTestUtils.CreateTableQuerySegment(
-                            new List<DatafileImport>
-                            {
-                                new DatafileImport()
-                            }
-                        )
+                        new List<ReleaseChecklistIssue>
+                        {
+                            new ReleaseChecklistIssue(DataFileImportsMustBeCompleted),
+                            new ReleaseChecklistIssue(DataFileReplacementsMustBeCompleted),
+                        }
                     );
 
-                tableStorageService.Setup(service => service.GetTableAsync(DatafileImportsTableName, true))
-                    .ReturnsAsync(cloudTableMock.Object);
-
-                var releaseService = BuildReleaseService(context,
-                    metaGuidanceService: metaGuidanceService.Object,
-                    tableStorageService: tableStorageService.Object);
+                var releaseService = BuildReleaseService(
+                    context,
+                    releaseChecklistService: releaseChecklistService.Object);
 
                 var result = await releaseService
                     .UpdateRelease(
@@ -942,241 +932,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.True(result.IsLeft);
                 AssertValidationProblem(result.Left, DataFileImportsMustBeCompleted);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateRelease_Approved_FailsDataReplacementInProgress()
-        {
-            var release = new Release
-            {
-                Type = new ReleaseType
-                {
-                    Title = "Ad Hoc"
-                },
-                Publication = new Publication
-                {
-                    Title = "Old publication"
-                },
-                ReleaseName = "2030",
-                Slug = "2030",
-                PublishScheduled = DateTime.UtcNow,
-                Version = 0
-            };
-
-            var originalFile = new ReleaseFile
-            {
-                Release = release,
-                ReleaseFileReference = new ReleaseFileReference
-                {
-                    Filename = "original.csv",
-                    Release = release,
-                    ReleaseFileType = ReleaseFileTypes.Data,
-                    SubjectId = Guid.NewGuid()
-                }
-            };
-
-            var replacementFile = new ReleaseFile
-            {
-                Release = release,
-                ReleaseFileReference = new ReleaseFileReference
-                {
-                    Filename = "replacement.csv",
-                    Release = release,
-                    ReleaseFileType = ReleaseFileTypes.Data,
-                    SubjectId = Guid.NewGuid(),
-                    Replacing = originalFile.ReleaseFileReference
-                }
-            };
-
-            originalFile.ReleaseFileReference.ReplacedBy = replacementFile.ReleaseFileReference;
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.AddAsync(release);
-                await context.AddRangeAsync(originalFile, replacementFile);
-                await context.SaveChangesAsync();
-            }
-
-            var metaGuidanceService = new Mock<IMetaGuidanceService>(MockBehavior.Strict);
-            var tableStorageService = new Mock<ITableStorageService>();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var cloudTableMock = TableStorageTestUtils.MockCloudTable();
-
-                cloudTableMock
-                    .Setup(table => table.ExecuteQuerySegmentedAsync(It.IsAny<TableQuery<DatafileImport>>(), null))
-                    .ReturnsAsync(TableStorageTestUtils.CreateTableQuerySegment(new List<DatafileImport>()));
-
-                tableStorageService.Setup(service => service.GetTableAsync(DatafileImportsTableName, true))
-                    .ReturnsAsync(cloudTableMock.Object);
-
-                var releaseService = BuildReleaseService(context,
-                    metaGuidanceService: metaGuidanceService.Object,
-                    tableStorageService: tableStorageService.Object);
-
-                var result = await releaseService
-                    .UpdateRelease(
-                        release.Id,
-                        new UpdateReleaseViewModel
-                        {
-                            PublishScheduled = "2051-06-30",
-                            TypeId = release.Type.Id,
-                            ReleaseName = "2030",
-                            TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                            Status = ReleaseStatus.Approved
-                        }
-                    );
-
-                Assert.True(result.IsLeft);
-
                 AssertValidationProblem(result.Left, DataFileReplacementsMustBeCompleted);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateRelease_Approved_FailsMetaGuidanceNotPopulated()
-        {
-            var release = new Release
-            {
-                Type = new ReleaseType
-                {
-                    Title = "Ad Hoc"
-                },
-                Publication = new Publication
-                {
-                    Title = "Old publication"
-                },
-                ReleaseName = "2030",
-                Slug = "2030",
-                PublishScheduled = DateTime.UtcNow,
-                Version = 0
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.AddAsync(release);
-                await context.SaveChangesAsync();
-            }
-
-            var metaGuidanceService = new Mock<IMetaGuidanceService>(MockBehavior.Strict);
-            var tableStorageService = new Mock<ITableStorageService>();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var cloudTableMock = TableStorageTestUtils.MockCloudTable();
-
-                cloudTableMock
-                    .Setup(table => table.ExecuteQuerySegmentedAsync(It.IsAny<TableQuery<DatafileImport>>(), null))
-                    .ReturnsAsync(TableStorageTestUtils.CreateTableQuerySegment(new List<DatafileImport>()));
-
-                metaGuidanceService.Setup(service => service.Validate(release.Id))
-                    .ReturnsAsync(ValidationActionResult(PublicMetaGuidanceRequired));
-
-                tableStorageService.Setup(service => service.GetTableAsync(DatafileImportsTableName, true))
-                    .ReturnsAsync(cloudTableMock.Object);
-
-                var releaseService = BuildReleaseService(context,
-                    metaGuidanceService: metaGuidanceService.Object,
-                    tableStorageService: tableStorageService.Object);
-
-                var result = await releaseService
-                    .UpdateRelease(
-                        release.Id,
-                        new UpdateReleaseViewModel
-                        {
-                            PublishScheduled = "2051-06-30",
-                            TypeId = release.Type.Id,
-                            ReleaseName = "2030",
-                            TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                            Status = ReleaseStatus.Approved
-                        }
-                    );
-
-                Assert.True(result.IsLeft);
-
-                metaGuidanceService.Verify(mock => mock.Validate(release.Id), Times.Once);
-
-                AssertValidationProblem(result.Left, PublicMetaGuidanceRequired);
-            }
-        }
-
-        [Fact]
-        public async Task UpdateRelease_Approved_FailsMethodologyNotApproved()
-        {
-            var release = new Release
-            {
-                Type = new ReleaseType
-                {
-                    Title = "Ad Hoc"
-                },
-                Publication = new Publication
-                {
-                    Title = "Old publication",
-                    Methodology = new Methodology
-                    {
-                        Title = "Test methodology",
-                        Status = MethodologyStatus.Draft
-                    }
-                },
-                ReleaseName = "2030",
-                Slug = "2030",
-                PublishScheduled = DateTime.UtcNow,
-                Version = 0
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.AddAsync(release);
-                await context.SaveChangesAsync();
-            }
-
-            var metaGuidanceService = new Mock<IMetaGuidanceService>(MockBehavior.Strict);
-            var tableStorageService = new Mock<ITableStorageService>();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var cloudTableMock = TableStorageTestUtils.MockCloudTable();
-
-                cloudTableMock
-                    .Setup(table => table.ExecuteQuerySegmentedAsync(It.IsAny<TableQuery<DatafileImport>>(), null))
-                    .ReturnsAsync(TableStorageTestUtils.CreateTableQuerySegment(new List<DatafileImport>()));
-
-                metaGuidanceService.Setup(service => service.Validate(release.Id))
-                    .ReturnsAsync(Unit.Instance);
-
-                tableStorageService.Setup(service => service.GetTableAsync(DatafileImportsTableName, true))
-                    .ReturnsAsync(cloudTableMock.Object);
-
-                var releaseService = BuildReleaseService(context,
-                    metaGuidanceService: metaGuidanceService.Object,
-                    tableStorageService: tableStorageService.Object);
-
-                var result = await releaseService
-                    .UpdateRelease(
-                        release.Id,
-                        new UpdateReleaseViewModel
-                        {
-                            PublishScheduled = "2051-06-30",
-                            TypeId = release.Type.Id,
-                            ReleaseName = "2030",
-                            TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                            Status = ReleaseStatus.Approved
-                        }
-                    );
-
-                Assert.True(result.IsLeft);
-
-                metaGuidanceService.Verify(mock => mock.Validate(release.Id), Times.Once);
-
-                AssertValidationProblem(result.Left, MethodologyMustBeApproved);
             }
         }
 
@@ -1208,22 +964,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-            var metaGuidanceService = new Mock<IMetaGuidanceService>(MockBehavior.Strict);
-            var tableStorageService = new Mock<ITableStorageService>();
-
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                var cloudTableMock = TableStorageTestUtils.MockCloudTable();
-
-                cloudTableMock
-                    .Setup(table => table.ExecuteQuerySegmentedAsync(It.IsAny<TableQuery<DatafileImport>>(), null))
-                    .ReturnsAsync(TableStorageTestUtils.CreateTableQuerySegment(new List<DatafileImport>()));
-
-                tableStorageService.Setup(service => service.GetTableAsync(DatafileImportsTableName, true))
-                    .ReturnsAsync(cloudTableMock.Object);
-                var releaseService = BuildReleaseService(context,
-                    metaGuidanceService: metaGuidanceService.Object,
-                    tableStorageService: tableStorageService.Object);
+                var releaseService = BuildReleaseService(context);
 
                 var result = await releaseService
                     .UpdateRelease(
@@ -1271,26 +1014,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-            var metaGuidanceService = new Mock<IMetaGuidanceService>(MockBehavior.Strict);
-            var tableStorageService = new Mock<ITableStorageService>();
-
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                var cloudTableMock = TableStorageTestUtils.MockCloudTable();
-
-                cloudTableMock
-                    .Setup(table => table.ExecuteQuerySegmentedAsync(It.IsAny<TableQuery<DatafileImport>>(), null))
-                    .ReturnsAsync(TableStorageTestUtils.CreateTableQuerySegment(new List<DatafileImport>()));
-
-                metaGuidanceService.Setup(service => service.Validate(release.Id))
-                    .ReturnsAsync(Unit.Instance);
-
-                tableStorageService.Setup(service => service.GetTableAsync(DatafileImportsTableName, true))
-                    .ReturnsAsync(cloudTableMock.Object);
-
-                var releaseService = BuildReleaseService(context,
-                    metaGuidanceService: metaGuidanceService.Object,
-                    tableStorageService: tableStorageService.Object);
+                var releaseService = BuildReleaseService(context);
 
                 var result = await releaseService
                     .UpdateRelease(
@@ -1306,8 +1032,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     );
 
                 Assert.True(result.IsLeft);
-
-                metaGuidanceService.Verify(mock => mock.Validate(release.Id), Times.Once);
 
                 AssertValidationProblem(result.Left, ApprovedReleaseMustHavePublishScheduledDate);
             }
@@ -1642,7 +1366,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IImportStatusService importStatusService = null,
             IFootnoteService footnoteService = null,
             IDataBlockService dataBlockService = null,
-            IMetaGuidanceService metaGuidanceService = null,
+            IReleaseChecklistService releaseChecklistService = null,
             IReleaseSubjectService releaseSubjectService = null)
         {
             var userService = MockUtils.AlwaysTrueUserService();
@@ -1666,7 +1390,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 footnoteService ?? new Mock<IFootnoteService>().Object,
                 statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
                 dataBlockService ?? new Mock<IDataBlockService>().Object,
-                metaGuidanceService ?? new Mock<IMetaGuidanceService>().Object,
+                releaseChecklistService ?? new Mock<IReleaseChecklistService>().Object,
                 releaseSubjectService ?? new Mock<IReleaseSubjectService>().Object,
                 new SequentialGuidGenerator()
             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseSubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseSubjectServiceTests.cs
@@ -32,14 +32,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
             {
-                var service = BuildReleaseSubjectService(statisticsDbContext);
+                var subjectDeleter = new Mock<ReleaseSubjectService.SubjectDeleter>();
+
+                subjectDeleter
+                    .Setup(
+                        s =>
+                            s.Delete(
+                                It.Is<Subject>(subject => subject.Id == releaseSubject.SubjectId),
+                                It.IsAny<StatisticsDbContext>()
+                            )
+                    );
+
+                var service = BuildReleaseSubjectService(statisticsDbContext, subjectDeleter: subjectDeleter.Object);
                 await service.DeleteReleaseSubject(releaseSubject.ReleaseId, releaseSubject.SubjectId);
             }
 
             await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
             {
                 Assert.Empty(statisticsDbContext.ReleaseSubject.ToList());
-                Assert.Empty(statisticsDbContext.Subject.IgnoreQueryFilters().ToList());
             }
         }
 
@@ -183,14 +193,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
             {
-                var service = BuildReleaseSubjectService(statisticsDbContext);
+                var subjectDeleter = new Mock<ReleaseSubjectService.SubjectDeleter>();
+
+                subjectDeleter
+                    .Setup(
+                        s =>
+                            s.Delete(
+                                It.Is<Subject>(subject => subject.Id == releaseSubject1.SubjectId),
+                                It.IsAny<StatisticsDbContext>()
+                            )
+                    );
+                subjectDeleter
+                    .Setup(
+                        s => s.Delete(
+                            It.Is<Subject>(subject => subject.Id == releaseSubject2.SubjectId),
+                            It.IsAny<StatisticsDbContext>()
+                        )
+                    );
+
+                var service = BuildReleaseSubjectService(statisticsDbContext, subjectDeleter: subjectDeleter.Object);
                 await service.DeleteAllReleaseSubjects(release.Id);
+
+                MockUtils.VerifyAllMocks(subjectDeleter);
             }
 
             await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
             {
                 Assert.Empty(statisticsDbContext.ReleaseSubject.ToList());
-                Assert.Empty(statisticsDbContext.Subject.IgnoreQueryFilters().ToList());
             }
         }
 
@@ -240,11 +269,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
         private ReleaseSubjectService BuildReleaseSubjectService(
             StatisticsDbContext statisticsDbContext,
-            IFootnoteRepository footnoteRepository = null)
+            IFootnoteRepository footnoteRepository = null,
+            ReleaseSubjectService.SubjectDeleter subjectDeleter = null)
         {
             return new ReleaseSubjectService(
                 statisticsDbContext,
-                footnoteRepository ?? new Mock<IFootnoteRepository>().Object
+                footnoteRepository ?? new Mock<IFootnoteRepository>().Object,
+                subjectDeleter ?? new Mock<ReleaseSubjectService.SubjectDeleter>().Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -26,6 +26,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         private readonly IReleaseFileService _releaseFileService;
         private readonly IReleaseDataFileService _releaseDataFileService;
         private readonly IReleaseStatusService _releaseStatusService;
+        private readonly IReleaseChecklistService _releaseChecklistService;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IDataBlockService _dataBlockService;
 
@@ -34,6 +35,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             IReleaseFileService releaseFileService,
             IReleaseDataFileService releaseDataFileService,
             IReleaseStatusService releaseStatusService,
+            IReleaseChecklistService releaseChecklistService,
             UserManager<ApplicationUser> userManager,
             IDataBlockService dataBlockService
         )
@@ -42,6 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             _releaseDataFileService = releaseDataFileService;
             _releaseFileService = releaseFileService;
             _releaseStatusService = releaseStatusService;
+            _releaseChecklistService = releaseChecklistService;
             _userManager = userManager;
             _dataBlockService = dataBlockService;
         }
@@ -298,6 +301,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         {
             return await _releaseStatusService
                 .GetReleaseStatusAsync(releaseId)
+                .HandleFailuresOrOk();
+        }
+
+        [HttpGet("releases/{releaseId}/checklist")]
+        public async Task<ActionResult<ReleaseChecklistViewModel>> GetChecklist(Guid releaseId)
+        {
+            return await _releaseChecklistService
+                .GetChecklist(releaseId)
                 .HandleFailuresOrOk();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileRepository.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -101,6 +103,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             await _contentDbContext.SaveChangesAsync();
 
             return file;
+        }
+
+        public async Task<IList<ReleaseFileReference>> ListDataFiles(Guid releaseId)
+        {
+            return await ListDataFilesQuery(releaseId).ToListAsync();
+        }
+
+        public async Task<bool> HasAnyDataFiles(Guid releaseId)
+        {
+            return await ListDataFilesQuery(releaseId).AnyAsync();
+        }
+
+        private IQueryable<ReleaseFileReference> ListDataFilesQuery(Guid releaseId)
+        {
+            return _contentDbContext
+                .ReleaseFiles
+                .Include(rf => rf.ReleaseFileReference)
+                .Where(
+                    rf => rf.ReleaseId == releaseId
+                          && rf.ReleaseFileReference.ReleaseFileType == ReleaseFileTypes.Data
+                          && rf.ReleaseFileReference.ReplacingId == null
+                          && rf.ReleaseFileReference.SubjectId.HasValue
+                )
+                .Select(rf => rf.ReleaseFileReference);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/FileRepository.cs
@@ -128,5 +128,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 )
                 .Select(rf => rf.ReleaseFileReference);
         }
+
+        public async Task<IList<ReleaseFileReference>> ListReplacementDataFiles(Guid releaseId)
+        {
+            return await _contentDbContext
+                .ReleaseFiles
+                .Include(rf => rf.ReleaseFileReference)
+                .Where(
+                    rf => rf.ReleaseId == releaseId
+                          && rf.ReleaseFileReference.ReleaseFileType == ReleaseFileTypes.Data
+                          && rf.ReleaseFileReference.ReplacingId != null
+                )
+                .Select(rf => rf.ReleaseFileReference)
+                .ToListAsync();
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -7,7 +8,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IFileRepository
     {
-        public Task<ReleaseFileReference> Create(Guid releaseId,
+        public Task<ReleaseFileReference> Create(
+            Guid releaseId,
             string filename,
             ReleaseFileTypes type,
             ReleaseFileReference replacingFile = null,
@@ -21,7 +23,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         public Task<ReleaseFileReference> Get(Guid id);
 
-        public Task<ReleaseFileReference> UpdateFilename(Guid releaseId,
+        public Task<IList<ReleaseFileReference>> ListDataFiles(Guid releaseId);
+
+        public Task<bool> HasAnyDataFiles(Guid releaseId);
+
+        public Task<ReleaseFileReference> UpdateFilename(
+            Guid releaseId,
             Guid fileId,
             string filename);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IFileRepository.cs
@@ -31,5 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             Guid releaseId,
             Guid fileId,
             string filename);
+
+        public Task<IList<ReleaseFileReference>> ListReplacementDataFiles(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseChecklistService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseChecklistService.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
+{
+    public interface IReleaseChecklistService
+    {
+        Task<Either<ActionResult, ReleaseChecklistViewModel>> GetChecklist(Guid releaseId);
+
+        Task<List<ReleaseChecklistIssue>> GetErrors(Release release);
+
+        Task<List<ReleaseChecklistIssue>> GetWarnings(Release release);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
@@ -77,13 +77,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     {
                         if (string.IsNullOrWhiteSpace(release.MetaGuidance))
                         {
-                            return ValidationActionResult(ValidationErrorMessages.MetaGuidanceMustBePopulated);
+                            return ValidationActionResult(ValidationErrorMessages.PublicMetaGuidanceRequired);
                         }
 
                         return await _metaGuidanceSubjectService.Validate(releaseId)
                             .OnSuccess(valid => valid
                                 ? (Either<ActionResult, Unit>) Unit.Instance
-                                : ValidationActionResult(ValidationErrorMessages.MetaGuidanceMustBePopulated));
+                                : ValidationActionResult(ValidationErrorMessages.PublicMetaGuidanceRequired));
                     }
 
                     return Unit.Instance;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -197,7 +197,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 // TODO: this will want updating when methodology status is fully implemented
                 if (methodology.Status != MethodologyStatus.Approved)
                 {
-                    return ValidationActionResult(MethodologyMustBeApprovedOrPublished);
+                    return ValidationActionResult(MethodologyMustBeApproved);
                 }
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
@@ -55,13 +55,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<Either<ActionResult, ReleaseChecklistViewModel>> GetChecklist(Guid releaseId)
         {
-            return await _persistenceHelper.CheckEntityExists<Release>(
-                    releaseId,
-                    release =>
-                        release.Include(r => r.Publication)
-                            .ThenInclude(p => p.Methodology)
-                            .Include(r => r.Updates)
-                )
+            return await _persistenceHelper.CheckEntityExists<Release>(releaseId, HydrateReleaseForChecklist)
                 .OnSuccess(_userService.CheckCanViewRelease)
                 .OnSuccess(
                     async release => new ReleaseChecklistViewModel(
@@ -69,6 +63,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         await GetWarnings(release)
                     )
                 );
+        }
+
+        public static IQueryable<Release> HydrateReleaseForChecklist(IQueryable<Release> query)
+        {
+            return query.Include(r => r.Publication)
+                .ThenInclude(p => p.Methodology)
+                .Include(r => r.Updates);
         }
 
         public async Task<List<ReleaseChecklistIssue>> GetErrors(Release release)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Cosmos.Table;
+using Microsoft.EntityFrameworkCore;
+using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
+{
+    public class ReleaseChecklistService : IReleaseChecklistService
+    {
+        private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
+        private readonly ITableStorageService _tableStorageService;
+        private readonly IUserService _userService;
+        private readonly IMetaGuidanceService _metaGuidanceService;
+        private readonly IFileRepository _fileRepository;
+        private readonly IFootnoteRepository _footnoteRepository;
+        private readonly IDataBlockService _dataBlockService;
+
+        public ReleaseChecklistService(
+            IPersistenceHelper<ContentDbContext> persistenceHelper,
+            ITableStorageService tableStorageService,
+            IUserService userService,
+            IMetaGuidanceService metaGuidanceService,
+            IFileRepository fileRepository,
+            IFootnoteRepository footnoteRepository,
+            IDataBlockService dataBlockService)
+        {
+            _persistenceHelper = persistenceHelper;
+            _tableStorageService = tableStorageService;
+            _userService = userService;
+            _metaGuidanceService = metaGuidanceService;
+            _fileRepository = fileRepository;
+            _footnoteRepository = footnoteRepository;
+            _dataBlockService = dataBlockService;
+        }
+
+        public async Task<Either<ActionResult, ReleaseChecklistViewModel>> GetChecklist(Guid releaseId)
+        {
+            return await _persistenceHelper.CheckEntityExists<Release>(
+                    releaseId,
+                    release =>
+                        release.Include(r => r.Publication)
+                            .ThenInclude(p => p.Methodology)
+                            .Include(r => r.Updates)
+                )
+                .OnSuccess(_userService.CheckCanViewRelease)
+                .OnSuccess(
+                    async release => new ReleaseChecklistViewModel(
+                        await GetErrors(release),
+                        await GetWarnings(release)
+                    )
+                );
+        }
+
+        public async Task<List<ReleaseChecklistIssue>> GetErrors(Release release)
+        {
+            var errors = new List<ReleaseChecklistIssue>();
+
+            if (await HasDataFilesUploading(release))
+            {
+                errors.Add(new ReleaseChecklistIssue(ValidationErrorMessages.DataFileImportsMustBeCompleted));
+            }
+
+            var replacementDataFiles = await _fileRepository.ListReplacementDataFiles(release.Id);
+
+            if (replacementDataFiles.Any())
+            {
+                errors.Add(new ReleaseChecklistIssue(ValidationErrorMessages.DataFileReplacementsMustBeCompleted));
+            }
+
+            if (release.Publication.Methodology != null
+                && release.Publication.Methodology.Status != MethodologyStatus.Approved)
+            {
+                errors.Add(new MethodologyMustBeApprovedError(release.Publication.Methodology.Id));
+            }
+
+            var isMetaGuidanceValid = await _metaGuidanceService.Validate(release.Id);
+
+            if (isMetaGuidanceValid.IsLeft)
+            {
+                errors.Add(new ReleaseChecklistIssue(ValidationErrorMessages.PublicMetaGuidanceRequired));
+            }
+
+            if (release.PreReleaseAccessList.IsNullOrEmpty())
+            {
+                errors.Add(new ReleaseChecklistIssue(ValidationErrorMessages.PublicPreReleaseAccessListRequired));
+            }
+
+            if (release.Amendment && release.Updates.All(update => update.ReleaseId != release.Id))
+            {
+                errors.Add(new ReleaseChecklistIssue(ValidationErrorMessages.ReleaseNoteRequired));
+            }
+
+            return errors;
+        }
+
+        private async Task<bool> HasDataFilesUploading(Release release)
+        {
+            var filters = TableQuery.CombineFilters(
+                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, release.Id.ToString()),
+                TableOperators.And,
+                TableQuery.GenerateFilterCondition("Status", QueryComparisons.NotEqual, IStatus.COMPLETE.ToString())
+            );
+
+            var query = new TableQuery<DatafileImport>().Where(filters);
+            var cloudTable = await _tableStorageService.GetTableAsync(TableStorageTableNames.DatafileImportsTableName);
+            var results = await cloudTable.ExecuteQuerySegmentedAsync(query, null);
+
+            return results.Results.Any();
+        }
+
+        public async Task<List<ReleaseChecklistIssue>> GetWarnings(Release release)
+        {
+            var warnings = new List<ReleaseChecklistIssue>();
+
+            if (!release.Publication.MethodologyId.HasValue)
+            {
+                warnings.Add(new ReleaseChecklistIssue(ValidationErrorMessages.NoMethodology));
+            }
+
+            if (release.NextReleaseDate == null)
+            {
+                warnings.Add(new ReleaseChecklistIssue(ValidationErrorMessages.NoNextReleaseDate));
+            }
+
+            var dataFiles = await _fileRepository.ListDataFiles(release.Id);
+
+            if (!dataFiles.Any())
+            {
+                warnings.Add(new ReleaseChecklistIssue(ValidationErrorMessages.NoDataFiles));
+            }
+            else
+            {
+                var subjectsWithNoFootnotes = await GetSubjectsWithNoFootnotes(release, dataFiles);
+
+                if (subjectsWithNoFootnotes.Any())
+                {
+                    warnings.Add(new NoFootnotesOnSubjectsWarning(subjectsWithNoFootnotes.Count));
+                }
+
+                var tableHighlights = await GetDataBlocksWithHighlights(release);
+
+                if (!tableHighlights.Any())
+                {
+                    warnings.Add(new ReleaseChecklistIssue(ValidationErrorMessages.NoTableHighlights));
+                }
+            }
+
+            return warnings;
+        }
+
+        private async Task<List<Subject>> GetSubjectsWithNoFootnotes(
+            Release release,
+            IEnumerable<ReleaseFileReference> dataFiles)
+        {
+            var allowedSubjectIds = dataFiles
+                .Where(dataFile => dataFile.SubjectId.HasValue)
+                .Select(dataFile => dataFile.SubjectId.Value);
+
+            return (await _footnoteRepository.GetSubjectsWithNoFootnotes(release.Id))
+                .Where(subject => allowedSubjectIds.Contains(subject.Id))
+                .ToList();
+        }
+
+        private async Task<List<DataBlockViewModel>> GetDataBlocksWithHighlights(Release release)
+        {
+            return (await _dataBlockService.List(release.Id))
+                .FoldRight(
+                    dataBlocks => dataBlocks
+                        .Where(dataBlock => !dataBlock.HighlightName.IsNullOrEmpty())
+                        .ToList(),
+                    new List<DataBlockViewModel>()
+                );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -18,7 +18,6 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.Cosmos.Table;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
@@ -48,7 +47,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IImportStatusService _importStatusService;
 	    private readonly IFootnoteService _footnoteService;
         private readonly IDataBlockService _dataBlockService;
-        private readonly IMetaGuidanceService _metaGuidanceService;
+        private readonly IReleaseChecklistService _releaseChecklistService;
         private readonly IReleaseSubjectService _releaseSubjectService;
         private readonly IGuidGenerator _guidGenerator;
 
@@ -69,7 +68,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IFootnoteService footnoteService,
             StatisticsDbContext statisticsDbContext,
             IDataBlockService dataBlockService,
-            IMetaGuidanceService metaGuidanceService,
+            IReleaseChecklistService releaseChecklistService,
             IReleaseSubjectService releaseSubjectService,
             IGuidGenerator guidGenerator)
         {
@@ -87,7 +86,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _footnoteService = footnoteService;
             _statisticsDbContext = statisticsDbContext;
             _dataBlockService = dataBlockService;
-            _metaGuidanceService = metaGuidanceService;
+            _releaseChecklistService = releaseChecklistService;
             _releaseSubjectService = releaseSubjectService;
             _guidGenerator = guidGenerator;
         }
@@ -261,14 +260,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             Guid releaseId, UpdateReleaseViewModel request)
         {
             return await _persistenceHelper
-                .CheckEntityExists<Release>(releaseId)
+                .CheckEntityExists<Release>(releaseId, ReleaseChecklistService.HydrateReleaseForChecklist)
                 .OnSuccess(_userService.CheckCanUpdateRelease)
                 .OnSuccessDo(release => _userService.CheckCanUpdateReleaseStatus(release, request.Status))
                 .OnSuccessDo(async release => await ValidateReleaseSlugUniqueToPublication(request.Slug, release.PublicationId, releaseId))
-                .OnSuccessDo(async release => await CheckDataReplacementNotInProgress(release, request.Status))
-                .OnSuccessDo(async release => await CheckAllDataFilesUploaded(release, request.Status))
-                .OnSuccessDo(async release => await CheckMetaGuidancePopulated(release, request.Status))
-                .OnSuccessDo(async release => await CheckMethodologyHasBeenApproved(release, request.Status))
                 .OnSuccess(async release =>
                 {
                     if (request.Status != ReleaseStatus.Approved && release.Published.HasValue)
@@ -276,9 +271,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         return ValidationActionResult(PublishedReleaseCannotBeUnapproved);
                     }
 
-                    if (request.Status == ReleaseStatus.Approved &&
-                        request.PublishMethod == PublishMethod.Scheduled &&
-                        !request.PublishScheduledDate.HasValue)
+                    if (request.Status == ReleaseStatus.Approved
+                        && request.PublishMethod == PublishMethod.Scheduled
+                        && !request.PublishScheduledDate.HasValue)
                     {
                         return ValidationActionResult(ApprovedReleaseMustHavePublishScheduledDate);
                     }
@@ -296,24 +291,50 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     release.NextReleaseDate = request.NextReleaseDate;
 
                     release.PublishScheduled = request.PublishMethod == PublishMethod.Immediate &&
-                        request.Status == ReleaseStatus.Approved
+                                               request.Status == ReleaseStatus.Approved
                         ? DateTime.UtcNow
                         : request.PublishScheduledDate;
 
-                    _context.Releases.Update(release);
-                    await _context.SaveChangesAsync();
+                    return await ValidateReleaseWithChecklist(release)
+                        .OnSuccess(async () =>
+                        {
+                            _context.Releases.Update(release);
+                            await _context.SaveChangesAsync();
 
-                    // Only need to inform Publisher if changing release status to or from Approved
-                    if (oldStatus == ReleaseStatus.Approved || request.Status == ReleaseStatus.Approved)
-                    {
-                        await _publishingService.ReleaseChanged(releaseId, request.PublishMethod == PublishMethod.Immediate);
-                    }
+                            // Only need to inform Publisher if changing release status to or from Approved
+                            if (oldStatus == ReleaseStatus.Approved || request.Status == ReleaseStatus.Approved)
+                            {
+                                await _publishingService.ReleaseChanged(
+                                    releaseId,
+                                    request.PublishMethod == PublishMethod.Immediate
+                                );
+                            }
 
-                    _context.Update(release);
-                    await _context.SaveChangesAsync();
+                            _context.Update(release);
+                            await _context.SaveChangesAsync();
 
-                    return await GetRelease(releaseId);
+                            return await GetRelease(releaseId);
+                        });
                 });
+        }
+
+        private async Task<Either<ActionResult, Unit>> ValidateReleaseWithChecklist(Release release)
+        {
+            if (release.Status != ReleaseStatus.Approved)
+            {
+                return Unit.Instance;
+            }
+
+            var errors = (await _releaseChecklistService.GetErrors(release))
+                .Select(error => error.Code)
+                .ToList();
+
+            if (!errors.Any())
+            {
+                return Unit.Instance;
+            }
+
+            return ValidationActionResult(errors);
         }
 
         public async Task<Either<ActionResult, TitleAndIdViewModel>> GetLatestReleaseAsync(Guid publicationId)
@@ -519,71 +540,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             if (!CanUpdateDataFiles(releaseId))
             {
                 return ValidationActionResult(CannotRemoveDataFilesOnceReleaseApproved);
-            }
-
-            return Unit.Instance;
-        }
-
-        private async Task<Either<ActionResult, Unit>> CheckMetaGuidancePopulated(Release release,
-            ReleaseStatus status)
-        {
-            return status == ReleaseStatus.Approved ? await _metaGuidanceService.Validate(release.Id) : Unit.Instance;
-        }
-
-        private async Task<Either<ActionResult, Unit>> CheckMethodologyHasBeenApproved(Release release,
-            ReleaseStatus status)
-        {
-            if (status == ReleaseStatus.Approved)
-            {
-                var publication = await _context.Publications
-                    .Include(publication => publication.Methodology)
-                    .FirstAsync(publication => publication.Id == release.PublicationId);
-
-                if (publication.Methodology != null && publication.Methodology.Status != MethodologyStatus.Approved)
-                {
-                    return ValidationActionResult(MethodologyMustBeApproved);
-                }
-            }
-
-            return Unit.Instance;
-        }
-
-        private async Task<Either<ActionResult, Unit>> CheckAllDataFilesUploaded(Release release, ReleaseStatus status)
-        {
-            if (status == ReleaseStatus.Approved)
-            {
-                var filters = TableQuery.CombineFilters(
-                    TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, release.Id.ToString()),
-                    TableOperators.And,
-                    TableQuery.GenerateFilterCondition("Status", QueryComparisons.NotEqual, IStatus.COMPLETE.ToString())
-                );
-
-                var query = new TableQuery<DatafileImport>().Where(filters);
-                var cloudTable = await _coreTableStorageService.GetTableAsync(DatafileImportsTableName);
-                var results = await cloudTable.ExecuteQuerySegmentedAsync(query, null);
-
-                if (results.Results.Count != 0)
-                {
-                    return ValidationActionResult(DataFileImportsMustBeCompleted);
-                }
-            }
-
-            return Unit.Instance;
-        }
-
-        private async Task<Either<ActionResult, Unit>> CheckDataReplacementNotInProgress(Release release, ReleaseStatus status)
-        {
-            if (status == ReleaseStatus.Approved)
-            {
-                if (await _context.ReleaseFiles
-                    .Include(rf => rf.ReleaseFileReference)
-                    .Where(rf => rf.ReleaseId == release.Id
-                                 && rf.ReleaseFileReference.ReleaseFileType == ReleaseFileTypes.Data
-                                 && rf.ReleaseFileReference.ReplacingId != null)
-                    .AnyAsync())
-                {
-                    return ValidationActionResult(DataFileReplacementsMustBeCompleted);
-                }
             }
 
             return Unit.Instance;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -541,7 +541,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                 if (publication.Methodology != null && publication.Methodology.Status != MethodologyStatus.Approved)
                 {
-                    return ValidationActionResult(MethodologyMustBeApprovedOrPublished);
+                    return ValidationActionResult(MethodologyMustBeApproved);
                 }
             }
 
@@ -564,7 +564,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                 if (results.Results.Count != 0)
                 {
-                    return ValidationActionResult(AllDatafilesUploadedMustBeComplete);
+                    return ValidationActionResult(DataFileImportsMustBeCompleted);
                 }
             }
 
@@ -582,7 +582,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                  && rf.ReleaseFileReference.ReplacingId != null)
                     .AnyAsync())
                 {
-                    return ValidationActionResult(DataReplacementInProgress);
+                    return ValidationActionResult(DataFileReplacementsMustBeCompleted);
                 }
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -235,6 +235,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<ILegacyReleaseService, LegacyReleaseService>();
             services.AddTransient<IReleaseService, ReleaseService>();
             services.AddTransient<IReleaseSubjectService, ReleaseSubjectService>();
+            services.AddTransient<IReleaseChecklistService, ReleaseChecklistService>();
             services.AddTransient<IReleaseRepository, ReleaseRepository>();
             services.AddTransient<IMethodologyService, MethodologyService>();
             services.AddTransient<IMethodologyContentService, MethodologyContentService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -234,6 +234,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IContactService, ContactService>();
             services.AddTransient<ILegacyReleaseService, LegacyReleaseService>();
             services.AddTransient<IReleaseService, ReleaseService>();
+            services.AddTransient<ReleaseSubjectService.SubjectDeleter, ReleaseSubjectService.SubjectDeleter>();
             services.AddTransient<IReleaseSubjectService, ReleaseSubjectService>();
             services.AddTransient<IReleaseChecklistService, ReleaseChecklistService>();
             services.AddTransient<IReleaseRepository, ReleaseRepository>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -84,7 +84,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
 
         // Methodology
         MethodologyDoesNotExist,
-        MethodologyMustBeApprovedOrPublished,
+        MethodologyMustBeApproved,
         CannotSpecifyMethodologyAndExternalMethodology,
 
         // Theme
@@ -113,7 +113,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         DataFilenameCannotContainSpacesOrSpecialCharacters,
         CannotRemoveDataFilesUntilImportComplete,
         CannotRemoveDataFilesOnceReleaseApproved,
-        AllDatafilesUploadedMustBeComplete,
         FileTypeMustBeData,
 
         // Data zip file
@@ -135,9 +134,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
 
         // Release
         ReleaseNotApproved,
-        MetaGuidanceMustBePopulated,
-        DataReplacementInProgress,
         ApprovedReleaseMustHavePublishScheduledDate,
-        PublishedReleaseCannotBeUnapproved
+        PublishedReleaseCannotBeUnapproved,
+
+        // Release checklist errors
+        DataFileImportsMustBeCompleted,
+        DataFileReplacementsMustBeCompleted,
+        ReleaseNoteRequired,
+        PublicMetaGuidanceRequired,
+        PublicPreReleaseAccessListRequired,
+
+        // Release checklist warnings
+        NoMethodology,
+        NoNextReleaseDate,
+        NoDataFiles,
+        NoFootnotesOnSubjects,
+        NoTableHighlights,
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -38,6 +39,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         {
             ModelStateDictionary errors = new ModelStateDictionary();
             errors.AddModelError(string.Empty, message.ToString().ScreamingSnakeCase());
+            return new BadRequestObjectResult(new ValidationProblemDetails(errors));
+        }
+
+        public static ActionResult ValidationActionResult(IEnumerable<ValidationErrorMessages> messages)
+        {
+            ModelStateDictionary errors = new ModelStateDictionary();
+
+            foreach (var message in messages)
+            {
+                errors.AddModelError(string.Empty, message.ToString().ScreamingSnakeCase());
+            }
+
             return new BadRequestObjectResult(new ValidationProblemDetails(errors));
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseChecklistViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseChecklistViewModels.cs
@@ -1,0 +1,54 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
+{
+    public class ReleaseChecklistViewModel
+    {
+        public bool Valid => !Errors.Any();
+        public List<ReleaseChecklistIssue> Errors { get; }
+        public List<ReleaseChecklistIssue> Warnings { get; }
+
+        public ReleaseChecklistViewModel(List<ReleaseChecklistIssue> errors, List<ReleaseChecklistIssue> warnings)
+        {
+            Errors = errors;
+            Warnings = warnings;
+        }
+    }
+
+    public class ReleaseChecklistIssue
+    {
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ValidationErrorMessages Code { get; }
+
+        public ReleaseChecklistIssue(ValidationErrorMessages code)
+        {
+            Code = code;
+        }
+    }
+
+    public class MethodologyMustBeApprovedError : ReleaseChecklistIssue
+    {
+        public Guid MethodologyId { get; }
+
+        public MethodologyMustBeApprovedError(Guid methodologyId) : base(ValidationErrorMessages.MethodologyMustBeApproved)
+        {
+            MethodologyId = methodologyId;
+        }
+    }
+
+    public class NoFootnotesOnSubjectsWarning : ReleaseChecklistIssue
+    {
+        public int TotalSubjects { get; }
+
+        public NoFootnotesOnSubjectsWarning(int totalSubjects) : base(ValidationErrorMessages.NoFootnotesOnSubjects)
+        {
+            TotalSubjects = totalSubjects;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/SubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/SubjectViewModel.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
+{
+    public class SubjectViewModel
+    {
+        public Guid Id { get; set; }
+        public string Filename { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/EitherTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/EitherTest.cs
@@ -28,6 +28,66 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model
             Assert.Equal("a success", either.Right);
             Assert.Throws<ArgumentException>(() => either.Left);
         }
+
+        [Fact]
+        public void Fold_Right()
+        {
+            var result = new Either<int, string>("a success")
+                .Fold(
+                    value => value.ToString(),
+                    value => value.ToUpper()
+                );
+
+            Assert.Equal("A SUCCESS", result);
+        }
+
+        [Fact]
+        public void Fold_Left()
+        {
+            var result = new Either<int, string>(10)
+                .Fold(
+                    value => value.ToString(),
+                    value => value.ToUpper()
+                );
+
+            Assert.Equal("10", result);
+        }
+
+        [Fact]
+        public void FoldRight_Right()
+        {
+            var result = new Either<int, string>("a success")
+                .FoldRight(value => value.ToUpper(), "a default");
+
+            Assert.Equal("A SUCCESS", result);
+        }
+
+        [Fact]
+        public void FoldRight_Left()
+        {
+            var result = new Either<int, string>(10)
+                .FoldRight(value => value.ToUpper(), "a default");
+
+            Assert.Equal("a default", result);
+        }
+
+        [Fact]
+        public void FoldLeft_Left()
+        {
+            var result = new Either<int, string>(10)
+                .FoldLeft(value => value.ToString(), "a default");
+
+            Assert.Equal("10", result);
+        }
+
+        [Fact]
+        public void FoldLeft_Right()
+        {
+            var result = new Either<int, string>("a success")
+                .FoldLeft(value => value.ToString(), "a default");
+
+            Assert.Equal("a default", result);
+        }
     }
 
     public class EitherTaskTest

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -41,6 +41,12 @@ public class Either<Tl, Tr> {
 
         public Either<Tl, Tr> OrElse(Func<Tr> func) => IsLeft ? func() : Right;
 
+        public T Fold<T>(Func<Tl, T> leftFunc, Func<Tr, T> rightFunc) => IsRight ? rightFunc(Right) : leftFunc(Left);
+
+        public T FoldLeft<T>(Func<Tl, T> leftFunc, T defaultValue) => IsLeft ? leftFunc(Left) : defaultValue;
+
+        public T FoldRight<T>(Func<Tr, T> rightFunc, T defaultValue) => IsRight ? rightFunc(Right) : defaultValue;
+
         public static implicit operator Either<Tl, Tr>(Tl left) => new Either<Tl, Tr>(left);
 
         public static implicit operator Either<Tl, Tr>(Tr right) => new Either<Tl, Tr>(right);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/FootnoteRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/FootnoteRepositoryTests.cs
@@ -1,0 +1,705 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
+{
+    public class FootnoteRepositoryTests
+    {
+        [Fact]
+        public async Task GetFootnotes_MapsAllCriteria()
+        {
+            var release = new Release();
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject()
+            };
+
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject()
+            };
+
+            var footnote = new Footnote
+            {
+                Content = "Test footnote",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                Subjects = new List<SubjectFootnote>
+                {
+                    new SubjectFootnote
+                    {
+                        Subject = releaseSubject1.Subject
+                    },
+                    new SubjectFootnote
+                    {
+                        Subject = releaseSubject2.Subject
+                    },
+                },
+                Filters = new List<FilterFootnote>
+                {
+                    new FilterFootnote
+                    {
+                        Filter = new Filter
+                        {
+                            Subject = releaseSubject1.Subject
+                        }
+                    },
+                    new FilterFootnote
+                    {
+                        Filter = new Filter
+                        {
+                            Subject = releaseSubject2.Subject
+                        }
+                    }
+                },
+                FilterGroups = new List<FilterGroupFootnote>
+                {
+                    new FilterGroupFootnote
+                    {
+                        FilterGroup = new FilterGroup
+                        {
+                            Filter = new Filter
+                            {
+                                Subject = releaseSubject1.Subject
+                            }
+                        }
+                    },
+                    new FilterGroupFootnote
+                    {
+                        FilterGroup = new FilterGroup
+                        {
+                            Filter = new Filter
+                            {
+                                Subject = releaseSubject2.Subject
+                            }
+                        }
+                    }
+                },
+                FilterItems = new List<FilterItemFootnote>
+                {
+                    new FilterItemFootnote
+                    {
+                        FilterItem = new FilterItem
+                        {
+                            FilterGroup = new FilterGroup
+                            {
+                                Filter = new Filter
+                                {
+                                    Subject = releaseSubject1.Subject,
+                                }
+                            }
+                        }
+                    },
+                    new FilterItemFootnote
+                    {
+                        FilterItem = new FilterItem
+                        {
+                            FilterGroup = new FilterGroup
+                            {
+                                Filter = new Filter
+                                {
+                                    Subject = releaseSubject2.Subject,
+                                }
+                            }
+                        }
+                    }
+                },
+                Indicators = new List<IndicatorFootnote>
+                {
+                    new IndicatorFootnote
+                    {
+                        Indicator = new Indicator
+                        {
+                            IndicatorGroup = new IndicatorGroup
+                            {
+                                Subject = releaseSubject1.Subject
+                            }
+                        }
+                    },
+                    new IndicatorFootnote
+                    {
+                        Indicator = new Indicator
+                        {
+                            IndicatorGroup = new IndicatorGroup
+                            {
+                                Subject = releaseSubject2.Subject
+                            }
+                        }
+                    }
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await context.AddAsync(release);
+                await context.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await context.AddAsync(footnote);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildFootnoteRepository(context);
+                var results = service.GetFootnotes(release.Id).ToList();
+
+                Assert.Single(results);
+
+                Assert.Equal("Test footnote", results[0].Content);
+
+                var footnoteReleases = results[0].Releases.ToList();
+
+                Assert.Single(footnoteReleases);
+                Assert.Equal(release.Id, footnoteReleases[0].ReleaseId);
+
+                var footnoteSubjects = results[0].Subjects.ToList();
+
+                Assert.Equal(2, footnoteSubjects.Count);
+                Assert.Equal(releaseSubject1.SubjectId, footnoteSubjects[0].SubjectId);
+                Assert.Equal(releaseSubject2.SubjectId, footnoteSubjects[1].SubjectId);
+
+                var footnoteFilters = results[0].Filters.ToList();
+
+                Assert.Equal(2, footnoteSubjects.Count);
+                Assert.Equal(releaseSubject1.SubjectId, footnoteFilters[0].Filter.SubjectId);
+                Assert.Equal(releaseSubject2.SubjectId, footnoteFilters[1].Filter.SubjectId);
+
+                var footnoteFilterGroups = results[0].FilterGroups.ToList();
+
+                Assert.Equal(2, footnoteFilterGroups.Count);
+                Assert.Equal(releaseSubject1.SubjectId, footnoteFilterGroups[0].FilterGroup.Filter.SubjectId);
+                Assert.Equal(releaseSubject2.SubjectId, footnoteFilterGroups[1].FilterGroup.Filter.SubjectId);
+
+                var footnoteFilterItems = results[0].FilterItems.ToList();
+
+                Assert.Equal(2, footnoteFilterItems.Count);
+                Assert.Equal(releaseSubject1.SubjectId, footnoteFilterItems[0].FilterItem.FilterGroup.Filter.SubjectId);
+                Assert.Equal(releaseSubject2.SubjectId, footnoteFilterItems[1].FilterItem.FilterGroup.Filter.SubjectId);
+
+                var footnoteIndicators = results[0].Indicators.ToList();
+
+                Assert.Equal(2, footnoteIndicators.Count);
+                Assert.Equal(releaseSubject1.SubjectId, footnoteIndicators[0].Indicator.IndicatorGroup.SubjectId);
+                Assert.Equal(releaseSubject2.SubjectId, footnoteIndicators[1].Indicator.IndicatorGroup.SubjectId);
+            }
+        }
+
+        [Fact]
+        public async Task GetFootnotes_FiltersByRelease()
+        {
+            var release = new Release();
+            var otherRelease = new Release();
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject()
+            };
+
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject()
+            };
+
+            var footnote1 = new Footnote
+            {
+                Content = "Test footnote 1",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                    // Check that footnote is still fetched
+                    // even if it also linked to another release
+                    new ReleaseFootnote
+                    {
+                        Release = otherRelease
+                    }
+                },
+                Subjects = new List<SubjectFootnote>
+                {
+                    new SubjectFootnote
+                    {
+                        Subject = releaseSubject1.Subject
+                    }
+                },
+            };
+
+            var footnote2 = new Footnote
+            {
+                Content = "Test footnote 2",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                Subjects = new List<SubjectFootnote>
+                {
+                    new SubjectFootnote
+                    {
+                        Subject = releaseSubject2.Subject
+                    }
+                },
+            };
+
+            var footnoteForOtherRelease = new Footnote
+            {
+                Content = "Test footnote for other release",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = new Release()
+                    },
+                },
+                Subjects = new List<SubjectFootnote>
+                {
+                    new SubjectFootnote
+                    {
+                        Subject = new Subject()
+                    }
+                },
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await context.AddAsync(release);
+                await context.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await context.AddRangeAsync(footnote1, footnote2, footnoteForOtherRelease);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildFootnoteRepository(context);
+                var results = service.GetFootnotes(release.Id).ToList();
+
+                Assert.Equal(2, results.Count);
+
+                Assert.Equal("Test footnote 1", results[0].Content);
+
+                var footnote1Releases = results[0].Releases.ToList();
+
+                Assert.Single(footnote1Releases);
+                Assert.Equal(release.Id, footnote1Releases[0].ReleaseId);
+
+                var footnote1Subjects = results[0].Subjects.ToList();
+
+                Assert.Single(footnote1Subjects);
+                Assert.Equal(releaseSubject1.SubjectId, footnote1Subjects[0].SubjectId);
+
+                Assert.Equal("Test footnote 2", results[1].Content);
+
+                var footnote2Releases = results[1].Releases.ToList();
+
+                Assert.Single(footnote2Releases);
+                Assert.Equal(release.Id, footnote2Releases[0].ReleaseId);
+
+                var footnote2Subjects = results[1].Subjects.ToList();
+                Assert.Single(footnote2Subjects);
+                Assert.Equal(releaseSubject2.SubjectId, footnote2Subjects[0].SubjectId);
+            }
+        }
+
+        [Fact]
+        public async Task GetFootnotes_FiltersBySubjectId()
+        {
+            var release = new Release();
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject()
+            };
+
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject()
+            };
+
+            var footnote1 = new Footnote
+            {
+                Content = "Test footnote 1",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                Subjects = new List<SubjectFootnote>
+                {
+                    new SubjectFootnote
+                    {
+                        Subject = releaseSubject1.Subject
+                    }
+                },
+            };
+
+            var footnote2 = new Footnote
+            {
+                Content = "Test footnote 2",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                Subjects = new List<SubjectFootnote>
+                {
+                    new SubjectFootnote
+                    {
+                        Subject = releaseSubject2.Subject
+                    }
+                },
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await context.AddAsync(release);
+                await context.AddRangeAsync(releaseSubject1, releaseSubject2);
+                await context.AddRangeAsync(footnote1, footnote2);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildFootnoteRepository(context);
+                var results = service.GetFootnotes(release.Id, releaseSubject2.SubjectId).ToList();
+
+                Assert.Single(results);
+                Assert.Equal("Test footnote 2", results[0].Content);
+            }
+        }
+
+        [Fact]
+        public async Task GetFootnotes_FiltersBySubjectIds()
+        {
+            var release = new Release();
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject()
+            };
+
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject()
+            };
+
+            var releaseSubject3 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject()
+            };
+
+            var footnote1 = new Footnote
+            {
+                Content = "Test footnote 1",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                Subjects = new List<SubjectFootnote>
+                {
+                    new SubjectFootnote
+                    {
+                        Subject = releaseSubject1.Subject
+                    }
+                },
+            };
+
+            var footnote2 = new Footnote
+            {
+                Content = "Test footnote 2",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                Subjects = new List<SubjectFootnote>
+                {
+                    new SubjectFootnote
+                    {
+                        Subject = releaseSubject2.Subject
+                    }
+                },
+            };
+
+            var footnote3 = new Footnote
+            {
+                Content = "Test footnote 3",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                Subjects = new List<SubjectFootnote>
+                {
+                    new SubjectFootnote
+                    {
+                        Subject = releaseSubject3.Subject
+                    }
+                },
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await context.AddAsync(release);
+                await context.AddRangeAsync(releaseSubject1, releaseSubject2, releaseSubject3);
+                await context.AddRangeAsync(footnote1, footnote2, footnote3);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildFootnoteRepository(context);
+                var results = service.GetFootnotes(
+                    release.Id,
+                    new List<Guid> { releaseSubject1.SubjectId, releaseSubject3.SubjectId }
+                )
+                    .ToList();
+
+                Assert.Equal(2, results.Count);
+
+                Assert.Equal("Test footnote 1", results[0].Content);
+                Assert.Equal("Test footnote 3", results[1].Content);
+            }
+        }
+
+        [Fact]
+        public async Task GetFootnotes_FiltersCriteriaBySubjectId()
+        {
+            var release = new Release();
+            var otherRelease = new Release();
+
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject for release"
+                }
+            };
+
+            var otherReleaseSubject = new ReleaseSubject
+            {
+                Release = otherRelease,
+                Subject = new Subject
+                {
+                    Name = "Test subject for other release"
+                }
+            };
+
+            var footnote = new Footnote
+            {
+                Content = "Test footnote",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                    new ReleaseFootnote
+                    {
+                        Release = otherRelease
+                    }
+                },
+                Subjects = new List<SubjectFootnote>
+                {
+                    new SubjectFootnote
+                    {
+                        Subject = releaseSubject.Subject
+                    },
+                    new SubjectFootnote
+                    {
+                        Subject = otherReleaseSubject.Subject
+                    },
+                },
+                Filters = new List<FilterFootnote>
+                {
+                    new FilterFootnote
+                    {
+                        Filter = new Filter
+                        {
+                            Subject = releaseSubject.Subject
+                        }
+                    },
+                    new FilterFootnote
+                    {
+                        Filter = new Filter
+                        {
+                            Subject = otherReleaseSubject.Subject
+                        }
+                    }
+                },
+                FilterGroups = new List<FilterGroupFootnote>
+                {
+                    new FilterGroupFootnote
+                    {
+                        FilterGroup = new FilterGroup
+                        {
+                            Filter = new Filter
+                            {
+                                Subject = releaseSubject.Subject
+                            }
+                        }
+                    },
+                    new FilterGroupFootnote
+                    {
+                        FilterGroup = new FilterGroup
+                        {
+                            Filter = new Filter
+                            {
+                                Subject = otherReleaseSubject.Subject
+                            }
+                        }
+                    }
+                },
+                FilterItems = new List<FilterItemFootnote>
+                {
+                    new FilterItemFootnote
+                    {
+                        FilterItem = new FilterItem
+                        {
+                            FilterGroup = new FilterGroup
+                            {
+                                Filter = new Filter
+                                {
+                                    Subject = releaseSubject.Subject
+                                }
+                            }
+                        }
+                    },
+                    new FilterItemFootnote
+                    {
+                        FilterItem = new FilterItem
+                        {
+                            FilterGroup = new FilterGroup
+                            {
+                                Filter = new Filter
+                                {
+                                    Subject = otherReleaseSubject.Subject,
+                                }
+                            }
+                        }
+                    }
+                },
+                Indicators = new List<IndicatorFootnote>
+                {
+                    new IndicatorFootnote
+                    {
+                        Indicator = new Indicator
+                        {
+                            IndicatorGroup = new IndicatorGroup
+                            {
+                                Subject = releaseSubject.Subject
+                            }
+                        }
+                    },
+                    new IndicatorFootnote
+                    {
+                        Indicator = new Indicator
+                        {
+                            IndicatorGroup = new IndicatorGroup
+                            {
+                                Subject = otherReleaseSubject.Subject
+                            }
+                        }
+                    }
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await context.AddRangeAsync(release, otherRelease);
+                await context.AddRangeAsync(releaseSubject, otherReleaseSubject);
+                await context.AddAsync(footnote);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildFootnoteRepository(context);
+                var results = service.GetFootnotes(release.Id, releaseSubject.SubjectId).ToList();
+
+                Assert.Single(results);
+                Assert.Equal("Test footnote", results[0].Content);
+
+                var footnoteReleases = results[0].Releases.ToList();
+
+                Assert.Single(footnoteReleases);
+                Assert.Equal(releaseSubject.ReleaseId, footnoteReleases[0].ReleaseId);
+
+                var footnoteSubjects = results[0].Subjects.ToList();
+
+                Assert.Single(footnoteSubjects);
+                Assert.Equal(releaseSubject.SubjectId, footnoteSubjects[0].SubjectId);
+
+                var footnoteFilters = results[0].Filters.ToList();
+
+                Assert.Single(footnoteSubjects);
+                Assert.Equal(releaseSubject.SubjectId, footnoteFilters[0].Filter.SubjectId);
+
+                var footnoteFilterGroups = results[0].FilterGroups.ToList();
+
+                Assert.Single(footnoteFilterGroups);
+                Assert.Equal(releaseSubject.SubjectId, footnoteFilterGroups[0].FilterGroup.Filter.SubjectId);
+
+                var footnoteFilterItems = results[0].FilterItems.ToList();
+
+                Assert.Single(footnoteFilterItems);
+                Assert.Equal(releaseSubject.SubjectId, footnoteFilterItems[0].FilterItem.FilterGroup.Filter.SubjectId);
+
+                var footnoteIndicators = results[0].Indicators.ToList();
+
+                Assert.Single(footnoteIndicators);
+                Assert.Equal(releaseSubject.SubjectId, footnoteIndicators[0].Indicator.IndicatorGroup.SubjectId);
+            }
+        }
+
+        private static FootnoteRepository BuildFootnoteRepository(StatisticsDbContext context)
+        {
+            return new FootnoteRepository(context, new Mock<ILogger<FootnoteRepository>>().Object);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/FootnoteRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/FootnoteRepositoryTests.cs
@@ -156,8 +156,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
 
             await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
             {
-                var service = BuildFootnoteRepository(context);
-                var results = service.GetFootnotes(release.Id).ToList();
+                var repository = BuildFootnoteRepository(context);
+                var results = repository.GetFootnotes(release.Id).ToList();
 
                 Assert.Single(results);
 
@@ -293,8 +293,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
 
             await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
             {
-                var service = BuildFootnoteRepository(context);
-                var results = service.GetFootnotes(release.Id).ToList();
+                var repository = BuildFootnoteRepository(context);
+                var results = repository.GetFootnotes(release.Id).ToList();
 
                 Assert.Equal(2, results.Count);
 
@@ -390,8 +390,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
 
             await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
             {
-                var service = BuildFootnoteRepository(context);
-                var results = service.GetFootnotes(release.Id, releaseSubject2.SubjectId).ToList();
+                var repository = BuildFootnoteRepository(context);
+                var results = repository.GetFootnotes(release.Id, releaseSubject2.SubjectId).ToList();
 
                 Assert.Single(results);
                 Assert.Equal("Test footnote 2", results[0].Content);
@@ -490,11 +490,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
 
             await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
             {
-                var service = BuildFootnoteRepository(context);
-                var results = service.GetFootnotes(
-                    release.Id,
-                    new List<Guid> { releaseSubject1.SubjectId, releaseSubject3.SubjectId }
-                )
+                var repository = BuildFootnoteRepository(context);
+                var results = repository.GetFootnotes(
+                        release.Id,
+                        new List<Guid> {releaseSubject1.SubjectId, releaseSubject3.SubjectId}
+                    )
                     .ToList();
 
                 Assert.Equal(2, results.Count);
@@ -659,8 +659,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
 
             await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
             {
-                var service = BuildFootnoteRepository(context);
-                var results = service.GetFootnotes(release.Id, releaseSubject.SubjectId).ToList();
+                var repository = BuildFootnoteRepository(context);
+                var results = repository.GetFootnotes(release.Id, releaseSubject.SubjectId).ToList();
 
                 Assert.Single(results);
                 Assert.Equal("Test footnote", results[0].Content);
@@ -694,6 +694,358 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
 
                 Assert.Single(footnoteIndicators);
                 Assert.Equal(releaseSubject.SubjectId, footnoteIndicators[0].Indicator.IndicatorGroup.SubjectId);
+            }
+        }
+
+        [Fact]
+        public async Task GetSubjectsWithNoFootnotes_FootnotePerSubject()
+        {
+            var release = new Release();
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject 1"
+                }
+            };
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject 2"
+                }
+            };
+            var releaseSubject3 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject 3"
+                }
+            };
+            var releaseSubject4 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject 4"
+                }
+            };
+            var releaseSubject5 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject 5",
+                }
+            };
+            var releaseSubjectWithNoFootnotes = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject with no footnotes"
+                }
+            };
+
+            var footnote1 = new Footnote
+            {
+                Content = "Test footnote 1",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                Subjects = new List<SubjectFootnote>
+                {
+                    new SubjectFootnote
+                    {
+                        Subject = releaseSubject1.Subject,
+                    }
+                }
+            };
+            var footnote2 = new Footnote
+            {
+                Content = "Test footnote 2",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                Filters = new List<FilterFootnote>
+                {
+                    new FilterFootnote
+                    {
+                        Filter = new Filter
+                        {
+                            Subject = releaseSubject2.Subject
+                        }
+                    }
+                }
+            };
+            var footnote3 = new Footnote
+            {
+                Content = "Test footnote 3",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                FilterGroups = new List<FilterGroupFootnote>
+                {
+                    new FilterGroupFootnote
+                    {
+                        FilterGroup = new FilterGroup
+                        {
+                            Filter = new Filter
+                            {
+                                Subject = releaseSubject3.Subject
+                            }
+                        }
+                    }
+                }
+            };
+            var footnote4 = new Footnote
+            {
+                Content = "Test footnote 4",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                FilterItems = new List<FilterItemFootnote>
+                {
+                    new FilterItemFootnote
+                    {
+                        FilterItem = new FilterItem
+                        {
+                            FilterGroup = new FilterGroup
+                            {
+                                Filter = new Filter
+                                {
+                                    Subject = releaseSubject4.Subject
+                                }
+                            }
+                        }
+                    },
+                }
+            };
+            var footnote5 = new Footnote
+            {
+                Content = "Test footnote 5",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                Indicators = new List<IndicatorFootnote>
+                {
+                    new IndicatorFootnote
+                    {
+                        Indicator = new Indicator
+                        {
+                            IndicatorGroup = new IndicatorGroup
+                            {
+                                Subject = releaseSubject5.Subject
+                            }
+                        }
+                    }
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await context.AddRangeAsync(release);
+                await context.AddRangeAsync(
+                    releaseSubject1,
+                    releaseSubject2,
+                    releaseSubject3,
+                    releaseSubject4,
+                    releaseSubject5,
+                    releaseSubjectWithNoFootnotes
+                );
+                await context.AddRangeAsync(footnote1, footnote2, footnote3, footnote4, footnote5);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var repository = BuildFootnoteRepository(context);
+                var results = await repository.GetSubjectsWithNoFootnotes(release.Id);
+
+                Assert.Single(results);
+
+                Assert.Equal(releaseSubjectWithNoFootnotes.Subject.Id, results[0].Id);
+                Assert.Equal(releaseSubjectWithNoFootnotes.Subject.Name, results[0].Name);
+            }
+        }
+
+        [Fact]
+        public async Task GetSubjectsWithNoFootnotes_FootnoteForMultipleSubjects()
+        {
+            var release = new Release();
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject 1"
+                }
+            };
+            var releaseSubject2 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject 2"
+                }
+            };
+            var releaseSubject3 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject 3"
+                }
+            };
+            var releaseSubject4 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject 4"
+                }
+            };
+            var releaseSubject5 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject 5",
+                }
+            };
+            var releaseSubjectWithNoFootnotes = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Name = "Test subject with no footnotes"
+                }
+            };
+
+            var footnote = new Footnote
+            {
+                Content = "Test footnote 1",
+                Releases = new List<ReleaseFootnote>
+                {
+                    new ReleaseFootnote
+                    {
+                        Release = release
+                    },
+                },
+                Subjects = new List<SubjectFootnote>
+                {
+                    new SubjectFootnote
+                    {
+                        Subject = releaseSubject1.Subject,
+                    }
+                },
+                Filters = new List<FilterFootnote>
+                {
+                    new FilterFootnote
+                    {
+                        Filter = new Filter
+                        {
+                            Subject = releaseSubject2.Subject
+                        },
+                    }
+                },
+                FilterGroups = new List<FilterGroupFootnote>
+                {
+                    new FilterGroupFootnote
+                    {
+                        FilterGroup = new FilterGroup
+                        {
+                            Filter = new Filter
+                            {
+                                Subject = releaseSubject3.Subject
+                            },
+                        }
+                    }
+                },
+                FilterItems = new List<FilterItemFootnote>
+                {
+                    new FilterItemFootnote
+                    {
+                        FilterItem = new FilterItem
+                        {
+                            FilterGroup = new FilterGroup
+                            {
+                                Filter = new Filter
+                                {
+                                    Subject = releaseSubject4.Subject
+                                },
+                            }
+                        }
+                    }
+                },
+                Indicators = new List<IndicatorFootnote>
+                {
+                    new IndicatorFootnote
+                    {
+                        Indicator = new Indicator
+                        {
+                            IndicatorGroup = new IndicatorGroup
+                            {
+                                Subject = releaseSubject5.Subject
+                            }
+                        }
+                    }
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await context.AddRangeAsync(release);
+                await context.AddRangeAsync(
+                    releaseSubject1,
+                    releaseSubject2,
+                    releaseSubject3,
+                    releaseSubject4,
+                    releaseSubject5,
+                    releaseSubjectWithNoFootnotes
+                );
+                await context.AddRangeAsync(footnote);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var repository = BuildFootnoteRepository(context);
+                var results = await repository.GetSubjectsWithNoFootnotes(release.Id);
+
+                Assert.Single(results);
+
+                Assert.Equal(releaseSubjectWithNoFootnotes.Subject.Id, results[0].Id);
+                Assert.Equal(releaseSubjectWithNoFootnotes.Subject.Name, results[0].Name);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/IFootnoteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/IFootnoteRepository.cs
@@ -20,7 +20,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfa
 
         IEnumerable<Footnote> GetFootnotes(Guid releaseId, Guid subjectId);
 
-        IEnumerable<Footnote> GetFootnotes(Guid releaseId, List<Guid> subjects);
+        IEnumerable<Footnote> GetFootnotes(Guid releaseId, IEnumerable<Guid> subjectIds);
+
+        Task<IList<Subject>> GetSubjectsWithNoFootnotes(Guid releaseId);
 
         Task DeleteFootnote(Guid releaseId, Guid id);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/ReleaseSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/ReleaseSubjectService.cs
@@ -12,11 +12,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
     {
         private readonly StatisticsDbContext _statisticsDbContext;
         private readonly IFootnoteRepository _footnoteRepository;
+        private readonly SubjectDeleter _subjectDeleter;
 
-        public ReleaseSubjectService(StatisticsDbContext statisticsDbContext, IFootnoteRepository footnoteRepository)
+        public ReleaseSubjectService(
+            StatisticsDbContext statisticsDbContext,
+            IFootnoteRepository footnoteRepository,
+            SubjectDeleter subjectDeleter)
         {
             _statisticsDbContext = statisticsDbContext;
             _footnoteRepository = footnoteRepository;
+            _subjectDeleter = subjectDeleter;
         }
 
         public async Task SoftDeleteAllReleaseSubjects(Guid releaseId)
@@ -85,15 +90,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
             }
             else
             {
-                // Manually detach subject from state tracking to stop EF from
-                // performing cascading deletes of child relationships in the wrong order.
-                // By detaching it, we just let the database handle the cascading delete instead.
-                // This is more efficient (fewer delete queries) and works correctly.
-                _statisticsDbContext.Entry(subject).State = EntityState.Detached;
-
-                // N.B. This delete will be slow if there are a large number of observations but this is only
-                // executed by the tests when the topic is torn down so ensure files used are < 1000 rows.
-                _statisticsDbContext.Subject.Remove(subject);
+                _subjectDeleter.Delete(subject, _statisticsDbContext);
             }
 
             await _statisticsDbContext.SaveChangesAsync();
@@ -102,6 +99,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
         private bool IsSubjectOrphaned(Subject subject)
         {
             return _statisticsDbContext.ReleaseSubject.Count(rs => rs.SubjectId == subject.Id) == 0;
+        }
+
+        // Separate this into a separate class
+        // for ease of mocking in tests.
+        public class SubjectDeleter
+        {
+            public virtual void Delete(Subject subject, StatisticsDbContext context)
+            {
+                // Use raw delete as EF can't correctly figure out how to cascade the delete, whilst the database can.
+                // N.B. This delete will be slow if there are a large number of observations but this is only
+                // executed by the tests when the topic is torn down so ensure files used are < 1000 rows.
+                context.Subject.FromSqlInterpolated($"DELETE Subject WHERE Id = {subject.Id}");
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Subject.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Subject.cs
@@ -8,7 +8,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public Guid Id { get; set; }
         public string Filename { get; set; }
         public string Name { get; set; }
-        public IEnumerable<Observation> Observations { get; set; }
+        public ICollection<Observation> Observations { get; set; }
+        public ICollection<Filter> Filters { get; set; }
+        public ICollection<IndicatorGroup> IndicatorGroups { get; set; }
         public ICollection<SubjectFootnote> Footnotes { get; set; }
         public bool SoftDeleted { get; set; }
     }

--- a/src/explore-education-statistics-admin/src/components/Link.tsx
+++ b/src/explore-education-statistics-admin/src/components/Link.tsx
@@ -22,12 +22,13 @@ const Link = ({
   ...props
 }: LinkProps) => {
   const isAbsolute = typeof to === 'string' && to.startsWith('http');
+  const isHash = typeof to === 'string' && to.startsWith('#');
 
-  if (isAbsolute) {
+  if (isAbsolute || isHash) {
     return (
       <a
-        rel="noopener noreferrer"
-        target="_blank"
+        rel={isAbsolute ? 'noopener noreferrer' : undefined}
+        target={isAbsolute ? '_blank' : undefined}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
         href={to as string}

--- a/src/explore-education-statistics-admin/src/components/__tests__/Link.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/__tests__/Link.test.tsx
@@ -55,4 +55,18 @@ describe('Link', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     expect(link).toHaveAttribute('target', '_blank');
   });
+
+  test('links to hash URL correctly', () => {
+    const { getByText } = render(
+      <MemoryRouter>
+        <Link to="#test">Test Link</Link>
+      </MemoryRouter>,
+    );
+
+    const link = getByText('Test Link');
+
+    expect(link).toHaveAttribute('href', '#test');
+    expect(link).not.toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link).not.toHaveAttribute('target', '_blank');
+  });
 });

--- a/src/explore-education-statistics-admin/src/components/editable/EditableSectionBlocks.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableSectionBlocks.tsx
@@ -1,10 +1,11 @@
-import { useEditingContext } from '@admin/contexts/EditingContext';
 import BlockDraggable from '@admin/components/editable/BlockDraggable';
 import BlockDroppable from '@admin/components/editable/BlockDroppable';
 import Comments, {
   CommentsChangeHandler,
 } from '@admin/components/editable/Comments';
+import { useEditingContext } from '@admin/contexts/EditingContext';
 import { EditableBlock } from '@admin/services/types/content';
+import InsetText from '@common/components/InsetText';
 import SectionBlocks, {
   SectionBlocksProps,
 } from '@common/modules/find-statistics/components/SectionBlocks';
@@ -68,11 +69,7 @@ const EditableSectionBlocks = (props: EditableSectionBlockProps) => {
   }
 
   if (content.length === 0) {
-    return (
-      <div className="govuk-inset-text">
-        There is no content for this section.
-      </div>
-    );
+    return <InsetText>There is no content for this section.</InsetText>;
   }
 
   return (

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ManagePublicationsAndReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ManagePublicationsAndReleasesTab.tsx
@@ -13,6 +13,7 @@ import { Topic } from '@admin/services/topicService';
 import appendQuery from '@admin/utils/url/appendQuery';
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
+import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
@@ -186,9 +187,7 @@ const ManagePublicationsAndReleasesTab = () => {
                       ))}
                     </Accordion>
                   ) : (
-                    <div className="govuk-inset-text">
-                      No publications available
-                    </div>
+                    <InsetText>No publications available</InsetText>
                   )}
 
                   {canCreatePublication && (

--- a/src/explore-education-statistics-admin/src/pages/methodology/MethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/MethodologiesPage.tsx
@@ -7,6 +7,7 @@ import {
 import methodologyService, {
   MethodologyStatusListItem,
 } from '@admin/services/methodologyService';
+import InsetText from '@common/components/InsetText';
 import RelatedInformation from '@common/components/RelatedInformation';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
@@ -137,9 +138,7 @@ const MethodologiesPage = () => {
           {model && model.liveMethodologies.length ? (
             <MethodologiesTable methodologies={model.liveMethodologies} />
           ) : (
-            <div className="govuk-inset-text">
-              There are currently no live methodologies
-            </div>
+            <InsetText>There are currently no live methodologies</InsetText>
           )}
           <Link to="/methodologies/create" className="govuk-button">
             Create new methodology
@@ -156,9 +155,7 @@ const MethodologiesPage = () => {
           {model && model.draftMethodologies.length ? (
             <MethodologiesTable methodologies={model.draftMethodologies} />
           ) : (
-            <div className="govuk-inset-text">
-              There are currently no draft methodologies
-            </div>
+            <InsetText>There are currently no draft methodologies</InsetText>
           )}
         </TabsSection>
         <TabsSection
@@ -172,9 +169,7 @@ const MethodologiesPage = () => {
           {model && model.approvedMethodologies.length ? (
             <MethodologiesTable methodologies={model.approvedMethodologies} />
           ) : (
-            <div className="govuk-inset-text">
-              There are currently no approved methodologies
-            </div>
+            <InsetText>There are currently no approved methodologies</InsetText>
           )}
         </TabsSection>
       </Tabs>

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePreReleaseAccessPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePreReleaseAccessPage.tsx
@@ -18,6 +18,11 @@ import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React from 'react';
 import { generatePath } from 'react-router';
 
+export const releasePreReleaseAccessPageTabs = {
+  users: 'preReleaseAccess-users',
+  publicAccessList: 'preReleaseAccess-publicList',
+};
+
 const ReleasePreReleaseAccessPage = () => {
   const { releaseId } = useManageReleaseContext();
 
@@ -33,7 +38,10 @@ const ReleasePreReleaseAccessPage = () => {
     <LoadingSpinner loading={isLoading}>
       {release && (
         <Tabs id="preReleaseAccess">
-          <TabsSection id="preReleaseAccess-users" title="Pre-release users">
+          <TabsSection
+            id={releasePreReleaseAccessPageTabs.users}
+            title="Pre-release users"
+          >
             <h2>Manage pre-release user access</h2>
             <InsetText>
               <h3>Before you start</h3>
@@ -90,7 +98,7 @@ const ReleasePreReleaseAccessPage = () => {
             )}
           </TabsSection>
           <TabsSection
-            id="preReleaseAccess-publicList"
+            id={releasePreReleaseAccessPageTabs.publicAccessList}
             title="Public access list"
           >
             <h2>Public pre-release access list</h2>

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePreReleaseAccessPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePreReleaseAccessPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '@admin/routes/releaseRoutes';
 import { preReleaseRoute } from '@admin/routes/routes';
 import releaseService from '@admin/services/releaseService';
+import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
@@ -34,7 +35,7 @@ const ReleasePreReleaseAccessPage = () => {
         <Tabs id="preReleaseAccess">
           <TabsSection id="preReleaseAccess-users" title="Pre-release users">
             <h2>Manage pre-release user access</h2>
-            <div className="govuk-inset-text">
+            <InsetText>
               <h3>Before you start</h3>
               <p>
                 Pre-release users will receive an email with a link to preview
@@ -42,7 +43,7 @@ const ReleasePreReleaseAccessPage = () => {
                 preview will show a holding page until 24 hours before the
                 scheduled publication date.
               </p>
-            </div>
+            </InsetText>
 
             {!release.live && (
               <>

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusEditPage.tsx
@@ -1,0 +1,59 @@
+import ReleaseStatusChecklist from '@admin/pages/release/components/ReleaseStatusChecklist';
+import ReleaseStatusForm from '@admin/pages/release/components/ReleaseStatusForm';
+import { ReleaseStatusPermissions } from '@admin/services/permissionService';
+import releaseService, { Release } from '@admin/services/releaseService';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import { formatISO } from 'date-fns';
+import React from 'react';
+
+interface Props {
+  release: Release;
+  statusPermissions: ReleaseStatusPermissions;
+  onCancel: () => void;
+  onUpdate: (values: Release) => void;
+}
+
+const ReleaseStatusEditPage = ({
+  release,
+  statusPermissions,
+  onCancel,
+  onUpdate,
+}: Props) => {
+  const { value: checklist, isLoading } = useAsyncHandledRetry(
+    async () => releaseService.getReleaseChecklist(release.id),
+    [release.id],
+  );
+
+  return (
+    <LoadingSpinner loading={isLoading}>
+      <h2>Edit release status</h2>
+
+      {checklist && (
+        <ReleaseStatusChecklist checklist={checklist} release={release} />
+      )}
+
+      <ReleaseStatusForm
+        release={release}
+        statusPermissions={statusPermissions}
+        onCancel={onCancel}
+        onSubmit={async values => {
+          const nextRelease = await releaseService.updateRelease(release.id, {
+            ...release,
+            typeId: release.type.id,
+            ...values,
+            publishScheduled: values.publishScheduled
+              ? formatISO(values.publishScheduled, {
+                  representation: 'date',
+                })
+              : undefined,
+          });
+
+          onUpdate(nextRelease);
+        }}
+      />
+    </LoadingSpinner>
+  );
+};
+
+export default ReleaseStatusEditPage;

--- a/src/explore-education-statistics-admin/src/pages/release/components/PreReleaseUserAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/PreReleaseUserAccessForm.tsx
@@ -6,6 +6,7 @@ import ButtonText from '@common/components/ButtonText';
 import Form from '@common/components/form/Form';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
 import Gate from '@common/components/Gate';
+import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
@@ -113,12 +114,12 @@ const PreReleaseUserAccessForm = ({
 
       {users.length > 0 ? (
         <>
-          <div className="govuk-inset-text">
+          <InsetText>
             <p>
               These people will have access to a preview of the release 24 hours
               before the scheduled publish date.
             </p>
-          </div>
+          </InsetText>
 
           <table>
             <thead>
@@ -160,9 +161,7 @@ const PreReleaseUserAccessForm = ({
           </table>
         </>
       ) : (
-        <p className="govuk-inset-text">
-          No pre-release users have been invited.
-        </p>
+        <InsetText>No pre-release users have been invited.</InsetText>
       )}
     </LoadingSpinner>
   );

--- a/src/explore-education-statistics-admin/src/pages/release/components/PublicPreReleaseAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/PublicPreReleaseAccessForm.tsx
@@ -5,6 +5,7 @@ import styles from '@admin/pages/release/components/PublicPreReleaseAccessForm.m
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import { Form } from '@common/components/form';
+import InsetText from '@common/components/InsetText';
 import WarningMessage from '@common/components/WarningMessage';
 import useToggle from '@common/hooks/useToggle';
 import { Formik } from 'formik';
@@ -46,7 +47,7 @@ const PublicPreReleaseAccessForm = ({
   return (
     <>
       {!isReleaseLive && (
-        <div className="govuk-inset-text">
+        <InsetText>
           <h3 className="govuk-heading-m">Before you start</h3>
           <ul>
             <li>
@@ -58,7 +59,7 @@ const PublicPreReleaseAccessForm = ({
               released
             </li>
           </ul>
-        </div>
+        </InsetText>
       )}
 
       {showForm ? (

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
@@ -165,7 +165,7 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
       <h3>Publishing checklist</h3>
 
       {errors.length === 0 && checklist.warnings.length === 0 && (
-        <InsetText variant="success">
+        <InsetText variant="success" testId="releaseChecklist-success">
           <h4 className="govuk-heading-m">All checks passed</h4>
 
           <p>No issues to resolve. This release can be published.</p>
@@ -173,7 +173,7 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
       )}
 
       {errors.length > 0 && (
-        <InsetText variant="error">
+        <InsetText variant="error" testId="releaseChecklist-errors">
           <h4 className="govuk-heading-m">Errors</h4>
 
           <p>
@@ -200,7 +200,7 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
       )}
 
       {warnings.length > 0 && (
-        <InsetText variant="warning">
+        <InsetText variant="warning" testId="releaseChecklist-warnings">
           <h4 className="govuk-heading-m">Warnings</h4>
 
           <p>

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
@@ -1,0 +1,234 @@
+import Link from '@admin/components/Link';
+import { releaseDataPageTabIds } from '@admin/pages/release/data/ReleaseDataPage';
+import { releasePreReleaseAccessPageTabs } from '@admin/pages/release/ReleasePreReleaseAccessPage';
+import {
+  MethodologyRouteParams,
+  methodologyStatusRoute,
+} from '@admin/routes/methodologyRoutes';
+import {
+  releaseContentRoute,
+  releaseDataBlocksRoute,
+  releaseDataRoute,
+  releaseFootnotesRoute,
+  releasePreReleaseAccessRoute,
+  ReleaseRouteParams,
+} from '@admin/routes/releaseRoutes';
+import {
+  publicationEditRoute,
+  PublicationRouteParams,
+} from '@admin/routes/routes';
+import {
+  Release,
+  ReleaseChecklist,
+  ReleaseChecklistError,
+  ReleaseChecklistWarning,
+} from '@admin/services/releaseService';
+import InsetText from '@common/components/InsetText';
+import React, { useMemo } from 'react';
+import { generatePath } from 'react-router';
+import { formId } from './ReleaseStatusForm';
+
+interface ChecklistMessage {
+  message: string;
+  link?: string;
+}
+
+interface Props {
+  checklist: ReleaseChecklist;
+  release: Release;
+}
+
+const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
+  const releaseRouteParams = useMemo<ReleaseRouteParams>(
+    () => ({
+      releaseId: release.id,
+      publicationId: release.publicationId,
+    }),
+    [release.id, release.publicationId],
+  );
+
+  const errors = useMemo<ChecklistMessage[]>(() => {
+    return checklist.errors.map(error => {
+      switch (error.code) {
+        case 'DataFileImportsMustBeCompleted':
+          return {
+            message: 'All data file imports must be completed',
+            link: `${generatePath<ReleaseRouteParams>(
+              releaseDataRoute.path,
+              releaseRouteParams,
+            )}#${releaseDataPageTabIds.dataUploads}`,
+          };
+        case 'DataFileReplacementsMustBeCompleted':
+          return {
+            message: 'All data file replacements must be completed',
+            link: `${generatePath<ReleaseRouteParams>(
+              releaseDataRoute.path,
+              releaseRouteParams,
+            )}#${releaseDataPageTabIds.dataUploads}`,
+          };
+        case 'MethodologyMustBeApproved':
+          return {
+            message: 'Methodology must be approved',
+            link: generatePath<MethodologyRouteParams>(
+              methodologyStatusRoute.path,
+              { methodologyId: error.methodologyId },
+            ),
+          };
+        case 'PublicMetaGuidanceRequired':
+          return {
+            message: 'All public metadata guidance must be populated',
+            link: `${generatePath<ReleaseRouteParams>(
+              releaseDataRoute.path,
+              releaseRouteParams,
+            )}#${releaseDataPageTabIds.metaGuidance}`,
+          };
+        case 'PublicPreReleaseAccessListRequired':
+          return {
+            message: 'Public pre-release access list is required',
+            link: `${generatePath<ReleaseRouteParams>(
+              releasePreReleaseAccessRoute.path,
+              releaseRouteParams,
+            )}#${releasePreReleaseAccessPageTabs.publicAccessList}`,
+          };
+        case 'ReleaseNoteRequired':
+          return {
+            message: 'Public release note for this amendment is required',
+            link: generatePath<ReleaseRouteParams>(
+              releaseContentRoute.path,
+              releaseRouteParams,
+            ),
+          };
+        default:
+          // Show error code, even if there is no mapping,
+          // as this is better than having invisible errors.
+          return {
+            message: (error as ReleaseChecklistError).code,
+          };
+      }
+    });
+  }, [checklist.errors, releaseRouteParams]);
+
+  const warnings = useMemo<ChecklistMessage[]>(() => {
+    return checklist.warnings.map(warning => {
+      switch (warning.code) {
+        case 'NoDataFiles':
+          return {
+            message: 'No data files uploaded',
+            link: `${generatePath<ReleaseRouteParams>(
+              releaseDataRoute.path,
+              releaseRouteParams,
+            )}#${releaseDataPageTabIds.dataUploads}`,
+          };
+        case 'NoFootnotesOnSubjects':
+          return {
+            message: `No footnotes for ${warning.totalSubjects} ${
+              warning.totalSubjects === 1 ? 'subject' : 'subjects'
+            }`,
+            link: generatePath<ReleaseRouteParams>(
+              releaseFootnotesRoute.path,
+              releaseRouteParams,
+            ),
+          };
+        case 'NoMethodology':
+          return {
+            message: 'No methodology attached to publication',
+            link: generatePath<PublicationRouteParams>(
+              publicationEditRoute.path,
+              { publicationId: release.publicationId },
+            ),
+          };
+        case 'NoNextReleaseDate':
+          return {
+            message: 'No next release expected date',
+            link: `#${formId}-nextReleaseDate-month`,
+          };
+        case 'NoTableHighlights':
+          return {
+            message: 'No table highlights',
+            link: generatePath<ReleaseRouteParams>(
+              releaseDataBlocksRoute.path,
+              releaseRouteParams,
+            ),
+          };
+        default:
+          // Show warning code, even if there is no mapping,
+          // as this is better than having invisible warnings.
+          return {
+            message: (warning as ReleaseChecklistWarning).code,
+          };
+      }
+    });
+  }, [checklist.warnings, release.publicationId, releaseRouteParams]);
+
+  return (
+    <div className="govuk-!-width-two-thirds">
+      <h3>Publishing checklist</h3>
+
+      {errors.length === 0 && checklist.warnings.length === 0 && (
+        <InsetText variant="success">
+          <h4 className="govuk-heading-m">All checks passed</h4>
+
+          <p>No issues to resolve. This release can be published.</p>
+        </InsetText>
+      )}
+
+      {errors.length > 0 && (
+        <InsetText variant="error">
+          <h4 className="govuk-heading-m">Errors</h4>
+
+          <p>
+            <strong>
+              {`${errors.length} ${errors.length === 1 ? 'issue' : 'issues'}`}
+            </strong>{' '}
+            that must be resolved before this release can be published.
+          </p>
+
+          <ul>
+            {errors.map(error => (
+              <li key={error.message}>
+                {error.link ? (
+                  <Link to={error.link} unvisited>
+                    {error.message}
+                  </Link>
+                ) : (
+                  error.message
+                )}
+              </li>
+            ))}
+          </ul>
+        </InsetText>
+      )}
+
+      {warnings.length > 0 && (
+        <InsetText variant="warning">
+          <h4 className="govuk-heading-m">Warnings</h4>
+
+          <p>
+            <strong>
+              {`${warnings.length} potential ${
+                warnings.length === 1 ? 'issue' : 'issues'
+              }`}
+            </strong>{' '}
+            that do not need to be resolved to publish this release.
+          </p>
+
+          <ul>
+            {warnings.map(warning => (
+              <li key={warning.message}>
+                {warning.link ? (
+                  <Link to={warning.link} unvisited>
+                    {warning.message}
+                  </Link>
+                ) : (
+                  warning.message
+                )}
+              </li>
+            ))}
+          </ul>
+        </InsetText>
+      )}
+    </div>
+  );
+};
+
+export default ReleaseStatusChecklist;

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -30,7 +30,7 @@ export interface ReleaseStatusFormValues {
   internalReleaseNote: string;
 }
 
-const formId = 'releaseStatusForm';
+export const formId = 'releaseStatusForm';
 
 const errorMappings = [
   mapFieldErrors<ReleaseStatusFormValues>({
@@ -153,8 +153,6 @@ const ReleaseStatusForm = ({
     >
       {form => (
         <Form id={formId}>
-          <h2>Edit release status</h2>
-
           <FormFieldRadioGroup<ReleaseStatusFormValues>
             legend="Status"
             name="status"

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -38,16 +38,20 @@ const errorMappings = [
     messages: {
       APPROVED_RELEASE_MUST_HAVE_PUBLISH_SCHEDULED_DATE:
         'Enter a publish scheduled date before approving',
-      ALL_DATAFILES_UPLOADED_MUST_BE_COMPLETE:
-        'Check all uploaded datafiles are complete before approving',
       PUBLISHED_RELEASE_CANNOT_BE_UNAPPROVED:
         'Release has already been published and cannot be un-approved',
-      META_GUIDANCE_MUST_BE_POPULATED:
-        'All public metadata guidance must be populated before release can be approved',
-      DATA_REPLACEMENT_IN_PROGRESS:
-        'Pending data file replacements that are in progress must be completed or cancelled before release can be approved',
-      METHODOLOGY_MUST_BE_APPROVED_OR_PUBLISHED:
-        "The publication's methodology must be approved before release can be approved",
+      PUBLIC_META_GUIDANCE_REQUIRED:
+        'All public metadata guidance must be populated before the release can be approved',
+      PUBLIC_PRE_RELEASE_ACCESS_LIST_REQUIRED:
+        'Public pre-release access list is required before the release can be approved',
+      DATA_FILE_REPLACEMENTS_MUST_BE_COMPLETED:
+        'Pending data file replacements that are in progress must be completed or cancelled before the release can be approved',
+      DATA_FILE_IMPORTS_MUST_BE_COMPLETED:
+        'All data file imports must be completed before the release can be approved',
+      METHODOLOGY_MUST_BE_APPROVED:
+        "The publication's methodology must be approved before the release can be approved",
+      RELEASE_NOTE_REQUIRED:
+        'A public release note must be added for this amendment before it can be approved',
     },
   }),
   mapFieldErrors<ReleaseStatusFormValues>({

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
@@ -1,0 +1,256 @@
+import ReleaseStatusChecklist from '@admin/pages/release/components/ReleaseStatusChecklist';
+import { Release } from '@admin/services/releaseService';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+describe('ReleaseStatusChecklist', () => {
+  const testRelease: Release = {
+    id: 'release-1',
+    slug: 'release-1-slug',
+    status: 'Draft',
+    latestRelease: false,
+    live: false,
+    amendment: false,
+    releaseName: 'Release 1',
+    publicationId: 'publication-1',
+    publicationTitle: 'Publication 1',
+    publicationSlug: 'publication-1-slug',
+    timePeriodCoverage: { value: 'W51', label: 'Week 51' },
+    title: 'Release Title',
+    type: {
+      id: 'type-1',
+      title: 'Official Statistics',
+    },
+    contact: {
+      id: 'contact-1',
+      teamName: 'Test name',
+      teamEmail: 'test@test.com',
+      contactName: 'Test contact name',
+      contactTelNo: '1111 1111 1111',
+    },
+    previousVersionId: '',
+    preReleaseAccessList: '',
+  };
+
+  test('renders correctly with errors', () => {
+    render(
+      <MemoryRouter>
+        <ReleaseStatusChecklist
+          checklist={{
+            valid: false,
+            warnings: [],
+            errors: [
+              { code: 'DataFileImportsMustBeCompleted' },
+              { code: 'DataFileReplacementsMustBeCompleted' },
+              {
+                code: 'MethodologyMustBeApproved',
+                methodologyId: 'methodology-1',
+              },
+              { code: 'PublicMetaGuidanceRequired' },
+              { code: 'PublicPreReleaseAccessListRequired' },
+              { code: 'ReleaseNoteRequired' },
+            ],
+          }}
+          release={testRelease}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByRole('heading', { name: 'All checks passed' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Errors' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Warnings' }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByText('6 issues')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', {
+        name: 'All data file imports must be completed',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/data#data-uploads',
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'All data file replacements must be completed',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/data#data-uploads',
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Methodology must be approved',
+      }),
+    ).toHaveAttribute('href', '/methodologies/methodology-1/status');
+
+    expect(
+      screen.getByRole('link', {
+        name: 'All public metadata guidance must be populated',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/data#metadata-guidance',
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Public pre-release access list is required',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/prerelease-access#preReleaseAccess-publicList',
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Public release note for this amendment is required',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/content',
+    );
+  });
+
+  test('renders correctly with warnings', () => {
+    render(
+      <MemoryRouter>
+        <ReleaseStatusChecklist
+          checklist={{
+            valid: true,
+            warnings: [
+              { code: 'NoMethodology' },
+              { code: 'NoNextReleaseDate' },
+              { code: 'NoFootnotesOnSubjects', totalSubjects: 3 },
+              { code: 'NoTableHighlights' },
+              { code: 'NoDataFiles' },
+            ],
+            errors: [],
+          }}
+          release={testRelease}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByRole('heading', { name: 'All checks passed' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Errors' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Warnings' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('5 potential issues')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', {
+        name: 'No methodology attached to publication',
+      }),
+    ).toHaveAttribute('href', '/publication/publication-1/edit');
+
+    expect(
+      screen.getByRole('link', {
+        name: 'No next release expected date',
+      }),
+    ).toHaveAttribute('href', '#releaseStatusForm-nextReleaseDate-month');
+
+    expect(
+      screen.getByRole('link', {
+        name: 'No footnotes for 3 subjects',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/footnotes',
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'No table highlights',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/datablocks',
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'No data files uploaded',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/data#data-uploads',
+    );
+  });
+
+  test('renders correctly with both warnings and errors', () => {
+    render(
+      <MemoryRouter>
+        <ReleaseStatusChecklist
+          checklist={{
+            valid: true,
+            warnings: [{ code: 'NoMethodology' }],
+            errors: [{ code: 'PublicMetaGuidanceRequired' }],
+          }}
+          release={testRelease}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.queryByRole('heading', { name: 'All checks passed' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Errors' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Warnings' }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('1 issue')).toBeInTheDocument();
+    expect(screen.getByText('1 potential issue')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', {
+        name: 'All public metadata guidance must be populated',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', {
+        name: 'No methodology attached to publication',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders correctly with no warnings or errors', () => {
+    render(
+      <MemoryRouter>
+        <ReleaseStatusChecklist
+          checklist={{
+            valid: true,
+            warnings: [],
+            errors: [],
+          }}
+          release={testRelease}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'All checks passed' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Errors' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Warnings' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -558,7 +558,7 @@ describe('ReleaseStatusForm', () => {
     test('shows mapped server validation error from failed `onSubmit`', async () => {
       const handleSubmit = jest.fn().mockImplementation(() => {
         throw createServerValidationErrorMock([
-          'META_GUIDANCE_MUST_BE_POPULATED',
+          'PUBLIC_META_GUIDANCE_REQUIRED',
         ]);
       });
 
@@ -578,7 +578,7 @@ describe('ReleaseStatusForm', () => {
         expect(
           screen.getByRole('link', {
             name:
-              'All public metadata guidance must be populated before release can be approved',
+              'All public metadata guidance must be populated before the release can be approved',
           }),
         ).toBeInTheDocument();
       });

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNotesSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNotesSection.tsx
@@ -4,7 +4,7 @@ import releaseNoteService from '@admin/services/releaseNoteService';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import Details from '@common/components/Details';
-import { Form, FormFieldset } from '@common/components/form';
+import { Form } from '@common/components/form';
 import FormFieldDateInput from '@common/components/form/FormFieldDateInput';
 import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
 import FormattedDate from '@common/components/FormattedDate';
@@ -18,7 +18,7 @@ interface Props {
   release: EditableRelease;
 }
 
-interface AddFormValues {
+interface CreateFormValues {
   reason: string;
 }
 
@@ -48,7 +48,7 @@ const ReleaseNotesSection = ({ release }: Props) => {
   );
   const { isEditing } = useEditingContext();
 
-  const addReleaseNote = (releaseNote: AddFormValues) => {
+  const addReleaseNote = (releaseNote: CreateFormValues) => {
     return new Promise(resolve => {
       releaseNoteService
         .create(release.id, releaseNote)
@@ -85,12 +85,14 @@ const ReleaseNotesSection = ({ release }: Props) => {
   };
 
   const renderAddForm = () => {
+    const formId = 'createReleaseNoteForm';
+
     return !addFormOpen ? (
       <Button onClick={openAddForm}>Add note</Button>
     ) : (
-      <Formik<AddFormValues>
+      <Formik<CreateFormValues>
         initialValues={{ reason: '' }}
-        validationSchema={Yup.object<AddFormValues>({
+        validationSchema={Yup.object<CreateFormValues>({
           reason: Yup.string().required('Release note must be provided'),
         })}
         onSubmit={releaseNote =>
@@ -101,22 +103,16 @@ const ReleaseNotesSection = ({ release }: Props) => {
       >
         {form => {
           return (
-            <Form {...form} id="create-new-release-note-form">
-              <FormFieldset
-                id="allFieldsFieldset"
-                legend="Add new release note"
-                legendSize="m"
-              >
-                <FormFieldTextArea
-                  id="reason"
-                  label="Release note"
-                  name="reason"
-                  rows={3}
-                />
-              </FormFieldset>
+            <Form id={formId}>
+              <FormFieldTextArea<CreateFormValues>
+                id={`${formId}-reason`}
+                label="New release note"
+                name="reason"
+                rows={3}
+              />
 
               <ButtonGroup>
-                <Button type="submit">Add note</Button>
+                <Button type="submit">Save note</Button>
                 <Button
                   variant="secondary"
                   onClick={() => {
@@ -135,7 +131,7 @@ const ReleaseNotesSection = ({ release }: Props) => {
   };
 
   const renderEditForm = () => {
-    const formId = 'edit-release-note-form';
+    const formId = 'editReleaseNoteForm';
 
     return (
       <Formik<EditFormValues>
@@ -164,28 +160,22 @@ const ReleaseNotesSection = ({ release }: Props) => {
       >
         {form => {
           return (
-            <Form {...form} id={formId}>
-              <FormFieldset
-                id="allFieldsFieldset"
-                legend="Edit release note"
-                legendSize="m"
-              >
-                <FormFieldDateInput<EditFormValues>
-                  id={`${formId}-on`}
-                  name="on"
-                  legend="Edit date"
-                  legendSize="s"
-                />
-                <FormFieldTextArea<EditFormValues>
-                  id="reason"
-                  label="Edit release note"
-                  name="reason"
-                  rows={3}
-                />
-              </FormFieldset>
+            <Form id={formId}>
+              <FormFieldDateInput<EditFormValues>
+                id={`${formId}-on`}
+                name="on"
+                legend="Edit date"
+                legendSize="s"
+              />
+              <FormFieldTextArea<EditFormValues>
+                id={`${formId}-reason`}
+                label="Edit release note"
+                name="reason"
+                rows={3}
+              />
 
               <ButtonGroup>
-                <Button type="submit">Update</Button>
+                <Button type="submit">Update note</Button>
                 <Button
                   variant="secondary"
                   onClick={() => {
@@ -236,13 +226,13 @@ const ReleaseNotesSection = ({ release }: Props) => {
                               variant="secondary"
                               onClick={() => openEditForm(elem)}
                             >
-                              Edit
+                              Edit note
                             </Button>
                             <Button
                               variant="warning"
                               onClick={() => setDeletedReleaseNote(elem)}
                             >
-                              Remove
+                              Remove note
                             </Button>
                           </ButtonGroup>
                         )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
@@ -10,6 +10,12 @@ import TabsSection from '@common/components/TabsSection';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React, { useState } from 'react';
 
+export const releaseDataPageTabIds = {
+  dataUploads: 'data-uploads',
+  fileUploads: 'file-uploads',
+  metaGuidance: 'metadata-guidance',
+};
+
 const ReleaseDataPage = () => {
   const { publication, releaseId } = useManageReleaseContext();
   const [dataFiles, setDataFiles] = useState<DataFile[]>([]);
@@ -25,7 +31,10 @@ const ReleaseDataPage = () => {
   return (
     <LoadingSpinner loading={isLoading}>
       <Tabs id="dataUploadTab">
-        <TabsSection id="data-uploads" title="Data uploads">
+        <TabsSection
+          id={releaseDataPageTabIds.dataUploads}
+          title="Data uploads"
+        >
           <ReleaseDataUploadsSection
             publicationId={publication.id}
             releaseId={releaseId}
@@ -33,13 +42,20 @@ const ReleaseDataPage = () => {
             onDataFilesChange={setDataFiles}
           />
         </TabsSection>
-        <TabsSection id="file-uploads" title="Ancillary file uploads">
+        <TabsSection
+          id={releaseDataPageTabIds.fileUploads}
+          title="Ancillary file uploads"
+        >
           <ReleaseFileUploadsSection
             releaseId={releaseId}
             canUpdateRelease={canUpdateRelease}
           />
         </TabsSection>
-        <TabsSection id="metadata-guidance" title="Metadata guidance" lazy>
+        <TabsSection
+          id={releaseDataPageTabIds.metaGuidance}
+          title="Metadata guidance"
+          lazy
+        >
           <ReleaseMetaGuidanceSection
             // Track data files so that we can re-render this
             // section automatically whenever there is a change

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
@@ -17,6 +17,7 @@ import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import CollapsibleList from '@common/components/CollapsibleList';
 import Details from '@common/components/Details';
+import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import ModalConfirm from '@common/components/ModalConfirm';
 import SummaryList from '@common/components/SummaryList';
@@ -468,7 +469,9 @@ const DataFileReplacementPlan = ({
             >
               <p>Are you sure you want to delete the following footnote?</p>
 
-              <p className="govuk-inset-text">{deleteFootnote?.content}</p>
+              <InsetText>
+                <p>{deleteFootnote?.content}</p>
+              </InsetText>
             </ModalConfirm>
           )}
         </>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -17,6 +17,7 @@ import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
 import ButtonText from '@common/components/ButtonText';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
+import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import ModalConfirm from '@common/components/ModalConfirm';
 import WarningMessage from '@common/components/WarningMessage';
@@ -24,9 +25,9 @@ import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import logger from '@common/services/logger';
 import { mapFieldErrors } from '@common/validation/serverValidations';
 import Yup from '@common/validation/yup';
+import orderBy from 'lodash/orderBy';
 import React, { useCallback, useState } from 'react';
 import { generatePath } from 'react-router';
-import orderBy from 'lodash/orderBy';
 
 interface FormValues extends DataFileUploadFormValues {
   subjectTitle: string;
@@ -139,7 +140,7 @@ const ReleaseDataUploadsSection = ({
   return (
     <>
       <h2>Add data file to release</h2>
-      <div className="govuk-inset-text">
+      <InsetText>
         <h3>Before you start</h3>
         <p>
           Data files will be displayed in the table tool and can be used to
@@ -165,7 +166,7 @@ const ReleaseDataUploadsSection = ({
             </a>
           </li>
         </ul>
-      </div>
+      </InsetText>
       {canUpdateRelease ? (
         <DataFileUploadForm
           id={formId}
@@ -278,7 +279,7 @@ const ReleaseDataUploadsSection = ({
             ))}
           </Accordion>
         ) : (
-          <p className="govuk-inset-text">No data files have been uploaded.</p>
+          <InsetText>No data files have been uploaded.</InsetText>
         )}
       </LoadingSpinner>
       {deleteDataFile && (

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -10,6 +10,7 @@ import ButtonText from '@common/components/ButtonText';
 import { Form } from '@common/components/form';
 import FormFieldFileInput from '@common/components/form/FormFieldFileInput';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
+import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import ModalConfirm from '@common/components/ModalConfirm';
 import SummaryList from '@common/components/SummaryList';
@@ -144,14 +145,14 @@ const ReleaseFileUploadsSection = ({ releaseId, canUpdateRelease }: Props) => {
         {form => (
           <>
             <h2>Add file to release</h2>
-            <div className="govuk-inset-text">
+            <InsetText>
               <h3>Before you start</h3>
               <p>
                 Ancillary files are additional files attached to the release for
                 users to download. They will appear in the associated files list
                 on the release page and the download files page.
               </p>
-            </div>
+            </InsetText>
 
             {canUpdateRelease ? (
               <Form id={formId}>
@@ -250,7 +251,7 @@ const ReleaseFileUploadsSection = ({ releaseId, canUpdateRelease }: Props) => {
             ))}
           </Accordion>
         ) : (
-          <p className="govuk-inset-text">No files have been uploaded.</p>
+          <InsetText>No files have been uploaded.</InsetText>
         )}
       </LoadingSpinner>
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseMetaGuidanceSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseMetaGuidanceSection.tsx
@@ -8,6 +8,7 @@ import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
 import { Form } from '@common/components/form';
+import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import SanitizeHtml from '@common/components/SanitizeHtml';
 import WarningMessage from '@common/components/WarningMessage';
@@ -79,7 +80,7 @@ const ReleaseMetaGuidanceSection = ({ releaseId, canUpdateRelease }: Props) => {
       <h2>Public metadata guidance document</h2>
 
       {canUpdateRelease ? (
-        <div className="govuk-inset-text">
+        <InsetText>
           <h3>Before you start</h3>
 
           <ul>
@@ -96,7 +97,7 @@ const ReleaseMetaGuidanceSection = ({ releaseId, canUpdateRelease }: Props) => {
               released
             </li>
           </ul>
-        </div>
+        </InsetText>
       ) : (
         <WarningMessage>
           This release has been approved, and can no longer be updated.
@@ -151,9 +152,9 @@ const ReleaseMetaGuidanceSection = ({ releaseId, canUpdateRelease }: Props) => {
                       ) : (
                         <>
                           {!canUpdateRelease && !metaGuidance?.content ? (
-                            <p className="govuk-inset-text">
+                            <InsetText>
                               No guidance content was saved.
-                            </p>
+                            </InsetText>
                           ) : (
                             <SanitizeHtml
                               dirtyHtml={form.values.content}
@@ -238,10 +239,10 @@ const ReleaseMetaGuidanceSection = ({ releaseId, canUpdateRelease }: Props) => {
                     upload at least one data file.
                   </WarningMessage>
                 ) : (
-                  <p className="govuk-inset-text">
+                  <InsetText>
                     The public metadata guidance document has not been created
                     as no data files were uploaded.
-                  </p>
+                  </InsetText>
                 )}
               </>
             )}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
@@ -12,6 +12,7 @@ import permissionService from '@admin/services/permissionService';
 import Button from '@common/components/Button';
 import { FormSelect } from '@common/components/form';
 import Gate from '@common/components/Gate';
+import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import ModalConfirm from '@common/components/ModalConfirm';
 import UrlContainer from '@common/components/UrlContainer';
@@ -117,14 +118,14 @@ const ReleaseDataBlocksPageInternal = ({
     <>
       <h2>Data blocks</h2>
 
-      <div className="govuk-inset-text">
+      <InsetText>
         <h3>Before you start</h3>
         <p>
           A data block is a smaller cut of data from your original file that you
           can embed into your publication as a presentation table, build charts
           from, or link users directly to.
         </p>
-      </div>
+      </InsetText>
 
       <div ref={pageRef}>
         {dataBlockOptions.length > 0 && (

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/ReleaseFootnotesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/ReleaseFootnotesPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '@admin/routes/releaseRoutes';
 import footnotesService from '@admin/services/footnoteService';
 import permissionService from '@admin/services/permissionService';
+import InsetText from '@common/components/InsetText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
@@ -102,14 +103,14 @@ const ReleaseFootnotesPage = ({
   return (
     <LoadingSpinner loading={isPermissionLoading}>
       <h2>Footnotes</h2>
-      <div className="govuk-inset-text">
+      <InsetText>
         <h3>Before you start</h3>
         <p>
           A footnote should outline any necessary caveats within your data.
           These should be used sparingly, and only for information that is
           critical to understanding the data in the table or chart it refers to.
         </p>
-      </div>
+      </InsetText>
       {!canUpdateRelease && (
         <p>This release has been approved, and can no longer be updated.</p>
       )}

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnotesList.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnotesList.tsx
@@ -10,6 +10,7 @@ import { Footnote, FootnoteMeta } from '@admin/services/footnoteService';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import Details from '@common/components/Details';
+import InsetText from '@common/components/InsetText';
 import ModalConfirm from '@common/components/ModalConfirm';
 import React, { useMemo, useState } from 'react';
 import { generatePath } from 'react-router';
@@ -38,7 +39,7 @@ const FootnotesList = ({
   }, [footnoteMeta]);
 
   if (footnotes.length === 0) {
-    return <p className="govuk-inset-text">No footnotes have been created.</p>;
+    return <InsetText>No footnotes have been created.</InsetText>;
   }
 
   return (
@@ -119,7 +120,10 @@ const FootnotesList = ({
           }}
         >
           <p>Are you sure you want to delete the following footnote:</p>
-          <p className="govuk-inset-text">{deleteFootnote.content}</p>
+
+          <InsetText>
+            <p>{deleteFootnote.content}</p>
+          </InsetText>
         </ModalConfirm>
       )}
     </>

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -110,6 +110,39 @@ export interface ReleaseStageStatuses {
   lastUpdated?: string;
 }
 
+export type ReleaseChecklistError =
+  | {
+      code:
+        | 'DataFileImportsMustBeCompleted'
+        | 'DataFileReplacementsMustBeCompleted'
+        | 'PublicMetaGuidanceRequired'
+        | 'PublicPreReleaseAccessListRequired'
+        | 'ReleaseNoteRequired';
+    }
+  | {
+      code: 'MethodologyMustBeApproved';
+      methodologyId: string;
+    };
+
+export type ReleaseChecklistWarning =
+  | {
+      code:
+        | 'NoMethodology'
+        | 'NoNextReleaseDate'
+        | 'NoDataFiles'
+        | 'NoTableHighlights';
+    }
+  | {
+      code: 'NoFootnotesOnSubjects';
+      totalSubjects: number;
+    };
+
+export interface ReleaseChecklist {
+  valid: boolean;
+  errors: ReleaseChecklistError[];
+  warnings: ReleaseChecklistWarning[];
+}
+
 export interface ReleasePublicationStatus {
   publishScheduled: string;
   nextReleaseDate?: PartialDate;
@@ -158,6 +191,10 @@ const releaseService = {
 
   getReleaseStatus(releaseId: string): Promise<ReleaseStageStatuses> {
     return client.get<ReleaseStageStatuses>(`/releases/${releaseId}/status`);
+  },
+
+  getReleaseChecklist(releaseId: string): Promise<ReleaseChecklist> {
+    return client.get(`/releases/${releaseId}/checklist`);
   },
 
   createReleaseAmendment(releaseId: string): Promise<ReleaseSummary> {

--- a/src/explore-education-statistics-common/src/components/InsetText.module.scss
+++ b/src/explore-education-statistics-common/src/components/InsetText.module.scss
@@ -1,0 +1,13 @@
+@import '~govuk-frontend/govuk/base';
+
+.success {
+  border-left-color: govuk-colour('turquoise');
+}
+
+.warning {
+  border-left-color: govuk-colour('orange');
+}
+
+.error {
+  border-left-color: govuk-colour('red');
+}

--- a/src/explore-education-statistics-common/src/components/InsetText.tsx
+++ b/src/explore-education-statistics-common/src/components/InsetText.tsx
@@ -1,0 +1,25 @@
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+import styles from './InsetText.module.scss';
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+  testId?: string;
+  variant?: 'success' | 'error' | 'warning';
+}
+
+const InsetText = ({ children, className, testId, variant }: Props) => {
+  const variantStyle = variant && styles[variant];
+
+  return (
+    <div
+      className={classNames('govuk-inset-text', className, variantStyle)}
+      data-testid={testId}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default InsetText;

--- a/src/explore-education-statistics-common/src/components/Tabs.tsx
+++ b/src/explore-education-statistics-common/src/components/Tabs.tsx
@@ -1,4 +1,5 @@
 import { useDesktopMedia } from '@common/hooks/useMedia';
+import useMounted from '@common/hooks/useMounted';
 import isComponentType from '@common/utils/type-guards/components/isComponentType';
 import classNames from 'classnames';
 import React, {
@@ -100,11 +101,17 @@ const Tabs = ({ children, id, modifyHash = true, testId, onToggle }: Props) => {
         selectTab(sections.length - 1);
       }
 
-      sections.forEach((element, index) => {
-        if (element.props.id === window.location.hash.substr(1)) {
-          selectTab(index);
+      if (window.location.hash) {
+        const matchingTabIndex = sections.findIndex(
+          element => element.props.id === window.location.hash.substr(1),
+        );
+
+        if (matchingTabIndex > -1) {
+          // Set index directly as we don't want to modify
+          // the location hash again by using `selectTab`
+          setSelectedTabIndex(matchingTabIndex);
         }
-      });
+      }
     }
   }, [sections, selectTab, selectedTabIndex]);
 

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -81,6 +81,16 @@ Add basic release content
     user waits until h2 is visible  ${PUBLICATION_NAME}
     user adds basic release content  ${PUBLICATION_NAME}
 
+Add public prerelease access list
+    [Tags]  HappyPath
+    user clicks link  Pre-release access
+    user waits until h2 is visible  Manage pre-release user access
+    user creates public prerelease access list  Initial test public access list
+
+Update public prerelease access list
+    [Tags]  HappyPath
+    user updates public prerelease access list  Updated test public access list
+
 Go to "Sign off" page
     [Tags]  HappyPath
     user clicks link   Sign off
@@ -152,24 +162,6 @@ Invite users to prerelease for scheduled release
     user enters text into element  css:input[name="email"]  analyst1@example.com
     user clicks button  Invite new user
     user checks results table cell contains  2  1  analyst1@example.com
-
-Add public prerelease access list
-    [Tags]  HappyPath
-    user clicks link  Public access list
-    user waits until h2 is visible  Public pre-release access list
-    user clicks button   Create public pre-release access list
-    user presses keys  CTRL+a+BACKSPACE
-    user presses keys  Initial test public access list
-    user clicks button  Save access list
-    user waits until element contains  css:[data-testid="publicPreReleaseAccessListPreview"]  Initial test public access list
-
-Update public prerelease access list
-    [Tags]  HappyPath
-    user clicks button   Edit public pre-release access list
-    user presses keys  CTRL+a+BACKSPACE
-    user presses keys  Updated test public access list
-    user clicks button  Save access list
-    user waits until element contains  css:[data-testid="publicPreReleaseAccessListPreview"]  Updated test public access list
 
 Validate prerelease has not started for Analyst user
     [Tags]  HappyPath

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -39,8 +39,8 @@ Add summary content to release
 Add release note to release
     [Tags]  HappyPath
     user clicks button   Add note
-    user enters text into element  css:textarea#reason  Test release note one
-    user clicks button   Add note
+    user enters text into element  id:createReleaseNoteForm-reason  Test release note one
+    user clicks button   Save note
     user opens details dropdown  See all 1 updates  id:releaseLastUpdated
     ${date}=  get current datetime   %-d %B %Y
     user waits until element contains  css:#releaseNotes li:nth-of-type(1) time  ${date}

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -11,20 +11,54 @@ Suite Teardown    user closes the browser
 ${TOPIC_NAME}        %{TEST_TOPIC_NAME}
 ${PUBLICATION_NAME}  UI tests - release status %{RUN_IDENTIFIER}
 
+*** Keywords ***
+user checks checklist errors contains
+    [Arguments]  ${text}
+    user waits until element contains  css:[data-testid="releaseChecklist-errors"]  ${text}
+
+user checks checklist warnings contains
+    [Arguments]  ${text}
+    user waits until element contains  css:[data-testid="releaseChecklist-warnings"]  ${text}
+
+user checks checklist errors contains link
+    [Arguments]  ${text}
+    user waits until parent contains element  css:[data-testid="releaseChecklist-errors"]  link:${text}
+
+user checks checklist warnings contains link
+    [Arguments]  ${text}
+    user waits until parent contains element  css:[data-testid="releaseChecklist-warnings"]  link:${text}
+
 *** Test Cases ***
 Create new publication and release via API
     [Tags]  HappyPath
     ${PUBLICATION_ID}=  user creates test publication via api   ${PUBLICATION_NAME}
     user create test release via api  ${PUBLICATION_ID}   FY    3000
 
-Submit release for Higher Review
+Go to release sign off page
     [Tags]  HappyPath
     user navigates to release summary from admin dashboard  ${PUBLICATION_NAME}  Financial Year 3000-01 (not Live)
-
     user clicks link  Sign off
     user waits until h2 is visible  Sign off
 
+Verify release checklist with errors
+    [Tags]  HappyPath
     user clicks button  Edit release status
+    user waits until h2 is visible  Edit release status
+
+    user waits until page contains testid  releaseChecklist-errors
+    user checks checklist errors contains  1 issue that must be resolved before this release can be published
+    user checks checklist errors contains link  Public pre-release access list is required
+
+    user waits until page contains testid  releaseChecklist-warnings
+    user checks checklist warnings contains  3 potential issues that do not need to be resolved to publish this release
+    user checks checklist warnings contains link  No methodology attached to publication
+    user checks checklist warnings contains link  No next release expected date
+    user checks checklist warnings contains link  No data files uploaded
+
+    user checks page does not contain testid  releaseChecklist-success
+
+Submit release for Higher Review
+    [Tags]  HappyPath
     user clicks radio  Ready for higher review
     user enters text into element  id:releaseStatusForm-internalReleaseNote     Submitted for Higher Review
     user enters text into element  id:releaseStatusForm-nextReleaseDate-month   12
@@ -38,20 +72,43 @@ Verify release status is Higher Review
     user checks summary list contains  Scheduled release  Not scheduled
     user checks summary list contains  Next release expected  December 3001
 
-Add public prerelease access list
+Verify updated release checklist
     [Tags]  HappyPath
-    user clicks link  Pre-release access
-    user waits until h2 is visible  Manage pre-release user access
-    user creates public prerelease access list   Test public access list
-
-Approve release
-    [Tags]  HappyPath
-    user clicks link  Sign off
-    user waits until h2 is visible  Sign off
-
     user clicks button  Edit release status
     user waits until h2 is visible  Edit release status
 
+    user waits until page contains testid  releaseChecklist-errors
+    user checks checklist errors contains  1 issue that must be resolved before this release can be published
+    user checks checklist errors contains link  Public pre-release access list is required
+
+    user waits until page contains testid  releaseChecklist-warnings
+    user checks checklist warnings contains  2 potential issues that do not need to be resolved to publish this release
+    user checks checklist warnings contains link  No methodology attached to publication
+    user checks checklist warnings contains link  No data files uploaded
+
+    user checks page does not contain testid  releaseChecklist-success
+
+Add public prerelease access list via release checklist
+    [Tags]  HappyPath
+    user clicks link  Public pre-release access list is required
+    user creates public prerelease access list   Test public access list
+
+Verify release checklist does not contain errors
+    [Tags]  HappyPath
+    user clicks link  Sign off
+    user clicks button  Edit release status
+    user waits until h2 is visible  Edit release status
+
+    user waits until page contains testid  releaseChecklist-warnings
+    user checks checklist warnings contains  2 potential issues that do not need to be resolved to publish this release
+    user checks checklist warnings contains link  No methodology attached to publication
+    user checks checklist warnings contains link  No data files uploaded
+
+    user checks page does not contain testid  releaseChecklist-errors
+    user checks page does not contain testid  releaseChecklist-success
+
+Approve release
+    [Tags]  HappyPath
     user clicks radio   Approved for publication
     user enters text into element   id:releaseStatusForm-internalReleaseNote    Approved for release
 

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -38,8 +38,17 @@ Verify release status is Higher Review
     user checks summary list contains  Scheduled release  Not scheduled
     user checks summary list contains  Next release expected  December 3001
 
+Add public prerelease access list
+    [Tags]  HappyPath
+    user clicks link  Pre-release access
+    user waits until h2 is visible  Manage pre-release user access
+    user creates public prerelease access list   Test public access list
+
 Approve release
     [Tags]  HappyPath
+    user clicks link  Sign off
+    user waits until h2 is visible  Sign off
+
     user clicks button  Edit release status
     user waits until h2 is visible  Edit release status
 

--- a/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
@@ -204,6 +204,12 @@ Check footnote in Preview content mode
     user checks page does not contain  ${FOOTNOTE_TEXT_2}
     user checks page does not contain  ${FOOTNOTE_TEXT_1}
 
+Add public prerelease access list
+    [Tags]  HappyPath
+    user clicks link  Pre-release access
+    user waits until h2 is visible  Manage pre-release user access
+    user creates public prerelease access list   Test public access list
+
 Go to "Sign off" page
     [Tags]  HappyPath
     user clicks link   Sign off

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -19,10 +19,25 @@ Create new publication and release via API
     ${PUBLICATION_ID}=  user creates test publication via api   ${PUBLICATION_NAME}
     user create test release via api  ${PUBLICATION_ID}   FY   3000
 
-Go to "Sign off" page
+Navigate to release
     [Tags]  HappyPath
     user navigates to release summary from admin dashboard  ${PUBLICATION_NAME}  Financial Year 3000-01 (not Live)
 
+Add public prerelease access list
+    [Tags]  HappyPath
+    user clicks link  Pre-release access
+    user waits until h2 is visible  Manage pre-release user access
+
+    user clicks link  Public access list
+    user waits until h2 is visible  Public pre-release access list
+    user clicks button   Create public pre-release access list
+    user presses keys  CTRL+a+BACKSPACE
+    user presses keys  Test public access list
+    user clicks button  Save access list
+    user waits until element contains  css:[data-testid="publicPreReleaseAccessListPreview"]  Test public access list
+
+Go to "Sign off" page
+    [Tags]  HappyPath
     user clicks link   Sign off
     user waits until h2 is visible  Sign off
     user waits until page contains button  Edit release status
@@ -154,6 +169,12 @@ Save data block as a highlight
 
     user clicks button   Save data block
     user waits until page contains    Delete this data block
+
+Add public prerelease access list for new release
+    [Tags]  HappyPath
+    user clicks link  Pre-release access
+    user waits until h2 is visible  Manage pre-release user access
+    user creates public prerelease access list   Test public access list
 
 Go to "Sign off" page for new release
     [Tags]  HappyPath

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -177,14 +177,7 @@ Add public prerelease access list
     [Tags]  HappyPath
     user clicks link  Pre-release access
     user waits until h2 is visible  Manage pre-release user access
-
-    user clicks link  Public access list
-    user waits until h2 is visible  Public pre-release access list
-    user clicks button   Create public pre-release access list
-    user presses keys  CTRL+a+BACKSPACE
-    user presses keys  Test public access list
-    user clicks button  Save access list
-    user waits until element contains  css:[data-testid="publicPreReleaseAccessListPreview"]  Test public access list
+    user creates public prerelease access list  Test public access list
 
 Go to "Sign off" tab
     [Tags]  HappyPath
@@ -545,19 +538,21 @@ Update second accordion section text for amendment
     user opens accordion section  Test text
     user adds content to accordion section text block  Test text  1  Updated test text!
 
+Add release note to amendment
+    [Tags]  HappyPath
+    user clicks button   Add note
+    user enters text into element  id:createReleaseNoteForm-reason  Test release note one
+    user clicks button   Save note
+    user opens details dropdown  See all 1 updates  id:releaseLastUpdated
+    ${date}=  get current datetime   %-d %B %Y
+    user waits until element contains  css:#releaseNotes li:nth-of-type(1) time  ${date}
+    user waits until element contains  css:#releaseNotes li:nth-of-type(1) p     Test release note one
+
 Update public prerelease access list for amendment
     [Tags]  HappyPath
     user clicks link  Pre-release access
     user waits until h2 is visible  Manage pre-release user access
-
-    user clicks link  Public access list
-    user waits until h2 is visible  Public pre-release access list
-    user clicks button   Edit public pre-release access list
-    user presses keys  CTRL+a
-    user presses keys  BACKSPACE
-    user presses keys  Updated public access list
-    user clicks button  Save access list
-    user waits until element contains  css:[data-testid="publicPreReleaseAccessListPreview"]  Updated public access list
+    user updates public prerelease access list  Updated public access list
 
 Go to "Sign off" page again
     [Tags]  HappyPath

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -126,6 +126,12 @@ Add meta guidance to second Subject
     ...  meta guidance content
     user clicks button  Save guidance
 
+Add public prerelease access list
+    [Tags]  HappyPath
+    user clicks link  Pre-release access
+    user waits until h2 is visible  Manage pre-release user access
+    user creates public prerelease access list   Test public access list
+
 Go to "Sign off" page
     [Tags]  HappyPath
     user clicks link   Sign off
@@ -368,6 +374,22 @@ Delete second subject file
     user clicks element  ${button}
     user clicks button  Confirm
 
+Navigate to 'Content' page for amendment
+    [Tags]  HappyPath
+    user clicks link   Content
+    user waits until h2 is visible  ${PUBLICATION_NAME}
+    user waits until page contains button  Add a summary text block
+
+Add release note to amendment
+    [Tags]  HappyPath
+    user clicks button   Add note
+    user enters text into element  id:createReleaseNoteForm-reason  Test release note one
+    user clicks button   Save note
+    user opens details dropdown  See all 1 updates  id:releaseLastUpdated
+    ${date}=  get current datetime   %-d %B %Y
+    user waits until element contains  css:#releaseNotes li:nth-of-type(1) time  ${date}
+    user waits until element contains  css:#releaseNotes li:nth-of-type(1) p     Test release note one
+
 Go to "Sign off" page and approve amendment
     [Tags]  HappyPath
     user clicks link   Sign off
@@ -394,7 +416,7 @@ Go to permalink page & check for error element to be present
     user goes to url  ${PERMA_LOCATION_URL}
     user waits until page contains  WARNING - The data used in this permalink may be out-of-date.
 
-Check the table has the same results as original table 
+Check the table has the same results as original table
     [Tags]  HappyPath
     user checks results table row heading contains  1  1  Asian/Asian British
     user checks results table row heading contains  2  1  Black/African/Caribbean/Black British

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -167,6 +167,27 @@ user approves methodology
     user waits until h2 is visible  Methodology status
     user checks page contains tag  Approved
 
+user creates public prerelease access list
+    [Arguments]  ${content}
+    user clicks link  Public access list
+    user waits until h2 is visible  Public pre-release access list
+    user clicks button   Create public pre-release access list
+    user presses keys  CTRL+a+BACKSPACE
+    user presses keys  ${content}
+    user clicks button  Save access list
+    user waits until element contains  css:[data-testid="publicPreReleaseAccessListPreview"]  ${content}
+
+user updates public prerelease access list
+    [Arguments]  ${content}
+    user clicks link  Public access list
+    user waits until h2 is visible  Public pre-release access list
+    user clicks button   Edit public pre-release access list
+    user presses keys  CTRL+a
+    user presses keys  BACKSPACE
+    user presses keys  ${content}
+    user clicks button  Save access list
+    user waits until element contains  css:[data-testid="publicPreReleaseAccessListPreview"]  ${content}
+
 user checks draft releases tab contains publication
     [Arguments]    ${publication_name}
     user checks page contains element   xpath://*[@id="draft-releases"]//h3[text()="${publication_name}"]


### PR DESCRIPTION
This PR adds the following checklist to the release status page:

![image](https://user-images.githubusercontent.com/9917868/102079724-18fe2700-3e05-11eb-943c-ed6e48246b60.png)

The checklist is generated before the user submits the form, allowing them to correct any issues before they try and approve the release. Upon submission, the release will also be validated against this checklist if they try to approve it.

## Related changes

- Added `InsetText` component that can be coloured in success/warning/error flavours.
- Fixed `Tabs` modifying the URL hash multiple times when it renders. This was causing the user's back button to not behave as they would expect when linked to one of the tabs. This was particularly a problem when linking to the relevant places from the release checklist.

## Other changes

- Fixed cascading delete not working correctly with new relationships on `Subject`. To prevent foreign key exceptions (caused by EF trying to delete its related entities incorrectly) when attempting to the delete the `Subject`, we just run raw SQL query to bypass EF.
- Added `Fold`, `FoldLeft` and `FoldRight` methods to `Either`. This is a convenient way to unbox the result without having to do a `IsLeft` or `IsRight` check beforehand.
- Refactored various data file queries into `FileRepository`.