### PR TITLE
EES-1941 Configure Deployment Slot in Virtual Network

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -783,7 +783,7 @@
           "httpLoggingEnabled": true,
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
-          // "scmIpSecurityRestrictions": "[variables('ipWhiteList').addresses]",
+          "vnetName": "[variables('vNetName')]",
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
@@ -796,7 +796,8 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/Sites', variables('dataAppName'))]"
+        "[resourceId('Microsoft.Web/Sites', variables('dataAppName'))]",
+        "[variables('vNetRef')]"
       ]
     },
     {
@@ -988,7 +989,7 @@
           "httpLoggingEnabled": true,
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
-          // "scmIpSecurityRestrictions": "[variables('ipWhiteList').addresses]",
+          "vnetName": "[variables('vNetName')]",
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
@@ -1001,7 +1002,8 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/Sites', variables('contentAppName'))]"
+        "[resourceId('Microsoft.Web/Sites', variables('contentAppName'))]",
+        "[variables('vNetRef')]"
       ]
     },
     {
@@ -1213,8 +1215,7 @@
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
           "use32BitWorkerProcess": false,
-          // "ipSecurityRestrictions": "[variables('ipWhiteList').addresses]",
-          // "scmIpSecurityRestrictionsUseMain": true,
+          "vnetName": "[variables('vNetName')]",
           "cors": {
             "allowedOrigins": [
               "https://localhost:3000",
@@ -1224,7 +1225,8 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Web/Sites', variables('adminAppName'))]"
+        "[resourceId('Microsoft.Web/Sites', variables('adminAppName'))]",
+        "[variables('vNetRef')]"
       ]
     },
     {


### PR DESCRIPTION
This makes a change to configure the deployment slots for each of the three app services to use the virtual network.

Currently they do not. When the production app service is swapped with the non-production service, it has the virtual network removed. This can be seen in the changelog of the slots during deployment time.

If there are requests in progress as the production slot is  swapped they may still try acquiring a database  pool connection which would then be blocked by the firewall.

We also think this might be the cause of intermittent start-up failures, if the reverse happens and start-up occurs after deployment before the virtual network has been assigned.