### PR TITLE
EES-1848 Allow data blocks to be inspected after release is published

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServicePermissionTests.cs
@@ -1,16 +1,14 @@
 using System;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
-using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using Microsoft.AspNetCore.Mvc;
+using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
@@ -25,66 +23,112 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             Id = Guid.NewGuid()
         };
 
-        private readonly DataBlock _dataBlock = new DataBlock()
+        private readonly DataBlock _dataBlock = new DataBlock
         {
             Id = Guid.NewGuid()
         };
 
         [Fact]
+        public void Get()
+        {
+            PermissionTestUtils.PolicyCheckBuilder<ContentSecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = BuildDataBlockService(userService.Object);
+                        return service.Get(_dataBlock.Id);
+                    });
+        }
+
+        [Fact]
+        public void GetDeletePlan()
+        {
+            PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = BuildDataBlockService(userService.Object);
+                        return service.GetDeletePlan(_release.Id, _dataBlock.Id);
+                    });
+        }
+
+        [Fact]
         public void Create()
         {
-            AssertSecurityPoliciesChecked(service =>
-                service.Create(_release.Id, new DataBlockCreateViewModel()), CanUpdateSpecificRelease);
+            PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = BuildDataBlockService(userService.Object);
+                        return service.Create(_release.Id, new DataBlockCreateViewModel());
+                    });
         }
 
         [Fact]
         public void Update()
         {
-            AssertSecurityPoliciesChecked(service =>
-                service.Update(_dataBlock.Id, new DataBlockUpdateViewModel()), CanUpdateSpecificRelease);
+            PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = BuildDataBlockService(userService.Object);
+                        return service.Update(_dataBlock.Id, new DataBlockUpdateViewModel());
+                    });
         }
 
         [Fact]
         public void Delete()
         {
-            AssertSecurityPoliciesChecked(service => service.Delete(_release.Id, _dataBlock.Id), CanUpdateSpecificRelease);
-        }
-
-        private void AssertSecurityPoliciesChecked<T>(
-            Func<DataBlockService, Task<Either<ActionResult, T>>> protectedAction, params SecurityPolicies[] policies)
-        {
-            var (userService, persistenceHelper, fileStorageService) = Mocks();
-
-            using (var context = DbUtils.InMemoryApplicationDbContext())
-            {
-                context.Add(new ReleaseContentBlock
+            PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
+                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+                .AssertForbidden(
+                    userService =>
                     {
-                        Release = _release,
-                        ContentBlockId = _dataBlock.Id
+                        var service = BuildDataBlockService(userService.Object);
+                        return service.Delete(_release.Id, _dataBlock.Id);
                     });
-                context.SaveChanges();
-
-                var service = new DataBlockService(context, AdminMapper(),
-                    persistenceHelper.Object, userService.Object,
-                    fileStorageService.Object);
-
-                PermissionTestUtil.AssertSecurityPoliciesChecked(protectedAction, _release, userService, service, policies);
-            }
         }
 
-        private (
-            Mock<IUserService>,
-            Mock<IPersistenceHelper<ContentDbContext>>,
-            Mock<IReleaseFileService>) Mocks()
+        private Mock<IPersistenceHelper<ContentDbContext>> PersistenceHelperMock()
         {
             var persistenceHelper = MockUtils.MockPersistenceHelper<ContentDbContext>();
+
             MockUtils.SetupCall(persistenceHelper, _release.Id, _release);
             MockUtils.SetupCall(persistenceHelper, _dataBlock.Id, _dataBlock);
-
-            return (
-                new Mock<IUserService>(),
+            MockUtils.SetupCall(
                 persistenceHelper,
-                new Mock<IReleaseFileService>());
+                new ReleaseContentBlock
+                {
+                    Release = _release,
+                    ReleaseId = _release.Id,
+                    ContentBlock = _dataBlock,
+                    ContentBlockId = _dataBlock.Id,
+                }
+            );
+
+            return persistenceHelper;
+        }
+
+        private DataBlockService BuildDataBlockService(
+            IUserService userService,
+            IPersistenceHelper<ContentDbContext> persistenceHelper = null,
+            IReleaseFileService releaseFileService = null)
+        {
+            using var context = DbUtils.InMemoryApplicationDbContext();
+
+            var service = new DataBlockService(
+                context,
+                AdminMapper(),
+                persistenceHelper ?? PersistenceHelperMock().Object,
+                userService,
+                releaseFileService ?? new Mock<IReleaseFileService>().Object
+            );
+
+            return service;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
@@ -139,7 +139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.Get(dataBlock.Id);
 
                 Assert.True(result.IsLeft);
-                Assert.IsType<ForbidResult>(result.Left);
+                Assert.IsType<NotFoundResult>(result.Left);
             }
         }
 
@@ -581,6 +581,58 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task Delete_NotFound()
+        {
+            var release = new Release();
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.AddAsync(release);
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var service = BuildDataBlockService(context);
+                var result = await service.Delete(release.Id, Guid.NewGuid());
+
+                Assert.True(result.IsLeft);
+                Assert.IsType<NotFoundResult>(result.Left);
+            }
+        }
+
+        [Fact]
+        public async Task Delete_ReleaseNotFound()
+        {
+            var dataBlock = new DataBlock();
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                await context.AddAsync(
+                    new ReleaseContentBlock
+                    {
+                        Release = new Release(),
+                        ContentBlock = dataBlock
+                    }
+                );
+                await context.SaveChangesAsync();
+            }
+
+            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            {
+                var service = BuildDataBlockService(context);
+                var result = await service.Delete(Guid.NewGuid(), dataBlock.Id);
+
+                Assert.True(result.IsLeft);
+                Assert.IsType<NotFoundResult>(result.Left);
+            }
+        }
+
+        [Fact]
         public async Task Update()
         {
             var release = new Release();
@@ -716,6 +768,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(updateRequest.Table, updatedDataBlock.Table);
                 Assert.Equal(updateRequest.Charts, updatedDataBlock.Charts);
             }
+        }
+
+        [Fact]
+        public async Task Update_NotFound()
+        {
+            var contextId = Guid.NewGuid().ToString();
+
+            await using var context = ContentDbUtils.InMemoryContentDbContext(contextId);
+
+            var service = BuildDataBlockService(context);
+            var result = await service.Update(Guid.NewGuid(), new DataBlockUpdateViewModel());
+
+            Assert.True(result.IsLeft);
+            Assert.IsType<NotFoundResult>(result.Left);
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IDataBlockService.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, DeleteDataBlockPlan>> GetDeletePlan(Guid releaseId, Guid id);
 
-        Task<DeleteDataBlockPlan> GetDeletePlan(Guid releaseId, Subject subject);
+        Task<DeleteDataBlockPlan> GetDeletePlan(Guid releaseId, Subject? subject);
 
         Task<Either<ActionResult, Unit>> RemoveChartFile(Guid releaseId, Guid id);
     }

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -21,6 +21,7 @@ import {
   releaseStatusRoute,
   releaseSummaryEditRoute,
   releaseSummaryRoute,
+  releaseTableToolRoute,
 } from '@admin/routes/releaseRoutes';
 import publicationService, {
   BasicPublicationDetails,
@@ -52,6 +53,7 @@ const routes = [
   releaseSummaryEditRoute,
   releaseFootnotesCreateRoute,
   releaseFootnotesEditRoute,
+  releaseTableToolRoute,
   releaseDataBlockCreateRoute,
   releaseDataBlockEditRoute,
 ];

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -7,20 +7,20 @@ import ManageReleaseContext from '@admin/pages/release/contexts/ManageReleaseCon
 import { getReleaseStatusLabel } from '@admin/pages/release/utils/releaseSummaryUtil';
 import {
   releaseContentRoute,
+  releaseDataBlockCreateRoute,
+  releaseDataBlockEditRoute,
   releaseDataBlocksRoute,
+  releaseDataFileReplacementCompleteRoute,
   releaseDataFileRoute,
-  releaseFootnotesRoute,
   releaseDataRoute,
+  releaseFootnotesCreateRoute,
+  releaseFootnotesEditRoute,
+  releaseFootnotesRoute,
   releasePreReleaseAccessRoute,
   ReleaseRouteParams,
   releaseStatusRoute,
   releaseSummaryEditRoute,
   releaseSummaryRoute,
-  releaseFootnotesCreateRoute,
-  releaseFootnotesEditRoute,
-  releaseDataFileReplacementCompleteRoute,
-  releaseDataBlockEditRoute,
-  releaseDataBlockCreateRoute,
 } from '@admin/routes/releaseRoutes';
 import publicationService, {
   BasicPublicationDetails,
@@ -33,7 +33,7 @@ import RelatedInformation from '@common/components/RelatedInformation';
 import Tag from '@common/components/Tag';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React from 'react';
-import { generatePath, Route, RouteComponentProps } from 'react-router';
+import { generatePath, Route, RouteComponentProps, Switch } from 'react-router';
 
 const navRoutes = [
   releaseSummaryRoute,
@@ -181,9 +181,11 @@ const ReleasePageContainer = ({
               onChangeReleaseStatus: reloadRelease,
             }}
           >
-            {routes.map(route => (
-              <Route exact key={route.path} {...route} />
-            ))}
+            <Switch>
+              {routes.map(route => (
+                <Route exact key={route.path} {...route} />
+              ))}
+            </Switch>
           </ManageReleaseContext.Provider>
 
           <PreviousNextLinks

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockCreatePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockCreatePage.tsx
@@ -1,5 +1,5 @@
 import Link from '@admin/components/Link';
-import ReleaseDataBlocksPageTabs from '@admin/pages/release/datablocks/components/ReleaseDataBlocksPageTabs';
+import DataBlockPageTabs from '@admin/pages/release/datablocks/components/DataBlockPageTabs';
 import {
   releaseDataBlockEditRoute,
   ReleaseDataBlockRouteParams,
@@ -59,7 +59,7 @@ const ReleaseDataBlockCreatePage = ({
 
       <section>
         {canUpdateRelease ? (
-          <ReleaseDataBlocksPageTabs
+          <DataBlockPageTabs
             releaseId={releaseId}
             onDataBlockSave={handleDataBlockSave}
           />

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
@@ -115,7 +115,7 @@ const ReleaseDataBlockEditPage = ({
               <DataBlockPageTabs
                 key={dataBlockId}
                 releaseId={releaseId}
-                selectedDataBlock={dataBlock}
+                dataBlock={dataBlock}
                 onDataBlockSave={handleDataBlockSave}
               />
             </section>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
@@ -2,7 +2,7 @@ import Link from '@admin/components/Link';
 import { useConfig } from '@admin/contexts/ConfigContext';
 import DataBlockDeletePlanModal from '@admin/pages/release/datablocks/components/DataBlockDeletePlanModal';
 import DataBlockSelector from '@admin/pages/release/datablocks/components/DataBlockSelector';
-import ReleaseDataBlocksPageTabs from '@admin/pages/release/datablocks/components/ReleaseDataBlocksPageTabs';
+import DataBlockPageTabs from '@admin/pages/release/datablocks/components/DataBlockPageTabs';
 import {
   ReleaseDataBlockRouteParams,
   releaseDataBlocksRoute,
@@ -112,7 +112,7 @@ const ReleaseDataBlockEditPage = ({
                 Delete this data block
               </Button>
 
-              <ReleaseDataBlocksPageTabs
+              <DataBlockPageTabs
                 key={dataBlockId}
                 releaseId={releaseId}
                 selectedDataBlock={dataBlock}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
@@ -1,8 +1,9 @@
 import Link from '@admin/components/Link';
 import { useConfig } from '@admin/contexts/ConfigContext';
 import DataBlockDeletePlanModal from '@admin/pages/release/datablocks/components/DataBlockDeletePlanModal';
-import DataBlockSelector from '@admin/pages/release/datablocks/components/DataBlockSelector';
+import DataBlockPageReadOnlyTabs from '@admin/pages/release/datablocks/components/DataBlockPageReadOnlyTabs';
 import DataBlockPageTabs from '@admin/pages/release/datablocks/components/DataBlockPageTabs';
+import DataBlockSelector from '@admin/pages/release/datablocks/components/DataBlockSelector';
 import {
   ReleaseDataBlockRouteParams,
   releaseDataBlocksRoute,
@@ -11,8 +12,11 @@ import {
 import dataBlocksService, {
   ReleaseDataBlock,
 } from '@admin/services/dataBlockService';
+import permissionService from '@admin/services/permissionService';
 import Button from '@common/components/Button';
 import LoadingSpinner from '@common/components/LoadingSpinner';
+import SummaryList from '@common/components/SummaryList';
+import SummaryListItem from '@common/components/SummaryListItem';
 import UrlContainer from '@common/components/UrlContainer';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import useToggle from '@common/hooks/useToggle';
@@ -31,6 +35,11 @@ const ReleaseDataBlockEditPage = ({
   const pageRef = useRef<HTMLDivElement>(null);
 
   const [isDeleting, toggleDeleting] = useToggle(false);
+
+  const { value: canUpdate = false } = useAsyncHandledRetry(
+    () => permissionService.canUpdateRelease(releaseId),
+    [releaseId],
+  );
 
   const {
     value: dataBlock,
@@ -78,9 +87,10 @@ const ReleaseDataBlockEditPage = ({
         Back
       </Link>
 
-      <h2>Edit data block</h2>
+      <h2>{canUpdate ? 'Edit data block' : 'View data block'}</h2>
 
       <DataBlockSelector
+        canUpdate={canUpdate}
         publicationId={publicationId}
         releaseId={releaseId}
         dataBlockId={dataBlockId}
@@ -94,33 +104,43 @@ const ReleaseDataBlockEditPage = ({
             <h2 className="govuk-heading-m">{dataBlock.name}</h2>
 
             <section>
-              <p className="govuk-!-margin-bottom-6">
-                <strong>Fast track URL:</strong>
+              <SummaryList smallKey noBorder>
+                {!canUpdate && (
+                  <SummaryListItem term="Highlight name">
+                    {dataBlock.highlightName}
+                  </SummaryListItem>
+                )}
 
-                <UrlContainer
-                  className="govuk-!-margin-left-4"
-                  data-testid="fastTrackUrl"
-                  url={`${config.PublicAppUrl}/data-tables/fast-track/${dataBlockId}`}
+                <SummaryListItem term="Fast track URL">
+                  <UrlContainer
+                    data-testid="fastTrackUrl"
+                    url={`${config.PublicAppUrl}/data-tables/fast-track/${dataBlockId}`}
+                  />
+                </SummaryListItem>
+              </SummaryList>
+
+              {canUpdate && (
+                <Button variant="warning" onClick={toggleDeleting.on}>
+                  Delete this data block
+                </Button>
+              )}
+
+              {canUpdate ? (
+                <DataBlockPageTabs
+                  key={dataBlockId}
+                  releaseId={releaseId}
+                  dataBlock={dataBlock}
+                  onDataBlockSave={handleDataBlockSave}
                 />
-              </p>
-
-              <Button
-                type="button"
-                variant="warning"
-                onClick={toggleDeleting.on}
-              >
-                Delete this data block
-              </Button>
-
-              <DataBlockPageTabs
-                key={dataBlockId}
-                releaseId={releaseId}
-                dataBlock={dataBlock}
-                onDataBlockSave={handleDataBlockSave}
-              />
+              ) : (
+                <DataBlockPageReadOnlyTabs
+                  releaseId={releaseId}
+                  dataBlock={dataBlock}
+                />
+              )}
             </section>
 
-            {isDeleting && (
+            {isDeleting && canUpdate && (
               <DataBlockDeletePlanModal
                 releaseId={releaseId}
                 dataBlockId={dataBlockId}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
@@ -114,11 +114,9 @@ const ReleaseDataBlocksPage = ({
                   >
                     Highlight name
                   </th>
-                  {canUpdateRelease && (
-                    <th scope="col" className="govuk-table__header--actions">
-                      Actions
-                    </th>
-                  )}
+                  <th scope="col" className="govuk-table__header--actions">
+                    Actions
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -128,28 +126,28 @@ const ReleaseDataBlocksPage = ({
                     <td>{dataBlock.chartsCount > 0 ? 'Yes' : 'No'}</td>
                     <td>{dataBlock.contentSectionId ? 'Yes' : 'No'}</td>
                     <td>{dataBlock.highlightName || 'None'}</td>
-                    {canUpdateRelease && (
-                      <td className="govuk-table__cell--actions">
-                        <Link
-                          unvisited
-                          to={generatePath<ReleaseDataBlockRouteParams>(
-                            releaseDataBlockEditRoute.path,
-                            {
-                              publicationId,
-                              releaseId,
-                              dataBlockId: dataBlock.id,
-                            },
-                          )}
-                        >
-                          Edit block
-                        </Link>
+                    <td className="govuk-table__cell--actions">
+                      <Link
+                        unvisited
+                        to={generatePath<ReleaseDataBlockRouteParams>(
+                          releaseDataBlockEditRoute.path,
+                          {
+                            publicationId,
+                            releaseId,
+                            dataBlockId: dataBlock.id,
+                          },
+                        )}
+                      >
+                        {canUpdateRelease ? 'Edit block' : 'View block'}
+                      </Link>
+                      {canUpdateRelease && (
                         <ButtonText
                           onClick={() => setDeleteDataBlock(dataBlock)}
                         >
                           Delete block
                         </ButtonText>
-                      </td>
-                    )}
+                      )}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlocksPage.tsx
@@ -6,6 +6,7 @@ import {
   releaseDataBlockEditRoute,
   ReleaseDataBlockRouteParams,
   ReleaseRouteParams,
+  releaseTableToolRoute,
 } from '@admin/routes/releaseRoutes';
 import dataBlocksService, {
   ReleaseDataBlockSummary,
@@ -85,10 +86,21 @@ const ReleaseDataBlocksPage = ({
         </p>
       </InsetText>
 
-      {!canUpdateRelease && (
-        <WarningMessage>
-          This release has been approved, and can no longer be updated.
-        </WarningMessage>
+      {!canUpdateRelease && !isLoading && (
+        <>
+          <WarningMessage>
+            This release has been approved, and can no longer be updated.
+          </WarningMessage>
+
+          <ButtonLink
+            to={generatePath<ReleaseRouteParams>(releaseTableToolRoute.path, {
+              publicationId,
+              releaseId,
+            })}
+          >
+            Go to table tool
+          </ButtonLink>
+        </>
       )}
 
       <LoadingSpinner loading={isLoading}>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseTableToolPage.tsx
@@ -1,0 +1,136 @@
+import Link from '@admin/components/Link';
+import {
+  releaseDataBlocksRoute,
+  ReleaseRouteParams,
+} from '@admin/routes/releaseRoutes';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import TableHeadersForm from '@common/modules/table-tool/components/TableHeadersForm';
+import TableToolWizard, {
+  InitialTableToolState,
+} from '@common/modules/table-tool/components/TableToolWizard';
+import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
+import WizardStep from '@common/modules/table-tool/components/WizardStep';
+import WizardStepHeading from '@common/modules/table-tool/components/WizardStepHeading';
+import { FullTable } from '@common/modules/table-tool/types/fullTable';
+import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
+import tableBuilderService from '@common/services/tableBuilderService';
+import React, { useEffect, useRef, useState } from 'react';
+import { generatePath, RouteComponentProps } from 'react-router-dom';
+
+interface ReleaseTableToolFinalStepProps {
+  table: FullTable;
+  tableHeaders: TableHeadersConfig;
+}
+
+const ReleaseTableToolFinalStep = ({
+  table,
+  tableHeaders,
+}: ReleaseTableToolFinalStepProps) => {
+  const dataTableRef = useRef<HTMLElement>(null);
+  const [currentTableHeaders, setCurrentTableHeaders] = useState<
+    TableHeadersConfig
+  >();
+
+  useEffect(() => {
+    setCurrentTableHeaders(tableHeaders);
+  }, [tableHeaders]);
+
+  return (
+    <div className="govuk-!-margin-bottom-4">
+      <TableHeadersForm
+        initialValues={currentTableHeaders}
+        onSubmit={tableHeaderConfig => {
+          setCurrentTableHeaders(tableHeaderConfig);
+
+          if (dataTableRef.current) {
+            dataTableRef.current.scrollIntoView({
+              behavior: 'smooth',
+              block: 'start',
+            });
+          }
+        }}
+      />
+      {table && currentTableHeaders && (
+        <TimePeriodDataTable
+          ref={dataTableRef}
+          fullTable={table}
+          tableHeadersConfig={currentTableHeaders}
+        />
+      )}
+    </div>
+  );
+};
+
+const ReleaseTableToolPage = ({
+  match,
+}: RouteComponentProps<ReleaseRouteParams>) => {
+  const { publicationId, releaseId } = match.params;
+
+  const { value: initialState, isLoading } = useAsyncHandledRetry<
+    InitialTableToolState | undefined
+  >(async () => {
+    const { subjects } = await tableBuilderService.getReleaseMeta(releaseId);
+
+    return {
+      initialStep: 1,
+      subjects,
+      query: {
+        publicationId,
+        releaseId,
+        subjectId: '',
+        indicators: [],
+        filters: [],
+        locations: {},
+      },
+    };
+  }, [releaseId]);
+
+  return (
+    <>
+      <Link
+        back
+        className="govuk-!-margin-bottom-6"
+        to={generatePath<ReleaseRouteParams>(releaseDataBlocksRoute.path, {
+          publicationId,
+          releaseId,
+        })}
+      >
+        Back
+      </Link>
+
+      <LoadingSpinner loading={isLoading}>
+        {initialState && (
+          <>
+            <h2>Table tool</h2>
+
+            <TableToolWizard
+              themeMeta={[]}
+              initialState={initialState}
+              finalStep={({ response, query }) => (
+                <WizardStep>
+                  {wizardStepProps => (
+                    <>
+                      <WizardStepHeading {...wizardStepProps}>
+                        Explore data
+                      </WizardStepHeading>
+
+                      {query && response && (
+                        <ReleaseTableToolFinalStep
+                          table={response.table}
+                          tableHeaders={response.tableHeaders}
+                        />
+                      )}
+                    </>
+                  )}
+                </WizardStep>
+              )}
+            />
+          </>
+        )}
+      </LoadingSpinner>
+    </>
+  );
+};
+
+export default ReleaseTableToolPage;

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__data__/tableToolServiceData.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__data__/tableToolServiceData.ts
@@ -11,33 +11,12 @@ export const testSubjectMeta: SubjectMeta = {
       legend: 'Characteristic',
       name: 'characteristic',
       options: {
-        EthnicGroupMajor: {
-          label: 'Ethnic group major',
+        Gender: {
+          label: 'Gender',
           options: [
             {
-              label: 'Ethnicity Major Chinese',
-              value: 'ethnicity-major-chinese',
-            },
-          ],
-        },
-      },
-    },
-    SchoolType: {
-      totalValue: '',
-      hint: 'Filter by school type',
-      legend: 'School type',
-      name: 'school_type',
-      options: {
-        Default: {
-          label: 'Default',
-          options: [
-            {
-              label: 'State-funded primary',
-              value: 'state-funded-primary',
-            },
-            {
-              label: 'State-funded secondary',
-              value: 'state-funded-secondary',
+              label: 'Gender female',
+              value: 'gender-female',
             },
           ],
         },
@@ -55,149 +34,79 @@ export const testSubjectMeta: SubjectMeta = {
           name: 'sess_authorised',
           decimalPlaces: 2,
         },
-        {
-          value: 'overall-absence-sessions',
-          label: 'Number of overall absence sessions',
-          unit: '',
-          name: 'sess_overall',
-          decimalPlaces: 2,
-        },
       ],
     },
   },
   locations: {
     localAuthority: {
       legend: 'Local authority',
-      options: [
-        { value: 'barnet', label: 'Barnet' },
-        { value: 'barnsley', label: 'Barnsley' },
-      ],
+      options: [{ value: 'barnet', label: 'Barnet' }],
     },
   },
   timePeriod: {
     legend: 'Time period',
-    options: [{ label: '2014/15', code: 'AY', year: 2014 }],
+    options: [{ label: '2020/21', code: 'AY', year: 2020 }],
   },
 };
 
 export const testTableData: TableDataResponse = {
   subjectMeta: {
+    publicationName: '',
+    boundaryLevels: [],
+    footnotes: [],
+    subjectName: 'Subject 1',
+    geoJsonAvailable: false,
+    locations: [
+      {
+        level: 'localAuthority',
+        label: 'Barnet',
+        value: 'barnet',
+      },
+    ],
+    timePeriodRange: [{ code: 'AY', year: 2020, label: '2020/21' }],
+    indicators: [
+      {
+        value: 'authorised-absence-sessions',
+        label: 'Number of authorised absence sessions',
+        unit: '',
+        name: 'sess_authorised',
+        decimalPlaces: 2,
+      },
+    ],
     filters: {
       Characteristic: {
         totalValue: '',
         hint: 'Filter by pupil characteristic',
         legend: 'Characteristic',
-        options: {
-          EthnicGroupMajor: {
-            label: 'Ethnic group major',
-            options: [
-              {
-                label: 'Ethnicity Major Chinese',
-                value: 'ethnicity-major-chinese',
-              },
-            ],
-          },
-        },
         name: 'characteristic',
-      },
-      SchoolType: {
-        totalValue: '',
-        hint: 'Filter by school type',
-        legend: 'School type',
         options: {
-          Default: {
-            label: 'Default',
+          Gender: {
+            label: 'Gender',
             options: [
               {
-                label: 'State-funded primary',
-                value: 'state-funded-primary',
-              },
-              {
-                label: 'State-funded secondary',
-                value: 'state-funded-secondary',
+                label: 'Gender female',
+                value: 'gender-female',
               },
             ],
           },
         },
-        name: 'school_type',
       },
     },
-    footnotes: [],
-    indicators: [
-      {
-        label: 'Number of authorised absence sessions',
-        unit: '',
-        value: 'authorised-absence-sessions',
-        name: 'sess_authorised',
-      },
-      {
-        label: 'Number of overall absence sessions',
-        unit: '',
-        value: 'overall-absence-sessions',
-        name: 'sess_overall',
-      },
-    ],
-    locations: [
-      { level: 'localAuthority', label: 'Barnet', value: 'barnet' },
-      { level: 'localAuthority', label: 'Barnsley', value: 'barnsley' },
-    ],
-    boundaryLevels: [],
-    publicationName: 'Pupil absence in schools in England',
-    subjectName: 'Absence by characteristic',
-    timePeriodRange: [
-      { code: 'AY', label: '2014/15', year: 2014 },
-      { code: 'AY', label: '2015/16', year: 2015 },
-    ],
-    geoJsonAvailable: true,
   },
   results: [
     {
-      filters: ['ethnicity-major-chinese', 'state-funded-primary'],
-      geographicLevel: 'localAuthority',
-      location: {
-        localAuthority: { code: 'barnet', name: 'Barnet' },
-      },
+      timePeriod: '2020_AY',
       measures: {
-        'authorised-absence-sessions': '2613',
-        'overall-absence-sessions': '3134',
+        'authorised-absence-sessions': '123',
       },
-      timePeriod: '2014_AY',
-    },
-    {
-      filters: ['ethnicity-major-chinese', 'state-funded-secondary'],
-      geographicLevel: 'localAuthority',
       location: {
-        localAuthority: { code: 'barnsley', name: 'Barnsley' },
+        localAuthority: {
+          name: 'Barnet',
+          code: 'barnet',
+        },
       },
-      measures: {
-        'authorised-absence-sessions': 'x',
-        'overall-absence-sessions': 'x',
-      },
-      timePeriod: '2014_AY',
-    },
-    {
-      filters: ['ethnicity-major-chinese', 'state-funded-secondary'],
       geographicLevel: 'localAuthority',
-      location: {
-        localAuthority: { code: 'barnet', name: 'Barnet' },
-      },
-      measures: {
-        'authorised-absence-sessions': '1939',
-        'overall-absence-sessions': '2269',
-      },
-      timePeriod: '2014_AY',
-    },
-    {
-      filters: ['ethnicity-major-chinese', 'state-funded-primary'],
-      geographicLevel: 'localAuthority',
-      location: {
-        localAuthority: { code: 'barnsley', name: 'Barnsley' },
-      },
-      measures: {
-        'authorised-absence-sessions': '39',
-        'overall-absence-sessions': '83',
-      },
-      timePeriod: '2014_AY',
+      filters: ['gender-female'],
     },
   ],
 };

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksCreatePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksCreatePage.test.tsx
@@ -1,10 +1,5 @@
 import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
 import {
-  testSubjectMeta,
-  testTableData,
-} from '@admin/pages/release/datablocks/__data__/tableToolServiceData';
-import ReleaseDataBlockEditPage from '@admin/pages/release/datablocks/ReleaseDataBlockEditPage';
-import {
   releaseDataBlockEditRoute,
   ReleaseDataBlockRouteParams,
 } from '@admin/routes/releaseRoutes';

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksPage.test.tsx
@@ -80,10 +80,15 @@ describe('ReleaseDataBlocksPage', () => {
     expect(row1Cells[1]).toHaveTextContent('Yes');
     expect(row1Cells[2]).toHaveTextContent('Yes');
     expect(row1Cells[3]).toHaveTextContent('Block 1 highlight name');
-    expect(within(row1Cells[4]).getByRole('link')).toHaveAttribute(
+    expect(
+      within(row1Cells[4]).getByRole('link', { name: 'Edit block' }),
+    ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-1/data-blocks/block-1',
     );
+    expect(
+      within(row1Cells[4]).getByRole('button', { name: 'Delete block' }),
+    ).toBeInTheDocument();
 
     const row2Cells = within(rows[2]).getAllByRole('cell');
 
@@ -92,10 +97,15 @@ describe('ReleaseDataBlocksPage', () => {
     expect(row2Cells[1]).toHaveTextContent('No');
     expect(row2Cells[2]).toHaveTextContent('No');
     expect(row2Cells[3]).toHaveTextContent('None');
-    expect(within(row2Cells[4]).getByRole('link')).toHaveAttribute(
+    expect(
+      within(row2Cells[4]).getByRole('link', { name: 'Edit block' }),
+    ).toHaveAttribute(
       'href',
       '/publication/publication-1/release/release-1/data-blocks/block-2',
     );
+    expect(
+      within(row2Cells[4]).getByRole('button', { name: 'Delete block' }),
+    ).toBeInTheDocument();
   });
 
   test('renders page correctly when release cannot be updated', async () => {
@@ -121,22 +131,34 @@ describe('ReleaseDataBlocksPage', () => {
 
     const row1Cells = within(rows[1]).getAllByRole('cell');
 
-    expect(row1Cells).toHaveLength(4);
+    expect(row1Cells).toHaveLength(5);
     expect(row1Cells[0]).toHaveTextContent('Block 1');
     expect(row1Cells[1]).toHaveTextContent('Yes');
     expect(row1Cells[2]).toHaveTextContent('Yes');
     expect(row1Cells[3]).toHaveTextContent('Block 1 highlight name');
+    expect(
+      within(row1Cells[4]).getByRole('link', { name: 'View block' }),
+    ).toBeInTheDocument();
+    expect(
+      within(row1Cells[4]).queryByRole('button', { name: 'Delete block' }),
+    ).not.toBeInTheDocument();
 
     const row2Cells = within(rows[2]).getAllByRole('cell');
 
-    expect(row2Cells).toHaveLength(4);
+    expect(row2Cells).toHaveLength(5);
     expect(row2Cells[0]).toHaveTextContent('Block 2');
     expect(row2Cells[1]).toHaveTextContent('No');
     expect(row2Cells[2]).toHaveTextContent('No');
     expect(row2Cells[3]).toHaveTextContent('None');
+    expect(
+      within(row2Cells[4]).getByRole('link', { name: 'View block' }),
+    ).toBeInTheDocument();
+    expect(
+      within(row2Cells[4]).queryByRole('button', { name: 'Delete block' }),
+    ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByRole('button', { name: 'Create data block' }),
+      screen.queryByRole('link', { name: 'Create data block' }),
     ).not.toBeInTheDocument();
   });
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlocksPage.test.tsx
@@ -160,6 +160,10 @@ describe('ReleaseDataBlocksPage', () => {
     expect(
       screen.queryByRole('link', { name: 'Create data block' }),
     ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('link', { name: 'Go to table tool' }),
+    ).toBeInTheDocument();
   });
 
   test('clicking `Delete block` button shows modal', async () => {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
@@ -1,0 +1,70 @@
+import ReleaseTableToolPage from '@admin/pages/release/datablocks/ReleaseTableToolPage';
+import {
+  ReleaseRouteParams,
+  releaseTableToolRoute,
+} from '@admin/routes/releaseRoutes';
+import _tableBuilderService from '@common/services/tableBuilderService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { generatePath, MemoryRouter, Route } from 'react-router-dom';
+
+jest.mock('@common/services/tableBuilderService');
+
+const tableBuilderService = _tableBuilderService as jest.Mocked<
+  typeof _tableBuilderService
+>;
+
+describe('ReleaseTableToolPage', () => {
+  test('renders correctly on step 1', async () => {
+    tableBuilderService.getReleaseMeta.mockResolvedValue({
+      releaseId: 'release-1',
+      subjects: [
+        {
+          id: 'subject-1',
+          label: 'Subject 1',
+        },
+        {
+          id: 'subject-2',
+          label: 'Subject 2',
+        },
+      ],
+      highlights: [],
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
+
+      expect(stepHeadings).toHaveLength(1);
+      expect(stepHeadings[0]).toHaveTextContent(
+        'Step 1 (current): Choose a subject',
+      );
+    });
+
+    const step = within(screen.getByTestId('wizardStep-1'));
+
+    expect(step.getAllByLabelText(/Subject/)).toHaveLength(2);
+
+    expect(step.getByLabelText('Subject 1')).toBeInTheDocument();
+    expect(step.getByLabelText('Subject 2')).toBeInTheDocument();
+  });
+
+  const renderPage = () => {
+    return render(
+      <MemoryRouter
+        initialEntries={[
+          generatePath<ReleaseRouteParams>(releaseTableToolRoute.path, {
+            publicationId: 'publication-1',
+            releaseId: 'release-1',
+          }),
+        ]}
+      >
+        <Route
+          component={ReleaseTableToolPage}
+          path={releaseTableToolRoute.path}
+        />
+      </MemoryRouter>,
+    );
+  };
+});

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
@@ -1,0 +1,109 @@
+import TableTabSection from '@admin/pages/release/datablocks/components/TableTabSection';
+import { ReleaseDataBlock } from '@admin/services/dataBlockService';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import Tabs from '@common/components/Tabs';
+import TabsSection from '@common/components/TabsSection';
+import WarningMessage from '@common/components/WarningMessage';
+import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import ChartRenderer from '@common/modules/charts/components/ChartRenderer';
+import { AxesConfiguration } from '@common/modules/charts/types/chart';
+import { FullTable } from '@common/modules/table-tool/types/fullTable';
+import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
+import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
+import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHeadersConfig';
+import tableBuilderService, {
+  ReleaseTableDataQuery,
+} from '@common/services/tableBuilderService';
+import React from 'react';
+
+interface Model {
+  table: FullTable;
+  tableHeaders: TableHeadersConfig;
+}
+
+interface Props {
+  releaseId: string;
+  dataBlock: ReleaseDataBlock;
+}
+
+const DataBlockPageReadOnlyTabs = ({ releaseId, dataBlock }: Props) => {
+  const { value: model, isLoading } = useAsyncRetry<Model>(async () => {
+    const query: ReleaseTableDataQuery = {
+      ...dataBlock.query,
+      releaseId,
+      includeGeoJson: dataBlock.charts.some(chart => chart.type === 'map'),
+    };
+
+    const tableData = await tableBuilderService.getTableData(query);
+    const table = mapFullTable(tableData);
+
+    const tableHeaders = mapTableHeadersConfig(
+      dataBlock.table.tableHeaders,
+      table.subjectMeta,
+    );
+
+    return {
+      table,
+      tableHeaders,
+    };
+  }, [releaseId, dataBlock]);
+
+  return (
+    <LoadingSpinner text="Loading data block" loading={isLoading}>
+      {model ? (
+        <Tabs id="dataBlockTabs">
+          <TabsSection title="Table" key="table" id="dataBlockTabs-table">
+            <TableTabSection
+              dataBlock={dataBlock}
+              table={model.table}
+              tableHeaders={model.tableHeaders}
+            />
+          </TabsSection>
+          {dataBlock.charts.length > 0 && [
+            <TabsSection title="Chart" key="chart" id="dataBlockTabs-chart">
+              <div className="govuk-width-container">
+                {dataBlock.charts.map((chart, index) => {
+                  const key = index;
+
+                  const axes = { ...chart.axes } as Required<AxesConfiguration>;
+
+                  if (chart.type === 'infographic') {
+                    return (
+                      <ChartRenderer
+                        {...chart}
+                        key={key}
+                        id={`dataBlockTabs-chart-${index}`}
+                        axes={axes}
+                        data={model.table.results}
+                        meta={model.table.subjectMeta}
+                        source={dataBlock.source}
+                      />
+                    );
+                  }
+
+                  return (
+                    <ChartRenderer
+                      {...chart}
+                      key={key}
+                      id={`dataBlockTabs-chart-${index}`}
+                      axes={axes}
+                      data={model.table.results}
+                      meta={model.table.subjectMeta}
+                      source={dataBlock.source}
+                    />
+                  );
+                })}
+              </div>
+            </TabsSection>,
+          ]}
+        </Tabs>
+      ) : (
+        <WarningMessage>
+          There was a problem loading the data block
+        </WarningMessage>
+      )}
+    </LoadingSpinner>
+  );
+};
+
+export default DataBlockPageReadOnlyTabs;

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -298,6 +298,7 @@ const DataBlockPageTabs = ({
                 lazy
               >
                 <TableTabSection
+                  dataBlock={dataBlock}
                   table={response.table}
                   tableHeaders={response.tableHeaders}
                   onSave={handleTableHeadersSave}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -36,13 +36,13 @@ export type SavedDataBlock = CreateReleaseDataBlock & {
 
 interface Props {
   releaseId: string;
-  selectedDataBlock?: ReleaseDataBlock;
-  onDataBlockSave: (dataBlock: ReleaseDataBlock) => void;
+  dataBlock?: ReleaseDataBlock;
+  onDataBlockSave?: (dataBlock: ReleaseDataBlock) => void;
 }
 
 const DataBlockPageTabs = ({
   releaseId,
-  selectedDataBlock,
+  dataBlock,
   onDataBlockSave,
 }: Props) => {
   // Track number of saves as we can use this to
@@ -58,7 +58,7 @@ const DataBlockPageTabs = ({
   } = useAsyncRetry<InitialTableToolState>(async () => {
     const { subjects } = await tableBuilderService.getReleaseMeta(releaseId);
 
-    if (!selectedDataBlock) {
+    if (!dataBlock) {
       return {
         initialStep: 1,
         subjects,
@@ -74,11 +74,9 @@ const DataBlockPageTabs = ({
     }
 
     const query: ReleaseTableDataQuery = {
-      ...selectedDataBlock.query,
+      ...dataBlock.query,
       releaseId,
-      includeGeoJson: selectedDataBlock.charts.some(
-        chart => chart.type === 'map',
-      ),
+      includeGeoJson: dataBlock.charts.some(chart => chart.type === 'map'),
     };
 
     const tableData = await tableBuilderService.getTableData(query);
@@ -103,7 +101,7 @@ const DataBlockPageTabs = ({
 
     try {
       const tableHeaders = mapTableHeadersConfig(
-        selectedDataBlock.table.tableHeaders,
+        dataBlock.table.tableHeaders,
         table.subjectMeta,
       );
 
@@ -131,18 +129,20 @@ const DataBlockPageTabs = ({
   }, []);
 
   const handleDataBlockSave = useCallback(
-    async (dataBlock: SavedDataBlock) => {
+    async (nextDataBlock: SavedDataBlock) => {
       setIsSaving(true);
 
       const dataBlockToSave: SavedDataBlock = {
-        ...dataBlock,
+        ...nextDataBlock,
         query: {
-          ...(omit(dataBlock.query, ['releaseId']) as SavedDataBlock['query']),
-          includeGeoJson: dataBlock.charts[0]?.type === 'map',
+          ...(omit(nextDataBlock.query, [
+            'releaseId',
+          ]) as SavedDataBlock['query']),
+          includeGeoJson: nextDataBlock.charts[0]?.type === 'map',
         },
       };
 
-      const newDataBlock = await minDelay(() => {
+      const savedDataBlock = await minDelay(() => {
         if (dataBlockToSave.id) {
           return dataBlocksService.updateDataBlock(
             dataBlockToSave.id,
@@ -153,7 +153,9 @@ const DataBlockPageTabs = ({
         return dataBlocksService.createDataBlock(releaseId, dataBlockToSave);
       }, 500);
 
-      onDataBlockSave(newDataBlock);
+      if (onDataBlockSave) {
+        onDataBlockSave(savedDataBlock);
+      }
 
       setIsSaving(false);
       setSaveNumber(saveNumber + 1);
@@ -163,7 +165,7 @@ const DataBlockPageTabs = ({
 
   const handleDataBlockSourceSave: DataBlockSourceWizardSaveHandler = useCallback(
     async ({ query, table, tableHeaders, details }) => {
-      const charts = produce(selectedDataBlock?.charts ?? [], draft => {
+      const charts = produce(dataBlock?.charts ?? [], draft => {
         const majorAxis = draft[0]?.axes?.major;
 
         if (majorAxis?.dataSets) {
@@ -186,7 +188,7 @@ const DataBlockPageTabs = ({
       });
 
       await handleDataBlockSave({
-        ...(selectedDataBlock ?? {}),
+        ...(dataBlock ?? {}),
         ...details,
         query,
         charts,
@@ -196,12 +198,12 @@ const DataBlockPageTabs = ({
         },
       });
     },
-    [handleDataBlockSave, selectedDataBlock, setTableState],
+    [handleDataBlockSave, dataBlock, setTableState],
   );
 
   const handleTableHeadersSave = useCallback(
     async (tableHeaders: TableHeadersConfig) => {
-      if (!selectedDataBlock) {
+      if (!dataBlock) {
         throw new Error(
           'Cannot save table headers when no data block has been selected',
         );
@@ -224,14 +226,14 @@ const DataBlockPageTabs = ({
       });
 
       await handleDataBlockSave({
-        ...selectedDataBlock,
+        ...dataBlock,
         table: {
           tableHeaders: mapUnmappedTableHeaders(tableHeaders),
           indicators: [],
         },
       });
     },
-    [handleDataBlockSave, selectedDataBlock, setTableState, tableState],
+    [handleDataBlockSave, dataBlock, setTableState, tableState],
   );
 
   const handleChartTableUpdate: ChartBuilderTableUpdateHandler = useCallback(
@@ -265,7 +267,7 @@ const DataBlockPageTabs = ({
         />
       )}
 
-      {selectedDataBlock && tableState && tableState?.initialStep < 5 && (
+      {dataBlock && tableState && tableState?.initialStep < 5 && (
         <WarningMessage>
           There is a problem with this data block as we could not render a table
           with the selected options. Please re-check your choices to ensure the
@@ -279,14 +281,14 @@ const DataBlockPageTabs = ({
             {!isLoading && tableState && (
               <DataBlockSourceWizard
                 key={saveNumber}
-                dataBlock={selectedDataBlock}
+                dataBlock={dataBlock}
                 tableToolState={tableState}
                 onSave={handleDataBlockSourceSave}
               />
             )}
           </TabsSection>
 
-          {selectedDataBlock &&
+          {dataBlock &&
             query &&
             response && [
               <TabsSection
@@ -304,7 +306,7 @@ const DataBlockPageTabs = ({
               <TabsSection title="Chart" key="chart" id="dataBlockTabs-chart">
                 <ChartBuilderTabSection
                   key={saveNumber}
-                  dataBlock={selectedDataBlock}
+                  dataBlock={dataBlock}
                   query={query}
                   releaseId={releaseId}
                   table={response.table}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -40,7 +40,7 @@ interface Props {
   onDataBlockSave: (dataBlock: ReleaseDataBlock) => void;
 }
 
-const ReleaseDataBlocksPageTabs = ({
+const DataBlockPageTabs = ({
   releaseId,
   selectedDataBlock,
   onDataBlockSave,
@@ -274,8 +274,8 @@ const ReleaseDataBlocksPageTabs = ({
       )}
 
       {!error ? (
-        <Tabs id="manageDataBlocks">
-          <TabsSection title="Data source" id="manageDataBlocks-dataSource">
+        <Tabs id="dataBlockTabs">
+          <TabsSection title="Data source" id="dataBlockTabs-dataSource">
             {!isLoading && tableState && (
               <DataBlockSourceWizard
                 key={saveNumber}
@@ -292,7 +292,7 @@ const ReleaseDataBlocksPageTabs = ({
               <TabsSection
                 title="Table"
                 key="table"
-                id="manageDataBlocks-table"
+                id="dataBlockTabs-table"
                 lazy
               >
                 <TableTabSection
@@ -301,11 +301,7 @@ const ReleaseDataBlocksPageTabs = ({
                   onSave={handleTableHeadersSave}
                 />
               </TabsSection>,
-              <TabsSection
-                title="Chart"
-                key="chart"
-                id="manageDataBlocks-chart"
-              >
+              <TabsSection title="Chart" key="chart" id="dataBlockTabs-chart">
                 <ChartBuilderTabSection
                   key={saveNumber}
                   dataBlock={selectedDataBlock}
@@ -327,4 +323,4 @@ const ReleaseDataBlocksPageTabs = ({
   );
 };
 
-export default ReleaseDataBlocksPageTabs;
+export default DataBlockPageTabs;

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSelector.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSelector.tsx
@@ -14,12 +14,14 @@ import { generatePath, useHistory } from 'react-router';
 const emptyDataBlocks: ReleaseDataBlockSummary[] = [];
 
 interface Props {
+  canUpdate?: boolean;
   publicationId: string;
   releaseId: string;
   dataBlockId: string;
 }
 
 const DataBlockSelector = ({
+  canUpdate = true,
   publicationId,
   releaseId,
   dataBlockId,
@@ -47,7 +49,11 @@ const DataBlockSelector = ({
       id="selectedDataBlock"
       name="selectedDataBlock"
       className="govuk-!-margin-bottom-4"
-      label="Select a data block to edit"
+      label={
+        canUpdate
+          ? 'Select a data block to edit'
+          : 'Select a data block to view'
+      }
       disabled={isLoading}
       order={FormSelect.unordered}
       value={dataBlockId}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/TableTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/TableTabSection.tsx
@@ -1,3 +1,4 @@
+import { ReleaseDataBlock } from '@admin/services/dataBlockService';
 import TableHeadersForm from '@common/modules/table-tool/components/TableHeadersForm';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
@@ -5,12 +6,13 @@ import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeader
 import React, { useRef } from 'react';
 
 interface Props {
+  dataBlock: ReleaseDataBlock;
   table: FullTable;
   tableHeaders: TableHeadersConfig;
   onSave: (tableHeaders: TableHeadersConfig) => void;
 }
 
-const TableTabSection = ({ table, tableHeaders, onSave }: Props) => {
+const TableTabSection = ({ dataBlock, table, tableHeaders, onSave }: Props) => {
   const dataTableRef = useRef<HTMLElement>(null);
 
   return (
@@ -33,6 +35,8 @@ const TableTabSection = ({ table, tableHeaders, onSave }: Props) => {
       <TimePeriodDataTable
         fullTable={table}
         tableHeadersConfig={tableHeaders}
+        captionTitle={dataBlock.heading}
+        source={dataBlock.source}
         ref={dataTableRef}
       />
     </>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/TableTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/TableTabSection.tsx
@@ -9,7 +9,7 @@ interface Props {
   dataBlock: ReleaseDataBlock;
   table: FullTable;
   tableHeaders: TableHeadersConfig;
-  onSave: (tableHeaders: TableHeadersConfig) => void;
+  onSave?: (tableHeaders: TableHeadersConfig) => void;
 }
 
 const TableTabSection = ({ dataBlock, table, tableHeaders, onSave }: Props) => {
@@ -17,20 +17,22 @@ const TableTabSection = ({ dataBlock, table, tableHeaders, onSave }: Props) => {
 
   return (
     <>
-      <TableHeadersForm
-        initialValues={tableHeaders}
-        id="dataBlockContentTabs-tableHeadersForm"
-        onSubmit={async nextTableHeaders => {
-          await onSave(nextTableHeaders);
+      {onSave && (
+        <TableHeadersForm
+          initialValues={tableHeaders}
+          id="dataBlockTabs-tableHeadersForm"
+          onSubmit={async nextTableHeaders => {
+            await onSave(nextTableHeaders);
 
-          if (dataTableRef.current) {
-            dataTableRef.current.scrollIntoView({
-              behavior: 'smooth',
-              block: 'start',
-            });
-          }
-        }}
-      />
+            if (dataTableRef.current) {
+              dataTableRef.current.scrollIntoView({
+                behavior: 'smooth',
+                block: 'start',
+              });
+            }
+          }}
+        />
+      )}
 
       <TimePeriodDataTable
         fullTable={table}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
@@ -1,11 +1,12 @@
+import {
+  testSubjectMeta,
+  testTableData,
+} from '@admin/pages/release/datablocks/__data__/tableToolServiceData';
 import DataBlockPageTabs from '@admin/pages/release/datablocks/components/DataBlockPageTabs';
 import _dataBlockService, {
   ReleaseDataBlock,
 } from '@admin/services/dataBlockService';
-import _tableBuilderService, {
-  SubjectMeta,
-  TableDataResponse,
-} from '@common/services/tableBuilderService';
+import _tableBuilderService from '@common/services/tableBuilderService';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import noop from 'lodash/noop';
@@ -22,114 +23,6 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
 >;
 
 describe('DataBlockPageTabs', () => {
-  const testSubjectMeta: SubjectMeta = {
-    filters: {
-      Characteristic: {
-        totalValue: '',
-        hint: 'Filter by pupil characteristic',
-        legend: 'Characteristic',
-        name: 'characteristic',
-        options: {
-          Gender: {
-            label: 'Gender',
-            options: [
-              {
-                label: 'Gender female',
-                value: 'gender-female',
-              },
-            ],
-          },
-        },
-      },
-    },
-    indicators: {
-      AbsenceFields: {
-        label: 'Absence fields',
-        options: [
-          {
-            value: 'authorised-absence-sessions',
-            label: 'Number of authorised absence sessions',
-            unit: '',
-            name: 'sess_authorised',
-            decimalPlaces: 2,
-          },
-        ],
-      },
-    },
-    locations: {
-      localAuthority: {
-        legend: 'Local authority',
-        options: [{ value: 'barnet', label: 'Barnet' }],
-      },
-    },
-    timePeriod: {
-      legend: 'Time period',
-      options: [{ label: '2020/21', code: 'AY', year: 2020 }],
-    },
-  };
-
-  const testTableData: TableDataResponse = {
-    subjectMeta: {
-      publicationName: '',
-      boundaryLevels: [],
-      footnotes: [],
-      subjectName: 'Subject 1',
-      geoJsonAvailable: false,
-      locations: [
-        {
-          level: 'localAuthority',
-          label: 'Barnet',
-          value: 'barnet',
-        },
-      ],
-      timePeriodRange: [{ code: 'AY', year: 2020, label: '2020/21' }],
-      indicators: [
-        {
-          value: 'authorised-absence-sessions',
-          label: 'Number of authorised absence sessions',
-          unit: '',
-          name: 'sess_authorised',
-          decimalPlaces: 2,
-        },
-      ],
-      filters: {
-        Characteristic: {
-          totalValue: '',
-          hint: 'Filter by pupil characteristic',
-          legend: 'Characteristic',
-          name: 'characteristic',
-          options: {
-            Gender: {
-              label: 'Gender',
-              options: [
-                {
-                  label: 'Gender female',
-                  value: 'gender-female',
-                },
-              ],
-            },
-          },
-        },
-      },
-    },
-    results: [
-      {
-        timePeriod: '2020_AY',
-        measures: {
-          'authorised-absence-sessions': '123',
-        },
-        location: {
-          localAuthority: {
-            name: 'Barnet',
-            code: 'barnet',
-          },
-        },
-        geographicLevel: 'localAuthority',
-        filters: ['gender-female'],
-      },
-    ],
-  };
-
   const testDataBlock: ReleaseDataBlock = {
     name: 'Test data block',
     heading: 'Test title',

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
@@ -216,7 +216,7 @@ describe('DataBlockPageTabs', () => {
     render(
       <DataBlockPageTabs
         releaseId="release-1"
-        selectedDataBlock={testDataBlock}
+        dataBlock={testDataBlock}
         onDataBlockSave={noop}
       />,
     );
@@ -252,7 +252,7 @@ describe('DataBlockPageTabs', () => {
     render(
       <DataBlockPageTabs
         releaseId="release-1"
-        selectedDataBlock={testDataBlock}
+        dataBlock={testDataBlock}
         onDataBlockSave={noop}
       />,
     );
@@ -283,7 +283,7 @@ describe('DataBlockPageTabs', () => {
     render(
       <DataBlockPageTabs
         releaseId="release-1"
-        selectedDataBlock={testDataBlock}
+        dataBlock={testDataBlock}
         onDataBlockSave={noop}
       />,
     );
@@ -318,7 +318,7 @@ describe('DataBlockPageTabs', () => {
     render(
       <DataBlockPageTabs
         releaseId="release-1"
-        selectedDataBlock={{
+        dataBlock={{
           ...testDataBlock,
           table: {
             indicators: [],
@@ -366,7 +366,7 @@ describe('DataBlockPageTabs', () => {
       render(
         <DataBlockPageTabs
           releaseId="release-1"
-          selectedDataBlock={testDataBlock}
+          dataBlock={testDataBlock}
           onDataBlockSave={noop}
         />,
       );

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
@@ -1,4 +1,4 @@
-import ReleaseDataBlocksPageTabs from '@admin/pages/release/datablocks/components/ReleaseDataBlocksPageTabs';
+import DataBlockPageTabs from '@admin/pages/release/datablocks/components/DataBlockPageTabs';
 import _dataBlockService, {
   ReleaseDataBlock,
 } from '@admin/services/dataBlockService';
@@ -21,7 +21,7 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
   typeof _tableBuilderService
 >;
 
-describe('ReleaseDataBlocksPageTabs', () => {
+describe('DataBlockPageTabs', () => {
   const testSubjectMeta: SubjectMeta = {
     filters: {
       Characteristic: {
@@ -172,12 +172,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
       highlights: [],
     });
 
-    render(
-      <ReleaseDataBlocksPageTabs
-        releaseId="release-1"
-        onDataBlockSave={noop}
-      />,
-    );
+    render(<DataBlockPageTabs releaseId="release-1" onDataBlockSave={noop} />);
 
     await waitFor(() => {
       const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
@@ -198,12 +193,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
       highlights: [],
     });
 
-    render(
-      <ReleaseDataBlocksPageTabs
-        releaseId="release-1"
-        onDataBlockSave={noop}
-      />,
-    );
+    render(<DataBlockPageTabs releaseId="release-1" onDataBlockSave={noop} />);
 
     await waitFor(() => {
       const tabs = screen.getAllByRole('tab');
@@ -224,7 +214,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
     tableBuilderService.getTableData.mockResolvedValue(testTableData);
 
     render(
-      <ReleaseDataBlocksPageTabs
+      <DataBlockPageTabs
         releaseId="release-1"
         selectedDataBlock={testDataBlock}
         onDataBlockSave={noop}
@@ -260,7 +250,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
     tableBuilderService.getTableData.mockResolvedValue(testTableData);
 
     render(
-      <ReleaseDataBlocksPageTabs
+      <DataBlockPageTabs
         releaseId="release-1"
         selectedDataBlock={testDataBlock}
         onDataBlockSave={noop}
@@ -291,7 +281,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
     });
 
     render(
-      <ReleaseDataBlocksPageTabs
+      <DataBlockPageTabs
         releaseId="release-1"
         selectedDataBlock={testDataBlock}
         onDataBlockSave={noop}
@@ -326,7 +316,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
     tableBuilderService.getTableData.mockResolvedValue(testTableData);
 
     render(
-      <ReleaseDataBlocksPageTabs
+      <DataBlockPageTabs
         releaseId="release-1"
         selectedDataBlock={{
           ...testDataBlock,
@@ -374,7 +364,7 @@ describe('ReleaseDataBlocksPageTabs', () => {
       tableBuilderService.getTableData.mockResolvedValue(testTableData);
 
       render(
-        <ReleaseDataBlocksPageTabs
+        <DataBlockPageTabs
           releaseId="release-1"
           selectedDataBlock={testDataBlock}
           onDataBlockSave={noop}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
@@ -1,7 +1,7 @@
 import ChartBuilder, {
   TableQueryUpdateHandler,
 } from '@admin/pages/release/datablocks/components/chart/ChartBuilder';
-import { SavedDataBlock } from '@admin/pages/release/datablocks/components/ReleaseDataBlocksPageTabs';
+import { SavedDataBlock } from '@admin/pages/release/datablocks/components/DataBlockPageTabs';
 import { ReleaseDataBlock } from '@admin/services/dataBlockService';
 import releaseChartFileService from '@admin/services/releaseChartFileService';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -92,7 +92,7 @@ export const releaseDataBlocksRoute: ReleaseRouteProps = {
 };
 
 export const releaseDataBlockCreateRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/create-data-block',
+  path: '/publication/:publicationId/release/:releaseId/data-blocks/create',
   title: 'Create data block',
   component: ReleaseDataBlockCreatePage,
 };

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -5,6 +5,7 @@ import ReleaseDataPage from '@admin/pages/release/data/ReleaseDataPage';
 import ReleaseDataBlockCreatePage from '@admin/pages/release/datablocks/ReleaseDataBlockCreatePage';
 import ReleaseDataBlockEditPage from '@admin/pages/release/datablocks/ReleaseDataBlockEditPage';
 import ReleaseDataBlocksPage from '@admin/pages/release/datablocks/ReleaseDataBlocksPage';
+import ReleaseTableToolPage from '@admin/pages/release/datablocks/ReleaseTableToolPage';
 import ReleaseFootnoteCreatePage from '@admin/pages/release/footnotes/ReleaseFootnoteCreatePage';
 import ReleaseFootnoteEditPage from '@admin/pages/release/footnotes/ReleaseFootnoteEditPage';
 import ReleaseFootnotesPage from '@admin/pages/release/footnotes/ReleaseFootnotesPage';
@@ -89,6 +90,12 @@ export const releaseDataBlocksRoute: ReleaseRouteProps = {
   path: '/publication/:publicationId/release/:releaseId/data-blocks',
   title: 'Data blocks',
   component: ReleaseDataBlocksPage,
+};
+
+export const releaseTableToolRoute: ReleaseRouteProps = {
+  path: '/publication/:publicationId/release/:releaseId/data-blocks/table-tool',
+  title: 'Table tool',
+  component: ReleaseTableToolPage,
 };
 
 export const releaseDataBlockCreateRoute: ReleaseRouteProps = {

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -145,7 +145,7 @@ Create chart for data block
     [Tags]  HappyPath
     user waits until page contains link  Chart
     user waits until page does not contain loading spinner
-    user clicks element   id:manageDataBlocks-chart-tab
+    user clicks link  Chart
 
     user clicks button  Choose an infographic as alternative
     user chooses file  id:chartConfigurationForm-file       ${FILES_DIR}test-infographic.png
@@ -542,7 +542,7 @@ Update data block chart for amendment
     [Tags]  HappyPath
     user waits until page contains link  Chart
     user waits until page does not contain loading spinner
-    user clicks element   id:manageDataBlocks-chart-tab
+    user clicks link  Chart
 
     user waits until page contains element  id:chartConfigurationForm-title
     user enters text into element  id:chartConfigurationForm-title  Updated sample title


### PR DESCRIPTION
This PR adds a read-only variant of the 'Edit data block' page that is only visible once the release has been published. It looks like the following:

![image](https://user-images.githubusercontent.com/9917868/106923948-8001d300-6706-11eb-9cd6-12111176e743.png)

The user cannot modify the data block any further at this point and can only see the table and chart tabs.

If they want to play around with the table tool itself, they can do so by visting a new 'Go to table tool' button on the main 'Data blocks' page:

![image](https://user-images.githubusercontent.com/9917868/106924133-ad4e8100-6706-11eb-804e-3ee20cccf393.png)

This takes them to a read-only version of the table tool:

![image](https://user-images.githubusercontent.com/9917868/106924211-c5be9b80-6706-11eb-8ce9-72376e599fa9.png)

This table tool is essentially the same as the one in the public frontend, but does not offer any of the additional options (e.g. downloading as CSV/XLSX, permalinks, etc).

## Relevant changes

- Refactors `DataBlockService` to fetch the required `ReleaseContentBlocks` directly, instead of fetching a `DataBlock` then matching it with a `Release`. This simplifies a bunch of code around the handling of potential mismatches e.g. if you were to fetch a block that isn't a data block.

## Other changes

- Added `Switch` around the `ReleasePageContainer` route block. This prevents multiple routes potentially being rendered simultaneously and breaking the page. 
- Changed 'Create data block' route path to `/data-blocks/create`. This allows us to show the navbar's 'Data blocks' link as active when we are on that page. We were previously using `/create-data-blocks`, due to the missing `Switch` causing the edit and create routes to render simultaneously.
- Simplified test data for `data-blocks` pages. The previous data was making it difficult to render a working table.