### PR TITLE
EES-1807 Relax PRA public list checklist rule to warning

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
@@ -98,7 +98,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.False(checklist.Right.Valid);
 
-                Assert.Equal(6, checklist.Right.Errors.Count);
+                Assert.Equal(5, checklist.Right.Errors.Count);
 
                 Assert.Equal(DataFileImportsMustBeCompleted, checklist.Right.Errors[0].Code);
                 Assert.Equal(DataFileReplacementsMustBeCompleted, checklist.Right.Errors[1].Code);
@@ -109,8 +109,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(publication.MethodologyId, methodologyMustBeApprovedError.MethodologyId);
 
                 Assert.Equal(PublicMetaGuidanceRequired, checklist.Right.Errors[3].Code);
-                Assert.Equal(PublicPreReleaseAccessListRequired, checklist.Right.Errors[4].Code);
-                Assert.Equal(ReleaseNoteRequired, checklist.Right.Errors[5].Code);
+                Assert.Equal(ReleaseNoteRequired, checklist.Right.Errors[4].Code);
             }
         }
 
@@ -160,10 +159,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.False(checklist.Right.Valid);
 
-                Assert.Equal(3, checklist.Right.Warnings.Count);
+                Assert.Equal(4, checklist.Right.Warnings.Count);
                 Assert.Equal(NoMethodology, checklist.Right.Warnings[0].Code);
                 Assert.Equal(NoNextReleaseDate, checklist.Right.Warnings[1].Code);
                 Assert.Equal(NoDataFiles, checklist.Right.Warnings[2].Code);
+                Assert.Equal(NoPublicPreReleaseAccessList, checklist.Right.Warnings[3].Code);
             }
         }
 
@@ -269,7 +269,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.False(checklist.Right.Valid);
 
-                Assert.Equal(4, checklist.Right.Warnings.Count);
+                Assert.Equal(5, checklist.Right.Warnings.Count);
                 Assert.Equal(NoMethodology, checklist.Right.Warnings[0].Code);
                 Assert.Equal(NoNextReleaseDate, checklist.Right.Warnings[1].Code);
 
@@ -278,6 +278,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(1, noFootnotesWarning.TotalSubjects);
 
                 Assert.Equal(NoTableHighlights, checklist.Right.Warnings[3].Code);
+                Assert.Equal(NoPublicPreReleaseAccessList, checklist.Right.Warnings[4].Code);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
@@ -101,11 +101,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 errors.Add(new ReleaseChecklistIssue(ValidationErrorMessages.PublicMetaGuidanceRequired));
             }
 
-            if (release.PreReleaseAccessList.IsNullOrEmpty())
-            {
-                errors.Add(new ReleaseChecklistIssue(ValidationErrorMessages.PublicPreReleaseAccessListRequired));
-            }
-
             if (release.Amendment && release.Updates.All(update => update.ReleaseId != release.Id))
             {
                 errors.Add(new ReleaseChecklistIssue(ValidationErrorMessages.ReleaseNoteRequired));
@@ -164,6 +159,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 {
                     warnings.Add(new ReleaseChecklistIssue(ValidationErrorMessages.NoTableHighlights));
                 }
+            }
+
+            if (release.PreReleaseAccessList.IsNullOrEmpty())
+            {
+                warnings.Add(new ReleaseChecklistIssue(ValidationErrorMessages.NoPublicPreReleaseAccessList));
             }
 
             return warnings;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -153,7 +153,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         DataFileReplacementsMustBeCompleted,
         ReleaseNoteRequired,
         PublicMetaGuidanceRequired,
-        PublicPreReleaseAccessListRequired,
 
         // Release checklist warnings
         NoMethodology,
@@ -161,5 +160,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         NoDataFiles,
         NoFootnotesOnSubjects,
         NoTableHighlights,
+        NoPublicPreReleaseAccessList,
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
@@ -82,14 +82,6 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
               releaseRouteParams,
             )}#${releaseDataPageTabIds.metaGuidance}`,
           };
-        case 'PublicPreReleaseAccessListRequired':
-          return {
-            message: 'Public pre-release access list is required',
-            link: `${generatePath<ReleaseRouteParams>(
-              releasePreReleaseAccessRoute.path,
-              releaseRouteParams,
-            )}#${releasePreReleaseAccessPageTabs.publicAccessList}`,
-          };
         case 'ReleaseNoteRequired':
           return {
             message: 'Public release note for this amendment is required',
@@ -149,6 +141,14 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
               releaseDataBlocksRoute.path,
               releaseRouteParams,
             ),
+          };
+        case 'NoPublicPreReleaseAccessList':
+          return {
+            message: 'No public pre-release access list',
+            link: `${generatePath<ReleaseRouteParams>(
+              releasePreReleaseAccessRoute.path,
+              releaseRouteParams,
+            )}#${releasePreReleaseAccessPageTabs.publicAccessList}`,
           };
         default:
           // Show warning code, even if there is no mapping,

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
@@ -48,7 +48,6 @@ describe('ReleaseStatusChecklist', () => {
                 methodologyId: 'methodology-1',
               },
               { code: 'PublicMetaGuidanceRequired' },
-              { code: 'PublicPreReleaseAccessListRequired' },
               { code: 'ReleaseNoteRequired' },
             ],
           }}
@@ -65,7 +64,7 @@ describe('ReleaseStatusChecklist', () => {
       screen.queryByRole('heading', { name: 'Warnings' }),
     ).not.toBeInTheDocument();
 
-    expect(screen.getByText('6 issues')).toBeInTheDocument();
+    expect(screen.getByText('5 issues')).toBeInTheDocument();
 
     expect(
       screen.getByRole('link', {
@@ -102,15 +101,6 @@ describe('ReleaseStatusChecklist', () => {
 
     expect(
       screen.getByRole('link', {
-        name: 'Public pre-release access list is required',
-      }),
-    ).toHaveAttribute(
-      'href',
-      '/publication/publication-1/release/release-1/prerelease-access#preReleaseAccess-publicList',
-    );
-
-    expect(
-      screen.getByRole('link', {
         name: 'Public release note for this amendment is required',
       }),
     ).toHaveAttribute(
@@ -131,6 +121,7 @@ describe('ReleaseStatusChecklist', () => {
               { code: 'NoFootnotesOnSubjects', totalSubjects: 3 },
               { code: 'NoTableHighlights' },
               { code: 'NoDataFiles' },
+              { code: 'NoPublicPreReleaseAccessList' },
             ],
             errors: [],
           }}
@@ -149,7 +140,7 @@ describe('ReleaseStatusChecklist', () => {
       screen.getByRole('heading', { name: 'Warnings' }),
     ).toBeInTheDocument();
 
-    expect(screen.getByText('5 potential issues')).toBeInTheDocument();
+    expect(screen.getByText('6 potential issues')).toBeInTheDocument();
 
     expect(
       screen.getByRole('link', {
@@ -188,6 +179,15 @@ describe('ReleaseStatusChecklist', () => {
     ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-1/data#data-uploads',
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: 'No public pre-release access list',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/prerelease-access#preReleaseAccess-publicList',
     );
   });
 

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -116,7 +116,6 @@ export type ReleaseChecklistError =
         | 'DataFileImportsMustBeCompleted'
         | 'DataFileReplacementsMustBeCompleted'
         | 'PublicMetaGuidanceRequired'
-        | 'PublicPreReleaseAccessListRequired'
         | 'ReleaseNoteRequired';
     }
   | {
@@ -130,7 +129,8 @@ export type ReleaseChecklistWarning =
         | 'NoMethodology'
         | 'NoNextReleaseDate'
         | 'NoDataFiles'
-        | 'NoTableHighlights';
+        | 'NoTableHighlights'
+        | 'NoPublicPreReleaseAccessList';
     }
   | {
       code: 'NoFootnotesOnSubjects';

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -40,21 +40,23 @@ Go to release sign off page
     user clicks link  Sign off
     user waits until h2 is visible  Sign off
 
-Verify release checklist with errors
+Verify initial release checklist
     [Tags]  HappyPath
     user clicks button  Edit release status
     user waits until h2 is visible  Edit release status
 
-    user waits until page contains testid  releaseChecklist-errors
-    user checks checklist errors contains  1 issue that must be resolved before this release can be published
-    user checks checklist errors contains link  Public pre-release access list is required
+    # EES-1807 May be re-instated as error pending further decisions on release types
+#    user waits until page contains testid  releaseChecklist-errors
+#    user checks checklist errors contains  1 issue that must be resolved before this release can be published
+#    user checks checklist errors contains link  Public pre-release access list is required
 
     user waits until page contains testid  releaseChecklist-warnings
-    user checks checklist warnings contains  3 potential issues that do not need to be resolved to publish this release
+    user checks checklist warnings contains  4 potential issues that do not need to be resolved to publish this release
     user checks checklist warnings contains link  No methodology attached to publication
     user checks checklist warnings contains link  No next release expected date
     user checks checklist warnings contains link  No data files uploaded
 
+    user checks page does not contain testid  releaseChecklist-errors
     user checks page does not contain testid  releaseChecklist-success
 
 Submit release for Higher Review
@@ -72,28 +74,32 @@ Verify release status is Higher Review
     user checks summary list contains  Scheduled release  Not scheduled
     user checks summary list contains  Next release expected  December 3001
 
-Verify updated release checklist
+Verify release checklist has not been updated by status
     [Tags]  HappyPath
     user clicks button  Edit release status
     user waits until h2 is visible  Edit release status
 
-    user waits until page contains testid  releaseChecklist-errors
-    user checks checklist errors contains  1 issue that must be resolved before this release can be published
-    user checks checklist errors contains link  Public pre-release access list is required
+    # EES-1807 May be re-instated as error pending further decisions on release types
+#    user waits until page contains testid  releaseChecklist-errors
+#    user checks checklist errors contains  1 issue that must be resolved before this release can be published
+#    user checks checklist errors contains link  Public pre-release access list is required
 
     user waits until page contains testid  releaseChecklist-warnings
-    user checks checklist warnings contains  2 potential issues that do not need to be resolved to publish this release
+    user checks checklist warnings contains  3 potential issues that do not need to be resolved to publish this release
     user checks checklist warnings contains link  No methodology attached to publication
     user checks checklist warnings contains link  No data files uploaded
+    # EES-1807 May be re-instated as error pending further decisions on release types
+    user checks checklist warnings contains link  No public pre-release access list
 
+    user checks page does not contain testid  releaseChecklist-errors
     user checks page does not contain testid  releaseChecklist-success
 
 Add public prerelease access list via release checklist
     [Tags]  HappyPath
-    user clicks link  Public pre-release access list is required
+    user clicks link  No public pre-release access list
     user creates public prerelease access list   Test public access list
 
-Verify release checklist does not contain errors
+Verify release checklist has been updated
     [Tags]  HappyPath
     user clicks link  Sign off
     user clicks button  Edit release status


### PR DESCRIPTION
This PR changes the release checklist rule requiring a PRA public list from an error to a warning. This is necessary due to the weird release on Friday that doesn't fit nicely into our release model.