### PR TITLE
EES-1804 Fix legend item data sets not saving with optional properties

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -1032,7 +1032,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     replacementPrimarySchoolsFilterItem
                 }
             };
-            
+
             var replacementCombinedSchoolTypeFilterGroup = new FilterGroup
             {
                 Label = "Combined",
@@ -1358,7 +1358,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(2, dataBlockSchoolTypeFilterPlan.Value.Groups.Count);
 
-                var dataBlockIndividualSchoolTypeFilterGroupPlan = 
+                var dataBlockIndividualSchoolTypeFilterGroupPlan =
                     dataBlockSchoolTypeFilterPlan.Value.Groups.First(g => g.Key == originalIndividualSchoolTypeFilterGroup.Id);
 
                 Assert.Equal(originalIndividualSchoolTypeFilterGroup.Id, dataBlockIndividualSchoolTypeFilterGroupPlan.Value.Id);
@@ -1366,7 +1366,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Single(dataBlockIndividualSchoolTypeFilterGroupPlan.Value.Filters);
                 Assert.True(dataBlockIndividualSchoolTypeFilterGroupPlan.Value.Valid);
 
-                var dataBlockCombinedSchoolTypeFilterGroupPlan = 
+                var dataBlockCombinedSchoolTypeFilterGroupPlan =
                     dataBlockSchoolTypeFilterPlan.Value.Groups.First(g => g.Key == originalCombinedSchoolTypeFilterGroup.Id);
 
                 Assert.Equal(originalCombinedSchoolTypeFilterGroup.Id, dataBlockCombinedSchoolTypeFilterGroupPlan.Value.Id);
@@ -1979,7 +1979,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             {
                                 new ChartLegendItem
                                 {
-                                    DataSet = new ChartDataSet
+                                    DataSet = new ChartLegendItemDataSet
                                     {
                                         Filters = new List<Guid>
                                         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -718,7 +718,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         }
                     ).ToList();
 
-                    if (indicatorTargets.TryGetValue(dataSet.Indicator, out var targetIndicatorId))
+
+                    if (!dataSet.Indicator.HasValue)
+                    {
+                        return;
+                    }
+
+                    if (indicatorTargets.TryGetValue(dataSet.Indicator.Value, out var targetIndicatorId))
                     {
                         dataSet.Indicator = targetIndicatorId;
                     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartLegend.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartLegend.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -22,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
 
     public class ChartLegendItem
     {
-        public ChartDataSet DataSet;
+        public ChartLegendItemDataSet DataSet;
         public string Label;
         public string Colour;
 
@@ -31,5 +33,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
 
         [JsonConverter(typeof(StringEnumConverter))]
         public ChartLineStyle? LineStyle;
+    }
+
+    public class ChartLegendItemDataSet
+    {
+        public Guid? Indicator;
+        public List<Guid> Filters = new List<Guid>();
+        public ChartDataSetLocation? Location;
+        public string? TimePeriod;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -740,7 +740,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 {
                                     new ChartLegendItem
                                     {
-                                        DataSet = new ChartDataSet
+                                        DataSet = new ChartLegendItemDataSet
                                         {
                                             Indicator = Indicator(SubjectIds[SubjectName.AbsenceByCharacteristic], IndicatorName.Unauthorised_absence_rate),
                                             Filters = new List<Guid>
@@ -757,7 +757,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                     },
                                     new ChartLegendItem
                                     {
-                                        DataSet = new ChartDataSet
+                                        DataSet = new ChartLegendItemDataSet
                                         {
                                             Indicator = Indicator(SubjectIds[SubjectName.AbsenceByCharacteristic], IndicatorName.Overall_absence_rate),
                                             Filters = new List<Guid>
@@ -773,7 +773,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                     },
                                     new ChartLegendItem
                                     {
-                                        DataSet = new ChartDataSet
+                                        DataSet = new ChartLegendItemDataSet
                                         {
                                             Indicator = Indicator(SubjectIds[SubjectName.AbsenceByCharacteristic], IndicatorName.Authorised_absence_rate),
                                             Filters = new List<Guid>
@@ -929,7 +929,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                 {
                                     new ChartLegendItem
                                     {
-                                        DataSet = new ChartDataSet
+                                        DataSet = new ChartLegendItemDataSet
                                         {
                                             Indicator = Indicator(SubjectIds[SubjectName.AbsenceByCharacteristic], IndicatorName.Unauthorised_absence_rate),
                                             Filters = new List<Guid>
@@ -945,7 +945,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                     },
                                     new ChartLegendItem
                                     {
-                                        DataSet = new ChartDataSet
+                                        DataSet = new ChartLegendItemDataSet
                                         {
                                             Indicator = Indicator(SubjectIds[SubjectName.AbsenceByCharacteristic], IndicatorName.Overall_absence_rate),
                                             Filters = new List<Guid>
@@ -961,7 +961,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                                     },
                                     new ChartLegendItem
                                     {
-                                        DataSet = new ChartDataSet
+                                        DataSet = new ChartLegendItemDataSet
                                         {
                                             Indicator = Indicator(SubjectIds[SubjectName.AbsenceByCharacteristic], IndicatorName.Authorised_absence_rate),
                                             Filters = new List<Guid>


### PR DESCRIPTION
This change adds a new `ChartLegendItemDataSet` type which allows all of the constitutent properties to be optional. This is important as the frontend will typically remove the grouping filter type from the data set.

Previously this was causing empty guids to be persisted in the data sets when grouping by indicator. These would then be returned in the response and the data sets could not be matched correctly to the data.