### PR TITLE
EES-1785 Change PublisherExtensions#IsReleasePublished for amendment Releases not yet published

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Extensions/PublisherExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Extensions/PublisherExtensionTests.cs
@@ -12,14 +12,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Extensions
         public void IsReleasePublished_ReleasePublished()
         {
             var publication = new Publication();
-            
+
             var release = new Release
             {
                 Id = Guid.NewGuid(),
                 Publication = publication,
                 Published = DateTime.UtcNow.AddSeconds(-1)
             };
-            
+
             publication.Releases = new List<Release>
             {
                 release
@@ -32,14 +32,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Extensions
         public void IsReleasePublished_ReleaseNotPublished()
         {
             var publication = new Publication();
-            
+
             var release = new Release
             {
                 Id = Guid.NewGuid(),
                 Publication = publication,
                 Published = null
             };
-            
+
             publication.Releases = new List<Release>
             {
                 release
@@ -52,14 +52,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Extensions
         public void IsReleasePublished_ReleaseNotPublishedButIncluded()
         {
             var publication = new Publication();
-            
+
             var release = new Release
             {
                 Id = Guid.NewGuid(),
                 Publication = publication,
                 Published = null
             };
-            
+
             publication.Releases = new List<Release>
             {
                 release
@@ -68,6 +68,107 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Extensions
             Assert.True(release.IsReleasePublished(new List<Guid>
             {
                 release.Id
+            }));
+        }
+
+        [Fact]
+        public void IsReleasePublished_AmendmentReleaseNotPublished()
+        {
+            var publication = new Publication();
+
+            var originalRelease = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                Version = 0,
+                Published = DateTime.UtcNow.AddSeconds(-1)
+            };
+
+            var amendmentRelease = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                PreviousVersionId = originalRelease.Id,
+                Version = 1
+            };
+
+            publication.Releases = new List<Release>
+            {
+                originalRelease,
+                amendmentRelease
+            };
+
+            Assert.True(originalRelease.IsReleasePublished());
+            Assert.False(amendmentRelease.IsReleasePublished());
+        }
+
+        [Fact]
+        public void IsReleasePublished_AmendmentReleasePublished()
+        {
+            var publication = new Publication();
+
+            var originalRelease = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                Version = 0,
+                Published = DateTime.UtcNow.AddSeconds(-1)
+            };
+
+            var amendmentRelease = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                PreviousVersionId = originalRelease.Id,
+                Version = 1,
+                Published = DateTime.UtcNow.AddSeconds(-1)
+            };
+
+            publication.Releases = new List<Release>
+            {
+                originalRelease,
+                amendmentRelease
+            };
+
+            Assert.False(originalRelease.IsReleasePublished());
+            Assert.True(amendmentRelease.IsReleasePublished());
+        }
+
+        [Fact]
+        public void IsReleasePublished_AmendmentReleaseNotPublishedButIncluded()
+        {
+            var publication = new Publication();
+
+            var originalRelease = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                Version = 0,
+                Published = DateTime.UtcNow.AddSeconds(-1)
+            };
+
+            var amendmentRelease = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                PreviousVersionId = originalRelease.Id,
+                Version = 1
+            };
+
+            publication.Releases = new List<Release>
+            {
+                originalRelease,
+                amendmentRelease
+            };
+
+            Assert.False(originalRelease.IsReleasePublished(new List<Guid>
+            {
+                amendmentRelease.Id
+            }));
+
+            Assert.True(amendmentRelease.IsReleasePublished(new List<Guid>
+            {
+                amendmentRelease.Id
             }));
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Utils/PublisherUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Utils/PublisherUtils.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.Extensions.Hosting;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Utils
@@ -12,34 +9,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Utils
         {
             var environment = Environment.GetEnvironmentVariable("AZURE_FUNCTIONS_ENVIRONMENT");
             return environment?.Equals(EnvironmentName.Development) ?? false;
-        }
-
-        /// <summary>
-        /// Determines whether a Release will be the latest published version of a Release amongst a collection of Releases, i.e. no newer published amendments of that release exist or are about to be published.
-        /// </summary>
-        /// <param name="releases">Collection of Releases</param>
-        /// <param name="releaseId">The Release to test</param>
-        /// <param name="includedReleaseIds">Release id's which are not published yet but are in the process of being published</param>
-        /// <returns>True if the there's no published Release or included Releases referencing the specified Release as a previous version</returns>
-        public static bool IsLatestVersionOfRelease(IEnumerable<Release> releases, Release release, IEnumerable<Guid> includedReleaseIds)
-        {
-            if (!IsReleasePublished(release, includedReleaseIds))
-            {
-                return false;
-            }
-
-            return !releases.Any(r => r.PreviousVersionId == release.Id && IsReleasePublished(r, includedReleaseIds) && r.Id != release.Id);
-        }
-
-        /// <summary>
-        /// Determines whether a Release is published or not.
-        /// </summary>
-        /// <param name="release">The Release to test</param>
-        /// <param name="includedReleaseIds">Release id's which are not published yet but are in the process of being published</param>
-        /// <returns>True if the Release is published or is one of the included Releases</returns>
-        public static bool IsReleasePublished(Release release, IEnumerable<Guid> includedReleaseIds)
-        {
-            return release.Live || includedReleaseIds.Contains(release.Id);
         }
     }
 }


### PR DESCRIPTION
Change `PublisherExtensions#IsReleasePublished` to work correctly for amendment Releases not yet published but included for publishing.