### PR TITLE
Ees 1860 - fix footnotes UI test

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
@@ -170,6 +170,8 @@ Go back and delete a footnote
 Add data block to release
     [Tags]  HappyPath
     user clicks link  Content
+    user waits until button is enabled  Add secondary stats
+    user scrolls to element  xpath://button[text()="Add secondary stats"]
     user clicks button  Add secondary stats
     user waits until page contains element  secondaryStats-dataBlockSelectForm-selectedDataBlock
     user selects from list by label  secondaryStats-dataBlockSelectForm-selectedDataBlock  ${FOOTNOTE_DATABLOCK_NAME}


### PR DESCRIPTION
Fix `footnotes.robot` UI test by adding in some checks to make sure the clicks that selenium performs isn't intercepted by the "set page view" feature. 