### PR TITLE
EES-1873 Add highlight description field when create/updating data blocks

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
@@ -32,6 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Heading = "Test heading",
                 Name = "Test name",
                 HighlightName = "Test highlight name",
+                HighlightDescription = "Test highlight description",
                 Source = "Test source",
                 Order = 5,
                 Query = new ObservationQueryContext
@@ -94,6 +95,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataBlock.Heading, result.Right.Heading);
                 Assert.Equal(dataBlock.Name, result.Right.Name);
                 Assert.Equal(dataBlock.HighlightName, result.Right.HighlightName);
+                Assert.Equal(dataBlock.HighlightDescription, result.Right.HighlightDescription);
                 Assert.Equal(dataBlock.Source, result.Right.Source);
                 Assert.Equal(dataBlock.Order, result.Right.Order);
 
@@ -154,6 +156,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Heading = "Test heading 1",
                 Name = "Test name 1",
                 HighlightName = "Test highlight name 1",
+                HighlightDescription = "Test highlight description 1",
                 Source = "Test source 1",
                 Order = 5,
                 ContentSectionId = Guid.NewGuid(),
@@ -198,6 +201,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Heading = "Test heading 2",
                 Name = "Test name 2",
                 HighlightName = "Test highlight name 2",
+                HighlightDescription = "Test highlight description 2",
                 Source = "Test source 2",
                 Order = 7,
                 Query = new ObservationQueryContext
@@ -259,6 +263,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataBlock1.Heading, result.Right[0].Heading);
                 Assert.Equal(dataBlock1.Name, result.Right[0].Name);
                 Assert.Equal(dataBlock1.HighlightName, result.Right[0].HighlightName);
+                Assert.Equal(dataBlock1.HighlightDescription, result.Right[0].HighlightDescription);
                 Assert.Equal(dataBlock1.Source, result.Right[0].Source);
                 Assert.Equal(1, result.Right[0].ChartsCount);
                 Assert.Equal(dataBlock1.ContentSectionId, result.Right[0].ContentSectionId);
@@ -266,6 +271,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataBlock2.Heading, result.Right[1].Heading);
                 Assert.Equal(dataBlock2.Name, result.Right[1].Name);
                 Assert.Equal(dataBlock2.HighlightName, result.Right[1].HighlightName);
+                Assert.Equal(dataBlock2.HighlightDescription, result.Right[1].HighlightDescription);
                 Assert.Equal(dataBlock2.Source, result.Right[1].Source);
                 Assert.Equal(0, result.Right[1].ChartsCount);
                 Assert.Null(result.Right[1].ContentSectionId);
@@ -282,6 +288,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Heading = "Test heading 1",
                 Name = "Test name 1",
                 HighlightName = "Test highlight name 1",
+                HighlightDescription = "Test highlight description 1",
                 Source = "Test source 1",
                 Order = 5,
                 ContentSectionId = Guid.NewGuid(),
@@ -357,6 +364,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataBlock1.Heading, result.Right[0].Heading);
                 Assert.Equal(dataBlock1.Name, result.Right[0].Name);
                 Assert.Equal(dataBlock1.HighlightName, result.Right[0].HighlightName);
+                Assert.Equal(dataBlock1.HighlightDescription, result.Right[0].HighlightDescription);
                 Assert.Equal(dataBlock1.Source, result.Right[0].Source);
                 Assert.Equal(1, result.Right[0].ChartsCount);
                 Assert.Equal(dataBlock1.ContentSectionId, result.Right[0].ContentSectionId);
@@ -651,6 +659,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Heading = "Test heading",
                 Name = "Test name",
                 HighlightName = "Test highlight name",
+                HighlightDescription = "Test highlight description",
                 Source = "Test source",
                 Query = new ObservationQueryContext
                 {
@@ -698,6 +707,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(createRequest.Heading, result.Right.Heading);
                 Assert.Equal(createRequest.Name, result.Right.Name);
                 Assert.Equal(createRequest.HighlightName, result.Right.HighlightName);
+                Assert.Equal(createRequest.HighlightDescription, result.Right.HighlightDescription);
                 Assert.Equal(createRequest.Source, result.Right.Source);
 
                 Assert.Equal(createRequest.Query, result.Right.Query);
@@ -716,6 +726,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(createRequest.Heading, dataBlock.Heading);
                 Assert.Equal(createRequest.Name, dataBlock.Name);
                 Assert.Equal(createRequest.HighlightName, dataBlock.HighlightName);
+                Assert.Equal(createRequest.HighlightDescription, dataBlock.HighlightDescription);
                 Assert.Equal(createRequest.Source, dataBlock.Source);
 
                 Assert.Equal(createRequest.Query, dataBlock.Query);
@@ -766,6 +777,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Heading = "Old heading",
                 Name = "Old name",
                 HighlightName = "Old highlight name",
+                HighlightDescription = "Old highlight description",
                 Source = "Old source",
                 Order = 5,
                 Query = new ObservationQueryContext
@@ -823,6 +835,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Heading = "New heading",
                 Name = "New name",
                 HighlightName = "New highlight name",
+                HighlightDescription = "New highlight description",
                 Source = "New source",
                 Charts = new List<IChart>
                 {
@@ -846,6 +859,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(updateRequest.Heading, result.Right.Heading);
                 Assert.Equal(updateRequest.Name, result.Right.Name);
                 Assert.Equal(updateRequest.HighlightName, result.Right.HighlightName);
+                Assert.Equal(updateRequest.HighlightDescription, result.Right.HighlightDescription);
                 Assert.Equal(updateRequest.Source, result.Right.Source);
                 Assert.Equal(dataBlock.Order, result.Right.Order);
 
@@ -861,6 +875,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(updateRequest.Heading, updatedDataBlock.Heading);
                 Assert.Equal(updateRequest.Name, updatedDataBlock.Name);
                 Assert.Equal(updateRequest.HighlightName, updatedDataBlock.HighlightName);
+                Assert.Equal(updateRequest.HighlightDescription, updatedDataBlock.HighlightDescription);
                 Assert.Equal(updateRequest.Source, updatedDataBlock.Source);
 
                 Assert.Equal(updateRequest.Query, updatedDataBlock.Query);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210208180541_EES1873AddDataBlockHighlightDescription.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210208180541_EES1873AddDataBlockHighlightDescription.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210208180541_EES1873AddDataBlockHighlightDescription")]
+    partial class EES1873AddDataBlockHighlightDescription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -178,86 +180,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                             Order = 1,
                             Type = "Headlines"
                         });
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.DataImport", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime>("Created")
-                        .HasColumnType("datetime2");
-
-                    b.Property<Guid>("FileId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid>("MetaFileId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<bool>("Migrated")
-                        .HasColumnType("bit");
-
-                    b.Property<int>("NumBatches")
-                        .HasColumnType("int");
-
-                    b.Property<int>("Rows")
-                        .HasColumnType("int");
-
-                    b.Property<int>("RowsPerBatch")
-                        .HasColumnType("int");
-
-                    b.Property<int>("StagePercentageComplete")
-                        .HasColumnType("int");
-
-                    b.Property<string>("Status")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<Guid>("SubjectId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<int>("TotalRows")
-                        .HasColumnType("int");
-
-                    b.Property<Guid?>("ZipFileId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("FileId")
-                        .IsUnique();
-
-                    b.HasIndex("MetaFileId")
-                        .IsUnique();
-
-                    b.HasIndex("ZipFileId")
-                        .IsUnique()
-                        .HasFilter("[ZipFileId] IS NOT NULL");
-
-                    b.ToTable("DataImports");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.DataImportError", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime>("Created")
-                        .HasColumnType("datetime2");
-
-                    b.Property<Guid>("DataImportId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("Message")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("DataImportId");
-
-                    b.ToTable("DataImportErrors");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.File", b =>
@@ -1047,35 +969,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.ContentSection", "ContentSection")
                         .WithMany("Content")
                         .HasForeignKey("ContentSectionId");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.DataImport", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.File", "File")
-                        .WithOne()
-                        .HasForeignKey("GovUk.Education.ExploreEducationStatistics.Content.Model.DataImport", "FileId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.File", "MetaFile")
-                        .WithOne()
-                        .HasForeignKey("GovUk.Education.ExploreEducationStatistics.Content.Model.DataImport", "MetaFileId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.File", "ZipFile")
-                        .WithOne()
-                        .HasForeignKey("GovUk.Education.ExploreEducationStatistics.Content.Model.DataImport", "ZipFileId")
-                        .OnDelete(DeleteBehavior.Restrict);
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.DataImportError", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.DataImport", "DataImport")
-                        .WithMany("Errors")
-                        .HasForeignKey("DataImportId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.File", b =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210208180541_EES1873AddDataBlockHighlightDescription.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210208180541_EES1873AddDataBlockHighlightDescription.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES1873AddDataBlockHighlightDescription : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DataBlock_HighlightDescription",
+                table: "ContentBlock",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DataBlock_HighlightDescription",
+                table: "ContentBlock");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataBlockSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataBlockSummaryViewModel.cs
@@ -13,6 +13,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public string? HighlightName { get; set; }
 
+        public string? HighlightDescription { get; set; }
+
         public string Source { get; set; } = "";
 
         public Guid? ContentSectionId { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataBlockViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/DataBlockViewModels.cs
@@ -20,7 +20,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public string Name { get; set; }
 
-        public string HighlightName { get; set; }
+        public string? HighlightName { get; set; }
+
+        public string? HighlightDescription { get; set; }
 
         public string Source { get; set; }
 
@@ -43,7 +45,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         [Required]
         public string Name { get; set; }
 
-        public string HighlightName { get; set; }
+        public string? HighlightName { get; set; }
+
+        public string? HighlightDescription { get; set; }
 
         public string Source { get; set; }
 
@@ -64,7 +68,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         [Required]
         public string Name { get; set; }
 
-        public string HighlightName { get; set; }
+        public string? HighlightName { get; set; }
+
+        public string? HighlightDescription { get; set; }
 
         public string Source { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
@@ -77,6 +77,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public string? HighlightName { get; set; }
 
+        public string? HighlightDescription { get; set; }
+
         public string Source { get; set; }
 
         public ObservationQueryContext Query { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -263,6 +263,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .HasColumnName("DataBlock_HighlightName");
 
             modelBuilder.Entity<DataBlock>()
+                .Property(block => block.HighlightDescription)
+                .HasColumnName("DataBlock_HighlightDescription");
+
+            modelBuilder.Entity<DataBlock>()
                 .Property(block => block.Query)
                 .HasColumnName("DataBlock_Query")
                 .HasConversion(

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseDataBlockEditPage.tsx
@@ -121,9 +121,19 @@ const ReleaseDataBlockEditPage = ({
             <section>
               <SummaryList smallKey noBorder>
                 {!canUpdateRelease && (
-                  <SummaryListItem term="Highlight name">
-                    {dataBlock.highlightName}
-                  </SummaryListItem>
+                  <>
+                    {dataBlock.highlightName && (
+                      <SummaryListItem term="Highlight name">
+                        {dataBlock.highlightName || 'None'}
+                      </SummaryListItem>
+                    )}
+
+                    {dataBlock.highlightDescription && (
+                      <SummaryListItem term="Highlight description">
+                        {dataBlock.highlightDescription || 'None'}
+                      </SummaryListItem>
+                    )}
+                  </>
                 )}
 
                 <SummaryListItem term="Fast track URL">

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
@@ -43,6 +43,7 @@ describe('ReleaseDataBlockEditPage', () => {
     name: 'Test name 1',
     heading: 'Test title 1',
     highlightName: 'Test highlight name 1',
+    highlightDescription: 'Test highlight description 1',
     source: 'Test source 1',
     query: {
       includeGeoJson: false,
@@ -121,6 +122,7 @@ describe('ReleaseDataBlockEditPage', () => {
       name: 'Test name 2',
       heading: 'Test title 2',
       highlightName: 'Test highlight name 2',
+      highlightDescription: 'Test highlight description 2',
       source: 'Test source 2',
       chartsCount: 0,
     },
@@ -129,6 +131,7 @@ describe('ReleaseDataBlockEditPage', () => {
       name: testDataBlock.name,
       heading: testDataBlock.heading,
       highlightName: testDataBlock.highlightName,
+      highlightDescription: testDataBlock.highlightDescription,
       source: testDataBlock.source,
       chartsCount: 0,
     },
@@ -344,7 +347,7 @@ describe('ReleaseDataBlockEditPage', () => {
       });
     });
 
-    test('renders with correct data block details', async () => {
+    test('renders with correct data block details with highlight name and description', async () => {
       renderPage();
 
       await waitFor(() => {
@@ -355,6 +358,34 @@ describe('ReleaseDataBlockEditPage', () => {
         expect(screen.getByTestId('Highlight name')).toHaveTextContent(
           'Test highlight name 1',
         );
+        expect(screen.getByTestId('Highlight description')).toHaveTextContent(
+          'Test highlight description 1',
+        );
+        expect(screen.getByTestId('Fast track URL')).toHaveTextContent(
+          'http://localhost/data-tables/fast-track/block-1',
+        );
+      });
+    });
+
+    test('renders with correct data block details without highlight name and description', async () => {
+      dataBlockService.getDataBlock.mockResolvedValue({
+        ...testDataBlock,
+        highlightName: '',
+        highlightDescription: '',
+      });
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('heading', { name: 'Test name 1' }),
+        ).toBeInTheDocument();
+
+        expect(screen.queryByTestId('Highlight name')).not.toBeInTheDocument();
+        expect(
+          screen.queryByTestId('Highlight description'),
+        ).not.toBeInTheDocument();
+
         expect(screen.getByTestId('Fast track URL')).toHaveTextContent(
           'http://localhost/data-tables/fast-track/block-1',
         );

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDetailsForm.tsx
@@ -13,16 +13,11 @@ import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
 import React from 'react';
 
-interface Props {
-  initialValues?: DataBlockDetailsFormValues;
-  onTitleChange?: (title: string) => void;
-  onSubmit: (dataBlock: DataBlockDetailsFormValues) => void;
-}
-
 interface FormValues {
   heading: string;
   isHighlight?: boolean;
   highlightName: string;
+  highlightDescription: string;
   source: string;
   name: string;
 }
@@ -31,21 +26,29 @@ export type DataBlockDetailsFormValues = OmitStrict<FormValues, 'isHighlight'>;
 
 const formId = 'dataBlockDetailsForm';
 
+interface Props {
+  initialValues?: DataBlockDetailsFormValues;
+  onTitleChange?: (title: string) => void;
+  onSubmit: (dataBlock: DataBlockDetailsFormValues) => void;
+}
+
 const DataBlockDetailsForm = ({
   initialValues = {
     heading: '',
     name: '',
     highlightName: '',
+    highlightDescription: '',
     source: '',
   },
   onTitleChange,
   onSubmit,
 }: Props) => {
   const handleSubmit = useFormSubmit<FormValues>(
-    ({ highlightName, isHighlight, ...values }) => {
+    ({ highlightName, highlightDescription, isHighlight, ...values }) => {
       onSubmit({
         ...values,
         highlightName: isHighlight ? highlightName : '',
+        highlightDescription: isHighlight ? highlightDescription : '',
       });
     },
     [],
@@ -62,7 +65,11 @@ const DataBlockDetailsForm = ({
         isHighlight: Yup.boolean(),
         highlightName: Yup.string().when('isHighlight', {
           is: true,
-          then: Yup.string().required('Enter a table highlight name'),
+          then: Yup.string().required('Enter a highlight name'),
+        }),
+        highlightDescription: Yup.string().when('isHighlight', {
+          is: true,
+          then: Yup.string().required('Enter a highlight description'),
         }),
         heading: Yup.string().required('Enter a table title'),
         source: Yup.string(),
@@ -89,7 +96,7 @@ const DataBlockDetailsForm = ({
                 className="govuk-!-width-two-thirds"
                 label="Table title"
                 hint="Use a concise descriptive title that summarises the main message in the table."
-                rows={2}
+                rows={3}
                 onChange={e => {
                   if (onTitleChange) onTitleChange(e.target.value);
                 }}
@@ -107,20 +114,29 @@ const DataBlockDetailsForm = ({
                 id={`${formId}-highlight`}
                 legend="Would you like to make this a table highlight?"
                 legendSize="s"
-                hint="Checking this option will make this table available as a fast track link when the publication is selected via the table builder"
+                hint="Checking this option will make this table available as a popular table when the publication is selected via the table builder"
               >
                 <FormFieldCheckbox<FormValues>
                   name="isHighlight"
                   id={`${formId}-isHighlight`}
                   label="Set as a table highlight for this publication"
                   conditional={
-                    <FormFieldTextInput<FormValues>
-                      name="highlightName"
-                      id={`${formId}-highlightName`}
-                      label="Table highlight name"
-                      hint="We will show this name to table builder users"
-                      className="govuk-!-width-one-half"
-                    />
+                    <>
+                      <FormFieldTextInput<FormValues>
+                        name="highlightName"
+                        id={`${formId}-highlightName`}
+                        label="Highlight name"
+                        hint="We will show this name to table builder users as a popular table"
+                        className="govuk-!-width-two-thirds"
+                      />
+                      <FormFieldTextArea<FormValues>
+                        name="highlightDescription"
+                        id={`${formId}-highlightDescription`}
+                        label="Highlight description"
+                        hint="Describe the contents of this highlight to table builder users"
+                        className="govuk-!-width-two-thirds"
+                      />
+                    </>
                   }
                 />
               </FormFieldset>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -101,6 +101,7 @@ const DataBlockSourceWizardFinalStep = ({
         initialValues={{
           heading: dataBlock?.heading ?? generateTableTitle(table.subjectMeta),
           highlightName: dataBlock?.highlightName ?? '',
+          highlightDescription: dataBlock?.highlightDescription ?? '',
           name: dataBlock?.name ?? '',
           source: dataBlock?.source ?? '',
         }}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockDetailsForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockDetailsForm.test.tsx
@@ -14,6 +14,7 @@ describe('DataBlockDetailsForm', () => {
           name: 'Test name',
           heading: 'Test heading',
           highlightName: 'Test highlight name',
+          highlightDescription: 'Test highlight description',
           source: 'Test source',
         }}
         onSubmit={noop}
@@ -23,8 +24,11 @@ describe('DataBlockDetailsForm', () => {
     expect(screen.getByLabelText('Name')).toHaveValue('Test name');
     expect(screen.getByLabelText('Table title')).toHaveValue('Test heading');
     expect(screen.getByLabelText('Source')).toHaveValue('Test source');
-    expect(screen.getByLabelText('Table highlight name')).toHaveValue(
+    expect(screen.getByLabelText('Highlight name')).toHaveValue(
       'Test highlight name',
+    );
+    expect(screen.getByLabelText('Highlight description')).toHaveValue(
+      'Test highlight description',
     );
   });
 
@@ -54,26 +58,45 @@ describe('DataBlockDetailsForm', () => {
     });
   });
 
-  test('shows validation error if no table highlight when checkbox is checked', async () => {
+  test('shows validation error if no name when table highlight checkbox is checked', async () => {
     render(<DataBlockDetailsForm onSubmit={noop} />);
 
     userEvent.click(
       screen.getByLabelText('Set as a table highlight for this publication'),
     );
 
-    expect(screen.getByLabelText('Table highlight name')).toBeInTheDocument();
+    expect(screen.getByLabelText('Highlight name')).toBeInTheDocument();
 
-    userEvent.click(screen.getByLabelText('Table highlight name'));
+    userEvent.click(screen.getByLabelText('Highlight name'));
     userEvent.tab();
 
     await waitFor(() => {
       expect(
-        screen.getByRole('link', { name: 'Enter a table highlight name' }),
+        screen.getByRole('link', { name: 'Enter a highlight name' }),
       ).toHaveAttribute('href', '#dataBlockDetailsForm-highlightName');
     });
   });
 
-  test('submitting form with invalid values and highlight name shows error messages', async () => {
+  test('shows validation error if no description when table highlight checkbox is checked', async () => {
+    render(<DataBlockDetailsForm onSubmit={noop} />);
+
+    userEvent.click(
+      screen.getByLabelText('Set as a table highlight for this publication'),
+    );
+
+    expect(screen.getByLabelText('Highlight description')).toBeInTheDocument();
+
+    userEvent.click(screen.getByLabelText('Highlight description'));
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Enter a highlight description' }),
+      ).toHaveAttribute('href', '#dataBlockDetailsForm-highlightDescription');
+    });
+  });
+
+  test('submitting form with invalid values and table highlight checked shows error messages', async () => {
     render(<DataBlockDetailsForm onSubmit={noop} />);
 
     userEvent.click(
@@ -85,25 +108,31 @@ describe('DataBlockDetailsForm', () => {
       const alert = screen.getByRole('alert');
       const errors = within(alert).getAllByRole('link');
 
-      expect(errors).toHaveLength(3);
+      expect(errors).toHaveLength(4);
       expect(errors[0]).toHaveTextContent('Enter a data block name');
       expect(errors[0]).toHaveAttribute('href', '#dataBlockDetailsForm-name');
 
-      expect(errors[1]).toHaveTextContent('Enter a table highlight name');
+      expect(errors[1]).toHaveTextContent('Enter a highlight name');
       expect(errors[1]).toHaveAttribute(
         'href',
         '#dataBlockDetailsForm-highlightName',
       );
 
-      expect(errors[2]).toHaveTextContent('Enter a table title');
+      expect(errors[2]).toHaveTextContent('Enter a highlight description');
       expect(errors[2]).toHaveAttribute(
+        'href',
+        '#dataBlockDetailsForm-highlightDescription',
+      );
+
+      expect(errors[3]).toHaveTextContent('Enter a table title');
+      expect(errors[3]).toHaveAttribute(
         'href',
         '#dataBlockDetailsForm-heading',
       );
     });
   });
 
-  test('submitting form with invalid values and no highlight name shows error messages', async () => {
+  test('submitting form with invalid values and table highlight unchecked shows error messages', async () => {
     render(<DataBlockDetailsForm onSubmit={noop} />);
 
     userEvent.click(screen.getByRole('button', { name: 'Save data block' }));
@@ -138,8 +167,12 @@ describe('DataBlockDetailsForm', () => {
     );
 
     await userEvent.type(
-      screen.getByLabelText('Table highlight name'),
+      screen.getByLabelText('Highlight name'),
       'Test highlight name',
+    );
+    await userEvent.type(
+      screen.getByLabelText('Highlight description'),
+      'Test highlight description',
     );
 
     expect(handleSubmit).not.toHaveBeenCalled();
@@ -150,6 +183,7 @@ describe('DataBlockDetailsForm', () => {
       name: 'Test name',
       heading: 'Test title',
       highlightName: 'Test highlight name',
+      highlightDescription: 'Test highlight description',
       source: 'Test source',
     };
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
@@ -29,6 +29,7 @@ describe('DataBlockPageTabs', () => {
     id: 'block-1',
     source: 'Test source',
     highlightName: '',
+    highlightDescription: '',
     query: {
       includeGeoJson: false,
       subjectId: 'subject-1',

--- a/src/explore-education-statistics-admin/src/services/dataBlockService.ts
+++ b/src/explore-education-statistics-admin/src/services/dataBlockService.ts
@@ -8,6 +8,7 @@ export interface ReleaseDataBlockSummary {
   id: string;
   name: string;
   highlightName?: string;
+  highlightDescription?: string;
   heading: string;
   source: string;
   chartsCount: number;

--- a/src/explore-education-statistics-common/src/services/types/blocks.ts
+++ b/src/explore-education-statistics-common/src/services/types/blocks.ts
@@ -69,6 +69,7 @@ export interface DataBlock extends BaseBlock {
   type: 'DataBlock';
   name: string;
   highlightName?: string;
+  highlightDescription?: string;
   heading: string;
   source: string;
   query: TableDataQuery;

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -173,6 +173,7 @@ Save data block
     user clicks checkbox  Set as a table highlight for this publication
     user waits until page contains element  id:dataBlockDetailsForm-highlightName
     user enters text into element  id:dataBlockDetailsForm-highlightName    UI test highlight name
+    user enters text into element  id:dataBlockDetailsForm-highlightDescription    UI test highlight description
 
     user clicks button   Save data block
     user waits until page contains    Delete this data block

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -171,6 +171,7 @@ Save data block as a highlight
     user clicks checkbox  Set as a table highlight for this publication
     user waits until page contains element  id:dataBlockDetailsForm-highlightName
     user enters text into element  id:dataBlockDetailsForm-highlightName    Test highlight name
+    user enters text into element  id:dataBlockDetailsForm-highlightDescription    Test highlight description
 
     user clicks button   Save data block
     user waits until page contains    Delete this data block


### PR DESCRIPTION
This PR adds a new 'Highlight description' field that can be seen when create/updating data blocks. It looks like the following:

![image](https://user-images.githubusercontent.com/9917868/107382184-84076980-6ae7-11eb-8269-caa404066b01.png)

## Relevant changes

- Updated the 'Table highlight name' field label to simply 'Highlight name'
- Fixes highlight name summary row rendering in the read-only view, even if there is no highlight name to show. We now just hide the row for the name and description unless they are filled out.