### PR TITLE
Ees 1806 performance quick wins with data block queries

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/FootnoteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/FootnoteRepository.cs
@@ -20,15 +20,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
             Guid releaseId,
             Guid subjectId,
             IQueryable<Observation> observations,
-            IEnumerable<Guid> indicators)
+            IEnumerable<Guid> indicatorIds)
         {
-            var filterItems = observations.SelectMany(observation => observation.FilterItems)
-                .Select(item => item.FilterItem.Id).Distinct();
+            var filterItemIds = observations.SelectMany(observation => observation.FilterItems)
+                .Select(item => item.FilterItemId).Distinct();
 
             var releaseIdParam = new SqlParameter("releaseId", releaseId);
             var subjectIdParam = new SqlParameter("subjectId", subjectId);
-            var indicatorListParam = CreateIdListType("indicatorList", indicators);
-            var filterItemListParam = CreateIdListType("filterItemList", filterItems);
+            var indicatorListParam = CreateIdListType("indicatorList", indicatorIds);
+            var filterItemListParam = CreateIdListType("filterItemList", filterItemIds);
 
             return _context
                 .Footnote

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/IFootnoteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/Interfaces/IFootnoteRepository.cs
@@ -11,7 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfa
             Guid releaseId,
             Guid subjectId,
             IQueryable<Observation> observations,
-            IEnumerable<Guid> indicators
+            IEnumerable<Guid> indicatorIds
         );
 
         Task<Footnote> GetFootnote(Guid id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
@@ -190,6 +190,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 // lines in total in which case create a zero lines batch
                 if (table.Rows.Count == 0 && (batchCount != numBatches || batchFilesExist))
                 {
+                    _logger.LogInformation($"Skipping batch file for row count {table.Rows.Count} with batchCount {batchCount} and numBatches {numBatches} and batchFilesExist {batchFilesExist} and batch {batch.Count()}");
                     batchCount++;
                     continue;
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
@@ -124,6 +124,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 .Where(o => ids.Contains(o.Id))
                 .ToList();
 
+            _logger.LogDebug($"Fetched {ids.Length} Observations from their ids in {phasesStopwatch.Elapsed.Milliseconds} ms");
+            phasesStopwatch.Restart();
+
             var locationIds = observations
                 .Select(o => o.LocationId);
             
@@ -135,7 +138,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
             observations.ForEach(o => o.Location = locations[o.LocationId]);
 
+            _logger.LogDebug($"Assigned Locations to {ids.Length} Observations in {phasesStopwatch.Elapsed.Milliseconds} ms");
+            phasesStopwatch.Restart();
+
             _logger.LogDebug($"Finished fetching {observations.Count} Observations in a total of {totalStopwatch.Elapsed.Milliseconds} ms");
+            totalStopwatch.Stop();
             phasesStopwatch.Stop();
             
             return observations;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
@@ -138,7 +138,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             // Load of the Location owned entities is removed from the Observation fetching code above as another
             // "Include" as it was generating very inefficient sql.	
             var locationIds = observations
-                .Select(o => o.LocationId);
+                .Select(o => o.LocationId)
+                .Distinct();
             
             var locations = _context
                 .Location

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
@@ -109,12 +109,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     planningAreaListParam,
                     filterItemListParam);
 
-            _logger.LogDebug($"Executed FilteredObservations stored procedure in {phasesStopwatch.Elapsed.Milliseconds} ms");
+            _logger.LogDebug($"Executed FilteredObservations stored procedure in {phasesStopwatch.Elapsed.TotalMilliseconds} ms");
             phasesStopwatch.Restart();
 
             var ids = inner.Select(obs => obs.Id).ToArray();
 
-            _logger.LogDebug($"Fetched {ids.Length} Observation ids from inner result in {phasesStopwatch.Elapsed.Milliseconds} ms");
+            _logger.LogDebug($"Fetched {ids.Length} Observation ids from inner result in {phasesStopwatch.Elapsed.TotalMilliseconds} ms");
             phasesStopwatch.Restart();
             
             var observations = _context
@@ -124,7 +124,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 .Where(o => ids.Contains(o.Id))
                 .ToList();
 
-            _logger.LogDebug($"Fetched {ids.Length} Observations from their ids in {phasesStopwatch.Elapsed.Milliseconds} ms");
+            _logger.LogDebug($"Fetched {ids.Length} Observations from their ids in {phasesStopwatch.Elapsed.TotalMilliseconds} ms");
             phasesStopwatch.Restart();
 
             // Load of the Location owned entities is removed from the Observation fetching code above as another
@@ -140,13 +140,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
             observations.ForEach(o => o.Location = locations[o.LocationId]);
 
-            _logger.LogDebug($"Assigned Locations to {ids.Length} Observations in {phasesStopwatch.Elapsed.Milliseconds} ms");
-            phasesStopwatch.Restart();
-
-            _logger.LogDebug($"Finished fetching {observations.Count} Observations in a total of {totalStopwatch.Elapsed.Milliseconds} ms");
-            totalStopwatch.Stop();
-            phasesStopwatch.Stop();
+            _logger.LogDebug($"Assigned Locations to {ids.Length} Observations in {phasesStopwatch.Elapsed.TotalMilliseconds} ms");
             
+            _logger.LogDebug($"Finished fetching {observations.Count} Observations in a total of {totalStopwatch.Elapsed.TotalMilliseconds} ms");
             return observations;
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
@@ -127,6 +127,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             _logger.LogDebug($"Fetched {ids.Length} Observations from their ids in {phasesStopwatch.Elapsed.Milliseconds} ms");
             phasesStopwatch.Restart();
 
+            // Load of the Location owned entities is removed from the Observation fetching code above as another
+            // "Include" as it was generating very inefficient sql.	
             var locationIds = observations
                 .Select(o => o.LocationId);
             

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TableBuilderService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -80,7 +79,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 .OnSuccessDo(CheckCanViewSubjectData)
                 .OnSuccess(async () =>
                 {
-                    var observations = GetObservations(queryContext).AsQueryable();
+                    var observations = _observationService.FindObservations(queryContext).AsQueryable();
 
                     if (!observations.Any())
                     {
@@ -110,11 +109,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             }
 
             return new ForbidResult();
-        }
-
-        private IEnumerable<Observation> GetObservations(ObservationQueryContext queryContext)
-        {
-            return _observationService.FindObservations(queryContext);
         }
     }
 }


### PR DESCRIPTION
This PR:

- cuts out unnecessary joins to fetch Filters from Observations when returning for data block queries and meta queries.  The Filters are never used by the calling code.  A more robust approach to this would be to return an `ObservationRowResult` or some other class that contained just what the calling code actually needed from the Observations, namely the FilterItem IDs and nothing more (as per on the EES-1795 branch)
- fixes issue whereby if Observation results were in several batches, the Locations were being selected and reapplied to previous batches of Observations each time a new batch was processed (look how `result` is used as a basis to find Location IDs and then select and assign those found Locations to everything in `result` again and again. 