### PR TITLE
EES-1759 Skip null or empty content before updating FastTrack links.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ReleaseTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ReleaseTests.cs
@@ -761,5 +761,87 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 amendmentContentBlock4.Body
             );
         }
+
+        [Fact]
+        public void CreateReleaseAmendment_UpdatesFastTrackLinkIds_NullHtmlBlockBody()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var section1Id = Guid.NewGuid();
+
+            var contentBlock = new HtmlBlock
+            {
+                Id = Guid.NewGuid(),
+                Order = 1,
+                Body = null,
+                ContentSectionId = section1Id
+            };
+
+            var dataBlock = new DataBlock
+            {
+                Id = Guid.NewGuid(),
+                Order = 2,
+                Heading = "Block 2 heading",
+                Name = "Block 2 name",
+                Source = "Block 2 source",
+                ContentSectionId = section1Id
+            };
+
+            release.Content = new List<ReleaseContentSection>
+            {
+                new ReleaseContentSection
+                {
+                    Release = release,
+                    ReleaseId = release.Id,
+                    ContentSectionId = section1Id,
+                    ContentSection = new ContentSection
+                    {
+                        Id = section1Id,
+                        Heading = "Section 1",
+                        Content = new List<ContentBlock>
+                        {
+                            contentBlock,
+                            dataBlock
+                        }
+                    }
+                }
+            };
+
+            release.ContentBlocks = new List<ReleaseContentBlock>
+            {
+                new ReleaseContentBlock
+                {
+                    ReleaseId = release.Id,
+                    Release = release,
+                    ContentBlockId = contentBlock.Id,
+                    ContentBlock = contentBlock
+                },
+                new ReleaseContentBlock
+                {
+                    ReleaseId = release.Id,
+                    Release = release,
+                    ContentBlockId = dataBlock.Id,
+                    ContentBlock =  dataBlock
+                }
+            };
+
+            var createdDate = DateTime.Now;
+            var createdById = Guid.NewGuid();
+
+            // Minimal test to make sure that a null HtmlBlock body doesn't affect creating a Release amendment
+            var amendment = release.CreateReleaseAmendment(createdDate, createdById);
+
+            Assert.Equal(2, amendment.ContentBlocks.Count);
+
+            var releaseBlock1 = amendment.ContentBlocks[0];
+            Assert.NotEqual(release.ContentBlocks[0].ContentBlockId, releaseBlock1.ContentBlockId);
+
+            var block1 = Assert.IsType<HtmlBlock>(releaseBlock1.ContentBlock);
+            Assert.NotEqual(release.ContentBlocks[0].ContentBlock.Id, block1.Id);
+            Assert.Null(block1.Body);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using Newtonsoft.Json;
@@ -261,7 +262,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         // Bit cheeky to re-use the clone context, but it's a nice
         // easy way to access and modify all of the content blocks
         // that we used during the clone.
-        private void UpdateAmendmentContent(CloneContext context)
+        private static void UpdateAmendmentContent(CloneContext context)
         {
             var dataBlocks = context.ContentBlocks
                 .Where(pair => pair.Key is DataBlock && pair.Value is DataBlock)
@@ -281,8 +282,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
             }
         }
 
-        private string UpdateFastTrackLinks(string content, Dictionary<DataBlock, DataBlock> dataBlocks)
+        private static string UpdateFastTrackLinks(string content, Dictionary<DataBlock, DataBlock> dataBlocks)
         {
+            if (content.IsNullOrEmpty())
+            {
+                return content;
+            }
+
             var nextContent = content;
 
             foreach (var (oldDataBlock, newDataBlock) in dataBlocks)


### PR DESCRIPTION
Skip null or empty content before updating FastTrack links.

If a user creates a text block but doesn't add any text, there was previously an error occurring when amending that Release if it also had data blocks.