### PR TITLE
EES-1819 Add ETag to data block table query endpoint for invalidation

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ControllerExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/ControllerExtensions.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 {
@@ -16,8 +18,51 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 
             var requestHeaders = controller.Request.GetTypedHeaders();
 
-            if (requestHeaders.IfModifiedSince.HasValue
+            if (lastModified.HasValue
+                && requestHeaders.IfModifiedSince.HasValue
                 && requestHeaders.IfModifiedSince.Value >= lastModified)
+            {
+                return controller.StatusCode(StatusCodes.Status304NotModified);
+            }
+
+            return await Task.FromResult(Unit.Instance);
+        }
+
+        public static async Task<Either<ActionResult, Unit>> CacheWithETag(
+            this ControllerBase controller,
+            string content,
+            bool isWeak = true)
+        {
+            var eTag = new EntityTagHeaderValue($"\"{content}\"", isWeak);
+
+            controller.Response.GetTypedHeaders().ETag = eTag;
+
+            var requestHeaders = controller.Request.GetTypedHeaders();
+
+            if (requestHeaders.IfNoneMatch.Contains(eTag))
+            {
+                return controller.StatusCode(StatusCodes.Status304NotModified);
+            }
+
+            return await Task.FromResult(Unit.Instance);
+        }
+
+        public static async Task<Either<ActionResult, Unit>> CacheWithLastModifiedAndETag(
+            this ControllerBase controller,
+            DateTimeOffset? lastModified,
+            string eTagContent,
+            bool isWeak = true)
+        {
+            var eTag = new EntityTagHeaderValue($"\"{eTagContent}\"", isWeak);
+
+            controller.Response.GetTypedHeaders().ETag = eTag;
+
+            var requestHeaders = controller.Request.GetTypedHeaders();
+
+            if (lastModified.HasValue
+                && requestHeaders.IfModifiedSince.HasValue
+                && requestHeaders.IfModifiedSince.Value >= lastModified
+                && requestHeaders.IfNoneMatch.Contains(eTag))
             {
                 return controller.StatusCode(StatusCodes.Status304NotModified);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
@@ -52,7 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
         }
 
         [ResponseCache(Duration = 300)]
-        [HttpGet("release/{releaseId}/datablock/{dataBlockId}")]
+        [HttpGet("release/{releaseId}/data-block/{dataBlockId}")]
         public async Task<ActionResult<TableBuilderResultViewModel>> QueryForDataBlock(
             Guid releaseId,
             Guid dataBlockId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/TableBuilderController.cs
@@ -19,6 +19,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
     [ApiController]
     public class TableBuilderController : ControllerBase
     {
+        // Change this whenever there is a breaking change
+        // that requires cache invalidation.
+        public const string ApiVersion = "1";
+
         private readonly ITableBuilderService _tableBuilderService;
         private readonly IDataBlockService _dataBlockService;
         private readonly IPersistenceHelper<ContentDbContext> _contentPersistenceHelper;
@@ -62,7 +66,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
                                    && rcb.ContentBlockId == dataBlockId
                         )
                 )
-                .OnSuccessDo(block => this.CacheWithLastModified(block.Release.Published))
+                .OnSuccessDo(block => this.CacheWithLastModifiedAndETag(block.Release.Published, ApiVersion))
                 .OnSuccess(block => _dataBlockService.GetDataBlockTableResult(block))
                 .HandleFailuresOrOk();
         }

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -215,7 +215,7 @@ const tableBuilderService = {
     dataBlockId: string,
   ): Promise<TableDataResponse> {
     return dataApi.get(
-      `/tablebuilder/release/${releaseId}/datablock/${dataBlockId}`,
+      `/tablebuilder/release/${releaseId}/data-block/${dataBlockId}`,
     );
   },
 };


### PR DESCRIPTION
This PR adds an `ETag` header to the data block table query endpoint. We primarily need this to enable us to invalidate the cache if there is a breaking change to the API.

In this instance, we have changed location levels to be camelCased on the server. This is a breaking change, but we cannot inform clients that the cache should be invalidated using just `LastModified`. With `ETag`, we can trigger invalidation by changing some string, such as a API version number.

## Relevant changes

- Added an additional `CacheWithETag` method that can be used in other controllers if required.
- Fixed casing of `/tablebuilder/release/{releaseId}/data-block/{dataBlockId}` endpoint URL