### PR TITLE
EES-1879 Fix incorrect state flickering on data blocks pages

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockCreatePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockCreatePage.tsx
@@ -8,6 +8,7 @@ import {
 } from '@admin/routes/releaseRoutes';
 import { ReleaseDataBlock } from '@admin/services/dataBlockService';
 import permissionService from '@admin/services/permissionService';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React, { useCallback } from 'react';
@@ -21,7 +22,7 @@ const ReleaseDataBlockCreatePage = ({
     params: { publicationId, releaseId },
   } = match;
 
-  const { value: canUpdateRelease } = useAsyncHandledRetry(
+  const { value: canUpdateRelease, isLoading } = useAsyncHandledRetry(
     () => permissionService.canUpdateRelease(releaseId),
     [releaseId],
   );
@@ -55,20 +56,22 @@ const ReleaseDataBlockCreatePage = ({
         Back
       </Link>
 
-      <h2>Create data block</h2>
+      <LoadingSpinner loading={isLoading}>
+        <h2>Create data block</h2>
 
-      <section>
-        {canUpdateRelease ? (
-          <DataBlockPageTabs
-            releaseId={releaseId}
-            onDataBlockSave={handleDataBlockSave}
-          />
-        ) : (
-          <WarningMessage>
-            This release has been approved, and can no longer be updated.
-          </WarningMessage>
-        )}
-      </section>
+        <section>
+          {canUpdateRelease ? (
+            <DataBlockPageTabs
+              releaseId={releaseId}
+              onDataBlockSave={handleDataBlockSave}
+            />
+          ) : (
+            <WarningMessage>
+              This release has been approved, and can no longer be updated.
+            </WarningMessage>
+          )}
+        </section>
+      </LoadingSpinner>
     </>
   );
 };


### PR DESCRIPTION
This fixes incorrect state being shown on data blocks due to not waiting for the `canUpdateRelease` check to finish loading. We've now refactored these pages to use a model-based approach to ensure all the required state has been loaded before rendering.