### PR TITLE
EES-1730 Add initial performance optimizations for charts/tables

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/ObservationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/ObservationViewModel.cs
@@ -1,7 +1,5 @@
 using System.Collections.Generic;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
-using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -12,13 +10,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
         public IEnumerable<string> Filters { get; set; }
 
         // TODO could this be [JsonConverter(typeof(EnumToEnumValueJsonConverter<GeographicLevel>))]?
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(StringEnumConverter), true)]
         public GeographicLevel GeographicLevel { get; set; }
 
         public LocationViewModel Location { get; set; }
 
         public Dictionary<string, string> Measures { get; set; }
-        
+
         public string TimePeriod { get; set; }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -13,7 +13,13 @@ import WizardStepHeading from '@common/modules/table-tool/components/WizardStepH
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 import { ReleaseTableDataQuery } from '@common/services/tableBuilderService';
-import React, { createRef, useCallback, useEffect, useState } from 'react';
+import React, {
+  createRef,
+  memo,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 
 export type DataBlockSourceWizardSaveHandler = (params: {
   details: DataBlockDetailsFormValues;
@@ -105,6 +111,10 @@ const DataBlockSourceWizardFinalStep = ({
   );
 };
 
+const DataBlockSourceWizardFinalStepWrapped = memo(
+  DataBlockSourceWizardFinalStep,
+);
+
 interface DataBlockSourceWizardProps {
   dataBlock?: ReleaseDataBlock;
   tableToolState: InitialTableToolState;
@@ -132,7 +142,7 @@ const DataBlockSourceWizard = ({
                 </WizardStepHeading>
 
                 {query && response && (
-                  <DataBlockSourceWizardFinalStep
+                  <DataBlockSourceWizardFinalStepWrapped
                     dataBlock={dataBlock}
                     query={query}
                     table={response.table}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ReleaseDataBlocksPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/ReleaseDataBlocksPageTabs.tsx
@@ -293,6 +293,7 @@ const ReleaseDataBlocksPageTabs = ({
                 title="Table"
                 key="table"
                 id="manageDataBlocks-table"
+                lazy
               >
                 <TableTabSection
                   table={response.table}

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -29,7 +29,6 @@ import { unsafeCountDecimals } from '@common/utils/number/countDecimals';
 import formatPretty, {
   defaultMaxDecimalPlaces,
 } from '@common/utils/number/formatPretty';
-import getMinMax from '@common/utils/number/getMinMax';
 import { roundDownToNearest } from '@common/utils/number/roundNearest';
 import classNames from 'classnames';
 import { Feature, FeatureCollection, Geometry } from 'geojson';
@@ -80,18 +79,96 @@ function calculateScaledColour({
   return lighten(colour, 90 - (scale / groupSize) * 30);
 }
 
-function getDefaultDecimalPlaces(values: number[]): number {
-  const maxDecimals = values.reduce<number>((acc, value) => {
-    const decimals = unsafeCountDecimals(value?.toString() ?? 0);
+interface MinMax {
+  min: number;
+  max: number;
+}
 
-    if (decimals > acc) {
-      return decimals;
-    }
+interface MinMaxDecimalPlaces extends MinMax {
+  decimalPlaces: number;
+}
 
-    return acc;
-  }, 0);
+/**
+ * Extracts the min, max and decimal places that are being used in
+ * some {@param dataSetCategories}. A {@param selectedDataSetKey} must
+ * be provided to select which data set category to use.
+ *
+ * As an optimization, if {@param explicitDecimalPlaces} is provided,
+ * then we don't do further work to find the decimal places using the data.
+ *
+ * Note that this function does several things simultaneously for
+ * performance reasons as the number of data sets can be quite large.
+ */
+function getMinMaxDecimalPlaces(
+  dataSetCategories: MapDataSetCategory[],
+  selectedDataSetKey: string,
+  explicitDecimalPlaces?: number,
+): MinMaxDecimalPlaces {
+  const reduce = (
+    initialAcc: MinMaxDecimalPlaces,
+    callback?: (acc: MinMaxDecimalPlaces, value: number) => MinMaxDecimalPlaces,
+  ) => {
+    const { min, max, decimalPlaces } = dataSetCategories.reduce<
+      MinMaxDecimalPlaces
+    >((acc, category) => {
+      const value = category.dataSets[selectedDataSetKey]?.value;
 
-  return clamp(maxDecimals, 0, defaultMaxDecimalPlaces);
+      if (typeof value !== 'number') {
+        return acc;
+      }
+
+      if (value < acc.min) {
+        acc.min = value;
+      }
+
+      if (value > acc.max) {
+        acc.max = value;
+      }
+
+      if (callback) {
+        return callback(acc, value);
+      }
+
+      return acc;
+    }, initialAcc);
+
+    return {
+      min: Number.isFinite(min) ? min : 0,
+      max: Number.isFinite(max) ? max : 0,
+      decimalPlaces,
+    };
+  };
+
+  if (typeof explicitDecimalPlaces === 'number') {
+    return reduce({
+      min: Number.POSITIVE_INFINITY,
+      max: Number.NEGATIVE_INFINITY,
+      decimalPlaces: explicitDecimalPlaces,
+    });
+  }
+
+  const { min, max, decimalPlaces } = reduce(
+    {
+      min: Number.POSITIVE_INFINITY,
+      max: Number.NEGATIVE_INFINITY,
+      decimalPlaces: 0,
+    },
+    (acc, value) => {
+      const decimals = unsafeCountDecimals(value?.toString() ?? 0);
+
+      if (decimals > acc.decimalPlaces) {
+        acc.decimalPlaces = decimals;
+      }
+
+      return acc;
+    },
+  );
+
+  return {
+    min,
+    max,
+    decimalPlaces: clamp(decimalPlaces, 0, defaultMaxDecimalPlaces),
+  };
 }
 
 function generateGeometryAndLegend(
@@ -102,22 +179,16 @@ function generateGeometryAndLegend(
   legend: LegendEntry[];
 } {
   const selectedDataSetKey = selectedDataSetConfiguration.dataKey;
-
-  // Use reduce to be more efficient than map/filter
-  const values = dataSetCategories.reduce<number[]>((acc, category) => {
-    if (typeof category.dataSets[selectedDataSetKey]?.value !== 'undefined') {
-      acc.push(category.dataSets[selectedDataSetKey]?.value);
-    }
-
-    return acc;
-  }, []);
-
   const {
     unit,
-    decimalPlaces = getDefaultDecimalPlaces(values),
+    decimalPlaces: explicitDecimalPlaces,
   } = selectedDataSetConfiguration.dataSet.indicator;
 
-  const { min = 0, max = 0 } = getMinMax(values);
+  const { min, max, decimalPlaces } = getMinMaxDecimalPlaces(
+    dataSetCategories,
+    selectedDataSetKey,
+    explicitDecimalPlaces,
+  );
 
   const range = max - min;
 
@@ -172,7 +243,7 @@ function generateGeometryAndLegend(
   const geometry: FeatureCollection<Geometry, MapFeatureProperties> = {
     type: 'FeatureCollection',
     features: dataSetCategories.map(({ dataSets, filter, geoJson }) => {
-      const data = dataSets?.[selectedDataSetKey]?.value;
+      const value = dataSets?.[selectedDataSetKey]?.value;
 
       // Create a scale for the colour. This goes from 0 to
       // the last group's minimum e.g. 0.8 (when there are 5 groups).
@@ -181,9 +252,9 @@ function generateGeometryAndLegend(
       // the colours shown in the legend.
       const scale =
         // Avoid divisions by 0
-        range !== 0
+        range !== 0 && typeof value !== 'undefined'
           ? clamp(
-              roundDownToNearest((data - min) / range, groupSize),
+              roundDownToNearest((value - min) / range, groupSize),
               0,
               lastGroupMin,
             )
@@ -191,7 +262,7 @@ function generateGeometryAndLegend(
 
       // Defaults to white if there is no data
       const scaledColour =
-        typeof data !== 'undefined'
+        typeof value !== 'undefined'
           ? calculateScaledColour({ colour, groupSize, scale })
           : '#fff';
 
@@ -202,7 +273,7 @@ function generateGeometryAndLegend(
           ...geoJson.properties,
           dataSets,
           colour: scaledColour,
-          data,
+          data: value,
         },
       };
     }),

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testChartData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testChartData.ts
@@ -165,7 +165,7 @@ export const testChartTableData: TableDataResponse = {
   results: [
     {
       filters: ['characteristic-total', 'school-type-total'],
-      geographicLevel: 'Country',
+      geographicLevel: 'country',
       location: { country: { code: 'england', name: 'England' } },
       measures: {
         'authorised-absence-rate': '3.5',
@@ -176,7 +176,7 @@ export const testChartTableData: TableDataResponse = {
     },
     {
       filters: ['characteristic-total', 'school-type-total'],
-      geographicLevel: 'Country',
+      geographicLevel: 'country',
       location: { country: { code: 'england', name: 'England' } },
       measures: {
         'authorised-absence-rate': '4.2',
@@ -187,7 +187,7 @@ export const testChartTableData: TableDataResponse = {
     },
     {
       filters: ['characteristic-total', 'school-type-total'],
-      geographicLevel: 'Country',
+      geographicLevel: 'country',
       location: { country: { code: 'england', name: 'England' } },
       measures: {
         'authorised-absence-rate': '3.5',
@@ -198,7 +198,7 @@ export const testChartTableData: TableDataResponse = {
     },
     {
       filters: ['characteristic-total', 'school-type-total'],
-      geographicLevel: 'Country',
+      geographicLevel: 'country',
       location: { country: { code: 'england', name: 'England' } },
       measures: {
         'authorised-absence-rate': '3.4',
@@ -209,7 +209,7 @@ export const testChartTableData: TableDataResponse = {
     },
     {
       filters: ['characteristic-total', 'school-type-total'],
-      geographicLevel: 'Country',
+      geographicLevel: 'country',
       location: { country: { code: 'england', name: 'England' } },
       measures: {
         'authorised-absence-rate': '3.4',

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
@@ -358,7 +358,7 @@ export const testMapTableData: TableDataResponse = {
   results: [
     {
       filters: ['characteristic-total', 'school-type-total'],
-      geographicLevel: 'LocalAuthorityDistrict',
+      geographicLevel: 'localAuthorityDistrict',
       location: {
         country: { code: 'E92000001', name: 'England' },
         localAuthority: { code: '383', name: 'Leeds' },
@@ -374,7 +374,7 @@ export const testMapTableData: TableDataResponse = {
     },
     {
       filters: ['characteristic-total', 'school-type-total'],
-      geographicLevel: 'LocalAuthorityDistrict',
+      geographicLevel: 'localAuthorityDistrict',
       location: {
         country: { code: 'E92000001', name: 'England' },
         localAuthority: { code: '352', name: 'Manchester' },
@@ -390,7 +390,7 @@ export const testMapTableData: TableDataResponse = {
     },
     {
       filters: ['characteristic-total', 'school-type-total'],
-      geographicLevel: 'LocalAuthorityDistrict',
+      geographicLevel: 'localAuthorityDistrict',
       location: {
         country: { code: 'E92000001', name: 'England' },
         localAuthority: { code: '373', name: 'Sheffield' },

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
@@ -82,7 +82,7 @@ describe('createDataSetCategories', () => {
     results: [
       {
         filters: ['ethnicity-major-chinese', 'state-funded-primary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnet', name: 'Barnet' },
         },
@@ -94,7 +94,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-black-total', 'state-funded-primary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnet', name: 'Barnet' },
         },
@@ -106,7 +106,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-chinese', 'state-funded-secondary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnsley', name: 'Barnsley' },
         },
@@ -118,7 +118,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-black-total', 'state-funded-secondary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnsley', name: 'Barnsley' },
         },
@@ -130,7 +130,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-chinese', 'state-funded-secondary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnet', name: 'Barnet' },
         },
@@ -142,7 +142,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-black-total', 'state-funded-secondary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnet', name: 'Barnet' },
         },
@@ -154,7 +154,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-chinese', 'state-funded-primary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnsley', name: 'Barnsley' },
         },
@@ -166,7 +166,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-black-total', 'state-funded-primary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnsley', name: 'Barnsley' },
         },
@@ -178,7 +178,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-black-total', 'state-funded-secondary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnet', name: 'Barnet' },
         },
@@ -190,7 +190,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-chinese', 'state-funded-primary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnsley', name: 'Barnsley' },
         },
@@ -202,7 +202,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-black-total', 'state-funded-primary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnet', name: 'Barnet' },
         },
@@ -214,7 +214,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-chinese', 'state-funded-primary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnet', name: 'Barnet' },
         },
@@ -226,7 +226,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-chinese', 'state-funded-secondary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnet', name: 'Barnet' },
         },
@@ -238,7 +238,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-black-total', 'state-funded-secondary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnsley', name: 'Barnsley' },
         },
@@ -250,7 +250,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-black-total', 'state-funded-primary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnsley', name: 'Barnsley' },
         },
@@ -262,7 +262,7 @@ describe('createDataSetCategories', () => {
       },
       {
         filters: ['ethnicity-major-chinese', 'state-funded-secondary'],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           localAuthority: { code: 'barnsley', name: 'Barnsley' },
         },
@@ -1244,7 +1244,7 @@ describe('createDataSetCategories', () => {
       results: [
         {
           filters: ['state-funded-primary'],
-          geographicLevel: 'Region',
+          geographicLevel: 'region',
           location: {
             country: { code: 'E92000001', name: 'England' },
             region: { code: 'E12000001', name: 'North East' },
@@ -1254,14 +1254,14 @@ describe('createDataSetCategories', () => {
         },
         {
           filters: ['state-funded-primary'],
-          geographicLevel: 'Country',
+          geographicLevel: 'country',
           location: { country: { code: 'E92000001', name: 'England' } },
           measures: { 'authorised-absence-sessions': '42219483' },
           timePeriod: '2015_AY',
         },
         {
           filters: ['state-funded-secondary'],
-          geographicLevel: 'Region',
+          geographicLevel: 'region',
           location: {
             country: { code: 'E92000001', name: 'England' },
             region: { code: 'E12000001', name: 'North East' },
@@ -1271,7 +1271,7 @@ describe('createDataSetCategories', () => {
         },
         {
           filters: ['state-funded-secondary'],
-          geographicLevel: 'Country',
+          geographicLevel: 'country',
           location: { country: { code: 'E92000001', name: 'England' } },
           measures: { 'authorised-absence-sessions': '37997247' },
           timePeriod: '2015_AY',

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/groupResultMeasuresByDataSet.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/groupResultMeasuresByDataSet.test.ts
@@ -1,0 +1,235 @@
+import groupResultMeasuresByDataSet from '@common/modules/charts/util/groupResultMeasuresByDataSet';
+import { LocationFilter } from '@common/modules/table-tool/types/filters';
+
+describe('groupResultMeasuresByDataSet', () => {
+  test('creates different groups based on location', () => {
+    const resultMeasures = groupResultMeasuresByDataSet([
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-1': '1000',
+          'indicator-2': '2000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnsley',
+            name: 'Barnsley',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-1': '3000',
+          'indicator-2': '4000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+    ]);
+
+    expect(resultMeasures).toEqual({
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      })]: {
+        '2018_AY': {
+          'filter-1': {
+            'filter-2': {
+              'indicator-1': '1000',
+              'indicator-2': '2000',
+            },
+          },
+        },
+      },
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnsley',
+      })]: {
+        '2018_AY': {
+          'filter-1': {
+            'filter-2': {
+              'indicator-1': '3000',
+              'indicator-2': '4000',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('creates different groups based on time period', () => {
+    const resultMeasures = groupResultMeasuresByDataSet([
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-1': '1000',
+          'indicator-2': '2000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2019_AY',
+        measures: {
+          'indicator-1': '3000',
+          'indicator-2': '4000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+    ]);
+
+    expect(resultMeasures).toEqual({
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      })]: {
+        '2018_AY': {
+          'filter-1': {
+            'filter-2': {
+              'indicator-1': '1000',
+              'indicator-2': '2000',
+            },
+          },
+        },
+        '2019_AY': {
+          'filter-1': {
+            'filter-2': {
+              'indicator-1': '3000',
+              'indicator-2': '4000',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('creates different groups based on filters', () => {
+    const resultMeasures = groupResultMeasuresByDataSet([
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-1': '1000',
+          'indicator-2': '2000',
+        },
+        filters: ['filter-1', 'filter-3'],
+      },
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-1': '3000',
+          'indicator-2': '4000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+    ]);
+
+    expect(resultMeasures).toEqual({
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      })]: {
+        '2018_AY': {
+          'filter-1': {
+            'filter-2': {
+              'indicator-1': '3000',
+              'indicator-2': '4000',
+            },
+            'filter-3': {
+              'indicator-1': '1000',
+              'indicator-2': '2000',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('merges groups with same data set', () => {
+    const resultMeasures = groupResultMeasuresByDataSet([
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-1': '1000',
+          'indicator-2': '2000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-3': '3000',
+          'indicator-4': '4000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+    ]);
+
+    expect(resultMeasures).toEqual({
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      })]: {
+        '2018_AY': {
+          'filter-1': {
+            'filter-2': {
+              'indicator-1': '1000',
+              'indicator-2': '2000',
+              'indicator-3': '3000',
+              'indicator-4': '4000',
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/charts/util/groupResultMeasuresByDataSet.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/groupResultMeasuresByDataSet.ts
@@ -14,7 +14,7 @@ export function getIndicatorPath(dataSet: DataSet): string[] {
   return compact([locationKey, timePeriod, ...sortedFilters, indicator]);
 }
 
-interface MeasuresGroupedByDataSet {
+export interface MeasuresGroupedByDataSet {
   [location: string]: {
     // This will nest the more filters there are, so it's
     // not possible to know the data structure beyond this.

--- a/src/explore-education-statistics-common/src/modules/charts/util/groupResultMeasuresByDataSet.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/groupResultMeasuresByDataSet.ts
@@ -1,0 +1,64 @@
+import { DataSet } from '@common/modules/charts/types/dataSet';
+import { LocationFilter } from '@common/modules/table-tool/types/filters';
+import { TableDataResult } from '@common/services/tableBuilderService';
+import compact from 'lodash/compact';
+import get from 'lodash/get';
+import set from 'lodash/set';
+
+export function getIndicatorPath(dataSet: DataSet): string[] {
+  const { filters, timePeriod, location, indicator } = dataSet;
+
+  const locationKey = location ? LocationFilter.createId(location) : undefined;
+  const sortedFilters = [...filters].sort();
+
+  return compact([locationKey, timePeriod, ...sortedFilters, indicator]);
+}
+
+interface MeasuresGroupedByDataSet {
+  [location: string]: {
+    // This will nest the more filters there are, so it's
+    // not possible to know the data structure beyond this.
+    [timePeriod: string]: unknown;
+  };
+}
+
+/**
+ * Group {@param results} and their measures by their
+ * associated data set (excluding the indicator).
+ *
+ * This is convenient for larger result sets where iteration
+ * can be really expensive. By converting the results to
+ * a dictionary, we can achieve O(1) time complexity.
+ */
+export default function groupResultMeasuresByDataSet(
+  results: TableDataResult[],
+): MeasuresGroupedByDataSet {
+  return results.reduce<MeasuresGroupedByDataSet>((acc, result) => {
+    const { geographicLevel, filters, timePeriod, location, measures } = result;
+
+    const path = getIndicatorPath({
+      filters,
+      timePeriod,
+      indicator: '',
+      location: location[geographicLevel]
+        ? {
+            value: location[geographicLevel].code,
+            level: geographicLevel,
+          }
+        : undefined,
+    });
+
+    const existing = get(acc, path);
+
+    if (existing) {
+      set(acc, path, {
+        ...existing,
+        ...measures,
+      });
+    } else {
+      set(acc, path, measures);
+    }
+
+    return acc;
+  }, {});
+}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadCsvButton.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadCsvButton.tsx
@@ -7,7 +7,6 @@ import {
 } from '@common/modules/table-tool/types/filters';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import cartesian from '@common/utils/cartesian';
-import camelCase from 'lodash/camelCase';
 import React from 'react';
 import { utils, writeFile } from 'xlsx';
 
@@ -44,7 +43,7 @@ export const getCsvData = (fullTable: FullTable): string[][] => {
 
       const indicatorCells = indicators.map(indicator => {
         const matchingResult = results.find(result => {
-          const geographicLevel = camelCase(result.geographicLevel);
+          const { geographicLevel } = result;
 
           return (
             filterOptions.every(filter =>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -13,7 +13,6 @@ import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeader
 import { TableDataResult } from '@common/services/tableBuilderService';
 import cartesian from '@common/utils/cartesian';
 import formatPretty from '@common/utils/number/formatPretty';
-import camelCase from 'lodash/camelCase';
 import last from 'lodash/last';
 import React, { forwardRef, memo } from 'react';
 import DataTableCaption from './DataTableCaption';
@@ -106,7 +105,7 @@ const TimePeriodDataTableInternal = forwardRef<HTMLElement, Props>(
                 }
 
                 if (filter instanceof LocationFilter) {
-                  const geographicLevel = camelCase(result.geographicLevel);
+                  const { geographicLevel } = result;
 
                   return (
                     result.location[geographicLevel] &&

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.tsx
@@ -55,9 +55,7 @@ const WizardStep = ({ children, id, ...restProps }: WizardStepProps) => {
         </span>
 
         {typeof children === 'function'
-          ? children({
-              ...injectedWizardProps,
-            })
+          ? children(injectedWizardProps)
           : children}
       </div>
     </li>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DownloadCsvButton.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DownloadCsvButton.test.tsx
@@ -138,7 +138,7 @@ describe('DownloadCsvButton', () => {
           {
             filters: ['gender_female', 'school_primary'],
             timePeriod: '2015_AY',
-            geographicLevel: 'Country',
+            geographicLevel: 'country',
             location: {
               country: {
                 code: 'england',
@@ -153,7 +153,7 @@ describe('DownloadCsvButton', () => {
           {
             filters: ['gender_female', 'school_secondary'],
             timePeriod: '2015_AY',
-            geographicLevel: 'Country',
+            geographicLevel: 'country',
             location: {
               country: {
                 code: 'england',
@@ -168,7 +168,7 @@ describe('DownloadCsvButton', () => {
           {
             filters: ['gender_female', 'school_primary'],
             timePeriod: '2015_AY',
-            geographicLevel: 'LocalAuthority',
+            geographicLevel: 'localAuthority',
             location: {
               localAuthority: {
                 code: 'barnsley',
@@ -183,7 +183,7 @@ describe('DownloadCsvButton', () => {
           {
             filters: ['gender_female', 'school_secondary'],
             timePeriod: '2015_AY',
-            geographicLevel: 'LocalAuthority',
+            geographicLevel: 'localAuthority',
             location: {
               localAuthority: {
                 code: 'barnsley',
@@ -248,7 +248,7 @@ describe('DownloadCsvButton', () => {
           {
             filters: ['gender_female', 'school_primary'],
             timePeriod: '2015_AY',
-            geographicLevel: 'Country',
+            geographicLevel: 'country',
             location: {
               country: {
                 code: 'england',
@@ -262,7 +262,7 @@ describe('DownloadCsvButton', () => {
           {
             filters: ['gender_female', 'school_secondary'],
             timePeriod: '2015_AY',
-            geographicLevel: 'Country',
+            geographicLevel: 'country',
             location: {
               country: {
                 code: 'england',
@@ -318,7 +318,7 @@ describe('DownloadCsvButton', () => {
           {
             filters: ['gender_female', 'school_primary'],
             timePeriod: '2015_AY',
-            geographicLevel: 'Country',
+            geographicLevel: 'country',
             location: {
               country: {
                 code: 'england',
@@ -364,7 +364,7 @@ describe('DownloadCsvButton', () => {
           {
             filters: ['gender_female'],
             timePeriod: '2015_AY',
-            geographicLevel: 'Country',
+            geographicLevel: 'country',
             location: {
               country: {
                 code: 'england',
@@ -396,7 +396,7 @@ describe('DownloadCsvButton', () => {
           {
             filters: ['gender_female'],
             timePeriod: '2015_AY',
-            geographicLevel: 'Country',
+            geographicLevel: 'country',
             location: {
               country: {
                 code: 'england',
@@ -429,7 +429,7 @@ describe('DownloadCsvButton', () => {
           {
             filters: ['gender_female'],
             timePeriod: '2015_AY',
-            geographicLevel: 'Country',
+            geographicLevel: 'country',
             location: {
               country: {
                 code: 'england',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
@@ -254,9 +254,7 @@ describe('TimePeriodDataTable', () => {
             decimalPlaces: 1,
           },
         ],
-        locations: [
-          { value: 'E92000001', label: 'England', level: 'localAuthority' },
-        ],
+        locations: [{ value: 'E92000001', label: 'England', level: 'country' }],
         boundaryLevels: [],
         publicationName: 'Pupil absence in schools in England',
         subjectName: 'Absence in prus',
@@ -266,8 +264,8 @@ describe('TimePeriodDataTable', () => {
       results: [
         {
           filters: ['598ed9fd-b37e-4e08-baec-08d78f6f2c4d'],
-          geographicLevel: 'localAuthority',
-          location: { localAuthority: { code: 'E92000001', name: 'England' } },
+          geographicLevel: 'country',
+          location: { country: { code: 'E92000001', name: 'England' } },
           measures: { '6160c4f8-4c9f-40f0-a623-2a4f742860af': '18.3' },
           timePeriod: '2014_AY',
         },
@@ -285,7 +283,7 @@ describe('TimePeriodDataTable', () => {
           ],
         ],
         rowGroups: [
-          [{ value: 'E92000001', type: 'Location', level: 'localAuthority' }],
+          [{ value: 'E92000001', type: 'Location', level: 'country' }],
         ],
         columns: [{ value: '2014_AY', type: 'TimePeriod' }],
         rows: [
@@ -349,9 +347,7 @@ describe('TimePeriodDataTable', () => {
             decimalPlaces: 1,
           },
         ],
-        locations: [
-          { value: 'E92000001', label: 'England', level: 'localAuthority' },
-        ],
+        locations: [{ value: 'E92000001', label: 'England', level: 'country' }],
         boundaryLevels: [],
         publicationName: 'Pupil absence in schools in England',
         subjectName: 'Absence in prus',
@@ -361,8 +357,8 @@ describe('TimePeriodDataTable', () => {
       results: [
         {
           filters: [],
-          geographicLevel: 'localAuthority',
-          location: { localAuthority: { code: 'E92000001', name: 'England' } },
+          geographicLevel: 'country',
+          location: { country: { code: 'E92000001', name: 'England' } },
           measures: { '6160c4f8-4c9f-40f0-a623-2a4f742860af': '18.3' },
           timePeriod: '2014_AY',
         },
@@ -373,7 +369,7 @@ describe('TimePeriodDataTable', () => {
       {
         columnGroups: [],
         rowGroups: [
-          [{ value: 'E92000001', level: 'localAuthority', type: 'Location' }],
+          [{ value: 'E92000001', level: 'country', type: 'Location' }],
         ],
         columns: [{ value: '2014_AY', type: 'TimePeriod' }],
         rows: [
@@ -436,9 +432,7 @@ describe('TimePeriodDataTable', () => {
             unit: '%',
           },
         ],
-        locations: [
-          { value: 'E92000001', label: 'England', level: 'localAuthority' },
-        ],
+        locations: [{ value: 'E92000001', label: 'England', level: 'country' }],
         boundaryLevels: [],
         publicationName: 'Pupil absence in schools in England',
         subjectName: 'Absence in prus',
@@ -448,8 +442,8 @@ describe('TimePeriodDataTable', () => {
       results: [
         {
           filters: [],
-          geographicLevel: 'localAuthority',
-          location: { localAuthority: { code: 'E92000001', name: 'England' } },
+          geographicLevel: 'country',
+          location: { country: { code: 'E92000001', name: 'England' } },
           measures: { '6160c4f8-4c9f-40f0-a623-2a4f742860af': '18.3' },
           timePeriod: '2014_AY',
         },
@@ -460,7 +454,7 @@ describe('TimePeriodDataTable', () => {
       {
         columnGroups: [],
         rowGroups: [
-          [{ value: 'E92000001', type: 'Location', level: 'localAuthority' }],
+          [{ value: 'E92000001', type: 'Location', level: 'country' }],
         ],
         columns: [{ value: '2014_AY', type: 'TimePeriod' }],
         rows: [

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
@@ -254,7 +254,9 @@ describe('TimePeriodDataTable', () => {
             decimalPlaces: 1,
           },
         ],
-        locations: [{ value: 'E92000001', label: 'England', level: 'country' }],
+        locations: [
+          { value: 'E92000001', label: 'England', level: 'localAuthority' },
+        ],
         boundaryLevels: [],
         publicationName: 'Pupil absence in schools in England',
         subjectName: 'Absence in prus',
@@ -264,8 +266,8 @@ describe('TimePeriodDataTable', () => {
       results: [
         {
           filters: ['598ed9fd-b37e-4e08-baec-08d78f6f2c4d'],
-          geographicLevel: 'Country',
-          location: { country: { code: 'E92000001', name: 'England' } },
+          geographicLevel: 'localAuthority',
+          location: { localAuthority: { code: 'E92000001', name: 'England' } },
           measures: { '6160c4f8-4c9f-40f0-a623-2a4f742860af': '18.3' },
           timePeriod: '2014_AY',
         },
@@ -283,7 +285,7 @@ describe('TimePeriodDataTable', () => {
           ],
         ],
         rowGroups: [
-          [{ value: 'E92000001', type: 'Location', level: 'country' }],
+          [{ value: 'E92000001', type: 'Location', level: 'localAuthority' }],
         ],
         columns: [{ value: '2014_AY', type: 'TimePeriod' }],
         rows: [
@@ -347,7 +349,9 @@ describe('TimePeriodDataTable', () => {
             decimalPlaces: 1,
           },
         ],
-        locations: [{ value: 'E92000001', label: 'England', level: 'country' }],
+        locations: [
+          { value: 'E92000001', label: 'England', level: 'localAuthority' },
+        ],
         boundaryLevels: [],
         publicationName: 'Pupil absence in schools in England',
         subjectName: 'Absence in prus',
@@ -357,8 +361,8 @@ describe('TimePeriodDataTable', () => {
       results: [
         {
           filters: [],
-          geographicLevel: 'Country',
-          location: { country: { code: 'E92000001', name: 'England' } },
+          geographicLevel: 'localAuthority',
+          location: { localAuthority: { code: 'E92000001', name: 'England' } },
           measures: { '6160c4f8-4c9f-40f0-a623-2a4f742860af': '18.3' },
           timePeriod: '2014_AY',
         },
@@ -369,7 +373,7 @@ describe('TimePeriodDataTable', () => {
       {
         columnGroups: [],
         rowGroups: [
-          [{ value: 'E92000001', level: 'country', type: 'Location' }],
+          [{ value: 'E92000001', level: 'localAuthority', type: 'Location' }],
         ],
         columns: [{ value: '2014_AY', type: 'TimePeriod' }],
         rows: [
@@ -432,7 +436,9 @@ describe('TimePeriodDataTable', () => {
             unit: '%',
           },
         ],
-        locations: [{ value: 'E92000001', label: 'England', level: 'country' }],
+        locations: [
+          { value: 'E92000001', label: 'England', level: 'localAuthority' },
+        ],
         boundaryLevels: [],
         publicationName: 'Pupil absence in schools in England',
         subjectName: 'Absence in prus',
@@ -442,8 +448,8 @@ describe('TimePeriodDataTable', () => {
       results: [
         {
           filters: [],
-          geographicLevel: 'Country',
-          location: { country: { code: 'E92000001', name: 'England' } },
+          geographicLevel: 'localAuthority',
+          location: { localAuthority: { code: 'E92000001', name: 'England' } },
           measures: { '6160c4f8-4c9f-40f0-a623-2a4f742860af': '18.3' },
           timePeriod: '2014_AY',
         },
@@ -454,7 +460,7 @@ describe('TimePeriodDataTable', () => {
       {
         columnGroups: [],
         rowGroups: [
-          [{ value: 'E92000001', type: 'Location', level: 'country' }],
+          [{ value: 'E92000001', type: 'Location', level: 'localAuthority' }],
         ],
         columns: [{ value: '2014_AY', type: 'TimePeriod' }],
         rows: [

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__data__/TimePeriodDataTable.data.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__data__/TimePeriodDataTable.data.tsx
@@ -85,7 +85,7 @@ export const testData1 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -102,7 +102,7 @@ export const testData1 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -119,7 +119,7 @@ export const testData1 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -136,7 +136,7 @@ export const testData1 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -153,7 +153,7 @@ export const testData1 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -170,7 +170,7 @@ export const testData1 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -187,7 +187,7 @@ export const testData1 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -204,7 +204,7 @@ export const testData1 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -221,7 +221,7 @@ export const testData1 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -238,7 +238,7 @@ export const testData1 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -255,7 +255,7 @@ export const testData1 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -272,7 +272,7 @@ export const testData1 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -289,7 +289,7 @@ export const testData1 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -306,7 +306,7 @@ export const testData1 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -323,7 +323,7 @@ export const testData1 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -340,7 +340,7 @@ export const testData1 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -476,7 +476,7 @@ export const testData2 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -490,7 +490,7 @@ export const testData2 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -504,7 +504,7 @@ export const testData2 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -518,7 +518,7 @@ export const testData2 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -532,7 +532,7 @@ export const testData2 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -546,7 +546,7 @@ export const testData2 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -560,7 +560,7 @@ export const testData2 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -574,7 +574,7 @@ export const testData2 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -588,7 +588,7 @@ export const testData2 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -602,7 +602,7 @@ export const testData2 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -616,7 +616,7 @@ export const testData2 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -630,7 +630,7 @@ export const testData2 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -644,7 +644,7 @@ export const testData2 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -658,7 +658,7 @@ export const testData2 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -672,7 +672,7 @@ export const testData2 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -686,7 +686,7 @@ export const testData2 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -812,7 +812,7 @@ export const testData3 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -826,7 +826,7 @@ export const testData3 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -840,7 +840,7 @@ export const testData3 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -854,7 +854,7 @@ export const testData3 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -868,7 +868,7 @@ export const testData3 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -882,7 +882,7 @@ export const testData3 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'd7e7e412-f462-444f-84ac-3454fa471cb8',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000003', name: 'Barnet' },
@@ -896,7 +896,7 @@ export const testData3 = {
           '067de12b-014b-4bbd-baf1-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -910,7 +910,7 @@ export const testData3 = {
           '598ed9fd-b37e-4e08-baec-08d78f6f2c4d',
           'a9fe9fa6-e91f-460b-a0b1-66877b97c581',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000016', name: 'Barnsley' },
@@ -1002,7 +1002,7 @@ export const testDataNoFilters = {
     results: [
       {
         filters: [],
-        geographicLevel: 'Country',
+        geographicLevel: 'country',
         location: { country: { code: 'E92000001', name: 'England' } },
         measures: {
           '9cf0dcf1-367e-4207-2b50-08d78f6f2b08': '2453340',
@@ -1013,7 +1013,7 @@ export const testDataNoFilters = {
       },
       {
         filters: [],
-        geographicLevel: 'Country',
+        geographicLevel: 'country',
         location: { country: { code: 'E92000001', name: 'England' } },
         measures: {
           '9cf0dcf1-367e-4207-2b50-08d78f6f2b08': '2212399',
@@ -1024,7 +1024,7 @@ export const testDataNoFilters = {
       },
       {
         filters: [],
-        geographicLevel: 'Country',
+        geographicLevel: 'country',
         location: { country: { code: 'E92000001', name: 'England' } },
         measures: {
           '9cf0dcf1-367e-4207-2b50-08d78f6f2b08': '2637752',
@@ -1141,7 +1141,7 @@ export const testDataFiltersWithNoResults = {
           '5675d1fa-77fd-4dfd-bb1f-08d78f6f2c4d',
           'b3207d77-143b-43d5-8b48-32d29727e96f',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000026', name: 'Coventry' },
@@ -1158,7 +1158,7 @@ export const testDataFiltersWithNoResults = {
           '53da1e17-184f-43f6-bb27-08d78f6f2c4d',
           'b3207d77-143b-43d5-8b48-32d29727e96f',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000008', name: 'Croydon' },
@@ -1175,7 +1175,7 @@ export const testDataFiltersWithNoResults = {
           '5675d1fa-77fd-4dfd-bb1f-08d78f6f2c4d',
           'b3207d77-143b-43d5-8b48-32d29727e96f',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000026', name: 'Coventry' },
@@ -1192,7 +1192,7 @@ export const testDataFiltersWithNoResults = {
           '5675d1fa-77fd-4dfd-bb1f-08d78f6f2c4d',
           'b3207d77-143b-43d5-8b48-32d29727e96f',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000008', name: 'Croydon' },
@@ -1209,7 +1209,7 @@ export const testDataFiltersWithNoResults = {
           '5675d1fa-77fd-4dfd-bb1f-08d78f6f2c4d',
           'b3207d77-143b-43d5-8b48-32d29727e96f',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000008', name: 'Croydon' },
@@ -1226,7 +1226,7 @@ export const testDataFiltersWithNoResults = {
           '5675d1fa-77fd-4dfd-bb1f-08d78f6f2c4d',
           'b3207d77-143b-43d5-8b48-32d29727e96f',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E08000026', name: 'Coventry' },
@@ -1243,7 +1243,7 @@ export const testDataFiltersWithNoResults = {
           '5675d1fa-77fd-4dfd-bb1f-08d78f6f2c4d',
           'b3207d77-143b-43d5-8b48-32d29727e96f',
         ],
-        geographicLevel: 'LocalAuthority',
+        geographicLevel: 'localAuthority',
         location: {
           country: { code: 'E92000001', name: 'England' },
           localAuthority: { code: 'E09000008', name: 'Croydon' },

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/groupResultsMeasuresByCombination.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/groupResultsMeasuresByCombination.test.ts
@@ -1,0 +1,515 @@
+import groupResultMeasuresByCombination from '@common/modules/table-tool/components/utils/groupResultMeasuresByCombination';
+import { LocationFilter } from '@common/modules/table-tool/types/filters';
+
+describe('groupResultMeasuresByCombination', () => {
+  test('creates different groups based on location', () => {
+    const resultMeasures = groupResultMeasuresByCombination([
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-1': '1000',
+          'indicator-2': '2000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnsley',
+            name: 'Barnsley',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-1': '3000',
+          'indicator-2': '4000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+    ]);
+
+    expect(resultMeasures).toEqual({
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      })]: {
+        '2018_AY': {
+          'filter-1': {
+            'filter-2': {
+              'indicator-1': '1000',
+              'indicator-2': '2000',
+            },
+          },
+        },
+      },
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnsley',
+      })]: {
+        '2018_AY': {
+          'filter-1': {
+            'filter-2': {
+              'indicator-1': '3000',
+              'indicator-2': '4000',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('creates different groups based on time period', () => {
+    const resultMeasures = groupResultMeasuresByCombination([
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-1': '1000',
+          'indicator-2': '2000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2019_AY',
+        measures: {
+          'indicator-1': '3000',
+          'indicator-2': '4000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+    ]);
+
+    expect(resultMeasures).toEqual({
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      })]: {
+        '2018_AY': {
+          'filter-1': {
+            'filter-2': {
+              'indicator-1': '1000',
+              'indicator-2': '2000',
+            },
+          },
+        },
+        '2019_AY': {
+          'filter-1': {
+            'filter-2': {
+              'indicator-1': '3000',
+              'indicator-2': '4000',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('creates different groups based on filters', () => {
+    const resultMeasures = groupResultMeasuresByCombination([
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-1': '1000',
+          'indicator-2': '2000',
+        },
+        filters: ['filter-1', 'filter-3'],
+      },
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-1': '3000',
+          'indicator-2': '4000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+    ]);
+
+    expect(resultMeasures).toEqual({
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      })]: {
+        '2018_AY': {
+          'filter-1': {
+            'filter-2': {
+              'indicator-1': '3000',
+              'indicator-2': '4000',
+            },
+            'filter-3': {
+              'indicator-1': '1000',
+              'indicator-2': '2000',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('merges groups with same data set', () => {
+    const resultMeasures = groupResultMeasuresByCombination([
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-1': '1000',
+          'indicator-2': '2000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+      {
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: {
+            code: 'barnet',
+            name: 'Barnet',
+          },
+        },
+        timePeriod: '2018_AY',
+        measures: {
+          'indicator-3': '3000',
+          'indicator-4': '4000',
+        },
+        filters: ['filter-1', 'filter-2'],
+      },
+    ]);
+
+    expect(resultMeasures).toEqual({
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      })]: {
+        '2018_AY': {
+          'filter-1': {
+            'filter-2': {
+              'indicator-1': '1000',
+              'indicator-2': '2000',
+              'indicator-3': '3000',
+              'indicator-4': '4000',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  test('can exclude grouping by location', () => {
+    const excludedFilterIds = [
+      LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      }),
+    ];
+
+    const resultMeasures = groupResultMeasuresByCombination(
+      [
+        {
+          geographicLevel: 'localAuthority',
+          location: {
+            localAuthority: {
+              code: 'barnet',
+              name: 'Barnet',
+            },
+          },
+          timePeriod: '2018_AY',
+          measures: {
+            'indicator-1': '1000',
+            'indicator-2': '2000',
+          },
+          filters: ['filter-1', 'filter-2'],
+        },
+        {
+          geographicLevel: 'localAuthority',
+          location: {
+            localAuthority: {
+              code: 'barnet',
+              name: 'Barnet',
+            },
+          },
+          timePeriod: '2018_AY',
+          measures: {
+            'indicator-3': '3000',
+            'indicator-4': '4000',
+          },
+          filters: ['filter-1', 'filter-2'],
+        },
+      ],
+      excludedFilterIds,
+    );
+
+    expect(resultMeasures).toEqual({
+      '2018_AY': {
+        'filter-1': {
+          'filter-2': {
+            'indicator-1': '1000',
+            'indicator-2': '2000',
+            'indicator-3': '3000',
+            'indicator-4': '4000',
+          },
+        },
+      },
+    });
+  });
+
+  test('can exclude grouping by time period', () => {
+    const excludedFilterIds = ['2018_AY'];
+
+    const resultMeasures = groupResultMeasuresByCombination(
+      [
+        {
+          geographicLevel: 'localAuthority',
+          location: {
+            localAuthority: {
+              code: 'barnet',
+              name: 'Barnet',
+            },
+          },
+          timePeriod: '2018_AY',
+          measures: {
+            'indicator-1': '1000',
+            'indicator-2': '2000',
+          },
+          filters: ['filter-1', 'filter-2'],
+        },
+        {
+          geographicLevel: 'localAuthority',
+          location: {
+            localAuthority: {
+              code: 'barnet',
+              name: 'Barnet',
+            },
+          },
+          timePeriod: '2018_AY',
+          measures: {
+            'indicator-3': '3000',
+            'indicator-4': '4000',
+          },
+          filters: ['filter-1', 'filter-2'],
+        },
+      ],
+      excludedFilterIds,
+    );
+
+    expect(resultMeasures).toEqual({
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      })]: {
+        'filter-1': {
+          'filter-2': {
+            'indicator-1': '1000',
+            'indicator-2': '2000',
+            'indicator-3': '3000',
+            'indicator-4': '4000',
+          },
+        },
+      },
+    });
+  });
+
+  test('can exclude grouping by single filter', () => {
+    const excludedFilterIds = ['filter-2'];
+
+    const resultMeasures = groupResultMeasuresByCombination(
+      [
+        {
+          geographicLevel: 'localAuthority',
+          location: {
+            localAuthority: {
+              code: 'barnet',
+              name: 'Barnet',
+            },
+          },
+          timePeriod: '2018_AY',
+          measures: {
+            'indicator-1': '1000',
+            'indicator-2': '2000',
+          },
+          filters: ['filter-1', 'filter-2'],
+        },
+        {
+          geographicLevel: 'localAuthority',
+          location: {
+            localAuthority: {
+              code: 'barnet',
+              name: 'Barnet',
+            },
+          },
+          timePeriod: '2018_AY',
+          measures: {
+            'indicator-3': '3000',
+            'indicator-4': '4000',
+          },
+          filters: ['filter-1', 'filter-2'],
+        },
+      ],
+      excludedFilterIds,
+    );
+
+    expect(resultMeasures).toEqual({
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      })]: {
+        '2018_AY': {
+          'filter-1': {
+            'indicator-1': '1000',
+            'indicator-2': '2000',
+            'indicator-3': '3000',
+            'indicator-4': '4000',
+          },
+        },
+      },
+    });
+  });
+
+  test('can exclude grouping by multiple filters', () => {
+    const excludedFilterIds = ['filter-1', 'filter-2'];
+
+    const resultMeasures = groupResultMeasuresByCombination(
+      [
+        {
+          geographicLevel: 'localAuthority',
+          location: {
+            localAuthority: {
+              code: 'barnet',
+              name: 'Barnet',
+            },
+          },
+          timePeriod: '2018_AY',
+          measures: {
+            'indicator-1': '1000',
+            'indicator-2': '2000',
+          },
+          filters: ['filter-1', 'filter-2'],
+        },
+        {
+          geographicLevel: 'localAuthority',
+          location: {
+            localAuthority: {
+              code: 'barnet',
+              name: 'Barnet',
+            },
+          },
+          timePeriod: '2018_AY',
+          measures: {
+            'indicator-3': '3000',
+            'indicator-4': '4000',
+          },
+          filters: ['filter-1', 'filter-2'],
+        },
+      ],
+      excludedFilterIds,
+    );
+
+    expect(resultMeasures).toEqual({
+      [LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      })]: {
+        '2018_AY': {
+          'indicator-1': '1000',
+          'indicator-2': '2000',
+          'indicator-3': '3000',
+          'indicator-4': '4000',
+        },
+      },
+    });
+  });
+
+  test('can exclude grouping of different filter types', () => {
+    const excludedFilterIds = [
+      LocationFilter.createId({
+        level: 'localAuthority',
+        value: 'barnet',
+      }),
+      '2018_AY',
+      'filter-1',
+    ];
+
+    const resultMeasures = groupResultMeasuresByCombination(
+      [
+        {
+          geographicLevel: 'localAuthority',
+          location: {
+            localAuthority: {
+              code: 'barnet',
+              name: 'Barnet',
+            },
+          },
+          timePeriod: '2018_AY',
+          measures: {
+            'indicator-1': '1000',
+            'indicator-2': '2000',
+          },
+          filters: ['filter-1', 'filter-2'],
+        },
+        {
+          geographicLevel: 'localAuthority',
+          location: {
+            localAuthority: {
+              code: 'barnet',
+              name: 'Barnet',
+            },
+          },
+          timePeriod: '2018_AY',
+          measures: {
+            'indicator-3': '3000',
+            'indicator-4': '4000',
+          },
+          filters: ['filter-1', 'filter-2'],
+        },
+      ],
+      excludedFilterIds,
+    );
+
+    expect(resultMeasures).toEqual({
+      'filter-2': {
+        'indicator-1': '1000',
+        'indicator-2': '2000',
+        'indicator-3': '3000',
+        'indicator-4': '4000',
+      },
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/groupResultMeasuresByCombination.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/groupResultMeasuresByCombination.ts
@@ -1,0 +1,60 @@
+import {
+  getIndicatorPath,
+  MeasuresGroupedByDataSet,
+} from '@common/modules/charts/util/groupResultMeasuresByDataSet';
+import { TableDataResult } from '@common/services/tableBuilderService';
+import { Dictionary } from '@common/types';
+import get from 'lodash/get';
+import set from 'lodash/set';
+
+/**
+ * Group {@param results} and their measures by their
+ * associated combination of filters at each level
+ * of a nested dictionary.
+ *
+ * {@param excludedFilterIds} should be used to prevent filters
+ * that have been stripped out of the table headers from being
+ * included in the path. Otherwise, it will not be possible
+ * to resolve all combinations to a result.
+ *
+ * This is convenient for larger result sets where iteration
+ * can be really expensive. By grouping the results in such a
+ * way, we can achieve O(1) time complexity.
+ *
+ * Note that we cannot specify a return type as it's not
+ * possible to define one due to the dynamic nature of the result.
+ */
+export default function groupResultMeasuresByCombination(
+  results: TableDataResult[],
+  excludedFilterIds: string[] = [],
+): Dictionary<unknown> {
+  return results.reduce<MeasuresGroupedByDataSet>((acc, result) => {
+    const { geographicLevel, filters, timePeriod, location, measures } = result;
+
+    const path = getIndicatorPath({
+      filters,
+      timePeriod,
+      indicator: '',
+      location: location[geographicLevel]
+        ? {
+            value: location[geographicLevel].code,
+            level: geographicLevel,
+          }
+        : undefined,
+    });
+
+    const filteredPath = path.filter(id => !excludedFilterIds.includes(id));
+    const existing = get(acc, filteredPath);
+
+    if (existing) {
+      set(acc, filteredPath, {
+        ...existing,
+        ...measures,
+      });
+    } else {
+      set(acc, filteredPath, measures);
+    }
+
+    return acc;
+  }, {});
+}

--- a/src/explore-education-statistics-common/src/modules/table-tool/types/filters.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/types/filters.ts
@@ -6,7 +6,6 @@ import {
   LocationOption,
   TimePeriodOption,
 } from '@common/services/tableBuilderService';
-import camelCase from 'lodash/camelCase';
 
 interface GroupedFilterOption extends FilterOption {
   group?: string;
@@ -76,7 +75,7 @@ export class LocationFilter extends Filter {
   }: GroupedFilterOption & LocationOption) {
     super({ value, label, group });
 
-    this.level = camelCase(level);
+    this.level = level;
     this.geoJson = geoJson;
   }
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
@@ -12,7 +12,7 @@ import permalinkService from '@common/services/permalinkService';
 import publicationService from '@common/services/publicationService';
 import { TableDataQuery } from '@common/services/tableBuilderService';
 import Link from '@frontend/components/Link';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { memo, useEffect, useRef, useState } from 'react';
 import DownloadCsvButton from '@common/modules/table-tool/components/DownloadCsvButton';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
 import DownloadExcelButton from '@common/modules/table-tool/components/DownloadExcelButton';
@@ -212,4 +212,4 @@ const TableToolFinalStep = ({
   );
 };
 
-export default TableToolFinalStep;
+export default memo(TableToolFinalStep);


### PR DESCRIPTION
This PR adds the following performance optimizations:

- Adds pre-grouping of result measures by their respective set of filters. This drastically speeds up lookup of results during `createDataSetCategories` (up to ~10x faster)
- Adds a similar pre-grouping of result measures optimization to `TimePeriodDataTable` as well (~4-5x faster)
- Aggregates multiple operations required for calculating `MapBlock` geometries into a single operation (~0.25x faster)
- Removes client-side camelCasing of `geographicLevel` for both charts and tables. This only shaves off a fairly neglible amount of time (~1%), but it mainly makes sense to push any camelCasing onto the server for consistency.

## Relevant changes

- Fixes `ReleaseDataBlockSourceWizardFinalStep` rendering its table twice unnecessarily.
- Changes 'Table' tab in `ReleaseDataBlocksPageTabs` to be rendered lazily i.e. will only be rendered when the user visits the tab. This should help mitigate potentially slow initial renders.

## Benchmark notes

I benchmarked by creating two data blocks from absence data. They were created with map charts using the following filters:

- Block 1: all local authorities, 5 time periods, 3 indicators  and 1 filter
- Block 2: all local authorities, 1 time period, 3 indicators and 2 school types

### Baseline

- Block 1
  - Map: 2566.8ms
  - Table: 428.6ms
- Block 2
  - Map: 174ms
  - Table: 174ms

### After optimizations

- Block 1
  - Map: 199.9 - 203.3ms
  - Table: 91.5ms
- Block 2
  - Map: 101.2 - 114.8ms
  - Table: 43ms

## Further work

There are most likely some more minor performance tweaks that we can do to the main bottlenecked areas (`createDataSetCategories` and `TimePeriodDataTable`), however, these may not have a very good benefit/effort ratio. These may only yield 10-20% speed ups for quite a lot of refactoring and general decrease in readability.

The crux of the issue is that for large tables/charts, there are just a lot of iterations that have to be performed as there is a lot of data to crunch! Additionally, a fairly large chunk of execution time is out of our control as it's up to Leaflet to actually render the maps.

A better investment of time would be to try and remove/reduce UI freezes so that users can't really perceive any slowness. Ideally we want to offload any processing to another thread before the table/chart renders. Web workers will most likely be needed for this (see [EES-1809](https://dfedigital.atlassian.net/browse/EES-1809)).