### PR TITLE
EES-78 Remove unnecessary fieldset from CookiesPage and general cleanup

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/cookies/CookiesPage.module.scss
+++ b/src/explore-education-statistics-frontend/src/modules/cookies/CookiesPage.module.scss
@@ -1,8 +1,7 @@
+@import '~govuk-frontend/govuk/base';
+
 .submitNotification {
-  border: 2px solid #1d70b8;
-  padding: 20px;
-  > h2 {
-    font-size: 24px;
-    line-height: 1.25;
-  }
+  border: $govuk-border-width solid govuk-colour('blue');
+  margin: govuk-spacing(2) 0 govuk-spacing(6);
+  padding: govuk-spacing(6);
 }

--- a/src/explore-education-statistics-frontend/src/modules/cookies/CookiesPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/cookies/CookiesPage.tsx
@@ -1,4 +1,5 @@
 import Button from '@common/components/Button';
+import ButtonText from '@common/components/ButtonText';
 import { Form, FormFieldRadioGroup, FormGroup } from '@common/components/form';
 import useMounted from '@common/hooks/useMounted';
 import { Dictionary } from '@common/types';
@@ -8,6 +9,7 @@ import Page from '@frontend/components/Page';
 import { useCookies } from '@frontend/hooks/useCookies';
 import { Formik } from 'formik';
 import { GetServerSideProps } from 'next';
+import { useRouter } from 'next/router';
 import { parseCookies } from 'nookies';
 import React, { useState } from 'react';
 import styles from './CookiesPage.module.scss';
@@ -22,6 +24,7 @@ interface Props {
 
 function CookiesPage({ cookies }: Props) {
   const [submitted, setSubmitted] = useState(false);
+  const { back } = useRouter();
 
   const { getCookie, setBannerSeenCookie, setGADisabledCookie } = useCookies(
     cookies,
@@ -37,24 +40,22 @@ function CookiesPage({ cookies }: Props) {
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          {!submitted ? null : (
+          {submitted && (
             <div
               id="submit-notification"
-              className={`${styles.submitNotification} govuk-!-margin-bottom-6 govuk-!-margin-top-2`}
+              className={styles.submitNotification}
+              role="alert"
             >
               <h2>Your cookie settings were saved</h2>
               <p>We have stored your cookie settings.</p>
               <p>
-                <a
-                  href="#"
-                  onClick={() => window.history.back()}
-                  title="Go back to the previous page"
-                >
+                <ButtonText onClick={() => back()}>
                   Go back to the page you were looking at
-                </a>
+                </ButtonText>
               </p>
             </div>
           )}
+
           <p>
             Cookies are files saved on your phone, tablet or computer when you
             visit a website.

--- a/src/explore-education-statistics-frontend/src/modules/cookies/CookiesPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/cookies/CookiesPage.tsx
@@ -1,13 +1,7 @@
 import Button from '@common/components/Button';
-import {
-  Form,
-  FormFieldRadioGroup,
-  FormFieldset,
-  FormGroup,
-} from '@common/components/form';
+import { Form, FormFieldRadioGroup, FormGroup } from '@common/components/form';
 import useMounted from '@common/hooks/useMounted';
 import { Dictionary } from '@common/types';
-import createErrorHelper from '@common/validation/createErrorHelper';
 import Yup from '@common/validation/yup';
 import Link from '@frontend/components/Link';
 import Page from '@frontend/components/Page';
@@ -19,7 +13,7 @@ import React, { useState } from 'react';
 import styles from './CookiesPage.module.scss';
 
 interface FormValues {
-  googleAnalytics: string;
+  googleAnalytics: 'on' | 'off';
 }
 
 interface Props {
@@ -90,9 +84,7 @@ function CookiesPage({ cookies }: Props) {
                   .oneOf(['on', 'off']),
               })}
             >
-              {form => {
-                const { getError } = createErrorHelper(form);
-
+              {() => {
                 return (
                   <Form id="cookieSettingsForm">
                     <h2 className="govuk-!-margin-top-6">Cookie settings</h2>
@@ -124,35 +116,28 @@ function CookiesPage({ cookies }: Props) {
                         We do not allow Google to use or share the data about
                         how you use this site.
                       </p>
-                      <FormFieldset
-                        error={getError('googleAnalytics')}
-                        id="cookieSettingsForm-googleAnalytics"
-                        legend=""
-                      >
-                        <FormGroup>
-                          <FormFieldRadioGroup
-                            legend="Google analytics and cookies"
-                            legendHidden
-                            inline
-                            orderDirection={['desc']}
-                            showError={false}
-                            name="googleAnalytics"
-                            id="cookieSettingsForm-googleAnalytics"
-                            options={[
-                              {
-                                id: 'googleAnalytics-on',
-                                label: 'On',
-                                value: 'on',
-                              },
-                              {
-                                id: 'googleAnalytics-off',
-                                label: 'Off',
-                                value: 'off',
-                              },
-                            ]}
-                          />
-                        </FormGroup>
-                      </FormFieldset>
+
+                      <FormGroup>
+                        <FormFieldRadioGroup<FormValues>
+                          legend="Allow Google Analytics cookies"
+                          legendHidden
+                          inline
+                          orderDirection={['desc']}
+                          showError={false}
+                          name="googleAnalytics"
+                          id="cookieSettingsForm-googleAnalytics"
+                          options={[
+                            {
+                              label: 'On',
+                              value: 'on',
+                            },
+                            {
+                              label: 'Off',
+                              value: 'off',
+                            },
+                          ]}
+                        />
+                      </FormGroup>
                     </section>
                     <section className="govuk-!-margin-bottom-6">
                       <h3>Strictly necessary cookies</h3>


### PR DESCRIPTION
This PR:
- Removes the unnecessary `FormFieldset` wrapping the GA cookie options.
- Cleans up styling and markup for the success message.