### PR TITLE
EES-1880 Add natural ordering to table tool and chart labels

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -161,7 +161,7 @@ const ReleaseStatusForm = ({
             legend="Status"
             name="status"
             id={`${formId}-status`}
-            orderDirection={[]}
+            order={[]}
             options={[
               {
                 label: 'In draft',

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -1,8 +1,11 @@
 import ButtonText from '@common/components/ButtonText';
 import useMounted from '@common/hooks/useMounted';
 import { OmitStrict, PartialBy } from '@common/types/util';
+import naturalOrderBy, {
+  OrderDirection,
+  OrderKeys,
+} from '@common/utils/array/naturalOrderBy';
 import classNames from 'classnames';
-import orderBy from 'lodash/orderBy';
 import React, {
   FocusEventHandler,
   memo,
@@ -39,10 +42,8 @@ interface BaseFormCheckboxGroupProps {
   selectAll?: boolean;
   selectAllText?: (isAllChecked: boolean, options: CheckboxOption[]) => string;
   small?: boolean;
-  order?:
-    | (keyof CheckboxOption)[]
-    | ((option: CheckboxOption) => CheckboxOption[keyof CheckboxOption])[];
-  orderDirection?: ('asc' | 'desc')[];
+  order?: OrderKeys<CheckboxOption>;
+  orderDirection?: OrderDirection | OrderDirection[];
   value: string[];
   onAllChange?: CheckboxGroupAllChangeEventHandler;
   onBlur?: FocusEventHandler<HTMLInputElement>;
@@ -117,7 +118,7 @@ export const BaseFormCheckboxGroup = ({
         </ButtonText>
       )}
 
-      {orderBy(options, order, orderDirection).map(option => (
+      {naturalOrderBy(options, order, orderDirection).map(option => (
         <FormCheckbox
           disabled={disabled}
           {...option}

--- a/src/explore-education-statistics-common/src/components/form/FormFieldRadioGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldRadioGroup.tsx
@@ -13,9 +13,9 @@ function FormFieldRadioGroup<FormValues, Value extends string = string>(
   props: Props<FormValues, Value>,
 ) {
   return (
-    <FormField<string> {...props}>
+    <FormField<Value> {...props}>
       {({ field }) => (
-        <FormRadioGroup
+        <FormRadioGroup<Value>
           {...props}
           {...field}
           onChange={(event, option) => {

--- a/src/explore-education-statistics-common/src/components/form/FormRadioGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormRadioGroup.tsx
@@ -1,6 +1,9 @@
 import { OmitStrict, PartialBy } from '@common/types/util';
+import naturalOrderBy, {
+  OrderDirection,
+  OrderKeys,
+} from '@common/utils/array/naturalOrderBy';
 import classNames from 'classnames';
-import orderBy from 'lodash/orderBy';
 import React, { FocusEventHandler, memo } from 'react';
 import FormFieldset, { FormFieldsetProps } from './FormFieldset';
 import FormRadio, {
@@ -23,10 +26,8 @@ export type FormRadioGroupProps<Value extends string = string> = {
   onChange?: RadioChangeEventHandler;
   options: RadioOption<Value>[];
   small?: boolean;
-  order?:
-    | (keyof RadioOption)[]
-    | ((option: RadioOption) => RadioOption[keyof RadioOption])[];
-  orderDirection?: ('asc' | 'desc')[];
+  order?: OrderKeys<RadioOption<Value>>;
+  orderDirection?: OrderDirection | OrderDirection[];
   value?: string;
 } & OmitStrict<FormFieldsetProps, 'onBlur' | 'onFocus'> & {
     onFieldsetBlur?: FocusEventHandler<HTMLFieldSetElement>;
@@ -48,11 +49,6 @@ const FormRadioGroup = <Value extends string = string>({
 }: FormRadioGroupProps<Value>) => {
   const { id } = props;
 
-  const orderedOptions =
-    orderDirection && orderDirection.length === 0
-      ? options
-      : orderBy(options, order, orderDirection);
-
   return (
     <FormFieldset
       {...props}
@@ -67,7 +63,7 @@ const FormRadioGroup = <Value extends string = string>({
           'govuk-radios--small': small,
         })}
       >
-        {orderedOptions.map(option => (
+        {naturalOrderBy(options, order, orderDirection).map(option => (
           <FormRadio
             {...props}
             {...option}
@@ -85,4 +81,4 @@ const FormRadioGroup = <Value extends string = string>({
   );
 };
 
-export default memo(FormRadioGroup);
+export default memo(FormRadioGroup) as typeof FormRadioGroup;

--- a/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
@@ -16,11 +16,11 @@ import {
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import { TableDataResult } from '@common/services/tableBuilderService';
 import { Dictionary, Pair } from '@common/types';
+import naturalOrderBy from '@common/utils/array/naturalOrderBy';
 import cartesian from '@common/utils/cartesian';
 import parseNumber from '@common/utils/number/parseNumber';
 import get from 'lodash/get';
 import groupBy from 'lodash/groupBy';
-import orderBy from 'lodash/orderBy';
 
 /**
  * We use this form of a data set as it's
@@ -218,7 +218,7 @@ function sortDataSetCategories(
     return dataSetCategories;
   }
 
-  return orderBy(
+  return naturalOrderBy(
     dataSetCategories,
     data => {
       if (sortBy === 'name') {
@@ -231,7 +231,7 @@ function sortDataSetCategories(
 
       return parseNumber(data.dataSets[sortBy]) ?? 0;
     },
-    [sortAsc ? 'asc' : 'desc'],
+    sortAsc ? 'asc' : 'desc',
   );
 }
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -158,15 +158,12 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
                                 legend={filterGroup.legend}
                                 hint={filterGroup.hint}
                                 disabled={form.isSubmitting}
-                                order={[]}
-                                options={Object.entries(
-                                  filterGroup.options,
-                                ).map(([_, group]) => {
-                                  return {
+                                options={Object.values(filterGroup.options).map(
+                                  group => ({
                                     legend: group.label,
                                     options: group.options,
-                                  };
-                                })}
+                                  }),
+                                )}
                               />
                             );
                           },

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -26,6 +26,8 @@ export type LocationFiltersFormSubmitHandler = (values: {
   locations: Dictionary<string[]>;
 }) => void;
 
+const formId = 'locationFiltersForm';
+
 interface Props {
   options: SubjectMeta['locations'];
   initialValues?: Dictionary<string[]>;
@@ -42,8 +44,6 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
     stepNumber,
     initialValues = {},
   } = props;
-
-  const formId = 'locationFiltersForm';
 
   const formOptions = useMemo(() => options, [options]);
 
@@ -116,7 +116,6 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
                           name={`locations.${levelKey}`}
                           key={levelKey}
                           options={level.options}
-                          order={[]}
                           id={`${formId}-levels-${levelKey}`}
                           legend={level.legend}
                           legendHidden

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableHighlightsList.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableHighlightsList.tsx
@@ -1,5 +1,6 @@
 import { FormTextSearchInput } from '@common/components/form';
 import { TableHighlight } from '@common/services/tableBuilderService';
+import naturalOrderBy from '@common/utils/array/naturalOrderBy';
 import React, { cloneElement, ReactElement, ReactNode, useState } from 'react';
 
 interface Props {
@@ -10,13 +11,14 @@ interface Props {
 const TableHighlightsList = ({ highlights = [], renderLink }: Props) => {
   const [highlightSearch, setHighlightSearch] = useState('');
 
-  const filteredHighlights = highlights
-    .filter(
+  const filteredHighlights = naturalOrderBy(
+    highlights.filter(
       highlight =>
         highlight.name.toLowerCase().includes(highlightSearch) ||
         highlight.description.toLowerCase().includes(highlightSearch),
-    )
-    .sort();
+    ),
+    'name',
+  );
 
   if (!highlights.length) {
     return (

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -246,6 +246,7 @@ const TableToolWizard = ({
 
     const table = mapFullTable(tableData);
     const tableHeaders = getDefaultTableHeaderConfig(table.subjectMeta);
+
     if (onSubmit) {
       onSubmit(table);
     }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableHighlightsList.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableHighlightsList.test.tsx
@@ -14,13 +14,13 @@ describe('TableHighlightsList', () => {
     },
     {
       id: 'highlight-2',
-      name: '2 - Similar name',
-      description: '2 - Unique description',
+      name: '10 - Similar name',
+      description: '10 - Unique description',
     },
     {
       id: 'highlight-3',
-      name: '3 - Similar name',
-      description: '3 - Same description',
+      name: '2 - Similar name',
+      description: '2 - Same description',
     },
   ];
 
@@ -60,18 +60,18 @@ describe('TableHighlightsList', () => {
     const link2 = within(listItems[1]).getByRole('link', {
       name: '2 - Similar name',
     });
-
     expect(link2).toBeInTheDocument();
     expect(getDescribedBy(listItems[1], link2)).toHaveTextContent(
-      '2 - Unique description',
+      '2 - Same description',
     );
 
     const link3 = within(listItems[2]).getByRole('link', {
-      name: '3 - Similar name',
+      name: '10 - Similar name',
     });
+
     expect(link3).toBeInTheDocument();
     expect(getDescribedBy(listItems[2], link3)).toHaveTextContent(
-      '3 - Same description',
+      '10 - Unique description',
     );
   });
 
@@ -142,7 +142,7 @@ describe('TableHighlightsList', () => {
 
       expect(listItems).toHaveLength(2);
       expect(listItems[0]).toHaveTextContent('2 - Similar name');
-      expect(listItems[1]).toHaveTextContent('3 - Similar name');
+      expect(listItems[1]).toHaveTextContent('10 - Similar name');
     });
   });
 
@@ -164,30 +164,7 @@ describe('TableHighlightsList', () => {
       const listItems = screen.getAllByRole('listitem');
 
       expect(listItems).toHaveLength(1);
-      expect(listItems[0]).toHaveTextContent('2 - Unique description');
-    });
-  });
-
-  test('renders multiple results for search term on name', async () => {
-    render(
-      <TableHighlightsList
-        highlights={testHighlights}
-        renderLink={renderLink}
-      />,
-    );
-
-    await userEvent.type(screen.getByRole('textbox'), 'same description');
-
-    jest.runOnlyPendingTimers();
-
-    await waitFor(() => {
-      expect(screen.getByText(/Found 2 matching tables/)).toBeInTheDocument();
-
-      const listItems = screen.getAllByRole('listitem');
-
-      expect(listItems).toHaveLength(2);
-      expect(listItems[0]).toHaveTextContent('1 - Same description');
-      expect(listItems[1]).toHaveTextContent('3 - Same description');
+      expect(listItems[0]).toHaveTextContent('10 - Unique description');
     });
   });
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/getDefaultTableHeadersConfig.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/getDefaultTableHeadersConfig.test.ts
@@ -112,8 +112,8 @@ describe('getDefaultTableHeadersConfig', () => {
 
     expect(columnGroups).toHaveLength(1);
     expect(columnGroups[0]).toHaveLength(2);
-    expect(columnGroups[0][0].label).toBe('Barnsley');
-    expect(columnGroups[0][1].label).toBe('Barnet');
+    expect(columnGroups[0][0].label).toBe('Barnet');
+    expect(columnGroups[0][1].label).toBe('Barnsley');
 
     expect(columns).toHaveLength(2);
     expect(columns[0].label).toBe('2014/15');
@@ -121,13 +121,13 @@ describe('getDefaultTableHeadersConfig', () => {
 
     expect(rowGroups).toHaveLength(2);
     expect(rowGroups[0]).toHaveLength(2);
-    expect(rowGroups[0][0].label).toBe('Ethnicity Major Black Total');
-    expect(rowGroups[0][1].label).toBe('Ethnicity Major Asian Total');
+    expect(rowGroups[0][0].label).toBe('Ethnicity Major Asian Total');
+    expect(rowGroups[0][1].label).toBe('Ethnicity Major Black Total');
 
     expect(rowGroups[1]).toHaveLength(3);
-    expect(rowGroups[1][0].label).toBe('State-funded secondary');
-    expect(rowGroups[1][1].label).toBe('Special');
-    expect(rowGroups[1][2].label).toBe('State-funded primary');
+    expect(rowGroups[1][0].label).toBe('Special');
+    expect(rowGroups[1][1].label).toBe('State-funded primary');
+    expect(rowGroups[1][2].label).toBe('State-funded secondary');
 
     expect(rows).toHaveLength(4);
     expect(rows[0].label).toBe('Number of overall absence sessions');
@@ -241,8 +241,8 @@ describe('getDefaultTableHeadersConfig', () => {
 
     expect(columnGroups).toHaveLength(1);
     expect(columnGroups[0]).toHaveLength(2);
-    expect(columnGroups[0][0].label).toBe('Barnsley');
-    expect(columnGroups[0][1].label).toBe('Barnet');
+    expect(columnGroups[0][0].label).toBe('Barnet');
+    expect(columnGroups[0][1].label).toBe('Barnsley');
 
     expect(columns).toHaveLength(5);
     expect(columns[0].label).toBe('2014/15');
@@ -253,13 +253,13 @@ describe('getDefaultTableHeadersConfig', () => {
 
     expect(rowGroups).toHaveLength(2);
     expect(rowGroups[0]).toHaveLength(2);
-    expect(rowGroups[0][0].label).toBe('Ethnicity Major Black Total');
-    expect(rowGroups[0][1].label).toBe('Ethnicity Major Asian Total');
+    expect(rowGroups[0][0].label).toBe('Ethnicity Major Asian Total');
+    expect(rowGroups[0][1].label).toBe('Ethnicity Major Black Total');
 
     expect(rowGroups[1]).toHaveLength(3);
-    expect(rowGroups[1][0].label).toBe('State-funded secondary');
-    expect(rowGroups[1][1].label).toBe('Special');
-    expect(rowGroups[1][2].label).toBe('State-funded primary');
+    expect(rowGroups[1][0].label).toBe('Special');
+    expect(rowGroups[1][1].label).toBe('State-funded primary');
+    expect(rowGroups[1][2].label).toBe('State-funded secondary');
 
     expect(rows).toHaveLength(3);
     expect(rows[0].label).toBe('Number of overall absence sessions');
@@ -358,8 +358,8 @@ describe('getDefaultTableHeadersConfig', () => {
 
     expect(columnGroups).toHaveLength(1);
     expect(columnGroups[0]).toHaveLength(2);
-    expect(columnGroups[0][0].label).toBe('Barnsley');
-    expect(columnGroups[0][1].label).toBe('Barnet');
+    expect(columnGroups[0][0].label).toBe('Barnet');
+    expect(columnGroups[0][1].label).toBe('Barnsley');
 
     expect(columns).toHaveLength(2);
     expect(columns[0].label).toBe('2014/15');
@@ -367,12 +367,12 @@ describe('getDefaultTableHeadersConfig', () => {
 
     expect(rowGroups).toHaveLength(2);
     expect(rowGroups[0]).toHaveLength(2);
-    expect(rowGroups[0][0].label).toBe('State-funded secondary');
-    expect(rowGroups[0][1].label).toBe('Special');
+    expect(rowGroups[0][0].label).toBe('Special');
+    expect(rowGroups[0][1].label).toBe('State-funded secondary');
 
     expect(rowGroups[1]).toHaveLength(2);
-    expect(rowGroups[1][0].label).toBe('Ethnicity Major Black Total');
-    expect(rowGroups[1][1].label).toBe('Ethnicity Major Asian Total');
+    expect(rowGroups[1][0].label).toBe('Ethnicity Major Asian Total');
+    expect(rowGroups[1][1].label).toBe('Ethnicity Major Black Total');
 
     expect(rows).toHaveLength(2);
     expect(rows[0].label).toBe('Number of overall absence sessions');

--- a/src/explore-education-statistics-common/src/utils/array/__tests__/naturalOrderBy.test.ts
+++ b/src/explore-education-statistics-common/src/utils/array/__tests__/naturalOrderBy.test.ts
@@ -1,0 +1,624 @@
+import naturalOrderBy from '@common/utils/array/naturalOrderBy';
+
+describe('naturalOrderBy', () => {
+  describe('single string key', () => {
+    const items = [
+      { firstName: 'John' },
+      { firstName: 'Aaron' },
+      { firstName: 'Robert' },
+      { firstName: 'Mel' },
+    ];
+
+    test('orders items in ascending order', () => {
+      const expected = [
+        { firstName: 'Aaron' },
+        { firstName: 'John' },
+        { firstName: 'Mel' },
+        { firstName: 'Robert' },
+      ];
+
+      expect(naturalOrderBy(items, ['firstName'], ['asc'])).toEqual(expected);
+      expect(naturalOrderBy(items, 'firstName', 'asc')).toEqual(expected);
+      expect(naturalOrderBy(items, [item => item.firstName], 'asc')).toEqual(
+        expected,
+      );
+      expect(naturalOrderBy(items, item => item.firstName, 'asc')).toEqual(
+        expected,
+      );
+    });
+
+    test('orders items in ascending order by default', () => {
+      const expected = [
+        { firstName: 'Aaron' },
+        { firstName: 'John' },
+        { firstName: 'Mel' },
+        { firstName: 'Robert' },
+      ];
+
+      expect(naturalOrderBy(items, ['firstName'])).toEqual(expected);
+      expect(naturalOrderBy(items, 'firstName')).toEqual(expected);
+
+      expect(naturalOrderBy(items, [item => item.firstName])).toEqual(expected);
+      expect(naturalOrderBy(items, item => item.firstName)).toEqual(expected);
+    });
+
+    test('orders items in descending order', () => {
+      const expected = [
+        { firstName: 'Robert' },
+        { firstName: 'Mel' },
+        { firstName: 'John' },
+        { firstName: 'Aaron' },
+      ];
+
+      expect(naturalOrderBy(items, ['firstName'], ['desc'])).toEqual(expected);
+      expect(naturalOrderBy(items, 'firstName', 'desc')).toEqual(expected);
+
+      expect(naturalOrderBy(items, [item => item.firstName], ['desc'])).toEqual(
+        expected,
+      );
+      expect(naturalOrderBy(items, item => item.firstName, 'desc')).toEqual(
+        expected,
+      );
+    });
+  });
+
+  describe('multiple string keys', () => {
+    const items = [
+      { firstName: 'John', lastName: 'Smith' },
+      { firstName: 'Mel', lastName: 'Gibbs' },
+      { firstName: 'John', lastName: 'Acre' },
+      { firstName: 'Aaron', lastName: 'White' },
+    ];
+
+    test('orders items in ascending order', () => {
+      const expected = [
+        { firstName: 'Aaron', lastName: 'White' },
+        { firstName: 'John', lastName: 'Acre' },
+        { firstName: 'John', lastName: 'Smith' },
+        { firstName: 'Mel', lastName: 'Gibbs' },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['firstName', 'lastName'], ['asc', 'asc']),
+      ).toEqual(expected);
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.firstName, item => item.lastName],
+          ['asc', 'asc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in ascending order by default', () => {
+      const expected = [
+        { firstName: 'Aaron', lastName: 'White' },
+        { firstName: 'John', lastName: 'Acre' },
+        { firstName: 'John', lastName: 'Smith' },
+        { firstName: 'Mel', lastName: 'Gibbs' },
+      ];
+
+      expect(naturalOrderBy(items, ['firstName', 'lastName'])).toEqual(
+        expected,
+      );
+      expect(naturalOrderBy(items, ['firstName', 'lastName'], ['asc'])).toEqual(
+        expected,
+      );
+
+      expect(
+        naturalOrderBy(items, [item => item.firstName, item => item.lastName]),
+      ).toEqual(expected);
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.firstName, item => item.lastName],
+          ['asc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in descending order', () => {
+      const expected = [
+        { firstName: 'Mel', lastName: 'Gibbs' },
+        { firstName: 'John', lastName: 'Smith' },
+        { firstName: 'John', lastName: 'Acre' },
+        { firstName: 'Aaron', lastName: 'White' },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['firstName', 'lastName'], ['desc', 'desc']),
+      ).toEqual(expected);
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.firstName, item => item.lastName],
+          ['desc', 'desc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in descending order and tie-breaks in ascending order by default', () => {
+      const expected = [
+        { firstName: 'Mel', lastName: 'Gibbs' },
+        { firstName: 'John', lastName: 'Acre' },
+        { firstName: 'John', lastName: 'Smith' },
+        { firstName: 'Aaron', lastName: 'White' },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['firstName', 'lastName'], ['desc']),
+      ).toEqual(expected);
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.firstName, item => item.lastName],
+          ['desc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in ascending order and tie-breaks in descending order', () => {
+      const expected = [
+        { firstName: 'Aaron', lastName: 'White' },
+        { firstName: 'John', lastName: 'Smith' },
+        { firstName: 'John', lastName: 'Acre' },
+        { firstName: 'Mel', lastName: 'Gibbs' },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['firstName', 'lastName'], ['asc', 'desc']),
+      ).toEqual(expected);
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.firstName, item => item.lastName],
+          ['asc', 'desc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in descending order and tie-breaks in ascending order', () => {
+      const expected = [
+        { firstName: 'Mel', lastName: 'Gibbs' },
+        { firstName: 'John', lastName: 'Acre' },
+        { firstName: 'John', lastName: 'Smith' },
+        { firstName: 'Aaron', lastName: 'White' },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['firstName', 'lastName'], ['desc', 'asc']),
+      ).toEqual(expected);
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.firstName, item => item.lastName],
+          ['desc', 'asc'],
+        ),
+      ).toEqual(expected);
+    });
+  });
+
+  describe('single number key', () => {
+    const items = [{ number: 4 }, { number: 3 }, { number: 1 }, { number: 2 }];
+
+    test('orders items by key in ascending order', () => {
+      const expected = [
+        { number: 1 },
+        { number: 2 },
+        { number: 3 },
+        { number: 4 },
+      ];
+
+      expect(naturalOrderBy(items, ['number'], ['asc'])).toEqual(expected);
+      expect(naturalOrderBy(items, 'number', 'asc')).toEqual(expected);
+
+      expect(naturalOrderBy(items, [item => item.number], ['asc'])).toEqual(
+        expected,
+      );
+      expect(naturalOrderBy(items, item => item.number, 'asc')).toEqual(
+        expected,
+      );
+    });
+
+    test('orders items by key in descending order', () => {
+      const expected = [
+        { number: 4 },
+        { number: 3 },
+        { number: 2 },
+        { number: 1 },
+      ];
+
+      expect(naturalOrderBy(items, ['number'], ['desc'])).toEqual(expected);
+      expect(naturalOrderBy(items, 'number', 'desc')).toEqual(expected);
+
+      expect(naturalOrderBy(items, [item => item.number], ['desc'])).toEqual(
+        expected,
+      );
+      expect(naturalOrderBy(items, item => item.number, 'desc')).toEqual(
+        expected,
+      );
+    });
+  });
+
+  describe('multiple number keys', () => {
+    const items = [
+      { number: 4, other: 1 },
+      { number: 2, other: 4 },
+      { number: 1, other: 2 },
+      { number: 2, other: 3 },
+    ];
+
+    test('orders items in ascending order', () => {
+      const expected = [
+        { number: 1, other: 2 },
+        { number: 2, other: 3 },
+        { number: 2, other: 4 },
+        { number: 4, other: 1 },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['number', 'other'], ['asc', 'asc']),
+      ).toEqual(expected);
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.number, item => item.other],
+          ['asc', 'asc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in ascending order by default', () => {
+      const expected = [
+        { number: 1, other: 2 },
+        { number: 2, other: 3 },
+        { number: 2, other: 4 },
+        { number: 4, other: 1 },
+      ];
+
+      expect(naturalOrderBy(items, ['number', 'other'])).toEqual(expected);
+      expect(naturalOrderBy(items, ['number', 'other'], ['asc'])).toEqual(
+        expected,
+      );
+
+      expect(
+        naturalOrderBy(items, [item => item.number, item => item.other]),
+      ).toEqual(expected);
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.number, item => item.other],
+          ['asc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in descending order', () => {
+      const expected = [
+        { number: 4, other: 1 },
+        { number: 2, other: 4 },
+        { number: 2, other: 3 },
+        { number: 1, other: 2 },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['number', 'other'], ['desc', 'desc']),
+      ).toEqual(expected);
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.number, item => item.other],
+          ['desc', 'desc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in descending order and tie-breaks in ascending order by default', () => {
+      const expected = [
+        { number: 4, other: 1 },
+        { number: 2, other: 3 },
+        { number: 2, other: 4 },
+        { number: 1, other: 2 },
+      ];
+
+      expect(naturalOrderBy(items, ['number', 'other'], ['desc'])).toEqual(
+        expected,
+      );
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.number, item => item.other],
+          ['desc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in ascending order and tie-breaks in descending order', () => {
+      const expected = [
+        { number: 1, other: 2 },
+        { number: 2, other: 4 },
+        { number: 2, other: 3 },
+        { number: 4, other: 1 },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['number', 'other'], ['asc', 'desc']),
+      ).toEqual(expected);
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.number, item => item.other],
+          ['asc', 'desc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in descending order and tie-breaks in ascending order', () => {
+      const expected = [
+        { number: 4, other: 1 },
+        { number: 2, other: 3 },
+        { number: 2, other: 4 },
+        { number: 1, other: 2 },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['number', 'other'], ['desc', 'asc']),
+      ).toEqual(expected);
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.number, item => item.other],
+          ['desc', 'asc'],
+        ),
+      ).toEqual(expected);
+    });
+  });
+
+  describe('mixed keys', () => {
+    const items = [
+      { number: 4, firstName: 'Laura' },
+      { number: 2, firstName: 'Michelle' },
+      { number: 1, firstName: 'Robert' },
+      { number: 2, firstName: 'Aaron' },
+    ];
+
+    test('orders items in ascending order', () => {
+      const expected = [
+        { number: 1, firstName: 'Robert' },
+        { number: 2, firstName: 'Aaron' },
+        { number: 2, firstName: 'Michelle' },
+        { number: 4, firstName: 'Laura' },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['number', 'firstName'], ['asc', 'asc']),
+      ).toEqual(expected);
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.number, item => item.firstName],
+          ['asc', 'asc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in ascending order by default', () => {
+      const expected = [
+        { number: 1, firstName: 'Robert' },
+        { number: 2, firstName: 'Aaron' },
+        { number: 2, firstName: 'Michelle' },
+        { number: 4, firstName: 'Laura' },
+      ];
+
+      expect(naturalOrderBy(items, ['number', 'firstName'])).toEqual(expected);
+      expect(naturalOrderBy(items, ['number', 'firstName'], ['asc'])).toEqual(
+        expected,
+      );
+
+      expect(
+        naturalOrderBy(items, [item => item.number, item => item.firstName]),
+      ).toEqual(expected);
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.number, item => item.firstName],
+          ['asc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in descending order', () => {
+      const expected = [
+        { number: 4, firstName: 'Laura' },
+        { number: 2, firstName: 'Michelle' },
+        { number: 2, firstName: 'Aaron' },
+        { number: 1, firstName: 'Robert' },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['number', 'firstName'], ['desc', 'desc']),
+      ).toEqual(expected);
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.number, item => item.firstName],
+          ['desc', 'desc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in descending order and tie-breaks in ascending order by default', () => {
+      const expected = [
+        { number: 4, firstName: 'Laura' },
+        { number: 2, firstName: 'Aaron' },
+        { number: 2, firstName: 'Michelle' },
+        { number: 1, firstName: 'Robert' },
+      ];
+
+      expect(naturalOrderBy(items, ['number', 'firstName'], ['desc'])).toEqual(
+        expected,
+      );
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.number, item => item.firstName],
+          ['desc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in ascending order and tie-breaks in descending order', () => {
+      const expected = [
+        { number: 1, firstName: 'Robert' },
+        { number: 2, firstName: 'Michelle' },
+        { number: 2, firstName: 'Aaron' },
+        { number: 4, firstName: 'Laura' },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['number', 'firstName'], ['asc', 'desc']),
+      ).toEqual(expected);
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.number, item => item.firstName],
+          ['asc', 'desc'],
+        ),
+      ).toEqual(expected);
+    });
+
+    test('orders items in descending order and tie-breaks in ascending order', () => {
+      const expected = [
+        { number: 4, firstName: 'Laura' },
+        { number: 2, firstName: 'Aaron' },
+        { number: 2, firstName: 'Michelle' },
+        { number: 1, firstName: 'Robert' },
+      ];
+
+      expect(
+        naturalOrderBy(items, ['number', 'firstName'], ['desc', 'asc']),
+      ).toEqual(expected);
+
+      expect(
+        naturalOrderBy(
+          items,
+          [item => item.number, item => item.firstName],
+          ['desc', 'asc'],
+        ),
+      ).toEqual(expected);
+    });
+  });
+
+  describe('specific cases', () => {
+    test('returns empty array if no items', () => {
+      expect(naturalOrderBy([], [])).toEqual([]);
+    });
+
+    test('does not order items if no keys are provided', () => {
+      const items = [
+        { firstName: 'John' },
+        { firstName: 'Aaron' },
+        { firstName: 'Robert' },
+        { firstName: 'Mel' },
+      ];
+
+      expect(naturalOrderBy(items, [])).toEqual(items);
+    });
+
+    test('orders items with random strings in natural order', () => {
+      const items = [
+        { value: '12345asd' },
+        { value: '123asd' },
+        { value: '19asd' },
+        { value: 'asd12' },
+        { value: 'asd123' },
+      ];
+
+      const expected = [
+        { value: '19asd' },
+        { value: '123asd' },
+        { value: '12345asd' },
+        { value: 'asd12' },
+        { value: 'asd123' },
+      ];
+
+      expect(naturalOrderBy(items, ['value'])).toEqual(expected);
+    });
+
+    test('orders items with dates in natural order', () => {
+      const items = [
+        { value: '10/10/12' },
+        { value: '1/10/12' },
+        { value: '01/10/12' },
+        { value: '11/10/12' },
+      ];
+
+      const expected = [
+        { value: '1/10/12' },
+        { value: '01/10/12' },
+        { value: '10/10/12' },
+        { value: '11/10/12' },
+      ];
+
+      expect(naturalOrderBy(items, ['value'])).toEqual(expected);
+    });
+
+    test('orders items with variety of strings in natural order', () => {
+      const items = [
+        { value: '3rd' },
+        { value: 'Apple' },
+        { value: '24th' },
+        { value: '99 in the shade' },
+        { value: 'Dec' },
+        { value: '10000' },
+        { value: '101' },
+        { value: '$1.23' },
+      ];
+
+      const expected = [
+        { value: '$1.23' },
+        { value: '3rd' },
+        { value: '24th' },
+        { value: '99 in the shade' },
+        { value: '101' },
+        { value: '10000' },
+        { value: 'Apple' },
+        { value: 'Dec' },
+      ];
+
+      expect(naturalOrderBy(items, ['value'])).toEqual(expected);
+    });
+
+    test('does not order items with invalid values', () => {
+      const items = [
+        { value: false },
+        { value: true },
+        { value: undefined },
+        { value: null },
+        { value: {} },
+        {
+          value: {
+            something: 'else',
+          },
+        },
+        { value: [] },
+        { value: ['test'] },
+      ];
+
+      expect(naturalOrderBy(items, ['value'] as never)).toEqual(items);
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/utils/array/naturalOrderBy.ts
+++ b/src/explore-education-statistics-common/src/utils/array/naturalOrderBy.ts
@@ -1,0 +1,67 @@
+import { KeysWithType } from '@common/types';
+
+const collator = new Intl.Collator('en', {
+  numeric: true,
+  ignorePunctuation: true,
+});
+
+export const naturalComparator = collator.compare;
+
+type Key<T> = KeysWithType<T, string | number>;
+type CustomKey<T> = (item: T) => string | number;
+
+export type OrderKeys<T> = Key<T> | CustomKey<T> | (Key<T> | CustomKey<T>)[];
+
+export type OrderDirection = 'asc' | 'desc';
+
+type Criteria<T> = (item: T) => string;
+
+/**
+ * Naturally order some {@param items} using a set of {@param keys}
+ * matched to specific ordering {@param directions}.
+ *
+ * This should be used in preference to {@see orderBy} for
+ * user-facing data as the ordering is usually more natural to humans.
+ *
+ * Defaults to ordering in ascending order when no direction(s) specified.
+ */
+export default function naturalOrderBy<T>(
+  items: T[],
+  keys: OrderKeys<T>,
+  directions: OrderDirection | OrderDirection[] = [],
+): T[] {
+  const keysArray = Array.isArray(keys) ? keys : [keys];
+  const directionsArray = Array.isArray(directions) ? directions : [directions];
+
+  const criterias: Criteria<T>[] = keysArray.map(key => {
+    return item => {
+      const value = typeof key === 'function' ? key(item) : item[key];
+
+      const isComparable =
+        typeof value === 'string' || typeof value === 'number';
+
+      // Make incomparable values empty strings
+      // so that we don't order them.
+      return isComparable ? `${value}` : '';
+    };
+  });
+
+  return [...(items ?? [])].sort((x, y) => {
+    let index = 0;
+    const lastIndex = criterias.length - 1;
+
+    while (index <= lastIndex) {
+      const criteria = criterias[index];
+      const comparison = naturalComparator(criteria(x), criteria(y));
+
+      if (comparison !== 0) {
+        const direction = directionsArray[index] ?? 'asc';
+        return comparison * (direction === 'asc' ? 1 : -1);
+      }
+
+      index += 1;
+    }
+
+    return 0;
+  });
+}


### PR DESCRIPTION
This PR adds improved sorting for:

- Table tool checkboxes
- Table tool table headers
- Chart axis labels

We have implemented this via a new `naturalOrderBy` function. It roughly mimics `lodash/orderBy` and should replace it in cases where we display sorted information to the user. 

It's still fine to use `orderBy`, but `naturalOrderBy` does a much better job of sorting items on string properties that contain numeric information e.g. dates, or numbers in general.