### PR TITLE
EES-1610 Auto-generate form field ids using field names

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/Comments.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/Comments.tsx
@@ -122,7 +122,6 @@ const Comments = ({
               <FormFieldTextArea<FormValues>
                 label="Comment"
                 name="content"
-                id={`${blockId}-addCommentForm-content`}
                 rows={3}
               />
 

--- a/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableKeyStat.tsx
@@ -106,7 +106,6 @@ const EditableKeyStat = ({
                 value={keyStat.value}
               >
                 <FormFieldTextInput<KeyStatsFormValues>
-                  id={`${formId}-dataSummary`}
                   name="dataSummary"
                   label={<span className={styles.trendText}>Trend</span>}
                 />
@@ -114,7 +113,6 @@ const EditableKeyStat = ({
 
               <FormFieldTextInput<KeyStatsFormValues>
                 formGroupClass="govuk-!-margin-top-2"
-                id={`${formId}-dataDefinitionTitle`}
                 name="dataDefinitionTitle"
                 label="Guidance title"
               />
@@ -122,7 +120,6 @@ const EditableKeyStat = ({
               <FormFieldEditor<KeyStatsFormValues>
                 name="dataDefinition"
                 toolbarConfig={toolbarConfigs.simple}
-                id={`${formId}-dataDefinition`}
                 label="Guidance text"
               />
 

--- a/src/explore-education-statistics-admin/src/components/form/FormFieldEditor.tsx
+++ b/src/explore-education-statistics-admin/src/components/form/FormFieldEditor.tsx
@@ -1,4 +1,5 @@
 import FormEditor, { FormEditorProps } from '@admin/components/form/FormEditor';
+import { useFormContext } from '@common/components/form/contexts/FormContext';
 import FormGroup from '@common/components/form/FormGroup';
 import { OmitStrict } from '@common/types';
 import createErrorHelper from '@common/validation/createErrorHelper';
@@ -6,20 +7,24 @@ import { Field, FieldProps } from 'formik';
 import React from 'react';
 
 type Props<FormValues> = {
+  id?: string;
   name: keyof FormValues | string;
   showError?: boolean;
   formGroupClass?: string;
   testId?: string;
-} & OmitStrict<FormEditorProps, 'value' | 'onChange'>;
+} & OmitStrict<FormEditorProps, 'id' | 'value' | 'onChange'>;
 
 function FormFieldEditor<T>({
   error,
+  id,
   name,
   showError = true,
   formGroupClass,
   testId,
   ...props
 }: Props<T>) {
+  const { prefixFormId, fieldId } = useFormContext();
+
   return (
     <Field name={name}>
       {({ field, form }: FieldProps) => {
@@ -37,6 +42,7 @@ function FormFieldEditor<T>({
               testId={testId}
               {...props}
               {...field}
+              id={id ? prefixFormId(id) : fieldId(name as string)}
               onBlur={() => {
                 form.setFieldTouched(name as string, true);
               }}

--- a/src/explore-education-statistics-admin/src/pages/legacy-releases/components/LegacyReleaseForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/legacy-releases/components/LegacyReleaseForm.tsx
@@ -50,14 +50,12 @@ const LegacyReleaseForm = ({
         <Form id={formId}>
           <FormFieldTextInput<FormValues>
             name="description"
-            id={`${formId}-description`}
             label="Description"
             className="govuk-!-width-two-thirds"
           />
 
           <FormFieldTextInput<FormValues>
             name="url"
-            id={`${formId}-url`}
             label="URL"
             className="govuk-!-width-two-thirds"
           />
@@ -65,7 +63,6 @@ const LegacyReleaseForm = ({
           {typeof initialValues?.order !== 'undefined' && (
             <FormFieldNumberInput<FormValues>
               name="order"
-              id={`${formId}-order`}
               label="Order"
               width={2}
             />

--- a/src/explore-education-statistics-admin/src/pages/methodology/components/MethodologySummaryForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/components/MethodologySummaryForm.tsx
@@ -83,14 +83,12 @@ const MethodologySummaryForm = ({
         return (
           <Form id={id}>
             <FormFieldTextInput<MethodologySummaryFormValues>
-              id={`${id}-title`}
               label="Enter methodology title"
               name="title"
             />
 
             {isContactEnabled && (
               <FormFieldSelect<MethodologySummaryFormValues>
-                id={`${id}-contactId`}
                 hint="They will be the main point of contact for this methodology and its associated publications."
                 label="Choose the contact for this methodology"
                 name="contactId"

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -140,7 +140,6 @@ const MethodologyStatusPage = ({
                           'Once approved, changes will be available to the public immediately.'
                         }
                         name="status"
-                        id={`${formId}-status`}
                         options={[
                           {
                             label: 'In draft',
@@ -153,7 +152,6 @@ const MethodologyStatusPage = ({
                               <FormFieldTextArea<FormValues>
                                 name="internalReleaseNote"
                                 className="govuk-!-width-one-half"
-                                id={`${formId}-internalReleaseNote`}
                                 label="Internal release note"
                                 rows={2}
                               />

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
@@ -193,7 +193,6 @@ const PublicationForm = ({
       {form => (
         <Form id={id}>
           <FormFieldTextInput<FormValues>
-            id={`${id}-title`}
             label="Publication title"
             name="title"
             className="govuk-!-width-two-thirds"
@@ -210,7 +209,6 @@ const PublicationForm = ({
           )}
 
           <FormFieldRadioGroup<FormValues, FormValues['methodologyChoice']>
-            id={`${id}-methodologyChoice`}
             legend="Choose a methodology for this publication"
             legendSize="m"
             name="methodologyChoice"
@@ -220,7 +218,6 @@ const PublicationForm = ({
                 label: 'Choose an existing methodology',
                 conditional: (
                   <FormFieldSelect<FormValues>
-                    id={`${id}-methodologyId`}
                     name="methodologyId"
                     label="Select methodology"
                     placeholder="Choose a methodology"
@@ -244,13 +241,11 @@ const PublicationForm = ({
                   <FormGroup>
                     <FormFieldTextInput
                       label="Link title"
-                      id={`${id}-externalMethodologyTitle`}
                       name="externalMethodology.title"
                       className="govuk-!-width-two-thirds"
                     />
                     <FormFieldTextInput
                       label="URL"
-                      id={`${id}-externalMethodologyUrl`}
                       name="externalMethodology.url"
                       className="govuk-!-width-two-thirds"
                     />
@@ -297,35 +292,31 @@ const PublicationForm = ({
             }}
           />
           <FormFieldset
-            id={`${id}-contact`}
+            id="contact"
             legend="Contact for this publication"
             legendSize="m"
             hint="They will be the main point of contact for data and methodology enquiries for this publication and its releases."
           >
             <FormFieldTextInput<FormValues>
               name="teamName"
-              id={`${id}-teamName`}
               label="Team name"
               className="govuk-!-width-one-half"
             />
 
             <FormFieldTextInput<FormValues>
               name="teamEmail"
-              id={`${id}-teamEmail`}
               label="Team email address"
               className="govuk-!-width-one-half"
             />
 
             <FormFieldTextInput<FormValues>
               name="contactName"
-              id={`${id}-contactName`}
               label="Contact name"
               className="govuk-!-width-one-half"
             />
 
             <FormFieldTextInput<FormValues>
               name="contactTelNo"
-              id={`${id}-contactTelNo`}
               label="Contact telephone number"
               width={10}
             />

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/PublicationForm.test.tsx
@@ -223,7 +223,7 @@ describe('PublicationForm', () => {
     await waitFor(() => {
       expect(
         screen.getByText('Enter an external methodology link title', {
-          selector: '#publicationForm-externalMethodologyTitle-error',
+          selector: '#publicationForm-externalMethodology-title-error',
         }),
       ).toBeInTheDocument();
     });
@@ -248,7 +248,7 @@ describe('PublicationForm', () => {
     await waitFor(() => {
       expect(
         screen.getByText('Enter an external methodology URL', {
-          selector: '#publicationForm-externalMethodologyUrl-error',
+          selector: '#publicationForm-externalMethodology-url-error',
         }),
       ).toBeInTheDocument();
     });
@@ -273,7 +273,7 @@ describe('PublicationForm', () => {
     await waitFor(() => {
       expect(
         screen.getByText('Enter a valid external methodology URL', {
-          selector: '#publicationForm-externalMethodologyUrl-error',
+          selector: '#publicationForm-externalMethodology-url-error',
         }),
       ).toBeInTheDocument();
     });

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -160,7 +160,6 @@ const ReleaseStatusForm = ({
           <FormFieldRadioGroup<ReleaseStatusFormValues>
             legend="Status"
             name="status"
-            id={`${formId}-status`}
             order={[]}
             options={[
               {
@@ -184,14 +183,12 @@ const ReleaseStatusForm = ({
           <FormFieldTextArea<ReleaseStatusFormValues>
             name="internalReleaseNote"
             className="govuk-!-width-one-half"
-            id={`${formId}-internalReleaseNote`}
             label="Internal release note"
             rows={3}
           />
 
           {form.values.status === 'Approved' && (
             <FormFieldRadioGroup<ReleaseStatusFormValues>
-              id={`${formId}-publishMethod`}
               name="publishMethod"
               legend="When to publish"
               legendSize="m"
@@ -203,7 +200,6 @@ const ReleaseStatusForm = ({
                   value: 'Scheduled',
                   conditional: (
                     <FormFieldDateInput<ReleaseStatusFormValues>
-                      id={`${formId}-publishScheduled`}
                       name="publishScheduled"
                       legend="Publish date"
                       legendSize="s"
@@ -226,7 +222,6 @@ const ReleaseStatusForm = ({
           )}
 
           <FormFieldDateInput<ReleaseStatusFormValues>
-            id={`${formId}-nextReleaseDate`}
             name="nextReleaseDate"
             legend="Next release expected (optional)"
             legendSize="m"

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseSummaryForm.tsx
@@ -125,18 +125,16 @@ const ReleaseSummaryForm = <
         return (
           <Form id={formId}>
             <FormFieldset
-              id={`${formId}-timePeriodCoverageFieldset`}
+              id="timePeriodCoverage"
               legend="Select time period coverage"
               legendSize="m"
             >
               <FormFieldSelect<ReleaseSummaryFormValues>
-                id={`${formId}-timePeriodCoverage`}
                 label="Type"
                 name="timePeriodCoverageCode"
                 optGroups={timePeriodOptions}
               />
               <FormFieldNumberInput<ReleaseSummaryFormValues>
-                id={`${formId}-timePeriodCoverageStartYear`}
                 name="timePeriodCoverageStartYear"
                 label={`
                       ${
@@ -156,7 +154,6 @@ const ReleaseSummaryForm = <
             </FormFieldset>
 
             <FormFieldRadioGroup<ReleaseSummaryFormValues>
-              id={`${formId}-releaseTypeId`}
               legend="Release Type"
               name="releaseTypeId"
               options={releaseTypes.map(type => ({

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/RelatedInformationSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/RelatedInformationSection.tsx
@@ -62,18 +62,14 @@ const RelatedInformationSection = ({ release }: Props) => {
       >
         {form => {
           return (
-            <Form {...form} id="create-new-link-form">
+            <Form {...form} id="relatedInformationForm">
               <FormFieldset
-                id="allFieldsFieldset"
+                id="relatedLink"
                 legend="Add related information"
                 legendSize="m"
               >
-                <FormFieldTextInput
-                  id="title"
-                  label="Title"
-                  name="description"
-                />
-                <FormFieldTextInput id="link-url" label="Link url" name="url" />
+                <FormFieldTextInput label="Title" name="description" />
+                <FormFieldTextInput label="Link url" name="url" />
               </FormFieldset>
               <Button
                 type="submit"

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNotesSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseNotesSection.tsx
@@ -105,7 +105,6 @@ const ReleaseNotesSection = ({ release }: Props) => {
           return (
             <Form id={formId}>
               <FormFieldTextArea<CreateFormValues>
-                id={`${formId}-reason`}
                 label="New release note"
                 name="reason"
                 rows={3}
@@ -162,13 +161,11 @@ const ReleaseNotesSection = ({ release }: Props) => {
           return (
             <Form id={formId}>
               <FormFieldDateInput<EditFormValues>
-                id={`${formId}-on`}
                 name="on"
                 legend="Edit date"
                 legendSize="s"
               />
               <FormFieldTextArea<EditFormValues>
-                id={`${formId}-reason`}
                 label="Edit release note"
                 name="reason"
                 rows={3}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -177,7 +177,6 @@ const DataFileUploadForm = <FormValues extends DataFileUploadFormValues>({
               {beforeFields}
 
               <FormFieldRadioGroup<DataFileUploadFormValues>
-                id={`${id}-uploadType`}
                 name="uploadType"
                 legend="Choose upload method"
                 options={[
@@ -187,14 +186,12 @@ const DataFileUploadForm = <FormValues extends DataFileUploadFormValues>({
                     conditional: (
                       <>
                         <FormFieldFileInput<DataFileUploadFormValues>
-                          id={`${id}-dataFile`}
                           name="dataFile"
                           label="Upload data file"
                           accept=".csv"
                         />
 
                         <FormFieldFileInput<DataFileUploadFormValues>
-                          id={`${id}-metadataFile`}
                           name="metadataFile"
                           label="Upload metadata file"
                           accept=".csv"
@@ -208,7 +205,6 @@ const DataFileUploadForm = <FormValues extends DataFileUploadFormValues>({
                     value: 'zip',
                     conditional: (
                       <FormFieldFileInput<DataFileUploadFormValues>
-                        id={`${id}-zipFile`}
                         hint="Must contain both the data and metadata CSV files"
                         name="zipFile"
                         label="Upload ZIP file"

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -224,7 +224,6 @@ const ReleaseDataUploadsSection = ({
           }
           beforeFields={
             <FormFieldTextInput<FormValues>
-              id={`${formId}-subjectTitle`}
               name="subjectTitle"
               label="Subject title"
               width={20}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -162,14 +162,12 @@ const ReleaseFileUploadsSection = ({ releaseId, canUpdateRelease }: Props) => {
                   )}
 
                   <FormFieldTextInput<FormValues>
-                    id={`${formId}-name`}
                     name="name"
                     label="Name"
                     width={20}
                   />
 
                   <FormFieldFileInput<FormValues>
-                    id={`${formId}-file`}
                     name="file"
                     label="Upload file"
                   />

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseMetaGuidanceSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseMetaGuidanceSection.tsx
@@ -145,7 +145,6 @@ const ReleaseMetaGuidanceSection = ({ releaseId, canUpdateRelease }: Props) => {
                     <Form id={formId}>
                       {isEditing ? (
                         <FormFieldEditor<MetaGuidanceFormValues>
-                          id={`${formId}-content`}
                           name="content"
                           label="Main guidance content"
                         />
@@ -184,7 +183,6 @@ const ReleaseMetaGuidanceSection = ({ releaseId, canUpdateRelease }: Props) => {
                                     isEditing ? (
                                       <FormFieldEditor<MetaGuidanceFormValues>
                                         toolbarConfig={toolbarConfigs.simple}
-                                        id={`${formId}-subjects${index}Content`}
                                         name={`subjects[${index}].content`}
                                         label="File guidance content"
                                         testId="fileGuidanceContent"

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseMetaGuidanceSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseMetaGuidanceSection.test.tsx
@@ -434,7 +434,7 @@ describe('ReleaseMetaGuidanceSection', () => {
 
         expect(fileGuidanceContent).toHaveAttribute(
           'id',
-          'metaGuidanceForm-subjects0Content',
+          'metaGuidanceForm-subjects-0-content',
         );
       });
     });

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDetailsForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockDetailsForm.tsx
@@ -83,7 +83,6 @@ const DataBlockDetailsForm = ({
 
             <FormGroup>
               <FormFieldTextInput<FormValues>
-                id={`${formId}-name`}
                 name="name"
                 label="Name"
                 hint="Name of the data block. This will not be visible to users."
@@ -91,7 +90,6 @@ const DataBlockDetailsForm = ({
               />
 
               <FormFieldTextArea<FormValues>
-                id={`${formId}-heading`}
                 name="heading"
                 className="govuk-!-width-two-thirds"
                 label="Table title"
@@ -103,7 +101,6 @@ const DataBlockDetailsForm = ({
               />
 
               <FormFieldTextInput<FormValues>
-                id={`${formId}-source`}
                 name="source"
                 label="Source"
                 hint="The data source used to create this data."
@@ -111,27 +108,24 @@ const DataBlockDetailsForm = ({
               />
 
               <FormFieldset
-                id={`${formId}-highlight`}
+                id="highlight"
                 legend="Would you like to make this a table highlight?"
                 legendSize="s"
                 hint="Checking this option will make this table available as a popular table when the publication is selected via the table builder"
               >
                 <FormFieldCheckbox<FormValues>
                   name="isHighlight"
-                  id={`${formId}-isHighlight`}
                   label="Set as a table highlight for this publication"
                   conditional={
                     <>
                       <FormFieldTextInput<FormValues>
                         name="highlightName"
-                        id={`${formId}-highlightName`}
                         label="Highlight name"
                         hint="We will show this name to table builder users as a popular table"
                         className="govuk-!-width-two-thirds"
                       />
                       <FormFieldTextArea<FormValues>
                         name="highlightDescription"
-                        id={`${formId}-highlightDescription`}
                         label="Highlight description"
                         hint="Describe the contents of this highlight to table builder users"
                         className="govuk-!-width-two-thirds"

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
@@ -322,14 +322,9 @@ const ChartAxisConfiguration = ({
 
           <div className="govuk-grid-row">
             <div className="govuk-grid-column-one-half govuk-!-margin-bottom-6">
-              <FormFieldset
-                id={`${id}-general`}
-                legend="General"
-                legendSize="s"
-              >
+              <FormFieldset id="general" legend="General" legendSize="s">
                 {validationSchema.fields.size && (
                   <FormFieldNumberInput<AxisConfiguration>
-                    id={`${id}-size`}
                     name="size"
                     min={0}
                     label="Size of axis (px)"
@@ -339,7 +334,6 @@ const ChartAxisConfiguration = ({
 
                 {validationSchema.fields.groupBy && (
                   <FormFieldSelect<AxisConfiguration>
-                    id={`${id}-groupBy`}
                     label="Group data by"
                     name="groupBy"
                     options={groupByOptions}
@@ -348,7 +342,6 @@ const ChartAxisConfiguration = ({
 
                 {validationSchema.fields.showGrid && (
                   <FormFieldCheckbox<AxisConfiguration>
-                    id={`${id}-showGrid`}
                     name="showGrid"
                     label="Show grid lines"
                   />
@@ -356,13 +349,11 @@ const ChartAxisConfiguration = ({
 
                 {validationSchema.fields.visible && (
                   <FormFieldCheckbox<AxisConfiguration>
-                    id={`${id}-visible`}
                     name="visible"
                     label="Show axis"
                     conditional={
                       <>
                         <FormFieldTextInput<AxisConfiguration>
-                          id={`${id}-unit`}
                           label="Displayed unit"
                           name="unit"
                           hint="Leave blank to set default from metadata"
@@ -373,15 +364,10 @@ const ChartAxisConfiguration = ({
                   />
                 )}
 
-                <FormFieldset id={`${id}-axis`} legend="Labels" legendSize="s">
-                  <FormFieldTextInput
-                    id={`${id}-label-text`}
-                    label="Label"
-                    name="label.text"
-                  />
+                <FormFieldset id="labels" legend="Labels" legendSize="s">
+                  <FormFieldTextInput label="Label" name="label.text" />
 
                   <FormFieldNumberInput
-                    id={`${id}-label-width`}
                     label="Width (px)"
                     name="label.width"
                     width={5}
@@ -391,7 +377,6 @@ const ChartAxisConfiguration = ({
                   {(validationSchema.fields.label as ObjectSchema<Label>).fields
                     .rotated && (
                     <FormFieldCheckbox
-                      id={`${id}-label-rotated`}
                       name="label.rotated"
                       label="Rotate 90 degrees"
                     />
@@ -402,7 +387,7 @@ const ChartAxisConfiguration = ({
 
             <div className="govuk-grid-column-one-half govuk-!-margin-bottom-6">
               {validationSchema.fields.sortAsc && (
-                <FormFieldset id={`${id}-sort`} legend="Sorting" legendSize="s">
+                <FormFieldset id="sort" legend="Sorting" legendSize="s">
                   {/* <FormFieldSelect<AxisConfiguration>*/}
                   {/*  id={`${id}-sortBy`}*/}
                   {/*  name="sortBy"*/}
@@ -410,7 +395,6 @@ const ChartAxisConfiguration = ({
                   {/*  options={sortOptions}*/}
                   {/* />*/}
                   <FormFieldCheckbox<AxisConfiguration>
-                    id={`${id}-sortAsc`}
                     name="sortAsc"
                     label="Sort ascending"
                   />
@@ -419,7 +403,6 @@ const ChartAxisConfiguration = ({
 
               {validationSchema.fields.tickConfig && (
                 <FormFieldRadioGroup<AxisConfiguration>
-                  id={`${id}-tickConfig`}
                   name="tickConfig"
                   legend="Tick display type"
                   legendSize="s"
@@ -438,7 +421,6 @@ const ChartAxisConfiguration = ({
                       value: 'custom',
                       conditional: (
                         <FormFieldNumberInput<AxisConfiguration>
-                          id={`${id}-tickSpacing`}
                           name="tickSpacing"
                           width={10}
                           label="Every nth value"
@@ -453,7 +435,7 @@ const ChartAxisConfiguration = ({
                 (validationSchema.fields.min ||
                   validationSchema.fields.max) && (
                   <FormFieldset
-                    id={`${id}-minorAxisRange`}
+                    id="minorAxisRange"
                     legend="Axis range"
                     legendSize="s"
                     hint="Leaving these values blank will set them to 'auto'"
@@ -461,7 +443,6 @@ const ChartAxisConfiguration = ({
                     <div className={styles.axisRange}>
                       {validationSchema.fields.min && (
                         <FormFieldNumberInput<AxisConfiguration>
-                          id={`${id}-minorMin`}
                           name="min"
                           width={10}
                           label="Minimum value"
@@ -470,7 +451,6 @@ const ChartAxisConfiguration = ({
                       )}
                       {validationSchema.fields.max && (
                         <FormFieldNumberInput<AxisConfiguration>
-                          id={`${id}-minorMax`}
                           name="max"
                           width={10}
                           label="Maximum value"
@@ -484,13 +464,12 @@ const ChartAxisConfiguration = ({
                 (validationSchema.fields.min ||
                   validationSchema.fields.max) && (
                   <FormFieldset
-                    id={`${id}-majorAxisRange`}
+                    id="majorAxisRange"
                     legend="Axis range"
                     legendSize="s"
                   >
                     {validationSchema.fields.min && (
                       <FormFieldSelect<AxisConfiguration>
-                        id={`${id}-majorMin`}
                         label="Minimum"
                         name="min"
                         placeholder="Default"
@@ -499,7 +478,6 @@ const ChartAxisConfiguration = ({
                     )}
                     {validationSchema.fields.max && (
                       <FormFieldSelect<AxisConfiguration>
-                        id={`${id}-majorMax`}
                         label="Maximum"
                         name="max"
                         placeholder="Default"

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -192,7 +192,6 @@ const ChartConfiguration = ({
 
             {validationSchema.fields.file && (
               <FormFieldFileInput<FormValues>
-                id={`${formId}-file`}
                 name="file"
                 label="Upload new infographic"
                 accept="image/*"
@@ -200,7 +199,6 @@ const ChartConfiguration = ({
             )}
 
             <FormFieldTextArea<FormValues>
-              id={`${formId}-title`}
               name="title"
               label="Title"
               className="govuk-!-width-three-quarters"
@@ -210,7 +208,6 @@ const ChartConfiguration = ({
             />
 
             <FormFieldTextArea<FormValues>
-              id={`${formId}-alt`}
               className="govuk-!-width-three-quarters"
               name="alt"
               label="Alt text"
@@ -221,7 +218,6 @@ const ChartConfiguration = ({
 
             {validationSchema.fields.stacked && (
               <FormFieldCheckbox<FormValues>
-                id={`${formId}-stacked`}
                 name="stacked"
                 label="Stacked bars"
               />
@@ -229,7 +225,6 @@ const ChartConfiguration = ({
 
             {validationSchema.fields.height && (
               <FormFieldNumberInput<FormValues>
-                id={`${formId}-height`}
                 name="height"
                 label="Height (px)"
                 width={5}
@@ -238,7 +233,6 @@ const ChartConfiguration = ({
 
             {validationSchema.fields.width && (
               <FormFieldNumberInput<FormValues>
-                id={`${formId}-width`}
                 name="width"
                 label="Width (px)"
                 hint="Leave blank to set as full width"
@@ -248,7 +242,6 @@ const ChartConfiguration = ({
 
             {validationSchema.fields.barThickness && (
               <FormFieldNumberInput<FormValues>
-                id={`${formId}-barThickness`}
                 name="barThickness"
                 label="Bar thickness (px)"
                 width={5}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
@@ -140,7 +140,6 @@ const ChartDataSetsConfiguration = ({
                 .map(([categoryName, filters]) => (
                   <FormFieldSelect
                     key={categoryName}
-                    id={`${formId}-filters${categoryName}`}
                     name={`filters.${categoryName}`}
                     label={categoryName}
                     formGroupClass={styles.formSelectGroup}
@@ -156,7 +155,6 @@ const ChartDataSetsConfiguration = ({
 
               {indicatorOptions.length > 1 && (
                 <FormFieldSelect<FormValues>
-                  id={`${formId}-indicator`}
                   name="indicator"
                   label="Indicator"
                   formGroupClass={styles.formSelectGroup}
@@ -168,7 +166,6 @@ const ChartDataSetsConfiguration = ({
 
               {locationOptions.length > 1 && (
                 <FormFieldSelect<FormValues>
-                  id={`${formId}-location`}
                   name="location"
                   label="Location"
                   formGroupClass={styles.formSelectGroup}
@@ -180,7 +177,6 @@ const ChartDataSetsConfiguration = ({
 
               {meta.timePeriodRange.length > 1 && (
                 <FormFieldSelect<FormValues>
-                  id={`${formId}-timePeriod`}
                   name="timePeriod"
                   label="Time period"
                   formGroupClass={styles.formSelectGroup}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartLegendConfiguration.tsx
@@ -260,7 +260,6 @@ const ChartLegendConfiguration = ({
 
           {validationSchema.fields.position && (
             <FormFieldSelect<FormValues>
-              id={`${formId}-position`}
               name="position"
               label="Position"
               options={positionOptions}
@@ -274,7 +273,7 @@ const ChartLegendConfiguration = ({
             {form.values.items?.length > 0 ? (
               <>
                 {form.values.items?.map((dataSet, index) => {
-                  const itemId = `${formId}-items${index}`;
+                  const itemId = `items-${index}`;
                   const itemName = `items[${index}]`;
 
                   const itemErrors: string[] = Object.values(
@@ -292,7 +291,6 @@ const ChartLegendConfiguration = ({
                         <div className="dfe-flex dfe-justify-content--space-between">
                           <div className={styles.labelInput}>
                             <FormFieldTextInput
-                              id={`${itemId}Label`}
                               name={`${itemName}.label`}
                               label="Label"
                               formGroup={false}
@@ -302,7 +300,6 @@ const ChartLegendConfiguration = ({
 
                           <div className={styles.colourInput}>
                             <FormFieldColourInput
-                              id={`${itemId}Colour`}
                               name={`${itemName}.colour`}
                               label="Colour"
                               colours={colours}
@@ -314,7 +311,6 @@ const ChartLegendConfiguration = ({
                           {capabilities.hasSymbols && (
                             <div className={styles.configurationInput}>
                               <FormFieldSelect
-                                id={`${itemId}Symbol`}
                                 name={`${itemName}.symbol`}
                                 label="Symbol"
                                 placeholder="None"
@@ -328,7 +324,6 @@ const ChartLegendConfiguration = ({
                           {capabilities.hasLineStyle && (
                             <div className={styles.configurationInput}>
                               <FormFieldSelect
-                                id={`${itemId}LineStyle`}
                                 name={`${itemName}.lineStyle`}
                                 label="Style"
                                 order={FormSelect.unordered}

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FilterGroupDetails.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FilterGroupDetails.tsx
@@ -41,7 +41,6 @@ const FilterGroupDetails = ({
       <div className={styles.filterOverflow}>
         {selectAll && groupId && (
           <FormFieldCheckbox
-            id={`select-all-${groupId}`}
             name={`${groupPath}.selected`}
             disabled={parentSelected}
             label="Select all"
@@ -66,7 +65,6 @@ const FilterGroupDetails = ({
             <div key={filterGroupId}>
               {!hideGrouping && (
                 <FormFieldCheckbox
-                  id={`filterGroup-${filterGroupId}`}
                   name={`${groupPath}.filterGroups[${filterGroupId}].selected`}
                   label={`${filterGroup.label} ${groupValue ? '(All)' : ''}`}
                   small

--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnoteForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnoteForm.tsx
@@ -122,7 +122,6 @@ const FootnoteForm = ({
                 </legend>
 
                 <FormFieldCheckbox
-                  id={`subject-${subjectId}`}
                   label="Select all indicators and filters for this subject"
                   name={`subjects.${subjectId}.selected`}
                   small
@@ -173,11 +172,7 @@ const FootnoteForm = ({
             );
           })}
 
-          <FormFieldTextArea<BaseFootnote>
-            id={`${id}-content`}
-            name="content"
-            label="Footnote"
-          />
+          <FormFieldTextArea<BaseFootnote> name="content" label="Footnote" />
 
           <ButtonGroup>
             <Button type="submit">Save footnote</Button>

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseUserAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseUserAccessForm.tsx
@@ -113,7 +113,6 @@ const PreReleaseUserAccessForm = ({
           {form => (
             <Form id={formId}>
               <FormFieldTextInput<FormValues>
-                id={`${formId}-email`}
                 label="Invite new user by email"
                 name="email"
                 className="govuk-!-width-one-third"

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PublicPreReleaseAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PublicPreReleaseAccessForm.tsx
@@ -72,7 +72,6 @@ const PublicPreReleaseAccessForm = ({
           <Form id={formId}>
             <FormFieldEditor<FormValues>
               name="preReleaseAccessList"
-              id={`${formId}-preReleaseAccessList`}
               label="Public access list"
               focusOnInit
             />

--- a/src/explore-education-statistics-admin/src/pages/themes/components/ThemeForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/themes/components/ThemeForm.tsx
@@ -55,14 +55,12 @@ const ThemeForm = ({
       {form => (
         <Form id={id}>
           <FormFieldTextInput<ThemeFormValues>
-            id={`${id}-title`}
             label="Title"
             name="title"
             className="govuk-!-width-two-thirds"
           />
 
           <FormFieldTextInput<ThemeFormValues>
-            id={`${id}-summary`}
             label="Summary"
             name="summary"
             className="govuk-!-width-two-thirds"

--- a/src/explore-education-statistics-admin/src/pages/themes/topics/components/TopicForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/themes/topics/components/TopicForm.tsx
@@ -52,7 +52,6 @@ const TopicForm = ({
       {form => (
         <Form id={id}>
           <FormFieldTextInput<TopicFormValues>
-            id={`${id}-title`}
             label="Title"
             name="title"
             className="govuk-!-width-two-thirds"

--- a/src/explore-education-statistics-admin/src/pages/users/ManageUserPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/ManageUserPage.tsx
@@ -140,11 +140,7 @@ const ManageUserPage = ({ match }: RouteComponentProps<{ userId: string }>) => {
               {() => {
                 return (
                   <Form id={formId}>
-                    <FormFieldset
-                      id={`${formId}-details`}
-                      legend="Details"
-                      legendSize="m"
-                    >
+                    <FormFieldset id="user" legend="Details" legendSize="m">
                       <SummaryList>
                         <SummaryListItem term="Name">
                           {model.user.name}
@@ -158,7 +154,7 @@ const ManageUserPage = ({ match }: RouteComponentProps<{ userId: string }>) => {
                       </SummaryList>
                     </FormFieldset>
                     <FormFieldset
-                      id={`${formId}-role`}
+                      id="role"
                       legend="Role"
                       legendSize="m"
                       hint="The users role within the service."
@@ -166,7 +162,6 @@ const ManageUserPage = ({ match }: RouteComponentProps<{ userId: string }>) => {
                       <div className="govuk-grid-row">
                         <div className="govuk-grid-column-one-quarter">
                           <FormFieldSelect<UpdateRoleFormValues>
-                            id={`${formId}-selectedRoleId`}
                             label="Role"
                             name="selectedRoleId"
                             options={roles?.map(role => ({
@@ -204,7 +199,7 @@ const ManageUserPage = ({ match }: RouteComponentProps<{ userId: string }>) => {
                 return (
                   <Form id={`${formId}-releaseRole`}>
                     <FormFieldset
-                      id={`${formId}-role`}
+                      id="role"
                       legend="Release access"
                       legendSize="m"
                       hint="The releases a user can access within the service."
@@ -212,7 +207,6 @@ const ManageUserPage = ({ match }: RouteComponentProps<{ userId: string }>) => {
                       <div className="govuk-grid-row">
                         <div className="govuk-grid-column-one-half">
                           <FormFieldSelect<AddReleaseRoleFormValues>
-                            id={`${formId}-selectedReleaseId`}
                             label="Release"
                             name="selectedReleaseId"
                             options={releases?.map(release => ({
@@ -224,7 +218,6 @@ const ManageUserPage = ({ match }: RouteComponentProps<{ userId: string }>) => {
 
                         <div className="govuk-grid-column-one-quarter">
                           <FormFieldSelect<AddReleaseRoleFormValues>
-                            id={`${formId}-selectedReleaseRoleId`}
                             label="Release role"
                             name="selectedReleaseRoleId"
                             options={releaseRoles?.map(releaseRole => ({

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -112,26 +112,24 @@ const UserInvitePage = ({
             return (
               <Form id={formId}>
                 <FormFieldset
-                  id={`${formId}-userEmailFieldset`}
+                  id="email-fieldset"
                   legend="Provide the email address for the user"
                   legendSize="m"
                   hint="The invited user must have a @education.gov.uk email address"
                 >
                   <FormFieldTextInput<FormValues>
-                    id={`${formId}-userEmail`}
                     label="User email"
                     name="userEmail"
                   />
                 </FormFieldset>
 
                 <FormFieldset
-                  id={`${formId}-selectedRoleIdFieldset`}
+                  id="role-fieldset"
                   legend="Role"
                   legendSize="m"
                   hint="The users role within the service."
                 >
                   <FormFieldSelect<FormValues>
-                    id={`${formId}-selectedRoleId`}
                     label="Role"
                     name="selectedRoleId"
                     placeholder="Choose role"

--- a/src/explore-education-statistics-common/src/components/form/Form.tsx
+++ b/src/explore-education-statistics-common/src/components/form/Form.tsx
@@ -1,6 +1,7 @@
 import ErrorSummary, {
   ErrorSummaryMessage,
 } from '@common/components/ErrorSummary';
+import { FormContextProvider } from '@common/components/form/contexts/FormContext';
 import useMountedRef from '@common/hooks/useMountedRef';
 import useToggle from '@common/hooks/useToggle';
 import createErrorHelper from '@common/validation/createErrorHelper';
@@ -121,18 +122,20 @@ const Form = ({
   );
 
   return (
-    <form id={id} onSubmit={handleSubmit}>
-      {showErrorSummary && (
-        <ErrorSummary
-          errors={allErrors}
-          id={`${id}-summary`}
-          focusOnError={hasSummaryFocus}
-          onFocus={toggleSummaryFocus.off}
-        />
-      )}
+    <FormContextProvider id={id}>
+      <form id={id} onSubmit={handleSubmit}>
+        {showErrorSummary && (
+          <ErrorSummary
+            errors={allErrors}
+            id={`${id}-summary`}
+            focusOnError={hasSummaryFocus}
+            onFocus={toggleSummaryFocus.off}
+          />
+        )}
 
-      {children}
-    </form>
+        {children}
+      </form>
+    </FormContextProvider>
   );
 };
 

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -123,7 +123,9 @@ export const BaseFormCheckboxGroup = ({
           disabled={disabled}
           {...option}
           id={
-            option.id ? option.id : `${id}-${option.value.replace(/\s/g, '-')}`
+            option.id
+              ? `${id}-${option.id}`
+              : `${id}-${option.value.replace(/\s/g, '-')}`
           }
           name={name}
           key={option.value}
@@ -139,7 +141,7 @@ export const BaseFormCheckboxGroup = ({
 };
 
 export type FormCheckboxGroupProps = BaseFormCheckboxGroupProps &
-  OmitStrict<FormFieldsetProps, 'onBlur' | 'onFocus'> & {
+  OmitStrict<FormFieldsetProps, 'useFormId' | 'onBlur' | 'onFocus'> & {
     onFieldsetBlur?: FocusEventHandler<HTMLFieldSetElement>;
     onFieldsetFocus?: FocusEventHandler<HTMLFieldSetElement>;
   };
@@ -150,7 +152,12 @@ const FormCheckboxGroup = ({
   ...props
 }: FormCheckboxGroupProps) => {
   return (
-    <FormFieldset {...props} onBlur={onFieldsetBlur} onFocus={onFieldsetFocus}>
+    <FormFieldset
+      {...props}
+      useFormId={false}
+      onBlur={onFieldsetBlur}
+      onFocus={onFieldsetFocus}
+    >
       <BaseFormCheckboxGroup {...props} />
     </FormFieldset>
   );

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchGroup.tsx
@@ -62,11 +62,7 @@ const FormCheckboxSearchGroup = ({
   }
 
   return (
-    <FormFieldset
-      {...fieldsetProps}
-      onBlur={onFieldsetBlur}
-      onFocus={onFieldsetFocus}
-    >
+    <FormFieldset {...fieldsetProps} useFormId={false}>
       <FormTextSearchInput
         id={`${id}-search`}
         name={`${name}-search`}
@@ -83,7 +79,7 @@ const FormCheckboxSearchGroup = ({
       <div aria-live="assertive" className={styles.optionsContainer}>
         <BaseFormCheckboxGroup
           {...groupProps}
-          id={`${id}-checkboxes`}
+          id={`${id}-options`}
           value={value}
           name={name}
           options={filteredOptions}

--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxSearchSubGroups.tsx
@@ -124,7 +124,7 @@ const FormCheckboxSearchSubGroups = ({
   }
 
   return (
-    <FormFieldset {...fieldsetProps}>
+    <FormFieldset {...fieldsetProps} useFormId={false}>
       {isMounted && (
         <>
           {totalOptions > 1 && options.length > 1 && (
@@ -168,7 +168,11 @@ const FormCheckboxSearchSubGroups = ({
                 {...groupProps}
                 key={optionGroup.legend}
                 name={name}
-                id={optionGroup.id ? optionGroup.id : `${id}-${index + 1}`}
+                id={
+                  optionGroup.id
+                    ? `${id}-${optionGroup.id}`
+                    : `${id}-options-${index + 1}`
+                }
                 legend={optionGroup.legend}
                 legendSize="s"
                 options={optionGroup.options}

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckbox.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckbox.tsx
@@ -18,13 +18,13 @@ function FormFieldCheckbox<FormValues>({
 }: Props<FormValues>) {
   return (
     <FormField<string> {...props} type="checkbox" formGroup={formGroup}>
-      {({ field }) => (
+      {({ field, id }) => (
         <div
           className={classNames('govuk-checkboxes', {
             'govuk-checkboxes--small': small,
           })}
         >
-          <FormCheckbox {...props} {...field} />
+          <FormCheckbox {...props} {...field} id={id} />
         </div>
       )}
     </FormField>

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxGroup.tsx
@@ -16,10 +16,11 @@ function FormFieldCheckboxGroup<FormValues>(props: Props<FormValues>) {
 
   return (
     <FormField<string[]> {...props} formGroup={false}>
-      {({ field, helpers, meta }) => (
+      {({ id, field, helpers, meta }) => (
         <FormCheckboxGroup
           {...props}
           {...field}
+          id={id}
           onAllChange={(event, checked) => {
             if (props.onAllChange) {
               props.onAllChange(event, checked);

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchGroup.tsx
@@ -20,11 +20,12 @@ function FormFieldCheckboxSearchGroup<FormValues>(
 
   return (
     <FormField<string[]> {...props}>
-      {({ field, helpers, meta }) => {
+      {({ id, field, helpers, meta }) => {
         return (
           <FormCheckboxSearchGroup
             {...props}
             {...field}
+            id={id}
             onAllChange={(event, checked) => {
               if (props.onAllChange) {
                 props.onAllChange(event, checked);

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchSubGroups.tsx
@@ -20,11 +20,12 @@ function FormFieldCheckboxSearchSubGroups<FormValues>(
 
   return (
     <FormField<string[]> {...props}>
-      {({ field, helpers, meta }) => {
+      {({ id, field, helpers, meta }) => {
         return (
           <FormCheckboxSearchSubGroups
             {...props}
             {...field}
+            id={id}
             small
             onAllChange={(event, checked) => {
               if (event.isDefaultPrevented()) {

--- a/src/explore-education-statistics-common/src/components/form/FormFieldDateInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldDateInput.tsx
@@ -1,3 +1,4 @@
+import { useFormContext } from '@common/components/form/contexts/FormContext';
 import FormFieldset from '@common/components/form/FormFieldset';
 import FormNumberInput from '@common/components/form/FormNumberInput';
 import { FormGroup } from '@common/components/form/index';
@@ -11,7 +12,7 @@ import React, { ChangeEvent, useCallback, useRef, useState } from 'react';
 
 interface Props<FormValues> {
   hint?: string;
-  id: string;
+  id?: string;
   legend: string;
   legendSize?: 'xl' | 'l' | 'm' | 's';
   name: keyof FormValues | string;
@@ -21,7 +22,7 @@ interface Props<FormValues> {
 }
 
 function FormFieldDateInput<FormValues>({
-  id,
+  id: customId,
   name,
   showError = true,
   hint,
@@ -30,6 +31,9 @@ function FormFieldDateInput<FormValues>({
   partialDateType = 'dayMonthYear',
   type = 'date',
 }: Props<FormValues>) {
+  const { prefixFormId, fieldId } = useFormContext();
+  const id = customId ? prefixFormId(customId) : fieldId(name as string);
+
   const isFocused = useRef(false);
 
   const [field, meta, helpers] = useField<
@@ -99,6 +103,7 @@ function FormFieldDateInput<FormValues>({
       legendSize={legendSize}
       hint={hint}
       error={errorMessage}
+      useFormId={false}
       onBlur={async event => {
         event.persist();
 

--- a/src/explore-education-statistics-common/src/components/form/FormFieldFileInput.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldFileInput.tsx
@@ -26,7 +26,7 @@ function FormFieldFileInput<FormValues>(props: Props<FormValues>) {
 
   return (
     <FormField<File | null> {...props}>
-      {({ field, helpers, meta }) => (
+      {({ id, field, helpers, meta }) => (
         <>
           <Effect
             value={meta.touched}
@@ -42,6 +42,7 @@ function FormFieldFileInput<FormValues>(props: Props<FormValues>) {
           <FormFileInput
             {...props}
             {...field}
+            id={id}
             onClick={toggleClicked.on}
             onChange={event => {
               if (props.onChange) {

--- a/src/explore-education-statistics-common/src/components/form/FormFieldRadioGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldRadioGroup.tsx
@@ -14,10 +14,11 @@ function FormFieldRadioGroup<FormValues, Value extends string = string>(
 ) {
   return (
     <FormField<Value> {...props}>
-      {({ field }) => (
-        <FormRadioGroup<Value>
+      {({ id, field }) => (
+        <FormRadioGroup
           {...props}
           {...field}
+          id={id}
           onChange={(event, option) => {
             if (props.onChange) {
               props.onChange(event, option);

--- a/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldset.tsx
@@ -1,3 +1,4 @@
+import { useFormContext } from '@common/components/form/contexts/FormContext';
 import classNames from 'classnames';
 import React, { FocusEventHandler, ReactNode } from 'react';
 import ErrorMessage from '../ErrorMessage';
@@ -12,6 +13,11 @@ export interface FormFieldsetProps {
   legend: ReactNode | string;
   legendSize?: 'xl' | 'l' | 'm' | 's';
   legendHidden?: boolean;
+  /**
+   * Set to false to disable default prefixing
+   * of `id` with the current form context's form id.
+   */
+  useFormId?: boolean;
   onBlur?: FocusEventHandler<HTMLFieldSetElement>;
   onFocus?: FocusEventHandler<HTMLFieldSetElement>;
 }
@@ -25,20 +31,24 @@ const FormFieldset = ({
   legend,
   legendSize = 'l',
   legendHidden = false,
+  useFormId = true,
   onBlur,
   onFocus,
 }: FormFieldsetProps) => {
+  const { prefixFormId } = useFormContext();
+  const fieldId = useFormId ? prefixFormId(id) : id;
+
   return (
     <FormGroup hasError={!!error}>
       <fieldset
         aria-describedby={
           classNames({
-            [`${id}-error`]: !!error,
-            [`${id}-hint`]: !!hint,
+            [`${fieldId}-error`]: !!error,
+            [`${fieldId}-hint`]: !!hint,
           }) || undefined
         }
         className={classNames('govuk-fieldset', className)}
-        id={id}
+        id={fieldId}
         onBlur={onBlur}
         onFocus={onFocus}
       >
@@ -55,12 +65,12 @@ const FormFieldset = ({
         </legend>
 
         {hint && (
-          <span className="govuk-hint" id={`${id}-hint`}>
+          <span className="govuk-hint" id={`${fieldId}-hint`}>
             {hint}
           </span>
         )}
 
-        {error && <ErrorMessage id={`${id}-error`}>{error}</ErrorMessage>}
+        {error && <ErrorMessage id={`${fieldId}-error`}>{error}</ErrorMessage>}
 
         {children}
       </fieldset>

--- a/src/explore-education-statistics-common/src/components/form/FormRadioGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormRadioGroup.tsx
@@ -29,7 +29,8 @@ export type FormRadioGroupProps<Value extends string = string> = {
   order?: OrderKeys<RadioOption<Value>>;
   orderDirection?: OrderDirection | OrderDirection[];
   value?: string;
-} & OmitStrict<FormFieldsetProps, 'onBlur' | 'onFocus'> & {
+} & OmitStrict<FormFieldsetProps, 'useFormId' | 'onBlur' | 'onFocus'> & {
+    useFieldsetFormId?: boolean;
     onFieldsetBlur?: FocusEventHandler<HTMLFieldSetElement>;
     onFieldsetFocus?: FocusEventHandler<HTMLFieldSetElement>;
   };
@@ -54,6 +55,7 @@ const FormRadioGroup = <Value extends string = string>({
       {...props}
       hint={hint}
       legendSize={legendSize}
+      useFormId={false}
       onBlur={onFieldsetBlur}
       onFocus={onFieldsetFocus}
     >
@@ -69,7 +71,7 @@ const FormRadioGroup = <Value extends string = string>({
             {...option}
             id={
               option.id
-                ? option.id
+                ? `${id}-${option.id}`
                 : `${id}-${option.value.replace(/\s/g, '-')}`
             }
             checked={value === option.value}

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxSearchGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxSearchGroup.test.tsx
@@ -1,12 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
 import FormCheckboxSearchGroup from '../FormCheckboxSearchGroup';
 
 jest.mock('lodash/debounce');
 
 describe('FormCheckboxSearchGroup', () => {
   test('renders list of checkboxes in correct order', () => {
-    const { container, getAllByLabelText } = render(
+    const { container } = render(
       <FormCheckboxSearchGroup
         name="testCheckboxes"
         id="test-checkboxes"
@@ -20,7 +21,9 @@ describe('FormCheckboxSearchGroup', () => {
       />,
     );
 
-    const checkboxes = getAllByLabelText(/Test checkbox/) as HTMLInputElement[];
+    const checkboxes = screen.getAllByLabelText(
+      /Test checkbox/,
+    ) as HTMLInputElement[];
 
     expect(checkboxes).toHaveLength(3);
     expect(checkboxes[0]).toHaveAttribute('value', '1');
@@ -30,10 +33,10 @@ describe('FormCheckboxSearchGroup', () => {
     expect(container.innerHTML).toMatchSnapshot();
   });
 
-  test('providing a search term renders only relevant checkboxes', () => {
+  test('providing a search term renders only relevant checkboxes', async () => {
     jest.useFakeTimers();
 
-    const { getByLabelText, getAllByLabelText } = render(
+    render(
       <FormCheckboxSearchGroup
         name="testCheckboxes"
         id="test-checkboxes"
@@ -48,26 +51,24 @@ describe('FormCheckboxSearchGroup', () => {
       />,
     );
 
-    const searchInput = getByLabelText('Search options');
+    const searchInput = screen.getByLabelText('Search options');
 
-    fireEvent.change(searchInput, {
-      target: {
-        value: '2',
-      },
-    });
+    await userEvent.type(searchInput, '2');
 
     jest.runAllTimers();
 
-    const checkboxes = getAllByLabelText(/Test checkbox/) as HTMLInputElement[];
+    const checkboxes = screen.getAllByLabelText(
+      /Test checkbox/,
+    ) as HTMLInputElement[];
 
     expect(checkboxes).toHaveLength(1);
     expect(checkboxes[0]).toHaveAttribute('value', '2');
   });
 
-  test('does not throw error if search term that is invalid regex is used', () => {
+  test('does not throw error if search term that is invalid regex is used', async () => {
     jest.useFakeTimers();
 
-    const { getByLabelText, queryAllByLabelText } = render(
+    render(
       <FormCheckboxSearchGroup
         name="testCheckboxes"
         id="test-checkboxes"
@@ -82,29 +83,25 @@ describe('FormCheckboxSearchGroup', () => {
       />,
     );
 
-    const searchInput = getByLabelText('Search options');
+    const searchInput = screen.getByLabelText('Search options');
 
-    fireEvent.change(searchInput, {
-      target: {
-        value: '[',
-      },
-    });
+    await userEvent.type(searchInput, '[');
 
     expect(() => {
       jest.runAllTimers();
     }).not.toThrow();
 
-    const checkboxes = queryAllByLabelText(
+    const checkboxes = screen.queryAllByLabelText(
       /Test checkbox/,
     ) as HTMLInputElement[];
 
     expect(checkboxes).toHaveLength(0);
   });
 
-  test('providing a search term does not remove checkboxes that have already been checked', () => {
+  test('providing a search term does not remove checkboxes that have already been checked', async () => {
     jest.useFakeTimers();
 
-    const { getByLabelText, getAllByLabelText } = render(
+    render(
       <FormCheckboxSearchGroup
         name="testCheckboxes"
         id="test-checkboxes"
@@ -119,17 +116,15 @@ describe('FormCheckboxSearchGroup', () => {
       />,
     );
 
-    const searchInput = getByLabelText('Search options');
+    const searchInput = screen.getByLabelText('Search options');
 
-    fireEvent.change(searchInput, {
-      target: {
-        value: '2',
-      },
-    });
+    await userEvent.type(searchInput, '2');
 
     jest.runAllTimers();
 
-    const checkboxes = getAllByLabelText(/Test checkbox/) as HTMLInputElement[];
+    const checkboxes = screen.getAllByLabelText(
+      /Test checkbox/,
+    ) as HTMLInputElement[];
 
     expect(checkboxes).toHaveLength(2);
     expect(checkboxes[0]).toHaveAttribute('value', '1');

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxSearchSubGroups.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormCheckboxSearchSubGroups.test.tsx
@@ -1,5 +1,6 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { fireEvent, render, screen, within } from '@testing-library/react';
 import FormCheckboxSearchSubGroups from '../FormCheckboxSearchSubGroups';
 
 describe('FormCheckboxSearchSubGroups', () => {
@@ -83,7 +84,7 @@ describe('FormCheckboxSearchSubGroups', () => {
   });
 
   test('generates group IDs if none provided', () => {
-    const { container } = render(
+    render(
       <FormCheckboxSearchSubGroups
         id="test-checkboxes"
         name="test-checkboxes"
@@ -103,9 +104,15 @@ describe('FormCheckboxSearchSubGroups', () => {
       />,
     );
 
-    expect(container.querySelector('#test-checkboxes-1')).not.toBeNull();
-    expect(container.querySelector('#test-checkboxes-2')).toBeNull();
-    expect(container.querySelector('#custom-group-id')).not.toBeNull();
+    expect(screen.getByRole('group', { name: 'Group A' })).toHaveAttribute(
+      'id',
+      'test-checkboxes-options-1',
+    );
+
+    expect(screen.getByRole('group', { name: 'Group B' })).toHaveAttribute(
+      'id',
+      'test-checkboxes-custom-group-id',
+    );
   });
 
   test('renders `Select all options` button correctly', () => {
@@ -235,7 +242,7 @@ describe('FormCheckboxSearchSubGroups', () => {
     ).toBeInTheDocument();
   });
 
-  test('providing a search term renders only relevant checkboxes', () => {
+  test('providing a search term renders only relevant checkboxes', async () => {
     jest.useFakeTimers();
 
     render(
@@ -264,11 +271,7 @@ describe('FormCheckboxSearchSubGroups', () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText('Search options'), {
-      target: {
-        value: '2',
-      },
-    });
+    await userEvent.type(screen.getByLabelText('Search options'), '2');
 
     jest.runAllTimers();
 
@@ -280,7 +283,7 @@ describe('FormCheckboxSearchSubGroups', () => {
     expect(checkboxes[0]).toHaveAttribute('value', '2');
   });
 
-  test('does not throw error if search term that is invalid regex is used', () => {
+  test('does not throw error if search term that is invalid regex is used', async () => {
     jest.useFakeTimers();
 
     render(
@@ -309,11 +312,7 @@ describe('FormCheckboxSearchSubGroups', () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText('Search options'), {
-      target: {
-        value: '[',
-      },
-    });
+    await userEvent.type(screen.getByLabelText('Search options'), '[');
 
     jest.runAllTimers();
 
@@ -324,7 +323,7 @@ describe('FormCheckboxSearchSubGroups', () => {
     expect(checkboxes).toHaveLength(0);
   });
 
-  test('providing a search term does not remove checkboxes that have already been checked', () => {
+  test('providing a search term does not remove checkboxes that have already been checked', async () => {
     jest.useFakeTimers();
 
     render(
@@ -355,11 +354,7 @@ describe('FormCheckboxSearchSubGroups', () => {
 
     const searchInput = screen.getByLabelText('Search options');
 
-    fireEvent.change(searchInput, {
-      target: {
-        value: '2',
-      },
-    });
+    await userEvent.type(searchInput, '2');
 
     jest.runAllTimers();
 

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxGroup.test.tsx
@@ -1,8 +1,10 @@
+import { Form } from '@common/components/form';
 import Yup from '@common/validation/yup';
 import { waitFor } from '@testing-library/dom';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Formik } from 'formik';
+import noop from 'lodash/noop';
 import React from 'react';
 import FormFieldCheckboxGroup from '../FormFieldCheckboxGroup';
 
@@ -11,13 +13,157 @@ describe('FormFieldCheckboxGroup', () => {
     test: string[];
   }
 
+  test('renders with correct default ids without form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={noop}
+      >
+        <FormFieldCheckboxGroup<FormValues>
+          name="test"
+          legend="Test checkboxes"
+          selectAll
+          options={[
+            { label: 'Checkbox 1', value: '1' },
+            { label: 'Checkbox 2', value: '2' },
+            { label: 'Checkbox 3', value: '3' },
+          ]}
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'test');
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute('id', 'test-1');
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute('id', 'test-2');
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute('id', 'test-3');
+  });
+
+  test('renders with correct default ids with form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={noop}
+      >
+        <Form id="testForm">
+          <FormFieldCheckboxGroup<FormValues>
+            name="test"
+            legend="Test checkboxes"
+            selectAll
+            options={[
+              { label: 'Checkbox 1', value: '1' },
+              { label: 'Checkbox 2', value: '2' },
+              { label: 'Checkbox 3', value: '3' },
+            ]}
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'testForm-test');
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'testForm-test-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'testForm-test-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'testForm-test-3',
+    );
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={noop}
+      >
+        <Form id="testForm">
+          <FormFieldCheckboxGroup<FormValues>
+            id="customId"
+            name="test"
+            legend="Test checkboxes"
+            selectAll
+            options={[
+              { label: 'Checkbox 1', value: '1' },
+              { label: 'Checkbox 2', value: '2' },
+              { id: 'customOption', label: 'Checkbox 3', value: '3' },
+            ]}
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute(
+      'id',
+      'testForm-customId',
+    );
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'testForm-customId-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'testForm-customId-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'testForm-customId-customOption',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={noop}
+      >
+        <FormFieldCheckboxGroup<FormValues>
+          id="customId"
+          name="test"
+          legend="Test checkboxes"
+          selectAll
+          options={[
+            { label: 'Checkbox 1', value: '1' },
+            { label: 'Checkbox 2', value: '2' },
+            { id: 'customOption', label: 'Checkbox 3', value: '3' },
+          ]}
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'customId');
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'customId-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'customId-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'customId-customOption',
+    );
+  });
+
   test('checking option checks it', () => {
     render(
       <Formik
         initialValues={{
           test: [],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxGroup<FormValues>
@@ -49,7 +195,7 @@ describe('FormFieldCheckboxGroup', () => {
         initialValues={{
           test: ['1'],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxGroup<FormValues>
@@ -81,7 +227,7 @@ describe('FormFieldCheckboxGroup', () => {
         initialValues={{
           test: [],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxGroup<FormValues>
@@ -120,7 +266,7 @@ describe('FormFieldCheckboxGroup', () => {
         initialValues={{
           test: ['1', '2', '3'],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxGroup<FormValues>
@@ -161,7 +307,7 @@ describe('FormFieldCheckboxGroup', () => {
         initialValues={{
           test: [],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxGroup<FormValues>
@@ -212,7 +358,7 @@ describe('FormFieldCheckboxGroup', () => {
         initialValues={{
           test: ['1', '2', '3'],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxGroup<FormValues>
@@ -258,7 +404,7 @@ describe('FormFieldCheckboxGroup', () => {
           initialValues={{
             test: [],
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}
@@ -287,7 +433,7 @@ describe('FormFieldCheckboxGroup', () => {
           initialValues={{
             test: [],
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}
@@ -313,7 +459,7 @@ describe('FormFieldCheckboxGroup', () => {
 
       expect(screen.queryByText('Select at least one option')).toBeNull();
 
-      fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+      userEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
       await waitFor(() => {
         expect(
@@ -328,7 +474,7 @@ describe('FormFieldCheckboxGroup', () => {
           initialValues={{
             test: [],
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}
@@ -364,7 +510,7 @@ describe('FormFieldCheckboxGroup', () => {
           initialValues={{
             test: [],
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}
@@ -409,7 +555,7 @@ describe('FormFieldCheckboxGroup', () => {
           initialTouched={{
             test: true,
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}
@@ -451,7 +597,7 @@ describe('FormFieldCheckboxGroup', () => {
           initialValues={{
             test: ['1'],
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSearchGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSearchGroup.test.tsx
@@ -1,6 +1,10 @@
+import { Form } from '@common/components/form';
 import Yup from '@common/validation/yup';
-import { fireEvent, render, wait } from '@testing-library/react';
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Formik } from 'formik';
+import noop from 'lodash/noop';
 import React from 'react';
 import FormFieldCheckboxSearchGroup from '../FormFieldCheckboxSearchGroup';
 
@@ -11,13 +15,184 @@ describe('FormFieldCheckboxSearchGroup', () => {
     test: string[];
   }
 
+  test('renders with correct default ids without form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={noop}
+      >
+        <FormFieldCheckboxSearchGroup<FormValues>
+          name="test"
+          legend="Test checkboxes"
+          selectAll
+          options={[
+            { label: 'Checkbox 1', value: '1' },
+            { label: 'Checkbox 2', value: '2' },
+            { label: 'Checkbox 3', value: '3' },
+          ]}
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'test');
+
+    expect(screen.getByRole('textbox')).toHaveAttribute('id', 'test-search');
+
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'test-options-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'test-options-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'test-options-3',
+    );
+  });
+
+  test('renders with correct default ids with form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={noop}
+      >
+        <Form id="testForm">
+          <FormFieldCheckboxSearchGroup<FormValues>
+            name="test"
+            legend="Test checkboxes"
+            selectAll
+            options={[
+              { label: 'Checkbox 1', value: '1' },
+              { label: 'Checkbox 2', value: '2' },
+              { label: 'Checkbox 3', value: '3' },
+            ]}
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'testForm-test');
+
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'id',
+      'testForm-test-search',
+    );
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'testForm-test-options-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'testForm-test-options-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'testForm-test-options-3',
+    );
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={noop}
+      >
+        <Form id="testForm">
+          <FormFieldCheckboxSearchGroup<FormValues>
+            id="customId"
+            name="test"
+            legend="Test checkboxes"
+            selectAll
+            options={[
+              { label: 'Checkbox 1', value: '1' },
+              { label: 'Checkbox 2', value: '2' },
+              { id: 'customOption', label: 'Checkbox 3', value: '3' },
+            ]}
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute(
+      'id',
+      'testForm-customId',
+    );
+
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'id',
+      'testForm-customId-search',
+    );
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'testForm-customId-options-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'testForm-customId-options-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'testForm-customId-options-customOption',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={noop}
+      >
+        <FormFieldCheckboxSearchGroup<FormValues>
+          id="customId"
+          name="test"
+          legend="Test checkboxes"
+          selectAll
+          options={[
+            { label: 'Checkbox 1', value: '1' },
+            { label: 'Checkbox 2', value: '2' },
+            { id: 'customOption', label: 'Checkbox 3', value: '3' },
+          ]}
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'customId');
+
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'id',
+      'customId-search',
+    );
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'customId-options-1',
+    );
+    expect(screen.getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'customId-options-2',
+    );
+    expect(screen.getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'customId-options-customOption',
+    );
+  });
+
   test('checking option checks it', async () => {
-    const { getByLabelText } = render(
+    render(
       <Formik
         initialValues={{
           test: [],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxSearchGroup<FormValues>
@@ -34,19 +209,19 @@ describe('FormFieldCheckboxSearchGroup', () => {
       </Formik>,
     );
 
-    const checkbox = getByLabelText('Checkbox 1') as HTMLInputElement;
+    const checkbox = screen.getByLabelText('Checkbox 1') as HTMLInputElement;
 
     expect(checkbox.checked).toBe(false);
 
-    fireEvent.click(checkbox);
+    userEvent.click(checkbox);
 
-    await wait();
-
-    expect(checkbox.checked).toBe(true);
+    await waitFor(() => {
+      expect(checkbox.checked).toBe(true);
+    });
   });
 
   test('un-checking option un-checks it', async () => {
-    const { getByLabelText } = render(
+    render(
       <Formik
         initialValues={{
           test: ['1'],
@@ -68,19 +243,19 @@ describe('FormFieldCheckboxSearchGroup', () => {
       </Formik>,
     );
 
-    const checkbox = getByLabelText('Checkbox 1') as HTMLInputElement;
+    const checkbox = screen.getByLabelText('Checkbox 1') as HTMLInputElement;
 
     expect(checkbox.checked).toBe(true);
 
-    fireEvent.click(checkbox);
+    userEvent.click(checkbox);
 
-    await wait();
-
-    expect(checkbox.checked).toBe(false);
+    await waitFor(() => {
+      expect(checkbox.checked).toBe(false);
+    });
   });
 
   test('clicking `Select all 3 options` button checks all values', () => {
-    const { getByLabelText, getByText } = render(
+    render(
       <Formik
         initialValues={{
           test: [],
@@ -103,21 +278,21 @@ describe('FormFieldCheckboxSearchGroup', () => {
       </Formik>,
     );
 
-    fireEvent.click(getByText('Select all 3 options'));
+    userEvent.click(screen.getByText('Select all 3 options'));
 
-    expect((getByLabelText('Checkbox 1') as HTMLInputElement).checked).toBe(
-      true,
-    );
-    expect((getByLabelText('Checkbox 2') as HTMLInputElement).checked).toBe(
-      true,
-    );
-    expect((getByLabelText('Checkbox 3') as HTMLInputElement).checked).toBe(
-      true,
-    );
+    expect(
+      (screen.getByLabelText('Checkbox 1') as HTMLInputElement).checked,
+    ).toBe(true);
+    expect(
+      (screen.getByLabelText('Checkbox 2') as HTMLInputElement).checked,
+    ).toBe(true);
+    expect(
+      (screen.getByLabelText('Checkbox 3') as HTMLInputElement).checked,
+    ).toBe(true);
   });
 
   test('clicking `Unselect all 3 options` button un-checks all values', () => {
-    const { getByLabelText, getByText } = render(
+    render(
       <Formik
         initialValues={{
           test: ['1', '2', '3'],
@@ -140,15 +315,15 @@ describe('FormFieldCheckboxSearchGroup', () => {
       </Formik>,
     );
 
-    const checkbox1 = getByLabelText('Checkbox 1') as HTMLInputElement;
-    const checkbox2 = getByLabelText('Checkbox 2') as HTMLInputElement;
-    const checkbox3 = getByLabelText('Checkbox 3') as HTMLInputElement;
+    const checkbox1 = screen.getByLabelText('Checkbox 1') as HTMLInputElement;
+    const checkbox2 = screen.getByLabelText('Checkbox 2') as HTMLInputElement;
+    const checkbox3 = screen.getByLabelText('Checkbox 3') as HTMLInputElement;
 
     expect(checkbox1.checked).toBe(true);
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(true);
 
-    fireEvent.click(getByText('Unselect all 3 options'));
+    userEvent.click(screen.getByText('Unselect all 3 options'));
 
     expect(checkbox1.checked).toBe(false);
     expect(checkbox2.checked).toBe(false);
@@ -184,25 +359,25 @@ describe('FormFieldCheckboxSearchGroup', () => {
     const checkbox3 = getByLabelText('Checkbox 3') as HTMLInputElement;
 
     expect(checkbox1.checked).toBe(false);
-    expect(queryByText('Select all 3 options')).not.toBeNull();
-    expect(queryByText('Unselect all 3 options')).toBeNull();
+    expect(queryByText('Select all 3 options')).toBeInTheDocument();
+    expect(queryByText('Unselect all 3 options')).not.toBeInTheDocument();
 
-    fireEvent.click(checkbox1);
-    fireEvent.click(checkbox2);
-    fireEvent.click(checkbox3);
+    userEvent.click(checkbox1);
+    userEvent.click(checkbox2);
+    userEvent.click(checkbox3);
 
-    await wait();
+    await waitFor(() => {
+      expect(checkbox1.checked).toBe(true);
+      expect(checkbox2.checked).toBe(true);
+      expect(checkbox3.checked).toBe(true);
 
-    expect(checkbox1.checked).toBe(true);
-    expect(checkbox2.checked).toBe(true);
-    expect(checkbox3.checked).toBe(true);
-
-    expect(queryByText('Select all 3 options')).toBeNull();
-    expect(queryByText('Unselect all 3 options')).not.toBeNull();
+      expect(queryByText('Select all 3 options')).not.toBeInTheDocument();
+      expect(queryByText('Unselect all 3 options')).toBeInTheDocument();
+    });
   });
 
   test('un-checking any options renders the `Select all 3 options` button ', async () => {
-    const { getByLabelText, queryByText } = render(
+    render(
       <Formik
         initialValues={{
           test: ['1', '2', '3'],
@@ -225,24 +400,26 @@ describe('FormFieldCheckboxSearchGroup', () => {
       </Formik>,
     );
 
-    const checkbox = getByLabelText('Checkbox 1') as HTMLInputElement;
+    const checkbox = screen.getByLabelText('Checkbox 1') as HTMLInputElement;
 
     expect(checkbox.checked).toBe(true);
-    expect(queryByText('Unselect all 3 options')).not.toBeNull();
-    expect(queryByText('Select all 3 options')).toBeNull();
+    expect(screen.queryByText('Unselect all 3 options')).toBeInTheDocument();
+    expect(screen.queryByText('Select all 3 options')).not.toBeInTheDocument();
 
-    fireEvent.click(checkbox);
+    userEvent.click(checkbox);
 
-    await wait();
-
-    expect(checkbox.checked).toBe(false);
-    expect(queryByText('Unselect all 3 options')).toBeNull();
-    expect(queryByText('Select all 3 options')).not.toBeNull();
+    await waitFor(() => {
+      expect(checkbox.checked).toBe(false);
+      expect(
+        screen.queryByText('Unselect all 3 options'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Select all 3 options')).toBeInTheDocument();
+    });
   });
 
   describe('error messages', () => {
     test('does not display validation message when checkboxes are untouched', async () => {
-      const { queryByText } = render(
+      render(
         <Formik
           initialValues={{
             test: [],
@@ -267,11 +444,13 @@ describe('FormFieldCheckboxSearchGroup', () => {
         </Formik>,
       );
 
-      expect(queryByText('Select at least one option')).toBeNull();
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
     });
 
     test('displays validation message when no checkboxes are checked', async () => {
-      const { getByLabelText, queryByText } = render(
+      render(
         <Formik
           initialValues={{
             test: ['1'],
@@ -299,21 +478,25 @@ describe('FormFieldCheckboxSearchGroup', () => {
         </Formik>,
       );
 
-      const checkbox = getByLabelText('Checkbox 1') as HTMLInputElement;
+      const checkbox = screen.getByLabelText('Checkbox 1') as HTMLInputElement;
 
       expect(checkbox.checked).toBe(true);
-      expect(queryByText('Select at least one option')).toBeNull();
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
 
-      fireEvent.click(checkbox);
+      userEvent.click(checkbox);
 
-      await wait();
-
-      expect(checkbox.checked).toBe(false);
-      expect(queryByText('Select at least one option')).not.toBeNull();
+      await waitFor(() => {
+        expect(checkbox.checked).toBe(false);
+        expect(
+          screen.queryByText('Select at least one option'),
+        ).toBeInTheDocument();
+      });
     });
 
     test('does not display validation message when `showError` is false', async () => {
-      const { getByLabelText, queryByText } = render(
+      render(
         <Formik
           initialValues={{
             test: ['1'],
@@ -342,24 +525,28 @@ describe('FormFieldCheckboxSearchGroup', () => {
         </Formik>,
       );
 
-      const checkbox = getByLabelText('Checkbox 1') as HTMLInputElement;
+      const checkbox = screen.getByLabelText('Checkbox 1') as HTMLInputElement;
 
       expect(checkbox.checked).toBe(true);
-      expect(queryByText('Select at least one option')).toBeNull();
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
 
-      fireEvent.click(checkbox);
+      userEvent.click(checkbox);
 
-      await wait();
-
-      expect(checkbox.checked).toBe(false);
-      expect(queryByText('Select at least one option')).toBeNull();
+      await waitFor(() => {
+        expect(checkbox.checked).toBe(false);
+        expect(
+          screen.queryByText('Select at least one option'),
+        ).not.toBeInTheDocument();
+      });
     });
   });
 
-  test('providing a search term does not remove checkboxes that have already been checked', () => {
+  test('providing a search term does not remove checkboxes that have already been checked', async () => {
     jest.useFakeTimers();
 
-    const { getAllByLabelText, getByLabelText } = render(
+    render(
       <Formik
         initialValues={{
           test: ['1'],
@@ -382,20 +569,18 @@ describe('FormFieldCheckboxSearchGroup', () => {
       </Formik>,
     );
 
-    const searchInput = getByLabelText('Search options') as HTMLInputElement;
+    const searchInput = screen.getByLabelText(
+      'Search options',
+    ) as HTMLInputElement;
 
-    expect(getByLabelText('Checkbox 1')).toHaveAttribute('checked');
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute('checked');
 
-    fireEvent.change(searchInput, {
-      target: {
-        value: '2',
-      },
-    });
+    await userEvent.type(searchInput, '2');
 
     jest.runAllTimers();
 
-    expect(getAllByLabelText(/Checkbox/)).toHaveLength(2);
-    expect(getByLabelText('Checkbox 1')).toHaveAttribute('checked');
-    expect(getByLabelText('Checkbox 2')).not.toHaveAttribute('checked');
+    expect(screen.getAllByLabelText(/Checkbox/)).toHaveLength(2);
+    expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute('checked');
+    expect(screen.getByLabelText('Checkbox 2')).not.toHaveAttribute('checked');
   });
 });

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSearchSubGroups.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldCheckboxSearchSubGroups.test.tsx
@@ -1,7 +1,10 @@
+import { Form } from '@common/components/form';
 import Yup from '@common/validation/yup';
 import { waitFor } from '@testing-library/dom';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Formik } from 'formik';
+import noop from 'lodash/noop';
 import React from 'react';
 import FormFieldCheckboxSearchSubGroups from '../FormFieldCheckboxSearchSubGroups';
 
@@ -10,13 +13,269 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     test: string[];
   }
 
+  test('renders with correct default ids without form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={noop}
+      >
+        <FormFieldCheckboxSearchSubGroups<FormValues>
+          name="test"
+          legend="Test checkboxes"
+          options={[
+            {
+              legend: 'Group A',
+              options: [
+                { value: '1', label: 'Checkbox 1' },
+                { value: '2', label: 'Checkbox 2' },
+              ],
+            },
+            {
+              legend: 'Group B',
+              options: [
+                { value: '3', label: 'Checkbox 3' },
+                { value: '4', label: 'Checkbox 4' },
+              ],
+            },
+          ]}
+        />
+      </Formik>,
+    );
+
+    const fieldset = screen.getByRole('group', { name: 'Test checkboxes' });
+    const groupA = screen.getByRole('group', { name: 'Group A' });
+    const groupB = screen.getByRole('group', { name: 'Group B' });
+
+    expect(fieldset).toHaveAttribute('id', 'test');
+    expect(groupA).toHaveAttribute('id', 'test-options-1');
+    expect(groupB).toHaveAttribute('id', 'test-options-2');
+
+    expect(within(fieldset).getByRole('textbox')).toHaveAttribute(
+      'id',
+      'test-search',
+    );
+
+    expect(within(fieldset).getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'test-options-1-1',
+    );
+    expect(within(groupA).getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'test-options-1-2',
+    );
+    expect(within(groupB).getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'test-options-2-3',
+    );
+    expect(within(groupB).getByLabelText('Checkbox 4')).toHaveAttribute(
+      'id',
+      'test-options-2-4',
+    );
+  });
+
+  test('renders with correct default ids with form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={noop}
+      >
+        <Form id="testForm">
+          <FormFieldCheckboxSearchSubGroups<FormValues>
+            name="test"
+            legend="Test checkboxes"
+            options={[
+              {
+                legend: 'Group A',
+                options: [
+                  { value: '1', label: 'Checkbox 1' },
+                  { value: '2', label: 'Checkbox 2' },
+                ],
+              },
+              {
+                legend: 'Group B',
+                options: [
+                  { value: '3', label: 'Checkbox 3' },
+                  { value: '4', label: 'Checkbox 4' },
+                ],
+              },
+            ]}
+          />
+        </Form>
+      </Formik>,
+    );
+
+    const fieldset = screen.getByRole('group', { name: 'Test checkboxes' });
+    const groupA = screen.getByRole('group', { name: 'Group A' });
+    const groupB = screen.getByRole('group', { name: 'Group B' });
+
+    expect(fieldset).toHaveAttribute('id', 'testForm-test');
+    expect(groupA).toHaveAttribute('id', 'testForm-test-options-1');
+    expect(groupB).toHaveAttribute('id', 'testForm-test-options-2');
+
+    expect(within(fieldset).getByRole('textbox')).toHaveAttribute(
+      'id',
+      'testForm-test-search',
+    );
+
+    expect(within(fieldset).getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'testForm-test-options-1-1',
+    );
+    expect(within(groupA).getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'testForm-test-options-1-2',
+    );
+    expect(within(groupB).getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'testForm-test-options-2-3',
+    );
+    expect(within(groupB).getByLabelText('Checkbox 4')).toHaveAttribute(
+      'id',
+      'testForm-test-options-2-4',
+    );
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={noop}
+      >
+        <Form id="testForm">
+          <FormFieldCheckboxSearchSubGroups<FormValues>
+            id="customId"
+            name="test"
+            legend="Test checkboxes"
+            options={[
+              {
+                legend: 'Group A',
+                options: [
+                  { value: '1', label: 'Checkbox 1' },
+                  { id: 'customOption2', value: '2', label: 'Checkbox 2' },
+                ],
+              },
+              {
+                legend: 'Group B',
+                id: 'customGroup',
+                options: [
+                  { value: '3', label: 'Checkbox 3' },
+                  { id: 'customOption4', value: '4', label: 'Checkbox 4' },
+                ],
+              },
+            ]}
+          />
+        </Form>
+      </Formik>,
+    );
+
+    const fieldset = screen.getByRole('group', { name: 'Test checkboxes' });
+    const groupA = screen.getByRole('group', { name: 'Group A' });
+    const groupB = screen.getByRole('group', { name: 'Group B' });
+
+    expect(fieldset).toHaveAttribute('id', 'testForm-customId');
+    expect(groupA).toHaveAttribute('id', 'testForm-customId-options-1');
+    expect(groupB).toHaveAttribute('id', 'testForm-customId-customGroup');
+
+    expect(within(fieldset).getByRole('textbox')).toHaveAttribute(
+      'id',
+      'testForm-customId-search',
+    );
+
+    expect(within(fieldset).getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'testForm-customId-options-1-1',
+    );
+    expect(within(groupA).getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'testForm-customId-options-1-customOption2',
+    );
+    expect(within(groupB).getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'testForm-customId-customGroup-3',
+    );
+    expect(within(groupB).getByLabelText('Checkbox 4')).toHaveAttribute(
+      'id',
+      'testForm-customId-customGroup-customOption4',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: [],
+        }}
+        onSubmit={noop}
+      >
+        <FormFieldCheckboxSearchSubGroups<FormValues>
+          id="customId"
+          name="test"
+          legend="Test checkboxes"
+          options={[
+            {
+              legend: 'Group A',
+              options: [
+                { value: '1', label: 'Checkbox 1' },
+                { id: 'customOption2', value: '2', label: 'Checkbox 2' },
+              ],
+            },
+            {
+              legend: 'Group B',
+              id: 'customGroup',
+              options: [
+                { value: '3', label: 'Checkbox 3' },
+                { id: 'customOption4', value: '4', label: 'Checkbox 4' },
+              ],
+            },
+          ]}
+        />
+      </Formik>,
+    );
+
+    const fieldset = screen.getByRole('group', { name: 'Test checkboxes' });
+    const groupA = screen.getByRole('group', { name: 'Group A' });
+    const groupB = screen.getByRole('group', { name: 'Group B' });
+
+    expect(fieldset).toHaveAttribute('id', 'customId');
+    expect(groupA).toHaveAttribute('id', 'customId-options-1');
+    expect(groupB).toHaveAttribute('id', 'customId-customGroup');
+
+    expect(within(fieldset).getByRole('textbox')).toHaveAttribute(
+      'id',
+      'customId-search',
+    );
+
+    expect(within(fieldset).getByLabelText('Checkbox 1')).toHaveAttribute(
+      'id',
+      'customId-options-1-1',
+    );
+    expect(within(groupA).getByLabelText('Checkbox 2')).toHaveAttribute(
+      'id',
+      'customId-options-1-customOption2',
+    );
+    expect(within(groupB).getByLabelText('Checkbox 3')).toHaveAttribute(
+      'id',
+      'customId-customGroup-3',
+    );
+    expect(within(groupB).getByLabelText('Checkbox 4')).toHaveAttribute(
+      'id',
+      'customId-customGroup-customOption4',
+    );
+  });
+
   test('checking option checks it', () => {
     render(
       <Formik
         initialValues={{
           test: [],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxSearchSubGroups<FormValues>
@@ -48,7 +307,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
 
     expect(checkbox.checked).toBe(false);
 
-    fireEvent.click(checkbox);
+    userEvent.click(checkbox);
 
     expect(checkbox.checked).toBe(true);
   });
@@ -59,7 +318,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
         initialValues={{
           test: ['1'],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxSearchSubGroups<FormValues>
@@ -91,7 +350,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
 
     expect(checkbox.checked).toBe(true);
 
-    fireEvent.click(checkbox);
+    userEvent.click(checkbox);
 
     expect(checkbox.checked).toBe(false);
   });
@@ -102,7 +361,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
         initialValues={{
           test: [],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxSearchSubGroups<FormValues>
@@ -135,7 +394,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     expect(checkbox2.checked).toBe(false);
     expect(checkbox3.checked).toBe(false);
 
-    fireEvent.click(
+    userEvent.click(
       screen.getByRole('button', {
         name: 'Select all 3 options',
       }),
@@ -158,7 +417,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
         initialValues={{
           test: ['1', '2', '3'],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxSearchSubGroups<FormValues>
@@ -191,7 +450,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(true);
 
-    fireEvent.click(
+    userEvent.click(
       screen.getByRole('button', {
         name: 'Unselect all 3 options',
       }),
@@ -208,7 +467,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
         initialValues={{
           test: [],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxSearchSubGroups<FormValues>
@@ -239,9 +498,9 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
       }),
     ).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByLabelText('Checkbox 1'));
-    fireEvent.click(screen.getByLabelText('Checkbox 2'));
-    fireEvent.click(screen.getByLabelText('Checkbox 3'));
+    userEvent.click(screen.getByLabelText('Checkbox 1'));
+    userEvent.click(screen.getByLabelText('Checkbox 2'));
+    userEvent.click(screen.getByLabelText('Checkbox 3'));
 
     expect(
       screen.getByRole('button', {
@@ -256,7 +515,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
         initialValues={{
           test: [],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxSearchSubGroups<FormValues>
@@ -292,7 +551,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     expect(checkbox2.checked).toBe(false);
     expect(checkbox3.checked).toBe(false);
 
-    fireEvent.click(
+    userEvent.click(
       group2.getByRole('button', {
         name: 'Select all 2 subgroup options',
       }),
@@ -309,7 +568,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
         initialValues={{
           test: ['2', '3'],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxSearchSubGroups<FormValues>
@@ -345,7 +604,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(true);
 
-    fireEvent.click(
+    userEvent.click(
       group2.getByRole('button', { name: 'Unselect all 2 subgroup options' }),
     );
 
@@ -360,7 +619,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
         initialValues={{
           test: [],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxSearchSubGroups<FormValues>
@@ -398,20 +657,20 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     ).toBeInTheDocument();
     expect(
       group2.queryByRole('button', { name: 'Unselect all 2 subgroup options' }),
-    ).toBeNull();
+    ).not.toBeInTheDocument();
 
-    fireEvent.click(checkbox2);
-    fireEvent.click(checkbox3);
+    userEvent.click(checkbox2);
+    userEvent.click(checkbox3);
 
     expect(checkbox2.checked).toBe(true);
     expect(checkbox3.checked).toBe(true);
 
     expect(
       group2.queryByRole('button', { name: 'Select all 2 subgroup options' }),
-    ).toBeNull();
+    ).not.toBeInTheDocument();
     expect(
       group2.getByRole('button', { name: 'Unselect all 2 subgroup options' }),
-    ).not.toBeNull();
+    ).toBeInTheDocument();
   });
 
   test('un-checking any options renders the corresponding `Unselect all options` button', () => {
@@ -420,7 +679,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
         initialValues={{
           test: ['2', '3'],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxSearchSubGroups<FormValues>
@@ -455,12 +714,12 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
 
     expect(
       group2.queryByRole('button', { name: 'Select all 2 subgroup options' }),
-    ).toBeNull();
+    ).not.toBeInTheDocument();
     expect(
       group2.getByRole('button', { name: 'Unselect all 2 subgroup options' }),
     ).toBeInTheDocument();
 
-    fireEvent.click(checkbox2);
+    userEvent.click(checkbox2);
 
     expect(checkbox2.checked).toBe(false);
     expect(checkbox3.checked).toBe(true);
@@ -470,7 +729,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
     ).toBeInTheDocument();
     expect(
       group2.queryByRole('name', { name: 'Unselect all 2 subgroup options' }),
-    ).toBeNull();
+    ).not.toBeInTheDocument();
   });
 
   describe('error messages', () => {
@@ -480,7 +739,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
           initialValues={{
             test: [],
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}
@@ -511,7 +770,9 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
         </Formik>,
       );
 
-      expect(screen.queryByText('Select at least one option')).toBeNull();
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
     });
 
     test('displays validation message when no checkboxes are checked', async () => {
@@ -523,7 +784,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
           initialTouched={{
             test: true,
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}
@@ -559,7 +820,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
       expect(checkbox.checked).toBe(true);
       expect(screen.queryByText('Select at least one option')).toBeNull();
 
-      fireEvent.click(checkbox);
+      userEvent.click(checkbox);
 
       await waitFor(() => {
         expect(checkbox.checked).toBe(false);
@@ -579,7 +840,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
           initialTouched={{
             test: true,
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}
@@ -614,16 +875,20 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
       const checkbox = screen.getByLabelText('Checkbox 1') as HTMLInputElement;
 
       expect(checkbox.checked).toBe(true);
-      expect(screen.queryByText('Select at least one option')).toBeNull();
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
 
-      fireEvent.click(checkbox);
+      userEvent.click(checkbox);
 
       expect(checkbox.checked).toBe(false);
-      expect(screen.queryByText('Select at least one option')).toBeNull();
+      expect(
+        screen.queryByText('Select at least one option'),
+      ).not.toBeInTheDocument();
     });
   });
 
-  test('providing a search term does not remove checkboxes that have already been checked', () => {
+  test('providing a search term does not remove checkboxes that have already been checked', async () => {
     jest.useFakeTimers();
 
     render(
@@ -631,7 +896,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
         initialValues={{
           test: ['1'],
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldCheckboxSearchSubGroups<FormValues>
@@ -666,11 +931,7 @@ describe('FormFieldCheckboxSearchSubGroups', () => {
 
     expect(screen.getByLabelText('Checkbox 1')).toHaveAttribute('checked');
 
-    fireEvent.change(searchInput, {
-      target: {
-        value: '2',
-      },
-    });
+    await userEvent.type(searchInput, '2');
 
     jest.runAllTimers();
 

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldDateInput.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldDateInput.test.tsx
@@ -1,6 +1,8 @@
+import { Form } from '@common/components/form';
 import FormFieldDateInput from '@common/components/form/FormFieldDateInput';
 import { PartialDate } from '@common/utils/date/partialDate';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Formik } from 'formik';
 import noop from 'lodash/noop';
 import React from 'react';
@@ -21,7 +23,7 @@ describe('FormFieldDateInput', () => {
   });
 
   test('renders with an error message correctly', () => {
-    const { container } = render(
+    render(
       <Formik
         initialValues={{}}
         initialErrors={{
@@ -40,7 +42,7 @@ describe('FormFieldDateInput', () => {
       </Formik>,
     );
 
-    expect(container.querySelector('fieldset')).toHaveAttribute(
+    expect(screen.getByRole('group')).toHaveAttribute(
       'aria-describedby',
       'startDate-error',
     );
@@ -51,7 +53,7 @@ describe('FormFieldDateInput', () => {
   });
 
   test('renders with a hint correctly', () => {
-    const { container } = render(
+    render(
       <Formik initialValues={{}} onSubmit={noop}>
         <FormFieldDateInput
           legend="Start date"
@@ -62,7 +64,7 @@ describe('FormFieldDateInput', () => {
       </Formik>,
     );
 
-    expect(container.querySelector('fieldset')).toHaveAttribute(
+    expect(screen.getByRole('group')).toHaveAttribute(
       'aria-describedby',
       'startDate-hint',
     );
@@ -73,7 +75,7 @@ describe('FormFieldDateInput', () => {
   });
 
   test('renders with a hint and error correctly', () => {
-    const { container } = render(
+    render(
       <Formik
         initialValues={{}}
         initialErrors={{
@@ -93,7 +95,7 @@ describe('FormFieldDateInput', () => {
       </Formik>,
     );
 
-    expect(container.querySelector('fieldset')).toHaveAttribute(
+    expect(screen.getByRole('group')).toHaveAttribute(
       'aria-describedby',
       'startDate-error startDate-hint',
     );
@@ -107,7 +109,177 @@ describe('FormFieldDateInput', () => {
     );
   });
 
-  test('sets a valid UTC date as a form value', () => {
+  test('renders with correct defaults ids with form', () => {
+    render(
+      <Formik
+        initialValues={{}}
+        initialErrors={{
+          startDate: 'The date is wrong',
+        }}
+        initialTouched={{
+          startDate: true,
+        }}
+        onSubmit={noop}
+      >
+        <Form id="testForm">
+          <FormFieldDateInput
+            legend="Start date"
+            hint="Test hint"
+            name="startDate"
+          />
+        </Form>
+      </Formik>,
+    );
+
+    const group = within(screen.getByRole('group'));
+
+    expect(group.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-startDate-hint',
+    );
+    expect(group.getByText('The date is wrong')).toHaveAttribute(
+      'id',
+      'testForm-startDate-error',
+    );
+    expect(group.getByLabelText('Day')).toHaveAttribute(
+      'id',
+      'testForm-startDate-day',
+    );
+    expect(group.getByLabelText('Month')).toHaveAttribute(
+      'id',
+      'testForm-startDate-month',
+    );
+    expect(group.getByLabelText('Year')).toHaveAttribute(
+      'id',
+      'testForm-startDate-year',
+    );
+  });
+
+  test('renders with correct defaults ids without form', () => {
+    render(
+      <Formik
+        initialValues={{}}
+        initialErrors={{
+          startDate: 'The date is wrong',
+        }}
+        initialTouched={{
+          startDate: true,
+        }}
+        onSubmit={noop}
+      >
+        <FormFieldDateInput
+          legend="Start date"
+          hint="Test hint"
+          name="startDate"
+        />
+      </Formik>,
+    );
+
+    const group = within(screen.getByRole('group'));
+
+    expect(group.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'startDate-hint',
+    );
+    expect(group.getByText('The date is wrong')).toHaveAttribute(
+      'id',
+      'startDate-error',
+    );
+    expect(group.getByLabelText('Day')).toHaveAttribute('id', 'startDate-day');
+    expect(group.getByLabelText('Month')).toHaveAttribute(
+      'id',
+      'startDate-month',
+    );
+    expect(group.getByLabelText('Year')).toHaveAttribute(
+      'id',
+      'startDate-year',
+    );
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <Formik
+        initialValues={{}}
+        initialErrors={{
+          startDate: 'The date is wrong',
+        }}
+        initialTouched={{
+          startDate: true,
+        }}
+        onSubmit={noop}
+      >
+        <Form id="testForm">
+          <FormFieldDateInput
+            legend="Start date"
+            hint="Test hint"
+            name="startDate"
+            id="customId"
+          />
+        </Form>
+      </Formik>,
+    );
+
+    const group = within(screen.getByRole('group'));
+
+    expect(group.getByText('Test hint')).toHaveAttribute(
+      'id',
+      'testForm-customId-hint',
+    );
+    expect(group.getByText('The date is wrong')).toHaveAttribute(
+      'id',
+      'testForm-customId-error',
+    );
+    expect(group.getByLabelText('Day')).toHaveAttribute(
+      'id',
+      'testForm-customId-day',
+    );
+    expect(group.getByLabelText('Month')).toHaveAttribute(
+      'id',
+      'testForm-customId-month',
+    );
+    expect(group.getByLabelText('Year')).toHaveAttribute(
+      'id',
+      'testForm-customId-year',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <Formik
+        initialValues={{}}
+        initialErrors={{
+          startDate: 'The date is wrong',
+        }}
+        initialTouched={{
+          startDate: true,
+        }}
+        onSubmit={noop}
+      >
+        <FormFieldDateInput
+          legend="Start date"
+          hint="Test hint"
+          name="startDate"
+          id="customId"
+        />
+      </Formik>,
+    );
+
+    const group = within(screen.getByRole('group'));
+
+    expect(group.getByText('Test hint')).toHaveAttribute('id', 'customId-hint');
+    expect(group.getByText('The date is wrong')).toHaveAttribute(
+      'id',
+      'customId-error',
+    );
+    expect(group.getByLabelText('Day')).toHaveAttribute('id', 'customId-day');
+    expect(group.getByLabelText('Month')).toHaveAttribute(
+      'id',
+      'customId-month',
+    );
+    expect(group.getByLabelText('Year')).toHaveAttribute('id', 'customId-year');
+  });
+
+  test('sets a valid UTC date as a form value', async () => {
     const onChange = jest.fn();
 
     render(
@@ -126,23 +298,9 @@ describe('FormFieldDateInput', () => {
       </Formik>,
     );
 
-    fireEvent.change(screen.getByLabelText('Day'), {
-      target: {
-        value: 10,
-      },
-    });
-
-    fireEvent.change(screen.getByLabelText('Month'), {
-      target: {
-        value: 12,
-      },
-    });
-
-    fireEvent.change(screen.getByLabelText('Year'), {
-      target: {
-        value: 2020,
-      },
-    });
+    await userEvent.type(screen.getByLabelText('Day'), '10');
+    await userEvent.type(screen.getByLabelText('Month'), '12');
+    await userEvent.type(screen.getByLabelText('Year'), '2020');
 
     expect(screen.getByLabelText('Day')).toHaveValue(10);
     expect(screen.getByLabelText('Month')).toHaveValue(12);
@@ -151,7 +309,7 @@ describe('FormFieldDateInput', () => {
     expect(onChange).toHaveBeenCalledWith(new Date('2020-12-10T00:00:00.000Z'));
   });
 
-  test('does not set an invalid date as a form value', () => {
+  test('does not set an invalid date as a form value', async () => {
     const onChange = jest.fn();
 
     render(
@@ -170,23 +328,9 @@ describe('FormFieldDateInput', () => {
       </Formik>,
     );
 
-    fireEvent.change(screen.getByLabelText('Day'), {
-      target: {
-        value: 32,
-      },
-    });
-
-    fireEvent.change(screen.getByLabelText('Month'), {
-      target: {
-        value: 12,
-      },
-    });
-
-    fireEvent.change(screen.getByLabelText('Year'), {
-      target: {
-        value: 2020,
-      },
-    });
+    await userEvent.type(screen.getByLabelText('Day'), '32');
+    await userEvent.type(screen.getByLabelText('Month'), '12');
+    await userEvent.type(screen.getByLabelText('Year'), '2020');
 
     expect(screen.getByLabelText('Day')).toHaveValue(32);
     expect(screen.getByLabelText('Month')).toHaveValue(12);
@@ -195,7 +339,7 @@ describe('FormFieldDateInput', () => {
     expect(onChange).toHaveBeenCalledWith(undefined);
   });
 
-  test('does not set a partial date as a form value', () => {
+  test('does not set a partial date as a form value', async () => {
     const onChange = jest.fn();
 
     render(
@@ -214,11 +358,7 @@ describe('FormFieldDateInput', () => {
       </Formik>,
     );
 
-    fireEvent.change(screen.getByLabelText('Day'), {
-      target: {
-        value: 10,
-      },
-    });
+    await userEvent.type(screen.getByLabelText('Day'), '10');
 
     expect(screen.getByLabelText('Day')).toHaveValue(10);
     expect(onChange).toHaveBeenCalledWith(undefined);
@@ -260,7 +400,7 @@ describe('FormFieldDateInput', () => {
     expect(screen.getByLabelText('Year')).toBeInTheDocument();
   });
 
-  test('can set a full PartialDate as a form value when `type = partialDate`', () => {
+  test('can set a full PartialDate as a form value when `type = partialDate`', async () => {
     const onChange = jest.fn();
 
     render(
@@ -280,23 +420,9 @@ describe('FormFieldDateInput', () => {
       </Formik>,
     );
 
-    fireEvent.change(screen.getByLabelText('Day'), {
-      target: {
-        value: 15,
-      },
-    });
-
-    fireEvent.change(screen.getByLabelText('Month'), {
-      target: {
-        value: 6,
-      },
-    });
-
-    fireEvent.change(screen.getByLabelText('Year'), {
-      target: {
-        value: 2020,
-      },
-    });
+    await userEvent.type(screen.getByLabelText('Day'), '15');
+    await userEvent.type(screen.getByLabelText('Month'), '6');
+    await userEvent.type(screen.getByLabelText('Year'), '2020');
 
     expect(screen.getByLabelText('Day')).toHaveValue(15);
     expect(screen.getByLabelText('Month')).toHaveValue(6);
@@ -309,7 +435,7 @@ describe('FormFieldDateInput', () => {
     });
   });
 
-  test('can set only a day for a form value when `type = partialDate`', () => {
+  test('can set only a day for a form value when `type = partialDate`', async () => {
     const onChange = jest.fn();
 
     render(
@@ -329,11 +455,7 @@ describe('FormFieldDateInput', () => {
       </Formik>,
     );
 
-    fireEvent.change(screen.getByLabelText('Day'), {
-      target: {
-        value: 15,
-      },
-    });
+    await userEvent.type(screen.getByLabelText('Day'), '15');
 
     expect(screen.getByLabelText('Day')).toHaveValue(15);
 
@@ -342,7 +464,7 @@ describe('FormFieldDateInput', () => {
     });
   });
 
-  test('can set an invalid PartialDate as a form value when `type = partialDate`', () => {
+  test('can set an invalid PartialDate as a form value when `type = partialDate`', async () => {
     const onChange = jest.fn();
 
     render(
@@ -362,23 +484,9 @@ describe('FormFieldDateInput', () => {
       </Formik>,
     );
 
-    fireEvent.change(screen.getByLabelText('Day'), {
-      target: {
-        value: 32,
-      },
-    });
-
-    fireEvent.change(screen.getByLabelText('Month'), {
-      target: {
-        value: 6,
-      },
-    });
-
-    fireEvent.change(screen.getByLabelText('Year'), {
-      target: {
-        value: 2020,
-      },
-    });
+    await userEvent.type(screen.getByLabelText('Day'), '32');
+    await userEvent.type(screen.getByLabelText('Month'), '6');
+    await userEvent.type(screen.getByLabelText('Year'), '2020');
 
     expect(screen.getByLabelText('Day')).toHaveValue(32);
     expect(screen.getByLabelText('Month')).toHaveValue(6);

--- a/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldRadioGroup.test.tsx
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/FormFieldRadioGroup.test.tsx
@@ -1,8 +1,10 @@
+import { Form } from '@common/components/form';
 import Yup from '@common/validation/yup';
 import { waitFor } from '@testing-library/dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Formik } from 'formik';
+import noop from 'lodash/noop';
 import React from 'react';
 import FormFieldRadioGroup from '../FormFieldRadioGroup';
 
@@ -11,13 +13,153 @@ describe('FormFieldRadioGroup', () => {
     test: string;
   }
 
+  test('renders with correct default ids without form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: '',
+        }}
+        onSubmit={noop}
+      >
+        <FormFieldRadioGroup<FormValues>
+          name="test"
+          legend="Test radios"
+          options={[
+            { value: '1', label: 'Radio 1' },
+            { value: '2', label: 'Radio 2' },
+            { value: '3', label: 'Radio 3' },
+          ]}
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'test');
+    expect(screen.getByLabelText('Radio 1')).toHaveAttribute('id', 'test-1');
+    expect(screen.getByLabelText('Radio 2')).toHaveAttribute('id', 'test-2');
+    expect(screen.getByLabelText('Radio 3')).toHaveAttribute('id', 'test-3');
+  });
+
+  test('renders with correct default ids with form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: '',
+        }}
+        onSubmit={noop}
+      >
+        <Form id="testForm">
+          <FormFieldRadioGroup<FormValues>
+            name="test"
+            legend="Test radios"
+            options={[
+              { value: '1', label: 'Radio 1' },
+              { value: '2', label: 'Radio 2' },
+              { value: '3', label: 'Radio 3' },
+            ]}
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'testForm-test');
+    expect(screen.getByLabelText('Radio 1')).toHaveAttribute(
+      'id',
+      'testForm-test-1',
+    );
+    expect(screen.getByLabelText('Radio 2')).toHaveAttribute(
+      'id',
+      'testForm-test-2',
+    );
+    expect(screen.getByLabelText('Radio 3')).toHaveAttribute(
+      'id',
+      'testForm-test-3',
+    );
+  });
+
+  test('renders with correct custom ids with form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: '',
+        }}
+        onSubmit={noop}
+      >
+        <Form id="testForm">
+          <FormFieldRadioGroup<FormValues>
+            name="test"
+            id="customId"
+            legend="Test radios"
+            options={[
+              { value: '1', label: 'Radio 1' },
+              { value: '2', label: 'Radio 2' },
+              { id: 'customOption', value: '3', label: 'Radio 3' },
+            ]}
+          />
+        </Form>
+      </Formik>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute(
+      'id',
+      'testForm-customId',
+    );
+    expect(screen.getByLabelText('Radio 1')).toHaveAttribute(
+      'id',
+      'testForm-customId-1',
+    );
+    expect(screen.getByLabelText('Radio 2')).toHaveAttribute(
+      'id',
+      'testForm-customId-2',
+    );
+    expect(screen.getByLabelText('Radio 3')).toHaveAttribute(
+      'id',
+      'testForm-customId-customOption',
+    );
+  });
+
+  test('renders with correct custom ids without form', () => {
+    render(
+      <Formik<FormValues>
+        initialValues={{
+          test: '',
+        }}
+        onSubmit={noop}
+      >
+        <FormFieldRadioGroup<FormValues>
+          name="test"
+          id="customId"
+          legend="Test radios"
+          options={[
+            { value: '1', label: 'Radio 1' },
+            { value: '2', label: 'Radio 2' },
+            { id: 'customOption', value: '3', label: 'Radio 3' },
+          ]}
+        />
+      </Formik>,
+    );
+
+    expect(screen.getByRole('group')).toHaveAttribute('id', 'customId');
+    expect(screen.getByLabelText('Radio 1')).toHaveAttribute(
+      'id',
+      'customId-1',
+    );
+    expect(screen.getByLabelText('Radio 2')).toHaveAttribute(
+      'id',
+      'customId-2',
+    );
+    expect(screen.getByLabelText('Radio 3')).toHaveAttribute(
+      'id',
+      'customId-customOption',
+    );
+  });
+
   test('checking an option checks it', async () => {
     render(
       <Formik
         initialValues={{
           test: '',
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldRadioGroup<FormValues>
@@ -49,7 +191,7 @@ describe('FormFieldRadioGroup', () => {
         initialValues={{
           test: '1',
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         {() => (
           <FormFieldRadioGroup<FormValues>
@@ -85,7 +227,7 @@ describe('FormFieldRadioGroup', () => {
           initialValues={{
             test: '',
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}
@@ -126,7 +268,7 @@ describe('FormFieldRadioGroup', () => {
           initialValues={{
             test: '',
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}
@@ -162,7 +304,7 @@ describe('FormFieldRadioGroup', () => {
           initialValues={{
             test: '',
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}
@@ -191,7 +333,7 @@ describe('FormFieldRadioGroup', () => {
           initialValues={{
             test: '',
           }}
-          onSubmit={() => undefined}
+          onSubmit={noop}
           validationSchema={Yup.object({
             test: Yup.array().required('Select at least one option'),
           })}

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxGroup.test.tsx.snap
@@ -11,40 +11,40 @@ exports[`FormCheckboxGroup renders checkboxes with some pre-checked 1`] = `
     <div class="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input"
-               id="checkbox-1"
+               id="test-checkboxes-checkbox-1"
                name="test-checkboxes"
                type="checkbox"
                value="1"
         >
         <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-1"
+               for="test-checkboxes-checkbox-1"
         >
           Test checkbox 1
         </label>
       </div>
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input"
-               id="checkbox-2"
+               id="test-checkboxes-checkbox-2"
                name="test-checkboxes"
                type="checkbox"
                value="2"
                checked
         >
         <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-2"
+               for="test-checkboxes-checkbox-2"
         >
           Test checkbox 2
         </label>
       </div>
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input"
-               id="checkbox-3"
+               id="test-checkboxes-checkbox-3"
                name="test-checkboxes"
                type="checkbox"
                value="3"
         >
         <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-3"
+               for="test-checkboxes-checkbox-3"
         >
           Test checkbox 3
         </label>
@@ -65,13 +65,13 @@ exports[`FormCheckboxGroup renders correctly with legend 1`] = `
     <div class="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input"
-               id="checkbox-1"
+               id="test-checkboxes-checkbox-1"
                name="test-checkboxes"
                type="checkbox"
                value="1"
         >
         <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-1"
+               for="test-checkboxes-checkbox-1"
         >
           Test checkbox 1
         </label>
@@ -103,14 +103,14 @@ exports[`FormCheckboxGroup renders correctly with small size variants 1`] = `
         >
           <input
             class="govuk-checkboxes__input"
-            id="checkbox-1"
+            id="test-checkboxes-checkbox-1"
             name="test-checkboxes"
             type="checkbox"
             value="1"
           />
           <label
             class="govuk-label govuk-checkboxes__label"
-            for="checkbox-1"
+            for="test-checkboxes-checkbox-1"
           >
             Test checkbox 1
           </label>
@@ -132,39 +132,39 @@ exports[`FormCheckboxGroup renders list of checkboxes in correct order 1`] = `
     <div class="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input"
-               id="checkbox-1"
+               id="test-checkboxes-checkbox-1"
                name="test-checkboxes"
                type="checkbox"
                value="1"
         >
         <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-1"
+               for="test-checkboxes-checkbox-1"
         >
           Test checkbox 1
         </label>
       </div>
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input"
-               id="checkbox-2"
+               id="test-checkboxes-checkbox-2"
                name="test-checkboxes"
                type="checkbox"
                value="2"
         >
         <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-2"
+               for="test-checkboxes-checkbox-2"
         >
           Test checkbox 2
         </label>
       </div>
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input"
-               id="checkbox-3"
+               id="test-checkboxes-checkbox-3"
                name="test-checkboxes"
                type="checkbox"
                value="3"
         >
         <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-3"
+               for="test-checkboxes-checkbox-3"
         >
           Test checkbox 3
         </label>
@@ -185,13 +185,13 @@ exports[`FormCheckboxGroup renders option with conditional contents 1`] = `
     <div class="govuk-checkboxes">
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input"
-               id="checkbox-1"
+               id="test-checkboxes-checkbox-1"
                name="test-checkboxes"
                type="checkbox"
                value="1"
         >
         <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-1"
+               for="test-checkboxes-checkbox-1"
         >
           Test checkbox 1
         </label>
@@ -203,14 +203,14 @@ exports[`FormCheckboxGroup renders option with conditional contents 1`] = `
       </div>
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input"
-               id="checkbox-2"
+               id="test-checkboxes-checkbox-2"
                name="test-checkboxes"
                type="checkbox"
                value="2"
                checked
         >
         <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-2"
+               for="test-checkboxes-checkbox-2"
         >
           Test checkbox 2
         </label>
@@ -222,13 +222,13 @@ exports[`FormCheckboxGroup renders option with conditional contents 1`] = `
       </div>
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input"
-               id="checkbox-3"
+               id="test-checkboxes-checkbox-3"
                name="test-checkboxes"
                type="checkbox"
                value="3"
         >
         <label class="govuk-label govuk-checkboxes__label"
-               for="checkbox-3"
+               for="test-checkboxes-checkbox-3"
         >
           Test checkbox 3
         </label>

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchGroup.test.tsx.snap
@@ -25,39 +25,39 @@ exports[`FormCheckboxSearchGroup renders list of checkboxes in correct order 1`]
       <div class="govuk-checkboxes govuk-checkboxes--small">
         <div class="govuk-checkboxes__item">
           <input class="govuk-checkboxes__input"
-                 id="test-checkboxes-checkboxes-1"
+                 id="test-checkboxes-options-1"
                  name="testCheckboxes"
                  type="checkbox"
                  value="1"
           >
           <label class="govuk-label govuk-checkboxes__label"
-                 for="test-checkboxes-checkboxes-1"
+                 for="test-checkboxes-options-1"
           >
             Test checkbox 1
           </label>
         </div>
         <div class="govuk-checkboxes__item">
           <input class="govuk-checkboxes__input"
-                 id="test-checkboxes-checkboxes-2"
+                 id="test-checkboxes-options-2"
                  name="testCheckboxes"
                  type="checkbox"
                  value="2"
           >
           <label class="govuk-label govuk-checkboxes__label"
-                 for="test-checkboxes-checkboxes-2"
+                 for="test-checkboxes-options-2"
           >
             Test checkbox 2
           </label>
         </div>
         <div class="govuk-checkboxes__item">
           <input class="govuk-checkboxes__input"
-                 id="test-checkboxes-checkboxes-3"
+                 id="test-checkboxes-options-3"
                  name="testCheckboxes"
                  type="checkbox"
                  value="3"
           >
           <label class="govuk-label govuk-checkboxes__label"
-                 for="test-checkboxes-checkboxes-3"
+                 for="test-checkboxes-options-3"
           >
             Test checkbox 3
           </label>

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchSubGroups.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormCheckboxSearchSubGroups.test.tsx.snap
@@ -30,13 +30,13 @@ exports[`FormCheckboxSearchSubGroups renders groups of checkboxes in correct ord
     >
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset"
-                  id="test-checkboxes-1"
+                  id="test-checkboxes-options-1"
         >
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
             Group A
           </legend>
           <div class="govuk-checkboxes">
-            <button id="test-checkboxes-1-all"
+            <button id="test-checkboxes-options-1-all"
                     class="button noUnderline selectAll"
                     type="button"
             >
@@ -44,26 +44,26 @@ exports[`FormCheckboxSearchSubGroups renders groups of checkboxes in correct ord
             </button>
             <div class="govuk-checkboxes__item">
               <input class="govuk-checkboxes__input"
-                     id="test-checkboxes-1-1"
+                     id="test-checkboxes-options-1-1"
                      name="testCheckboxes"
                      type="checkbox"
                      value="1"
               >
               <label class="govuk-label govuk-checkboxes__label"
-                     for="test-checkboxes-1-1"
+                     for="test-checkboxes-options-1-1"
               >
                 Checkbox 1
               </label>
             </div>
             <div class="govuk-checkboxes__item">
               <input class="govuk-checkboxes__input"
-                     id="test-checkboxes-1-2"
+                     id="test-checkboxes-options-1-2"
                      name="testCheckboxes"
                      type="checkbox"
                      value="2"
               >
               <label class="govuk-label govuk-checkboxes__label"
-                     for="test-checkboxes-1-2"
+                     for="test-checkboxes-options-1-2"
               >
                 Checkbox 2
               </label>
@@ -73,13 +73,13 @@ exports[`FormCheckboxSearchSubGroups renders groups of checkboxes in correct ord
       </div>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset"
-                  id="test-checkboxes-2"
+                  id="test-checkboxes-options-2"
         >
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
             Group B
           </legend>
           <div class="govuk-checkboxes">
-            <button id="test-checkboxes-2-all"
+            <button id="test-checkboxes-options-2-all"
                     class="button noUnderline selectAll"
                     type="button"
             >
@@ -87,26 +87,26 @@ exports[`FormCheckboxSearchSubGroups renders groups of checkboxes in correct ord
             </button>
             <div class="govuk-checkboxes__item">
               <input class="govuk-checkboxes__input"
-                     id="test-checkboxes-2-3"
+                     id="test-checkboxes-options-2-3"
                      name="testCheckboxes"
                      type="checkbox"
                      value="3"
               >
               <label class="govuk-label govuk-checkboxes__label"
-                     for="test-checkboxes-2-3"
+                     for="test-checkboxes-options-2-3"
               >
                 Checkbox 3
               </label>
             </div>
             <div class="govuk-checkboxes__item">
               <input class="govuk-checkboxes__input"
-                     id="test-checkboxes-2-4"
+                     id="test-checkboxes-options-2-4"
                      name="testCheckboxes"
                      type="checkbox"
                      value="4"
               >
               <label class="govuk-label govuk-checkboxes__label"
-                     for="test-checkboxes-2-4"
+                     for="test-checkboxes-options-2-4"
               >
                 Checkbox 4
               </label>

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldset.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormFieldset.test.tsx.snap
@@ -49,19 +49,13 @@ exports[`FormFieldset renders correctly with hint 1`] = `
 `;
 
 exports[`FormFieldset renders correctly with required props 1`] = `
-<div class="govuk-form-group">
-  <fieldset class="govuk-fieldset"
-            id="test-fieldset"
-  >
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-      Fill the form
-    </legend>
-    <input type="text"
-           name="test-input-1"
-    >
-    <input type="text"
-           name="test-input-2"
-    >
-  </fieldset>
-</div>
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+  Fill the form
+</legend>
+<input type="text"
+       name="test-input-1"
+>
+<input type="text"
+       name="test-input-2"
+>
 `;

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormRadioGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormRadioGroup.test.tsx.snap
@@ -13,13 +13,13 @@ exports[`FormRadioGroup renders correctly with legend 1`] = `
            data-testid="Radio item for Test radio 1"
       >
         <input class="govuk-radios__input"
-               id="radio-1"
+               id="test-radios-radio-1"
                name="test-radios"
                type="radio"
                value="1"
         >
         <label class="govuk-label govuk-radios__label"
-               for="radio-1"
+               for="test-radios-radio-1"
         >
           Test radio 1
         </label>
@@ -52,14 +52,14 @@ exports[`FormRadioGroup renders correctly with small size variants 1`] = `
         >
           <input
             class="govuk-radios__input"
-            id="radio-1"
+            id="test-radios-radio-1"
             name="test-radios"
             type="radio"
             value="1"
           />
           <label
             class="govuk-label govuk-radios__label"
-            for="radio-1"
+            for="test-radios-radio-1"
           >
             Test radio 1
           </label>
@@ -83,13 +83,13 @@ exports[`FormRadioGroup renders list of radios in correct order 1`] = `
            data-testid="Radio item for Test radio 1"
       >
         <input class="govuk-radios__input"
-               id="radio-1"
+               id="test-radios-radio-1"
                name="test-radios"
                type="radio"
                value="1"
         >
         <label class="govuk-label govuk-radios__label"
-               for="radio-1"
+               for="test-radios-radio-1"
         >
           Test radio 1
         </label>
@@ -98,13 +98,13 @@ exports[`FormRadioGroup renders list of radios in correct order 1`] = `
            data-testid="Radio item for Test radio 2"
       >
         <input class="govuk-radios__input"
-               id="radio-2"
+               id="test-radios-radio-2"
                name="test-radios"
                type="radio"
                value="2"
         >
         <label class="govuk-label govuk-radios__label"
-               for="radio-2"
+               for="test-radios-radio-2"
         >
           Test radio 2
         </label>
@@ -113,13 +113,13 @@ exports[`FormRadioGroup renders list of radios in correct order 1`] = `
            data-testid="Radio item for Test radio 3"
       >
         <input class="govuk-radios__input"
-               id="radio-3"
+               id="test-radios-radio-3"
                name="test-radios"
                type="radio"
                value="3"
         >
         <label class="govuk-label govuk-radios__label"
-               for="radio-3"
+               for="test-radios-radio-3"
         >
           Test radio 3
         </label>
@@ -142,21 +142,21 @@ exports[`FormRadioGroup renders option with conditional contents 1`] = `
            data-testid="Radio item for Test radio 1"
       >
         <input class="govuk-radios__input"
-               id="radio-1"
+               id="test-radios-radio-1"
                name="test-radios"
                type="radio"
                value="1"
-               aria-controls="radio-1-conditional"
+               aria-controls="test-radios-radio-1-conditional"
                aria-expanded="false"
         >
         <label class="govuk-label govuk-radios__label"
-               for="radio-1"
+               for="test-radios-radio-1"
         >
           Test radio 1
         </label>
       </div>
       <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-           id="radio-1-conditional"
+           id="test-radios-radio-1-conditional"
       >
         <p>
           Conditional 1
@@ -166,22 +166,22 @@ exports[`FormRadioGroup renders option with conditional contents 1`] = `
            data-testid="Radio item for Test radio 2"
       >
         <input class="govuk-radios__input"
-               id="radio-2"
+               id="test-radios-radio-2"
                name="test-radios"
                type="radio"
                value="2"
                checked
-               aria-controls="radio-2-conditional"
+               aria-controls="test-radios-radio-2-conditional"
                aria-expanded="true"
         >
         <label class="govuk-label govuk-radios__label"
-               for="radio-2"
+               for="test-radios-radio-2"
         >
           Test radio 2
         </label>
       </div>
       <div class="govuk-radios__conditional"
-           id="radio-2-conditional"
+           id="test-radios-radio-2-conditional"
       >
         <p>
           Conditional 2
@@ -191,21 +191,21 @@ exports[`FormRadioGroup renders option with conditional contents 1`] = `
            data-testid="Radio item for Test radio 3"
       >
         <input class="govuk-radios__input"
-               id="radio-3"
+               id="test-radios-radio-3"
                name="test-radios"
                type="radio"
                value="3"
-               aria-controls="radio-3-conditional"
+               aria-controls="test-radios-radio-3-conditional"
                aria-expanded="false"
         >
         <label class="govuk-label govuk-radios__label"
-               for="radio-3"
+               for="test-radios-radio-3"
         >
           Test radio 3
         </label>
       </div>
       <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
-           id="radio-3-conditional"
+           id="test-radios-radio-3-conditional"
       >
         <p>
           Conditional 3

--- a/src/explore-education-statistics-common/src/components/form/contexts/FormContext.tsx
+++ b/src/explore-education-statistics-common/src/components/form/contexts/FormContext.tsx
@@ -1,0 +1,48 @@
+import fieldId from '@common/components/form/util/fieldId';
+import React, { createContext, ReactNode, useContext, useMemo } from 'react';
+
+interface FormContextValue {
+  formId: string;
+  /**
+   * Create an `id` string for a field
+   * based on its {@param name} and the
+   * form context's {@member formId}.
+   */
+  fieldId: (name: string) => string;
+  /**
+   * Prefix an {@param id} with the
+   * context's {@member formId}. Useful for
+   * ids that don't use a field name.
+   */
+  prefixFormId: (id: string) => string;
+}
+
+const FormContext = createContext<FormContextValue>({
+  formId: '',
+  fieldId: name => fieldId('', name),
+  prefixFormId: id => id,
+});
+
+interface FormContextProviderProps {
+  children: ReactNode;
+  id: string;
+}
+
+export const FormContextProvider = ({
+  children,
+  id: formId,
+}: FormContextProviderProps) => {
+  const value = useMemo<FormContextValue>(() => {
+    return {
+      formId,
+      fieldId: name => fieldId(formId, name),
+      prefixFormId: customId => `${formId}-${customId}`,
+    };
+  }, [formId]);
+
+  return <FormContext.Provider value={value}>{children}</FormContext.Provider>;
+};
+
+export function useFormContext(): FormContextValue {
+  return useContext(FormContext);
+}

--- a/src/explore-education-statistics-common/src/components/form/util/__tests__/fieldId.test.ts
+++ b/src/explore-education-statistics-common/src/components/form/util/__tests__/fieldId.test.ts
@@ -1,0 +1,34 @@
+import fieldId from '@common/components/form/util/fieldId';
+
+describe('fieldId', () => {
+  test('returns correct id from simple name', () => {
+    expect(fieldId('testForm', 'name')).toEqual('testForm-name');
+  });
+
+  test('returns correct id from name with property', () => {
+    expect(fieldId('testForm', 'user.name')).toEqual('testForm-user-name');
+  });
+
+  test('returns correct id from array name', () => {
+    expect(fieldId('testForm', 'users[0]')).toEqual('testForm-users-0');
+  });
+
+  test('returns correct id from array name with property', () => {
+    expect(fieldId('testForm', 'users[0].name')).toEqual(
+      'testForm-users-0-name',
+    );
+  });
+
+  test('returns correct id when empty form id', () => {
+    expect(fieldId('', 'name')).toEqual('name');
+    expect(fieldId('', 'user.name')).toEqual('user-name');
+    expect(fieldId('', 'users[0]')).toEqual('users-0');
+    expect(fieldId('', 'users[0].name')).toEqual('users-0-name');
+  });
+
+  test('throws if name is empty', () => {
+    expect(() => {
+      fieldId('testForm', '');
+    }).toThrow();
+  });
+});

--- a/src/explore-education-statistics-common/src/components/form/util/fieldId.ts
+++ b/src/explore-education-statistics-common/src/components/form/util/fieldId.ts
@@ -1,0 +1,20 @@
+import camelCase from 'lodash/camelCase';
+import toPath from 'lodash/toPath';
+
+/**
+ * Format a {@param formId} and {@param name} into a
+ * string for use in `id` attributes.
+ *
+ * We should use this to ensure that things like error summary
+ * messages will correctly reference the form fields.
+ */
+export default function fieldId(formId: string, name: string): string {
+  if (!name) {
+    throw new Error('Field name is required to create id');
+  }
+
+  const parts = toPath(name).map(camelCase);
+  const id = parts.join('-');
+
+  return formId ? `${formId}-${id}` : id;
+}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -13,7 +13,6 @@ import { Dictionary } from '@common/types';
 import createErrorHelper from '@common/validation/createErrorHelper';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
-import camelCase from 'lodash/camelCase';
 import mapValues from 'lodash/mapValues';
 import React, { useMemo } from 'react';
 import FormFieldCheckboxGroupsMenu from './FormFieldCheckboxGroupsMenu';
@@ -119,7 +118,6 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
                   <div className="govuk-grid-column-one-half-from-desktop">
                     <FormFieldCheckboxSearchSubGroups
                       name="indicators"
-                      id={`${formId}-indicators`}
                       legend={
                         <>
                           Indicators
@@ -140,7 +138,7 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
 
                     {Object.entries(subjectMeta.filters).length > 0 && (
                       <FormFieldset
-                        id={`${formId}-filters`}
+                        id="filters"
                         legend="Categories"
                         legendSize="m"
                         hint="Select at least one option from all categories"
@@ -154,7 +152,6 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
                               <FormFieldCheckboxGroupsMenu
                                 key={filterKey}
                                 name={filterName}
-                                id={`${formId}-${camelCase(filterKey)}`}
                                 legend={filterGroup.legend}
                                 hint={filterGroup.hint}
                                 disabled={form.isSubmitting}
@@ -176,7 +173,6 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
 
               <WizardStepFormActions
                 {...props}
-                formId={formId}
                 submitText="Create table"
                 submittingText="Creating table"
                 onSubmitClick={() => {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableList.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableList.tsx
@@ -1,14 +1,18 @@
+import { useFormContext } from '@common/components/form/contexts/FormContext';
 import { OmitStrict } from '@common/types/util';
 import { Field, FieldProps } from 'formik';
 import React from 'react';
 import FormSortableList, { FormSortableListProps } from './FormSortableList';
 
 type Props<FormValues> = {
+  id?: string;
   name: FormValues extends Record<string, unknown> ? keyof FormValues : string;
-} & OmitStrict<FormSortableListProps, 'value'>;
+} & OmitStrict<FormSortableListProps, 'id' | 'value'>;
 
 function FormFieldSortableList<FormValues>(props: Props<FormValues>) {
-  const { name } = props;
+  const { name, id } = props;
+
+  const { prefixFormId, fieldId } = useFormContext();
 
   return (
     <Field name={name}>
@@ -16,6 +20,7 @@ function FormFieldSortableList<FormValues>(props: Props<FormValues>) {
         return (
           <FormSortableList
             {...props}
+            id={id ? prefixFormId(id) : fieldId(name as string)}
             value={field.value}
             onChange={value => {
               form.setFieldValue(name as string, value);

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.tsx
@@ -1,4 +1,5 @@
 import { FormFieldset } from '@common/components/form';
+import { useFormContext } from '@common/components/form/contexts/FormContext';
 import useToggle from '@common/hooks/useToggle';
 import classNames from 'classnames';
 import { useField } from 'formik';
@@ -8,18 +9,21 @@ import FormFieldSortableList from './FormFieldSortableList';
 import styles from './FormFieldSortableListGroup.module.scss';
 
 interface Props<FormValues> {
-  id: string;
+  id?: string;
   name: FormValues extends Record<string, unknown> ? keyof FormValues : string;
   legend: string;
   groupLegend: string;
 }
 
 function FormFieldSortableListGroup<FormValues>({
-  id,
+  id: customId,
   name,
   legend,
   groupLegend,
 }: Props<FormValues>) {
+  const { prefixFormId, fieldId } = useFormContext();
+  const id = customId ? prefixFormId(customId) : fieldId(name as string);
+
   const [field, meta] = useField(name as string);
   const [isDragDisabled, toggleDragDisabled] = useToggle(false);
 
@@ -68,7 +72,6 @@ function FormFieldSortableListGroup<FormValues>({
                     >
                       <FormFieldSortableList
                         name={`${name}[${index}]`}
-                        id={`${id}-${index}`}
                         legend={`${groupLegend} ${index + 1}`}
                         legendSize="s"
                         onMouseEnter={toggleDragDisabled.on}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -99,7 +99,7 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
           return (
             <Form {...form} id={formId} showSubmitError>
               <FormFieldset
-                id={`${formId}-levels`}
+                id="levels"
                 legend={stepHeading}
                 hint="Select at least one"
                 error={
@@ -116,7 +116,6 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
                           name={`locations.${levelKey}`}
                           key={levelKey}
                           options={level.options}
-                          id={`${formId}-levels-${levelKey}`}
                           legend={level.legend}
                           legendHidden
                           disabled={form.isSubmitting}
@@ -127,7 +126,7 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
                 </div>
               </FormFieldset>
 
-              <WizardStepFormActions {...props} formId={formId} />
+              <WizardStepFormActions {...props} />
             </Form>
           );
         }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -111,7 +111,7 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
             <Form {...form} id={formId} showSubmitError>
               <FormFieldset
                 error={getError('publicationId')}
-                id={`${formId}-publicationId`}
+                id="publicationId"
                 legend={stepHeading}
               >
                 <FormGroup>
@@ -167,9 +167,6 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
                                 small
                                 showError={false}
                                 name="publicationId"
-                                id={`${formId}-publicationId-${camelCase(
-                                  topic.title,
-                                )}`}
                                 disabled={form.isSubmitting}
                                 options={topic.publications.map(
                                   publication => ({
@@ -189,7 +186,7 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
                 </FormGroup>
               </FormFieldset>
 
-              <WizardStepFormActions {...props} formId={formId} />
+              <WizardStepFormActions {...props} />
             </Form>
           );
         }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectForm.tsx
@@ -117,13 +117,12 @@ const SubjectForm = ({
               name="subjectId"
               legend={legend}
               legendSize={legendSize}
-              id={`${formId}-subjectId`}
               disabled={form.isSubmitting}
               options={radioOptions}
             />
 
             {radioOptions.length > 0 ? (
-              <WizardStepFormActions {...stepProps} formId={formId} />
+              <WizardStepFormActions {...stepProps} />
             ) : (
               <p>No subjects available.</p>
             )}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableHeadersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableHeadersForm.tsx
@@ -131,7 +131,6 @@ const TableHeadersForm = ({
                     <FormFieldSortableListGroup<
                       PickByType<TableHeadersConfig, Filter[][]>
                     >
-                      id={`${id}-rowGroups`}
                       name="rowGroups"
                       legend="Row groups"
                       groupLegend="Row group"
@@ -142,7 +141,6 @@ const TableHeadersForm = ({
                     <FormFieldSortableListGroup<
                       PickByType<TableHeadersConfig, Filter[][]>
                     >
-                      id={`${id}-columnGroups`}
                       name="columnGroups"
                       legend="Column groups"
                       groupLegend="Column group"

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
@@ -151,10 +151,9 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
       {form => {
         return isActive ? (
           <Form id={formId} showSubmitError>
-            <FormFieldset id={`${formId}-timePeriod`} legend={stepHeading}>
+            <FormFieldset id="timePeriod" legend={stepHeading}>
               <FormFieldSelect
                 name="start"
-                id={`${formId}-start`}
                 label="Start date"
                 disabled={form.isSubmitting}
                 options={timePeriodOptions}
@@ -162,7 +161,6 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
               />
               <FormFieldSelect
                 name="end"
-                id={`${formId}-end`}
                 label="End date"
                 disabled={form.isSubmitting}
                 options={timePeriodOptions}
@@ -170,7 +168,7 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
               />
             </FormFieldset>
 
-            <WizardStepFormActions {...props} formId={formId} />
+            <WizardStepFormActions {...props} />
           </Form>
         ) : (
           <>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepFormActions.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepFormActions.tsx
@@ -1,13 +1,13 @@
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import { FormGroup } from '@common/components/form';
+import { useFormContext } from '@common/components/form/contexts/FormContext';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import { useFormikContext } from 'formik';
 import React, { MouseEventHandler } from 'react';
 import { InjectedWizardProps } from './Wizard';
 
 interface Props {
-  formId: string;
   goToPreviousStep: InjectedWizardProps['goToPreviousStep'];
   onPreviousStep?: MouseEventHandler;
   stepNumber: InjectedWizardProps['stepNumber'];
@@ -17,7 +17,6 @@ interface Props {
 }
 
 const WizardStepFormActions = ({
-  formId,
   goToPreviousStep,
   onPreviousStep,
   stepNumber,
@@ -25,6 +24,7 @@ const WizardStepFormActions = ({
   submittingText = 'Submitting',
   onSubmitClick = () => {},
 }: Props) => {
+  const { formId } = useFormContext();
   const form = useFormikContext();
 
   return (

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FormFieldCheckboxGroupsMenu.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FormFieldCheckboxGroupsMenu.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Formik } from 'formik';
+import noop from 'lodash/noop';
 import React from 'react';
 import FormFieldCheckboxGroupsMenu from '../FormFieldCheckboxGroupsMenu';
 
@@ -10,7 +11,7 @@ describe('FormFieldCheckboxGroupsMenu', () => {
         initialValues={{
           test: '',
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         <FormFieldCheckboxGroupsMenu
           id="test"
@@ -54,7 +55,7 @@ describe('FormFieldCheckboxGroupsMenu', () => {
         initialValues={{
           test: '',
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         <FormFieldCheckboxGroupsMenu
           id="test"
@@ -89,7 +90,7 @@ describe('FormFieldCheckboxGroupsMenu', () => {
         initialValues={{
           test: '',
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         <FormFieldCheckboxGroupsMenu
           id="test"
@@ -122,7 +123,7 @@ describe('FormFieldCheckboxGroupsMenu', () => {
         initialTouched={{
           test: true,
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         <FormFieldCheckboxGroupsMenu
           id="test"
@@ -158,7 +159,7 @@ describe('FormFieldCheckboxGroupsMenu', () => {
         initialTouched={{
           test: true,
         }}
-        onSubmit={() => undefined}
+        onSubmit={noop}
       >
         <FormFieldCheckboxGroupsMenu
           id="test"

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/WizardStepFormActions.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/WizardStepFormActions.test.tsx
@@ -10,7 +10,6 @@ describe('WizardStepFormActions', () => {
       <Formik onSubmit={() => {}} initialValues={{}}>
         <Form>
           <WizardStepFormActions
-            formId="form"
             goToPreviousStep={() => {}}
             onPreviousStep={() => {}}
             stepNumber={1}
@@ -30,7 +29,6 @@ describe('WizardStepFormActions', () => {
       <Formik onSubmit={() => {}} initialValues={{}}>
         <Form>
           <WizardStepFormActions
-            formId="form"
             goToPreviousStep={() => {}}
             onPreviousStep={() => {}}
             stepNumber={1}
@@ -51,7 +49,6 @@ describe('WizardStepFormActions', () => {
       <Formik onSubmit={() => {}} initialValues={{}}>
         <Form>
           <WizardStepFormActions
-            formId="form"
             goToPreviousStep={() => {}}
             onPreviousStep={() => {}}
             stepNumber={1}
@@ -66,7 +63,6 @@ describe('WizardStepFormActions', () => {
       <Formik onSubmit={() => {}} initialValues={{}}>
         <Form>
           <WizardStepFormActions
-            formId="form"
             goToPreviousStep={() => {}}
             onPreviousStep={() => {}}
             stepNumber={2}
@@ -85,7 +81,6 @@ describe('WizardStepFormActions', () => {
       <Formik onSubmit={() => {}} initialValues={{}}>
         <Form>
           <WizardStepFormActions
-            formId="form"
             goToPreviousStep={goToPreviousStep}
             onPreviousStep={() => {}}
             stepNumber={2}
@@ -108,7 +103,6 @@ describe('WizardStepFormActions', () => {
       <Formik onSubmit={() => {}} initialValues={{}}>
         <Form>
           <WizardStepFormActions
-            formId="form"
             goToPreviousStep={goToPreviousStep}
             onPreviousStep={event => event.preventDefault()}
             stepNumber={2}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FormFieldCheckboxGroupsMenu.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FormFieldCheckboxGroupsMenu.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
     >
       <fieldset
         class="govuk-fieldset"
-        id="test-1"
+        id="test-options-1"
       >
         <legend
           class="govuk-fieldset__legend govuk-fieldset__legend--s"
@@ -52,7 +52,7 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
         >
           <button
             class="button noUnderline selectAll"
-            id="test-1-all"
+            id="test-options-1-all"
             type="button"
           >
             Select all 2 subgroup options
@@ -62,14 +62,14 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
           >
             <input
               class="govuk-checkboxes__input"
-              id="test-1-1"
+              id="test-options-1-1"
               name="test"
               type="checkbox"
               value="1"
             />
             <label
               class="govuk-label govuk-checkboxes__label"
-              for="test-1-1"
+              for="test-options-1-1"
             >
               Option 1
             </label>
@@ -79,14 +79,14 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
           >
             <input
               class="govuk-checkboxes__input"
-              id="test-1-2"
+              id="test-options-1-2"
               name="test"
               type="checkbox"
               value="2"
             />
             <label
               class="govuk-label govuk-checkboxes__label"
-              for="test-1-2"
+              for="test-options-1-2"
             >
               Option 2
             </label>
@@ -99,7 +99,7 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
     >
       <fieldset
         class="govuk-fieldset"
-        id="test-2"
+        id="test-options-2"
       >
         <legend
           class="govuk-fieldset__legend govuk-fieldset__legend--s"
@@ -111,7 +111,7 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
         >
           <button
             class="button noUnderline selectAll"
-            id="test-2-all"
+            id="test-options-2-all"
             type="button"
           >
             Select all 2 subgroup options
@@ -121,14 +121,14 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
           >
             <input
               class="govuk-checkboxes__input"
-              id="test-2-3"
+              id="test-options-2-3"
               name="test"
               type="checkbox"
               value="3"
             />
             <label
               class="govuk-label govuk-checkboxes__label"
-              for="test-2-3"
+              for="test-options-2-3"
             >
               Option 3
             </label>
@@ -138,14 +138,14 @@ exports[`FormFieldCheckboxGroupsMenu renders multiple checkbox groups in correct
           >
             <input
               class="govuk-checkboxes__input"
-              id="test-2-4"
+              id="test-options-2-4"
               name="test"
               type="checkbox"
               value="4"
             />
             <label
               class="govuk-label govuk-checkboxes__label"
-              for="test-2-4"
+              for="test-options-2-4"
             >
               Option 4
             </label>

--- a/src/explore-education-statistics-frontend/src/modules/subscriptions/SubscriptionPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/subscriptions/SubscriptionPage.tsx
@@ -119,7 +119,6 @@ const SubscriptionPage: NextPage<Props> = ({
               {form => (
                 <Form id={formId} showSubmitError>
                   <FormFieldTextInput<FormValues>
-                    id={`${formId}-email`}
                     label="Enter your email address"
                     hint="This will only be used to subscribe you to updates. You can unsubscribe at any time"
                     name="email"

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -427,9 +427,9 @@ Change vertical bar chart legend
     user waits until h3 is visible  Legend
 
     user counts legend form item rows  1
-    user checks element value should be  id:chartLegendConfigurationForm-items0Label  Admission Numbers (Nailsea Youngwood)
+    user checks element value should be  id:chartLegendConfigurationForm-items-0-label  Admission Numbers (Nailsea Youngwood)
 
-    user enters text into element  id:chartLegendConfigurationForm-items0Label  Admissions
+    user enters text into element  id:chartLegendConfigurationForm-items-0-label  Admissions
 
     user waits for chart preview to update
 
@@ -633,17 +633,17 @@ Change geographic chart legend
     user waits until h3 is visible  Legend
 
     user counts legend form item rows  5
-    user checks element value should be  id:chartLegendConfigurationForm-items0Label  Admission Numbers (2005)
-    user checks element value should be  id:chartLegendConfigurationForm-items1Label  Admission Numbers (2010)
-    user checks element value should be  id:chartLegendConfigurationForm-items2Label  Admission Numbers (2011)
-    user checks element value should be  id:chartLegendConfigurationForm-items3Label  Admission Numbers (2012)
-    user checks element value should be  id:chartLegendConfigurationForm-items4Label  Admission Numbers (2016)
+    user checks element value should be  id:chartLegendConfigurationForm-items-0-label  Admission Numbers (2005)
+    user checks element value should be  id:chartLegendConfigurationForm-items-1-label  Admission Numbers (2010)
+    user checks element value should be  id:chartLegendConfigurationForm-items-2-label  Admission Numbers (2011)
+    user checks element value should be  id:chartLegendConfigurationForm-items-3-label  Admission Numbers (2012)
+    user checks element value should be  id:chartLegendConfigurationForm-items-4-label  Admission Numbers (2016)
 
-    user enters text into element  id:chartLegendConfigurationForm-items0Label  Admissions in 2005
-    user enters text into element  id:chartLegendConfigurationForm-items1Label  Admissions in 2010
-    user enters text into element  id:chartLegendConfigurationForm-items2Label  Admissions in 2011
-    user enters text into element  id:chartLegendConfigurationForm-items3Label  Admissions in 2012
-    user enters text into element  id:chartLegendConfigurationForm-items4Label  Admissions in 2016
+    user enters text into element  id:chartLegendConfigurationForm-items-0-label  Admissions in 2005
+    user enters text into element  id:chartLegendConfigurationForm-items-1-label  Admissions in 2010
+    user enters text into element  id:chartLegendConfigurationForm-items-2-label  Admissions in 2011
+    user enters text into element  id:chartLegendConfigurationForm-items-3-label  Admissions in 2012
+    user enters text into element  id:chartLegendConfigurationForm-items-4-label  Admissions in 2016
 
     user waits for chart preview to update
 

--- a/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
+++ b/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
@@ -122,7 +122,7 @@ Create new release
     user clicks testid element  Create new release link for ${PUBLICATION_NAME}
     user waits until page contains element  id:releaseSummaryForm-timePeriodCoverage
     user waits until page contains element  id:releaseSummaryForm-timePeriodCoverageStartYear
-    user selects from list by label  id:releaseSummaryForm-timePeriodCoverage  Spring Term
+    user selects from list by label  id:releaseSummaryForm-timePeriodCoverageCode  Spring Term
     user enters text into element  id:releaseSummaryForm-timePeriodCoverageStartYear  2025
     user clicks radio  National Statistics
     user clicks button   Create new release
@@ -145,7 +145,7 @@ Edit release summary
     user clicks link  Edit release summary
     user waits until h2 is visible  Edit release summary
     user waits until page contains element  id:releaseSummaryForm-timePeriodCoverageStartYear
-    user selects from list by label  id:releaseSummaryForm-timePeriodCoverage  Summer Term
+    user selects from list by label  id:releaseSummaryForm-timePeriodCoverageCode  Summer Term
     user enters text into element  id:releaseSummaryForm-timePeriodCoverageStartYear  2026
     user clicks radio  Official Statistics
     user clicks button   Update release summary

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -133,7 +133,7 @@ Add metadata guidance
     user checks results table cell contains  1  2   Admission Numbers   id:metaGuidance-dataFiles
 
     user enters text into element  id:metaGuidanceForm-content  Test metadata guidance content
-    user enters text into element  id:metaGuidanceForm-subjects0Content  Test file guidance content
+    user enters text into element  id:metaGuidanceForm-subjects-0-content  Test file guidance content
 
     user clicks button  Save guidance
 

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -49,10 +49,8 @@ Add release note to release
 Add related guidance link to release
     [Tags]  HappyPath
     user clicks button  Add related information
-    user clicks element  css:input#title
-    user presses keys   Test link one
-    user clicks element  css:input#link-url
-    user presses keys   http://test1.example.com/test1
+    user enters text into element  id:relatedInformationForm-description  Test link one
+    user enters text into element  id:relatedInformationForm-url  http://test1.example.com/test1
     user clicks button  Create link
 
 # TODO: Add Secondary Stats

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -94,7 +94,7 @@ user creates release for publication
     user waits until page contains title caption  ${publication}
     user waits until h1 is visible  Create new release
     user waits until page contains element  id:releaseSummaryForm-timePeriodCoverage
-    user selects from list by label  id:releaseSummaryForm-timePeriodCoverage  ${time_period_coverage}
+    user selects from list by label  id:releaseSummaryForm-timePeriodCoverageCode  ${time_period_coverage}
     user enters text into element  id:releaseSummaryForm-timePeriodCoverageStartYear  ${start_year}
     user clicks radio   National Statistics
     user clicks radio if exists  Create new template


### PR DESCRIPTION
This PR replaces the current approach of manually configuring `id` attributes for form fields with auto-generated ones, based on the field's `name` prop.

The main motivation of this is to avoid situations where the `id` doesn't align with the error summary's message link. If they don't match, clicking the error summary message's link will not focus the user onto the respective field that has the error. By auto-generating the `id` attributes, we can basically avoid any mismatches by default.

We generate the `id` based on the wrapping `Form` id and the field's `name` e.g. `theForm-theField`, which is pretty much the convention that we've been using with most forms up til this point. For more complex field names like `theField[0].name`, this becomes: `theForm-theField-0-name`.

If required, we can still use a custom `id` attribute for fields, however, they will typically be prefixed with the form id still i.e. `theForm-someCustomFieldId`. In the majority of situations, we shouldn't need this.

## Relevant changes

- Added `useFormId` prop to `FormFieldset` to disable prefixing the `id` with the form id. This is necessary in certain situations where we have `FormFieldset` wrapping some other form components (e.g. `FormCheckbox/RadioGroup`), to avoid the id looking like `theForm-theForm-theField`.

## Other changes

- Cleaned up majority of `FormField*` component tests to better follow Testing Library best practices.