### PR TITLE
EES-1727 Disable ModalConfirm buttons and exits when confirming/cancelling

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
@@ -212,18 +212,18 @@ const PublicationSummary = ({ publication, onChangePublication }: Props) => {
       {amendReleaseId && (
         <ModalConfirm
           title="Confirm you want to amend this live release"
-          onConfirm={async () =>
-            releaseService
-              .createReleaseAmendment(amendReleaseId)
-              .then(amendment =>
-                history.push(
-                  generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
-                    publicationId: id,
-                    releaseId: amendment.id,
-                  }),
-                ),
-              )
-          }
+          onConfirm={async () => {
+            const amendment = await releaseService.createReleaseAmendment(
+              amendReleaseId,
+            );
+
+            history.push(
+              generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
+                publicationId: id,
+                releaseId: amendment.id,
+              }),
+            );
+          }}
           onExit={() => setAmendReleaseId(undefined)}
           onCancel={() => setAmendReleaseId(undefined)}
           mounted

--- a/src/explore-education-statistics-common/src/components/__tests__/ModalConfirm.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/ModalConfirm.test.tsx
@@ -1,0 +1,277 @@
+import ModalConfirm from '@common/components/ModalConfirm';
+import delay from '@common/utils/delay';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+describe('ModalConfirm', () => {
+  describe('confirming', () => {
+    test('clicking Confirm button disables all buttons', () => {
+      const handleExit = jest.fn();
+      const handleCancel = jest.fn();
+      const handleConfirm = jest.fn();
+
+      render(
+        <ModalConfirm
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          onExit={handleExit}
+          title="Test modal"
+        />,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    });
+
+    test('clicking Confirm button prevents closing modal using Esc', async () => {
+      const handleExit = jest.fn();
+      const handleCancel = jest.fn();
+      const handleConfirm = jest.fn();
+
+      render(
+        <ModalConfirm
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          onExit={handleExit}
+          title="Test modal"
+        />,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Esc' });
+
+      await waitFor(() => {
+        expect(handleExit).not.toHaveBeenCalled();
+      });
+    });
+
+    test('clicking Confirm button prevents closing modal by clicking the underlay', async () => {
+      const handleExit = jest.fn();
+      const handleCancel = jest.fn();
+      const handleConfirm = jest.fn();
+
+      const { baseElement } = render(
+        <ModalConfirm
+          underlayClass="underlay"
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          onExit={handleExit}
+          title="Test modal"
+        />,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      fireEvent.mouseDown(
+        baseElement.querySelector('.underlay') as HTMLElement,
+      );
+
+      await waitFor(() => {
+        expect(handleExit).not.toHaveBeenCalled();
+      });
+    });
+
+    test('re-enables buttons once `onConfirm` has completed', async () => {
+      jest.useFakeTimers();
+
+      const handleExit = jest.fn();
+      const handleCancel = jest.fn();
+      const handleConfirm = jest.fn(async () => {
+        await delay(500);
+      });
+
+      render(
+        <ModalConfirm
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          onExit={handleExit}
+          title="Test modal"
+        />,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+
+      jest.advanceTimersByTime(500);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Confirm' })).toBeEnabled();
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+      });
+    });
+
+    test('re-enables exiting once `onConfirm` has completed', async () => {
+      jest.useFakeTimers();
+
+      const handleExit = jest.fn();
+      const handleCancel = jest.fn();
+      const handleConfirm = jest.fn(async () => {
+        await delay(500);
+      });
+
+      const { container } = render(
+        <ModalConfirm
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          onExit={handleExit}
+          title="Test modal"
+        />,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+      jest.advanceTimersByTime(500);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Confirm' })).toBeEnabled();
+      });
+
+      fireEvent.keyDown(container, { key: 'Esc' });
+
+      await waitFor(() => {
+        expect(handleExit).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('cancelling', () => {
+    test('clicking Cancel button disables all buttons', () => {
+      const handleExit = jest.fn();
+      const handleCancel = jest.fn();
+      const handleConfirm = jest.fn();
+
+      render(
+        <ModalConfirm
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          onExit={handleExit}
+          title="Test modal"
+        />,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    });
+
+    test('clicking Cancel button prevents closing modal using Esc', async () => {
+      const handleExit = jest.fn();
+      const handleCancel = jest.fn();
+      const handleConfirm = jest.fn();
+
+      render(
+        <ModalConfirm
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          onExit={handleExit}
+          title="Test modal"
+        />,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Esc' });
+
+      await waitFor(() => {
+        expect(handleExit).not.toHaveBeenCalled();
+      });
+    });
+
+    test('clicking Cancel button prevents closing modal by clicking the underlay', async () => {
+      const handleExit = jest.fn();
+      const handleCancel = jest.fn();
+      const handleConfirm = jest.fn();
+
+      const { baseElement } = render(
+        <ModalConfirm
+          underlayClass="underlay"
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          onExit={handleExit}
+          title="Test modal"
+        />,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      fireEvent.mouseDown(
+        baseElement.querySelector('.underlay') as HTMLElement,
+      );
+
+      await waitFor(() => {
+        expect(handleExit).not.toHaveBeenCalled();
+      });
+    });
+
+    test('re-enables buttons once `onCancel` has completed', async () => {
+      jest.useFakeTimers();
+
+      const handleExit = jest.fn();
+      const handleCancel = jest.fn(async () => {
+        await delay(500);
+      });
+      const handleConfirm = jest.fn();
+
+      render(
+        <ModalConfirm
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          onExit={handleExit}
+          title="Test modal"
+        />,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+
+      jest.advanceTimersByTime(500);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Confirm' })).toBeEnabled();
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+      });
+    });
+
+    test('re-enables exiting once `onCancel` has completed', async () => {
+      jest.useFakeTimers();
+
+      const handleExit = jest.fn();
+      const handleCancel = jest.fn(async () => {
+        await delay(500);
+      });
+      const handleConfirm = jest.fn();
+
+      const { container } = render(
+        <ModalConfirm
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          onExit={handleExit}
+          title="Test modal"
+        />,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      jest.advanceTimersByTime(500);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+      });
+
+      fireEvent.keyDown(container, { key: 'Esc' });
+
+      await waitFor(() => {
+        expect(handleExit).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/hooks/useMountedRef.ts
+++ b/src/explore-education-statistics-common/src/hooks/useMountedRef.ts
@@ -1,0 +1,19 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+/**
+ * Returns a ref that can be used to determine if the
+ * component is currently mounted or not.
+ */
+export default function useMountedRef(): RefObject<boolean> {
+  const isMountedRef = useRef(false);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  });
+
+  return isMountedRef;
+}


### PR DESCRIPTION
This change prevents `ModalConfirm` buttons from being clicked and the modal from being exited (e.g. with Esc or an underlay click) whilst the current `onConfirm` or `onCancel` is in progress.

Whilst confirming/cancelling is in progress, the user should be unable to do anything to prevent them from getting the page into an inconsistent state.