### PR TITLE
EES-1721 Add HTTP cached endpoint for data block table queries

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -260,7 +261,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var result = await controller.GetTemplateReleaseAsync(_releaseId);
             AssertOkResult(result);
         }
-        
+
         [Fact]
         public async void CancelFileImport()
         {
@@ -275,15 +276,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             mocks.ImportService
                 .Setup(s => s.CancelImport(cancelRequest))
                 .ReturnsAsync(Unit.Instance);
-            
+
             var controller = ReleasesControllerWithMocks(mocks);
-            
+
             var result = await controller.CancelFileImport(cancelRequest);
             Assert.IsType<AcceptedResult>(result);
-            
+
             MockUtils.VerifyAllMocks(mocks.ImportService);
         }
-        
+
         [Fact]
         public async void CancelFileImportButNotAllowed()
         {
@@ -298,9 +299,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             mocks.ImportService
                 .Setup(s => s.CancelImport(cancelRequest))
                 .ReturnsAsync(new ForbidResult());
-            
+
             var controller = ReleasesControllerWithMocks(mocks);
-            
+
             var result = await controller.CancelFileImport(cancelRequest);
             Assert.IsType<ForbidResult>(result);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
@@ -3,8 +3,15 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Statistics;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -13,48 +20,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 {
     public class TableBuilderControllerTests
     {
-        private readonly TableBuilderController _controller;
-        private readonly Guid _releaseId = new Guid("03730cff-22d5-446c-8971-68921e933b50");
+        private readonly Guid _releaseId = Guid.NewGuid();
+        private readonly Guid _dataBlockId = Guid.NewGuid();
 
         private readonly ObservationQueryContext _query = new ObservationQueryContext
         {
             SubjectId = Guid.NewGuid()
         };
 
-        public TableBuilderControllerTests()
-        {
-            var (logger, tableBuilderService) = Mocks();
-            
-            _controller = new TableBuilderController(tableBuilderService.Object, logger.Object);
-        }
-
         [Fact]
-        public async Task Query_Post()
-        {
-            var result = await _controller.Query(_releaseId, _query);
-            Assert.IsAssignableFrom<TableBuilderResultViewModel>(result.Value);
-            Assert.Single(result.Value.Results);
-        }
-        
-        [Fact]
-        public async Task Query_Post_NoResult()
-        {
-            var result = await _controller.Query(_releaseId, new ObservationQueryContext());
-            Assert.IsAssignableFrom<TableBuilderResultViewModel>(result.Value);
-            Assert.Empty(result.Value.Results);
-        }
-        
-        private (
-            Mock<ILogger<TableBuilderController>>,
-            Mock<ITableBuilderService>) Mocks()
+        public async Task Query()
         {
             var tableBuilderService = new Mock<ITableBuilderService>();
-
-            tableBuilderService.Setup(s => s.Query(_releaseId, It.IsNotIn(_query))).ReturnsAsync(
-                new TableBuilderResultViewModel
-                {
-                    Results = new List<ObservationViewModel>()
-                });
 
             tableBuilderService.Setup(s => s.Query(_releaseId, _query)).ReturnsAsync(
                 new TableBuilderResultViewModel
@@ -63,11 +40,134 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                     {
                         new ObservationViewModel()
                     }
-                });
+                }
+            );
 
-            return (
-                new Mock<ILogger<TableBuilderController>>(),
-                tableBuilderService);
+            var controller = BuildTableBuilderController(tableBuilderService: tableBuilderService.Object);
+            var result = await controller.Query(_releaseId, _query);
+
+            Assert.IsAssignableFrom<TableBuilderResultViewModel>(result.Value);
+            Assert.Single(result.Value.Results);
+        }
+
+
+        [Fact]
+        public async Task QueryForDataBlock()
+        {
+            var tableBuilderService = new Mock<ITableBuilderService>();
+
+            tableBuilderService.Setup(s => s.Query(_releaseId, _query)).ReturnsAsync(
+                new TableBuilderResultViewModel
+                {
+                    Results = new List<ObservationViewModel>
+                    {
+                        new ObservationViewModel()
+                    }
+                }
+            );
+
+            var contentPersistenceHelper =
+                MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
+                    new ReleaseContentBlock
+                    {
+                        ReleaseId = _releaseId,
+                        Release = new Release
+                        {
+                            Id = _releaseId,
+                        },
+                        ContentBlockId = _dataBlockId,
+                        ContentBlock = new DataBlock
+                        {
+                            Id = _dataBlockId,
+                            Query = _query
+                        }
+                    }
+                );
+
+            var controller = BuildTableBuilderController(
+                tableBuilderService: tableBuilderService.Object,
+                contentPersistenceHelper: contentPersistenceHelper.Object
+            );
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
+            var result = await controller.QueryForDataBlock(_releaseId, _dataBlockId);
+
+            Assert.IsType<TableBuilderResultViewModel>(result.Value);
+            Assert.Single(result.Value.Results);
+
+            MockUtils.VerifyAllMocks(tableBuilderService, contentPersistenceHelper);
+        }
+
+        [Fact]
+        public async Task QueryForDataBlock_NotFound()
+        {
+            var contentPersistenceHelper =
+                MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(null);
+
+            var controller = BuildTableBuilderController(
+                contentPersistenceHelper: contentPersistenceHelper.Object
+            );
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
+            var result = await controller.QueryForDataBlock(_releaseId, _dataBlockId);
+
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task QueryForDataBlock_NotDataBlockType()
+        {
+            var contentPersistenceHelper =
+                MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
+                    new ReleaseContentBlock
+                    {
+                        ReleaseId = _releaseId,
+                        Release = new Release
+                        {
+                            Id = _releaseId,
+                        },
+                        ContentBlockId = _dataBlockId,
+                        ContentBlock = new HtmlBlock
+                        {
+                            Id = _dataBlockId,
+                        }
+                    }
+                );
+
+            var controller = BuildTableBuilderController(
+                contentPersistenceHelper: contentPersistenceHelper.Object
+            );
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
+            var result = await controller.QueryForDataBlock(_releaseId, _dataBlockId);
+
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+
+        private TableBuilderController BuildTableBuilderController(
+            ITableBuilderService tableBuilderService = null,
+            IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
+            IUserService userService = null,
+            ILogger<TableBuilderController> logger = null)
+        {
+            return new TableBuilderController(
+                tableBuilderService ?? new Mock<ITableBuilderService>().Object,
+                contentPersistenceHelper ?? MockUtils.MockPersistenceHelper<ContentDbContext>().Object,
+                userService ?? MockUtils.AlwaysTrueUserService().Object,
+                logger ?? new Mock<ILogger<TableBuilderController>>().Object
+            );
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Admin\GovUk.Education.ExploreEducationStatistics.Admin.csproj" />
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common.Tests\GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
-using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.ViewSpecificReleaseAuthorizationHandler;
@@ -21,24 +21,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         {
             // Assert that any users with the "AccessAllReleases" claim can view an arbitrary Release
             // (and no other claim allows this)
-            AssertReleaseHandlerSucceedsWithCorrectClaims<ViewSpecificReleaseRequirement>(
+            AssertReleaseHandlerSucceedsWithCorrectClaims<ViewReleaseRequirement>(
                 new CanSeeAllReleasesAuthorizationHandler(), AccessAllReleases);
         }
-        
+
         [Fact]
         public void HasUnrestrictedViewerRoleOnReleaseAuthorizationHandler()
         {
             // Assert that a User who has any unrestricted viewer role on a Release can view the Release
-            AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<ViewSpecificReleaseRequirement>(
+            AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<ViewReleaseRequirement>(
                 contentDbContext => new HasUnrestrictedViewerRoleOnReleaseAuthorizationHandler(contentDbContext),
                 ReleaseRole.Viewer, ReleaseRole.Lead, ReleaseRole.Contributor, ReleaseRole.Approver);
         }
-        
+
         [Fact]
         public void HasPreReleaseRoleWithinAccessWindowAuthorizationHandler()
         {
             var release = new Release();
-            
+
             var preReleaseService = new Mock<IPreReleaseService>();
 
             preReleaseService
@@ -47,16 +47,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 {
                     Access = PreReleaseAccess.Within
                 });
-            
-            // Assert that a User who specifically has the Pre Release role will cause this handler to pass 
+
+            // Assert that a User who specifically has the Pre Release role will cause this handler to pass
             // IF the Pre Release window is open
-            AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<ViewSpecificReleaseRequirement>(
+            AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<ViewReleaseRequirement>(
                 contentDbContext => new HasPreReleaseRoleWithinAccessWindowAuthorizationHandler(
                     contentDbContext, preReleaseService.Object),
                 release,
                 ReleaseRole.PrereleaseViewer);
         }
-        
+
         [Fact]
         public void HasPreReleaseRoleWithinAccessWindowAuthorizationHandler_PreReleaseWindowNotOpen()
         {
@@ -64,11 +64,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             {
                 Id = Guid.NewGuid()
             };
-            
+
             var preReleaseService = new Mock<IPreReleaseService>();
 
             var userId = Guid.NewGuid();
-            
+
             var failureScenario = new ReleaseHandlerTestScenario
             {
                 Release = release,
@@ -86,7 +86,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 UnexpectedPassMessage = "Expected the test to fail because the Pre Release window is not open at the " +
                                         "current time"
             };
-                
+
             GetEnumValues<PreReleaseAccess>()
                 .Where(value => value != PreReleaseAccess.Within)
                 .ToList()
@@ -98,13 +98,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         {
                             Access = access
                         });
-            
-                    // Assert that a User who specifically has the Pre Release role will cause this handler to fail 
+
+                    // Assert that a User who specifically has the Pre Release role will cause this handler to fail
                     // IF the Pre Release window is NOT open
-                    AssertReleaseHandlerHandlesScenarioSuccessfully<ViewSpecificReleaseRequirement>(
+                    AssertReleaseHandlerHandlesScenarioSuccessfully<ViewReleaseRequirement>(
                         contentDbContext => new HasPreReleaseRoleWithinAccessWindowAuthorizationHandler(
                             contentDbContext, preReleaseService.Object),
-                        failureScenario);           
+                        failureScenario);
                 });
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServicePermissionTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
@@ -11,6 +11,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServicePermissionTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
@@ -27,12 +28,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             Id = Guid.NewGuid()
         };
-        
+
         private static readonly Subject Subject = new Subject
         {
             Id = Guid.NewGuid()
         };
-        
+
         private static readonly Footnote Footnote = new Footnote
         {
             Id = Guid.NewGuid(),
@@ -40,63 +41,71 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 new SubjectFootnote
                 {
-                    SubjectId = Subject.Id 
+                    SubjectId = Subject.Id
                 }
             }
         };
 
         private static readonly IReadOnlyCollection<Guid> SubjectIdsList = new List<Guid>
         {
-            Subject.Id    
+            Subject.Id
         };
-        
+
         private static readonly IReadOnlyCollection<Guid> GuidList = new List<Guid>();
-        
+
         [Fact]
         public void CreateFootnote()
         {
-            AssertSecurityPoliciesChecked(service => service
-                .CreateFootnote(
-                    Release.Id,
-                    "", 
-                    GuidList, 
-                    GuidList, 
-                    GuidList, 
-                    GuidList, 
-                    SubjectIdsList), 
-                CanUpdateSpecificRelease);
+            AssertSecurityPoliciesChecked(
+                service => service
+                    .CreateFootnote(
+                        Release.Id,
+                        "",
+                        GuidList,
+                        GuidList,
+                        GuidList,
+                        GuidList,
+                        SubjectIdsList
+                    ),
+                CanUpdateSpecificRelease
+            );
         }
-        
+
         [Fact]
         public void UpdateFootnote()
         {
-            AssertSecurityPoliciesChecked(service => service
+            AssertSecurityPoliciesChecked(
+                service => service
                     .UpdateFootnote(
-                        Release.Id, 
+                        Release.Id,
                         Footnote.Id,
-                        "", 
-                        GuidList, 
-                        GuidList, 
-                        GuidList, 
-                        GuidList, 
-                        SubjectIdsList), 
-                CanUpdateSpecificRelease);
+                        "",
+                        GuidList,
+                        GuidList,
+                        GuidList,
+                        GuidList,
+                        SubjectIdsList
+                    ),
+                CanUpdateSpecificRelease
+            );
         }
-        
+
         [Fact]
         public void DeleteFootnote()
         {
-            AssertSecurityPoliciesChecked(service => service
-                    .DeleteFootnote(Release.Id, Footnote.Id), 
-                CanUpdateSpecificRelease);
+            AssertSecurityPoliciesChecked(
+                service => service
+                    .DeleteFootnote(Release.Id, Footnote.Id),
+                CanUpdateSpecificRelease
+            );
         }
-        
+
         private void AssertSecurityPoliciesChecked<T>(
             Func<FootnoteService, Task<Either<ActionResult, T>>> protectedAction, params SecurityPolicies[] policies)
         {
             var (
-                _, 
-                releaseHelper, 
+                _,
+                releaseHelper,
                 userService,
                 footnoteService,
                 footnoteHelper,
@@ -106,7 +115,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using var context = InMemoryStatisticsDbContext();
             var service = new FootnoteService(
                 context,
-                releaseHelper.Object, 
+                releaseHelper.Object,
                 userService.Object,
                 footnoteService.Object,
                 footnoteHelper.Object,
@@ -126,12 +135,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var contentPersistenceHelper = MockUtils.MockPersistenceHelper<ContentDbContext>();
             MockUtils.SetupCall(contentPersistenceHelper, Release.Id, Release);
-            
+
             return (
-                new Mock<ILogger<FootnoteService>>(), 
+                new Mock<ILogger<FootnoteService>>(),
                 contentPersistenceHelper,
                 new Mock<IUserService>(),
-                new Mock<IFootnoteRepository>(), 
+                new Mock<IFootnoteRepository>(),
                 MockUtils.MockPersistenceHelper<StatisticsDbContext, Footnote>(Footnote.Id, Footnote),
                 new Mock<IGuidGenerator>());
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/FootnoteServiceTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ImportServiceTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
 using Microsoft.AspNetCore.Mvc;
@@ -22,7 +23,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var userService = new Mock<IUserService>(MockBehavior.Strict);
             var queueService = new Mock<IStorageQueueService>(MockBehavior.Strict);
-            
+
             var cancelRequest = new ReleaseFileImportInfo
             {
                 ReleaseId = Guid.NewGuid(),
@@ -34,16 +35,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(true);
 
             queueService
-                .Setup(s => s.AddMessageAsync("imports-cancelling", 
-                    It.Is<CancelImportMessage>(m => m.ReleaseId == cancelRequest.ReleaseId 
+                .Setup(s => s.AddMessageAsync("imports-cancelling",
+                    It.Is<CancelImportMessage>(m => m.ReleaseId == cancelRequest.ReleaseId
                                                     && m.DataFileName == cancelRequest.DataFileName))).
                 Returns(Task.CompletedTask);
 
             var service = BuildImportService(queueService: queueService.Object, userService: userService.Object);
-            
+
             var result = await service.CancelImport(cancelRequest);
             Assert.True(result.IsRight);
-            
+
             MockUtils.VerifyAllMocks(userService, queueService);
         }
 
@@ -64,7 +65,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .ReturnsAsync(false);
 
             var service = BuildImportService(queueService: queueService.Object, userService: userService.Object);
-            
+
             var result = await service.CancelImport(cancelRequest);
             Assert.True(result.IsLeft);
             Assert.IsType<ForbidResult>(result.Left);
@@ -82,12 +83,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IUserService userService = null)
         {
             return new ImportService(
-                context ?? DbUtils.InMemoryApplicationDbContext(), 
-                mapper ?? new Mock<IMapper>().Object, 
-                logger ?? new Mock<ILogger<ImportService>>().Object, 
+                context ?? DbUtils.InMemoryApplicationDbContext(),
+                mapper ?? new Mock<IMapper>().Object,
+                logger ?? new Mock<ILogger<ImportService>>().Object,
                 queueService ?? new Mock<IStorageQueueService>().Object,
-                tableStorageService ?? new Mock<ITableStorageService>().Object, 
-                guidGenerator ?? new Mock<IGuidGenerator>().Object, 
+                tableStorageService ?? new Mock<ITableStorageService>().Object,
+                guidGenerator ?? new Mock<IGuidGenerator>().Object,
                 userService ?? MockUtils.AlwaysTrueUserService().Object);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ImportStatusBauServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ImportStatusBauServiceTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/LegacyReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/LegacyReleaseServiceTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ContentServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ContentServicePermissionTests.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageContent;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -20,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
     {
         private static readonly Guid ContentSectionId = Guid.NewGuid();
         private static readonly Guid ContentBlockId = Guid.NewGuid();
-        
+
         private readonly Release _release = new Release
         {
             Id = Guid.NewGuid(),
@@ -51,7 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void AddCommentAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.AddCommentAsync(
                         _release.Id,
                         ContentSectionId,
@@ -64,7 +65,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void DeleteCommentAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.DeleteCommentAsync(_comment.Id),
                 _comment,
                 SecurityPolicies.CanUpdateSpecificComment);
@@ -73,7 +74,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void UpdateCommentAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.UpdateCommentAsync(
                         _comment.Id,
                         new AddOrUpdateCommentRequest()),
@@ -84,7 +85,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void AddContentBlockAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.AddContentBlockAsync(
                         _release.Id,
                         ContentSectionId,
@@ -96,7 +97,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void AddContentSectionAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.AddContentSectionAsync(
                         _release.Id,
                         new AddContentSectionRequest()),
@@ -107,7 +108,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void AttachDataBlock()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.AttachDataBlock(
                         _release.Id,
                         ContentSectionId,
@@ -119,7 +120,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void RemoveContentBlockAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.RemoveContentBlockAsync(
                         _release.Id,
                         ContentSectionId,
@@ -131,7 +132,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void RemoveContentSectionAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.RemoveContentSectionAsync(
                         _release.Id,
                         ContentSectionId),
@@ -142,7 +143,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void ReorderContentBlocksAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.ReorderContentBlocksAsync(
                         _release.Id,
                         ContentSectionId,
@@ -154,7 +155,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void ReorderContentSectionsAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.ReorderContentSectionsAsync(
                         _release.Id,
                         new Dictionary<Guid, int>()),
@@ -165,7 +166,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void UpdateContentSectionHeadingAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.UpdateContentSectionHeadingAsync(
                         _release.Id,
                         ContentSectionId,
@@ -177,7 +178,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void UpdateTextBasedContentBlockAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.UpdateTextBasedContentBlockAsync(
                         _release.Id,
                         ContentSectionId,
@@ -190,7 +191,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void UpdateDataBlockAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.UpdateDataBlockAsync(
                         _release.Id,
                         ContentSectionId,
@@ -199,7 +200,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
                 _release,
                 SecurityPolicies.CanUpdateSpecificRelease);
         }
-        
+
         private void AssertSecurityPoliciesChecked<T, TProtectedResource>(
             Func<ContentService, Task<Either<ActionResult, T>>> protectedAction,
             TProtectedResource resource,
@@ -211,7 +212,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
 
             PermissionTestUtil.AssertSecurityPoliciesChecked(protectedAction, resource, userService, service, policies);
         }
-        
+
         private (
             Mock<ContentDbContext>,
             Mock<IPersistenceHelper<ContentDbContext>>,
@@ -221,11 +222,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
             var persistenceHelper = MockUtils.MockPersistenceHelper<ContentDbContext>();
             MockUtils.SetupCall(persistenceHelper, _release.Id, _release);
             MockUtils.SetupCall(persistenceHelper, _comment.Id, _comment);
-            
+
             return (
-                new Mock<ContentDbContext>(), 
+                new Mock<ContentDbContext>(),
                 persistenceHelper,
-                new Mock<IMapper>(), 
+                new Mock<IMapper>(),
                 new Mock<IUserService>());
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Manag
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageContent;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/RelatedInformationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/RelatedInformationServicePermissionTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Secur
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageContent;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -25,34 +26,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void AddRelatedInformationAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.AddRelatedInformationAsync(
                         _release.Id,
-                        new CreateUpdateLinkRequest()), 
+                        new CreateUpdateLinkRequest()),
                 SecurityPolicies.CanUpdateSpecificRelease);
         }
 
         [Fact]
         public void DeleteRelatedInformationAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.DeleteRelatedInformationAsync(
                         _release.Id,
-                        Guid.NewGuid()), 
+                        Guid.NewGuid()),
                 SecurityPolicies.CanUpdateSpecificRelease);
         }
 
         [Fact]
         public void UpdateRelatedInformationAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.UpdateRelatedInformationAsync(
                         _release.Id,
-                        Guid.NewGuid(), 
-                        new CreateUpdateLinkRequest()), 
+                        Guid.NewGuid(),
+                        new CreateUpdateLinkRequest()),
                 SecurityPolicies.CanUpdateSpecificRelease);
         }
-        
+
         private void AssertSecurityPoliciesChecked<T>(
             Func<RelatedInformationService, Task<Either<ActionResult, T>>> protectedAction, params SecurityPolicies[] policies)
         {
@@ -62,15 +63,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
 
             PermissionTestUtil.AssertSecurityPoliciesChecked(protectedAction, _release, userService, service, policies);
         }
-        
+
         private (
             Mock<ContentDbContext>,
             Mock<IPersistenceHelper<ContentDbContext>>,
             Mock<IUserService>) Mocks()
         {
             return (
-                new Mock<ContentDbContext>(), 
-                MockUtils.MockPersistenceHelper<ContentDbContext, Release>(_release.Id, _release), 
+                new Mock<ContentDbContext>(),
+                MockUtils.MockPersistenceHelper<ContentDbContext, Release>(_release.Id, _release),
                 new Mock<IUserService>());
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ReleaseNoteServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ReleaseNoteServicePermissionTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageContent;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -25,34 +26,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         [Fact]
         public void AddReleaseNoteAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.AddReleaseNoteAsync(
                         _release.Id,
-                        new CreateOrUpdateReleaseNoteRequest()), 
+                        new CreateOrUpdateReleaseNoteRequest()),
                 SecurityPolicies.CanUpdateSpecificRelease);
         }
 
         [Fact]
         public void DeleteReleaseNoteAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.DeleteReleaseNoteAsync(
                         _release.Id,
-                        Guid.NewGuid()), 
+                        Guid.NewGuid()),
                 SecurityPolicies.CanUpdateSpecificRelease);
         }
 
         [Fact]
         public void UpdateReleaseNoteAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.UpdateReleaseNoteAsync(
                         _release.Id,
-                        Guid.NewGuid(), 
-                        new CreateOrUpdateReleaseNoteRequest()), 
+                        Guid.NewGuid(),
+                        new CreateOrUpdateReleaseNoteRequest()),
                 SecurityPolicies.CanUpdateSpecificRelease);
         }
-        
+
         private void AssertSecurityPoliciesChecked<T>(
             Func<ReleaseNoteService, Task<Either<ActionResult, T>>> protectedAction, params SecurityPolicies[] policies)
         {
@@ -62,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
 
             PermissionTestUtil.AssertSecurityPoliciesChecked(protectedAction, _release, userService, service, policies);
         }
-        
+
         private (
             Mock<IMapper>,
             Mock<ContentDbContext>,
@@ -70,9 +71,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
             Mock<IUserService>) Mocks()
         {
             return (
-                new Mock<IMapper>(), 
-                new Mock<ContentDbContext>(), 
-                MockUtils.MockPersistenceHelper<ContentDbContext, Release>(_release.Id, _release), 
+                new Mock<IMapper>(),
+                new Mock<ContentDbContext>(),
+                MockUtils.MockPersistenceHelper<ContentDbContext, Release>(_release.Id, _release),
                 new Mock<IUserService>());
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServicePermissionTests.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServicePermissionTests.cs
@@ -8,10 +8,12 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -25,8 +27,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void Get()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
-                .ExpectResourceCheckToFail(_release, SecurityPolicies.CanViewSpecificRelease)
+            PolicyCheckBuilder<ContentSecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -39,7 +41,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void Update()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, SecurityPolicies.CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Methodolo
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PermissionTestUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PermissionTestUtil.cs
@@ -4,9 +4,9 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Castle.Core.Internal;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
-using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
@@ -16,9 +16,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
     public static class PermissionTestUtil
     {
-        public static SecurityPolicyCheckBuilder PolicyCheckBuilder()
+        public static PolicyCheckBuilder<SecurityPolicies> PolicyCheckBuilder(Mock<IUserService> userService = null)
         {
-            return new SecurityPolicyCheckBuilder();
+            return new PolicyCheckBuilder<SecurityPolicies>(userService);
         }
 
         [Obsolete("Use SecurityPolicyCheckBuilder class or PolicyCheckBuilder method")]
@@ -36,7 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var result = await protectedAction.Invoke(service);
 
-            AssertForbidden(result);
+            PermissionTestUtils.AssertForbidden(result);
 
             policies.ToList().ForEach(policy =>
                 userService.Verify(s => s.MatchesPolicy(resource, policy)));
@@ -50,13 +50,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var publicMethods = typeof(TClass).GetMethods(BindingFlags.Public);
             publicMethods.ToList().ForEach(method => Assert.Null(method.GetAttribute<AuthorizeAttribute>()));
-        }
-
-        public static void AssertForbidden<T>(Either<ActionResult,T> result)
-        {
-            Assert.NotNull(result);
-            Assert.True(result.IsLeft);
-            Assert.IsAssignableFrom<ForbidResult>(result.Left);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseSummaryServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseSummaryServicePermissionTests.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseSummaryServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseSummaryServiceTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServiceTests.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -8,6 +8,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServicePermissionTests.cs
@@ -2,6 +2,7 @@
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.Extensions.Configuration;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServiceTests.cs
@@ -2,6 +2,7 @@
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServicePermissionTests.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServicePermissionTests.cs
@@ -8,10 +8,11 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using Moq;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.PermissionTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -26,8 +27,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void GetChecklist()
         {
-            PolicyCheckBuilder()
-                .ExpectResourceCheckToFail(_release, SecurityPolicies.CanViewSpecificRelease)
+            PolicyCheckBuilder<ContentSecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
@@ -8,6 +8,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServicePermissionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -8,13 +9,14 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.PermissionTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -28,7 +30,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void Delete()
         {
-            PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
@@ -42,7 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void Delete_MultipleFiles()
         {
-            PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
@@ -78,7 +80,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 contentDbContext.SaveChangesAsync();
             }
 
-            PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
@@ -94,8 +96,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void GetInfo()
         {
-            PolicyCheckBuilder()
-                .ExpectResourceCheckToFail(_release, CanViewSpecificRelease)
+            PolicyCheckBuilder<ContentSecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -108,8 +110,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void ListAll()
         {
-            PolicyCheckBuilder()
-                .ExpectResourceCheckToFail(_release, CanViewSpecificRelease)
+            PolicyCheckBuilder<ContentSecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -122,7 +124,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void Upload()
         {
-            PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
@@ -141,7 +143,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void UploadAsZip()
         {
-            PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServicePermissionTests.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTest.cs
@@ -11,6 +11,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServicePermissionTests.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServicePermissionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -8,12 +9,13 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.PermissionTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -27,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void Delete()
         {
-            PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
@@ -42,7 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void Delete_MultipleFiles()
         {
-            PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
@@ -79,7 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 contentDbContext.SaveChangesAsync();
             }
 
-            PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
@@ -95,8 +97,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void ListAll()
         {
-            PolicyCheckBuilder()
-                .ExpectResourceCheckToFail(_release, CanViewSpecificRelease)
+            PolicyCheckBuilder<ContentSecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -109,8 +111,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void Stream()
         {
-            PolicyCheckBuilder()
-                .ExpectResourceCheckToFail(_release, CanViewSpecificRelease)
+            PolicyCheckBuilder<ContentSecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -124,7 +126,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void UploadAncillary()
         {
-            PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
@@ -140,7 +142,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void UploadChart()
         {
-            PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseMetaServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseMetaServicePermissionTests.cs
@@ -2,6 +2,7 @@
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseMetaServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseMetaServicePermissionTests.cs
@@ -6,10 +6,10 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Moq;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -23,8 +23,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void GetSubjects()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
-                .ExpectResourceCheckToFail(_release, CanViewSpecificRelease)
+            PermissionTestUtils.PolicyCheckBuilder<ContentSecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseMetaServiceTests.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models.Api;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
@@ -13,12 +14,14 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
 using IFootnoteService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IFootnoteService;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
@@ -43,8 +46,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void GetRelease()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
-                .ExpectResourceCheckToFail(_release, CanViewSpecificRelease)
+            PolicyCheckBuilder<ContentSecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -57,7 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void CreateReleaseAsync()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(Publication, CanCreateReleaseForSpecificPublication)
                 .AssertForbidden(
                     userService =>
@@ -76,7 +79,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void UpdateRelease()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
@@ -93,7 +96,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void UpdateRelease_Draft()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheck(_release, CanUpdateSpecificRelease)
                 .ExpectResourceCheckToFail(_release, CanMarkSpecificReleaseAsDraft)
                 .AssertForbidden(
@@ -114,7 +117,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void UpdateRelease_SubmitForHigherLevelReview()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheck(_release, CanUpdateSpecificRelease)
                 .ExpectResourceCheckToFail(_release, CanSubmitSpecificReleaseToHigherReview)
                 .AssertForbidden(
@@ -135,7 +138,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void UpdateRelease_Approve()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheck(_release, CanUpdateSpecificRelease)
                 .ExpectResourceCheckToFail(_release, CanApproveSpecificRelease)
                 .AssertForbidden(
@@ -156,7 +159,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void GetLatestReleaseAsync()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(Publication, CanViewSpecificPublication)
                 .AssertForbidden(
                     userService =>
@@ -170,7 +173,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void CreateReleaseAmendmentAsync()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanMakeAmendmentOfSpecificRelease)
                 .AssertForbidden(
                     userService =>
@@ -184,7 +187,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void DeleteRelease()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanDeleteSpecificRelease)
                 .AssertForbidden(
                     userService =>
@@ -212,7 +215,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Setup(s => s.GetAllReleasesForReleaseStatusesAsync(ReleaseStatus.Approved))
                 .ReturnsAsync(list);
 
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectCheck(CanAccessSystem)
                 .ExpectCheck(CanViewAllReleases)
                 .AssertSuccess(
@@ -251,7 +254,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Setup(s => s.GetReleasesForReleaseStatusRelatedToUserAsync(_userId, ReleaseStatus.Approved))
                 .ReturnsAsync(list);
 
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectCheck(CanAccessSystem)
                 .ExpectCheckToFail(CanViewAllReleases)
                 .AssertSuccess(
@@ -280,7 +283,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void GetMyReleasesForReleaseStatusesAsync_NoAccessToSystem()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectCheckToFail(CanAccessSystem)
                 .AssertForbidden(
                     async userService =>
@@ -294,7 +297,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void RemoveDataFiles()
         {
-            PermissionTestUtil.PolicyCheckBuilder()
+            PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     async userService =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseStatusServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseStatusServicePermissionTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -22,34 +23,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             Id = Guid.NewGuid()
         };
-        
+
         [Fact]
         public void GetReleaseStatusesAsync()
         {
-            AssertSecurityPoliciesChecked(service => 
+            AssertSecurityPoliciesChecked(service =>
                     service.GetReleaseStatusAsync(_release.Id), _release, CanViewSpecificRelease);
         }
-        
+
         private void AssertSecurityPoliciesChecked<T, TEntity>(
             Func<ReleaseStatusService, Task<Either<ActionResult, T>>> protectedAction, TEntity protectedEntity, params SecurityPolicies[] policies)
             where TEntity : class
         {
             var (mapper, userService, persistenceHelper, tableStorageService) = Mocks();
 
-            var service = new ReleaseStatusService(mapper.Object, userService.Object, 
+            var service = new ReleaseStatusService(mapper.Object, userService.Object,
                 persistenceHelper.Object, tableStorageService.Object);
             PermissionTestUtil.AssertSecurityPoliciesChecked(protectedAction, protectedEntity, userService, service, policies);
         }
-        
+
         private (
             Mock<IMapper>,
-            Mock<IUserService>, 
+            Mock<IUserService>,
             Mock<IPersistenceHelper<ContentDbContext>>,
             Mock<ITableStorageService>) Mocks()
         {
             return (
-                new Mock<IMapper>(), 
-                new Mock<IUserService>(), 
+                new Mock<IMapper>(),
+                new Mock<IUserService>(),
                 MockUtils.MockPersistenceHelper<ContentDbContext, Release>(_release.Id, _release),
                 new Mock<ITableStorageService>());
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseSubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseSubjectServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServicePermissionTests.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserManagementServicePermissionTests.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Identity;
@@ -71,8 +72,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                                 userAndRolesDbContext,
                                 userService.Object);
                             return await userManagementService.InviteUser(
-                                "test@test.com", 
-                                "Test User", 
+                                "test@test.com",
+                                "Test User",
                                 role.Id);
                         }
                     });

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/TableBuilderController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -74,8 +75,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
                     {
                         if (block.ContentBlock is DataBlock dataBlock)
                         {
+                            var query = dataBlock.Query.Clone();
+                            query.IncludeGeoJson = dataBlock.Charts.Any(chart => chart.Type == ChartType.Map);
+
                             return await _userService.CheckCanViewRelease(block.Release)
-                                .OnSuccess(_ => _tableBuilderService.Query(block.ReleaseId, dataBlock.Query));
+                                .OnSuccess(_ => _tableBuilderService.Query(block.ReleaseId, query));
                         }
 
                         return new NotFoundResult();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/TableBuilderController.cs
@@ -1,12 +1,20 @@
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Statistics
@@ -17,12 +25,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
     public class TableBuilderController : ControllerBase
     {
         private readonly ITableBuilderService _tableBuilderService;
+        private readonly IPersistenceHelper<ContentDbContext> _contentPersistenceHelper;
+        private readonly IUserService _userService;
         private readonly ILogger _logger;
 
-        public TableBuilderController(ITableBuilderService tableBuilderService,
+        public TableBuilderController(
+            ITableBuilderService tableBuilderService,
+            IPersistenceHelper<ContentDbContext> contentPersistenceHelper,
+            IUserService userService,
             ILogger<TableBuilderController> logger)
         {
             _tableBuilderService = tableBuilderService;
+            _contentPersistenceHelper = contentPersistenceHelper;
+            _userService = userService;
             _logger = logger;
         }
 
@@ -38,6 +53,35 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
             _logger.LogDebug("Query {Query} executed in {Time} ms", query, stopwatch.Elapsed.TotalMilliseconds);
 
             return tableBuilderResultViewModel.HandleFailuresOrOk();
+        }
+
+        [HttpGet("release/{releaseId}/datablock/{dataBlockId}")]
+        public async Task<ActionResult<TableBuilderResultViewModel>> QueryForDataBlock(
+            Guid releaseId,
+            Guid dataBlockId)
+        {
+            return await _contentPersistenceHelper.CheckEntityExists<ReleaseContentBlock>(
+                    query => query
+                        .Include(rcb => rcb.ContentBlock)
+                        .Include(rcb => rcb.Release)
+                        .Where(
+                            rcb => rcb.ReleaseId == releaseId
+                                   && rcb.ContentBlockId == dataBlockId
+                        )
+                )
+                .OnSuccess(
+                    async block =>
+                    {
+                        if (block.ContentBlock is DataBlock dataBlock)
+                        {
+                            return await _userService.CheckCanViewRelease(block.Release)
+                                .OnSuccess(_ => _tableBuilderService.Query(block.ReleaseId, dataBlock.Query));
+                        }
+
+                        return new NotFoundResult();
+                    }
+                )
+                .HandleFailuresOrOk();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlers.cs
@@ -2,16 +2,13 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using Microsoft.AspNetCore.Authorization;
+using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
 using static System.DateTime;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
-    public class ViewSpecificReleaseRequirement : IAuthorizationRequirement
-    {}
-    
-    public class ViewSpecificReleaseAuthorizationHandler : CompoundAuthorizationHandler<ViewSpecificReleaseRequirement, Release>
+    public class ViewSpecificReleaseAuthorizationHandler : CompoundAuthorizationHandler<ViewReleaseRequirement, Release>
     {
         public ViewSpecificReleaseAuthorizationHandler(
             ContentDbContext context, IPreReleaseService preReleaseService) : base(
@@ -19,29 +16,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             new HasUnrestrictedViewerRoleOnReleaseAuthorizationHandler(context),
             new HasPreReleaseRoleWithinAccessWindowAuthorizationHandler(context, preReleaseService))
         {
-            
         }
-    
+
         public class CanSeeAllReleasesAuthorizationHandler : HasClaimAuthorizationHandler<
-            ViewSpecificReleaseRequirement>
+            ViewReleaseRequirement>
         {
-            public CanSeeAllReleasesAuthorizationHandler() 
+            public CanSeeAllReleasesAuthorizationHandler()
                 : base(SecurityClaimTypes.AccessAllReleases) {}
         }
-    
+
         public class HasUnrestrictedViewerRoleOnReleaseAuthorizationHandler
-            : HasRoleOnReleaseAuthorizationHandler<ViewSpecificReleaseRequirement>
+            : HasRoleOnReleaseAuthorizationHandler<ViewReleaseRequirement>
         {
-            public HasUnrestrictedViewerRoleOnReleaseAuthorizationHandler(ContentDbContext context) 
+            public HasUnrestrictedViewerRoleOnReleaseAuthorizationHandler(ContentDbContext context)
                 : base(context, ctx => ContainsUnrestrictedViewerRole(ctx.Roles))
             {}
         }
-    
+
         public class HasPreReleaseRoleWithinAccessWindowAuthorizationHandler
-            : HasRoleOnReleaseAuthorizationHandler<ViewSpecificReleaseRequirement>
+            : HasRoleOnReleaseAuthorizationHandler<ViewReleaseRequirement>
         {
             public HasPreReleaseRoleWithinAccessWindowAuthorizationHandler(
-                ContentDbContext context, IPreReleaseService preReleaseService) 
+                ContentDbContext context, IPreReleaseService preReleaseService)
                 : base(context, ctx =>
                 {
                     if (!ContainsPreReleaseViewerRole(ctx.Roles))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSubjectDataAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ViewSubjectDataAuthorizationHandler.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Security.AuthorizationHandlers;
@@ -21,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 new SubjectBelongsToViewableReleaseAuthorizationHandler(contentDbContext, statisticsDbContext, preReleaseService)
             )
         { }
-    
+
         public class SubjectBelongsToViewableReleaseAuthorizationHandler : AuthorizationHandler<
             ViewSubjectDataRequirement, Subject>
         {
@@ -30,8 +31,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             private readonly StatisticsDbContext _statisticsDbContext;
 
             public SubjectBelongsToViewableReleaseAuthorizationHandler(
-                ContentDbContext contentDbContext, 
-                StatisticsDbContext statisticsDbContext, 
+                ContentDbContext contentDbContext,
+                StatisticsDbContext statisticsDbContext,
                 IPreReleaseService preReleaseService)
             {
                 _contentDbContext = contentDbContext;
@@ -40,7 +41,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             }
 
             protected override async Task HandleRequirementAsync(
-                AuthorizationHandlerContext context, 
+                AuthorizationHandlerContext context,
                 ViewSubjectDataRequirement requirement,
                 Subject subject)
             {
@@ -50,14 +51,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                     .Where(r => r.SubjectId == subject.Id)
                     .Select(r => r.Release);
 
-                var viewSpecificReleaseHandler = new 
+                var viewSpecificReleaseHandler = new
                     ViewSpecificReleaseAuthorizationHandler(_contentDbContext, _preReleaseService);
 
                 foreach (var release in linkedReleases)
                 {
                     var contentRelease = GetContentRelease(_contentDbContext, release);
                     var delegatedContext = new AuthorizationHandlerContext(
-                        new[] {new ViewSpecificReleaseRequirement()}, context.User, contentRelease);
+                        new[] {new ViewReleaseRequirement()}, context.User, contentRelease);
 
                     await viewSpecificReleaseHandler.HandleAsync(delegatedContext);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityPolicies.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityPolicies.cs
@@ -24,7 +24,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
          */
         CanCreateReleaseForSpecificPublication,
         CanViewAllReleases,
-        CanViewSpecificRelease,
         CanUpdateSpecificRelease,
         CanMarkSpecificReleaseAsDraft,
         CanSubmitSpecificReleaseToHigherReview,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
@@ -1,6 +1,8 @@
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Security.AuthorizationHandlers;
 using Microsoft.AspNetCore.Authorization;
@@ -64,8 +66,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
                     policy.RequireClaim(SecurityClaimTypes.AccessAllReleases.ToString()));
 
                 // does this user have permission to view a specific Release?
-                options.AddPolicy(SecurityPolicies.CanViewSpecificRelease.ToString(), policy =>
-                    policy.Requirements.Add(new ViewSpecificReleaseRequirement()));
+                options.AddPolicy(ContentSecurityPolicies.CanViewRelease.ToString(), policy =>
+                    policy.Requirements.Add(new ViewReleaseRequirement()));
 
                 // does this user have permission to update a specific Release?
                 options.AddPolicy(SecurityPolicies.CanUpdateSpecificRelease.ToString(), policy =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security
@@ -132,7 +133,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
         public static Task<Either<ActionResult, Release>> CheckCanViewRelease(
             this IUserService userService, Release release)
         {
-            return userService.CheckPolicy(release, SecurityPolicies.CanViewSpecificRelease);
+            return userService.CheckPolicy(release, ContentSecurityPolicies.CanViewRelease);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanUpdateRelease(
@@ -282,7 +283,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
                     DataFileName = dataFileName
                 })).IsRight
             };
-        }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.BAU;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -10,98 +9,98 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security
 {
-    public static class UserServiceExtensionMethods
+    public static class UserServiceExtensions
     {
         public static Task<Either<ActionResult, Unit>> CheckCanAccessSystem(this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanAccessSystem);
+            return userService.CheckPolicy(SecurityPolicies.CanAccessSystem);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanAccessAnalystPages(this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanAccessAnalystPages);
+            return userService.CheckPolicy(SecurityPolicies.CanAccessAnalystPages);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanAccessPrereleasePages(this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanAccessPrereleasePages);
+            return userService.CheckPolicy(SecurityPolicies.CanAccessPrereleasePages);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanManageAllUsers(this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanManageUsersOnSystem);
+            return userService.CheckPolicy(SecurityPolicies.CanManageUsersOnSystem);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanManageAllMethodologies(this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanManageMethodologiesOnSystem);
+            return userService.CheckPolicy(SecurityPolicies.CanManageMethodologiesOnSystem);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanViewAllImports(this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanAccessAllImports);
+            return userService.CheckPolicy(SecurityPolicies.CanAccessAllImports);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanViewAllMethodologies(this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanViewAllMethodologies);
+            return userService.CheckPolicy(SecurityPolicies.CanViewAllMethodologies);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanCreateMethodology(
             this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanCreateMethodologies);
+            return userService.CheckPolicy(SecurityPolicies.CanCreateMethodologies);
         }
 
         public static Task<Either<ActionResult, Methodology>> CheckCanViewMethodology(
             this IUserService userService, Methodology methodology)
         {
-            return userService.DoCheck(methodology, SecurityPolicies.CanViewSpecificMethodology);
+            return userService.CheckPolicy(methodology, SecurityPolicies.CanViewSpecificMethodology);
         }
 
         public static Task<Either<ActionResult, Methodology>> CheckCanUpdateMethodology(
             this IUserService userService, Methodology methodology)
         {
-            return userService.DoCheck(methodology, SecurityPolicies.CanUpdateSpecificMethodology);
+            return userService.CheckPolicy(methodology, SecurityPolicies.CanUpdateSpecificMethodology);
         }
 
         public static Task<Either<ActionResult, Methodology>> CheckCanMarkMethodologyAsDraft(
             this IUserService userService, Methodology methodology)
         {
-            return userService.DoCheck(methodology, SecurityPolicies.CanMarkSpecificMethodologyAsDraft);
+            return userService.CheckPolicy(methodology, SecurityPolicies.CanMarkSpecificMethodologyAsDraft);
         }
 
         public static Task<Either<ActionResult, Methodology>> CheckCanApproveMethodology(
             this IUserService userService, Methodology methodology)
         {
-            return userService.DoCheck(methodology, SecurityPolicies.CanApproveSpecificMethodology);
+            return userService.CheckPolicy(methodology, SecurityPolicies.CanApproveSpecificMethodology);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanViewAllTopics(this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanViewAllTopics);
+            return userService.CheckPolicy(SecurityPolicies.CanViewAllTopics);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanViewAllReleases(this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanViewAllReleases);
+            return userService.CheckPolicy(SecurityPolicies.CanViewAllReleases);
         }
 
         public static Task<Either<ActionResult, Theme>> CheckCanViewTheme(
             this IUserService userService, Theme theme)
         {
-            return userService.DoCheck(theme, SecurityPolicies.CanViewSpecificTheme);
+            return userService.CheckPolicy(theme, SecurityPolicies.CanViewSpecificTheme);
         }
 
         public static Task<Either<ActionResult, Topic>> CheckCanViewTopic(
             this IUserService userService, Topic topic)
         {
-            return userService.DoCheck(topic, SecurityPolicies.CanViewSpecificTopic);
+            return userService.CheckPolicy(topic, SecurityPolicies.CanViewSpecificTopic);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanManageAllTaxonomy(this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanManageAllTaxonomy);
+            return userService.CheckPolicy(SecurityPolicies.CanManageAllTaxonomy);
         }
 
         // Publication
@@ -109,37 +108,37 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
         public static Task<Either<ActionResult, Topic>> CheckCanCreatePublicationForTopic(
             this IUserService userService, Topic topic)
         {
-            return userService.DoCheck(topic, SecurityPolicies.CanCreatePublicationForSpecificTopic);
+            return userService.CheckPolicy(topic, SecurityPolicies.CanCreatePublicationForSpecificTopic);
         }
 
         public static Task<Either<ActionResult, Publication>> CheckCanUpdatePublication(
             this IUserService userService, Publication publication)
         {
-            return userService.DoCheck(publication, SecurityPolicies.CanUpdatePublication);
+            return userService.CheckPolicy(publication, SecurityPolicies.CanUpdatePublication);
         }
 
         public static Task<Either<ActionResult, Publication>> CheckCanCreateReleaseForPublication(
             this IUserService userService, Publication publication)
         {
-            return userService.DoCheck(publication, SecurityPolicies.CanCreateReleaseForSpecificPublication);
+            return userService.CheckPolicy(publication, SecurityPolicies.CanCreateReleaseForSpecificPublication);
         }
 
         public static Task<Either<ActionResult, Publication>> CheckCanViewPublication(
             this IUserService userService, Publication publication)
         {
-            return userService.DoCheck(publication, SecurityPolicies.CanViewSpecificPublication);
+            return userService.CheckPolicy(publication, SecurityPolicies.CanViewSpecificPublication);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanViewRelease(
             this IUserService userService, Release release)
         {
-            return userService.DoCheck(release, SecurityPolicies.CanViewSpecificRelease);
+            return userService.CheckPolicy(release, SecurityPolicies.CanViewSpecificRelease);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanUpdateRelease(
             this IUserService userService, Release release)
         {
-            return userService.DoCheck(release, SecurityPolicies.CanUpdateSpecificRelease);
+            return userService.CheckPolicy(release, SecurityPolicies.CanUpdateSpecificRelease);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanUpdateRelease(
@@ -155,7 +154,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
         public static Task<Either<ActionResult, Release>> CheckCanDeleteRelease(
             this IUserService userService, Release release)
         {
-            return userService.DoCheck(release, SecurityPolicies.CanDeleteSpecificRelease);
+            return userService.CheckPolicy(release, SecurityPolicies.CanDeleteSpecificRelease);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanUpdateReleaseStatus(
@@ -185,94 +184,94 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
         public static Task<Either<ActionResult, Release>> CheckCanMarkReleaseAsDraft(
             this IUserService userService, Release release)
         {
-            return userService.DoCheck(release, SecurityPolicies.CanMarkSpecificReleaseAsDraft);
+            return userService.CheckPolicy(release, SecurityPolicies.CanMarkSpecificReleaseAsDraft);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanSubmitReleaseToHigherApproval(
             this IUserService userService, Release release)
         {
-            return userService.DoCheck(release, SecurityPolicies.CanSubmitSpecificReleaseToHigherReview);
+            return userService.CheckPolicy(release, SecurityPolicies.CanSubmitSpecificReleaseToHigherReview);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanApproveRelease(
             this IUserService userService, Release release)
         {
-            return userService.DoCheck(release, SecurityPolicies.CanApproveSpecificRelease);
+            return userService.CheckPolicy(release, SecurityPolicies.CanApproveSpecificRelease);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanMakeAmendmentOfRelease(
             this IUserService userService, Release release)
         {
-            return userService.DoCheck(release, SecurityPolicies.CanMakeAmendmentOfSpecificRelease);
+            return userService.CheckPolicy(release, SecurityPolicies.CanMakeAmendmentOfSpecificRelease);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanRunMigrations(
             this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanRunReleaseMigrations);
+            return userService.CheckPolicy(SecurityPolicies.CanRunReleaseMigrations);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanViewPrereleaseContactsList(
             this IUserService userService)
         {
-            return userService.DoCheck(SecurityPolicies.CanViewPrereleaseContacts);
+            return userService.CheckPolicy(SecurityPolicies.CanViewPrereleaseContacts);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanAssignPrereleaseContactsToRelease(
             this IUserService userService, Release release)
         {
-            return userService.DoCheck(release, SecurityPolicies.CanAssignPrereleaseContactsToSpecificRelease);
+            return userService.CheckPolicy(release, SecurityPolicies.CanAssignPrereleaseContactsToSpecificRelease);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanViewPreReleaseSummary(
             this IUserService userService, Release release)
         {
-            return userService.DoCheck(release, SecurityPolicies.CanViewSpecificPreReleaseSummary);
+            return userService.CheckPolicy(release, SecurityPolicies.CanViewSpecificPreReleaseSummary);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanPublishRelease(
             this IUserService userService, Release release)
         {
-            return userService.DoCheck(release, SecurityPolicies.CanPublishSpecificRelease);
+            return userService.CheckPolicy(release, SecurityPolicies.CanPublishSpecificRelease);
         }
 
         public static Task<Either<ActionResult, Comment>> CheckCanUpdateComment(
             this IUserService userService, Comment comment)
         {
-            return userService.DoCheck(comment, SecurityPolicies.CanUpdateSpecificComment);
+            return userService.CheckPolicy(comment, SecurityPolicies.CanUpdateSpecificComment);
         }
 
         public static Task<Either<ActionResult, ReleaseFileImportInfo>> CheckCanCancelFileImport(
             this IUserService userService, ReleaseFileImportInfo import)
         {
-            return userService.DoCheck(import, SecurityPolicies.CanCancelOngoingImports);
+            return userService.CheckPolicy(import, SecurityPolicies.CanCancelOngoingImports);
         }
 
         public static Task<Either<ActionResult, Publication>> CheckCanCreateLegacyRelease(
             this IUserService userService, Publication publication)
         {
-            return userService.DoCheck(publication, SecurityPolicies.CanCreateLegacyRelease);
+            return userService.CheckPolicy(publication, SecurityPolicies.CanCreateLegacyRelease);
         }
 
         public static Task<Either<ActionResult, LegacyRelease>> CheckCanViewLegacyRelease(
             this IUserService userService, LegacyRelease legacyRelease)
         {
-            return userService.DoCheck(legacyRelease, SecurityPolicies.CanViewLegacyRelease);
+            return userService.CheckPolicy(legacyRelease, SecurityPolicies.CanViewLegacyRelease);
         }
 
         public static Task<Either<ActionResult, LegacyRelease>> CheckCanUpdateLegacyRelease(
             this IUserService userService, LegacyRelease legacyRelease)
         {
-            return userService.DoCheck(legacyRelease, SecurityPolicies.CanUpdateLegacyRelease);
+            return userService.CheckPolicy(legacyRelease, SecurityPolicies.CanUpdateLegacyRelease);
         }
 
         public static Task<Either<ActionResult, LegacyRelease>> CheckCanDeleteLegacyRelease(
             this IUserService userService, LegacyRelease legacyRelease)
         {
-            return userService.DoCheck(legacyRelease, SecurityPolicies.CanDeleteLegacyRelease);
+            return userService.CheckPolicy(legacyRelease, SecurityPolicies.CanDeleteLegacyRelease);
         }
 
-        public static async Task<DataFilePermissions> GetDataFilePermissions(this IUserService userService, 
+        public static async Task<DataFilePermissions> GetDataFilePermissions(this IUserService userService,
             Guid releaseId, string dataFileName)
         {
             return new DataFilePermissions
@@ -284,17 +283,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
                 })).IsRight
             };
         }
-
-        private static async Task<Either<ActionResult, T>> DoCheck<T>(this IUserService userService, T resource, SecurityPolicies policy)
-        {
-            var result = await userService.MatchesPolicy(resource, policy);
-            return result ? new Either<ActionResult, T>(resource) : new ForbidResult();
-        }
-
-        private static async Task<Either<ActionResult, Unit>> DoCheck(this IUserService userService, SecurityPolicies policy)
-        {
-            var result = await userService.MatchesPolicy(policy);
-            return result ? new Either<ActionResult, Unit>(Unit.Instance) : new ForbidResult();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseStatusService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseStatusService.cs
@@ -25,8 +25,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IUserService _userService;
         private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
 
-        public ReleaseStatusService(IMapper mapper, IUserService userService,
-            IPersistenceHelper<ContentDbContext> persistenceHelper, ITableStorageService publisherTableStorageService)
+        public ReleaseStatusService(
+            IMapper mapper,
+            IUserService userService,
+            IPersistenceHelper<ContentDbContext> persistenceHelper,
+            ITableStorageService publisherTableStorageService)
         {
             _mapper = mapper;
             _userService = userService;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -8,52 +7,52 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
 {
     public static class MockUtils
     {
-        public static Mock<IPersistenceHelper<TDbContext>> MockPersistenceHelper<TDbContext>() 
+        public static Mock<IPersistenceHelper<TDbContext>> MockPersistenceHelper<TDbContext>()
             where TDbContext : DbContext
         {
             return new Mock<IPersistenceHelper<TDbContext>>();
         }
-        
+
         public static Mock<IPersistenceHelper<TDbContext>> MockPersistenceHelper<TDbContext, TEntity>(
-            Guid id, TEntity entity) 
+            Guid id, TEntity entity)
             where TDbContext : DbContext where TEntity : class
         {
             var helper = new Mock<IPersistenceHelper<TDbContext>>();
             SetupCall(helper, id, entity);
             return helper;
         }
-        
-        public static Mock<IPersistenceHelper<TDbContext>> MockPersistenceHelper<TDbContext, TEntity>() 
-            where TDbContext : DbContext 
+
+        public static Mock<IPersistenceHelper<TDbContext>> MockPersistenceHelper<TDbContext, TEntity>()
+            where TDbContext : DbContext
             where TEntity : class
         {
             var helper = new Mock<IPersistenceHelper<TDbContext>>();
             SetupCall<TDbContext, TEntity>(helper);
             return helper;
         }
-        
+
         public static void SetupCall<TDbContext, TEntity>(
-            Mock<IPersistenceHelper<TDbContext>> helper, 
-            Guid id, 
-            TEntity entity) 
-            where TDbContext : DbContext 
+            Mock<IPersistenceHelper<TDbContext>> helper,
+            Guid id,
+            TEntity entity)
+            where TDbContext : DbContext
             where TEntity : class
         {
             helper
                 .Setup(s => s.CheckEntityExists(id,
-                                It.IsAny<Func<IQueryable<TEntity>, IQueryable<TEntity>>>()))
+                    It.IsAny<Func<IQueryable<TEntity>, IQueryable<TEntity>>>()))
                 .ReturnsAsync(new Either<ActionResult, TEntity>(entity));
         }
-        
+
         public static void SetupCall<TDbContext, TEntity>(
-            Mock<IPersistenceHelper<TDbContext>> helper) 
-            where TDbContext : DbContext 
+            Mock<IPersistenceHelper<TDbContext>> helper)
+            where TDbContext : DbContext
             where TEntity : class
-        { 
+        {
             helper
                 .Setup(s => s.CheckEntityExists(It.IsAny<Guid>(),
                     It.IsAny<Func<IQueryable<TEntity>, IQueryable<TEntity>>>()))
@@ -62,19 +61,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
         public static Mock<IUserService> AlwaysTrueUserService()
         {
+            return AlwaysTrueUserService<Enum>();
+        }
+
+        public static Mock<IUserService> AlwaysTrueUserService<T>()
+            where T : Enum
+        {
             var userService = new Mock<IUserService>();
 
             userService
-                .Setup(s => s.MatchesPolicy(It.IsAny<SecurityPolicies>()))
+                .Setup(s => s.MatchesPolicy(It.IsAny<T>()))
                 .ReturnsAsync(true);
 
             userService
-                .Setup(s => s.MatchesPolicy(It.IsAny<object>(), It.IsAny<SecurityPolicies>()))
+                .Setup(s => s.MatchesPolicy(It.IsAny<object>(), It.IsAny<T>()))
                 .ReturnsAsync(true);
 
             return userService;
         }
-        
+
         public static void VerifyAllMocks(params object[] mocks)
         {
             mocks

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/PermissionTestUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/PermissionTestUtils.cs
@@ -1,0 +1,25 @@
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
+{
+    public static class PermissionTestUtils
+    {
+        public static PolicyCheckBuilder<T> PolicyCheckBuilder<T>(Mock<IUserService> userService = null)
+            where T : Enum
+        {
+            return new PolicyCheckBuilder<T>(userService);
+        }
+
+        public static void AssertForbidden<T>(Either<ActionResult,T> result)
+        {
+            Assert.NotNull(result);
+            Assert.True(result.IsLeft);
+            Assert.IsAssignableFrom<ForbidResult>(result.Left);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/PolicyCheckBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/PolicyCheckBuilder.cs
@@ -1,20 +1,23 @@
 using System;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Utils
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
 {
-    public class SecurityPolicyCheckBuilder
+    public class PolicyCheckBuilder<TPolicy> where TPolicy : Enum
     {
-        private readonly Mock<IUserService> _userService = new Mock<IUserService>();
+        private readonly Mock<IUserService> _userService;
 
-        public SecurityPolicyCheckBuilder ExpectCheck(SecurityPolicies policy, bool checkResult = true)
+        public PolicyCheckBuilder(Mock<IUserService> userService = null)
+        {
+            _userService = userService ?? new Mock<IUserService>();
+        }
+
+        public PolicyCheckBuilder<TPolicy> ExpectCheck(TPolicy policy, bool checkResult = true)
         {
             _userService
                 .Setup(s => s.MatchesPolicy(policy))
@@ -23,14 +26,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Utils
             return this;
         }
 
-        public SecurityPolicyCheckBuilder ExpectCheckToFail(SecurityPolicies policy)
+        public PolicyCheckBuilder<TPolicy> ExpectCheckToFail(TPolicy policy)
         {
             return ExpectCheck(policy, false);
         }
 
-        public SecurityPolicyCheckBuilder ExpectResourceCheck(
+        public PolicyCheckBuilder<TPolicy> ExpectResourceCheck(
             object resource,
-            SecurityPolicies policy,
+            TPolicy policy,
             bool checkResult = true)
         {
             _userService
@@ -40,7 +43,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Utils
             return this;
         }
 
-        public SecurityPolicyCheckBuilder ExpectResourceCheckToFail(object resource, SecurityPolicies policy)
+        public PolicyCheckBuilder<TPolicy> ExpectResourceCheckToFail(object resource, TPolicy policy)
         {
             return ExpectResourceCheck(resource, policy, false);
         }
@@ -54,7 +57,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Utils
         {
             var result = await action.Invoke(_userService);
 
-            PermissionTestUtil.AssertForbidden(result);
+            PermissionTestUtils.AssertForbidden(result);
 
             _userService.VerifyAll();
             _userService.VerifyNoOtherCalls();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ControllerExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ControllerExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+{
+    public static class ControllerExtensions
+    {
+        public static async Task<Either<ActionResult, Unit>> CacheWithLastModified(
+            this ControllerBase controller,
+            DateTimeOffset? lastModified)
+        {
+            controller.Response.GetTypedHeaders().LastModified = lastModified;
+
+            var requestHeaders = controller.Request.GetTypedHeaders();
+
+            if (requestHeaders.IfModifiedSince.HasValue
+                && requestHeaders.IfModifiedSince.Value >= lastModified)
+            {
+                return controller.StatusCode(StatusCodes.Status304NotModified);
+            }
+
+            return await Task.FromResult(Unit.Instance);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/ObservationQueryContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/ObservationQueryContext.cs
@@ -13,6 +13,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query
         public LocationQuery Locations { get; set; }
         public bool? IncludeGeoJson { get; set; }
 
+        public ObservationQueryContext Clone()
+        {
+            var clone = MemberwiseClone() as ObservationQueryContext;
+            return clone;
+        }
+
         public override string ToString()
         {
             return

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/Security/IUserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/Security/IUserService.cs
@@ -1,14 +1,50 @@
 using System;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security
 {
     public interface IUserService
     {
         Guid GetUserId();
-        
+
         Task<bool> MatchesPolicy(Enum policy);
 
         Task<bool> MatchesPolicy(object resource, Enum policy);
+    }
+
+    public static class UserServiceExtensions
+    {
+        public static async Task<Either<ActionResult, TResource>> CheckPolicy<TResource, TPolicy>(
+            this IUserService userService,
+            TResource resource,
+            TPolicy policy)
+            where TPolicy : Enum
+        {
+            var result = await userService.MatchesPolicy(resource, policy);
+
+            if (result)
+            {
+                return resource;
+            }
+
+            return new ForbidResult();
+        }
+
+        public static async Task<Either<ActionResult, Unit>> CheckPolicy<TPolicy>(
+            this IUserService userService,
+            TPolicy policy)
+            where TPolicy : Enum
+        {
+            var result = await userService.MatchesPolicy(policy);
+
+            if (result)
+            {
+                return Unit.Instance;
+            }
+
+            return new ForbidResult();
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -19,7 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public string Summary { get; set; }
 
-        public List<Release> Releases { get; set; }
+        public List<Release> Releases { get; set; } = new List<Release>();
 
         public Guid? MethodologyId { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewReleaseAuthorizationHandlerTests.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.AuthorizationHandlers
+{
+    public class ViewReleaseAuthorizationHandlerTests
+    {
+        [Fact]
+        public async Task ReleaseIsLiveAndOnlyVersion()
+        {
+            var publication = new Publication();
+
+            var release = new Release
+            {
+                Published = DateTime.Parse("2019-10-10T12:00:00"),
+                Publication = publication
+            };
+
+            publication.Releases.Add(release);
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(publication);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var handler = new ViewReleaseAuthorizationHandler(contentDbContext);
+
+                var authContext = new AuthorizationHandlerContext(
+                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewReleaseRequirement>() },
+                    null,
+                    release
+                );
+
+                await handler.HandleAsync(authContext);
+
+                Assert.True(authContext.HasSucceeded);
+            }
+        }
+
+        [Fact]
+        public async Task ReleaseIsLiveAndLatestVersion()
+        {
+            var publication = new Publication();
+
+            var olderRelease = new Release
+            {
+                Published = DateTime.Parse("2019-10-08T12:00:00"),
+                Publication = publication
+            };
+
+            var newerRelease = new Release
+            {
+                Published = DateTime.Parse("2019-10-10T12:00:00"),
+                Publication = publication,
+                PreviousVersion = olderRelease,
+            };
+
+            publication.Releases.AddRange(
+                new List<Release>
+                {
+                    olderRelease,
+                    newerRelease,
+                }
+            );
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(publication);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var handler = new ViewReleaseAuthorizationHandler(contentDbContext);
+
+                var authContext = new AuthorizationHandlerContext(
+                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewReleaseRequirement>() },
+                    null,
+                    newerRelease
+                );
+
+                await handler.HandleAsync(authContext);
+
+                Assert.True(authContext.HasSucceeded);
+            }
+        }
+
+        [Fact]
+        public async Task ReleaseIsNotLive()
+        {
+            var publication = new Publication();
+
+            var release = new Release
+            {
+                Publication = publication
+            };
+
+            publication.Releases.Add(release);
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(publication);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var handler = new ViewReleaseAuthorizationHandler(contentDbContext);
+
+                var authContext = new AuthorizationHandlerContext(
+                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewReleaseRequirement>() },
+                    null,
+                    release
+                );
+
+                await handler.HandleAsync(authContext);
+
+                Assert.False(authContext.HasSucceeded);
+            }
+        }
+
+        [Fact]
+        public async Task ReleaseIsLiveButNotLatestVersion()
+        {
+            var publication = new Publication();
+
+            var olderRelease = new Release
+            {
+                Published = DateTime.Parse("2019-10-08T12:00:00"),
+                Publication = publication
+            };
+
+            var newerRelease = new Release
+            {
+                Published = DateTime.Parse("2019-10-10T12:00:00"),
+                Publication = publication,
+                PreviousVersion = olderRelease,
+            };
+
+            publication.Releases.AddRange(
+                new List<Release>
+                {
+                    olderRelease,
+                    newerRelease,
+                }
+            );
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(publication);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var handler = new ViewReleaseAuthorizationHandler(contentDbContext);
+
+                var authContext = new AuthorizationHandlerContext(
+                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewReleaseRequirement>() },
+                    null,
+                    olderRelease
+                );
+
+                await handler.HandleAsync(authContext);
+
+                Assert.False(authContext.HasSucceeded);
+            }
+        }
+
+        [Fact]
+        public async Task ReleaseNotFound()
+        {
+            await using (var contentDbContext = ContentDbUtils.InMemoryContentDbContext())
+            {
+                var handler = new ViewReleaseAuthorizationHandler(contentDbContext);
+
+                var authContext = new AuthorizationHandlerContext(
+                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewReleaseRequirement>() },
+                    null,
+                    new Release
+                    {
+                        Id = Guid.NewGuid()
+                    }
+                );
+
+                await handler.HandleAsync(authContext);
+
+                Assert.False(authContext.HasSucceeded);
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="Moq" Version="4.13.1" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
+    </ItemGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
+      <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model\GovUk.Education.ExploreEducationStatistics.Content.Model.csproj" />
+      <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Security\GovUk.Education.ExploreEducationStatistics.Content.Security.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/AuthorizationHandlers/ViewReleaseAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/AuthorizationHandlers/ViewReleaseAuthorizationHandler.cs
@@ -1,0 +1,45 @@
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers
+{
+    public class ViewReleaseRequirement : IAuthorizationRequirement
+    {
+    }
+
+    public class ViewReleaseAuthorizationHandler
+        : AuthorizationHandler<ViewReleaseRequirement, Release>
+    {
+        private readonly ContentDbContext _context;
+
+        public ViewReleaseAuthorizationHandler(ContentDbContext context)
+        {
+            _context = context;
+        }
+
+        protected override async Task HandleRequirementAsync(
+            AuthorizationHandlerContext authContext,
+            ViewReleaseRequirement requirement,
+            Release release)
+        {
+            var hydratedRelease = await _context.Releases
+                .Include(r => r.Publication)
+                .ThenInclude(p => p.Releases)
+                .FirstOrDefaultAsync(r => r.Id == release.Id);
+
+            if (hydratedRelease == null)
+            {
+                return;
+            }
+
+            if (hydratedRelease.IsLatestPublishedVersionOfRelease())
+            {
+                authContext.Succeed(requirement);
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/ContentSecurityPolicies.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/ContentSecurityPolicies.cs
@@ -1,0 +1,7 @@
+namespace GovUk.Education.ExploreEducationStatistics.Content.Security
+{
+    public enum ContentSecurityPolicies
+    {
+        CanViewRelease
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/Extensions/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/Extensions/UserServiceExtensions.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions
+{
+    public static class UserServiceExtensions
+    {
+        public static Task<Either<ActionResult, Release>> CheckCanViewRelease(
+            this IUserService userService,
+            Release release)
+        {
+            return userService.CheckPolicy(release, ContentSecurityPolicies.CanViewRelease);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/GovUk.Education.ExploreEducationStatistics.Content.Security.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/GovUk.Education.ExploreEducationStatistics.Content.Security.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.5" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model\GovUk.Education.ExploreEducationStatistics.Content.Model.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
@@ -2,9 +2,17 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
 using Moq;
 using Xunit;
 
@@ -12,30 +20,264 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 {
     public class TableBuilderControllerTests
     {
-        private readonly TableBuilderController _controller;
         private readonly ObservationQueryContext _query = new ObservationQueryContext();
-        private readonly Guid _releaseId = new Guid("03730cff-22d5-446c-8971-68921e933b50");
+        private readonly Guid _releaseId = Guid.NewGuid();
+        private readonly Guid _dataBlockId = Guid.NewGuid();
 
-        public TableBuilderControllerTests()
+        [Fact]
+        public async Task Query()
         {
             var tableBuilderService = new Mock<ITableBuilderService>();
 
-            tableBuilderService.Setup(s => s.Query(_releaseId, _query)).ReturnsAsync(new TableBuilderResultViewModel
-            {
-                Results = new List<ObservationViewModel>
+            tableBuilderService.Setup(s => s.Query(_releaseId, _query)).ReturnsAsync(
+                new TableBuilderResultViewModel
                 {
-                    new ObservationViewModel()
+                    Results = new List<ObservationViewModel>
+                    {
+                        new ObservationViewModel()
+                    }
                 }
-            });
+            );
 
-            _controller = new TableBuilderController(tableBuilderService.Object);
+            var controller = BuildTableBuilderController(tableBuilderService: tableBuilderService.Object);
+            var result = await controller.Query(_releaseId, _query);
+
+            Assert.IsType<TableBuilderResultViewModel>(result.Value);
+            Assert.Single(result.Value.Results);
         }
 
         [Fact]
-        public async Task Query_Post()
+        public async Task QueryForDataBlock()
         {
-            var result = await _controller.Query(_releaseId, _query);
+            var tableBuilderService = new Mock<ITableBuilderService>();
+
+            tableBuilderService.Setup(s => s.Query(_releaseId, _query)).ReturnsAsync(
+                new TableBuilderResultViewModel
+                {
+                    Results = new List<ObservationViewModel>
+                    {
+                        new ObservationViewModel()
+                    }
+                }
+            );
+
+            var contentPersistenceHelper =
+                MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
+                    new ReleaseContentBlock
+                    {
+                        ReleaseId = _releaseId,
+                        Release = new Release
+                        {
+                            Id = _releaseId,
+                        },
+                        ContentBlockId = _dataBlockId,
+                        ContentBlock = new DataBlock
+                        {
+                            Id = _dataBlockId,
+                            Query = _query
+                        }
+                    }
+                );
+
+            var controller = BuildTableBuilderController(
+                tableBuilderService: tableBuilderService.Object,
+                contentPersistenceHelper: contentPersistenceHelper.Object
+            );
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
+            var result = await controller.QueryForDataBlock(_releaseId, _dataBlockId);
+
             Assert.IsType<TableBuilderResultViewModel>(result.Value);
+            Assert.Single(result.Value.Results);
+
+            MockUtils.VerifyAllMocks(tableBuilderService, contentPersistenceHelper);
+        }
+
+        [Fact]
+        public async Task QueryForDataBlock_NotFound()
+        {
+            var contentPersistenceHelper =
+                MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(null);
+
+            var controller = BuildTableBuilderController(
+                contentPersistenceHelper: contentPersistenceHelper.Object
+            );
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
+            var result = await controller.QueryForDataBlock(_releaseId, _dataBlockId);
+
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task QueryForDataBlock_NotDataBlockType()
+        {
+            var contentPersistenceHelper =
+                MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
+                    new ReleaseContentBlock
+                    {
+                        ReleaseId = _releaseId,
+                        Release = new Release
+                        {
+                            Id = _releaseId,
+                        },
+                        ContentBlockId = _dataBlockId,
+                        ContentBlock = new HtmlBlock
+                        {
+                            Id = _dataBlockId,
+                        }
+                    }
+                );
+
+            var controller = BuildTableBuilderController(
+                contentPersistenceHelper: contentPersistenceHelper.Object
+            );
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
+            var result = await controller.QueryForDataBlock(_releaseId, _dataBlockId);
+
+            Assert.IsType<NotFoundResult>(result.Result);
+        }
+
+
+        [Fact]
+        public async Task QueryForDataBlock_NotModified()
+        {
+            var contentPersistenceHelper =
+                MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
+                    new ReleaseContentBlock
+                    {
+                        ReleaseId = _releaseId,
+                        Release = new Release
+                        {
+                            Id = _releaseId,
+                            Published = DateTime.Parse("2019-11-11T12:00:00Z")
+                        },
+                        ContentBlockId = _dataBlockId,
+                        ContentBlock = new DataBlock
+                        {
+                            Id = _dataBlockId,
+                            Query = _query
+                        }
+                    }
+                );
+
+            var controller = BuildTableBuilderController(
+                contentPersistenceHelper: contentPersistenceHelper.Object
+            );
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+                {
+                    Request =
+                    {
+                        Headers =
+                        {
+                            {
+                                HeaderNames.IfModifiedSince,
+                                DateTime.Parse("2019-11-11T12:00:00Z").ToUniversalTime().ToString("R")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = await controller.QueryForDataBlock(_releaseId, _dataBlockId);
+
+            var statusCodeResult = Assert.IsType<StatusCodeResult>(result.Result);
+            Assert.Equal(StatusCodes.Status304NotModified, statusCodeResult.StatusCode);
+
+            MockUtils.VerifyAllMocks(contentPersistenceHelper);
+        }
+
+        [Fact]
+        public async Task QueryForDataBlock_IsModified()
+        {
+            var tableBuilderService = new Mock<ITableBuilderService>();
+
+            tableBuilderService.Setup(s => s.Query(_releaseId, _query)).ReturnsAsync(
+                new TableBuilderResultViewModel
+                {
+                    Results = new List<ObservationViewModel>
+                    {
+                        new ObservationViewModel()
+                    }
+                }
+            );
+
+            var contentPersistenceHelper =
+                MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
+                    new ReleaseContentBlock
+                    {
+                        ReleaseId = _releaseId,
+                        Release = new Release
+                        {
+                            Id = _releaseId,
+                            Published = DateTime.Parse("2020-11-11T12:00:00Z")
+                        },
+                        ContentBlockId = _dataBlockId,
+                        ContentBlock = new DataBlock
+                        {
+                            Id = _dataBlockId,
+                            Query = _query
+                        }
+                    }
+                );
+
+            var controller = BuildTableBuilderController(
+                tableBuilderService: tableBuilderService.Object,
+                contentPersistenceHelper: contentPersistenceHelper.Object
+            );
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+                {
+                    Request =
+                    {
+                        Headers =
+                        {
+                            {
+                                HeaderNames.IfModifiedSince,
+                                DateTime.Parse("2019-11-11T12:00:00Z").ToUniversalTime().ToString("R")
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = await controller.QueryForDataBlock(_releaseId, _dataBlockId);
+
+            Assert.IsType<TableBuilderResultViewModel>(result.Value);
+            Assert.Single(result.Value.Results);
+
+            MockUtils.VerifyAllMocks(tableBuilderService, contentPersistenceHelper);
+        }
+
+        private TableBuilderController BuildTableBuilderController(
+            ITableBuilderService tableBuilderService = null,
+            IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
+            IUserService userService = null)
+
+        {
+            return new TableBuilderController(
+                tableBuilderService ?? new Mock<ITableBuilderService>().Object,
+                contentPersistenceHelper ?? MockUtils.MockPersistenceHelper<ContentDbContext>().Object,
+                userService ?? MockUtils.AlwaysTrueUserService().Object
+            );
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
@@ -20,7 +21,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 {
     public class TableBuilderControllerTests
     {
-        private readonly ObservationQueryContext _query = new ObservationQueryContext();
+        private readonly ObservationQueryContext _query = new ObservationQueryContext
+        {
+            SubjectId = Guid.NewGuid(),
+        };
+
         private readonly Guid _releaseId = Guid.NewGuid();
         private readonly Guid _dataBlockId = Guid.NewGuid();
 
@@ -51,15 +56,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
         {
             var tableBuilderService = new Mock<ITableBuilderService>();
 
-            tableBuilderService.Setup(s => s.Query(_releaseId, _query)).ReturnsAsync(
-                new TableBuilderResultViewModel
-                {
-                    Results = new List<ObservationViewModel>
+            tableBuilderService
+                .Setup(
+                    s =>
+                        s.Query(
+                            _releaseId,
+                            It.Is<ObservationQueryContext>(
+                                q => q.SubjectId == _query.SubjectId
+                            )
+                        )
+                )
+                .ReturnsAsync(
+                    new TableBuilderResultViewModel
                     {
-                        new ObservationViewModel()
+                        Results = new List<ObservationViewModel>
+                        {
+                            new ObservationViewModel()
+                        }
                     }
-                }
-            );
+                );
 
             var contentPersistenceHelper =
                 MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
@@ -74,7 +89,80 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                         ContentBlock = new DataBlock
                         {
                             Id = _dataBlockId,
-                            Query = _query
+                            Query = _query,
+                            Charts = new List<IChart>()
+                        }
+                    }
+                );
+
+            var controller = BuildTableBuilderController(
+                tableBuilderService: tableBuilderService.Object,
+                contentPersistenceHelper: contentPersistenceHelper.Object
+            );
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+
+            var result = await controller.QueryForDataBlock(_releaseId, _dataBlockId);
+
+            Assert.IsType<TableBuilderResultViewModel>(result.Value);
+            Assert.Single(result.Value.Results);
+
+            MockUtils.VerifyAllMocks(tableBuilderService, contentPersistenceHelper);
+        }
+
+        [Fact]
+        public async Task QueryForDataBlock_NoGeoJson()
+        {
+            var subjectId = Guid.NewGuid();
+
+            var tableBuilderService = new Mock<ITableBuilderService>();
+
+            tableBuilderService
+                .Setup(
+                    s =>
+                        s.Query(
+                            _releaseId,
+                            It.Is<ObservationQueryContext>(
+                                q =>
+                                    q.SubjectId == subjectId && q.IncludeGeoJson == true
+                            )
+                        )
+                )
+                .ReturnsAsync(
+                    new TableBuilderResultViewModel
+                    {
+                        Results = new List<ObservationViewModel>
+                        {
+                            new ObservationViewModel()
+                        }
+                    }
+                );
+
+            var contentPersistenceHelper =
+                MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
+                    new ReleaseContentBlock
+                    {
+                        ReleaseId = _releaseId,
+                        Release = new Release
+                        {
+                            Id = _releaseId,
+                        },
+                        ContentBlockId = _dataBlockId,
+                        ContentBlock = new DataBlock
+                        {
+                            Id = _dataBlockId,
+                            Query = new ObservationQueryContext
+                            {
+                                SubjectId = subjectId,
+                                IncludeGeoJson = false
+                            },
+                            Charts = new List<IChart>
+                            {
+                                new MapChart()
+                            }
                         }
                     }
                 );
@@ -208,15 +296,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
         {
             var tableBuilderService = new Mock<ITableBuilderService>();
 
-            tableBuilderService.Setup(s => s.Query(_releaseId, _query)).ReturnsAsync(
-                new TableBuilderResultViewModel
-                {
-                    Results = new List<ObservationViewModel>
+            tableBuilderService
+                .Setup(
+                    s =>
+                        s.Query(
+                            _releaseId,
+                            It.Is<ObservationQueryContext>(
+                                q => q.SubjectId == _query.SubjectId
+                            )
+                        )
+                )
+                .ReturnsAsync(
+                    new TableBuilderResultViewModel
                     {
-                        new ObservationViewModel()
+                        Results = new List<ObservationViewModel>
+                        {
+                            new ObservationViewModel()
+                        }
                     }
-                }
-            );
+                );
 
             var contentPersistenceHelper =
                 MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
@@ -232,7 +330,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                         ContentBlock = new DataBlock
                         {
                             Id = _dataBlockId,
-                            Query = _query
+                            Query = _query,
+                            Charts = new List<IChart>()
                         }
                     }
                 );

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.csproj
@@ -16,6 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common.Tests\GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj" />
       <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Api\GovUk.Education.ExploreEducationStatistics.Data.Api.csproj" />
     </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -69,8 +70,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
                     {
                         if (block.ContentBlock is DataBlock dataBlock)
                         {
+                            var query = dataBlock.Query.Clone();
+                            query.IncludeGeoJson = dataBlock.Charts.Any(chart => chart.Type == ChartType.Map);
+
                             return await _userService.CheckCanViewRelease(block.Release)
-                                .OnSuccess(_ => _tableBuilderService.Query(block.ReleaseId, dataBlock.Query));
+                                .OnSuccess(_ => _tableBuilderService.Query(block.ReleaseId, query));
                         }
 
                         return new NotFoundResult();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
@@ -1,10 +1,18 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
 {
@@ -13,12 +21,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
     public class TableBuilderController : ControllerBase
     {
         private readonly ITableBuilderService _tableBuilderService;
+        private readonly IPersistenceHelper<ContentDbContext> _contentPersistenceHelper;
+        private readonly IUserService _userService;
 
-        public TableBuilderController(ITableBuilderService tableBuilderService)
+        public TableBuilderController(
+            ITableBuilderService tableBuilderService,
+            IPersistenceHelper<ContentDbContext> contentPersistenceHelper,
+            IUserService userService)
         {
             _tableBuilderService = tableBuilderService;
+            _contentPersistenceHelper = contentPersistenceHelper;
+            _userService = userService;
         }
-        
+
         [HttpPost]
         public Task<ActionResult<TableBuilderResultViewModel>> Query([FromBody] ObservationQueryContext query)
         {
@@ -26,9 +41,42 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
         }
 
         [HttpPost("release/{releaseId}")]
-        public Task<ActionResult<TableBuilderResultViewModel>> Query(Guid releaseId, [FromBody] ObservationQueryContext query)
+        public Task<ActionResult<TableBuilderResultViewModel>> Query(
+            Guid releaseId,
+            [FromBody] ObservationQueryContext query)
         {
             return _tableBuilderService.Query(releaseId, query).HandleFailuresOrOk();
+        }
+
+        [ResponseCache(Duration = 300)]
+        [HttpGet("release/{releaseId}/datablock/{dataBlockId}")]
+        public async Task<ActionResult<TableBuilderResultViewModel>> QueryForDataBlock(
+            Guid releaseId,
+            Guid dataBlockId)
+        {
+            return await _contentPersistenceHelper.CheckEntityExists<ReleaseContentBlock>(
+                    query => query
+                        .Include(rcb => rcb.ContentBlock)
+                        .Include(rcb => rcb.Release)
+                        .Where(
+                            rcb => rcb.ReleaseId == releaseId
+                                   && rcb.ContentBlockId == dataBlockId
+                        )
+                )
+                .OnSuccessDo(block => this.CacheWithLastModified(block.Release.Published))
+                .OnSuccess(
+                    async block =>
+                    {
+                        if (block.ContentBlock is DataBlock dataBlock)
+                        {
+                            return await _userService.CheckCanViewRelease(block.Release)
+                                .OnSuccess(_ => _tableBuilderService.Query(block.ReleaseId, dataBlock.Query));
+                        }
+
+                        return new NotFoundResult();
+                    }
+                )
+                .HandleFailuresOrOk();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model\GovUk.Education.ExploreEducationStatistics.Content.Model.csproj" />
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Security\GovUk.Education.ExploreEducationStatistics.Content.Security.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Model\GovUk.Education.ExploreEducationStatistics.Data.Model.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Services\GovUk.Education.ExploreEducationStatistics.Data.Services.csproj" />
   </ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -57,9 +57,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
         public async Task<Either<ActionResult, PermalinkViewModel>> CreateAsync(CreatePermalinkRequest request)
         {
             var publicationId = _subjectService.GetPublicationForSubject(request.Query.SubjectId).Result.Id;
-            var releaseId = _releaseService.GetLatestPublishedRelease(publicationId);
+            var release = _releaseService.GetLatestPublishedRelease(publicationId);
 
-            return await CreateAsync(releaseId.Value, request);
+            if (release == null)
+            {
+                return new NotFoundResult();
+            }
+
+            return await CreateAsync(release.Id, request);
         }
 
         public async Task<Either<ActionResult, PermalinkViewModel>> CreateAsync(Guid releaseId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -9,6 +9,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Secu
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.ModelBinding;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Security;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Services;
@@ -136,17 +138,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
 
             services.AddAuthorization(options =>
             {
+                // does this use have permission to view a specific Release?
+                options.AddPolicy(ContentSecurityPolicies.CanViewRelease.ToString(), policy =>
+                    policy.Requirements.Add(new ViewReleaseRequirement()));
+
                 // does this user have permission to view the subject data of a specific Release?
                 options.AddPolicy(DataSecurityPolicies.CanViewSubjectData.ToString(), policy =>
                     policy.Requirements.Add(new ViewSubjectDataRequirement()));
             });
 
+            services.AddTransient<IAuthorizationHandler, ViewReleaseAuthorizationHandler>();
             services.AddTransient<IAuthorizationHandler, ViewSubjectDataForPublishedReleasesAuthorizationHandler>();
 
             services.AddCors();
             services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 
             AddPersistenceHelper<StatisticsDbContext>(services);
+            AddPersistenceHelper<ContentDbContext>(services);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/ReleaseServiceTests.cs
@@ -90,7 +90,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
                 var service = new ReleaseService(context, new Mock<ILogger<ReleaseService>>().Object);
 
                 var result = service.GetLatestPublishedRelease(publicationA.Id);
-                Assert.Equal(publicationARelease1.Id, result);
+                Assert.Equal(publicationARelease1, result);
             }
         }
 
@@ -106,7 +106,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
                 var service = new ReleaseService(context, new Mock<ILogger<ReleaseService>>().Object);
 
                 var result = service.GetLatestPublishedRelease(Guid.NewGuid());
-                Assert.False(result.HasValue);
+                Assert.Null(result);
             }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/SubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/SubjectServiceTests.cs
@@ -38,7 +38,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
 
                 releaseService
                     .Setup(s => s.GetLatestPublishedRelease(releaseSubject.Release.PublicationId))
-                    .Returns(releaseSubject.ReleaseId);
+                    .Returns(releaseSubject.Release);
 
                 var service = BuildSubjectService(context, releaseService: releaseService.Object);
                 var result = await service.IsSubjectForLatestPublishedRelease(releaseSubject.SubjectId);
@@ -74,7 +74,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
 
                 releaseService
                     .Setup(s => s.GetLatestPublishedRelease(releaseSubject.Release.PublicationId))
-                    .Returns(Guid.NewGuid());
+                    .Returns(new Release
+                    {
+                        Id = Guid.NewGuid()
+                    });
 
                 var service = BuildSubjectService(context, releaseService: releaseService.Object);
                 var result = await service.IsSubjectForLatestPublishedRelease(releaseSubject.SubjectId);
@@ -110,7 +113,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
 
                 releaseService
                     .Setup(s => s.GetLatestPublishedRelease(releaseSubject.Release.PublicationId))
-                    .Returns(Guid.NewGuid());
+                    .Returns(new Release
+                    {
+                        Id = Guid.NewGuid()
+                    });
 
                 var service = BuildSubjectService(context, releaseService: releaseService.Object);
                 var result = await service.IsSubjectForLatestPublishedRelease(releaseSubject.SubjectId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/IReleaseService.cs
@@ -1,9 +1,10 @@
+#nullable enable
 using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces
 {
     public interface IReleaseService : IRepository<Release, Guid>
     {
-        Guid? GetLatestPublishedRelease(Guid publicationId);
+        Release? GetLatestPublishedRelease(Guid publicationId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/ReleaseService.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -14,7 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
         {
         }
 
-        public Guid? GetLatestPublishedRelease(Guid publicationId)
+        public Release? GetLatestPublishedRelease(Guid publicationId)
         {
             return DbSet()
                 .Include(release => release.Publication)
@@ -23,9 +24,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
                 .Where(release => release.Live && IsLatestVersionOfRelease(release.Publication, release.Id))
                 .OrderBy(release => release.Year)
                 .ThenBy(release => release.TimeIdentifier)
-                .LastOrDefault()?.Id;
+                .LastOrDefault();
         }
-        
+
         private static bool IsLatestVersionOfRelease(Publication publication, Guid releaseId)
         {
             return !publication.Releases.Any(r => r.PreviousVersionId == releaseId && r.Live && r.Id != releaseId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/SubjectService.cs
@@ -25,14 +25,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
             var publication = await GetPublicationForSubject(subjectId);
             var latestRelease = _releaseService.GetLatestPublishedRelease(publication.Id);
 
-            if (!latestRelease.HasValue)
+            if (latestRelease == null)
             {
                 return false;
             }
 
             return _context
                 .ReleaseSubject
-                .Any(r => r.ReleaseId == latestRelease.Value && r.SubjectId == subjectId);
+                .Any(r => r.ReleaseId == latestRelease.Id && r.SubjectId == subjectId);
         }
 
         public async Task<Subject?> Get(Guid subjectId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Functions/ProcessorTests.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
@@ -119,7 +120,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
             MockUtils.VerifyAllMocks(processorService, importStatusService, batchService,
                 fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
         }
-        
+
         [Fact]
         public void ProcessUploadsButImportIsFinished()
         {
@@ -127,7 +128,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 .GetEnumValues<IStatus>()
                 .Where(ImportStatus.IsFinishedState)
                 .ToList();
-            
+
             finishedStates.ForEach(currentState =>
             {
                 var mocks = Mocks();
@@ -158,7 +159,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                     {
                         Status = currentState
                     });
-                
+
                 processor.ProcessUploads(
                     message,
                     null,
@@ -166,7 +167,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                     datafileProcessingMessageQueue.Object
                 );
 
-                // Verify that no Status updates occurred and that no further attempt to add further processing 
+                // Verify that no Status updates occurred and that no further attempt to add further processing
                 // messages to queues occurred.
                 MockUtils.VerifyAllMocks(processorService, importStatusService, batchService,
                     fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
@@ -239,13 +240,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 },
                 DataFileName = "my_data_file",
             };
-            
+
             var executionContext = new ExecutionContext();
-            
+
             var processor = new Processor.Functions.Processor(
                 fileImportService.Object,
                 batchService.Object,
-                importStatusService.Object, 
+                importStatusService.Object,
                 processorService.Object,
                 new Mock<ILogger<Processor.Functions.Processor>>().Object);
 
@@ -295,11 +296,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 },
                 DataFileName = "my_data_file",
             };
-            
+
             var processor = new Processor.Functions.Processor(
                 fileImportService.Object,
                 batchService.Object,
-                importStatusService.Object, 
+                importStatusService.Object,
                 processorService.Object,
                 new Mock<ILogger<Processor.Functions.Processor>>().Object);
 
@@ -349,11 +350,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 },
                 DataFileName = "my_data_file",
             };
-            
+
             var processor = new Processor.Functions.Processor(
                 fileImportService.Object,
                 batchService.Object,
-                importStatusService.Object, 
+                importStatusService.Object,
                 processorService.Object,
                 new Mock<ILogger<Processor.Functions.Processor>>().Object);
 
@@ -385,7 +386,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
             MockUtils.VerifyAllMocks(processorService, importStatusService, batchService,
                 fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
         }
-        
+
         [Fact]
         public void ProcessUploadsStage4Messages()
         {
@@ -403,11 +404,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 },
                 DataFileName = "my_data_file",
             };
-            
+
             var processor = new Processor.Functions.Processor(
                 fileImportService.Object,
                 batchService.Object,
-                importStatusService.Object, 
+                importStatusService.Object,
                 processorService.Object,
                 new Mock<ILogger<Processor.Functions.Processor>>().Object);
 
@@ -432,7 +433,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
             MockUtils.VerifyAllMocks(processorService, importStatusService, batchService,
                 fileImportService, importStagesMessageQueue, datafileProcessingMessageQueue);
         }
-        
+
         [Fact]
         public void CancelImport()
         {
@@ -444,11 +445,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 ReleaseId = Guid.NewGuid(),
                 DataFileName = "my_data_file"
             };
-            
+
             var processor = new Processor.Functions.Processor(
                 fileImportService.Object,
                 batchService.Object,
-                importStatusService.Object, 
+                importStatusService.Object,
                 processorService.Object,
                 new Mock<ILogger<Processor.Functions.Processor>>().Object);
 
@@ -458,7 +459,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Functi
                 PercentageComplete = 10,
                 PhasePercentageComplete = 50,
             };
-            
+
             importStatusService
                 .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
                 .ReturnsAsync(currentImportStatus);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Data.Importer.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             .GetEnumValues<IStatus>()
             .Where(ImportStatus.IsFinishedState)
             .ToList();
-        
+
         private static readonly List<IStatus> AbortingStatuses = EnumUtil
             .GetEnumValues<IStatus>()
             .Where(ImportStatus.IsAbortingState)
@@ -44,9 +44,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 TotalRows = 2,
                 SubjectId = Guid.NewGuid()
             };
-            
+
             var importStatusService = new Mock<IImportStatusService>(Strict);
-            
+
             var service = BuildFileImportService(
                 importStatusService: importStatusService.Object);
 
@@ -56,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 {
                     Status = STAGE_4
                 });
-            
+
             importStatusService
                 .Setup(s => s.UpdateStatus(
                     message.ReleaseId, message.DataFileName, COMPLETE, 100))
@@ -81,13 +81,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     });
 
                 await dbContext.SaveChangesAsync();
-                
+
                 await service.CheckComplete(message.ReleaseId, message, dbContext);
             }
 
             MockUtils.VerifyAllMocks(importStatusService);
         }
-        
+
         [Fact]
         public async Task CheckComplete_LastBatchFileCompleted()
         {
@@ -99,10 +99,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 TotalRows = 2,
                 SubjectId = Guid.NewGuid()
             };
-            
+
             var importStatusService = new Mock<IImportStatusService>(Strict);
             var fileStorageService = new Mock<IFileStorageService>();
-            
+
             var service = BuildFileImportService(
                 importStatusService: importStatusService.Object,
                 fileStorageService: fileStorageService.Object);
@@ -117,7 +117,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             fileStorageService
                 .Setup(s => s.GetNumBatchesRemaining(message.ReleaseId, message.DataFileName))
                 .ReturnsAsync(0);
-            
+
             importStatusService
                 .Setup(s => s.UpdateStatus(
                     message.ReleaseId, message.DataFileName, COMPLETE, 100))
@@ -138,13 +138,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     });
 
                 await dbContext.SaveChangesAsync();
-                
+
                 await service.CheckComplete(message.ReleaseId, message, dbContext);
             }
 
             MockUtils.VerifyAllMocks(importStatusService, fileStorageService);
         }
-        
+
         [Fact]
         public async Task CheckComplete_BatchedFilesStillProcessing()
         {
@@ -157,10 +157,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 SubjectId = Guid.NewGuid(),
                 BatchNo = 1
             };
-            
+
             var importStatusService = new Mock<IImportStatusService>(Strict);
             var fileStorageService = new Mock<IFileStorageService>();
-            
+
             var service = BuildFileImportService(
                 importStatusService: importStatusService.Object,
                 fileStorageService: fileStorageService.Object);
@@ -175,7 +175,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             fileStorageService
                 .Setup(s => s.GetNumBatchesRemaining(message.ReleaseId, message.DataFileName))
                 .ReturnsAsync(1);
-            
+
             importStatusService
                 .Setup(s => s.UpdateStatus(
                     message.ReleaseId, message.DataFileName, STAGE_4, 50))
@@ -190,7 +190,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
 
             MockUtils.VerifyAllMocks(importStatusService, fileStorageService);
         }
-        
+
         [Fact]
         public async Task CheckComplete_SingleDataFileCompleted_HasErrors()
         {
@@ -202,7 +202,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 TotalRows = 2,
                 SubjectId = Guid.NewGuid()
             };
-            
+
             var importStatusService = new Mock<IImportStatusService>(Strict);
 
             var service = BuildFileImportService(
@@ -215,7 +215,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     Status = STAGE_4,
                     Errors = "an error"
                 });
-            
+
             importStatusService
                 .Setup(s => s.UpdateStatus(
                     message.ReleaseId, message.DataFileName, FAILED, 100))
@@ -236,13 +236,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     });
 
                 await dbContext.SaveChangesAsync();
-                
+
                 await service.CheckComplete(message.ReleaseId, message, dbContext);
             }
 
             MockUtils.VerifyAllMocks(importStatusService);
         }
-        
+
         [Fact]
         public async Task CheckComplete_SingleDataFileCompleted_HasIncorrectObservationCount()
         {
@@ -254,7 +254,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 TotalRows = 3,
                 SubjectId = Guid.NewGuid()
             };
-            
+
             var importStatusService = new Mock<IImportStatusService>(Strict);
             var batchService = new Mock<IBatchService>(Strict);
 
@@ -294,13 +294,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     });
 
                 await dbContext.SaveChangesAsync();
-                
+
                 await service.CheckComplete(message.ReleaseId, message, dbContext);
             }
 
             MockUtils.VerifyAllMocks(importStatusService, batchService);
         }
-        
+
         [Fact]
         public async Task CheckComplete_LastBatchFileCompleted_HasErrors()
         {
@@ -312,10 +312,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 TotalRows = 2,
                 SubjectId = Guid.NewGuid()
             };
-            
+
             var importStatusService = new Mock<IImportStatusService>(Strict);
             var fileStorageService = new Mock<IFileStorageService>();
-            
+
             var service = BuildFileImportService(
                 importStatusService: importStatusService.Object,
                 fileStorageService: fileStorageService.Object);
@@ -331,7 +331,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             fileStorageService
                 .Setup(s => s.GetNumBatchesRemaining(message.ReleaseId, message.DataFileName))
                 .ReturnsAsync(0);
-            
+
             importStatusService
                 .Setup(s => s.UpdateStatus(
                     message.ReleaseId, message.DataFileName, FAILED, 100))
@@ -352,13 +352,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     });
 
                 await dbContext.SaveChangesAsync();
-                
+
                 await service.CheckComplete(message.ReleaseId, message, dbContext);
             }
 
             MockUtils.VerifyAllMocks(importStatusService, fileStorageService);
         }
-        
+
         [Fact]
         public async Task CheckComplete_LastBatchFileCompleted_HasIncorrectObservationCount()
         {
@@ -370,7 +370,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 TotalRows = 3,
                 SubjectId = Guid.NewGuid()
             };
-            
+
             var importStatusService = new Mock<IImportStatusService>(Strict);
             var fileStorageService = new Mock<IFileStorageService>();
             var batchService = new Mock<IBatchService>();
@@ -390,7 +390,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             fileStorageService
                 .Setup(s => s.GetNumBatchesRemaining(message.ReleaseId, message.DataFileName))
                 .ReturnsAsync(0);
-            
+
             batchService
                 .Setup(s => s.FailImport(message.ReleaseId, message.DataFileName, new List<ValidationError>
                 {
@@ -400,7 +400,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     )
                 }))
                 .Returns(Task.CompletedTask);
-            
+
             var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
 
             await using (dbContext)
@@ -416,13 +416,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     });
 
                 await dbContext.SaveChangesAsync();
-                
+
                 await service.CheckComplete(message.ReleaseId, message, dbContext);
             }
 
             MockUtils.VerifyAllMocks(importStatusService, fileStorageService, batchService);
         }
-        
+
         [Fact]
         public async Task CheckComplete_SingleDataFileCompleted_AlreadyFinished()
         {
@@ -436,9 +436,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     TotalRows = 2,
                     SubjectId = Guid.NewGuid()
                 };
-            
+
                 var importStatusService = new Mock<IImportStatusService>(Strict);
-            
+
                 var service = BuildFileImportService(
                     importStatusService: importStatusService.Object);
 
@@ -448,7 +448,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     {
                         Status = finishedStatus
                     });
-            
+
                 var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
 
                 await using (dbContext)
@@ -456,10 +456,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     await service.CheckComplete(message.ReleaseId, message, dbContext);
                 }
 
-                MockUtils.VerifyAllMocks(importStatusService);       
+                MockUtils.VerifyAllMocks(importStatusService);
             });
         }
-        
+
         [Fact]
         public async Task CheckComplete_LastBatchFileCompleted_AlreadyFinished()
         {
@@ -473,10 +473,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     TotalRows = 2,
                     SubjectId = Guid.NewGuid()
                 };
-            
+
                 var importStatusService = new Mock<IImportStatusService>(Strict);
                 var fileStorageService = new Mock<IFileStorageService>();
-            
+
                 var service = BuildFileImportService(
                     importStatusService: importStatusService.Object,
                     fileStorageService: fileStorageService.Object);
@@ -495,10 +495,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     await service.CheckComplete(message.ReleaseId, message, dbContext);
                 }
 
-                MockUtils.VerifyAllMocks(importStatusService, fileStorageService);       
+                MockUtils.VerifyAllMocks(importStatusService, fileStorageService);
             });
         }
-        
+
         [Fact]
         public async Task CheckComplete_SingleDataFileCompleted_Aborting()
         {
@@ -512,9 +512,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     TotalRows = 2,
                     SubjectId = Guid.NewGuid()
                 };
-            
+
                 var importStatusService = new Mock<IImportStatusService>(Strict);
-            
+
                 var service = BuildFileImportService(
                     importStatusService: importStatusService.Object);
 
@@ -522,16 +522,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 {
                     Status = abortingStatus
                 };
-                
+
                 importStatusService
                     .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
                     .ReturnsAsync(currentStatus);
-                
+
                 importStatusService
                     .Setup(s => s.UpdateStatus(
                         message.ReleaseId, message.DataFileName, currentStatus.GetFinishingStateOfAbortProcess(), 100))
                     .Returns(Task.CompletedTask);
-            
+
                 var dbContext = StatisticsDbUtils.InMemoryStatisticsDbContext();
 
                 await using (dbContext)
@@ -542,7 +542,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 MockUtils.VerifyAllMocks(importStatusService);
             });
         }
-        
+
         [Fact]
         public async Task CheckComplete_LastBatchFileCompleted_Aborting()
         {
@@ -556,10 +556,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     TotalRows = 2,
                     SubjectId = Guid.NewGuid()
                 };
-            
+
                 var importStatusService = new Mock<IImportStatusService>(Strict);
                 var fileStorageService = new Mock<IFileStorageService>();
-            
+
                 var service = BuildFileImportService(
                     importStatusService: importStatusService.Object,
                     fileStorageService: fileStorageService.Object);
@@ -568,7 +568,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 {
                     Status = abortingStatus
                 };
-                
+
                 importStatusService
                     .Setup(s => s.GetImportStatus(message.ReleaseId, message.DataFileName))
                     .ReturnsAsync(currentStatus);
@@ -585,10 +585,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                     await service.CheckComplete(message.ReleaseId, message, dbContext);
                 }
 
-                MockUtils.VerifyAllMocks(importStatusService, fileStorageService);       
+                MockUtils.VerifyAllMocks(importStatusService, fileStorageService);
             });
         }
-        
+
         private FileImportService BuildFileImportService(
             IFileStorageService fileStorageService = null,
             IImporterService importerService = null,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.csproj
@@ -17,6 +17,7 @@
     </ItemGroup>
     
     <ItemGroup>
+        <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common.Tests\GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj" />
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Services\GovUk.Education.ExploreEducationStatistics.Data.Services.csproj" />
     </ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServicePermissionTests.cs
@@ -1,0 +1,150 @@
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Security;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
+{
+    public class TableBuilderServicePermissionTests
+    {
+        private static readonly Guid SubjectId = Guid.NewGuid();
+        private static readonly Guid ReleaseId = Guid.NewGuid();
+
+        private readonly Subject _subject = new Subject
+        {
+            Id = SubjectId,
+        };
+
+        private readonly Release _release = new Release
+        {
+            Id = ReleaseId,
+        };
+
+        [Fact]
+        public void Query_LatestRelease_CanViewSubjectData()
+        {
+            PermissionTestUtils.PolicyCheckBuilder<DataSecurityPolicies>()
+                .ExpectResourceCheckToFail(_subject, DataSecurityPolicies.CanViewSubjectData)
+                .AssertForbidden(
+                    async userService =>
+                    {
+                        var publication = new Model.Publication
+                        {
+                            Id = Guid.NewGuid(),
+                        };
+
+                        var release = new Model.Release
+                        {
+                            Id = Guid.NewGuid(),
+                        };
+
+                        var subjectService = new Mock<ISubjectService>();
+
+                        subjectService
+                            .Setup(s => s.IsSubjectForLatestPublishedRelease(_subject.Id))
+                            .ReturnsAsync(false);
+
+                        subjectService
+                            .Setup(s => s.GetPublicationForSubject(_subject.Id))
+                            .ReturnsAsync(publication);
+
+                        var releaseService = new Mock<IReleaseService>();
+
+                        releaseService
+                            .Setup(s => s.GetLatestPublishedRelease(publication.Id))
+                            .Returns(release);
+
+                        var service = BuildTableBuilderService(
+                            userService: userService.Object,
+                            subjectService: subjectService.Object,
+                            releaseService: releaseService.Object
+                        );
+
+                        return await service.Query(
+                            new ObservationQueryContext
+                            {
+                                SubjectId = _subject.Id
+                            }
+                        );
+                    }
+                );
+        }
+
+        [Fact]
+        public void Query_ReleaseId_CanViewSubjectData()
+        {
+            PermissionTestUtils.PolicyCheckBuilder<DataSecurityPolicies>()
+                .ExpectResourceCheckToFail(_subject, DataSecurityPolicies.CanViewSubjectData)
+                .AssertForbidden(
+                    async userService =>
+                    {
+                        var releaseSubject = new ReleaseSubject
+                        {
+                            ReleaseId = _release.Id,
+                            Release = _release,
+                            SubjectId = _subject.Id,
+                            Subject = _subject,
+                        };
+
+                        var statisticsPersistenceHelper = StatisticsPersistenceHelperMock(_subject);
+
+                        MockUtils.SetupCall(statisticsPersistenceHelper, releaseSubject);
+
+                        var subjectService = new Mock<ISubjectService>();
+
+                        subjectService
+                            .Setup(s => s.IsSubjectForLatestPublishedRelease(_subject.Id))
+                            .ReturnsAsync(false);
+
+                        var service = BuildTableBuilderService(
+                            userService: userService.Object,
+                            subjectService: subjectService.Object,
+                            statisticsPersistenceHelper: statisticsPersistenceHelper.Object
+                        );
+                        return await service.Query(
+                            releaseSubject.ReleaseId,
+                            new ObservationQueryContext
+                            {
+                                SubjectId = _subject.Id
+                            }
+                        );
+                    }
+                );
+        }
+
+        private TableBuilderService BuildTableBuilderService(
+            IObservationService observationService = null,
+            IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper = null,
+            IResultSubjectMetaService resultSubjectMetaService = null,
+            ISubjectService subjectService = null,
+            IUserService userService = null,
+            IResultBuilder<Observation, ObservationViewModel> resultBuilder = null,
+            IReleaseService releaseService = null)
+        {
+            return new TableBuilderService(
+                observationService ?? new Mock<IObservationService>().Object,
+                statisticsPersistenceHelper ?? StatisticsPersistenceHelperMock(_subject).Object,
+                resultSubjectMetaService ?? new Mock<IResultSubjectMetaService>().Object,
+                subjectService ?? new Mock<ISubjectService>().Object,
+                userService ?? new Mock<IUserService>().Object,
+                resultBuilder ?? new ResultBuilder(DataServiceMapperUtils.DataServiceMapper()),
+                releaseService ?? new Mock<IReleaseService>().Object
+            );
+        }
+
+        private Mock<IPersistenceHelper<StatisticsDbContext>> StatisticsPersistenceHelperMock(Subject subject)
+        {
+            return MockUtils.MockPersistenceHelper<StatisticsDbContext, Subject>(subject.Id, subject);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
@@ -1,0 +1,488 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Query;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+using Release = GovUk.Education.ExploreEducationStatistics.Data.Model.Release;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
+{
+    public class TableBuilderServiceTests
+    {
+        [Fact]
+        public async Task Query_LatestRelease()
+        {
+            var publication = new Publication
+            {
+                Id = Guid.NewGuid(),
+            };
+
+            var release = new Release
+            {
+                PublicationId = publication.Id,
+                Publication = publication,
+            };
+
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Id = Guid.NewGuid()
+                }
+            };
+
+            var indicator1Id = Guid.NewGuid();
+            var indicator2Id = Guid.NewGuid();
+
+            var query = new ObservationQueryContext
+            {
+                SubjectId = releaseSubject.Subject.Id,
+                Indicators = new[] { indicator1Id, indicator2Id, },
+                Locations = new LocationQuery
+                {
+                    Country = new[] { "england" }
+                },
+                TimePeriod = new TimePeriodQuery
+                {
+                    StartYear = 2019,
+                    StartCode = TimeIdentifier.AcademicYear,
+                    EndYear = 2020,
+                    EndCode = TimeIdentifier.AcademicYear,
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var observations = new List<Observation>
+                {
+                    new Observation
+                    {
+                        Measures = new Dictionary<Guid, string>
+                        {
+                            { indicator1Id, "123" },
+                            { indicator2Id, "456" },
+                        },
+                        FilterItems = new List<ObservationFilterItem>(),
+                        Year = 2019,
+                        TimeIdentifier = TimeIdentifier.AcademicYear,
+                    },
+                    new Observation
+                    {
+                        Measures = new Dictionary<Guid, string>
+                        {
+                            { indicator1Id, "789" },
+                            { Guid.NewGuid(), "1123" },
+                            { Guid.NewGuid(), "1456" },
+                        },
+                        FilterItems = new List<ObservationFilterItem>(),
+                        Year = 2020,
+                        TimeIdentifier = TimeIdentifier.AcademicYear,
+                    },
+                };
+
+                var subjectMeta = new ResultSubjectMetaViewModel
+                {
+                    Indicators = new List<IndicatorMetaViewModel>
+                    {
+                        new IndicatorMetaViewModel
+                        {
+                            Label = "Test indicator"
+                        }
+                    },
+                };
+
+                var observationService = new Mock<IObservationService>();
+
+                observationService
+                    .Setup(s => s.FindObservations(query))
+                    .Returns(observations);
+
+                var resultSubjectMetaService = new Mock<IResultSubjectMetaService>();
+
+                resultSubjectMetaService
+                    .Setup(
+                        s => s.GetSubjectMeta(
+                            release.Id,
+                            It.IsAny<SubjectMetaQueryContext>(),
+                            It.IsAny<IQueryable<Observation>>()
+                        )
+                    )
+                    .ReturnsAsync(subjectMeta);
+
+                var subjectService = new Mock<ISubjectService>();
+
+                subjectService
+                    .Setup(s => s.GetPublicationForSubject(query.SubjectId))
+                    .ReturnsAsync(publication);
+
+                subjectService
+                    .Setup(s => s.IsSubjectForLatestPublishedRelease(query.SubjectId))
+                    .ReturnsAsync(true);
+
+                var releaseService = new Mock<IReleaseService>();
+
+                releaseService
+                    .Setup(s => s.GetLatestPublishedRelease(publication.Id))
+                    .Returns(release);
+
+                var service = BuildTableBuilderService(
+                    statisticsDbContext,
+                    observationService: observationService.Object,
+                    resultSubjectMetaService: resultSubjectMetaService.Object,
+                    subjectService: subjectService.Object,
+                    releaseService: releaseService.Object
+                );
+
+                var result = await service.Query(query);
+
+                Assert.True(result.IsRight);
+
+                var observationResults = result.Right.Results.ToList();
+
+                Assert.Equal(2, observationResults.Count);
+
+                Assert.Equal("2019_AY", observationResults[0].TimePeriod);
+                Assert.Equal(2, observationResults[0].Measures.Count);
+                Assert.Equal("123", observationResults[0].Measures[indicator1Id.ToString()]);
+                Assert.Equal("456", observationResults[0].Measures[indicator2Id.ToString()]);
+
+                Assert.Equal("2020_AY", observationResults[1].TimePeriod);
+                Assert.Single(observationResults[1].Measures);
+                Assert.Equal("789", observationResults[1].Measures[indicator1Id.ToString()]);
+
+                Assert.Equal(subjectMeta, result.Right.SubjectMeta);
+
+                MockUtils.VerifyAllMocks(observationService, resultSubjectMetaService, subjectService, releaseService);
+            }
+        }
+
+        [Fact]
+        public async Task Query_LatestRelease_ReleaseNotFound()
+        {
+            var publication = new Publication
+            {
+                Id = Guid.NewGuid(),
+            };
+
+            var query = new ObservationQueryContext
+            {
+                SubjectId = Guid.NewGuid(),
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var subjectService = new Mock<ISubjectService>();
+
+                subjectService
+                    .Setup(s => s.GetPublicationForSubject(query.SubjectId))
+                    .ReturnsAsync(publication);
+
+                var releaseService = new Mock<IReleaseService>();
+
+                releaseService
+                    .Setup(s => s.GetLatestPublishedRelease(publication.Id));
+
+                var service = BuildTableBuilderService(
+                    statisticsDbContext,
+                    subjectService: subjectService.Object,
+                    releaseService: releaseService.Object
+                );
+
+                var result = await service.Query(query);
+
+                Assert.True(result.IsLeft);
+                Assert.IsType<NotFoundResult>(result.Left);
+                MockUtils.VerifyAllMocks(subjectService, releaseService);
+            }
+        }
+
+        [Fact]
+        public async Task Query_LatestRelease_SubjectNotFound()
+        {
+            var publication = new Publication
+            {
+                Id = Guid.NewGuid(),
+            };
+
+            var release = new Release
+            {
+                PublicationId = publication.Id,
+                Publication = publication,
+            };
+
+            var query = new ObservationQueryContext
+            {
+                SubjectId = Guid.NewGuid(),
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var subjectService = new Mock<ISubjectService>();
+
+                subjectService
+                    .Setup(s => s.GetPublicationForSubject(query.SubjectId))
+                    .ReturnsAsync(publication);
+
+                var releaseService = new Mock<IReleaseService>();
+
+                releaseService
+                    .Setup(s => s.GetLatestPublishedRelease(publication.Id))
+                    .Returns(release);
+
+                var service = BuildTableBuilderService(
+                    statisticsDbContext,
+                    subjectService: subjectService.Object,
+                    releaseService: releaseService.Object
+                );
+
+                var result = await service.Query(query);
+
+                Assert.True(result.IsLeft);
+                Assert.IsType<NotFoundResult>(result.Left);
+                MockUtils.VerifyAllMocks(subjectService, releaseService);
+            }
+        }
+
+        [Fact]
+        public async Task Query_ReleaseId()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject
+                {
+                    Id = Guid.NewGuid()
+                },
+            };
+
+            var indicator1Id = Guid.NewGuid();
+            var indicator2Id = Guid.NewGuid();
+
+            var query = new ObservationQueryContext
+            {
+                SubjectId = releaseSubject.Subject.Id,
+                Indicators = new[] { indicator1Id, indicator2Id, },
+                Locations = new LocationQuery
+                {
+                    Country = new[] { "england" }
+                },
+                TimePeriod = new TimePeriodQuery
+                {
+                    StartYear = 2019,
+                    StartCode = TimeIdentifier.AcademicYear,
+                    EndYear = 2020,
+                    EndCode = TimeIdentifier.AcademicYear,
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var observations = new List<Observation>
+                {
+                    new Observation
+                    {
+                        Measures = new Dictionary<Guid, string>
+                        {
+                            { indicator1Id, "123" },
+                            { indicator2Id, "456" },
+                        },
+                        FilterItems = new List<ObservationFilterItem>(),
+                        Year = 2019,
+                        TimeIdentifier = TimeIdentifier.AcademicYear,
+                    },
+                    new Observation
+                    {
+                        Measures = new Dictionary<Guid, string>
+                        {
+                            { indicator1Id, "789" },
+                            { Guid.NewGuid(), "1123" },
+                            { Guid.NewGuid(), "1456" },
+                        },
+                        FilterItems = new List<ObservationFilterItem>(),
+                        Year = 2020,
+                        TimeIdentifier = TimeIdentifier.AcademicYear,
+                    },
+                };
+
+                var subjectMeta = new ResultSubjectMetaViewModel
+                {
+                    Indicators = new List<IndicatorMetaViewModel>
+                    {
+                        new IndicatorMetaViewModel
+                        {
+                            Label = "Test indicator"
+                        }
+                    },
+                };
+
+                var observationService = new Mock<IObservationService>();
+
+                observationService
+                    .Setup(s => s.FindObservations(query))
+                    .Returns(observations);
+
+                var resultSubjectMetaService = new Mock<IResultSubjectMetaService>();
+
+                resultSubjectMetaService
+                    .Setup(
+                        s => s.GetSubjectMeta(
+                            releaseSubject.ReleaseId,
+                            It.IsAny<SubjectMetaQueryContext>(),
+                            It.IsAny<IQueryable<Observation>>()
+                        )
+                    )
+                    .ReturnsAsync(subjectMeta);
+
+                var service = BuildTableBuilderService(
+                    statisticsDbContext,
+                    observationService: observationService.Object,
+                    resultSubjectMetaService: resultSubjectMetaService.Object
+                );
+
+                var result = await service.Query(releaseSubject.ReleaseId, query);
+
+                Assert.True(result.IsRight);
+
+                var observationResults = result.Right.Results.ToList();
+
+                Assert.Equal(2, observationResults.Count);
+
+                Assert.Equal("2019_AY", observationResults[0].TimePeriod);
+                Assert.Equal(2, observationResults[0].Measures.Count);
+                Assert.Equal("123", observationResults[0].Measures[indicator1Id.ToString()]);
+                Assert.Equal("456", observationResults[0].Measures[indicator2Id.ToString()]);
+
+                Assert.Equal("2020_AY", observationResults[1].TimePeriod);
+                Assert.Single(observationResults[1].Measures);
+                Assert.Equal("789", observationResults[1].Measures[indicator1Id.ToString()]);
+
+                Assert.Equal(subjectMeta, result.Right.SubjectMeta);
+
+                MockUtils.VerifyAllMocks(observationService, resultSubjectMetaService);
+            }
+        }
+
+        [Fact]
+        public async Task Query_ReleaseId_ReleaseNotFound()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject(),
+            };
+
+            var query = new ObservationQueryContext
+            {
+                SubjectId = releaseSubject.Subject.Id,
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildTableBuilderService(statisticsDbContext);
+
+                var result = await service.Query(Guid.NewGuid(), query);
+
+                Assert.True(result.IsLeft);
+                Assert.IsType<NotFoundResult>(result.Left);
+            }
+        }
+
+        [Fact]
+        public async Task Query_ReleaseId_SubjectNotFound()
+        {
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject(),
+            };
+
+            var query = new ObservationQueryContext
+            {
+                SubjectId = Guid.NewGuid(),
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var service = BuildTableBuilderService(statisticsDbContext);
+
+                var result = await service.Query(Guid.NewGuid(), query);
+
+                Assert.True(result.IsLeft);
+                Assert.IsType<NotFoundResult>(result.Left);
+            }
+        }
+
+        private TableBuilderService BuildTableBuilderService(
+            StatisticsDbContext statisticsDbContext,
+            IObservationService observationService = null,
+            IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper = null,
+            IResultSubjectMetaService resultSubjectMetaService = null,
+            ISubjectService subjectService = null,
+            IUserService userService = null,
+            IResultBuilder<Observation, ObservationViewModel> resultBuilder = null,
+            IReleaseService releaseService = null)
+        {
+            return new TableBuilderService(
+                observationService ?? new Mock<IObservationService>().Object,
+                statisticsPersistenceHelper ?? new PersistenceHelper<StatisticsDbContext>(statisticsDbContext),
+                resultSubjectMetaService ?? new Mock<IResultSubjectMetaService>().Object,
+                subjectService ?? new Mock<ISubjectService>().Object,
+                userService ?? MockUtils.AlwaysTrueUserService().Object,
+                resultBuilder ?? new ResultBuilder(DataServiceMapperUtils.DataServiceMapper()),
+                releaseService ?? new Mock<IReleaseService>().Object
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Utils/DataServiceMapperUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Utils/DataServiceMapperUtils.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Mappings;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils
+{
+    public class DataServiceMapperUtils
+    {
+        public static IMapper DataServiceMapper()
+        {
+            var serviceLookupByType = new Dictionary<Type, object>
+            {
+            };
+
+            object ServiceLocator(Type serviceType) => serviceLookupByType[serviceType];
+            return Common.Services.MapperUtils.MapperForProfile<DataServiceMappingProfiles>(ServiceLocator);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/GovUk.Education.ExploreEducationStatistics.Data.Services.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/GovUk.Education.ExploreEducationStatistics.Data.Services.csproj
@@ -16,6 +16,7 @@
     <ItemGroup>
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Common\GovUk.Education.ExploreEducationStatistics.Common.csproj" />
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model\GovUk.Education.ExploreEducationStatistics.Content.Model.csproj" />
+        <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Security\GovUk.Education.ExploreEducationStatistics.Content.Security.csproj" />
         <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Model\GovUk.Education.ExploreEducationStatistics.Data.Model.csproj" />
     </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/PublicationMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/PublicationMetaService.cs
@@ -36,8 +36,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         public async Task<Either<ActionResult, PublicationSubjectsMetaViewModel>> GetSubjectsForLatestRelease(
             Guid publicationId)
         {
-            var releaseId = _releaseService.GetLatestPublishedRelease(publicationId);
-            if (!releaseId.HasValue)
+            var release = _releaseService.GetLatestPublishedRelease(publicationId);
+
+            if (release == null)
             {
                 return new NotFoundResult();
             }
@@ -45,8 +46,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             return new PublicationSubjectsMetaViewModel
             {
                 PublicationId = publicationId,
-                Highlights = await GetHighlights(releaseId.Value),
-                Subjects = await GetSubjects(releaseId.Value)
+                Highlights = await GetHighlights(release.Id),
+                Subjects = await GetSubjects(release.Id)
             };
         }
 
@@ -54,10 +55,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         {
             var releaseFilter = TableQuery.GenerateFilterCondition(nameof(ReleaseFastTrack.PartitionKey),
                 QueryComparisons.Equal, releaseId.ToString());
-            
+
             var highlightFilter = TableQuery.GenerateFilterCondition(nameof(ReleaseFastTrack.HighlightName), QueryComparisons.NotEqual,
                     string.Empty);
-            
+
             var combineFilter = TableQuery.CombineFilters(releaseFilter, TableOperators.And, highlightFilter);
             var query = new TableQuery<ReleaseFastTrack>().Where(combineFilter);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
@@ -44,12 +44,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             _releaseService = releaseService;
         }
 
-        public Task<Either<ActionResult, TableBuilderResultViewModel>> Query(ObservationQueryContext queryContext)
+        public async Task<Either<ActionResult, TableBuilderResultViewModel>> Query(ObservationQueryContext queryContext)
         {
             var publicationId = _subjectService.GetPublicationForSubject(queryContext.SubjectId).Result.Id;
-            var releaseId = _releaseService.GetLatestPublishedRelease(publicationId);
+            var release = _releaseService.GetLatestPublishedRelease(publicationId);
 
-            return Query(releaseId.Value, queryContext);
+            if (release == null)
+            {
+                return new NotFoundResult();
+            }
+
+            return await Query(release.Id, queryContext);
         }
 
         public Task<Either<ActionResult, TableBuilderResultViewModel>> Query(Guid releaseId, ObservationQueryContext queryContext)

--- a/src/GovUk.Education.ExploreEducationStatistics.sln
+++ b/src/GovUk.Education.ExploreEducationStatistics.sln
@@ -49,6 +49,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEduc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests", "GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests\GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.csproj", "{98E32217-944F-4978-B7AD-6DDA250EF15C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEducationStatistics.Content.Security", "GovUk.Education.ExploreEducationStatistics.Content.Security\GovUk.Education.ExploreEducationStatistics.Content.Security.csproj", "{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GovUk.Education.ExploreEducationStatistics.Content.Security.Tests", "GovUk.Education.ExploreEducationStatistics.Content.Security.Tests\GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.csproj", "{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -335,6 +339,30 @@ Global
 		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Release|x64.Build.0 = Release|Any CPU
 		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Release|x86.ActiveCfg = Release|Any CPU
 		{98E32217-944F-4978-B7AD-6DDA250EF15C}.Release|x86.Build.0 = Release|Any CPU
+		{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}.Debug|x64.Build.0 = Debug|Any CPU
+		{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}.Debug|x86.Build.0 = Debug|Any CPU
+		{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}.Release|x64.ActiveCfg = Release|Any CPU
+		{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}.Release|x64.Build.0 = Release|Any CPU
+		{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}.Release|x86.ActiveCfg = Release|Any CPU
+		{9427EE59-63CD-4B67-9C26-F7A202E0AE3A}.Release|x86.Build.0 = Release|Any CPU
+		{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}.Debug|x64.Build.0 = Debug|Any CPU
+		{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}.Debug|x86.Build.0 = Debug|Any CPU
+		{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}.Release|x64.ActiveCfg = Release|Any CPU
+		{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}.Release|x64.Build.0 = Release|Any CPU
+		{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}.Release|x86.ActiveCfg = Release|Any CPU
+		{FF6B60C8-9705-4E10-92E4-ADB3F2D98AB0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
@@ -27,7 +27,6 @@ export interface KeyStatsFormValues {
 }
 
 interface EditableKeyStatProps extends KeyStatProps {
-  id: string;
   isEditing?: boolean;
   name: string;
   onRemove?: () => void;
@@ -35,10 +34,10 @@ interface EditableKeyStatProps extends KeyStatProps {
 }
 
 const EditableKeyStat = ({
-  id,
   isEditing = false,
   name,
-  query,
+  releaseId,
+  dataBlockId,
   summary,
   testId = 'keyStat',
   onRemove,
@@ -47,12 +46,12 @@ const EditableKeyStat = ({
   const [showForm, toggleShowForm] = useToggle(false);
   const [removing, toggleRemoving] = useToggle(false);
 
-  const { value: keyStat, isLoading, error } = useKeyStatQuery({
-    ...query,
-    includeGeoJson: false,
-  });
+  const { value: keyStat, isLoading, error } = useKeyStatQuery(
+    releaseId,
+    dataBlockId,
+  );
 
-  const formId = `editableKeyStatForm-${id}`;
+  const formId = `editableKeyStatForm-${dataBlockId}`;
 
   const renderInner = () => {
     if (error || !keyStat) {

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
@@ -2,7 +2,6 @@ import EditableKeyStat, {
   KeyStatsFormValues,
 } from '@admin/components/editable/EditableKeyStat';
 import _tableBuilderService, {
-  TableDataQuery,
   TableDataResponse,
 } from '@common/services/tableBuilderService';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -17,21 +16,6 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
 >;
 
 describe('EditableKeyStat', () => {
-  const testQuery: TableDataQuery = {
-    filters: ['filter-1'],
-    indicators: ['indicator-1'],
-    subjectId: 'subject-1',
-    timePeriod: {
-      startCode: 'AY',
-      startYear: 2020,
-      endCode: 'AY',
-      endYear: 2020,
-    },
-    locations: {
-      country: ['england'],
-    },
-  };
-
   const testTableDataResponse: TableDataResponse = {
     subjectMeta: {
       publicationName: 'Test publication',
@@ -92,14 +76,16 @@ describe('EditableKeyStat', () => {
   };
 
   test('renders correctly with read-only summary', async () => {
-    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
 
     render(
       <EditableKeyStat
-        id="test-id-1"
+        releaseId="release-1"
+        dataBlockId="block-1"
         name="Key Stat 1"
         onSubmit={noop}
-        query={testQuery}
         summary={{
           dataSummary: ['Down from 620,330 in 2017'],
           dataDefinitionTitle: ['What is the number of applications received?'],
@@ -112,7 +98,9 @@ describe('EditableKeyStat', () => {
     );
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
+        1,
+      );
 
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'Number of applications received',
@@ -137,19 +125,23 @@ describe('EditableKeyStat', () => {
   });
 
   test('renders correctly without read-only summary', async () => {
-    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
 
     render(
       <EditableKeyStat
-        id="test-id-1"
+        releaseId="release-1"
+        dataBlockId="block-1"
         name="Key Stat 1"
         onSubmit={noop}
-        query={testQuery}
       />,
     );
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
+        1,
+      );
 
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'Number of applications received',
@@ -165,15 +157,17 @@ describe('EditableKeyStat', () => {
   });
 
   test('clicking Edit button renders editable summary form with no initial summary', async () => {
-    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
 
     render(
       <EditableKeyStat
         isEditing
-        id="test-id-1"
+        releaseId="release-1"
+        dataBlockId="block-1"
         name="Key Stat 1"
         onSubmit={noop}
-        query={testQuery}
       />,
     );
 
@@ -198,15 +192,17 @@ describe('EditableKeyStat', () => {
   });
 
   test('clicking Edit button renders editable summary form with initial summary', async () => {
-    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
 
     render(
       <EditableKeyStat
         isEditing
-        id="test-id-1"
+        releaseId="release-1"
+        dataBlockId="block-1"
         name="Key Stat 1"
         onSubmit={noop}
-        query={testQuery}
         summary={{
           dataSummary: ['Down from 620,330 in 2017'],
           dataDefinitionTitle: ['What is the number of applications received?'],
@@ -247,16 +243,18 @@ describe('EditableKeyStat', () => {
   test('clicking Remove button calls the `onRemove` callback prop', async () => {
     const handleRemove = jest.fn();
 
-    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
 
     render(
       <EditableKeyStat
         isEditing
-        id="test-id-1"
+        releaseId="release-1"
+        dataBlockId="block-1"
         name="Key Stat 1"
         onRemove={handleRemove}
         onSubmit={noop}
-        query={testQuery}
         summary={{
           dataSummary: ['Down from 620,330 in 2017'],
           dataDefinitionTitle: ['What is the number of applications received?'],
@@ -282,15 +280,17 @@ describe('EditableKeyStat', () => {
   });
 
   test('clicking Cancel button shows read-only summary again', async () => {
-    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
 
     render(
       <EditableKeyStat
         isEditing
-        id="test-id-1"
+        releaseId="release-1"
+        dataBlockId="block-1"
         name="Key Stat 1"
         onSubmit={noop}
-        query={testQuery}
         summary={{
           dataSummary: ['Down from 620,330 in 2017'],
           dataDefinitionTitle: ['What is the number of applications received?'],
@@ -346,15 +346,17 @@ describe('EditableKeyStat', () => {
   test('can submit with updated summary field values', async () => {
     const handleSubmit = jest.fn();
 
-    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
 
     render(
       <EditableKeyStat
         isEditing
-        id="test-id-1"
+        releaseId="release-1"
+        dataBlockId="block-1"
         name="Key Stat 1"
         onSubmit={handleSubmit}
-        query={testQuery}
       />,
     );
 
@@ -393,17 +395,17 @@ describe('EditableKeyStat', () => {
   });
 
   test('renders correctly if there was an error fetching the table data', async () => {
-    tableBuilderService.getTableData.mockRejectedValue(
+    tableBuilderService.getDataBlockTableData.mockRejectedValue(
       new Error('Something went wrong'),
     );
 
     render(
       <EditableKeyStat
-        id="test-id-1"
+        releaseId="release-1"
+        dataBlockId="block-1"
         name="Key Stat 1"
         onRemove={noop}
         onSubmit={noop}
-        query={testQuery}
         summary={{
           dataSummary: ['Down from 620,330 in 2017'],
           dataDefinitionTitle: ['What is the number of applications received?'],
@@ -416,7 +418,9 @@ describe('EditableKeyStat', () => {
     );
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
+        1,
+      );
       expect(screen.getByText('Could not load key stat')).toBeInTheDocument();
       expect(
         screen.getByRole('button', { name: 'Remove' }),
@@ -435,7 +439,7 @@ describe('EditableKeyStat', () => {
   });
 
   test('renders correctly if there is no matching result in the response', async () => {
-    tableBuilderService.getTableData.mockResolvedValue({
+    tableBuilderService.getDataBlockTableData.mockResolvedValue({
       ...testTableDataResponse,
       subjectMeta: {
         ...testTableDataResponse.subjectMeta,
@@ -453,11 +457,11 @@ describe('EditableKeyStat', () => {
 
     render(
       <EditableKeyStat
-        id="test-id-1"
+        releaseId="release-1"
+        dataBlockId="block-1"
         name="Key Stat 1"
         onRemove={noop}
         onSubmit={noop}
-        query={testQuery}
         summary={{
           dataSummary: ['Down from 620,330 in 2017'],
           dataDefinitionTitle: ['What is the number of applications received?'],
@@ -470,7 +474,9 @@ describe('EditableKeyStat', () => {
     );
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
+        1,
+      );
       expect(screen.getByText('Could not load key stat')).toBeInTheDocument();
       expect(
         screen.getByRole('button', { name: 'Remove' }),
@@ -491,17 +497,17 @@ describe('EditableKeyStat', () => {
   test('clicking Remove button when there has been an error calls the `onRemove` callback prop', async () => {
     const handleRemove = jest.fn();
 
-    tableBuilderService.getTableData.mockRejectedValue(
+    tableBuilderService.getDataBlockTableData.mockRejectedValue(
       new Error('Something went wrong'),
     );
 
     render(
       <EditableKeyStat
-        id="test-id-1"
+        releaseId="release-1"
+        dataBlockId="block-1"
         name="Key Stat 1"
         onRemove={handleRemove}
         onSubmit={noop}
-        query={testQuery}
         summary={{
           dataSummary: ['Down from 620,330 in 2017'],
           dataDefinitionTitle: ['What is the number of applications received?'],

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatSelectForm.tsx
@@ -57,10 +57,8 @@ const KeyStatSelectForm = ({
         >
           <KeyStat
             summary={selectedDataBlock.summary}
-            query={{
-              ...selectedDataBlock.query,
-              releaseId,
-            }}
+            releaseId={releaseId}
+            dataBlockId={selectedDataBlock.id}
           />
         </Details>
       </section>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
@@ -38,12 +38,9 @@ const KeyStatistics = ({ release, isEditing }: KeyStatisticsProps) => {
           .map(block => (
             <EditableKeyStat
               key={block.id}
-              id={block.id}
               name={block.name}
-              query={{
-                ...block.query,
-                releaseId: release.id,
-              }}
+              releaseId={release.id}
+              dataBlockId={block.id}
               summary={block.summary}
               isEditing={isEditing}
               onRemove={async () => {

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -7,9 +7,7 @@ import withLazyLoad from '@common/hocs/withLazyLoad';
 import ChartRenderer from '@common/modules/charts/components/ChartRenderer';
 import { GetInfographic } from '@common/modules/charts/components/InfographicBlock';
 import { AxesConfiguration } from '@common/modules/charts/types/chart';
-import useTableQuery, {
-  TableQueryOptions,
-} from '@common/modules/find-statistics/hooks/useTableQuery';
+import useTableQuery from '@common/modules/find-statistics/hooks/useTableQuery';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
 import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/getDefaultTableHeadersConfig';
 import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
@@ -26,8 +24,7 @@ export interface DataBlockTabsProps {
   lastTabs?: ReactNode;
   getInfographic?: GetInfographic;
   id?: string;
-  releaseId?: string;
-  queryOptions?: TableQueryOptions;
+  releaseId: string;
   onToggle?: (section: { id: string; title: string }) => void;
 }
 
@@ -39,16 +36,11 @@ const DataBlockTabs = ({
   getInfographic,
   id = `dataBlock-${dataBlock.id}`,
   releaseId,
-  queryOptions,
   onToggle,
 }: DataBlockTabsProps) => {
   const { value: fullTable, isLoading, error } = useTableQuery(
-    {
-      ...dataBlock.query,
-      releaseId,
-      includeGeoJson: dataBlock.charts.some(chart => chart.type === 'map'),
-    },
-    queryOptions,
+    releaseId,
+    dataBlock.id,
   );
 
   const errorMessage = <WarningMessage>Could not load content</WarningMessage>;

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/KeyStat.tsx
@@ -2,8 +2,6 @@ import Details from '@common/components/Details';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import KeyStatTile from '@common/modules/find-statistics/components/KeyStatTile';
 import useKeyStatQuery from '@common/modules/find-statistics/hooks/useKeyStatQuery';
-import { TableQueryOptions } from '@common/modules/find-statistics/hooks/useTableQuery';
-import { ReleaseTableDataQuery } from '@common/services/tableBuilderService';
 import { Summary } from '@common/services/types/blocks';
 import React, { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -32,25 +30,22 @@ export const KeyStatColumn = ({ children, testId }: KeyStatColumnProps) => {
 
 export interface KeyStatProps {
   children?: ReactNode;
-  query: ReleaseTableDataQuery;
-  queryOptions?: TableQueryOptions;
+  releaseId: string;
+  dataBlockId: string;
   summary?: Summary;
   testId?: string;
 }
 
 const KeyStat = ({
   children,
-  query,
-  queryOptions,
   summary,
+  releaseId,
+  dataBlockId,
   testId = 'keyStat',
 }: KeyStatProps) => {
   const { value: keyStat, isLoading, error } = useKeyStatQuery(
-    {
-      ...query,
-      includeGeoJson: false,
-    },
-    queryOptions,
+    releaseId,
+    dataBlockId,
   );
 
   if (error) {

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/DataBlockTabs.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/DataBlockTabs.test.tsx
@@ -9,9 +9,7 @@ import {
 import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/getDefaultTableHeadersConfig';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import mapUnmappedTableHeaders from '@common/modules/table-tool/utils/mapUnmappedTableHeaders';
-import _tableBuilderService, {
-  ReleaseTableDataQuery,
-} from '@common/services/tableBuilderService';
+import _tableBuilderService from '@common/services/tableBuilderService';
 import { Chart, DataBlock } from '@common/services/types/blocks';
 import { screen, waitFor } from '@testing-library/dom';
 import { render } from '@testing-library/react';
@@ -30,7 +28,7 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
 
 describe('DataBlockTabs', () => {
   const testDataBlock: DataBlock = {
-    id: 'test-id',
+    id: 'block-1',
     type: 'DataBlock',
     heading: '',
     order: 0,
@@ -85,7 +83,7 @@ describe('DataBlockTabs', () => {
   };
 
   const testDataBlockMap: DataBlock = {
-    id: 'test-id',
+    id: 'block-1',
     type: 'DataBlock',
     heading: '',
     order: 0,
@@ -134,20 +132,17 @@ describe('DataBlockTabs', () => {
   };
 
   test('renders error message if table response is error', async () => {
-    tableBuilderService.getTableData.mockImplementation(() =>
-      // eslint-disable-next-line prefer-promise-reject-errors
-      Promise.reject({
-        isAxiosError: true,
-        message: 'Something went wrong',
-        response: {
-          status: 500,
-        },
-      } as AxiosError),
-    );
+    tableBuilderService.getDataBlockTableData.mockRejectedValue({
+      isAxiosError: true,
+      message: 'Something went wrong',
+      response: {
+        status: 500,
+      },
+    } as AxiosError);
 
     render(
       <DataBlockTabs
-        releaseId="test-release-id"
+        releaseId="release-1"
         id="test-datablock"
         dataBlock={{
           ...testDataBlock,
@@ -159,31 +154,27 @@ describe('DataBlockTabs', () => {
     forceVisible();
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toBeCalledWith({
-        ...testDataBlock.query,
-        releaseId: 'test-release-id',
-        includeGeoJson: false,
-      } as ReleaseTableDataQuery);
+      expect(tableBuilderService.getDataBlockTableData).toBeCalledWith(
+        'release-1',
+        'block-1',
+      );
 
       expect(screen.getAllByText('Could not load content')).toHaveLength(2);
     });
   });
 
   test('renders nothing if table response is 403', async () => {
-    tableBuilderService.getTableData.mockImplementation(() =>
-      // eslint-disable-next-line prefer-promise-reject-errors
-      Promise.reject({
-        isAxiosError: true,
-        message: 'Forbidden',
-        response: {
-          status: 403,
-        },
-      } as AxiosError),
-    );
+    tableBuilderService.getDataBlockTableData.mockRejectedValue({
+      isAxiosError: true,
+      message: 'Forbidden',
+      response: {
+        status: 403,
+      },
+    } as AxiosError);
 
     render(
       <DataBlockTabs
-        releaseId="test-release-id"
+        releaseId="release-1"
         id="test-datablock"
         dataBlock={{
           ...testDataBlock,
@@ -195,11 +186,10 @@ describe('DataBlockTabs', () => {
     forceVisible();
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toBeCalledWith({
-        ...testDataBlock.query,
-        releaseId: 'test-release-id',
-        includeGeoJson: false,
-      } as ReleaseTableDataQuery);
+      expect(tableBuilderService.getDataBlockTableData).toBeCalledWith(
+        'release-1',
+        'block-1',
+      );
 
       expect(
         screen.queryByText('Could not load content'),
@@ -209,13 +199,13 @@ describe('DataBlockTabs', () => {
   });
 
   test('renders line chart', async () => {
-    tableBuilderService.getTableData.mockImplementation(() =>
-      Promise.resolve(testChartTableData),
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testChartTableData,
     );
 
     const { container } = render(
       <DataBlockTabs
-        releaseId="test-release-id"
+        releaseId="release-1"
         id="test-datablock"
         dataBlock={{
           ...testDataBlock,
@@ -227,11 +217,10 @@ describe('DataBlockTabs', () => {
     forceVisible();
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toBeCalledWith({
-        ...testDataBlock.query,
-        releaseId: 'test-release-id',
-        includeGeoJson: false,
-      } as ReleaseTableDataQuery);
+      expect(tableBuilderService.getDataBlockTableData).toBeCalledWith(
+        'release-1',
+        'block-1',
+      );
 
       expect(screen.getAllByRole('tab')).toHaveLength(2);
 
@@ -240,13 +229,13 @@ describe('DataBlockTabs', () => {
   });
 
   test('renders horizontal chart', async () => {
-    tableBuilderService.getTableData.mockImplementation(() =>
-      Promise.resolve(testChartTableData),
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testChartTableData,
     );
 
     const { container } = render(
       <DataBlockTabs
-        releaseId="test-release-id"
+        releaseId="release-1"
         id="test-block"
         dataBlock={{
           ...testDataBlock,
@@ -263,11 +252,10 @@ describe('DataBlockTabs', () => {
     forceVisible();
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toBeCalledWith({
-        ...testDataBlock.query,
-        releaseId: 'test-release-id',
-        includeGeoJson: false,
-      } as ReleaseTableDataQuery);
+      expect(tableBuilderService.getDataBlockTableData).toBeCalledWith(
+        'release-1',
+        'block-1',
+      );
 
       expect(screen.getAllByRole('tab')).toHaveLength(2);
       expect(container.querySelectorAll('.recharts-bar')).toHaveLength(3);
@@ -275,13 +263,13 @@ describe('DataBlockTabs', () => {
   });
 
   test('renders vertical chart', async () => {
-    tableBuilderService.getTableData.mockImplementation(() => {
-      return Promise.resolve(testChartTableData);
-    });
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testChartTableData,
+    );
 
     const { container } = render(
       <DataBlockTabs
-        releaseId="test-release-id"
+        releaseId="release-1"
         id="test-block"
         dataBlock={{
           ...testDataBlock,
@@ -298,11 +286,10 @@ describe('DataBlockTabs', () => {
     forceVisible();
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toBeCalledWith({
-        ...testDataBlock.query,
-        releaseId: 'test-release-id',
-        includeGeoJson: false,
-      } as ReleaseTableDataQuery);
+      expect(tableBuilderService.getDataBlockTableData).toBeCalledWith(
+        'release-1',
+        'block-1',
+      );
 
       expect(screen.getAllByRole('tab')).toHaveLength(2);
       expect(container.querySelectorAll('.recharts-bar')).toHaveLength(3);
@@ -310,15 +297,15 @@ describe('DataBlockTabs', () => {
   });
 
   test('renders table', async () => {
-    tableBuilderService.getTableData.mockImplementation(() => {
-      return Promise.resolve(testChartTableData);
-    });
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testChartTableData,
+    );
 
     const fullTable = mapFullTable(testChartTableData);
 
     render(
       <DataBlockTabs
-        releaseId="test-release-id"
+        releaseId="release-1"
         id="test-block"
         dataBlock={{
           ...testDataBlock,
@@ -339,11 +326,10 @@ describe('DataBlockTabs', () => {
     forceVisible();
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toBeCalledWith({
-        ...testDataBlock.query,
-        releaseId: 'test-release-id',
-        includeGeoJson: false,
-      } as ReleaseTableDataQuery);
+      expect(tableBuilderService.getDataBlockTableData).toBeCalledWith(
+        'release-1',
+        'block-1',
+      );
 
       expect(screen.getByRole('table')).toBeInTheDocument();
       expect(screen.getAllByRole('row')).toHaveLength(4);
@@ -352,13 +338,13 @@ describe('DataBlockTabs', () => {
   });
 
   test('renders map', async () => {
-    const getDataBlockForSubject = tableBuilderService.getTableData.mockImplementation(
-      () => Promise.resolve(testMapTableData),
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testMapTableData,
     );
 
     const { container } = render(
       <DataBlockTabs
-        releaseId="test-release-id"
+        releaseId="release-1"
         id="test-block"
         dataBlock={testDataBlockMap}
       />,
@@ -367,19 +353,18 @@ describe('DataBlockTabs', () => {
     forceVisible();
 
     await waitFor(() => {
-      expect(getDataBlockForSubject).toBeCalledWith({
-        ...testDataBlockMap.query,
-        releaseId: 'test-release-id',
-        includeGeoJson: true,
-      } as ReleaseTableDataQuery);
+      expect(tableBuilderService.getDataBlockTableData).toBeCalledWith(
+        'release-1',
+        'block-1',
+      );
 
       expect(container.querySelector('.leaflet-container')).toBeInTheDocument();
     });
   });
 
   test('re-rendering with new data block does not throw error', async () => {
-    tableBuilderService.getTableData.mockImplementation(() =>
-      Promise.resolve(testChartTableData),
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testChartTableData,
     );
 
     const fullTable = mapFullTable(testChartTableData);
@@ -387,6 +372,7 @@ describe('DataBlockTabs', () => {
     const { rerender } = render(
       <DataBlockTabs
         id="test-block"
+        releaseId="release-1"
         dataBlock={{
           ...testDataBlock,
           table: {
@@ -411,40 +397,40 @@ describe('DataBlockTabs', () => {
       expect(screen.getAllByRole('cell')).toHaveLength(16);
     });
 
-    tableBuilderService.getTableData.mockImplementation(() =>
-      Promise.resolve({
-        subjectMeta: {
-          ...testChartTableData.subjectMeta,
-          indicators: [
-            {
-              label: 'Number of authorised absence sessions',
-              unit: '',
-              value: 'authorised-absence-sessions',
-              name: 'absence_sess',
-            },
-          ],
-          timePeriodRange: [{ code: 'AY', label: '2018/19', year: 2018 }],
-        },
-        results: [
+    tableBuilderService.getDataBlockTableData.mockResolvedValue({
+      subjectMeta: {
+        ...testChartTableData.subjectMeta,
+        indicators: [
           {
-            filters: ['characteristic-total', 'school-type-total'],
-            geographicLevel: 'Country',
-            location: { country: { code: 'E92000001', name: 'England' } },
-            measures: {
-              'authorised-absence-sessions': '500000',
-            },
-            timePeriod: '2018_AY',
+            label: 'Number of authorised absence sessions',
+            unit: '',
+            value: 'authorised-absence-sessions',
+            name: 'absence_sess',
           },
         ],
-      }),
-    );
+        timePeriodRange: [{ code: 'AY', label: '2018/19', year: 2018 }],
+      },
+      results: [
+        {
+          filters: ['characteristic-total', 'school-type-total'],
+          geographicLevel: 'Country',
+          location: { country: { code: 'E92000001', name: 'England' } },
+          measures: {
+            'authorised-absence-sessions': '500000',
+          },
+          timePeriod: '2018_AY',
+        },
+      ],
+    });
 
     expect(() => {
       rerender(
         <DataBlockTabs
           id="test-block"
+          releaseId="release-1"
           dataBlock={{
             ...testDataBlock,
+            id: 'block-2-id',
             query: {
               subjectId: '1',
               geographicLevel: 'country',

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStat.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStat.test.tsx
@@ -1,6 +1,5 @@
 import KeyStat from '@common/modules/find-statistics/components/KeyStat';
 import _tableBuilderService, {
-  TableDataQuery,
   TableDataResponse,
 } from '@common/services/tableBuilderService';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -13,21 +12,6 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
 >;
 
 describe('KeyStat', () => {
-  const testQuery: TableDataQuery = {
-    filters: ['filter-1'],
-    indicators: ['indicator-1'],
-    subjectId: 'subject-1',
-    timePeriod: {
-      startCode: 'AY',
-      startYear: 2020,
-      endCode: 'AY',
-      endYear: 2020,
-    },
-    locations: {
-      country: ['england'],
-    },
-  };
-
   const testTableDataResponse: TableDataResponse = {
     subjectMeta: {
       publicationName: 'Test publication',
@@ -88,11 +72,14 @@ describe('KeyStat', () => {
   };
 
   test('renders correctly with summary', async () => {
-    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
 
     render(
       <KeyStat
-        query={testQuery}
+        releaseId="release-1"
+        dataBlockId="block-1"
         summary={{
           dataSummary: ['Down from 620,330 in 2017'],
           dataDefinitionTitle: ['What is the number of applications received?'],
@@ -105,7 +92,9 @@ describe('KeyStat', () => {
     );
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
+        1,
+      );
 
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'Number of applications received',
@@ -130,12 +119,16 @@ describe('KeyStat', () => {
   });
 
   test('renders correctly without summary', async () => {
-    tableBuilderService.getTableData.mockResolvedValue(testTableDataResponse);
+    tableBuilderService.getDataBlockTableData.mockResolvedValue(
+      testTableDataResponse,
+    );
 
-    render(<KeyStat query={testQuery} />);
+    render(<KeyStat releaseId="release-1" dataBlockId="block-1" />);
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
+        1,
+      );
 
       expect(screen.getByTestId('keyStat-title')).toHaveTextContent(
         'Number of applications received',
@@ -152,13 +145,14 @@ describe('KeyStat', () => {
   });
 
   test('does not render if there was an error fetching the table data', async () => {
-    tableBuilderService.getTableData.mockRejectedValue(
+    tableBuilderService.getDataBlockTableData.mockRejectedValue(
       new Error('Something went wrong'),
     );
 
     render(
       <KeyStat
-        query={testQuery}
+        releaseId="release-1"
+        dataBlockId="block-1"
         summary={{
           dataSummary: ['Down from 620,330 in 2017'],
           dataDefinitionTitle: ['What is the number of applications received?'],
@@ -171,7 +165,9 @@ describe('KeyStat', () => {
     );
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
+        1,
+      );
       expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
       expect(screen.queryByTestId('keyStat-value')).not.toBeInTheDocument();
       expect(screen.queryByTestId('keyStat-summary')).not.toBeInTheDocument();
@@ -183,7 +179,7 @@ describe('KeyStat', () => {
   });
 
   test('does not render if there is no matching result in the response', async () => {
-    tableBuilderService.getTableData.mockResolvedValue({
+    tableBuilderService.getDataBlockTableData.mockResolvedValue({
       ...testTableDataResponse,
       subjectMeta: {
         ...testTableDataResponse.subjectMeta,
@@ -201,7 +197,8 @@ describe('KeyStat', () => {
 
     render(
       <KeyStat
-        query={testQuery}
+        releaseId="release-1"
+        dataBlockId="block-1"
         summary={{
           dataSummary: ['Down from 620,330 in 2017'],
           dataDefinitionTitle: ['What is the number of applications received?'],
@@ -214,7 +211,9 @@ describe('KeyStat', () => {
     );
 
     await waitFor(() => {
-      expect(tableBuilderService.getTableData).toHaveBeenCalledTimes(1);
+      expect(tableBuilderService.getDataBlockTableData).toHaveBeenCalledTimes(
+        1,
+      );
       expect(screen.queryByTestId('keyStat-title')).not.toBeInTheDocument();
       expect(screen.queryByTestId('keyStat-value')).not.toBeInTheDocument();
       expect(screen.queryByTestId('keyStat-summary')).not.toBeInTheDocument();

--- a/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useKeyStatQuery.ts
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useKeyStatQuery.ts
@@ -3,10 +3,7 @@ import {
   AsyncStateSetterParam,
 } from '@common/hooks/useAsyncCallback';
 import { AsyncRetryState } from '@common/hooks/useAsyncRetry';
-import useTableQuery, {
-  TableQueryOptions,
-} from '@common/modules/find-statistics/hooks/useTableQuery';
-import { ReleaseTableDataQuery } from '@common/services/tableBuilderService';
+import useTableQuery from '@common/modules/find-statistics/hooks/useTableQuery';
 import formatPretty from '@common/utils/number/formatPretty';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -16,20 +13,14 @@ interface KeyStatResult {
 }
 
 export default function useKeyStatQuery(
-  query: ReleaseTableDataQuery,
-  options: TableQueryOptions = {},
+  releaseId: string,
+  dataBlockId: string,
 ): AsyncRetryState<KeyStatResult> {
   const {
     value: tableData,
     setState: setTableQueryState,
     ...tableQueryState
-  } = useTableQuery(
-    {
-      ...query,
-      includeGeoJson: false,
-    },
-    options,
-  );
+  } = useTableQuery(releaseId, dataBlockId);
 
   const [value, setValue] = useState<KeyStatResult>();
 

--- a/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useTableQuery.ts
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/hooks/useTableQuery.ts
@@ -1,54 +1,18 @@
 import useAsyncRetry, { AsyncRetryState } from '@common/hooks/useAsyncRetry';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
-import storageService from '@common/services/storageService';
-import tableBuilderService, {
-  ReleaseTableDataQuery,
-  TableDataResponse,
-} from '@common/services/tableBuilderService';
-import { addSeconds } from 'date-fns';
-import { useRef } from 'react';
-
-export interface TableQueryOptions {
-  /**
-   * When was the data last published.
-   * This is used for cache invalidation.
-   */
-  dataLastPublished?: string;
-  /**
-   * How long to cache the table
-   * query response for, in seconds.
-   */
-  expiresIn?: number;
-}
+import tableBuilderService from '@common/services/tableBuilderService';
 
 export default function useTableQuery(
-  query: ReleaseTableDataQuery,
-  options: TableQueryOptions = {},
+  releaseId: string,
+  dataBlockId: string,
 ): AsyncRetryState<FullTable> {
-  const optionsRef = useRef<TableQueryOptions>(options);
-  optionsRef.current = options;
-
   return useAsyncRetry(async () => {
-    const { dataLastPublished, expiresIn } = optionsRef.current;
-
-    const queryKey = JSON.stringify({
-      ...query,
-      dataLastPublished,
-    });
-
-    let response = await storageService
-      .get<TableDataResponse>(queryKey)
-      .catch(() => null);
-
-    if (!response) {
-      response = await tableBuilderService.getTableData(query);
-
-      await storageService.set(queryKey, response, {
-        expiry: addSeconds(new Date(), expiresIn ?? 0),
-      });
-    }
+    const response = await tableBuilderService.getDataBlockTableData(
+      releaseId,
+      dataBlockId,
+    );
 
     return mapFullTable(response);
-  }, [JSON.stringify(query)]);
+  }, [releaseId, dataBlockId]);
 }

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -200,11 +200,23 @@ const tableBuilderService = {
   }): Promise<SubjectMeta> {
     return dataApi.post('/meta/subject', query);
   },
-  getTableData(query: ReleaseTableDataQuery): Promise<TableDataResponse> {
-    if (query.releaseId) {
-      return dataApi.post(`/tablebuilder/release/${query.releaseId}`, query);
+  getTableData({
+    releaseId,
+    ...query
+  }: ReleaseTableDataQuery): Promise<TableDataResponse> {
+    if (releaseId) {
+      return dataApi.post(`/tablebuilder/release/${releaseId}`, query);
     }
+
     return dataApi.post(`/tablebuilder`, query);
+  },
+  getDataBlockTableData(
+    releaseId: string,
+    dataBlockId: string,
+  ): Promise<TableDataResponse> {
+    return dataApi.get(
+      `/tablebuilder/release/${releaseId}/datablock/${dataBlockId}`,
+    );
   },
 };
 

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationReleaseHeadlinesSection.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationReleaseHeadlinesSection.tsx
@@ -22,7 +22,6 @@ const PublicationReleaseHeadlinesSection = ({
     headlinesSection,
     publication,
     slug,
-    dataLastPublished,
   },
 }: Props) => {
   const getChartFile = useGetChartFile(publication.slug, slug);
@@ -38,15 +37,9 @@ const PublicationReleaseHeadlinesSection = ({
           return (
             <KeyStat
               key={block.id}
-              query={{
-                releaseId: id,
-                ...block.query,
-              }}
+              releaseId={id}
+              dataBlockId={block.id}
               summary={block.summary}
-              queryOptions={{
-                dataLastPublished,
-                expiresIn: 60 * 60 * 24,
-              }}
             />
           );
         })}
@@ -69,10 +62,6 @@ const PublicationReleaseHeadlinesSection = ({
       getInfographic={getChartFile}
       dataBlock={keyStatisticsSecondarySection.content[0]}
       firstTabs={summaryTab}
-      queryOptions={{
-        dataLastPublished,
-        expiresIn: 60 * 60 * 24,
-      }}
     />
   );
 };

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
@@ -17,7 +17,7 @@ const PublicationSectionBlocks = ({
   release,
   blocks,
 }: PublicationSectionBlocksProps) => {
-  const { dataLastPublished, slug, publication } = release;
+  const { slug, publication } = release;
 
   const getChartFile = useGetChartFile(publication.slug, slug);
 
@@ -31,10 +31,6 @@ const PublicationSectionBlocks = ({
               dataBlock={block}
               releaseId={release.id}
               getInfographic={getChartFile}
-              queryOptions={{
-                expiresIn: 60 * 60 * 24,
-                dataLastPublished,
-              }}
               onToggle={section => {
                 logEvent(
                   'Publication Release Data Tabs',


### PR DESCRIPTION
:warning: Depends on EES-1754
----

This PR adds a new endpoint in data and admin APIs to perform table queries based solely on the data block's persisted query (`/data/releases/{releaseId}/datablock/{dataBlockId}`). We are able to implement this as a GET method, allowing us to use HTTP caching headers to prevent unnecessary load on release pages in the public frontend. Note that we only implement this caching for the public frontend (not the admin).

For now the caching rules are as follows:
- `Cache-Control` of `public` with `max-age` of 300 seconds (5 minutes)
- `Last-Modified` with the release's last published date

We should expect that once a release has been published, its associated data block table query responses will be automatically cached by the browser. This will continue until any amendment is made to the release (or the browser cache is flushed), in which case there is a cache-miss and the the full table query is performed again.

We hope that this should provide more of a robust caching solution than the client-side caching implementation using local storage. This should fix the following issues:

- The local storage cache could potentially fill up (relatively easy to do if you browse through a bunch of releases), causing attempts to cache new table query responses to fail and break relevant data blocks.
- Avoids large table query responses (e.g. for maps) having slow IO for fetching into/out of local storage and potentially slow serialization/deserialization.

Unfortunately, this is not a **full** caching solution for a data block responses. Ideally we still need to actually cache the table responses server-side so that we can completely avoid hitting the database. This will be done in EES-1722.

## Relevant changes

- Removed client-side caching from public frontend. Code for client-side caching still exists in common, in case we need it for something else.
- Optimized data block table query endpoint to only fetch GeoJSON if the data block actually contains a map chart. This was previously done on the client-side.
- Added `Content.Security` project to house rules surrounding permission checks on `Content.Model` e.g. releases. This introduces a new `CanViewRelease` policy.
- Updated admin's authorization handlers to use the new `CanViewRelease` policy.

## Other changes

- Refactored data `ReleaseService.GetLatestPublishedRelease` to return a `Release?` instead of `Guid?` (as this is more useful).
- Moved `MockUtils` into `Common.Test.Utils`.
- Moved and generalised `PolicyCheckBuilder` into `Common.Test.Utils`.