### PR TITLE
EES-1744 - add extra checks to ensure that a CANCELLING import status…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ImportStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/ImportStatus.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
@@ -46,6 +47,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         public bool IsFinishedOrAborting()
         {
             return IsFinishedOrAbortingState(Status);
+        }
+
+        public IStatus GetFinishingStateOfAbortProcess()
+        {
+            switch (Status)
+            {
+                case CANCELLING: 
+                    return CANCELLED;
+                default: 
+                    throw new ArgumentOutOfRangeException($"No final abort state exists for state {Status}");
+            }
         }
         
         public static bool IsFinishedState(IStatus state)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ImportStatusTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ImportStatusTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.IStatus;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
+{
+    public class ImportStatusTests
+    {
+        private static readonly List<IStatus> ExpectedFinishedStatuses = new List<IStatus>
+        {
+            COMPLETE,
+            FAILED,
+            NOT_FOUND,
+            CANCELLED
+        };
+
+        private static readonly List<IStatus> ExpectedAbortingStatuses = new List<IStatus>
+        {
+            CANCELLING,
+        };
+
+        [Fact]
+        public void FinishedAndAbortingStatuses()
+        {
+            EnumUtil.GetEnumValues<IStatus>().ForEach(status =>
+            {
+                var importStatus = new ImportStatus
+                {
+                    Status = status
+                };
+
+                var expectingToBeFinished = ExpectedFinishedStatuses.Contains(status);
+                var expectingToBeAborting = ExpectedAbortingStatuses.Contains(status);
+
+                Assert.Equal(expectingToBeFinished, importStatus.IsFinished());
+                Assert.Equal(expectingToBeAborting, importStatus.IsAborting());
+                Assert.Equal(expectingToBeFinished || expectingToBeAborting, importStatus.IsFinishedOrAborting());
+            });
+        }
+        
+        [Fact]
+        public void CancellingFinishingStatus()
+        {
+            var importStatus = new ImportStatus
+            {
+                Status = CANCELLING
+            };
+            
+            Assert.Equal(CANCELLED, importStatus.GetFinishingStateOfAbortProcess());
+        }
+
+        [Fact]
+        public void NoOtherAbortingFinishStates()
+        {
+            EnumUtil.GetEnumValues<IStatus>().ForEach(status =>
+            {
+                var importStatus = new ImportStatus
+                {
+                    Status = status
+                };
+
+                if (status != CANCELLING)
+                {
+                    Assert.Throws<ArgumentOutOfRangeException>(() => importStatus.GetFinishingStateOfAbortProcess());
+                }    
+            });
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
@@ -1,0 +1,609 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Importer.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.IStatus;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Services
+{
+    public class FileImportServiceTests
+    {
+        private static readonly List<IStatus> FinishedStatuses = EnumUtil
+            .GetEnumValues<IStatus>()
+            .Where(ImportStatus.IsFinishedState)
+            .ToList();
+        
+        private static readonly List<IStatus> AbortingStatuses = EnumUtil
+            .GetEnumValues<IStatus>()
+            .Where(ImportStatus.IsAbortingState)
+            .ToList();
+
+        [Fact]
+        public async Task CheckComplete_SingleDataFileCompleted()
+        {
+            var message = new ImportObservationsMessage
+            {
+                ReleaseId = Guid.NewGuid(),
+                NumBatches = 1,
+                DataFileName = "my_data_file.csv",
+                TotalRows = 2,
+                SubjectId = Guid.NewGuid()
+            };
+            
+            var importStatusService = new Mock<IImportStatusService>(Strict);
+            
+            var service = BuildFileImportService(
+                importStatusService: importStatusService.Object);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = STAGE_4
+                });
+            
+            importStatusService
+                .Setup(s => s.UpdateStatus(
+                    message.ReleaseId, message.DataFileName, COMPLETE, 100))
+                .Returns(Task.CompletedTask);
+
+            var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+
+            await using (dbContext)
+            {
+                await dbContext.Observation.AddRangeAsync(
+                    new Observation
+                    {
+                        SubjectId = message.SubjectId
+                    },
+                    new Observation
+                    {
+                        SubjectId = message.SubjectId
+                    },
+                    new Observation
+                    {
+                        SubjectId = Guid.NewGuid()
+                    });
+
+                await dbContext.SaveChangesAsync();
+                
+                await service.CheckComplete(message.ReleaseId, message, dbContext);
+            }
+
+            MockUtils.VerifyAllMocks(importStatusService);
+        }
+        
+        [Fact]
+        public async Task CheckComplete_LastBatchFileCompleted()
+        {
+            var message = new ImportObservationsMessage
+            {
+                ReleaseId = Guid.NewGuid(),
+                NumBatches = 2,
+                DataFileName = "my_data_file.csv",
+                TotalRows = 2,
+                SubjectId = Guid.NewGuid()
+            };
+            
+            var importStatusService = new Mock<IImportStatusService>(Strict);
+            var fileStorageService = new Mock<IFileStorageService>();
+            
+            var service = BuildFileImportService(
+                importStatusService: importStatusService.Object,
+                fileStorageService: fileStorageService.Object);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = STAGE_4
+                });
+
+            fileStorageService
+                .Setup(s => s.GetNumBatchesRemaining(message.ReleaseId, message.DataFileName))
+                .ReturnsAsync(0);
+            
+            importStatusService
+                .Setup(s => s.UpdateStatus(
+                    message.ReleaseId, message.DataFileName, COMPLETE, 100))
+                .Returns(Task.CompletedTask);
+
+            var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+
+            await using (dbContext)
+            {
+                await dbContext.Observation.AddRangeAsync(
+                    new Observation
+                    {
+                        SubjectId = message.SubjectId
+                    },
+                    new Observation
+                    {
+                        SubjectId = message.SubjectId
+                    });
+
+                await dbContext.SaveChangesAsync();
+                
+                await service.CheckComplete(message.ReleaseId, message, dbContext);
+            }
+
+            MockUtils.VerifyAllMocks(importStatusService, fileStorageService);
+        }
+        
+        [Fact]
+        public async Task CheckComplete_BatchedFilesStillProcessing()
+        {
+            var message = new ImportObservationsMessage
+            {
+                ReleaseId = Guid.NewGuid(),
+                NumBatches = 2,
+                DataFileName = "my_data_file.csv",
+                TotalRows = 2,
+                SubjectId = Guid.NewGuid(),
+                BatchNo = 1
+            };
+            
+            var importStatusService = new Mock<IImportStatusService>(Strict);
+            var fileStorageService = new Mock<IFileStorageService>();
+            
+            var service = BuildFileImportService(
+                importStatusService: importStatusService.Object,
+                fileStorageService: fileStorageService.Object);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = STAGE_4
+                });
+
+            fileStorageService
+                .Setup(s => s.GetNumBatchesRemaining(message.ReleaseId, message.DataFileName))
+                .ReturnsAsync(1);
+            
+            importStatusService
+                .Setup(s => s.UpdateStatus(
+                    message.ReleaseId, message.DataFileName, STAGE_4, 50))
+                .Returns(Task.CompletedTask);
+
+            var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+
+            await using (dbContext)
+            {
+                await service.CheckComplete(message.ReleaseId, message, dbContext);
+            }
+
+            MockUtils.VerifyAllMocks(importStatusService, fileStorageService);
+        }
+        
+        [Fact]
+        public async Task CheckComplete_SingleDataFileCompleted_HasErrors()
+        {
+            var message = new ImportObservationsMessage
+            {
+                ReleaseId = Guid.NewGuid(),
+                NumBatches = 1,
+                DataFileName = "my_data_file.csv",
+                TotalRows = 2,
+                SubjectId = Guid.NewGuid()
+            };
+            
+            var importStatusService = new Mock<IImportStatusService>(Strict);
+
+            var service = BuildFileImportService(
+                importStatusService: importStatusService.Object);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = STAGE_4,
+                    Errors = "an error"
+                });
+            
+            importStatusService
+                .Setup(s => s.UpdateStatus(
+                    message.ReleaseId, message.DataFileName, FAILED, 100))
+                .Returns(Task.CompletedTask);
+
+            var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+
+            await using (dbContext)
+            {
+                await dbContext.Observation.AddRangeAsync(
+                    new Observation
+                    {
+                        SubjectId = message.SubjectId
+                    },
+                    new Observation
+                    {
+                        SubjectId = message.SubjectId
+                    });
+
+                await dbContext.SaveChangesAsync();
+                
+                await service.CheckComplete(message.ReleaseId, message, dbContext);
+            }
+
+            MockUtils.VerifyAllMocks(importStatusService);
+        }
+        
+        [Fact]
+        public async Task CheckComplete_SingleDataFileCompleted_HasIncorrectObservationCount()
+        {
+            var message = new ImportObservationsMessage
+            {
+                ReleaseId = Guid.NewGuid(),
+                NumBatches = 1,
+                DataFileName = "my_data_file.csv",
+                TotalRows = 3,
+                SubjectId = Guid.NewGuid()
+            };
+            
+            var importStatusService = new Mock<IImportStatusService>(Strict);
+            var batchService = new Mock<IBatchService>(Strict);
+
+            var service = BuildFileImportService(
+                importStatusService: importStatusService.Object,
+                batchService: batchService.Object);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = STAGE_4,
+                });
+
+            batchService
+                .Setup(s => s.FailImport(message.ReleaseId, message.DataFileName, new List<ValidationError>
+                {
+                    new ValidationError(
+                        $"Number of observations inserted (2) " +
+                        $"does not equal that expected ({message.TotalRows}) : Please delete & retry"
+                    )
+                }))
+                .Returns(Task.CompletedTask);
+
+            var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+
+            await using (dbContext)
+            {
+                await dbContext.Observation.AddRangeAsync(
+                    new Observation
+                    {
+                        SubjectId = message.SubjectId
+                    },
+                    new Observation
+                    {
+                        SubjectId = message.SubjectId
+                    });
+
+                await dbContext.SaveChangesAsync();
+                
+                await service.CheckComplete(message.ReleaseId, message, dbContext);
+            }
+
+            MockUtils.VerifyAllMocks(importStatusService, batchService);
+        }
+        
+        [Fact]
+        public async Task CheckComplete_LastBatchFileCompleted_HasErrors()
+        {
+            var message = new ImportObservationsMessage
+            {
+                ReleaseId = Guid.NewGuid(),
+                NumBatches = 2,
+                DataFileName = "my_data_file.csv",
+                TotalRows = 2,
+                SubjectId = Guid.NewGuid()
+            };
+            
+            var importStatusService = new Mock<IImportStatusService>(Strict);
+            var fileStorageService = new Mock<IFileStorageService>();
+            
+            var service = BuildFileImportService(
+                importStatusService: importStatusService.Object,
+                fileStorageService: fileStorageService.Object);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = STAGE_4,
+                    Errors = "an error"
+                });
+
+            fileStorageService
+                .Setup(s => s.GetNumBatchesRemaining(message.ReleaseId, message.DataFileName))
+                .ReturnsAsync(0);
+            
+            importStatusService
+                .Setup(s => s.UpdateStatus(
+                    message.ReleaseId, message.DataFileName, FAILED, 100))
+                .Returns(Task.CompletedTask);
+
+            var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+
+            await using (dbContext)
+            {
+                await dbContext.Observation.AddRangeAsync(
+                    new Observation
+                    {
+                        SubjectId = message.SubjectId
+                    },
+                    new Observation
+                    {
+                        SubjectId = message.SubjectId
+                    });
+
+                await dbContext.SaveChangesAsync();
+                
+                await service.CheckComplete(message.ReleaseId, message, dbContext);
+            }
+
+            MockUtils.VerifyAllMocks(importStatusService, fileStorageService);
+        }
+        
+        [Fact]
+        public async Task CheckComplete_LastBatchFileCompleted_HasIncorrectObservationCount()
+        {
+            var message = new ImportObservationsMessage
+            {
+                ReleaseId = Guid.NewGuid(),
+                NumBatches = 2,
+                DataFileName = "my_data_file.csv",
+                TotalRows = 3,
+                SubjectId = Guid.NewGuid()
+            };
+            
+            var importStatusService = new Mock<IImportStatusService>(Strict);
+            var fileStorageService = new Mock<IFileStorageService>();
+            var batchService = new Mock<IBatchService>();
+
+            var service = BuildFileImportService(
+                importStatusService: importStatusService.Object,
+                fileStorageService: fileStorageService.Object,
+                batchService: batchService.Object);
+
+            importStatusService
+                .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
+                .ReturnsAsync(new ImportStatus
+                {
+                    Status = STAGE_4,
+                });
+
+            fileStorageService
+                .Setup(s => s.GetNumBatchesRemaining(message.ReleaseId, message.DataFileName))
+                .ReturnsAsync(0);
+            
+            batchService
+                .Setup(s => s.FailImport(message.ReleaseId, message.DataFileName, new List<ValidationError>
+                {
+                    new ValidationError(
+                        $"Number of observations inserted (2) " +
+                        $"does not equal that expected ({message.TotalRows}) : Please delete & retry"
+                    )
+                }))
+                .Returns(Task.CompletedTask);
+            
+            var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+
+            await using (dbContext)
+            {
+                await dbContext.Observation.AddRangeAsync(
+                    new Observation
+                    {
+                        SubjectId = message.SubjectId
+                    },
+                    new Observation
+                    {
+                        SubjectId = message.SubjectId
+                    });
+
+                await dbContext.SaveChangesAsync();
+                
+                await service.CheckComplete(message.ReleaseId, message, dbContext);
+            }
+
+            MockUtils.VerifyAllMocks(importStatusService, fileStorageService, batchService);
+        }
+        
+        [Fact]
+        public async Task CheckComplete_SingleDataFileCompleted_AlreadyFinished()
+        {
+            await FinishedStatuses.ForEachAsync(async finishedStatus =>
+            {
+                var message = new ImportObservationsMessage
+                {
+                    ReleaseId = Guid.NewGuid(),
+                    NumBatches = 1,
+                    DataFileName = "my_data_file.csv",
+                    TotalRows = 2,
+                    SubjectId = Guid.NewGuid()
+                };
+            
+                var importStatusService = new Mock<IImportStatusService>(Strict);
+            
+                var service = BuildFileImportService(
+                    importStatusService: importStatusService.Object);
+
+                importStatusService
+                    .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
+                    .ReturnsAsync(new ImportStatus
+                    {
+                        Status = finishedStatus
+                    });
+            
+                var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+
+                await using (dbContext)
+                {
+                    await service.CheckComplete(message.ReleaseId, message, dbContext);
+                }
+
+                MockUtils.VerifyAllMocks(importStatusService);       
+            });
+        }
+        
+        [Fact]
+        public async Task CheckComplete_LastBatchFileCompleted_AlreadyFinished()
+        {
+            await FinishedStatuses.ForEachAsync(async finishedStatus =>
+            {
+                var message = new ImportObservationsMessage
+                {
+                    ReleaseId = Guid.NewGuid(),
+                    NumBatches = 2,
+                    DataFileName = "my_data_file.csv",
+                    TotalRows = 2,
+                    SubjectId = Guid.NewGuid()
+                };
+            
+                var importStatusService = new Mock<IImportStatusService>(Strict);
+                var fileStorageService = new Mock<IFileStorageService>();
+            
+                var service = BuildFileImportService(
+                    importStatusService: importStatusService.Object,
+                    fileStorageService: fileStorageService.Object);
+
+                importStatusService
+                    .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
+                    .ReturnsAsync(new ImportStatus
+                    {
+                        Status = finishedStatus
+                    });
+
+                var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+
+                await using (dbContext)
+                {
+                    await service.CheckComplete(message.ReleaseId, message, dbContext);
+                }
+
+                MockUtils.VerifyAllMocks(importStatusService, fileStorageService);       
+            });
+        }
+        
+        [Fact]
+        public async Task CheckComplete_SingleDataFileCompleted_Aborting()
+        {
+            await AbortingStatuses.ForEachAsync(async abortingStatus =>
+            {
+                var message = new ImportObservationsMessage
+                {
+                    ReleaseId = Guid.NewGuid(),
+                    NumBatches = 1,
+                    DataFileName = "my_data_file.csv",
+                    TotalRows = 2,
+                    SubjectId = Guid.NewGuid()
+                };
+            
+                var importStatusService = new Mock<IImportStatusService>(Strict);
+            
+                var service = BuildFileImportService(
+                    importStatusService: importStatusService.Object);
+
+                var currentStatus = new ImportStatus
+                {
+                    Status = abortingStatus
+                };
+                
+                importStatusService
+                    .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
+                    .ReturnsAsync(currentStatus);
+                
+                importStatusService
+                    .Setup(s => s.UpdateStatus(
+                        message.ReleaseId, message.DataFileName, currentStatus.GetFinishingStateOfAbortProcess(), 100))
+                    .Returns(Task.CompletedTask);
+            
+                var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+
+                await using (dbContext)
+                {
+                    await service.CheckComplete(message.ReleaseId, message, dbContext);
+                }
+
+                MockUtils.VerifyAllMocks(importStatusService);
+            });
+        }
+        
+        [Fact]
+        public async Task CheckComplete_LastBatchFileCompleted_Aborting()
+        {
+            await AbortingStatuses.ForEachAsync(async abortingStatus =>
+            {
+                var message = new ImportObservationsMessage
+                {
+                    ReleaseId = Guid.NewGuid(),
+                    NumBatches = 2,
+                    DataFileName = "my_data_file.csv",
+                    TotalRows = 2,
+                    SubjectId = Guid.NewGuid()
+                };
+            
+                var importStatusService = new Mock<IImportStatusService>(Strict);
+                var fileStorageService = new Mock<IFileStorageService>();
+            
+                var service = BuildFileImportService(
+                    importStatusService: importStatusService.Object,
+                    fileStorageService: fileStorageService.Object);
+
+                var currentStatus = new ImportStatus
+                {
+                    Status = abortingStatus
+                };
+                
+                importStatusService
+                    .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
+                    .ReturnsAsync(currentStatus);
+
+                importStatusService
+                    .Setup(s => s.UpdateStatus(
+                        message.ReleaseId, message.DataFileName, currentStatus.GetFinishingStateOfAbortProcess(), 100))
+                    .Returns(Task.CompletedTask);
+
+                var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
+
+                await using (dbContext)
+                {
+                    await service.CheckComplete(message.ReleaseId, message, dbContext);
+                }
+
+                MockUtils.VerifyAllMocks(importStatusService, fileStorageService);       
+            });
+        }
+        
+        private FileImportService BuildFileImportService(
+            IFileStorageService fileStorageService = null,
+            IImporterService importerService = null,
+            IBatchService batchService = null,
+            ILogger<FileImportService> logger = null,
+            IImportStatusService importStatusService = null
+            )
+        {
+            return new FileImportService(
+                fileStorageService ?? new Mock<IFileStorageService>(Strict).Object,
+                importerService ?? new Mock<IImporterService>(Strict).Object,
+                batchService ?? new Mock<IBatchService>(Strict).Object,
+                logger ?? new Mock<ILogger<FileImportService>>().Object,
+                importStatusService ?? new Mock<IImportStatusService>(Strict).Object
+                );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -55,7 +55,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             
             if (status.Status == CANCELLING)
             {
-                await HandleBatchFileDuringImportCancellation(message, releaseId);
+                _logger.LogInformation($"Import for {message.DataFileName} is CANCELLING " +
+                                       $"{status.Status} - ignoring Observations in file {message.ObservationsFilePath} " +
+                                       $"and marking import as CANCELLED");
+
+                await _importStatusService.UpdateStatus(releaseId, message.DataFileName, CANCELLED, 100);
                 return;
             }
 
@@ -94,47 +98,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             await CheckComplete(releaseId, message, context);
         }
 
-        /**
-         * If this Import has been requested to be cancelled, ignore the current request to import Observation file.
-         *
-         * If it is the final batch file of a batch, delete it and mark the Import as CANCELLED.  Otherwise, continue
-         * and allow the subsequent batch file import requests to deal with the cancellation.
-         *
-         * If it is a single data file that was not batched for Import, mark the Import as CANCELLED.
-         */
-        private async Task HandleBatchFileDuringImportCancellation(ImportObservationsMessage message, Guid releaseId)
-        {
-            if (message.NumBatches > 1)
-            {
-                await _fileStorageService.DeleteBlobByPath(message.ObservationsFilePath);
-
-                var numBatchesRemaining = await _fileStorageService.GetNumBatchesRemaining(releaseId, message.DataFileName);
-
-                if (numBatchesRemaining > 0)
-                {
-                    _logger.LogInformation($"Import for {message.DataFileName} is in the process of being " +
-                                           $"cancelled, so not processing any further Observations - ignoring Observations " +
-                                           $"in file {message.ObservationsFilePath} and continuing");
-
-                } 
-                else 
-                {
-                    _logger.LogInformation($"Import for {message.DataFileName} has {message.ObservationsFilePath} " +
-                                           $"as the final batch file since the cancellation request was issued - marking " +
-                                           $"as cancelled");
-
-                    await _importStatusService.UpdateStatus(releaseId, message.DataFileName, CANCELLED, 100);
-                } 
-            }
-            else
-            {
-                _logger.LogInformation($"Import for {message.DataFileName} is not a batch import, so " +
-                                       $"marking import as cancelled immediately");
-
-                await _importStatusService.UpdateStatus(releaseId, message.DataFileName, CANCELLED, 100);
-            }
-        }
-
         public async Task ImportFiltersAndLocations(ImportMessage message, StatisticsDbContext context)
         {
             var dataFileBlobPath = FileStoragePathUtils.AdminReleasePath(message.Release.Id, FileType.Data, message.DataFileName);
@@ -169,13 +132,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 .FirstOrDefault(r => r.Subject.Id == subjectId && r.ReleaseId == releaseId);
         }
         
-        private async Task CheckComplete(Guid releaseId, ImportObservationsMessage message, StatisticsDbContext context)
+        public async Task CheckComplete(Guid releaseId, ImportObservationsMessage message, StatisticsDbContext context)
         {
-            var numBatchesRemaining = await _fileStorageService.GetNumBatchesRemaining(releaseId, message.DataFileName);
-            
             var import = await _importStatusService.GetImportStatus(releaseId, message.DataFileName);
 
-            if (message.NumBatches == 1 || numBatchesRemaining == 0)
+            if (import.IsFinished())
+            {
+                _logger.LogInformation($"Import for {message.DataFileName} is already finished in " +
+                                       $"state {import.Status} - not attempting to mark as completed or failed");
+                return;
+            }
+            
+            if (import.IsAborting())
+            {
+                _logger.LogInformation($"Import for {message.DataFileName} is trying to abort in " +
+                                       $"state {import.Status} - not attempting to mark as completed or failed, but " +
+                                       $"instead marking as {import.GetFinishingStateOfAbortProcess()}, the final " +
+                                       $"state of the aborting process");
+                
+                await _importStatusService.UpdateStatus(releaseId,
+                    message.DataFileName,
+                    import.GetFinishingStateOfAbortProcess(),
+                    100);
+                return;
+            }
+
+            if (message.NumBatches == 1 || 
+                await _fileStorageService.GetNumBatchesRemaining(releaseId, message.DataFileName) == 0)
             {
                 var observationCount = context.Observation.Count(o => o.SubjectId.Equals(message.SubjectId));
 
@@ -194,16 +177,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 {
                     if (import.Errors.IsNullOrEmpty())
                     {
-                        await _importStatusService.UpdateStatus(releaseId, message.DataFileName, COMPLETE);
+                        await _importStatusService.UpdateStatus(releaseId, message.DataFileName, COMPLETE, 100);
                     }
                     else
                     {
-                        await _importStatusService.UpdateStatus(releaseId, message.DataFileName, FAILED);
+                        await _importStatusService.UpdateStatus(releaseId, message.DataFileName, FAILED, 100);
                     }
                 }
             }
             else
             {
+                var numBatchesRemaining =
+                    await _fileStorageService.GetNumBatchesRemaining(releaseId, message.DataFileName);
+                
                 var percentageComplete = (double) (message.NumBatches - numBatchesRemaining) / message.NumBatches * 100;
 
                 await _importStatusService.UpdateStatus(releaseId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/ValidationError.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/ValidationError.cs
@@ -8,5 +8,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
         {
             Message = message;
         }
+
+        private bool Equals(ValidationError other)
+        {
+            return Message == other.Message;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((ValidationError) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Message != null ? Message.GetHashCode() : 0);
+        }
     }
 }


### PR DESCRIPTION
… is not accidentally misinterpreted as a failed import if the batch file messages are all in flight.

This PR:
- adds tests around FileImportService's code that checks the completion status of an import, and fixing the previous issue whereby if all batch file messages were picked up off the queue and being processed, the final one might misinterpret the cancellation as a failed import due to mismatched observation rows 