### PR TITLE
EES-1824 Restrict access to DBs using virtual network rules

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -533,6 +533,7 @@
     "publisherStorageAccountName": "[concat(parameters('subscription'), 'saeespublisher')]",
     "publisherStorageAccountId": "[concat(resourceGroup().id,'/providers/','Microsoft.Storage/storageAccounts/', variables('publisherStorageAccountName'))]",
     "loggingStorageAccountName": "[concat(parameters('subscription'), 'saeeslogging')]",
+
     "vNetName": "[concat(parameters('subscription'), '-vnet-', parameters('environment'))]",
     "adminSubnetName": "[concat(parameters('subscription'), '-snet-', parameters('environment'), '-admin')]",
     "adminSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('adminSubnetName'))]",
@@ -546,6 +547,40 @@
     "contentSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('contentSubnetName'))]",
     "dataSubnetName": "[concat(parameters('subscription'), '-snet-', parameters('environment'), '-data')]",
     "dataSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('dataSubnetName'))]",
+
+    "sqlAllowedSubnets": [
+      {
+        "name": "admin",
+        "id": "[variables('adminSubnetRef')]"
+      },
+      {
+        "name": "importer",
+        "id": "[variables('importerSubnetRef')]"
+      },
+      {
+        "name": "publisher",
+        "id": "[variables('publisherSubnetRef')]"
+      },
+      {
+        "name": "content",
+        "id": "[variables('contentSubnetRef')]"
+      },
+      {
+        "name": "data",
+        "id": "[variables('dataSubnetRef')]"
+      }
+    ],
+    "publicSqlAllowedSubnets": [
+      {
+        "name": "content",
+        "id": "[variables('contentSubnetRef')]"
+      },
+      {
+        "name": "data",
+        "id": "[variables('dataSubnetRef')]"
+      }
+    ],
+
     "dataFactoryName": "[concat(parameters('subscription'), '-df-', parameters('environment'), '-release')]",
     "keyVaultName": "[concat(parameters('subscription'), '-kv-', parameters('environment'), '-01')]",
 
@@ -1504,20 +1539,6 @@
           }
         },
         {
-          "type": "firewallrules",
-          "apiVersion": "2018-06-01-preview",
-          "dependsOn": [
-            "[variables('sqlserverName')]"
-          ],
-          "location": "[resourceGroup().location]",
-          "name": "AllowAllWindowsAzureIps",
-          "properties": {
-            "endIpAddress": "0.0.0.0",
-            "startIpAddress": "0.0.0.0"
-          }
-        },
-
-        {
           "name": "[concat(string(variables('sqlserverName')), '/statistics/current')]",
           "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
           "apiVersion": "2014-04-01",
@@ -1646,6 +1667,22 @@
       }
     },
     {
+      "name": "[concat(variables('sqlserverName'), '/', variables('sqlAllowedSubnets')[copyIndex()].name)]",
+      "type": "Microsoft.Sql/servers/virtualNetworkRules",
+      "apiVersion": "2015-05-01-preview",
+      "properties": {
+        "virtualNetworkSubnetId": "[variables('sqlAllowedSubnets')[copyIndex()].id]",
+        "ignoreMissingVnetServiceEndpoint": false
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers', variables('sqlserverName'))]"
+      ],
+      "copy": {
+        "name": "networkRuleLoop",
+        "count":  "[length(variables('sqlAllowedSubnets'))]"
+      }
+    },
+    {
       "name": "[variables('publicSqlServerName')]",
       "type": "Microsoft.Sql/servers",
       "apiVersion": "2018-06-01-preview",
@@ -1698,20 +1735,6 @@
             "tenantId": "[subscription().tenantId]"
           }
         },
-        {
-          "type": "firewallrules",
-          "apiVersion": "2018-06-01-preview",
-          "dependsOn": [
-            "[variables('publicSqlServerName')]"
-          ],
-          "location": "[resourceGroup().location]",
-          "name": "AllowAllWindowsAzureIps",
-          "properties": {
-            "endIpAddress": "0.0.0.0",
-            "startIpAddress": "0.0.0.0"
-          }
-        },
-
         {
           "name": "[concat(string(variables('publicSqlServerName')), '/public-statistics/current')]",
           "type": "Microsoft.Sql/servers/databases/transparentDataEncryption",
@@ -1826,6 +1849,22 @@
       "copy": {
         "name": "firewallloop",
         "count": "[length(parameters('sqlFirewallRules'))]"
+      }
+    },
+    {
+      "name": "[concat(variables('publicSqlserverName'), '/', variables('publicSqlAllowedSubnets')[copyIndex()].name)]",
+      "type": "Microsoft.Sql/servers/virtualNetworkRules",
+      "apiVersion": "2015-05-01-preview",
+      "properties": {
+        "virtualNetworkSubnetId": "[variables('publicSqlAllowedSubnets')[copyIndex()].id]",
+        "ignoreMissingVnetServiceEndpoint": false
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers', variables('publicSqlServerName'))]"
+      ],
+      "copy": {
+        "name": "networkRuleLoop",
+        "count":  "[length(variables('publicSqlAllowedSubnets'))]"
       }
     },
     {
@@ -2562,6 +2601,9 @@
               "addressPrefix": "10.0.0.0/24",
               "serviceEndpoints": [
                 {
+                  "service": "Microsoft.Sql"
+                },
+                {
                   "service": "Microsoft.Storage"
                 }
               ],
@@ -2583,6 +2625,9 @@
             "properties": {
               "addressPrefix": "10.0.1.0/24",
               "serviceEndpoints": [
+                {
+                  "service": "Microsoft.Sql"
+                },
                 {
                   "service": "Microsoft.Storage"
                 }
@@ -2606,6 +2651,9 @@
               "addressPrefix": "10.0.2.0/24",
               "serviceEndpoints": [
                 {
+                  "service": "Microsoft.Sql"
+                },
+                {
                   "service": "Microsoft.Storage"
                 }
               ],
@@ -2627,6 +2675,9 @@
             "properties": {
               "addressPrefix": "10.0.3.0/24",
               "serviceEndpoints": [
+                {
+                  "service": "Microsoft.Sql"
+                },
                 {
                   "service": "Microsoft.Storage"
                 }
@@ -2650,6 +2701,9 @@
               "addressPrefix": "10.0.4.0/24",
               "serviceEndpoints": [
                 {
+                  "service": "Microsoft.Sql"
+                },
+                {
                   "service": "Microsoft.Storage"
                 }
               ],
@@ -2671,6 +2725,9 @@
             "properties": {
               "addressPrefix": "10.0.5.0/24",
               "serviceEndpoints": [
+                {
+                  "service": "Microsoft.Sql"
+                },
                 {
                   "service": "Microsoft.Storage"
                 }


### PR DESCRIPTION
This PR:

- Removes the `AllowAllWindowsAzureIps` firewall rule from the SQL servers. This allows connections from anywhere in Azure, which is potentially a security vulnerability.
- Adds virtual network rules to allow access from our subnets for each respective application/function.

## Notes

- It seems like data factory already has some form of direct access to our SQL databases (via 'Linked services') so I don't _think_ it needs any additional work to reach the databases. We need to test that this is true on dev.
- Additional work needs to be done to segregate content/stats databases for more granular network access control - [EES-1825](https://dfedigital.atlassian.net/browse/EES-1825)