### PR TITLE
EES-1791 Add new custom time periods for forthcoming ad-hoc Release

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/TimePeriodLabelFormatterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Services/TimePeriodLabelFormatterTests.cs
@@ -149,6 +149,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
         }
 
         [Fact]
+        public void FormatTimePeriodUsingCustomPeriodIdentifiers()
+        {
+            Assert.Equal($"{FormattedAcademicYear} Apr to Sep", Format(Year, CustomPeriod1));
+            Assert.Equal($"{FormattedAcademicYear} Oct to Mar", Format(Year, CustomPeriod2));
+        }
+
+        [Fact]
         public void FormatTimePeriodWithFullLabelFormat()
         {
             Assert.Equal($"{Year} Calendar Year", Format(Year, CalendarYear, FullLabel));
@@ -159,6 +166,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             Assert.Equal($"{Year} Reporting Year", Format(Year, ReportingYear, FullLabel));
             Assert.Equal($"{Year} January", Format(Year, January, FullLabel));
             Assert.Equal($"{FormattedAcademicYear} Autumn Term", Format(Year, AutumnTerm, FullLabel));
+            Assert.Equal($"{FormattedAcademicYear} April to September", Format(Year, CustomPeriod1, FullLabel));
         }
 
         [Fact]
@@ -172,6 +180,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             Assert.Equal($"Reporting Year {Year}", Format(Year, ReportingYear, FullLabelBeforeYear));
             Assert.Equal($"January {Year}", Format(Year, January, FullLabelBeforeYear));
             Assert.Equal($"Autumn Term {FormattedAcademicYear}", Format(Year, AutumnTerm, FullLabelBeforeYear));
+            Assert.Equal($"April to September {FormattedAcademicYear}", Format(Year, CustomPeriod1, FullLabelBeforeYear));
         }
 
         [Fact]
@@ -185,6 +194,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             Assert.Equal($"{Year}", Format(Year, ReportingYear, NoLabel));
             Assert.Equal($"{Year}", Format(Year, January, NoLabel));
             Assert.Equal($"{FormattedAcademicYear}", Format(Year, AutumnTerm, NoLabel));
+            Assert.Equal($"{FormattedAcademicYear}", Format(Year, CustomPeriod1, NoLabel));
         }
 
         [Fact]
@@ -198,6 +208,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             Assert.Equal($"{Year}", Format(Year, ReportingYear, ShortLabel));
             Assert.Equal($"{Year}", Format(Year, January, ShortLabel));
             Assert.Equal($"{FormattedAcademicYear}", Format(Year, AutumnTerm, ShortLabel));
+            Assert.Equal($"{FormattedAcademicYear} Apr to Sep", Format(Year, CustomPeriod1, ShortLabel));
         }
 
         [Fact(Skip = "Use this to debug")]
@@ -293,6 +304,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Services
             _testOutputHelper.WriteLine($"Format({Year}, Week50)            {Format(Year, Week50)}");
             _testOutputHelper.WriteLine($"Format({Year}, Week51)            {Format(Year, Week51)}");
             _testOutputHelper.WriteLine($"Format({Year}, Week52)            {Format(Year, Week52)}");
+            _testOutputHelper.WriteLine($"Format({Year}, CustomPeriod1)     {Format(Year, CustomPeriod1)}");
+            _testOutputHelper.WriteLine($"Format({Year}, CustomPeriod2)     {Format(Year, CustomPeriod2)}");
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifier.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifier.cs
@@ -275,6 +275,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         Week51,
 
         [TimeIdentifierMeta("Week 52", "W52", Week)]
-        Week52
+        Week52,
+
+        [TimeIdentifierMeta("April to September", "P1", CustomPeriod, Academic, ShortLabel, "Apr to Sep")]
+        CustomPeriod1,
+
+        [TimeIdentifierMeta("October to March", "P2", CustomPeriod, Academic, ShortLabel, "Oct to Mar")]
+        CustomPeriod2
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifierCategory.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifierCategory.cs
@@ -10,13 +10,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         [EnumLabelValue("Calendar year")]
         CalendarYear,
 
-        [EnumLabelValue("Financial Year")]
+        [EnumLabelValue("Financial year")]
         FinancialYear,
 
-        [EnumLabelValue("Tax Year")]
+        [EnumLabelValue("Tax year")]
         TaxYear,
 
-        [EnumLabelValue("Reporting Year")]
+        [EnumLabelValue("Reporting year")]
         ReportingYear,
 
         [EnumLabelValue("Term")]
@@ -26,6 +26,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         Month,
 
         [EnumLabelValue("Week")]
-        Week
+        Week,
+
+        [EnumLabelValue("Other")]
+        CustomPeriod
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Extensions/TimeIdentifierExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Extensions/TimeIdentifierExtensionsTests.cs
@@ -28,6 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Extensi
             Assert.True(SpringTerm.IsAlike(SpringTerm));
             Assert.True(ReportingYear.IsAlike(ReportingYear));
             Assert.True(Week1.IsAlike(Week1));
+            Assert.True(CustomPeriod1.IsAlike(CustomPeriod1));
         }
 
         [Fact]
@@ -73,6 +74,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Extensi
         }
 
         [Fact]
+        public void CustomPeriodsAreAlike()
+        {
+            AssertTimeIdentifiersAreAlike(TimeIdentifierUtil.GetCustomPeriods());
+        }
+
+        [Fact]
         public void TimeIdentifiersAreAcademicQuarters()
         {
             AssertTimeIdentifiersMeetCondition(identifier => identifier.IsAcademicQuarter(),
@@ -103,25 +110,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Extensi
         [Fact]
         public void TimeIdentifiersAreYears()
         {
-            AssertTimeIdentifiersMeetCondition(identifier => identifier.IsYear(), TimeIdentifierUtil.GetYears());
+            AssertTimeIdentifiersMeetCondition(identifier => identifier.IsYear(),
+                TimeIdentifierUtil.GetYears());
         }
 
         [Fact]
         public void TimeIdentifiersAreMonths()
         {
-            AssertTimeIdentifiersMeetCondition(identifier => identifier.IsMonth(), TimeIdentifierUtil.GetMonths());
+            AssertTimeIdentifiersMeetCondition(identifier => identifier.IsMonth(),
+                TimeIdentifierUtil.GetMonths());
         }
 
         [Fact]
         public void TimeIdentifiersAreWeeks()
         {
-            AssertTimeIdentifiersMeetCondition(identifier => identifier.IsWeek(), TimeIdentifierUtil.GetWeeks());
+            AssertTimeIdentifiersMeetCondition(identifier => identifier.IsWeek(),
+                TimeIdentifierUtil.GetWeeks());
         }
 
         [Fact]
         public void TimeIdentifiersAreTerms()
         {
-            AssertTimeIdentifiersMeetCondition(identifier => identifier.IsTerm(), TimeIdentifierUtil.GetTerms());
+            AssertTimeIdentifiersMeetCondition(identifier => identifier.IsTerm(),
+                TimeIdentifierUtil.GetTerms());
+        }
+
+        [Fact]
+        public void TimeIdentifiersAreCustomPeriods()
+        {
+            AssertTimeIdentifiersMeetCondition(identifier => identifier.IsCustomPeriod(),
+                TimeIdentifierUtil.GetCustomPeriods());
         }
 
         [Fact]
@@ -177,9 +195,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Extensi
         }
 
         [Fact]
-        public void GetAssociatedRangeForTermReturnsAssociatedRange()
+        public void GetAssociatedRangeForTermsReturnsAssociatedRange()
         {
             Assert.Equal(TimeIdentifierUtil.GetTerms(), AutumnTerm.GetAssociatedRange());
+        }
+
+        [Fact]
+        public void GetAssociatedRangeForCustomPeriodsReturnsAssociatedRange()
+        {
+            Assert.Equal(TimeIdentifierUtil.GetCustomPeriods(), CustomPeriod1.GetAssociatedRange());
         }
 
         private void AssertTimeIdentifiersMeetCondition(Func<TimeIdentifier, bool> condition,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimeIdentifierUtilTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimeIdentifierUtilTests.cs
@@ -157,5 +157,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 SummerTerm
             }, TimeIdentifierUtil.GetTerms());
         }
+
+        [Fact]
+        public void GetCustomPeriodsReturnsCustomPeriods()
+        {
+            Assert.Equal(new[]
+            {
+                CustomPeriod1,
+                CustomPeriod2
+            }, TimeIdentifierUtil.GetCustomPeriods());
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodUtilTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodUtilTests.cs
@@ -143,6 +143,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 SummerTerm
             };
 
+            var customPeriodIdentifiers = new[]
+            {
+                CustomPeriod1,
+                CustomPeriod2
+            };
+
             foreach (var identifier in _allTimeIdentifiers.Except(calendarQuarterIdentifiers))
             {
                 Assert.Throws<ArgumentException>(() =>
@@ -165,6 +171,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 Assert.Throws<ArgumentException>(() =>
                     TimePeriodUtil.Range(new TimePeriodQuery(2018, AutumnTerm, 2019, identifier)));
+            }
+
+            foreach (var identifier in _allTimeIdentifiers.Except(customPeriodIdentifiers))
+            {
+                Assert.Throws<ArgumentException>(() =>
+                    TimePeriodUtil.Range(new TimePeriodQuery(2018, CustomPeriod1, 2019, identifier)));
             }
 
             Assert.Throws<ArgumentException>(() =>
@@ -567,6 +579,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     (2020, AutumnTerm)
                 },
                 TimePeriodUtil.Range(new TimePeriodQuery(2018, SpringTerm, 2020, AutumnTerm)).ToList());
+        }
+
+        [Fact]
+        public void RangeIsGeneratedForCustomPeriodQuery()
+        {
+            CollectionAssert.AreEquivalent(
+                new List<(int Year, TimeIdentifier TimeIdentifier)>
+                {
+                    (2021, CustomPeriod1)
+                },
+                TimePeriodUtil.Range(new TimePeriodQuery(2021, CustomPeriod1, 2021, CustomPeriod1)).ToList());
+
+            CollectionAssert.AreEquivalent(
+                new List<(int Year, TimeIdentifier TimeIdentifier)>
+                {
+                    (2021, CustomPeriod1),
+                    (2021, CustomPeriod2)
+                },
+                TimePeriodUtil.Range(new TimePeriodQuery(2021, CustomPeriod1, 2021, CustomPeriod2)).ToList());
+
+            CollectionAssert.AreEquivalent(
+                new List<(int Year, TimeIdentifier TimeIdentifier)>
+                {
+                    (2020, CustomPeriod1),
+                    (2020, CustomPeriod2),
+                    (2021, CustomPeriod1)
+                },
+                TimePeriodUtil.Range(new TimePeriodQuery(2020, CustomPeriod1, 2021, CustomPeriod1)).ToList());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Extensions/TimeIdentifierExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Extensions/TimeIdentifierExtensions.cs
@@ -20,7 +20,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Extensions
                    IsTaxQuarter(timeIdentifier) && IsTaxQuarter(compare) ||
                    IsMonth(timeIdentifier) && IsMonth(compare) ||
                    IsWeek(timeIdentifier) && IsWeek(compare) ||
-                   IsTerm(timeIdentifier) && IsTerm(compare);
+                   IsTerm(timeIdentifier) && IsTerm(compare) ||
+                   IsCustomPeriod(timeIdentifier) && IsCustomPeriod(compare);
         }
 
         public static bool IsYear(this TimeIdentifier timeIdentifier)
@@ -63,6 +64,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Extensions
             return GetTerms().Contains(timeIdentifier);
         }
 
+        public static bool IsCustomPeriod(this TimeIdentifier timeIdentifier)
+        {
+            return GetCustomPeriods().Contains(timeIdentifier);
+        }
+
         public static bool HasAssociatedRange(this TimeIdentifier timeIdentifier)
         {
             return !timeIdentifier.IsYear();
@@ -103,6 +109,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Extensions
             if (timeIdentifier.IsTerm())
             {
                 return GetTerms();
+            }
+
+            if (timeIdentifier.IsCustomPeriod())
+            {
+                return GetCustomPeriods();
             }
 
             throw new ArgumentOutOfRangeException(nameof(timeIdentifier),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TimeIdentifierUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TimeIdentifierUtil.cs
@@ -6,6 +6,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 {
     public static class TimeIdentifierUtil
     {
+        public static TimeIdentifier[] GetCustomPeriods()
+        {
+            return Category.CustomPeriod.GetTimeIdentifiers();
+        }
+
         public static TimeIdentifier[] GetMonths()
         {
             return Category.Month.GetTimeIdentifiers();


### PR DESCRIPTION
Adds two new custom time periods to support an upcoming ad-hoc Release that is for data recorded between

- April to September
- October to March

Full label format `2020/21 October to March`
Full label before year format `October to March 2020/21`
Short label format `2020/21 Oct to Mar`
Slug format `2020-21-oct-to-mar`
Expected CSV `time_identifier` value format `October to March`

![image](https://user-images.githubusercontent.com/4147126/103892207-167cad80-50e3-11eb-826d-e8b7ca493665.png)
