### PR TITLE
EES-1875 Add subject details on table tools

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
@@ -90,8 +90,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             releaseService.Setup(s => s.GetRelease(ReleaseId))
                 .ReturnsAsync(new ReleaseViewModel
                 {
-                    ReleaseId = ReleaseId,
-                    Subjects = subjectIds.Select(id => new IdLabel(id, $"Subject {id}")).ToList()
+                    Id = ReleaseId,
+                    Subjects = subjectIds
+                        .Select(id => new SubjectViewModel(
+                            id: id,
+                            name: $"Subject {id}",
+                            content: "Test content",
+                            timePeriods: new TimePeriodLabels(),
+                            geographicLevels: new List<string>()
+                        ))
+                        .ToList()
                 });
 
             filterService.Setup(s => s.GetFiltersIncludingItems(It.IsIn(subjectIds))).Returns(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -41,7 +41,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         "National", "Local Authority", "Local Authority District"
                     },
-                    TimePeriods = new MetaGuidanceSubjectTimePeriodsViewModel("2020/21 Q3", "2021/22 Q1"),
+                    TimePeriods = new TimePeriodLabels("2020/21 Q3", "2021/22 Q1"),
                     Variables = new List<LabelValue>
                     {
                         new LabelValue("Filter label", "test_filter"),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/FootnoteController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Statistics/FootnoteController.cs
@@ -115,7 +115,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Stati
                                     Filters = GetFilters(subject.Id),
                                     Indicators = GetIndicators(subject.Id),
                                     SubjectId = subject.Id,
-                                    SubjectName = subject.Label
+                                    SubjectName = subject.Name
                                 }
                         )
                     };

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MetaGuidanceServiceTests.cs
@@ -28,7 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
                     {
                         "National", "Local Authority", "Local Authority District"
                     },
-                    TimePeriods = new MetaGuidanceSubjectTimePeriodsViewModel("2020_AYQ3", "2021_AYQ1"),
+                    TimePeriods = new TimePeriodLabels("2020_AYQ3", "2021_AYQ1"),
                     Variables = new List<LabelValue>
                     {
                         new LabelValue("Filter label", "test_filter"),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -97,6 +97,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
             services.AddTransient<ITableBuilderService, TableBuilderService>();
             services.AddTransient<IDataBlockService, DataBlockService>();
             services.AddTransient<IPublicationService, PublicationService>();
+            services.AddTransient<IReleaseService, ReleaseService>();
             services.AddTransient<IThemeService, ThemeService>();
             services.AddTransient<IResultSubjectMetaService, ResultSubjectMetaService>();
             services.AddTransient<ISubjectMetaService, SubjectMetaService>();
@@ -121,6 +122,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
             services.AddTransient<IObservationService, ObservationService>();
             services.AddTransient<IReleaseRepository, ReleaseRepository>();
             services.AddTransient<ISubjectService, SubjectService>();
+            services.AddTransient<IMetaGuidanceSubjectService, MetaGuidanceSubjectService>();
             services.AddTransient<ITimePeriodService, TimePeriodService>();
             services.AddTransient<IPermalinkService, PermalinkService>();
             services.AddTransient<IPermalinkMigrationService, PermalinkMigrationService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/MetaGuidanceSubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/MetaGuidanceSubjectServiceTests.cs
@@ -629,6 +629,219 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             }
         }
 
+        [Fact]
+        public async Task GetTimePeriods()
+        {
+            var release = new Release();
+
+            var subject = new Subject
+            {
+                Filename = "file1.csv",
+                Name = "Subject 1"
+            };
+
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = release,
+                Subject = subject,
+                MetaGuidance = "Subject 1 Meta Guidance"
+            };
+
+            var subjectObservation1 = new Observation
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Subject = subject,
+                Year = 2030,
+                TimeIdentifier = TimeIdentifier.AcademicYearQ3
+            };
+
+            var subjectObservation2 = new Observation
+            {
+                GeographicLevel = GeographicLevel.LocalAuthority,
+                Subject = subject,
+                Year = 2020,
+                TimeIdentifier = TimeIdentifier.AcademicYearQ4
+            };
+
+            var subjectObservation3 = new Observation
+            {
+                GeographicLevel = GeographicLevel.LocalAuthorityDistrict,
+                Subject = subject,
+                Year = 2021,
+                TimeIdentifier = TimeIdentifier.AcademicYearQ1
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.AddAsync(release);
+                await statisticsDbContext.AddAsync(subject);
+                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.AddRangeAsync(
+                    subjectObservation1,
+                    subjectObservation2,
+                    subjectObservation3);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = SetupMetaGuidanceSubjectService(context: statisticsDbContext);
+
+                var result = await service.GetTimePeriods(subject.Id);
+
+                Assert.Equal("2020/21 Q4", result.From);
+                Assert.Equal("2030/31 Q3", result.To);
+            }
+        }
+
+        [Fact]
+        public async Task GetTimePeriods_NoObservations()
+        {
+            var release = new Release();
+
+            var subject = new Subject
+            {
+                Filename = "file1.csv",
+                Name = "Subject 1"
+            };
+
+            var releaseSubject1 = new ReleaseSubject
+            {
+                Release = release,
+                Subject = subject,
+                MetaGuidance = "Subject 1 Meta Guidance"
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.AddAsync(release);
+                await statisticsDbContext.AddAsync(subject);
+                await statisticsDbContext.AddAsync(releaseSubject1);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = SetupMetaGuidanceSubjectService(context: statisticsDbContext);
+
+                var result = await service.GetTimePeriods(subject.Id);
+
+                Assert.Null(result.From);
+                Assert.Null(result.To);
+            }
+        }
+
+        [Fact]
+        public async Task GetGeographicLevels()
+        {
+            var release = new Release();
+
+            var subject = new Subject
+            {
+                Filename = "file1.csv",
+                Name = "Subject 1"
+            };
+
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = release,
+                Subject = subject,
+                MetaGuidance = "Subject 1 Meta Guidance"
+            };
+
+            var subjectObservation1 = new Observation
+            {
+                GeographicLevel = GeographicLevel.Country,
+                Subject = subject,
+                Year = 2020,
+                TimeIdentifier = TimeIdentifier.AcademicYearQ3
+            };
+
+            var subjectObservation2 = new Observation
+            {
+                GeographicLevel = GeographicLevel.LocalAuthority,
+                Subject = subject,
+                Year = 2020,
+                TimeIdentifier = TimeIdentifier.AcademicYearQ4
+            };
+
+            var subjectObservation3 = new Observation
+            {
+                GeographicLevel = GeographicLevel.LocalAuthorityDistrict,
+                Subject = subject,
+                Year = 2021,
+                TimeIdentifier = TimeIdentifier.AcademicYearQ1
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.AddAsync(release);
+                await statisticsDbContext.AddAsync(subject);
+                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.AddRangeAsync(
+                    subjectObservation1,
+                    subjectObservation2,
+                    subjectObservation3);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = SetupMetaGuidanceSubjectService(context: statisticsDbContext);
+
+                var result = await service.GetGeographicLevels(subject.Id);
+
+                Assert.Equal(3, result.Count);
+                Assert.Equal("National", result[0]);
+                Assert.Equal("Local Authority", result[1]);
+                Assert.Equal("Local Authority District", result[2]);
+            }
+        }
+
+        [Fact]
+        public async Task GetGeographicLevels_NoObservations()
+        {
+            var release = new Release();
+
+            var subject = new Subject
+            {
+                Filename = "file1.csv",
+                Name = "Subject 1"
+            };
+
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = release,
+                Subject = subject,
+                MetaGuidance = "Subject 1 Meta Guidance"
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.AddAsync(release);
+                await statisticsDbContext.AddAsync(subject);
+                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = SetupMetaGuidanceSubjectService(context: statisticsDbContext);
+
+                var result = await service.GetGeographicLevels(subject.Id);
+
+                Assert.Empty(result);
+            }
+        }
+
         private static MetaGuidanceSubjectService SetupMetaGuidanceSubjectService(
             StatisticsDbContext context,
             IFilterService filterService = null,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/PublicationServiceTests.cs
@@ -2,20 +2,18 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services;
-using GovUk.Education.ExploreEducationStatistics.Data.Services.Mappings;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.Cosmos.Table;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
-using static GovUk.Education.ExploreEducationStatistics.Common.TableStorageTableNames;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 {
@@ -24,186 +22,119 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         [Fact]
         public async Task GetPublication()
         {
-            var publication = new Publication
-            {
-                Id = Guid.NewGuid(),
-            };
+            var publication = new Publication();
 
-            var publicationRelease1 = new Release
+            var release1 = new Release
             {
-                Id = Guid.NewGuid(),
-                PublicationId = publication.Id,
-                Published = DateTime.UtcNow,
+                Publication = publication,
+                Published = DateTime.Parse("2018-06-01T09:00:00Z"),
                 TimeIdentifier = AcademicYearQ1,
                 Year = 2018
             };
 
-            var publicationRelease2 = new Release
+            var release2 = new Release
             {
-                Id = Guid.NewGuid(),
-                PublicationId = publication.Id,
-                Published = DateTime.UtcNow,
+                Publication = publication,
+                Published = DateTime.Parse("2018-03-01T09:00:00Z"),
                 TimeIdentifier = AcademicYearQ4,
                 Year = 2017
             };
 
-            var publicationRelease3 = new Release
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
             {
-                Id = Guid.NewGuid(),
-                PublicationId = publication.Id,
-                Published = null,
-                TimeIdentifier = AcademicYearQ2,
-                Year = 2018
-            };
-
-            var publicationRelease1Subject1 = new Subject
-            {
-                Id = Guid.NewGuid(),
-                Name = "Release 1 subject 1",
-            };
-
-            var publicationRelease1Subject1Link = new ReleaseSubject
-            {
-                ReleaseId = publicationRelease1.Id,
-                SubjectId = publicationRelease1Subject1.Id
-            };
-
-            var publicationRelease1Subject2 = new Subject
-            {
-                Id = Guid.NewGuid(),
-                Name = "Release 1 subject 2"
-            };
-
-            var publicationRelease1Subject2Link = new ReleaseSubject
-            {
-                ReleaseId = publicationRelease1.Id,
-                SubjectId = publicationRelease1Subject2.Id
-            };
-
-            var publicationRelease2Subject = new Subject
-            {
-                Id = Guid.NewGuid(),
-                Name = "Release 2 subject"
-            };
-
-            var publicationRelease2SubjectLink = new ReleaseSubject
-            {
-                ReleaseId = publicationRelease2.Id,
-                SubjectId = publicationRelease2Subject.Id
-            };
-
-            var publicationRelease3Subject = new Subject
-            {
-                Id = Guid.NewGuid(),
-                Name = "Release 3 subject"
-            };
-
-            var publicationRelease3SubjectLink = new ReleaseSubject
-            {
-                ReleaseId = publicationRelease3.Id,
-                SubjectId = publicationRelease3Subject.Id
-            };
-
-            var releaseFastTrack1 = new ReleaseFastTrack(publicationRelease1.Id, Guid.NewGuid(), "table 1");
-            var releaseFastTrack2 = new ReleaseFastTrack(publicationRelease1.Id, Guid.NewGuid(), "table 2");
-
-            var builder = new DbContextOptionsBuilder<StatisticsDbContext>();
-            builder.UseInMemoryDatabase(Guid.NewGuid().ToString());
-            var options = builder.Options;
-
-            await using (var context = new StatisticsDbContext(options, null))
-            {
-                context.Add(publication);
-
-                await context.AddRangeAsync(new List<Release>
-                {
-                    publicationRelease1, publicationRelease2, publicationRelease3
-                });
-
-                await context.AddRangeAsync(new List<Subject>
-                {
-                    publicationRelease1Subject1,
-                    publicationRelease1Subject2,
-                    publicationRelease2Subject,
-                    publicationRelease3Subject
-                });
-
-                await context.AddRangeAsync(new List<ReleaseSubject>
-                {
-                    publicationRelease1Subject1Link,
-                    publicationRelease1Subject2Link,
-                    publicationRelease2SubjectLink,
-                    publicationRelease3SubjectLink
-                });
-
+                await context.AddAsync(publication);
+                await context.AddRangeAsync(release1, release2);
                 await context.SaveChangesAsync();
+            }
 
-                var mocks = Mocks();
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var subject1 = new SubjectViewModel(
+                    id: Guid.NewGuid(),
+                    name: "Subject 1",
+                    content: "Subject 1 content",
+                    timePeriods: new TimePeriodLabels("2018", "2021"),
+                    geographicLevels: new List<string>
+                    {
+                        "National",
+                        "Local Authority"
+                    }
+                );
+                var subject2 = new SubjectViewModel(
+                    id: Guid.NewGuid(),
+                    name: "Subject 2",
+                    content: "Subject 2 content",
+                    timePeriods: new TimePeriodLabels("2015", "2020"),
+                    geographicLevels: new List<string>
+                    {
+                        "Local Authority District"
+                    }
+                );
 
-                mocks.TableStorageService.Setup(storageService =>
-                    storageService.ExecuteQueryAsync(PublicReleaseFastTrackTableName,
-                        It.IsAny<TableQuery<ReleaseFastTrack>>())).ReturnsAsync(new List<ReleaseFastTrack>
-                {
-                    releaseFastTrack1, releaseFastTrack2
-                });
+                var highlight1 = new IdLabel(Guid.NewGuid(), "Highlight 1");
+                var highlight2 = new IdLabel(Guid.NewGuid(), "Highlight 2");
 
-                var service = BuildPublicationService(context, mocks);
+                var releaseService = new Mock<IReleaseService>();
+
+                releaseService
+                    .Setup(s => s.GetRelease(release1.Id))
+                    .ReturnsAsync(new ReleaseViewModel
+                    {
+                        Subjects = new List<SubjectViewModel>
+                        {
+                            subject1,
+                            subject2
+                        },
+                        Highlights = new List<IdLabel>
+                        {
+                            highlight1,
+                            highlight2,
+                        }
+                    });
+
+                var service = BuildPublicationService(context, releaseService: releaseService.Object);
 
                 var result = (await service.GetPublication(publication.Id)).Right;
+
                 var highlights = result.Highlights.ToList();
                 var subjects = result.Subjects.ToList();
 
                 Assert.Equal(publication.Id, result.Id);
+                Assert.Equal(release1.Id, result.LatestReleaseId);
+
                 Assert.Equal(2, highlights.Count);
-                Assert.Equal(releaseFastTrack1.FastTrackId, highlights[0].Id);
-                Assert.Equal(releaseFastTrack1.HighlightName, highlights[0].Label);
-                Assert.Equal(releaseFastTrack2.FastTrackId, highlights[1].Id);
-                Assert.Equal(releaseFastTrack2.HighlightName, highlights[1].Label);
+                Assert.Equal(highlight1, highlights[0]);
+                Assert.Equal(highlight2, highlights[1]);
+
                 Assert.Equal(2, subjects.Count);
-                Assert.Equal(publicationRelease1Subject1.Id, subjects[0].Id);
-                Assert.Equal(publicationRelease1Subject1.Name, subjects[0].Label);
-                Assert.Equal(publicationRelease1Subject2.Id, subjects[1].Id);
-                Assert.Equal(publicationRelease1Subject2.Name, subjects[1].Label);
+                Assert.Equal(subject1, subjects[0]);
+                Assert.Equal(subject2, subjects[1]);
+
+                MockUtils.VerifyAllMocks(releaseService);
             }
         }
 
         [Fact]
         public async Task GetPublication_PublicationNotFound()
         {
-            var builder = new DbContextOptionsBuilder<StatisticsDbContext>();
-            builder.UseInMemoryDatabase(Guid.NewGuid().ToString());
-            var options = builder.Options;
+            await using var context = StatisticsDbUtils.InMemoryStatisticsDbContext();
+            var service = BuildPublicationService(context);
 
-            await using (var context = new StatisticsDbContext(options, null))
-            {
-                var mocks = Mocks();
-                var service = BuildPublicationService(context, mocks);
-
-                var result = await service.GetPublication(Guid.NewGuid());
-                Assert.IsAssignableFrom<NotFoundResult>(result.Left);
-            }
+            var result = await service.GetPublication(Guid.NewGuid());
+            Assert.IsType<NotFoundResult>(result.Left);
         }
 
-        private static PublicationService BuildPublicationService(StatisticsDbContext context,
-            (Mock<ILogger<ReleaseRepository>> LoggerReleaseService,
-                Mock<ILogger<SubjectService>> LoggerSubjectService,
-                Mock<ITableStorageService> TableStorageService) mocks)
+        private static PublicationService BuildPublicationService(
+            StatisticsDbContext context,
+            IReleaseRepository releaseRepository = null,
+            IReleaseService releaseService = null)
         {
-            var releaseService = new ReleaseRepository(context, mocks.LoggerReleaseService.Object);
-            var subjectService = new SubjectService(context, mocks.LoggerSubjectService.Object, releaseService);
-            return new PublicationService(releaseService,
-                subjectService,
-                mocks.TableStorageService.Object,
-                MapperUtils.MapperForProfile<DataServiceMappingProfiles>());
-        }
-
-        private static (Mock<ILogger<ReleaseRepository>> LoggerReleaseService,
-            Mock<ILogger<SubjectService>> LoggerSubjectService,
-            Mock<ITableStorageService> TableStorageService) Mocks()
-        {
-            return (new Mock<ILogger<ReleaseRepository>>(),
-                new Mock<ILogger<SubjectService>>(),
-                new Mock<ITableStorageService>());
+            return new PublicationService(
+                releaseRepository ?? new ReleaseRepository(context, new Mock<ILogger<ReleaseRepository>>().Object),
+                releaseService ?? new Mock<IReleaseService>().Object
+            );
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServicePermissionTests.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using Moq;
 using Xunit;
 
@@ -38,14 +39,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             IPersistenceHelper<ContentDbContext> persistenceHelper = null,
             StatisticsDbContext statisticsDbContext = null,
             IDataImportRepository dataImportRepository = null,
-            IUserService userService = null)
+            IUserService userService = null,
+            IMetaGuidanceSubjectService metaGuidanceSubjectService = null)
         {
             return new ReleaseService(
                 contentDbContext ?? new Mock<ContentDbContext>().Object,
                 persistenceHelper ?? DefaultPersistenceHelperMock().Object,
                 statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
                 dataImportRepository ?? new Mock<IDataImportRepository>().Object,
-                userService ?? new Mock<IUserService>().Object
+                userService ?? new Mock<IUserService>().Object,
+                metaGuidanceSubjectService ?? new Mock<IMetaGuidanceSubjectService>().Object
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServicePermissionTests.cs
@@ -4,7 +4,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
@@ -38,7 +37,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             ContentDbContext contentDbContext = null,
             IPersistenceHelper<ContentDbContext> persistenceHelper = null,
             StatisticsDbContext statisticsDbContext = null,
-            IDataImportRepository dataImportRepository = null,
             IUserService userService = null,
             IMetaGuidanceSubjectService metaGuidanceSubjectService = null)
         {
@@ -46,7 +44,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 contentDbContext ?? new Mock<ContentDbContext>().Object,
                 persistenceHelper ?? DefaultPersistenceHelperMock().Object,
                 statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
-                dataImportRepository ?? new Mock<IDataImportRepository>().Object,
                 userService ?? new Mock<IUserService>().Object,
                 metaGuidanceSubjectService ?? new Mock<IMetaGuidanceSubjectService>().Object
             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IMetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IMetaGuidanceSubjectService.cs
@@ -12,10 +12,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
         Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(Guid releaseId,
             List<Guid> subjectIds = null);
 
-        Task<MetaGuidanceSubjectTimePeriodsViewModel> GetTimePeriods(Guid subjectId);
+        Task<TimePeriodLabels> GetTimePeriods(Guid subjectId);
 
         Task<List<string>> GetGeographicLevels(Guid subjectId);
-        
+
         Task<Either<ActionResult, bool>> Validate(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IMetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IMetaGuidanceSubjectService.cs
@@ -12,6 +12,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
         Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(Guid releaseId,
             List<Guid> subjectIds = null);
 
+        Task<MetaGuidanceSubjectTimePeriodsViewModel> GetTimePeriods(Guid subjectId);
+
+        Task<List<string>> GetGeographicLevels(Guid subjectId);
+        
         Task<Either<ActionResult, bool>> Validate(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
@@ -79,7 +79,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 rs => string.IsNullOrWhiteSpace(rs.MetaGuidance));
         }
 
-        public async Task<MetaGuidanceSubjectTimePeriodsViewModel> GetTimePeriods(Guid subjectId)
+        public async Task<TimePeriodLabels> GetTimePeriods(Guid subjectId)
         {
             var orderedTimePeriods = _context
                 .Observation
@@ -90,13 +90,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
             if (!orderedTimePeriods.Any())
             {
-                return new MetaGuidanceSubjectTimePeriodsViewModel();
+                return new TimePeriodLabels();
             }
 
             var first = await orderedTimePeriods.FirstAsync();
             var last = await orderedTimePeriods.LastAsync();
 
-            return new MetaGuidanceSubjectTimePeriodsViewModel(
+            return new TimePeriodLabels(
                 TimePeriodLabelFormatter.Format(first.Year, first.TimeIdentifier),
                 TimePeriodLabelFormatter.Format(last.Year, last.TimeIdentifier));
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
@@ -79,7 +79,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 rs => string.IsNullOrWhiteSpace(rs.MetaGuidance));
         }
 
-        private async Task<MetaGuidanceSubjectTimePeriodsViewModel> GetTimePeriods(Guid subjectId)
+        public async Task<MetaGuidanceSubjectTimePeriodsViewModel> GetTimePeriods(Guid subjectId)
         {
             var orderedTimePeriods = _context
                 .Observation
@@ -101,7 +101,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 TimePeriodLabelFormatter.Format(last.Year, last.TimeIdentifier));
         }
 
-        private async Task<List<string>> GetGeographicLevels(Guid subjectId)
+        public async Task<List<string>> GetGeographicLevels(Guid subjectId)
         {
             return await _context
                 .Observation

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
@@ -10,24 +10,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
         public string Filename { get; set; }
         public string Name { get; set; }
         public string Content { get; set; }
-        public MetaGuidanceSubjectTimePeriodsViewModel TimePeriods { get; set; }
+        public TimePeriodLabels TimePeriods { get; set; }
         public List<string> GeographicLevels { get; set; }
         public List<LabelValue> Variables { get; set; }
-    }
-
-    public class MetaGuidanceSubjectTimePeriodsViewModel
-    {
-        public string From { get; }
-        public string To { get; }
-
-        public MetaGuidanceSubjectTimePeriodsViewModel()
-        {
-        }
-
-        public MetaGuidanceSubjectTimePeriodsViewModel(string from, string to)
-        {
-            From = from;
-            To = to;
-        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/PublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/PublicationViewModel.cs
@@ -7,7 +7,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
     public class PublicationViewModel
     {
         public Guid Id { get; set; }
+
         public IEnumerable<IdLabel> Highlights { get; set; }
+
         public IEnumerable<IdLabel> Subjects { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/PublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/PublicationViewModel.cs
@@ -8,8 +8,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
     {
         public Guid Id { get; set; }
 
+        public Guid LatestReleaseId { get; set; }
+
         public IEnumerable<IdLabel> Highlights { get; set; }
 
-        public IEnumerable<IdLabel> Subjects { get; set; }
+        public IEnumerable<SubjectViewModel> Subjects { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/ReleaseViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/ReleaseViewModel.cs
@@ -6,8 +6,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
 {
     public class ReleaseViewModel
     {
-        public Guid ReleaseId { get; set; }
+        public Guid Id { get; set; }
+
         public List<IdLabel> Highlights { get; set; }
-        public List<IdLabel> Subjects { get; set; }
+
+        public List<SubjectViewModel> Subjects { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/SubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/SubjectViewModel.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
+{
+    public class SubjectViewModel
+    {
+        public Guid Id { get; }
+
+        public string Name { get; }
+
+        public string Content { get; }
+
+        public TimePeriodLabels TimePeriods { get; }
+
+        public List<string> GeographicLevels { get; }
+
+        public SubjectViewModel(
+            Guid id,
+            string name,
+            string content,
+            TimePeriodLabels timePeriods,
+            List<string> geographicLevels)
+        {
+            Id = id;
+            Name = name;
+            Content = content;
+            TimePeriods = timePeriods;
+            GeographicLevels = geographicLevels;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/TimePeriodLabels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/TimePeriodLabels.cs
@@ -1,0 +1,18 @@
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
+{
+    public class TimePeriodLabels
+    {
+        public string From { get; }
+        public string To { get; }
+
+        public TimePeriodLabels()
+        {
+        }
+
+        public TimePeriodLabels(string from, string to)
+        {
+            From = from;
+            To = to;
+        }
+    }
+}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
@@ -139,7 +139,18 @@ describe('ReleaseDataBlockEditPage', () => {
 
   const testRelease: Release = {
     id: 'release-1',
-    subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+    subjects: [
+      {
+        id: 'subject-1',
+        name: 'Test subject',
+        content: '<p>Test content</p>',
+        timePeriods: {
+          from: '2018',
+          to: '2020',
+        },
+        geographicLevels: ['National'],
+      },
+    ],
     highlights: [],
   };
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
@@ -21,11 +21,23 @@ describe('ReleaseTableToolPage', () => {
       subjects: [
         {
           id: 'subject-1',
-          label: 'Subject 1',
+          name: 'Subject 1',
+          content: '<p>Test content 1</p>',
+          timePeriods: {
+            from: '2018',
+            to: '2020',
+          },
+          geographicLevels: ['National'],
         },
         {
           id: 'subject-2',
-          label: 'Subject 2',
+          name: 'Subject 2',
+          content: '<p>Test content 2</p>',
+          timePeriods: {
+            from: '2015/16',
+            to: '2018/19',
+          },
+          geographicLevels: ['National'],
         },
       ],
       highlights: [],

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -191,7 +191,18 @@ describe('PreReleaseTableToolPage', () => {
   const testRelease: Release = {
     id: 'release-1',
     highlights: [{ id: 'block-1', label: 'Test highlight' }],
-    subjects: [{ id: 'subject-1', label: 'Test subject' }],
+    subjects: [
+      {
+        id: 'subject-1',
+        name: 'Test subject',
+        content: '<p>Test content</p>',
+        timePeriods: {
+          from: '2018',
+          to: '2020',
+        },
+        geographicLevels: ['National'],
+      },
+    ],
   };
 
   const testDataBlock: ReleaseDataBlock = {

--- a/src/explore-education-statistics-common/src/components/form/FormRadio.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormRadio.tsx
@@ -13,7 +13,7 @@ export interface FormRadioProps {
   checked?: boolean;
   defaultChecked?: boolean;
   conditional?: ReactNode;
-  hint?: string;
+  hint?: string | ReactNode;
   id: string;
   label: string;
   name: string;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -18,14 +18,16 @@ import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 import WizardStepHeading from './WizardStepHeading';
 
-interface FormValues {
+export interface PublicationFormValues {
   publicationId: string;
 }
 
-export type PublicationFormSubmitHandler = (values: FormValues) => void;
+export type PublicationFormSubmitHandler = (
+  values: PublicationFormValues,
+) => void;
 
 interface Props {
-  initialValues?: FormValues;
+  initialValues?: PublicationFormValues;
   onSubmit: PublicationFormSubmitHandler;
   options: Theme[];
 }
@@ -53,12 +55,12 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
   );
 
   return (
-    <Formik<FormValues>
+    <Formik<PublicationFormValues>
       enableReinitialize
       initialValues={initialValues}
       validateOnBlur={false}
       validateOnChange={false}
-      validationSchema={Yup.object<FormValues>({
+      validationSchema={Yup.object<PublicationFormValues>({
         publicationId: Yup.string().required('Choose publication'),
       })}
       onSubmit={async values => {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -8,7 +8,7 @@ import {
 } from '@common/components/form';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
-import { ThemeMeta } from '@common/services/tableBuilderService';
+import { Theme } from '@common/services/tableBuilderService';
 import createErrorHelper from '@common/validation/createErrorHelper';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
@@ -27,7 +27,7 @@ export type PublicationFormSubmitHandler = (values: FormValues) => void;
 interface Props {
   initialValues?: FormValues;
   onSubmit: PublicationFormSubmitHandler;
-  options: ThemeMeta[];
+  options: Theme[];
 }
 
 const formId = 'publicationForm';
@@ -70,7 +70,7 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
         const { values } = form;
         const { getError } = createErrorHelper(form);
 
-        const filteredOptions: ThemeMeta[] = options
+        const filteredOptions: Theme[] = options
           .filter(theme =>
             theme.topics.some(topic =>
               topic.publications.some(

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectForm.tsx
@@ -12,23 +12,21 @@ import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 import WizardStepHeading from './WizardStepHeading';
 
-export interface PublicationSubjectFormValues {
+export interface SubjectFormValues {
   subjectId: string;
 }
 
-export type PublicationSubjectFormSubmitHandler = (values: {
-  subjectId: string;
-}) => void;
+export type SubjectFormSubmitHandler = (values: { subjectId: string }) => void;
 
 const formId = 'publicationSubjectForm';
 
 interface Props {
   initialValues?: { subjectId: string };
-  onSubmit: PublicationSubjectFormSubmitHandler;
+  onSubmit: SubjectFormSubmitHandler;
   options: Subject[];
 }
 
-const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
+const SubjectForm = (props: Props & InjectedWizardProps) => {
   const {
     isActive,
     onSubmit,
@@ -107,11 +105,11 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
   );
 
   return (
-    <Formik<PublicationSubjectFormValues>
+    <Formik<SubjectFormValues>
       enableReinitialize
       initialValues={initialValues}
       validateOnBlur={false}
-      validationSchema={Yup.object<PublicationSubjectFormValues>({
+      validationSchema={Yup.object<SubjectFormValues>({
         subjectId: Yup.string().required('Choose a subject'),
       })}
       onSubmit={async ({ subjectId }) => {
@@ -124,7 +122,7 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
       {form => {
         return isActive ? (
           <Form {...form} id={formId} showSubmitError>
-            <FormFieldRadioGroup<PublicationSubjectFormValues>
+            <FormFieldRadioGroup<SubjectFormValues>
               name="subjectId"
               legend={stepHeading}
               legendSize="l"
@@ -160,4 +158,4 @@ const PublicationSubjectForm = (props: Props & InjectedWizardProps) => {
   );
 };
 
-export default PublicationSubjectForm;
+export default SubjectForm;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -23,7 +23,7 @@ import getDefaultTableHeaderConfig from '@common/modules/table-tool/utils/getDef
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import parseYearCodeTuple from '@common/modules/table-tool/utils/parseYearCodeTuple';
 import tableBuilderService, {
-  PublicationSubject,
+  Subject,
   ReleaseTableDataQuery,
   SubjectMeta,
   TableHighlight,
@@ -41,7 +41,7 @@ interface Publication {
 
 export interface InitialTableToolState {
   initialStep: number;
-  subjects?: PublicationSubject[];
+  subjects?: Subject[];
   highlights?: TableHighlight[];
   subjectMeta?: SubjectMeta;
   query?: ReleaseTableDataQuery;
@@ -52,7 +52,7 @@ export interface InitialTableToolState {
 }
 
 interface TableToolState extends InitialTableToolState {
-  subjects: PublicationSubject[];
+  subjects: Subject[];
   highlights: TableHighlight[];
   subjectMeta: SubjectMeta;
   query: ReleaseTableDataQuery;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -9,9 +9,9 @@ import PreviousStepModalConfirm from '@common/modules/table-tool/components/Prev
 import PublicationForm, {
   PublicationFormSubmitHandler,
 } from '@common/modules/table-tool/components/PublicationForm';
-import PublicationSubjectForm, {
-  PublicationSubjectFormSubmitHandler,
-} from '@common/modules/table-tool/components/PublicationSubjectForm';
+import SubjectForm, {
+  SubjectFormSubmitHandler,
+} from '@common/modules/table-tool/components/SubjectForm';
 import TimePeriodForm, {
   TimePeriodFormSubmitHandler,
 } from '@common/modules/table-tool/components/TimePeriodForm';
@@ -129,7 +129,7 @@ const TableToolWizard = ({
     });
   };
 
-  const handlePublicationSubjectFormSubmit: PublicationSubjectFormSubmitHandler = async ({
+  const handlePublicationSubjectFormSubmit: SubjectFormSubmitHandler = async ({
     subjectId: selectedSubjectId,
   }) => {
     const nextSubjectMeta = await tableBuilderService.getSubjectMeta(
@@ -302,7 +302,7 @@ const TableToolWizard = ({
                       'govuk-grid-column-full': !stepProps.isActive,
                     })}
                   >
-                    <PublicationSubjectForm
+                    <SubjectForm
                       {...stepProps}
                       initialValues={{
                         subjectId: state.query.subjectId,

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -27,7 +27,7 @@ import tableBuilderService, {
   ReleaseTableDataQuery,
   SubjectMeta,
   TableHighlight,
-  ThemeMeta,
+  Theme,
 } from '@common/services/tableBuilderService';
 import classNames from 'classnames';
 import React, { ReactElement, ReactNode, useMemo } from 'react';
@@ -68,7 +68,7 @@ export interface FinalStepRenderProps {
 }
 
 export interface TableToolWizardProps {
-  themeMeta?: ThemeMeta[];
+  themeMeta?: Theme[];
   initialState?: Partial<InitialTableToolState>;
   finalStep?: (props: FinalStepRenderProps) => ReactElement;
   renderHighlights?: (highlights: TableHighlight[]) => ReactNode;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/PublicationForm.test.tsx
@@ -1,35 +1,40 @@
-import PublicationForm from '@common/modules/table-tool/components/PublicationForm';
+import PublicationForm, {
+  PublicationFormValues,
+} from '@common/modules/table-tool/components/PublicationForm';
 import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
-import { fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
+import { Theme } from '@common/services/tableBuilderService';
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import noop from 'lodash/noop';
+import React from 'react';
 
 describe('PublicationForm', () => {
-  const testOptions = [
+  const testOptions: Theme[] = [
     {
-      id: '92c5df93-c4da-4629-ab25-51bd2920cdca',
+      id: 'theme-1',
       title: 'Further education',
       slug: 'further-education',
       topics: [
         {
-          id: '88d08425-fcfd-4c87-89da-70b2062a7367',
+          id: 'topic-1',
           title: 'Further education and skills',
           slug: 'further-education-and-skills',
           publications: [
             {
-              id: 'cf0ec981-3583-42a5-b21b-3f2f32008f1b',
+              id: 'publication-1',
               title: 'Apprenticeships and traineeships',
               slug: 'apprenticeships-and-traineeships',
             },
           ],
         },
         {
-          id: 'dc7b7a89-e968-4a7e-af5f-bd7d19c346a5',
+          id: 'topic-2',
           title: 'National achievement rates tables',
           slug: 'national-achievement-rates-tables',
           publications: [
             {
-              id: '7a57d4c0-5233-4d46-8e27-748fbc365715',
+              id: 'publication-2',
               title: 'National achievement rates tables',
               slug: 'national-achievement-rates-tables',
             },
@@ -38,17 +43,17 @@ describe('PublicationForm', () => {
       ],
     },
     {
-      id: 'cc8e02fd-5599-41aa-940d-26bca68eab53',
+      id: 'theme-2',
       title: 'Children, early years and social care',
       slug: 'children-and-early-years',
       topics: [
         {
-          id: '17b2e32c-ed2f-4896-852b-513cdf466769',
+          id: 'topic-3',
           title: 'Early years foundation stage profile',
           slug: 'early-years-foundation-stage-profile',
           publications: [
             {
-              id: 'fcda2962-82a6-4052-afa2-ea398c53c85f',
+              id: 'publication-3',
               title: 'Early years foundation stage profile results',
               slug: 'early-years-foundation-stage-profile-results',
             },
@@ -57,53 +62,53 @@ describe('PublicationForm', () => {
       ],
     },
     {
-      id: 'ee1855ca-d1e1-4f04-a795-cbd61d326a1f',
+      id: 'theme-3',
       title: 'Pupils and schools',
       slug: 'pupils-and-schools',
       topics: [
         {
-          id: '1a9636e4-29d5-4c90-8c07-f41db8dd019c',
+          id: 'topic-4',
           title: 'School applications',
           slug: 'school-applications',
           publications: [
             {
-              id: '66c8e9db-8bf2-4b0b-b094-cfab25c20b05',
+              id: 'publication-4',
               title: 'Secondary and primary schools applications and offers',
               slug: 'secondary-and-primary-schools-applications-and-offers',
             },
           ],
         },
         {
-          id: '67c249de-1cca-446e-8ccb-dcdac542f460',
+          id: 'topic-5',
           title: 'Pupil absence',
           slug: 'pupil-absence',
           publications: [
             {
-              id: 'cbbd299f-8297-44bc-92ac-558bcf51f8ad',
+              id: 'publication-5',
               title: 'Pupil absence in schools in England',
               slug: 'pupil-absence-in-schools-in-england',
             },
           ],
         },
         {
-          id: '85349b0a-19c7-4089-a56b-ad8dbe85449a',
+          id: 'topic-6',
           title: 'Special educational needs (SEN)',
           slug: 'sen',
           publications: [
             {
-              id: '88312cc0-fe1d-4ab5-81df-33fd708185cb',
+              id: 'publication-6',
               title: 'Statements of SEN and EHC plans',
               slug: 'statements-of-sen-and-ehc-plans',
             },
           ],
         },
         {
-          id: '77941b7d-bbd6-4069-9107-565af89e2dec',
+          id: 'topic-7',
           title: 'Exclusions',
           slug: 'exclusions',
           publications: [
             {
-              id: 'bf2b4284-6b84-46b0-aaaa-a2e0a23be2a9',
+              id: 'publication-7',
               title: 'Permanent and fixed-period exclusions in England',
               slug: 'permanent-and-fixed-period-exclusions-in-england',
             },
@@ -112,29 +117,29 @@ describe('PublicationForm', () => {
       ],
     },
     {
-      id: '74648781-85a9-4233-8be3-fe6f137165f4',
+      id: 'theme-4',
       title: 'School and college outcomes and performance',
       slug: 'outcomes-and-performance',
       topics: [
         {
-          id: 'eac38700-b968-4029-b8ac-0eb8e1356480',
+          id: 'topic-8',
           title: 'Key stage 2',
           slug: 'key-stage-two',
           publications: [
             {
-              id: '10370062-93b0-4dde-9097-5a56bf5b3064',
+              id: 'publication-8',
               title: 'National curriculum assessments at key stage 2',
               slug: 'national-curriculum-assessments-key-stage2',
             },
           ],
         },
         {
-          id: '1e763f55-bf09-4497-b838-7c5b054ba87b',
+          id: 'topic-9',
           title: 'GCSEs (key stage 4)',
           slug: 'key-stage-four',
           publications: [
             {
-              id: 'bfdcaae1-ce6b-4f63-9b2b-0a1f3942887f',
+              id: 'publication-9',
               title:
                 'GCSE and equivalent results, including pupil characteristics',
               slug: 'gcse-results-including-pupil-characteristics',
@@ -142,12 +147,12 @@ describe('PublicationForm', () => {
           ],
         },
         {
-          id: '85b5454b-3761-43b1-8e84-bd056a8efcd3',
+          id: 'topic-10',
           title: '16 to 19 attainment',
           slug: 'sixteen-to-nineteen-attainment',
           publications: [
             {
-              id: '2e95f880-629c-417b-981f-0901e97776ff',
+              id: 'publication-10',
               title: 'Level 2 and 3 attainment by young people aged 19',
               slug: 'Level 2 and 3 attainment by young people aged 19',
             },
@@ -168,61 +173,7 @@ describe('PublicationForm', () => {
     goToPreviousStep: () => undefined,
   };
 
-  test('renders publication options filtered by title when using search field', () => {
-    jest.useFakeTimers();
-
-    const { container } = render(
-      <PublicationForm
-        {...wizardProps}
-        onSubmit={noop}
-        options={testOptions}
-      />,
-    );
-
-    expect(container.querySelectorAll('input[type="radio"]')).toHaveLength(10);
-
-    fireEvent.change(screen.getByLabelText('Search publications'), {
-      target: {
-        value: 'Early years',
-      },
-    });
-
-    jest.runOnlyPendingTimers();
-
-    expect(container.querySelectorAll('input[type="radio"]')).toHaveLength(1);
-    expect(
-      screen.getByLabelText('Early years foundation stage profile results'),
-    ).toHaveAttribute('type', 'radio');
-  });
-
-  test('renders publication options filtered by case-insensitive title', () => {
-    jest.useFakeTimers();
-
-    const { container } = render(
-      <PublicationForm
-        {...wizardProps}
-        onSubmit={noop}
-        options={testOptions}
-      />,
-    );
-
-    expect(container.querySelectorAll('input[type="radio"]')).toHaveLength(10);
-
-    fireEvent.change(screen.getByLabelText('Search publications'), {
-      target: {
-        value: 'early years',
-      },
-    });
-
-    jest.runOnlyPendingTimers();
-
-    expect(container.querySelectorAll('input[type="radio"]')).toHaveLength(1);
-    expect(
-      screen.getByLabelText('Early years foundation stage profile results'),
-    ).toHaveAttribute('type', 'radio');
-  });
-
-  test('does not throw error if regex sensitive search term is used', () => {
+  test('renders publication options filtered by title when using search field', async () => {
     jest.useFakeTimers();
 
     render(
@@ -233,11 +184,59 @@ describe('PublicationForm', () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText('Search publications'), {
-      target: {
-        value: '[',
-      },
-    });
+    expect(screen.getAllByRole('radio', { hidden: true })).toHaveLength(10);
+
+    await userEvent.type(
+      screen.getByLabelText('Search publications'),
+      'Early years',
+    );
+
+    jest.runOnlyPendingTimers();
+
+    expect(screen.getAllByRole('radio')).toHaveLength(1);
+    expect(
+      screen.getByLabelText('Early years foundation stage profile results'),
+    ).toHaveAttribute('type', 'radio');
+  });
+
+  test('renders publication options filtered by case-insensitive title', async () => {
+    jest.useFakeTimers();
+
+    render(
+      <PublicationForm
+        {...wizardProps}
+        onSubmit={noop}
+        options={testOptions}
+      />,
+    );
+
+    expect(screen.getAllByRole('radio', { hidden: true })).toHaveLength(10);
+
+    await userEvent.type(
+      screen.getByLabelText('Search publications'),
+      'early years',
+    );
+
+    jest.runOnlyPendingTimers();
+
+    expect(screen.getAllByRole('radio')).toHaveLength(1);
+    expect(
+      screen.getByLabelText('Early years foundation stage profile results'),
+    ).toHaveAttribute('type', 'radio');
+  });
+
+  test('does not throw error if regex sensitive search term is used', async () => {
+    jest.useFakeTimers();
+
+    render(
+      <PublicationForm
+        {...wizardProps}
+        onSubmit={noop}
+        options={testOptions}
+      />,
+    );
+
+    await userEvent.type(screen.getByLabelText('Search publications'), '[');
 
     expect(() => {
       jest.runOnlyPendingTimers();
@@ -245,18 +244,16 @@ describe('PublicationForm', () => {
   });
 
   test('renders empty message when there are no publication options', () => {
-    const { container } = render(
-      <PublicationForm {...wizardProps} onSubmit={noop} options={[]} />,
-    );
+    render(<PublicationForm {...wizardProps} onSubmit={noop} options={[]} />);
 
-    expect(container.querySelectorAll('input[type="radio"]')).toHaveLength(0);
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
     expect(screen.queryByText('No publications found')).not.toBeNull();
   });
 
   test('renders empty message when there are no filtered publication options', async () => {
     jest.useFakeTimers();
 
-    const { container } = render(
+    render(
       <PublicationForm
         {...wizardProps}
         onSubmit={noop}
@@ -264,25 +261,24 @@ describe('PublicationForm', () => {
       />,
     );
 
-    expect(screen.queryByText('No publications found')).toBeNull();
-    expect(container.querySelectorAll('input[type="radio"]')).toHaveLength(10);
+    expect(screen.queryByText('No publications found')).not.toBeInTheDocument();
+    expect(screen.queryAllByRole('radio', { hidden: true })).toHaveLength(10);
 
-    fireEvent.change(screen.getByLabelText('Search publications'), {
-      target: {
-        value: 'not a publication',
-      },
-    });
+    await userEvent.type(
+      screen.getByLabelText('Search publications'),
+      'not a publication',
+    );
 
     jest.runOnlyPendingTimers();
 
-    expect(container.querySelectorAll('input[type="radio"]')).toHaveLength(0);
-    expect(screen.queryByText('No publications found')).not.toBeNull();
+    expect(screen.queryAllByRole('radio', { hidden: true })).toHaveLength(0);
+    expect(screen.getByText('No publications found')).toBeInTheDocument();
   });
 
-  test('renders selected publication option even if it does not match search field', () => {
+  test('renders selected publication option even if it does not match search field', async () => {
     jest.useFakeTimers();
 
-    const { container } = render(
+    render(
       <PublicationForm
         {...wizardProps}
         onSubmit={noop}
@@ -290,26 +286,25 @@ describe('PublicationForm', () => {
       />,
     );
 
-    expect(container.querySelectorAll('input[type="radio"]')).toHaveLength(10);
-    expect(screen.queryByText('No publications found')).toBeNull();
+    expect(screen.getAllByRole('radio', { hidden: true })).toHaveLength(10);
+    expect(screen.queryByText('No publications found')).not.toBeInTheDocument();
 
-    fireEvent.click(
+    userEvent.click(
       screen.getByLabelText('Pupil absence in schools in England'),
     );
 
-    fireEvent.change(screen.getByLabelText('Search publications'), {
-      target: {
-        value: 'not a publication',
-      },
-    });
+    await userEvent.type(
+      screen.getByLabelText('Search publications'),
+      'not a publication',
+    );
 
     jest.runOnlyPendingTimers();
 
-    expect(container.querySelectorAll('input[type="radio"]')).toHaveLength(1);
+    expect(screen.getAllByRole('radio')).toHaveLength(1);
     expect(
-      screen.queryByLabelText('Pupil absence in schools in England'),
-    ).not.toBeNull();
-    expect(screen.queryByText('No publications found')).toBeNull();
+      screen.getByLabelText('Pupil absence in schools in England'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('No publications found')).not.toBeInTheDocument();
   });
 
   test('renders dropdown for selected publication option as open', () => {
@@ -323,7 +318,7 @@ describe('PublicationForm', () => {
 
     expect(container.querySelectorAll('details[open]')).toHaveLength(0);
 
-    fireEvent.click(
+    userEvent.click(
       screen.getByLabelText('Pupil absence in schools in England'),
     );
 
@@ -335,11 +330,11 @@ describe('PublicationForm', () => {
   });
 
   test('renders read-only view with initial `publicationId` when step is not active', () => {
-    const { container } = render(
+    render(
       <PublicationForm
         {...wizardProps}
         initialValues={{
-          publicationId: '7a57d4c0-5233-4d46-8e27-748fbc365715',
+          publicationId: 'publication-2',
         }}
         isActive={false}
         onSubmit={noop}
@@ -347,18 +342,14 @@ describe('PublicationForm', () => {
       />,
     );
 
-    expect(container.querySelectorAll('input[type="radio"]')).toHaveLength(0);
-
-    expect(
-      screen.getByText('Publication', { selector: 'dt' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('National achievement rates tables', { selector: 'dd' }),
-    ).toBeInTheDocument();
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+    expect(screen.getByTestId('Publication')).toHaveTextContent(
+      'National achievement rates tables',
+    );
   });
 
   test('renders read-only view with selected publication when step is not active', () => {
-    const { container, rerender } = render(
+    const { rerender } = render(
       <PublicationForm
         {...wizardProps}
         onSubmit={noop}
@@ -366,7 +357,7 @@ describe('PublicationForm', () => {
       />,
     );
 
-    fireEvent.click(
+    userEvent.click(
       screen.getByLabelText('Pupil absence in schools in England'),
     );
 
@@ -379,15 +370,39 @@ describe('PublicationForm', () => {
       />,
     );
 
-    expect(container.querySelectorAll('input[type="radio"]')).toHaveLength(0);
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+    expect(screen.getByTestId('Publication')).toHaveTextContent(
+      'Pupil absence in schools in England',
+    );
+  });
 
-    expect(
-      screen.getByText('Publication', { selector: 'dt' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('Pupil absence in schools in England', {
-        selector: 'dd',
-      }),
-    ).toBeInTheDocument();
+  test('clicking `Next step` calls `onSubmit` with correct values', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <PublicationForm
+        {...wizardProps}
+        onSubmit={handleSubmit}
+        options={testOptions}
+      />,
+    );
+
+    expect(screen.queryByTestId('Publication')).not.toBeInTheDocument();
+
+    userEvent.click(screen.getByRole('button', { name: 'Pupils and schools' }));
+    userEvent.click(screen.getByRole('button', { name: 'Pupil absence' }));
+    userEvent.click(
+      screen.getByLabelText('Pupil absence in schools in England'),
+    );
+    userEvent.click(screen.getByRole('button', { name: 'Next step' }));
+
+    const expected: PublicationFormValues = {
+      publicationId: 'publication-5',
+    };
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+      expect(handleSubmit).toHaveBeenCalledWith(expected);
+    });
   });
 });

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/PublicationSubjectForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/PublicationSubjectForm.test.tsx
@@ -1,0 +1,186 @@
+import { getDescribedBy } from '@common-test/queries';
+import PublicationSubjectForm, {
+  PublicationSubjectFormValues,
+} from '@common/modules/table-tool/components/PublicationSubjectForm';
+import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
+import { Subject } from '@common/services/tableBuilderService';
+import { waitFor } from '@testing-library/dom';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import noop from 'lodash/noop';
+import React from 'react';
+
+describe('PublicationSubjectForm', () => {
+  const testOptions: Subject[] = [
+    {
+      id: 'subject-1',
+      name: 'Subject 1',
+      content: '<p>Test content 1</p>',
+      timePeriods: {
+        from: '2018/19',
+        to: '2020/21',
+      },
+      geographicLevels: ['Local Authority District', 'Ward'],
+    },
+    {
+      id: 'subject-2',
+      name: 'Subject 2',
+      content: '<p>Test content 2</p>',
+      timePeriods: {
+        from: '2015',
+        to: '2020',
+      },
+      geographicLevels: ['National', 'Local Authority'],
+    },
+  ];
+
+  const wizardProps: InjectedWizardProps = {
+    shouldScroll: true,
+    stepNumber: 1,
+    currentStep: 1,
+    setCurrentStep: noop,
+    isActive: true,
+    isLoading: false,
+    goToNextStep: noop,
+    goToPreviousStep: noop,
+  };
+
+  test('renders subjects correctly with details', () => {
+    jest.useFakeTimers();
+
+    const { container } = render(
+      <PublicationSubjectForm
+        {...wizardProps}
+        onSubmit={noop}
+        options={testOptions}
+      />,
+    );
+
+    const radios = screen.getAllByLabelText(/Subject/);
+
+    expect(radios).toHaveLength(2);
+    expect(radios[0]).toHaveAttribute('value', 'subject-1');
+    expect(radios[1]).toHaveAttribute('value', 'subject-2');
+
+    const subject1Hint = within(getDescribedBy(container, radios[0]));
+
+    expect(
+      within(subject1Hint.getByTestId('Content')).getByText('Test content 1', {
+        selector: 'p',
+      }),
+    ).toBeInTheDocument();
+    expect(subject1Hint.getByTestId('Geographic levels')).toHaveTextContent(
+      'Local Authority District; Ward',
+    );
+    expect(subject1Hint.getByTestId('Time period')).toHaveTextContent(
+      '2018/19 to 2020/21',
+    );
+
+    const subject2Hint = within(getDescribedBy(container, radios[1]));
+
+    expect(
+      within(subject2Hint.getByTestId('Content')).getByText('Test content 2', {
+        selector: 'p',
+      }),
+    ).toBeInTheDocument();
+    expect(subject2Hint.getByTestId('Geographic levels')).toHaveTextContent(
+      'Local Authority; National',
+    );
+    expect(subject2Hint.getByTestId('Time period')).toHaveTextContent(
+      '2015 to 2020',
+    );
+  });
+
+  test('renders empty message when there are no publication options', () => {
+    render(
+      <PublicationSubjectForm {...wizardProps} onSubmit={noop} options={[]} />,
+    );
+
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+    expect(screen.getByText(/No subjects available/)).toBeInTheDocument();
+  });
+
+  test('renders read-only view with initial `subjectId` when step is not active', () => {
+    render(
+      <PublicationSubjectForm
+        {...wizardProps}
+        initialValues={{
+          subjectId: 'subject-1',
+        }}
+        isActive={false}
+        onSubmit={noop}
+        options={testOptions}
+      />,
+    );
+
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+    expect(screen.getByTestId('Subject')).toHaveTextContent('Subject 1');
+  });
+
+  test('renders read-only view without initial `subjectId` when step is not active', () => {
+    render(
+      <PublicationSubjectForm
+        {...wizardProps}
+        isActive={false}
+        onSubmit={noop}
+        options={testOptions}
+      />,
+    );
+
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+    expect(screen.getByTestId('Subject')).toHaveTextContent('None');
+  });
+
+  test('renders read-only view with selected subject when step is not active', () => {
+    const { rerender } = render(
+      <PublicationSubjectForm
+        {...wizardProps}
+        onSubmit={noop}
+        options={testOptions}
+      />,
+    );
+
+    expect(screen.queryByTestId('Subject')).not.toBeInTheDocument();
+
+    userEvent.click(screen.getByLabelText('Subject 1'));
+
+    rerender(
+      <PublicationSubjectForm
+        {...wizardProps}
+        isActive={false}
+        onSubmit={noop}
+        options={testOptions}
+      />,
+    );
+
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+    expect(screen.getByTestId('Subject')).toHaveTextContent('Subject 1');
+  });
+
+  test('clicking `Next step` calls `onSubmit` with correct values', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <PublicationSubjectForm
+        {...wizardProps}
+        onSubmit={handleSubmit}
+        options={testOptions}
+      />,
+    );
+
+    expect(screen.queryByTestId('Subject')).not.toBeInTheDocument();
+
+    userEvent.click(screen.getByLabelText('Subject 1'));
+
+    userEvent.click(screen.getByRole('button', { name: 'Next step' }));
+
+    const expected: PublicationSubjectFormValues = {
+      subjectId: 'subject-1',
+    };
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+      expect(handleSubmit).toHaveBeenCalledWith(expected);
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/SubjectForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/SubjectForm.test.tsx
@@ -1,7 +1,7 @@
 import { getDescribedBy } from '@common-test/queries';
-import PublicationSubjectForm, {
-  PublicationSubjectFormValues,
-} from '@common/modules/table-tool/components/PublicationSubjectForm';
+import SubjectForm, {
+  SubjectFormValues,
+} from '@common/modules/table-tool/components/SubjectForm';
 import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
 import { Subject } from '@common/services/tableBuilderService';
 import { waitFor } from '@testing-library/dom';
@@ -10,7 +10,7 @@ import userEvent from '@testing-library/user-event';
 import noop from 'lodash/noop';
 import React from 'react';
 
-describe('PublicationSubjectForm', () => {
+describe('SubjectForm', () => {
   const testOptions: Subject[] = [
     {
       id: 'subject-1',
@@ -49,11 +49,7 @@ describe('PublicationSubjectForm', () => {
     jest.useFakeTimers();
 
     const { container } = render(
-      <PublicationSubjectForm
-        {...wizardProps}
-        onSubmit={noop}
-        options={testOptions}
-      />,
+      <SubjectForm {...wizardProps} onSubmit={noop} options={testOptions} />,
     );
 
     const radios = screen.getAllByLabelText(/Subject/);
@@ -92,9 +88,7 @@ describe('PublicationSubjectForm', () => {
   });
 
   test('renders empty message when there are no publication options', () => {
-    render(
-      <PublicationSubjectForm {...wizardProps} onSubmit={noop} options={[]} />,
-    );
+    render(<SubjectForm {...wizardProps} onSubmit={noop} options={[]} />);
 
     expect(screen.queryAllByRole('radio')).toHaveLength(0);
     expect(screen.getByText(/No subjects available/)).toBeInTheDocument();
@@ -102,7 +96,7 @@ describe('PublicationSubjectForm', () => {
 
   test('renders read-only view with initial `subjectId` when step is not active', () => {
     render(
-      <PublicationSubjectForm
+      <SubjectForm
         {...wizardProps}
         initialValues={{
           subjectId: 'subject-1',
@@ -119,7 +113,7 @@ describe('PublicationSubjectForm', () => {
 
   test('renders read-only view without initial `subjectId` when step is not active', () => {
     render(
-      <PublicationSubjectForm
+      <SubjectForm
         {...wizardProps}
         isActive={false}
         onSubmit={noop}
@@ -133,11 +127,7 @@ describe('PublicationSubjectForm', () => {
 
   test('renders read-only view with selected subject when step is not active', () => {
     const { rerender } = render(
-      <PublicationSubjectForm
-        {...wizardProps}
-        onSubmit={noop}
-        options={testOptions}
-      />,
+      <SubjectForm {...wizardProps} onSubmit={noop} options={testOptions} />,
     );
 
     expect(screen.queryByTestId('Subject')).not.toBeInTheDocument();
@@ -145,7 +135,7 @@ describe('PublicationSubjectForm', () => {
     userEvent.click(screen.getByLabelText('Subject 1'));
 
     rerender(
-      <PublicationSubjectForm
+      <SubjectForm
         {...wizardProps}
         isActive={false}
         onSubmit={noop}
@@ -161,7 +151,7 @@ describe('PublicationSubjectForm', () => {
     const handleSubmit = jest.fn();
 
     render(
-      <PublicationSubjectForm
+      <SubjectForm
         {...wizardProps}
         onSubmit={handleSubmit}
         options={testOptions}
@@ -174,7 +164,7 @@ describe('PublicationSubjectForm', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Next step' }));
 
-    const expected: PublicationSubjectFormValues = {
+    const expected: SubjectFormValues = {
       subjectId: 'subject-1',
     };
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -1,11 +1,11 @@
 import TableToolWizard from '@common/modules/table-tool/components/TableToolWizard';
-import { SubjectMeta, ThemeMeta } from '@common/services/tableBuilderService';
+import { SubjectMeta, Theme } from '@common/services/tableBuilderService';
 import { within } from '@testing-library/dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 
 describe('TableToolWizard', () => {
-  const testThemeMeta: ThemeMeta[] = [
+  const testThemeMeta: Theme[] = [
     {
       id: 'theme-1',
       title: 'Theme 1',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -1,5 +1,9 @@
 import TableToolWizard from '@common/modules/table-tool/components/TableToolWizard';
-import { SubjectMeta, Theme } from '@common/services/tableBuilderService';
+import {
+  Subject,
+  SubjectMeta,
+  Theme,
+} from '@common/services/tableBuilderService';
 import { within } from '@testing-library/dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
@@ -24,6 +28,29 @@ describe('TableToolWizard', () => {
           ],
         },
       ],
+    },
+  ];
+
+  const testSubjects: Subject[] = [
+    {
+      id: 'subject-1',
+      name: 'Subject 1',
+      content: 'Test content 1',
+      timePeriods: {
+        from: '2019/20',
+        to: '2020/21',
+      },
+      geographicLevels: ['National', 'Local Authority'],
+    },
+    {
+      id: 'subject-2',
+      name: 'Subject 2',
+      content: 'Test content 2',
+      timePeriods: {
+        from: '2015/16',
+        to: '2019/20',
+      },
+      geographicLevels: ['Local Authority District', 'Ward'],
     },
   ];
 
@@ -130,10 +157,7 @@ describe('TableToolWizard', () => {
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 2,
-          subjects: [
-            { id: 'subject-1', label: 'Subject 1' },
-            { id: 'subject-2', label: 'Subject 2' },
-          ],
+          subjects: testSubjects,
           query: {
             publicationId: 'publication-1',
             subjectId: '',
@@ -184,7 +208,7 @@ describe('TableToolWizard', () => {
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 2,
-          subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+          subjects: [testSubjects[0]],
           highlights: [
             { id: 'highlight-1', label: 'Test highlight 1' },
             { id: 'highlight-2', label: 'Test highlight 2' },
@@ -239,7 +263,7 @@ describe('TableToolWizard', () => {
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 3,
-          subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+          subjects: [testSubjects[0]],
           highlights: [
             { id: 'highlight-1', label: 'Test highlight 1' },
             { id: 'highlight-2', label: 'Test highlight 2' },
@@ -286,7 +310,7 @@ describe('TableToolWizard', () => {
         initialState={{
           initialStep: 5,
           subjectMeta: testSubjectMeta,
-          subjects: [{ id: 'subject-1', label: 'Subject 1' }],
+          subjects: [testSubjects[0]],
           highlights: [],
           query: {
             publicationId: 'publication-1',

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -74,9 +74,15 @@ export interface Theme {
   }[];
 }
 
-export interface PublicationSubject {
+export interface Subject {
   id: string;
-  label: string;
+  name: string;
+  content: string;
+  timePeriods: {
+    from?: string;
+    to?: string;
+  };
+  geographicLevels: string[];
 }
 
 export interface TableHighlight {
@@ -86,13 +92,13 @@ export interface TableHighlight {
 
 export interface Publication {
   id: string;
-  subjects: PublicationSubject[];
+  subjects: Subject[];
   highlights: TableHighlight[];
 }
 
 export interface Release {
   id: string;
-  subjects: PublicationSubject[];
+  subjects: Subject[];
   highlights: TableHighlight[];
 }
 

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -58,7 +58,7 @@ export interface LocationOption {
   geoJson?: GeoJsonFeature[];
 }
 
-export interface ThemeMeta {
+export interface Theme {
   id: string;
   title: string;
   slug: string;
@@ -181,7 +181,7 @@ export interface TableDataResponse {
 }
 
 const tableBuilderService = {
-  getThemes(): Promise<ThemeMeta[]> {
+  getThemes(): Promise<Theme[]> {
     return dataApi.get('/themes');
   },
   getPublication(publicationId: string): Promise<Publication> {

--- a/src/explore-education-statistics-common/test/queries/describedBy.ts
+++ b/src/explore-education-statistics-common/test/queries/describedBy.ts
@@ -1,0 +1,102 @@
+import { queryHelpers } from '@testing-library/dom';
+
+function getDescribedByIds(element: HTMLElement) {
+  const describedBy = element.getAttribute('aria-describedby');
+
+  if (!describedBy) {
+    throw queryHelpers.getElementError(
+      'Element does not have aria-describedby attribute',
+      element,
+    );
+  }
+
+  return describedBy.split(' ');
+}
+
+export function queryAllDescribedBy(
+  container: HTMLElement,
+  element: HTMLElement,
+): (HTMLElement | null)[] {
+  return getDescribedByIds(element).map(id => {
+    const els = queryHelpers.queryAllByAttribute('id', container, id);
+
+    if (els.length > 1) {
+      throw queryHelpers.getElementError(
+        `Found multiple elements matching aria-describedby id: ${id}`,
+        container,
+      );
+    }
+
+    return els[0];
+  });
+}
+
+export function getAllDescribedBy(
+  container: HTMLElement,
+  element: HTMLElement,
+): HTMLElement[] {
+  const ids = getDescribedByIds(element);
+
+  const elements = ids.map(id => {
+    const els = queryHelpers.queryAllByAttribute('id', container, id);
+
+    if (els.length > 1) {
+      throw queryHelpers.getElementError(
+        `Found multiple elements matching aria-describedby id: ${id}`,
+        container,
+      );
+    }
+
+    if (!els.length) {
+      throw queryHelpers.getElementError(
+        `Could not find element matching aria-describedby id: ${id}`,
+        container,
+      );
+    }
+
+    return els[0];
+  });
+
+  if (!elements.length) {
+    throw queryHelpers.getElementError(
+      `Could not find any elements matching aria-describedby ids: ${ids.join(
+        ', ',
+      )}`,
+      container,
+    );
+  }
+
+  return elements;
+}
+
+export function getDescribedBy(
+  container: HTMLElement,
+  element: HTMLElement,
+): HTMLElement {
+  const ids = getDescribedByIds(element);
+
+  if (ids.length > 1) {
+    throw queryHelpers.getElementError(
+      'Element cannot have multiple aria-describedby ids',
+      element,
+    );
+  }
+
+  return getAllDescribedBy(container, element)[0];
+}
+
+export function queryDescribedBy(
+  container: HTMLElement,
+  element: HTMLElement,
+): HTMLElement | null {
+  const ids = getDescribedByIds(element);
+
+  if (ids.length > 1) {
+    throw queryHelpers.getElementError(
+      'Element cannot have multiple aria-describedby ids',
+      element,
+    );
+  }
+
+  return queryAllDescribedBy(container, element)[0];
+}

--- a/src/explore-education-statistics-common/test/queries/index.ts
+++ b/src/explore-education-statistics-common/test/queries/index.ts
@@ -1,0 +1,1 @@
+export * from './describedBy';

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -9,7 +9,7 @@ import { FastTrackTable } from '@common/services/fastTrackService';
 import tableBuilderService, {
   Publication,
   SubjectMeta,
-  ThemeMeta,
+  Theme,
 } from '@common/services/tableBuilderService';
 import { Dictionary } from '@common/types';
 import Link from '@frontend/components/Link';
@@ -28,7 +28,7 @@ export interface TableToolPageProps {
   publication?: Publication;
   fastTrack?: FastTrackTable;
   subjectMeta?: SubjectMeta;
-  themeMeta: ThemeMeta[];
+  themeMeta: Theme[];
 }
 
 const TableToolPage: NextPage<TableToolPageProps> = ({


### PR DESCRIPTION
This PR adds extra details for subjects on table tool pages to assist users in selecting the correct subject. It looks like the following:

![image](https://user-images.githubusercontent.com/9917868/107767879-91ae3080-6d2d-11eb-9a80-fc77af58e61f.png)

This includes the geographic levels, time periods and meta guidance content.

## Relevant changes

- Refactors data `PublicationService.GetPublication` to consume `ReleaseService.GetRelease` to provide its view model. We can simply fetch the latest release for the publication and provide that to `GetRelease`.
- Refactors `ReleaseService.GetRelease` so that it filters its subjects in a single query, rather than in multiple individual queries.
- Renames poorly named `PublicationSubjectForm` to simply `SubjectForm`.

## Other changes

- Adds testing utils for querying for an element's `aria-describedby`  elements. This is typically useful for getting a form input's hint.