### PR TITLE
EES-1846 Add table highlights to pre-release table tool page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
@@ -86,8 +86,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             footnoteService.Setup(s => s.DeleteFootnote(ReleaseId, FootnoteId)).ReturnsAsync(Unit.Instance);
 
-            releaseMetaService.Setup(s => s.GetSubjects(ReleaseId))
-                .ReturnsAsync(new SubjectsMetaViewModel
+            releaseMetaService.Setup(s => s.GetSubjectsMeta(ReleaseId))
+                .ReturnsAsync(new ReleaseSubjectsMetaViewModel
                 {
                     ReleaseId = ReleaseId,
                     Subjects = subjectIds.Select(id => new IdLabel(id, $"Subject {id}")).ToList()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseMetaServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseMetaServicePermissionTests.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         };
 
         [Fact]
-        public void GetSubjects()
+        public void GetSubjectsMeta()
         {
             PermissionTestUtils.PolicyCheckBuilder<ContentSecurityPolicies>()
                 .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
@@ -29,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService =>
                     {
                         var service = BuildReleaseMetaService(userService: userService.Object);
-                        return service.GetSubjects(_release.Id);
+                        return service.GetSubjectsMeta(_release.Id);
                     }
                 );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/FootnoteController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/FootnoteController.cs
@@ -102,7 +102,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
         [HttpGet("releases/{releaseId}/footnotes-meta")]
         public async Task<ActionResult<FootnotesMetaViewModel>> GetFootnotesMeta(Guid releaseId)
         {
-            return await _releaseMetaService.GetSubjects(releaseId)
+            return await _releaseMetaService.GetSubjectsMeta(releaseId)
                 .OnSuccess(model =>
                 {
                     return new FootnotesMetaViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/TableBuilderMetaController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/TableBuilderMetaController.cs
@@ -41,9 +41,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
         }
 
         [HttpGet("release/{releaseId}")]
-        public async Task<ActionResult<SubjectsMetaViewModel>> GetSubjectsForRelease(Guid releaseId)
+        public async Task<ActionResult<ReleaseSubjectsMetaViewModel>> GetReleaseSubjectsMeta(Guid releaseId)
         {
-            return await _releaseMetaService.GetSubjects(releaseId)
+            return await _releaseMetaService.GetSubjectsMeta(releaseId)
                 .HandleFailuresOrOk();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseMetaService.cs
@@ -8,6 +8,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IReleaseMetaService
     {
-        Task<Either<ActionResult, SubjectsMetaViewModel>> GetSubjects(Guid releaseId);
+        Task<Either<ActionResult, ReleaseSubjectsMetaViewModel>> GetSubjectsMeta(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
@@ -19,7 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
     {
         public Guid Id { get; set; }
 
-        [JsonIgnore] public ContentSection ContentSection { get; set; }
+        [JsonIgnore] public ContentSection? ContentSection { get; set; }
 
         [JsonIgnore] public Guid? ContentSectionId { get; set; }
 
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<Comment> Comments { get; set; }
 
-        public ContentBlock Clone(Release.CloneContext context, ContentSection newContentSection)
+        public ContentBlock Clone(Release.CloneContext context, ContentSection? newContentSection)
         {
             var copy = MemberwiseClone() as ContentBlock;
             copy.Id = Guid.NewGuid();
@@ -75,7 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public string Name { get; set; }
 
-        public string HighlightName { get; set; }
+        public string? HighlightName { get; set; }
 
         public string Source { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/ReleaseSubjectsMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/ReleaseSubjectsMetaViewModel.cs
@@ -4,9 +4,10 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta
 {
-    public class SubjectsMetaViewModel
+    public class ReleaseSubjectsMetaViewModel
     {
         public Guid ReleaseId { get; set; }
+        public List<IdLabel> Highlights { get; set; }
         public List<IdLabel> Subjects { get; set; }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/ReleaseDataBlocksPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/ReleaseDataBlocksPageTabs.test.tsx
@@ -169,6 +169,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
     tableBuilderService.getReleaseMeta.mockResolvedValue({
       releaseId: 'release-1',
       subjects: [],
+      highlights: [],
     });
 
     render(
@@ -194,6 +195,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
     tableBuilderService.getReleaseMeta.mockResolvedValue({
       releaseId: 'release-1',
       subjects: [],
+      highlights: [],
     });
 
     render(
@@ -215,6 +217,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
     tableBuilderService.getReleaseMeta.mockResolvedValue({
       releaseId: 'release-1',
       subjects: [],
+      highlights: [],
     });
 
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
@@ -250,6 +253,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
     tableBuilderService.getReleaseMeta.mockResolvedValue({
       releaseId: 'release-1',
       subjects: [],
+      highlights: [],
     });
 
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
@@ -277,6 +281,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
     tableBuilderService.getReleaseMeta.mockResolvedValue({
       releaseId: 'release-1',
       subjects: [],
+      highlights: [],
     });
 
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
@@ -314,6 +319,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
     tableBuilderService.getReleaseMeta.mockResolvedValue({
       releaseId: 'release-1',
       subjects: [],
+      highlights: [],
     });
 
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
@@ -361,6 +367,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
       tableBuilderService.getReleaseMeta.mockResolvedValue({
         releaseId: 'release-1',
         subjects: [],
+        highlights: [],
       });
 
       tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleasePageContainer.tsx
@@ -16,7 +16,7 @@ import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import { format } from 'date-fns';
 import React from 'react';
 import { generatePath } from 'react-router';
-import { Route, RouteComponentProps } from 'react-router-dom';
+import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 
 interface Model {
   preReleaseWindowStatus: PreReleaseWindowStatus;
@@ -143,9 +143,11 @@ const PreReleasePageContainer = ({
             }))}
           />
 
-          {preReleaseNavRoutes.map(route => (
-            <Route key={route.path} {...route} />
-          ))}
+          <Switch>
+            {preReleaseNavRoutes.map(route => (
+              <Route key={route.path} {...route} />
+            ))}
+          </Switch>
         </>
       );
     }

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
@@ -1,6 +1,11 @@
+import Link from '@admin/components/Link';
 import PageTitle from '@admin/components/PageTitle';
 import PreReleaseTableToolFinalStep from '@admin/pages/release/pre-release/components/PreReleaseTableToolFinalStep';
-import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
+import {
+  preReleaseTableToolRoute,
+  PreReleaseTableToolRouteParams,
+} from '@admin/routes/preReleaseRoutes';
+import dataBlockService from '@admin/services/dataBlockService';
 import publicationService from '@admin/services/publicationService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
@@ -9,14 +14,18 @@ import TableToolWizard, {
 } from '@common/modules/table-tool/components/TableToolWizard';
 import WizardStep from '@common/modules/table-tool/components/WizardStep';
 import WizardStepHeading from '@common/modules/table-tool/components/WizardStepHeading';
+import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
+import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
 import tableBuilderService from '@common/services/tableBuilderService';
+import orderBy from 'lodash/orderBy';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
+import { generatePath } from 'react-router-dom';
 
 const PreReleaseTableToolPage = ({
   match,
-}: RouteComponentProps<ReleaseRouteParams>) => {
-  const { publicationId, releaseId } = match.params;
+}: RouteComponentProps<PreReleaseTableToolRouteParams>) => {
+  const { publicationId, releaseId, dataBlockId } = match.params;
 
   const { value: publication } = useAsyncHandledRetry(
     () => publicationService.getPublication(publicationId),
@@ -26,12 +35,55 @@ const PreReleaseTableToolPage = ({
   const { value: tableToolState, isLoading } = useAsyncHandledRetry<
     InitialTableToolState | undefined
   >(async () => {
-    const { subjects } = await tableBuilderService.getReleaseMeta(releaseId);
+    const {
+      subjects,
+      ...releaseMeta
+    } = await tableBuilderService.getReleaseMeta(releaseId);
+
+    const highlights = orderBy(
+      releaseMeta.highlights,
+      ['label'],
+      ['asc'],
+    ).filter(highlight => highlight.id !== dataBlockId);
+
+    if (dataBlockId) {
+      const { table, query } = await dataBlockService.getDataBlock(dataBlockId);
+
+      const [subjectMeta, tableData] = await Promise.all([
+        tableBuilderService.getSubjectMeta(query.subjectId),
+        tableBuilderService.getTableData({
+          releaseId,
+          ...query,
+        }),
+      ]);
+
+      const fullTable = mapFullTable(tableData);
+      const tableHeaders = mapTableHeadersConfig(
+        table.tableHeaders,
+        fullTable.subjectMeta,
+      );
+
+      return {
+        initialStep: 5,
+        subjects,
+        highlights,
+        query: {
+          ...query,
+          publicationId,
+          releaseId,
+        },
+        subjectMeta,
+        response: {
+          table: fullTable,
+          tableHeaders,
+        },
+      };
+    }
 
     return {
       initialStep: 1,
       subjects,
-      highlights: [],
+      highlights,
       query: {
         publicationId,
         releaseId,
@@ -41,30 +93,54 @@ const PreReleaseTableToolPage = ({
         locations: {},
       },
     };
-  }, [releaseId]);
+  }, [publicationId, releaseId, dataBlockId]);
 
   return (
-    <LoadingSpinner loading={isLoading}>
-      {tableToolState && (
-        <>
-          <PageTitle
-            title="Create your own tables online"
-            caption="Table Tool"
-          />
+    <>
+      <PageTitle title="Create your own tables online" caption="Table Tool" />
 
-          <p>
-            Choose the data and area of interest you want to explore and then
-            use filters to create your table.
-          </p>
+      <p>
+        Choose the data and area of interest you want to explore and then use
+        filters to create your table.
+      </p>
 
-          <p>
-            Once you've created your table, you can download the data it
-            contains for your own offline analysis.
-          </p>
+      <p>
+        Once you've created your table, you can download the data it contains
+        for your own offline analysis.
+      </p>
 
+      <LoadingSpinner loading={isLoading}>
+        {tableToolState && (
           <TableToolWizard
+            scrollOnMount
             themeMeta={[]}
             initialState={tableToolState}
+            renderHighlights={highlights => (
+              <aside>
+                <h3>Table highlights</h3>
+
+                <p>View popular tables related to this publication:</p>
+
+                <ul>
+                  {highlights.map(highlight => (
+                    <li key={highlight.id}>
+                      <Link
+                        to={generatePath<PreReleaseTableToolRouteParams>(
+                          preReleaseTableToolRoute.path,
+                          {
+                            publicationId,
+                            releaseId,
+                            dataBlockId: highlight.id,
+                          },
+                        )}
+                      >
+                        {highlight.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </aside>
+            )}
             finalStep={({ response, query }) => (
               <WizardStep>
                 {wizardStepProps => (
@@ -86,9 +162,9 @@ const PreReleaseTableToolPage = ({
               </WizardStep>
             )}
           />
-        </>
-      )}
-    </LoadingSpinner>
+        )}
+      </LoadingSpinner>
+    </>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -1,0 +1,362 @@
+import PreReleaseTableToolPage from '@admin/pages/release/pre-release/PreReleaseTableToolPage';
+import {
+  preReleaseTableToolRoute,
+  PreReleaseTableToolRouteParams,
+} from '@admin/routes/preReleaseRoutes';
+import _dataBlockService, {
+  ReleaseDataBlock,
+} from '@admin/services/dataBlockService';
+import _publicationService, {
+  BasicPublicationDetails,
+} from '@admin/services/publicationService';
+import _tableBuilderService, {
+  ReleaseMeta,
+  SubjectMeta,
+  TableDataResponse,
+} from '@common/services/tableBuilderService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router';
+import { generatePath } from 'react-router-dom';
+
+jest.mock('@admin/services/dataBlockService');
+jest.mock('@admin/services/publicationService');
+jest.mock('@common/services/tableBuilderService');
+
+const dataBlockService = _dataBlockService as jest.Mocked<
+  typeof _dataBlockService
+>;
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
+const tableBuilderService = _tableBuilderService as jest.Mocked<
+  typeof _tableBuilderService
+>;
+
+describe('PreReleaseTableToolPage', () => {
+  const testSubjectMeta: SubjectMeta = {
+    filters: {
+      SchoolType: {
+        totalValue: '',
+        hint: 'Filter by school type',
+        legend: 'School type',
+        name: 'school_type',
+        options: {
+          Default: {
+            label: 'Default',
+            options: [
+              {
+                label: 'State-funded primary',
+                value: 'state-funded-primary',
+              },
+              {
+                label: 'State-funded secondary',
+                value: 'state-funded-secondary',
+              },
+            ],
+          },
+        },
+      },
+    },
+    indicators: {
+      AbsenceFields: {
+        label: 'Absence fields',
+        options: [
+          {
+            value: 'authorised-absence-sessions',
+            label: 'Number of authorised absence sessions',
+            unit: '',
+            name: 'sess_authorised',
+            decimalPlaces: 2,
+          },
+        ],
+      },
+    },
+    locations: {
+      localAuthority: {
+        legend: 'Local authority',
+        options: [
+          { value: 'barnet', label: 'Barnet' },
+          { value: 'barnsley', label: 'Barnsley' },
+        ],
+      },
+    },
+    timePeriod: {
+      legend: 'Time period',
+      options: [{ label: '2014/15', code: 'AY', year: 2014 }],
+    },
+  };
+
+  const testTableData: TableDataResponse = {
+    subjectMeta: {
+      filters: {
+        SchoolType: {
+          totalValue: '',
+          hint: 'Filter by school type',
+          legend: 'School type',
+          options: {
+            Default: {
+              label: 'Default',
+              options: [
+                {
+                  label: 'State-funded primary',
+                  value: 'state-funded-primary',
+                },
+                {
+                  label: 'State-funded secondary',
+                  value: 'state-funded-secondary',
+                },
+              ],
+            },
+          },
+          name: 'school_type',
+        },
+      },
+      footnotes: [],
+      indicators: [
+        {
+          label: 'Number of authorised absence sessions',
+          unit: '',
+          value: 'authorised-absence-sessions',
+          name: 'sess_authorised',
+        },
+      ],
+      locations: [
+        { level: 'localAuthority', label: 'Barnet', value: 'barnet' },
+        { level: 'localAuthority', label: 'Barnsley', value: 'barnsley' },
+      ],
+      boundaryLevels: [],
+      publicationName: 'Pupil absence',
+      subjectName: 'Absence by characteristic',
+      timePeriodRange: [{ code: 'AY', label: '2014/15', year: 2014 }],
+      geoJsonAvailable: false,
+    },
+    results: [
+      {
+        filters: ['state-funded-primary'],
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: { code: 'barnet', name: 'Barnet' },
+        },
+        measures: {
+          'authorised-absence-sessions': '2613',
+        },
+        timePeriod: '2014_AY',
+      },
+      {
+        filters: ['state-funded-secondary'],
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: { code: 'barnsley', name: 'Barnsley' },
+        },
+        measures: {
+          'authorised-absence-sessions': 'x',
+        },
+        timePeriod: '2014_AY',
+      },
+      {
+        filters: ['state-funded-secondary'],
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: { code: 'barnet', name: 'Barnet' },
+        },
+        measures: {
+          'authorised-absence-sessions': '1939',
+        },
+        timePeriod: '2014_AY',
+      },
+      {
+        filters: ['state-funded-primary'],
+        geographicLevel: 'localAuthority',
+        location: {
+          localAuthority: { code: 'barnsley', name: 'Barnsley' },
+        },
+        measures: {
+          'authorised-absence-sessions': '39',
+        },
+        timePeriod: '2014_AY',
+      },
+    ],
+  };
+
+  const testPublication: BasicPublicationDetails = {
+    id: 'publication-1',
+    title: 'Pupil absence',
+    slug: 'pupil-absence',
+    themeId: 'theme-1',
+    topicId: 'topic-1',
+    legacyReleases: [],
+  };
+
+  const testReleaseMeta: ReleaseMeta = {
+    releaseId: 'release-1',
+    highlights: [{ id: 'block-1', label: 'Test highlight' }],
+    subjects: [{ id: 'subject-1', label: 'Test subject' }],
+  };
+
+  const testDataBlock: ReleaseDataBlock = {
+    id: 'block-1',
+    name: 'Test block',
+    highlightName: 'Test highlight name',
+    source: '',
+    heading: '',
+    table: {
+      tableHeaders: {
+        columnGroups: [
+          [
+            { value: 'barnet', type: 'Location', level: 'localAuthority' },
+            { value: 'barnsley', type: 'Location', level: 'localAuthority' },
+          ],
+        ],
+        rowGroups: [
+          [
+            { value: 'state-funded-primary', type: 'Filter' },
+            { value: 'state-funded-secondary', type: 'Filter' },
+          ],
+        ],
+        columns: [{ value: '2014_AY', type: 'TimePeriod' }],
+        rows: [{ value: 'authorised-absence-sessions', type: 'Indicator' }],
+      },
+      indicators: [],
+    },
+    charts: [],
+    query: {
+      subjectId: 'subject-1',
+      indicators: ['authorised-absence-sessions'],
+      filters: ['state-funded-primary', 'state-funded-secondary'],
+      timePeriod: {
+        startYear: 2014,
+        startCode: 'AY',
+        endYear: 2014,
+        endCode: 'AY',
+      },
+      locations: {
+        localAuthority: ['barnet', 'barnsley'],
+      },
+    },
+  };
+
+  test('renders correctly on step 1 with subjects and highlights', async () => {
+    publicationService.getPublication.mockResolvedValue(testPublication);
+    tableBuilderService.getReleaseMeta.mockResolvedValue(testReleaseMeta);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wizardStep-1')).toHaveAttribute(
+        'aria-current',
+        'step',
+      );
+
+      const step1 = within(screen.getByTestId('wizardStep-1'));
+
+      expect(step1.getByLabelText('Test subject')).toBeInTheDocument();
+      expect(
+        step1.getByRole('heading', { name: 'Table highlights' }),
+      ).toBeInTheDocument();
+      expect(
+        step1.getByRole('link', { name: 'Test highlight' }),
+      ).toHaveAttribute(
+        'href',
+        '/publication/publication-1/release/release-1/prerelease/table-tool/block-1',
+      );
+
+      expect(screen.queryByTestId('dataTableCaption')).not.toBeInTheDocument();
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+  });
+
+  test('renders correctly on step 1 without highlights', async () => {
+    publicationService.getPublication.mockResolvedValue(testPublication);
+    tableBuilderService.getReleaseMeta.mockResolvedValue({
+      ...testReleaseMeta,
+      highlights: [],
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wizardStep-1')).toHaveAttribute(
+        'aria-current',
+        'step',
+      );
+
+      const step1 = within(screen.getByTestId('wizardStep-1'));
+
+      expect(step1.getByLabelText('Test subject')).toBeInTheDocument();
+      expect(
+        step1.queryByRole('heading', { name: 'Table highlights' }),
+      ).not.toBeInTheDocument();
+
+      expect(screen.queryByTestId('dataTableCaption')).not.toBeInTheDocument();
+      expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    });
+  });
+
+  test('renders correctly on step 5 with `dataBlockId` route param', async () => {
+    publicationService.getPublication.mockResolvedValue(testPublication);
+    dataBlockService.getDataBlock.mockResolvedValue(testDataBlock);
+
+    tableBuilderService.getReleaseMeta.mockResolvedValue(testReleaseMeta);
+    tableBuilderService.getTableData.mockResolvedValue(testTableData);
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+
+    renderPage([
+      generatePath<PreReleaseTableToolRouteParams>(
+        preReleaseTableToolRoute.path,
+        {
+          publicationId: 'publication-1',
+          releaseId: 'release-1',
+          dataBlockId: 'block-1',
+        },
+      ),
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('wizardStep-5')).toHaveAttribute(
+        'aria-current',
+        'step',
+      );
+
+      expect(screen.getByTestId('dataTableCaption')).toHaveTextContent(
+        /Table showing Number of authorised absence sessions for 'Absence by characteristic'/,
+      );
+
+      expect(screen.getByRole('table')).toBeInTheDocument();
+      expect(screen.getAllByRole('row')).toHaveLength(3);
+      expect(screen.getAllByRole('cell')).toHaveLength(5);
+
+      expect(
+        screen.getByRole('button', {
+          name: 'Download the underlying data of this table (CSV)',
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {
+          name: 'Download table as Excel spreadsheet (XLSX)',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  const renderPage = (
+    initialEntries: string[] = [
+      generatePath<PreReleaseTableToolRouteParams>(
+        preReleaseTableToolRoute.path,
+        {
+          publicationId: 'publication-1',
+          releaseId: 'release-1',
+        },
+      ),
+    ],
+  ) => {
+    return render(
+      <MemoryRouter initialEntries={initialEntries}>
+        <Route
+          component={PreReleaseTableToolPage}
+          path={preReleaseTableToolRoute.path}
+        />
+      </MemoryRouter>,
+    );
+  };
+});

--- a/src/explore-education-statistics-admin/src/routes/preReleaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/preReleaseRoutes.ts
@@ -1,6 +1,13 @@
 import PreReleaseContentPage from '@admin/pages/release/pre-release/PreReleaseContentPage';
 import PreReleaseTableToolPage from '@admin/pages/release/pre-release/PreReleaseTableToolPage';
-import { ReleaseRouteProps } from '@admin/routes/releaseRoutes';
+import {
+  ReleaseRouteParams,
+  ReleaseRouteProps,
+} from '@admin/routes/releaseRoutes';
+
+export type PreReleaseTableToolRouteParams = ReleaseRouteParams & {
+  dataBlockId?: string;
+};
 
 export const preReleaseContentRoute: ReleaseRouteProps = {
   path: '/publication/:publicationId/release/:releaseId/prerelease/content',
@@ -10,7 +17,8 @@ export const preReleaseContentRoute: ReleaseRouteProps = {
 };
 
 export const preReleaseTableToolRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/prerelease/table-tool',
+  path:
+    '/publication/:publicationId/release/:releaseId/prerelease/table-tool/:dataBlockId?',
   title: 'Table tool',
   component: PreReleaseTableToolPage,
   exact: true,

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -1,17 +1,8 @@
 import TableToolWizard from '@common/modules/table-tool/components/TableToolWizard';
-import _tableBuilderService, {
-  SubjectMeta,
-  ThemeMeta,
-} from '@common/services/tableBuilderService';
+import { SubjectMeta, ThemeMeta } from '@common/services/tableBuilderService';
 import { within } from '@testing-library/dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-
-jest.mock('@common/services/tableBuilderService');
-
-const tableBuilderService = _tableBuilderService as jest.Mocked<
-  typeof _tableBuilderService
->;
 
 describe('TableToolWizard', () => {
   const testThemeMeta: ThemeMeta[] = [
@@ -161,11 +152,6 @@ describe('TableToolWizard', () => {
   });
 
   test('does not render publication step if `initialState.query.releaseId` is set', async () => {
-    tableBuilderService.getReleaseMeta.mockResolvedValue({
-      releaseId: 'release-1',
-      subjects: [{ id: 'subject-2', label: 'Subject 2' }],
-    });
-
     render(
       <TableToolWizard
         themeMeta={testThemeMeta}

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -93,6 +93,7 @@ export interface PublicationMeta {
 export interface ReleaseMeta {
   releaseId: string;
   subjects: PublicationSubject[];
+  highlights: TableHighlight[];
 }
 
 export interface SubjectMeta {

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -42,7 +42,13 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
       return undefined;
     }
 
-    const { publicationId, subjects, highlights } = publicationMeta;
+    const { publicationId, subjects } = publicationMeta;
+
+    const highlights = orderBy(
+      publicationMeta.highlights,
+      ['label'],
+      ['asc'],
+    ).filter(highlight => highlight.id !== fastTrack?.id);
 
     if (fastTrack && subjectMeta) {
       const fullTable = mapFullTable(fastTrack.fullTable);
@@ -102,18 +108,16 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
             <p>View popular tables related to this publication:</p>
 
             <ul>
-              {orderBy(highlights, ['label'], ['asc'])
-                .filter(highlight => highlight.id !== fastTrack?.id)
-                .map(highlight => (
-                  <li key={highlight.id}>
-                    <Link
-                      to="/data-tables/fast-track/[fastTrackId]"
-                      as={`/data-tables/fast-track/${highlight.id}`}
-                    >
-                      {highlight.label}
-                    </Link>
-                  </li>
-                ))}
+              {highlights.map(highlight => (
+                <li key={highlight.id}>
+                  <Link
+                    to="/data-tables/fast-track/[fastTrackId]"
+                    as={`/data-tables/fast-track/${highlight.id}`}
+                  >
+                    {highlight.label}
+                  </Link>
+                </li>
+              ))}
             </ul>
           </aside>
         )}


### PR DESCRIPTION
This PR adds this 'Table highlights' section to Step 1 of the pre-release table tool page:

![image](https://user-images.githubusercontent.com/9917868/106744164-4d2ce180-6617-11eb-82fe-49cf3bc05131.png)

This provides parity withe public frontend's equivalent page.

## Relevant changes

- Fixed public frontend `TableToolPage` potentially showing an empty list of table highlights if there was exactly one highlight and the user had already navigated to it.