### PR TITLE
EES-1132 and EES-1878

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -273,47 +273,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
 
         [Fact]
-        public async void CreatePublication_FailsWithUnapprovedMethodology()
-        {
-            var topic = new Topic
-            {
-                Title = "Test topic"
-            };
-            var methodology = new Methodology
-            {
-                Title = "Test methodology",
-                Status = MethodologyStatus.Draft,
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(topic);
-                context.Add(methodology);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context, Mocks());
-
-                // Service method under test
-                var result = await publicationService.CreatePublication(
-                    new PublicationSaveViewModel()
-                    {
-                        Title = "Test title",
-                        TopicId = topic.Id,
-                        MethodologyId = methodology.Id,
-                    }
-                );
-
-                Assert.True(result.IsLeft);
-                AssertValidationProblem(result.Left, MethodologyMustBeApproved);
-            }
-        }
-
-        [Fact]
         public async void CreatePublication_FailsWithNonUniqueSlug()
         {
             var topic = new Topic
@@ -805,52 +764,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.True(result.IsLeft);
                 AssertValidationProblem(result.Left, CannotSpecifyMethodologyAndExternalMethodology);
-            }
-        }
-
-        [Fact]
-        public async void UpdatePublication_FailsWithUnapprovedMethodology()
-        {
-            var methodology = new Methodology
-            {
-                Title = "Test methodology",
-                Status = MethodologyStatus.Draft,
-            };
-            var publication = new Publication
-            {
-                Topic = new Topic
-                {
-                    Title = "Test topic"
-                },
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(methodology);
-                context.Add(publication);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-
-                var publicationService = BuildPublicationService(context, Mocks());
-
-                // Service method under test
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveViewModel()
-                    {
-                        Title = "Test publication",
-                        TopicId = publication.TopicId,
-                        MethodologyId = methodology.Id,
-                    }
-                );
-
-                Assert.True(result.IsLeft);
-                AssertValidationProblem(result.Left, MethodologyMustBeApproved);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServicePermissionTests.cs
@@ -37,6 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         private ReleaseChecklistService BuildReleaseChecklistService(
+            ContentDbContext contentDbContext = null,
             IPersistenceHelper<ContentDbContext> persistenceHelper = null,
             IDataImportService dataImportService = null,
             IUserService userService = null,
@@ -47,6 +48,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
 
             return new ReleaseChecklistService(
+                contentDbContext ?? new Mock<ContentDbContext>().Object,
                 persistenceHelper ?? DefaultPersistenceHelperMock().Object,
                 dataImportService ?? new Mock<IDataImportService>().Object,
                 userService ?? MockUtils.AlwaysTrueUserService().Object,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServiceTests.cs
@@ -44,7 +44,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Version = 1,
             };
 
-            var releaseContentSection = new ReleaseContentSection
+            var releaseContentSection1 = new ReleaseContentSection
+            {
+                Release = release,
+                ContentSection = new ContentSection
+                {
+                    Type = ContentSectionType.Generic,
+                    Content = new List<ContentBlock>()
+                }
+            };
+
+            var releaseContentSection2 = new ReleaseContentSection
             {
                 Release = release,
                 ContentSection = new ContentSection
@@ -52,6 +62,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Type = ContentSectionType.Generic,
                     Content = new List<ContentBlock>
                     {
+                        new HtmlBlock
+                        {
+                            Body = "<p>Test</p>"
+                        },
+                        new DataBlock(),
                         new HtmlBlock
                         {
                             Body = ""
@@ -64,7 +79,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
             {
-                await context.AddRangeAsync(releaseContentSection, originalRelease);
+                await context.AddRangeAsync(
+                    releaseContentSection1,
+                    releaseContentSection2,
+                    originalRelease);
                 await context.SaveChangesAsync();
             }
 
@@ -109,7 +127,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.False(checklist.Right.Valid);
 
-                Assert.Equal(6, checklist.Right.Errors.Count);
+                Assert.Equal(7, checklist.Right.Errors.Count);
 
                 Assert.Equal(DataFileImportsMustBeCompleted, checklist.Right.Errors[0].Code);
                 Assert.Equal(DataFileReplacementsMustBeCompleted, checklist.Right.Errors[1].Code);
@@ -122,6 +140,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(PublicMetaGuidanceRequired, checklist.Right.Errors[3].Code);
                 Assert.Equal(ReleaseNoteRequired, checklist.Right.Errors[4].Code);
                 Assert.Equal(EmptyContentSectionExists, checklist.Right.Errors[5].Code);
+                Assert.Equal(GenericSectionsContainEmptyHtmlBlock, checklist.Right.Errors[6].Code);
             }
         }
 
@@ -347,10 +366,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         new HtmlBlock
                         {
                             Body = "<p>test</p>"
-                        },
-                        new HtmlBlock
-                        {
-                            Body = ""
                         }
                     }
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -192,12 +192,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 {
                     return ValidationActionResult(MethodologyDoesNotExist);
                 }
-
-                // TODO: this will want updating when methodology status is fully implemented
-                if (methodology.Status != MethodologyStatus.Approved)
-                {
-                    return ValidationActionResult(MethodologyMustBeApproved);
-                }
             }
 
             return Unit.Instance;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseChecklistService.cs
@@ -109,7 +109,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 errors.Add(new ReleaseChecklistIssue(ValidationErrorMessages.EmptyContentSectionExists));
             }
 
-            if (ReleaseGenericContentSectionsContainEmptyContentBlock(release.Id))
+            if (await ReleaseGenericContentSectionsContainEmptyContentBlock(release.Id))
             {
                 errors.Add(new ReleaseChecklistIssue(ValidationErrorMessages.GenericSectionsContainEmptyHtmlBlock));
             }
@@ -128,16 +128,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .AnyAsync(rcs => rcs.ContentSection.Content.Count == 0);
         }
 
-        private bool ReleaseGenericContentSectionsContainEmptyContentBlock(Guid releaseId)
+        private async Task<bool> ReleaseGenericContentSectionsContainEmptyContentBlock(Guid releaseId)
         {
-            return _contentDbContext.ReleaseContentSections
+            var releaseGenericContentBlocks = await _contentDbContext.ReleaseContentSections
                 .Include(rcs => rcs.ContentSection)
                 .ThenInclude(cs => cs.Content)
                 .Where(rcs =>
                     rcs.ReleaseId == releaseId
                     && rcs.ContentSection.Type == ContentSectionType.Generic)
                 .SelectMany(rcs => rcs.ContentSection.Content)
-                .ToList()
+                .ToListAsync();
+                
+            return releaseGenericContentBlocks 
                 .Any(block =>
                 {
                     if (block is HtmlBlock htmlBlock)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -76,6 +76,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         PartialDateNotValid,
 
         // Content blocks
+        EmptyContentSectionExists,
         ContentBlockNotFound,
         IncorrectContentBlockTypeForUpdate,
         ContentBlockAlreadyAttachedToContentSection,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -75,8 +75,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         // Partial date
         PartialDateNotValid,
 
-        // Content blocks
+        // Content
         EmptyContentSectionExists,
+        GenericSectionsContainEmptyHtmlBlock,
         ContentBlockNotFound,
         IncorrectContentBlockTypeForUpdate,
         ContentBlockAlreadyAttachedToContentSection,

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
@@ -225,12 +225,10 @@ const PublicationForm = ({
                     label="Select methodology"
                     placeholder="Choose a methodology"
                     options={orderBy(
-                      methodologies
-                        .filter(methodology => methodology.status !== 'Draft')
-                        .map(methodology => ({
-                          label: `${methodology.title} [${methodology.status}]`,
-                          value: methodology.id,
-                        })),
+                      methodologies.map(methodology => ({
+                        label: `${methodology.title} [${methodology.status}]`,
+                        value: methodology.id,
+                      })),
                       'label',
                     )}
                     order={[]}

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
@@ -90,6 +90,14 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
               releaseRouteParams,
             ),
           };
+        case 'EmptyContentSectionExists':
+          return {
+            message: 'Generic content sections cannot be empty',
+            link: generatePath<ReleaseRouteParams>(
+              releaseContentRoute.path,
+              releaseRouteParams,
+            ),
+          };
         default:
           // Show error code, even if there is no mapping,
           // as this is better than having invisible errors.

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
@@ -92,7 +92,15 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
           };
         case 'EmptyContentSectionExists':
           return {
-            message: 'Generic content sections cannot be empty',
+            message: 'Release content sections should not be empty',
+            link: generatePath<ReleaseRouteParams>(
+              releaseContentRoute.path,
+              releaseRouteParams,
+            ),
+          };
+        case 'GenericSectionsContainEmptyHtmlBlock':
+          return {
+            message: 'Release content should not contain empty text blocks',
             link: generatePath<ReleaseRouteParams>(
               releaseContentRoute.path,
               releaseRouteParams,

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
@@ -92,7 +92,7 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
           };
         case 'EmptyContentSectionExists':
           return {
-            message: 'Release content sections should not be empty',
+            message: 'Release content should not contain any empty sections',
             link: generatePath<ReleaseRouteParams>(
               releaseContentRoute.path,
               releaseRouteParams,

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -117,7 +117,8 @@ export type ReleaseChecklistError =
         | 'DataFileReplacementsMustBeCompleted'
         | 'PublicMetaGuidanceRequired'
         | 'ReleaseNoteRequired'
-        | 'EmptyContentSectionExists';
+        | 'EmptyContentSectionExists'
+        | 'GenericSectionsContainEmptyHtmlBlock';
     }
   | {
       code: 'MethodologyMustBeApproved';

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -116,7 +116,8 @@ export type ReleaseChecklistError =
         | 'DataFileImportsMustBeCompleted'
         | 'DataFileReplacementsMustBeCompleted'
         | 'PublicMetaGuidanceRequired'
-        | 'ReleaseNoteRequired';
+        | 'ReleaseNoteRequired'
+        | 'EmptyContentSectionExists';
     }
   | {
       code: 'MethodologyMustBeApproved';


### PR DESCRIPTION
EES-1132 adds extra validation to the release approval checklist. If a release has a generic content section that contain no content blocks, or if a generic content section contains only blank HtmlBlocks, the user will receive a release checklist error.

EES-1878 gives users the ability to attach any methodology to a publication. Previously, the frontend filtered the available methodologies so that only Approved methodologies were available, and the backend validated that created/updated publications methodologies were approved.