### PR TITLE
EES-1755 Temporarily be lenient if 'All files' zip is missing

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -577,6 +577,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                     .ReturnsAsync(true);
 
                 fileStorageService.Setup(s =>
+                        s.CheckBlobExists(PublicFilesContainerName, 
+                            PublicReleaseAllFilesZipPath(PublicationA.Slug, PublicationARelease2.Slug)))
+                    .ReturnsAsync(true);
+
+                fileStorageService.Setup(s =>
                         s.GetBlob(PublicFilesContainerName,
                             PublicationARelease2AncillaryReleaseFile.PublicPath()))
                     .ReturnsAsync(new BlobInfo
@@ -609,8 +614,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                     ));
 
                 fileStorageService.Setup(s => s.GetBlob(PublicFilesContainerName,
-                        PublicReleaseAllFilesZipPath(PublicationA.Slug,
-                            PublicationARelease2.Slug)))
+                        PublicReleaseAllFilesZipPath(PublicationA.Slug, PublicationARelease2.Slug)))
                     .ReturnsAsync(new BlobInfo
                     (
                         path: PublicReleaseAllFilesZipPath(PublicationA.Slug, PublicationARelease2.Slug),
@@ -736,6 +740,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                     .ReturnsAsync(true);
 
                 fileStorageService.Setup(s =>
+                        s.CheckBlobExists(PublicFilesContainerName, 
+                            PublicReleaseAllFilesZipPath(PublicationA.Slug, PublicationARelease2.Slug)))
+                    .ReturnsAsync(true);
+
+                fileStorageService.Setup(s =>
                         s.GetBlob(PublicFilesContainerName,
                             PublicationARelease2AncillaryReleaseFile.PublicPath()))
                     .ReturnsAsync(new BlobInfo
@@ -768,8 +777,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                     ));
 
                 fileStorageService.Setup(s => s.GetBlob(PublicFilesContainerName,
-                        PublicReleaseAllFilesZipPath(PublicationA.Slug,
-                            PublicationARelease2.Slug)))
+                        PublicReleaseAllFilesZipPath(PublicationA.Slug, PublicationARelease2.Slug)))
                     .ReturnsAsync(new BlobInfo
                     (
                         path: PublicReleaseAllFilesZipPath(PublicationA.Slug, PublicationARelease2.Slug),
@@ -889,9 +897,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var fileStorageService = new Mock<IFileStorageService>(MockBehavior.Strict);
 
+            fileStorageService.Setup(s =>
+                    s.CheckBlobExists(PublicFilesContainerName, 
+                        PublicReleaseAllFilesZipPath(PublicationA.Slug, PublicationARelease1V1.Slug)))
+                .ReturnsAsync(true);
+
             fileStorageService.Setup(s => s.GetBlob(PublicFilesContainerName,
-                    PublicReleaseAllFilesZipPath(PublicationA.Slug,
-                        PublicationARelease1V1.Slug)))
+                    PublicReleaseAllFilesZipPath(PublicationA.Slug, PublicationARelease1V1.Slug)))
                 .ReturnsAsync(new BlobInfo
                 (
                     path: PublicReleaseAllFilesZipPath(PublicationA.Slug, PublicationARelease1V1.Slug),
@@ -996,9 +1008,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var fileStorageService = new Mock<IFileStorageService>(MockBehavior.Strict);
 
+            fileStorageService.Setup(s =>
+                    s.CheckBlobExists(PublicFilesContainerName, 
+                        PublicReleaseAllFilesZipPath(PublicationA.Slug, PublicationARelease3.Slug)))
+                .ReturnsAsync(true);
+
             fileStorageService.Setup(s => s.GetBlob(PublicFilesContainerName,
-                    PublicReleaseAllFilesZipPath(PublicationA.Slug,
-                        PublicationARelease3.Slug)))
+                    PublicReleaseAllFilesZipPath(PublicationA.Slug, PublicationARelease3.Slug)))
                 .ReturnsAsync(new BlobInfo
                 (
                     path: PublicReleaseAllFilesZipPath(PublicationA.Slug, PublicationARelease3.Slug),


### PR DESCRIPTION
We should throw an exception if the 'All files' zip is missing when publishing a Release since it should never be missing.

This was already the case, although the  error (raised outside our project) is rather unhelpful and doesn't include the missing blob path.

Temporarily, in order to  to collect a list of missing files and not halt publishing while regenerating content for all releases, we log an error and continue by returning a `FileInfo` containing a null file path.

This is to assist cleaning up environments believed to contain bad test data.