### PR TITLE
EES-1664 Fix highlight links having potentially empty descriptions

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableHighlightsList.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableHighlightsList.tsx
@@ -58,12 +58,16 @@ const TableHighlightsList = ({ highlights = [], renderLink }: Props) => {
                   <p className="govuk-!-font-weight-bold govuk-!-margin-bottom-1">
                     {link
                       ? cloneElement(link as ReactElement, {
-                          'aria-describedby': descriptionId,
+                          'aria-describedby': highlight.description
+                            ? descriptionId
+                            : undefined,
                         })
                       : null}
                   </p>
 
-                  <p id={descriptionId}>{highlight.description}</p>
+                  {highlight.description && (
+                    <p id={descriptionId}>{highlight.description}</p>
+                  )}
                 </li>
               );
             })}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableHighlightsList.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableHighlightsList.test.tsx
@@ -75,6 +75,25 @@ describe('TableHighlightsList', () => {
     );
   });
 
+  test('does not add `aria-describedby` to highlight link if `description` is empty', () => {
+    render(
+      <TableHighlightsList
+        highlights={[
+          {
+            id: 'highlight-1',
+            name: 'Highlight 1',
+            description: '',
+          },
+        ]}
+        renderLink={renderLink}
+      />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'Highlight 1' }),
+    ).not.toHaveAttribute('aria-describedby');
+  });
+
   test('renders empty message if no highlights', () => {
     render(<TableHighlightsList highlights={[]} renderLink={renderLink} />);
 


### PR DESCRIPTION
This changes table highlights so that they no longer render empty descriptions. This could be a bit weird for screen readers as they would be directed to an empty paragraph.