### PR TITLE
EES-1722 Add blob storage caching of data block responses

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Mime;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -304,6 +305,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
                     ContentType = contentType,
                 },
                 options?.MetaValues
+            );
+        }
+
+        public async Task UploadAsJson<T>(
+            string containerName,
+            string path,
+            T content,
+            JsonSerializerSettings settings)
+        {
+            var json = JsonConvert.SerializeObject(content, typeof(T), settings);
+
+            await UploadText(
+                containerName: containerName,
+                path: path,
+                content: json,
+                contentType: MediaTypeNames.Application.Json
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -14,7 +14,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         {
             return "staging";
         }
-        
+
         private static string PublicContentDownloadPath(string prefix = null)
         {
             return $"{AppendPathSeparator(prefix)}download";
@@ -44,7 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         {
             return $"{PublicContentFastTrackPath(prefix)}/{releaseId}";
         }
-        
+
         public static string PublicContentFastTrackPath(string releaseId, string id, string prefix = null)
         {
             return $"{PublicContentReleaseFastTrackPath(releaseId, prefix)}/{id}.json";
@@ -70,6 +70,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return $"{PublicContentPublicationsPath(prefix)}/{slug}";
         }
 
+        public static string PublicContentReleaseParentPath(string publicationSlug, string releaseSlug, string prefix = null)
+        {
+            return $"{PublicContentPublicationParentPath(publicationSlug, prefix)}/releases/{releaseSlug}";
+        }
+
         public static string PublicContentPublicationPath(string slug, string prefix = null)
         {
             return $"{PublicContentPublicationParentPath(slug, prefix)}/publication.json";
@@ -79,10 +84,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         {
             return $"{PublicContentPublicationParentPath(slug, prefix)}/latest-release.json";
         }
-        
+
         public static string PublicContentReleasePath(string publicationSlug, string releaseSlug, string prefix = null)
         {
             return $"{PublicContentPublicationParentPath(publicationSlug, prefix)}/releases/{releaseSlug}.json";
+        }
+
+        public static string PublicContentDataBlockPath(
+            string publicationSlug,
+            string releaseSlug,
+            Guid dataBlockId,
+            string prefix = null)
+        {
+            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug, prefix)}/data-blocks/{dataBlockId}.json";
         }
 
         /**
@@ -210,7 +224,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
             return batchFileRegex.IsMatch(fullFilePath);
         }
-        
+
         private static string AppendPathSeparator(string segment = null)
         {
             return segment == null ? "" : segment + "/";

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Storage.DataMovement;
+using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 {
@@ -55,6 +56,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
             string content,
             string contentType,
             UploadTextOptions options = null);
+
+        public Task UploadAsJson<T>(
+            string containerName,
+            string path,
+            T content,
+            JsonSerializerSettings settings = null);
 
         public Task<bool> IsAppendSupported(string containerName, string path);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
@@ -89,6 +89,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 
         public Task<string> DownloadBlobText(string containerName, string path);
 
+        Task<T> GetDeserializedJson<T>(string containerName, string path);
+
         public class CopyDirectoryOptions
         {
             public string DestinationConnectionString { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/FileStorageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/FileStorageServiceTests.cs
@@ -1,8 +1,8 @@
-using System.Linq;
+using System.IO;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Services;
-using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
+using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainerNames;
@@ -22,12 +22,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
             var blobStorageService = new Mock<IBlobStorageService>();
 
             blobStorageService
-                .Setup(s => s.DownloadBlobText(PublicContentContainerName, "test-path"))
-                .ReturnsAsync(
-                    @"
+                .Setup(s => s.GetDeserializedJson<TestModel>(PublicContentContainerName, "test-path"))
+                .ReturnsAsync(new TestModel
                 {
-                    ""Name"": ""Test"" 
-                }");
+                    Name = "Test"
+                });
 
             var fileStorageService = new FileStorageService(blobStorageService.Object);
 
@@ -38,76 +37,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
         }
 
         [Fact]
-        public async Task GetDeserialized_ReleaseJson()
+        public async Task GetDeserialized_NotFound()
         {
             var blobStorageService = new Mock<IBlobStorageService>();
 
             blobStorageService
-                .Setup(s => s.DownloadBlobText(PublicContentContainerName, "test-path"))
-                .ReturnsAsync(SampleContentJson.ReleaseJson);
+                .Setup(s => s.GetDeserializedJson<TestModel>(PublicContentContainerName, "test-path"))
+                .ThrowsAsync(new FileNotFoundException("Blob not found"));
 
             var fileStorageService = new FileStorageService(blobStorageService.Object);
 
-            var result = await fileStorageService.GetDeserialized<CachedReleaseViewModel>("test-path");
+            var result = await fileStorageService.GetDeserialized<TestModel>("test-path");
 
-            Assert.True(result.IsRight);
-            var releaseViewModel = result.Right;
-
-            Assert.Single(releaseViewModel.Content);
-            var contentSection = releaseViewModel.Content[0];
-            Assert.Single(contentSection.Content);
-            Assert.IsAssignableFrom<HtmlBlockViewModel>(contentSection.Content.First());
-
-            var headlinesSection = releaseViewModel.HeadlinesSection;
-            Assert.Single(headlinesSection.Content);
-            Assert.IsAssignableFrom<MarkDownBlockViewModel>(headlinesSection.Content.First());
-
-            var keyStatisticsSection = releaseViewModel.KeyStatisticsSection;
-            Assert.Single(keyStatisticsSection.Content);
-            Assert.IsAssignableFrom<MarkDownBlockViewModel>(keyStatisticsSection.Content.First());
-
-            var keyStatisticsSecondarySection = releaseViewModel.KeyStatisticsSecondarySection;
-            Assert.Single(keyStatisticsSecondarySection.Content);
-            Assert.IsAssignableFrom<MarkDownBlockViewModel>(keyStatisticsSecondarySection.Content.First());
-
-            var summarySection = releaseViewModel.SummarySection;
-            Assert.Single(summarySection.Content);
-            Assert.IsAssignableFrom<MarkDownBlockViewModel>(summarySection.Content.First());
-        }
-
-        [Fact]
-        public async Task GetDeserialized_PublicationJson()
-        {
-            var blobStorageService = new Mock<IBlobStorageService>();
-
-            blobStorageService
-                .Setup(s => s.DownloadBlobText(PublicContentContainerName, "test-path"))
-                .ReturnsAsync(SampleContentJson.PublicationJson);
-
-            var fileStorageService = new FileStorageService(blobStorageService.Object);
-
-            var result = await fileStorageService.GetDeserialized<CachedPublicationViewModel>("test-path");
-
-            Assert.True(result.IsRight);
-            var viewModel = result.Right;
-
-            Assert.Single(viewModel.Releases);
-        }
-
-        [Fact]
-        public async Task GetDeserialized_MethodologyJson()
-        {
-            var blobStorageService = new Mock<IBlobStorageService>();
-
-            blobStorageService
-                .Setup(s => s.DownloadBlobText(PublicContentContainerName, "test-path"))
-                .ReturnsAsync(SampleContentJson.MethodologyJson);
-
-            var fileStorageService = new FileStorageService(blobStorageService.Object);
-
-            var result = await fileStorageService.GetDeserialized<MethodologyViewModel>("test-path");
-
-            Assert.True(result.IsRight);
+            Assert.True(result.IsLeft);
+            Assert.IsType<NotFoundResult>(result.Left);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/FileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/FileStorageService.cs
@@ -6,7 +6,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
 {
@@ -21,11 +20,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
 
         public async Task<Either<ActionResult, T>> GetDeserialized<T>(string path)
         {
-            var text = "";
-
             try
             {
-                text = await _blobStorageService.DownloadBlobText(
+                return await _blobStorageService.GetDeserializedJson<T>(
                     BlobContainerNames.PublicContentContainerName,
                     path
                 );
@@ -34,20 +31,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
             {
                 return new NotFoundResult();
             }
-
-            if (string.IsNullOrWhiteSpace(text))
-            {
-                throw new JsonException(
-                    $"Found empty file when trying to deserialize JSON for path: {path}");
-            }
-
-            return JsonConvert.DeserializeObject<T>(
-                text,
-                new JsonSerializerSettings
-                {
-                    TypeNameHandling = TypeNameHandling.Auto
-                }
-            );
         }
 
         public async Task<bool> IsBlobReleased(string containerName, string path)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/TableBuilderControllerTests.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers;
+using GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using Microsoft.AspNetCore.Http;
@@ -54,18 +54,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
         [Fact]
         public async Task QueryForDataBlock()
         {
-            var tableBuilderService = new Mock<ITableBuilderService>();
+            var releaseContentBlock = new ReleaseContentBlock
+            {
+                ReleaseId = _releaseId,
+                Release = new Release
+                {
+                    Id = _releaseId,
+                },
+                ContentBlockId = _dataBlockId,
+                ContentBlock = new DataBlock
+                {
+                    Id = _dataBlockId,
+                    Query = _query,
+                    Charts = new List<IChart>()
+                }
+            };
 
-            tableBuilderService
-                .Setup(
-                    s =>
-                        s.Query(
-                            _releaseId,
-                            It.Is<ObservationQueryContext>(
-                                q => q.SubjectId == _query.SubjectId
-                            )
-                        )
-                )
+            var dataBlockService = new Mock<IDataBlockService>();
+
+            dataBlockService
+                .Setup(s => s.GetDataBlockTableResult(releaseContentBlock))
                 .ReturnsAsync(
                     new TableBuilderResultViewModel
                     {
@@ -78,25 +86,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 
             var contentPersistenceHelper =
                 MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
-                    new ReleaseContentBlock
-                    {
-                        ReleaseId = _releaseId,
-                        Release = new Release
-                        {
-                            Id = _releaseId,
-                        },
-                        ContentBlockId = _dataBlockId,
-                        ContentBlock = new DataBlock
-                        {
-                            Id = _dataBlockId,
-                            Query = _query,
-                            Charts = new List<IChart>()
-                        }
-                    }
+                    releaseContentBlock
                 );
 
             var controller = BuildTableBuilderController(
-                tableBuilderService: tableBuilderService.Object,
+                dataBlockService: dataBlockService.Object,
                 contentPersistenceHelper: contentPersistenceHelper.Object
             );
 
@@ -110,79 +104,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             Assert.IsType<TableBuilderResultViewModel>(result.Value);
             Assert.Single(result.Value.Results);
 
-            MockUtils.VerifyAllMocks(tableBuilderService, contentPersistenceHelper);
-        }
-
-        [Fact]
-        public async Task QueryForDataBlock_NoGeoJson()
-        {
-            var subjectId = Guid.NewGuid();
-
-            var tableBuilderService = new Mock<ITableBuilderService>();
-
-            tableBuilderService
-                .Setup(
-                    s =>
-                        s.Query(
-                            _releaseId,
-                            It.Is<ObservationQueryContext>(
-                                q =>
-                                    q.SubjectId == subjectId && q.IncludeGeoJson == true
-                            )
-                        )
-                )
-                .ReturnsAsync(
-                    new TableBuilderResultViewModel
-                    {
-                        Results = new List<ObservationViewModel>
-                        {
-                            new ObservationViewModel()
-                        }
-                    }
-                );
-
-            var contentPersistenceHelper =
-                MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
-                    new ReleaseContentBlock
-                    {
-                        ReleaseId = _releaseId,
-                        Release = new Release
-                        {
-                            Id = _releaseId,
-                        },
-                        ContentBlockId = _dataBlockId,
-                        ContentBlock = new DataBlock
-                        {
-                            Id = _dataBlockId,
-                            Query = new ObservationQueryContext
-                            {
-                                SubjectId = subjectId,
-                                IncludeGeoJson = false
-                            },
-                            Charts = new List<IChart>
-                            {
-                                new MapChart()
-                            }
-                        }
-                    }
-                );
-
-            var controller = BuildTableBuilderController(
-                tableBuilderService: tableBuilderService.Object,
-                contentPersistenceHelper: contentPersistenceHelper.Object
-            );
-
-            controller.ControllerContext = new ControllerContext
-            {
-                HttpContext = new DefaultHttpContext()
-            };
-
-            var result = await controller.QueryForDataBlock(_releaseId, _dataBlockId);
-
-            Assert.IsType<TableBuilderResultViewModel>(result.Value);
-            Assert.Single(result.Value.Results);
-
-            MockUtils.VerifyAllMocks(tableBuilderService, contentPersistenceHelper);
+            MockUtils.VerifyAllMocks(dataBlockService, contentPersistenceHelper);
         }
 
         [Fact]
@@ -204,41 +126,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 
             Assert.IsType<NotFoundResult>(result.Result);
         }
-
-        [Fact]
-        public async Task QueryForDataBlock_NotDataBlockType()
-        {
-            var contentPersistenceHelper =
-                MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
-                    new ReleaseContentBlock
-                    {
-                        ReleaseId = _releaseId,
-                        Release = new Release
-                        {
-                            Id = _releaseId,
-                        },
-                        ContentBlockId = _dataBlockId,
-                        ContentBlock = new HtmlBlock
-                        {
-                            Id = _dataBlockId,
-                        }
-                    }
-                );
-
-            var controller = BuildTableBuilderController(
-                contentPersistenceHelper: contentPersistenceHelper.Object
-            );
-
-            controller.ControllerContext = new ControllerContext
-            {
-                HttpContext = new DefaultHttpContext()
-            };
-
-            var result = await controller.QueryForDataBlock(_releaseId, _dataBlockId);
-
-            Assert.IsType<NotFoundResult>(result.Result);
-        }
-
 
         [Fact]
         public async Task QueryForDataBlock_NotModified()
@@ -294,18 +181,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
         [Fact]
         public async Task QueryForDataBlock_IsModified()
         {
-            var tableBuilderService = new Mock<ITableBuilderService>();
+            var releaseContentBlock = new ReleaseContentBlock
+            {
+                ReleaseId = _releaseId,
+                Release = new Release
+                {
+                    Id = _releaseId,
+                    Published = DateTime.Parse("2020-11-11T12:00:00Z")
+                },
+                ContentBlockId = _dataBlockId,
+                ContentBlock = new DataBlock
+                {
+                    Id = _dataBlockId,
+                    Query = _query,
+                    Charts = new List<IChart>()
+                }
+            };
 
-            tableBuilderService
-                .Setup(
-                    s =>
-                        s.Query(
-                            _releaseId,
-                            It.Is<ObservationQueryContext>(
-                                q => q.SubjectId == _query.SubjectId
-                            )
-                        )
-                )
+            var dataBlockService = new Mock<IDataBlockService>();
+
+            dataBlockService
+                .Setup(s => s.GetDataBlockTableResult(releaseContentBlock))
                 .ReturnsAsync(
                     new TableBuilderResultViewModel
                     {
@@ -318,26 +214,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
 
             var contentPersistenceHelper =
                 MockUtils.MockPersistenceHelper<ContentDbContext, ReleaseContentBlock>(
-                    new ReleaseContentBlock
-                    {
-                        ReleaseId = _releaseId,
-                        Release = new Release
-                        {
-                            Id = _releaseId,
-                            Published = DateTime.Parse("2020-11-11T12:00:00Z")
-                        },
-                        ContentBlockId = _dataBlockId,
-                        ContentBlock = new DataBlock
-                        {
-                            Id = _dataBlockId,
-                            Query = _query,
-                            Charts = new List<IChart>()
-                        }
-                    }
+                    releaseContentBlock
                 );
 
             var controller = BuildTableBuilderController(
-                tableBuilderService: tableBuilderService.Object,
+                dataBlockService: dataBlockService.Object,
                 contentPersistenceHelper: contentPersistenceHelper.Object
             );
 
@@ -363,19 +244,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             Assert.IsType<TableBuilderResultViewModel>(result.Value);
             Assert.Single(result.Value.Results);
 
-            MockUtils.VerifyAllMocks(tableBuilderService, contentPersistenceHelper);
+            MockUtils.VerifyAllMocks(dataBlockService, contentPersistenceHelper);
         }
 
         private TableBuilderController BuildTableBuilderController(
             ITableBuilderService tableBuilderService = null,
-            IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
-            IUserService userService = null)
-
+            IDataBlockService dataBlockService = null,
+            IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null)
         {
             return new TableBuilderController(
                 tableBuilderService ?? new Mock<ITableBuilderService>().Object,
-                contentPersistenceHelper ?? MockUtils.MockPersistenceHelper<ContentDbContext>().Object,
-                userService ?? MockUtils.AlwaysTrueUserService().Object
+                dataBlockService ?? new Mock<IDataBlockService>().Object,
+                contentPersistenceHelper ?? MockUtils.MockPersistenceHelper<ContentDbContext>().Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServiceTests.cs
@@ -1,0 +1,412 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Api.Services;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainerNames;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
+{
+    public class DataBlockServiceTests
+    {
+        private readonly Guid _releaseId = Guid.NewGuid();
+        private readonly Guid _dataBlockId = Guid.NewGuid();
+
+        [Fact]
+        public async Task GetDataBlockTableResult()
+        {
+            var subjectId = Guid.NewGuid();
+
+            var releaseContentBlock = new ReleaseContentBlock
+            {
+                ReleaseId = _releaseId,
+                Release = new Release
+                {
+                    Id = _releaseId,
+                    Slug = "release-slug",
+                    Publication = new Publication
+                    {
+                        Slug = "publication-slug"
+                    }
+                },
+                ContentBlockId = _dataBlockId,
+                ContentBlock = new DataBlock
+                {
+                    Id = _dataBlockId,
+                    Query = new ObservationQueryContext
+                    {
+                        SubjectId = subjectId,
+                    },
+                    Charts = new List<IChart>
+                    {
+                        new LineChart()
+                    }
+                }
+            };
+
+            await using var contentDbContext = ContentDbUtils.InMemoryContentDbContext();
+
+            await contentDbContext.AddAsync(releaseContentBlock);
+            await contentDbContext.SaveChangesAsync();
+
+            var path = $"publications/publication-slug/releases/release-slug/data-blocks/{_dataBlockId}.json";
+
+            var tableResult = new TableBuilderResultViewModel
+            {
+                Results = new List<ObservationViewModel>
+                {
+                    new ObservationViewModel()
+                }
+            };
+
+            var blobStorageService = new Mock<IBlobStorageService>();
+
+            blobStorageService
+                .Setup(s => s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContentContainerName, path))
+                .ThrowsAsync(new FileNotFoundException());
+
+            blobStorageService
+                .Setup(s => s.UploadAsJson(PublicContentContainerName, path, tableResult, null));
+
+            var tableBuilderService = new Mock<ITableBuilderService>();
+
+            tableBuilderService
+                .Setup(
+                    s =>
+                        s.Query(
+                            _releaseId,
+                            It.Is<ObservationQueryContext>(q => q.SubjectId == subjectId)
+                        )
+                )
+                .ReturnsAsync(tableResult);
+
+            var service = BuildDataBlockService(
+                contentDbContext,
+                tableBuilderService: tableBuilderService.Object,
+                blobStorageService: blobStorageService.Object
+            );
+
+            var result = await service.GetDataBlockTableResult(releaseContentBlock);
+
+            Assert.True(result.IsRight);
+
+            Assert.IsType<TableBuilderResultViewModel>(result.Right);
+            Assert.Single(result.Right.Results);
+
+            MockUtils.VerifyAllMocks(blobStorageService, tableBuilderService);
+        }
+
+        [Fact]
+        public async Task GetDataBlockTableResult_MapChartForcesIncludeGeoJson()
+        {
+            var subjectId = Guid.NewGuid();
+
+            var releaseContentBlock = new ReleaseContentBlock
+            {
+                ReleaseId = _releaseId,
+                Release = new Release
+                {
+                    Id = _releaseId,
+                    Slug = "release-slug",
+                    Publication = new Publication
+                    {
+                        Slug = "publication-slug"
+                    }
+                },
+                ContentBlockId = _dataBlockId,
+                ContentBlock = new DataBlock
+                {
+                    Id = _dataBlockId,
+                    Query = new ObservationQueryContext
+                    {
+                        SubjectId = subjectId,
+                        // This is set to false in the persisted query but
+                        // we expect it to be converted to true in the
+                        // query that is actually ran by TableBuilderService
+                        IncludeGeoJson = false
+                    },
+                    Charts = new List<IChart>
+                    {
+                        new MapChart()
+                    }
+                }
+            };
+
+            await using var contentDbContext = ContentDbUtils.InMemoryContentDbContext();
+
+            await contentDbContext.AddAsync(releaseContentBlock);
+            await contentDbContext.SaveChangesAsync();
+
+            var path = $"publications/publication-slug/releases/release-slug/data-blocks/{_dataBlockId}.json";
+
+            var tableResult = new TableBuilderResultViewModel
+            {
+                Results = new List<ObservationViewModel>
+                {
+                    new ObservationViewModel()
+                }
+            };
+
+            var blobStorageService = new Mock<IBlobStorageService>();
+
+            blobStorageService
+                .Setup(s => s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContentContainerName, path))
+                .ThrowsAsync(new FileNotFoundException());
+
+            blobStorageService
+                .Setup(s => s.UploadAsJson(PublicContentContainerName, path, tableResult, null));
+
+            var tableBuilderService = new Mock<ITableBuilderService>();
+
+            tableBuilderService
+                .Setup(
+                    s =>
+                        s.Query(
+                            _releaseId,
+                            It.Is<ObservationQueryContext>(
+                                q =>
+                                    q.SubjectId == subjectId && q.IncludeGeoJson == true
+                            )
+                        )
+                )
+                .ReturnsAsync(tableResult);
+
+            var service = BuildDataBlockService(
+                contentDbContext,
+                tableBuilderService: tableBuilderService.Object,
+                blobStorageService: blobStorageService.Object
+            );
+
+            var result = await service.GetDataBlockTableResult(releaseContentBlock);
+
+            Assert.True(result.IsRight);
+
+            Assert.IsType<TableBuilderResultViewModel>(result.Right);
+            Assert.Single(result.Right.Results);
+
+            MockUtils.VerifyAllMocks(blobStorageService, tableBuilderService);
+        }
+
+        [Fact]
+        public async Task GetDataBlockTableResult_CachedResultExists()
+        {
+            var subjectId = Guid.NewGuid();
+
+            var releaseContentBlock = new ReleaseContentBlock
+            {
+                ReleaseId = _releaseId,
+                Release = new Release
+                {
+                    Id = _releaseId,
+                    Slug = "release-slug",
+                    Publication = new Publication
+                    {
+                        Slug = "publication-slug"
+                    }
+                },
+                ContentBlockId = _dataBlockId,
+                ContentBlock = new DataBlock
+                {
+                    Id = _dataBlockId,
+                    Query = new ObservationQueryContext
+                    {
+                        SubjectId = subjectId,
+                    },
+                    Charts = new List<IChart>
+                    {
+                        new LineChart()
+                    }
+                }
+            };
+
+            await using var contentDbContext = ContentDbUtils.InMemoryContentDbContext();
+
+            await contentDbContext.AddAsync(releaseContentBlock);
+            await contentDbContext.SaveChangesAsync();
+
+            var path = $"publications/publication-slug/releases/release-slug/data-blocks/{_dataBlockId}.json";
+
+            var tableResult = new TableBuilderResultViewModel
+            {
+                Results = new List<ObservationViewModel>
+                {
+                    new ObservationViewModel()
+                }
+            };
+
+            var blobStorageService = new Mock<IBlobStorageService>();
+
+            blobStorageService
+                .Setup(s => s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContentContainerName, path))
+                .ReturnsAsync(tableResult);
+
+            var tableBuilderService = new Mock<ITableBuilderService>();
+
+            var service = BuildDataBlockService(
+                contentDbContext,
+                tableBuilderService: tableBuilderService.Object,
+                blobStorageService: blobStorageService.Object
+            );
+
+            var result = await service.GetDataBlockTableResult(releaseContentBlock);
+
+            Assert.True(result.IsRight);
+
+            Assert.IsType<TableBuilderResultViewModel>(result.Right);
+            Assert.Single(result.Right.Results);
+
+            MockUtils.VerifyAllMocks(blobStorageService, tableBuilderService);
+        }
+
+        [Fact]
+        public async Task GetDataBlockTableResult_DeletesInvalidCachedResult()
+        {
+            var subjectId = Guid.NewGuid();
+
+            var releaseContentBlock = new ReleaseContentBlock
+            {
+                ReleaseId = _releaseId,
+                Release = new Release
+                {
+                    Id = _releaseId,
+                    Slug = "release-slug",
+                    Publication = new Publication
+                    {
+                        Slug = "publication-slug"
+                    }
+                },
+                ContentBlockId = _dataBlockId,
+                ContentBlock = new DataBlock
+                {
+                    Id = _dataBlockId,
+                    Query = new ObservationQueryContext
+                    {
+                        SubjectId = subjectId,
+                    },
+                    Charts = new List<IChart>
+                    {
+                        new LineChart()
+                    }
+                }
+            };
+
+            await using var contentDbContext = ContentDbUtils.InMemoryContentDbContext();
+
+            await contentDbContext.AddAsync(releaseContentBlock);
+            await contentDbContext.SaveChangesAsync();
+
+            var path = $"publications/publication-slug/releases/release-slug/data-blocks/{_dataBlockId}.json";
+
+            var tableResult = new TableBuilderResultViewModel
+            {
+                Results = new List<ObservationViewModel>
+                {
+                    new ObservationViewModel()
+                }
+            };
+
+            var blobStorageService = new Mock<IBlobStorageService>();
+
+            blobStorageService
+                .Setup(s =>
+                    s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContentContainerName, path))
+                .ThrowsAsync(new JsonException("Could not deserialize the JSON"));
+
+            blobStorageService
+                .Setup(s => s.DeleteBlob(PublicContentContainerName, path));
+
+            blobStorageService
+                .Setup(s => s.UploadAsJson(PublicContentContainerName, path, tableResult, null));
+
+            var tableBuilderService = new Mock<ITableBuilderService>();
+
+            tableBuilderService
+                .Setup(
+                    s =>
+                        s.Query(
+                            _releaseId,
+                            It.Is<ObservationQueryContext>(q => q.SubjectId == subjectId)
+                        )
+                )
+                .ReturnsAsync(tableResult);
+
+
+            var service = BuildDataBlockService(
+                contentDbContext,
+                tableBuilderService: tableBuilderService.Object,
+                blobStorageService: blobStorageService.Object
+            );
+
+            var result = await service.GetDataBlockTableResult(releaseContentBlock);
+
+            Assert.True(result.IsRight);
+
+            Assert.IsType<TableBuilderResultViewModel>(result.Right);
+            Assert.Single(result.Right.Results);
+
+            MockUtils.VerifyAllMocks(blobStorageService, tableBuilderService);
+        }
+
+        [Fact]
+        public async Task QueryForDataBlock_NotDataBlockType()
+        {
+            var releaseContentBlock = new ReleaseContentBlock
+            {
+                ReleaseId = _releaseId,
+                Release = new Release
+                {
+                    Id = _releaseId,
+                    Slug = "release-slug",
+                    Publication = new Publication
+                    {
+                        Slug = "publication-slug"
+                    }
+                },
+                ContentBlockId = _dataBlockId,
+                ContentBlock = new HtmlBlock(),
+            };
+
+            await using var contentDbContext = ContentDbUtils.InMemoryContentDbContext();
+
+            await contentDbContext.AddAsync(releaseContentBlock);
+            await contentDbContext.SaveChangesAsync();
+
+            var service = BuildDataBlockService(contentDbContext);
+
+            var result = await service.GetDataBlockTableResult(releaseContentBlock);
+
+            Assert.True(result.IsLeft);
+            Assert.IsType<NotFoundResult>(result.Left);
+        }
+
+
+        private DataBlockService BuildDataBlockService(
+            ContentDbContext contentDbContext,
+            IBlobStorageService blobStorageService = null,
+            ITableBuilderService tableBuilderService = null,
+            IUserService userService = null)
+        {
+            return new DataBlockService(
+                contentDbContext,
+                blobStorageService ?? new Mock<IBlobStorageService>().Object,
+                tableBuilderService ?? new Mock<ITableBuilderService>().Object,
+                userService ?? MockUtils.AlwaysTrueUserService().Object,
+                new Mock<ILogger<DataBlockService>>().Object
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
@@ -3,13 +3,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -22,17 +20,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
     public class TableBuilderController : ControllerBase
     {
         private readonly ITableBuilderService _tableBuilderService;
+        private readonly IDataBlockService _dataBlockService;
         private readonly IPersistenceHelper<ContentDbContext> _contentPersistenceHelper;
-        private readonly IUserService _userService;
 
         public TableBuilderController(
             ITableBuilderService tableBuilderService,
-            IPersistenceHelper<ContentDbContext> contentPersistenceHelper,
-            IUserService userService)
+            IDataBlockService dataBlockService,
+            IPersistenceHelper<ContentDbContext> contentPersistenceHelper)
         {
             _tableBuilderService = tableBuilderService;
+            _dataBlockService = dataBlockService;
             _contentPersistenceHelper = contentPersistenceHelper;
-            _userService = userService;
         }
 
         [HttpPost]
@@ -65,21 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
                         )
                 )
                 .OnSuccessDo(block => this.CacheWithLastModified(block.Release.Published))
-                .OnSuccess(
-                    async block =>
-                    {
-                        if (block.ContentBlock is DataBlock dataBlock)
-                        {
-                            var query = dataBlock.Query.Clone();
-                            query.IncludeGeoJson = dataBlock.Charts.Any(chart => chart.Type == ChartType.Map);
-
-                            return await _userService.CheckCanViewRelease(block.Release)
-                                .OnSuccess(_ => _tableBuilderService.Query(block.ReleaseId, query));
-                        }
-
-                        return new NotFoundResult();
-                    }
-                )
+                .OnSuccess(block => _dataBlockService.GetDataBlockTableResult(block))
                 .HandleFailuresOrOk();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainerNames;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
+{
+    public class DataBlockService : IDataBlockService
+    {
+        private readonly ContentDbContext _contentDbContext;
+        private readonly IBlobStorageService _blobStorageService;
+        private readonly ITableBuilderService _tableBuilderService;
+        private readonly IUserService _userService;
+        private readonly ILogger<DataBlockService> _logger;
+
+        public DataBlockService(
+            ContentDbContext contentDbContext,
+            IBlobStorageService blobStorageService,
+            ITableBuilderService tableBuilderService,
+            IUserService userService,
+            ILogger<DataBlockService> logger)
+        {
+            _contentDbContext = contentDbContext;
+            _blobStorageService = blobStorageService;
+            _tableBuilderService = tableBuilderService;
+            _userService = userService;
+            _logger = logger;
+        }
+
+        public async Task<Either<ActionResult, TableBuilderResultViewModel>> GetDataBlockTableResult(
+            ReleaseContentBlock block)
+        {
+            // Make sure block is hydrated correctly
+            await _contentDbContext.Entry(block)
+                .Reference(b => b.ContentBlock)
+                .LoadAsync();
+            await _contentDbContext.Entry(block)
+                .Reference(b => b.Release)
+                .LoadAsync();
+            await _contentDbContext.Entry(block.Release)
+                .Reference(r => r.Publication)
+                .LoadAsync();
+
+            return await _userService.CheckCanViewRelease(block.Release)
+                .OnSuccess(
+                    async _ =>
+                    {
+                        if (block.ContentBlock is DataBlock dataBlock)
+                        {
+                            var path = FileStoragePathUtils.PublicContentDataBlockPath(
+                                block.Release.Publication.Slug,
+                                block.Release.Slug,
+                                block.ContentBlockId
+                            );
+
+                            try
+                            {
+                                return await _blobStorageService.GetDeserializedJson<TableBuilderResultViewModel>(
+                                    PublicContentContainerName,
+                                    path
+                                );
+                            }
+                            catch (JsonException)
+                            {
+                                // If there's an error deserializing the blob, we should
+                                // assume it's not salvageable and just re-build it.
+                                await _blobStorageService.DeleteBlob(PublicContentContainerName, path);
+                            }
+                            catch (FileNotFoundException)
+                            {
+                                // Do nothing as the blob just doesn't exist
+                            }
+                            catch (Exception exception)
+                            {
+                                _logger.LogWarning(
+                                    exception,
+                                    $"Unable to fetch data block response from blob storage with path: {path}"
+                                );
+                            }
+
+                            var query = dataBlock.Query.Clone();
+                            query.IncludeGeoJson = dataBlock.Charts.Any(chart => chart.Type == ChartType.Map);
+
+                            return await _tableBuilderService.Query(block.ReleaseId, query)
+                                .OnSuccessDo(
+                                    result => _blobStorageService.UploadAsJson(PublicContentContainerName, path, result)
+                                );
+                        }
+
+                        return new NotFoundResult();
+                    }
+                );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/Interfaces/IDataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/Interfaces/IDataBlockService.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces
+{
+    public interface IDataBlockService
+    {
+        Task<Either<ActionResult, TableBuilderResultViewModel>> GetDataBlockTableResult(ReleaseContentBlock block);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -95,6 +95,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
             services.AddTransient<IResultBuilder<Observation, ObservationViewModel>, ResultBuilder>();
             services.AddTransient<IBoundaryLevelService, BoundaryLevelService>();
             services.AddTransient<ITableBuilderService, TableBuilderService>();
+            services.AddTransient<IDataBlockService, DataBlockService>();
             services.AddTransient<IPublicationMetaService, PublicationMetaService>();
             services.AddTransient<IThemeMetaService, ThemeMetaService>();
             services.AddTransient<IResultSubjectMetaService, ResultSubjectMetaService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FileStorageService.cs
@@ -279,13 +279,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         public async Task UploadAsJson(string filePath, object value, JsonSerializerSettings settings = null)
         {
-            var json = JsonConvert.SerializeObject(value, null, settings);
-
-            await _publicBlobStorageService.UploadText(
+            await _publicBlobStorageService.UploadAsJson(
                 PublicContentContainerName,
-                path: filePath,
-                content: json,
-                contentType: MediaTypeNames.Application.Json
+                filePath,
+                value,
+                settings
             );
         }
     }


### PR DESCRIPTION
This PR adds caching of release data block responses in blob storage. This is performed via a cache-aside strategy, so we don't perform all the caching up-front when a release is published. 

Instead, the very first user that fetches a data block table response will still go to the DB for the table response, but the result will be cached in blob storage. Users from that point onwards will receive the cached version instead. Once in cache, this results in much faster response times compared with hitting the DB.

## Relevant changes

- Lifted `GetDeserializedJson` and `UploadAsJson` methods into `BlobStorageService` as this makes it much more convenient to upload/download JSON objects from blob storage.