### PR TITLE
EES-1694 Fix content blocks breaking on IE11 due to syntax errors

### DIFF
--- a/src/explore-education-statistics-frontend/next.config.js
+++ b/src/explore-education-statistics-frontend/next.config.js
@@ -130,7 +130,15 @@ const nextConfig = {
 };
 
 module.exports = compose(
-  withTranspileModules(['explore-education-statistics-common', '@common']),
+  withTranspileModules([
+    'explore-education-statistics-common',
+    // Need to add explicit dependencies as they
+    // may be un-transpiled (ES6+) and cause
+    // IE11 to throw syntax errors.
+    'sanitize-html',
+    'sanitize-html/node_modules',
+    'nanoid',
+  ]),
   withFonts,
   withImages,
   withESLint,

--- a/src/explore-education-statistics-frontend/package-lock.json
+++ b/src/explore-education-statistics-frontend/package-lock.json
@@ -5360,6 +5360,11 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@webcomponents/shadydom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadydom/-/shadydom-1.8.0.tgz",
+      "integrity": "sha512-GYTJ4dr4uUZnut80cA94tpXXVip2RdoJpGMnYNKgh/Diz5x1U/m9Dy0RwZEzoEd7v2aRfEICac7TQ1wc50EKbQ=="
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",

--- a/src/explore-education-statistics-frontend/package.json
+++ b/src/explore-education-statistics-frontend/package.json
@@ -67,6 +67,7 @@
     "@types/yup": "^0.28.3",
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.4.0",
+    "@webcomponents/shadydom": "^1.8.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.5.2",

--- a/src/explore-education-statistics-frontend/src/polyfill.js
+++ b/src/explore-education-statistics-frontend/src/polyfill.js
@@ -2,3 +2,9 @@ import 'cross-fetch/polyfill';
 import 'core-js/features/array/flat';
 import 'core-js/features/array/flat-map';
 import '@common/polyfill';
+
+// Polyfill for dev server breaking in IE11
+// See: https://github.com/vercel/next.js/issues/13231
+if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
+  require('@webcomponents/shadydom');
+}


### PR DESCRIPTION
This PR fixes syntax errors being thrown on IE11 due to un-transpiled code (ES6+) being included in the bundle. This originated from `sanitize-html@2.0` which no longer provides a pre-built version of their module (they expect you to transpile it yourself).