### PR TITLE
EES-1767 Fix chart builder boundary level field not being initialized

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
@@ -92,22 +92,24 @@ export type TableQueryUpdateHandler = (
 ) => Promise<void>;
 
 interface Props {
+  boundaryLevel?: number;
   data: TableDataResult[];
   meta: FullTableMeta;
   releaseId: string;
-  initialConfiguration?: Chart;
+  initialChart?: Chart;
   onChartSave: (chart: Chart, file?: File) => Promise<void>;
   onChartDelete: (chart: Chart) => void;
   onTableQueryUpdate: TableQueryUpdateHandler;
 }
 
 const ChartBuilder = ({
+  boundaryLevel,
   data,
   meta,
   releaseId,
+  initialChart,
   onChartSave,
   onChartDelete,
-  initialConfiguration,
   onTableQueryUpdate,
 }: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -118,7 +120,7 @@ const ChartBuilder = ({
   const [isDeleting, setDeleting] = useState(false);
 
   const { state: chartBuilderState, actions } = useChartBuilderReducer(
-    initialConfiguration,
+    initialChart,
   );
 
   const { axes, definition, options, legend } = chartBuilderState;
@@ -253,11 +255,11 @@ const ChartBuilder = ({
   );
 
   const handleBoundaryLevelChange = useCallback(
-    async (boundaryLevel: string) => {
+    async (nextBoundaryLevel: string) => {
       setDataLoading(true);
 
       await onTableQueryUpdate({
-        boundaryLevel: parseNumber(boundaryLevel),
+        boundaryLevel: parseNumber(nextBoundaryLevel),
       });
 
       setDataLoading(false);
@@ -267,7 +269,7 @@ const ChartBuilder = ({
 
   const deleteButton = useMemo(
     () =>
-      initialConfiguration && (
+      initialChart && (
         <Button
           variant="warning"
           onClick={toggleDeleteModal.on}
@@ -276,7 +278,7 @@ const ChartBuilder = ({
           Delete chart
         </Button>
       ),
-    [initialConfiguration, isDeleting, toggleDeleteModal.on],
+    [initialChart, isDeleting, toggleDeleteModal.on],
   );
 
   return (
@@ -311,6 +313,7 @@ const ChartBuilder = ({
                   id={forms.options.id}
                 >
                   <ChartConfiguration
+                    boundaryLevel={boundaryLevel}
                     buttons={deleteButton}
                     submitError={submitError}
                     definition={definition}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
@@ -110,10 +110,11 @@ const ChartBuilderTabSection = ({
 
   return (
     <ChartBuilder
+      boundaryLevel={query.boundaryLevel}
       releaseId={releaseId}
       data={table.results}
       meta={meta}
-      initialConfiguration={dataBlock.charts[0]}
+      initialChart={dataBlock.charts[0]}
       onChartSave={handleChartSave}
       onChartDelete={handleChartDelete}
       onTableQueryUpdate={handleTableQueryUpdate}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -2,7 +2,7 @@ import ChartBuilderSaveActions from '@admin/pages/release/datablocks/components/
 import { useChartBuilderFormsContext } from '@admin/pages/release/datablocks/components/chart/contexts/ChartBuilderFormsContext';
 import { ChartOptions } from '@admin/pages/release/datablocks/components/chart/reducers/chartBuilderReducer';
 import Effect from '@common/components/Effect';
-import { Form, FormFieldSelect, FormGroup } from '@common/components/form';
+import { Form, FormGroup, FormSelect } from '@common/components/form';
 import FormFieldCheckbox from '@common/components/form/FormFieldCheckbox';
 import FormFieldFileInput from '@common/components/form/FormFieldFileInput';
 import FormFieldNumberInput from '@common/components/form/FormFieldNumberInput';
@@ -44,6 +44,7 @@ const replaceNewLines = (event: ChangeEvent<HTMLTextAreaElement>) => {
 };
 
 interface Props {
+  boundaryLevel?: number;
   buttons?: ReactNode;
   chartOptions: ChartOptions;
   definition: ChartDefinition;
@@ -57,6 +58,7 @@ interface Props {
 const formId = 'chartConfigurationForm';
 
 const ChartConfiguration = ({
+  boundaryLevel,
   buttons,
   chartOptions,
   definition,
@@ -254,35 +256,27 @@ const ChartConfiguration = ({
             )}
 
             {definition.type === 'map' && meta.boundaryLevels && (
-              <>
-                {meta.boundaryLevels.length === 1 && (
-                  <div>
-                    Using <em>{meta.boundaryLevels[0].label}</em>
-                  </div>
-                )}
-                {meta.boundaryLevels.length > 1 && (
-                  <FormGroup>
-                    <FormFieldSelect<FormValues>
-                      id={`${formId}-geographicId`}
-                      label="Select a version of geographical data to use"
-                      name="geographicId"
-                      order={[]}
-                      options={[
-                        { label: 'Latest', value: '' },
-                        ...meta.boundaryLevels.map(({ id, label }) => ({
-                          value: id,
-                          label,
-                        })),
-                      ]}
-                      onChange={e => {
-                        if (onBoundaryLevelChange) {
-                          onBoundaryLevelChange(e.target.value);
-                        }
-                      }}
-                    />
-                  </FormGroup>
-                )}
-              </>
+              <FormGroup>
+                <FormSelect
+                  id={`${formId}-boundaryLevel`}
+                  label="Select a version of geographical data to use"
+                  name="boundaryLevel"
+                  order={[]}
+                  value={boundaryLevel?.toString()}
+                  options={[
+                    { label: 'Latest', value: '' },
+                    ...meta.boundaryLevels.map(({ id, label }) => ({
+                      value: id,
+                      label,
+                    })),
+                  ]}
+                  onChange={e => {
+                    if (onBoundaryLevelChange) {
+                      onBoundaryLevelChange(e.target.value);
+                    }
+                  }}
+                />
+              </FormGroup>
             )}
 
             <ChartBuilderSaveActions formId={formId} formKey="options">

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/chartBuilderReducer.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/chartBuilderReducer.ts
@@ -19,7 +19,6 @@ import { Reducer } from 'use-immer';
 export interface ChartOptions extends ChartDefinitionOptions {
   file?: File;
   fileId?: string;
-  geographicId?: string;
 }
 
 export interface ChartBuilderState {

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -215,7 +215,6 @@ export interface MapBlockProps extends ChartProps {
   id: string;
   position?: { lat: number; lng: number };
   maxBounds?: LatLngBounds;
-  geographicId?: string;
   legend: LegendConfiguration;
   axes: {
     major: AxisConfiguration;


### PR DESCRIPTION
This change fixes the chart builder's boundary level field (for maps) not being initialized with a value (regardless of if you save the chart with a different boundary level or not).

This was due to `boundaryLevel` not being injected into the `chartBuilderReducer` (from the data block's table data query). Instead,
we have now completely removed the boundary level field from the `ChartConfiguration` form and `chartBuilderReducer`. It is now a standalone `FormSelect` controlled by the `boundaryLevel` prop.