### PR TITLE
EES-1941 Configure Deployment Slot in Virtual Network

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -783,7 +783,7 @@
           "httpLoggingEnabled": true,
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
-          "vnetName": "[variables('vNetName')]",
+          "vnetName": "[variables('vNetRef')]",
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
@@ -989,7 +989,7 @@
           "httpLoggingEnabled": true,
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
-          "vnetName": "[variables('vNetName')]",
+          "vnetName": "[variables('vNetRef')]",
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
@@ -1215,7 +1215,7 @@
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
           "use32BitWorkerProcess": false,
-          "vnetName": "[variables('vNetName')]",
+          "vnetName": "[variables('vNetRef')]",
           "cors": {
             "allowedOrigins": [
               "https://localhost:3000",


### PR DESCRIPTION
This is an update to the previous PR https://github.com/dfe-analytical-services/explore-education-statistics/pull/2381 to correct the vnetName value to be a resource id.

When we export the configuration from the app service we see that it's using resource id's for this value rather than names despite the property being called `vnetName`.

See the description of https://github.com/dfe-analytical-services/explore-education-statistics/pull/2381 for more information