### PR TITLE
EES-1904 Replace link `analytics` prop with `logEvent` calls

### DIFF
--- a/src/explore-education-statistics-common/src/components/__tests__/PageSearchForm.test.tsx
+++ b/src/explore-education-statistics-common/src/components/__tests__/PageSearchForm.test.tsx
@@ -3,17 +3,24 @@ import AccordionSection from '@common/components/AccordionSection';
 import Details from '@common/components/Details';
 import Tabs from '@common/components/Tabs';
 import TabsSection from '@common/components/TabsSection';
-import { fireEvent, render, wait } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import PageSearchForm from '../PageSearchForm';
 
 const labelText = 'Find on this page';
 
 describe('PageSearchForm', () => {
-  test('does not render results if input is less than default 3 characters', () => {
+  beforeEach(() => {
     jest.useFakeTimers();
+  });
 
-    const { container, getByLabelText } = render(
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('does not render results if input is less than default 3 characters', async () => {
+    const { container } = render(
       <div>
         <PageSearchForm inputLabel={labelText} />
 
@@ -46,11 +53,7 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'To',
-      },
-    });
+    await userEvent.type(screen.getByLabelText(labelText), 'To');
 
     jest.runOnlyPendingTimers();
 
@@ -61,10 +64,8 @@ describe('PageSearchForm', () => {
     expect(options).toHaveLength(0);
   });
 
-  test('does not render results if input is less the custom `minInput` prop', () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+  test('does not render results if input is less the custom `minInput` prop', async () => {
+    const { container } = render(
       <div>
         <PageSearchForm inputLabel={labelText} minInput={5} />
 
@@ -97,11 +98,7 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'Test',
-      },
-    });
+    await userEvent.type(screen.getByLabelText(labelText), 'Test');
 
     jest.runOnlyPendingTimers();
 
@@ -112,10 +109,8 @@ describe('PageSearchForm', () => {
     expect(options).toHaveLength(0);
   });
 
-  test('renders correct results when input is an acronym', () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+  test('renders correct results when input is an acronym', async () => {
+    const { container } = render(
       <div>
         <PageSearchForm inputLabel={labelText} />
 
@@ -148,11 +143,7 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'TEST',
-      },
-    });
+    await userEvent.type(screen.getByLabelText(labelText), 'TEST');
 
     jest.runOnlyPendingTimers();
 
@@ -167,10 +158,8 @@ describe('PageSearchForm', () => {
     expect(options[1]).toHaveTextContent('TEST 3');
   });
 
-  test('renders correct results when input is an acronym and is below `minInput`', () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+  test('renders correct results when input is an acronym and is below `minInput`', async () => {
+    const { container } = render(
       <div>
         <PageSearchForm inputLabel={labelText} minInput={5} />
 
@@ -203,11 +192,7 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'TE',
-      },
-    });
+    await userEvent.type(screen.getByLabelText(labelText), 'TE');
 
     jest.runOnlyPendingTimers();
 
@@ -223,9 +208,7 @@ describe('PageSearchForm', () => {
   });
 
   test('renders results found in default elements', async () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+    const { container } = render(
       <div>
         <PageSearchForm inputLabel={labelText} />
 
@@ -258,11 +241,7 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'Test',
-      },
-    });
+    await userEvent.type(screen.getByLabelText(labelText), 'Test');
 
     jest.runOnlyPendingTimers();
 
@@ -282,10 +261,8 @@ describe('PageSearchForm', () => {
     expect(container.querySelector('[role="listbox"]')).toMatchSnapshot();
   });
 
-  test('renders results found in custom selectors', () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+  test('renders results found in custom selectors', async () => {
+    const { container } = render(
       <div>
         <PageSearchForm
           inputLabel={labelText}
@@ -322,11 +299,7 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'Test',
-      },
-    });
+    await userEvent.type(screen.getByLabelText(labelText), 'Test');
 
     jest.runOnlyPendingTimers();
 
@@ -344,9 +317,7 @@ describe('PageSearchForm', () => {
   });
 
   test('result locations uses nearest heading', async () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+    const { container } = render(
       <div>
         <PageSearchForm inputLabel={labelText} />
 
@@ -366,11 +337,7 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'Test',
-      },
-    });
+    await userEvent.type(screen.getByLabelText(labelText), 'Test');
 
     jest.runOnlyPendingTimers();
 
@@ -389,10 +356,8 @@ describe('PageSearchForm', () => {
     expect(container.querySelector('[role="listbox"]')).toMatchSnapshot();
   });
 
-  test('result locations include heading hierarchy', () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+  test('result locations include heading hierarchy', async () => {
+    const { container } = render(
       <div>
         <PageSearchForm inputLabel={labelText} />
 
@@ -409,11 +374,7 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'Test',
-      },
-    });
+    await userEvent.type(screen.getByLabelText(labelText), 'Test');
 
     jest.runOnlyPendingTimers();
 
@@ -430,10 +391,8 @@ describe('PageSearchForm', () => {
     expect(container.querySelector('[role="listbox"]')).toMatchSnapshot();
   });
 
-  test('result locations include accordion sections', () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+  test('result locations include accordion sections', async () => {
+    const { container } = render(
       <div>
         <PageSearchForm inputLabel={labelText} />
 
@@ -456,11 +415,7 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'Test',
-      },
-    });
+    await userEvent.type(screen.getByLabelText(labelText), 'Test');
 
     jest.runOnlyPendingTimers();
 
@@ -484,9 +439,7 @@ describe('PageSearchForm', () => {
   });
 
   test('clicking result scrolls and focuses the element', async () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+    const { container } = render(
       <div>
         <h2>Section 1</h2>
         <p id="target">Test</p>
@@ -495,19 +448,13 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'Test',
-      },
-    });
+    await userEvent.type(screen.getByLabelText(labelText), 'Test');
 
     jest.runOnlyPendingTimers();
 
-    jest.useRealTimers();
+    userEvent.click(container.querySelector('[role="option"]') as HTMLElement);
 
-    fireEvent.click(container.querySelector('[role="option"]') as HTMLElement);
-
-    await wait(() => {
+    await waitFor(() => {
       const target = container.querySelector('#target');
 
       expect(target).toHaveFocus();
@@ -516,9 +463,7 @@ describe('PageSearchForm', () => {
   });
 
   test('pressing Enter on result scrolls and focuses the element', async () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+    const { container } = render(
       <div>
         <h2>Section 1</h2>
         <p id="target">Test</p>
@@ -527,22 +472,16 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'Test',
-      },
-    });
+    await userEvent.type(screen.getByLabelText(labelText), 'Test');
 
     jest.runOnlyPendingTimers();
-
-    jest.useRealTimers();
 
     const listBox = container.querySelector('[role="listbox"]') as HTMLElement;
 
     fireEvent.keyDown(listBox, { key: 'ArrowDown' });
     fireEvent.keyDown(listBox, { key: 'Enter' });
 
-    await wait(() => {
+    await waitFor(() => {
       const target = container.querySelector('#target');
 
       expect(target).toHaveFocus();
@@ -551,9 +490,7 @@ describe('PageSearchForm', () => {
   });
 
   test('opens parent accordion of selected result', async () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+    const { container } = render(
       <div>
         <Accordion id="test-accordion">
           <AccordionSection heading="Section 1">
@@ -565,13 +502,11 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    await wait();
-
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'Test',
-      },
+    await waitFor(() => {
+      expect(screen.getByLabelText(labelText)).toBeInTheDocument();
     });
+
+    await userEvent.type(screen.getByLabelText(labelText), 'Test');
 
     jest.runOnlyPendingTimers();
 
@@ -589,9 +524,7 @@ describe('PageSearchForm', () => {
   });
 
   test('opens parent details of selected result', async () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+    const { container } = render(
       <div>
         <Details summary="Details 1">
           <p id="target">Test</p>
@@ -601,13 +534,11 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    await wait();
-
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'Test',
-      },
+    await waitFor(() => {
+      expect(screen.getByLabelText(labelText)).toBeInTheDocument();
     });
+
+    await userEvent.type(screen.getByLabelText(labelText), 'Test');
 
     jest.runOnlyPendingTimers();
 
@@ -615,19 +546,15 @@ describe('PageSearchForm', () => {
 
     expect(summary).toHaveAttribute('aria-expanded', 'false');
 
-    jest.useRealTimers();
-
     fireEvent.click(container.querySelector('[role="option"]') as HTMLElement);
 
-    await wait(() => {
+    await waitFor(() => {
       expect(summary).toHaveAttribute('aria-expanded', 'true');
     });
   });
 
   test('opens parent tab section of selected result', async () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+    const { container } = render(
       <div>
         <Tabs id="test-tabs">
           <TabsSection title="Tab 1">
@@ -642,13 +569,11 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    await wait();
-
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'Test',
-      },
+    await waitFor(() => {
+      expect(screen.getByLabelText(labelText)).toBeInTheDocument();
     });
+
+    await userEvent.type(screen.getByLabelText(labelText), 'Test');
 
     jest.runOnlyPendingTimers();
 
@@ -660,20 +585,16 @@ describe('PageSearchForm', () => {
     expect(tabs[0]).toHaveAttribute('aria-selected', 'true');
     expect(tabs[1]).toHaveAttribute('aria-selected', 'false');
 
-    jest.useRealTimers();
-
     fireEvent.click(container.querySelector('[role="option"]') as HTMLElement);
 
-    await wait(() => {
+    await waitFor(() => {
       expect(tabs[0]).toHaveAttribute('aria-selected', 'false');
       expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
     });
   });
 
   test('opens nested sections of selected result', async () => {
-    jest.useFakeTimers();
-
-    const { container, getByLabelText } = render(
+    const { container } = render(
       <div>
         <Accordion id="test-accordion">
           <AccordionSection heading="Section 1">
@@ -694,13 +615,11 @@ describe('PageSearchForm', () => {
       </div>,
     );
 
-    await wait();
-
-    fireEvent.change(getByLabelText(labelText), {
-      target: {
-        value: 'Test',
-      },
+    await waitFor(() => {
+      expect(screen.getByLabelText(labelText)).toBeInTheDocument();
     });
+
+    await userEvent.type(screen.getByLabelText(labelText), 'Test');
 
     jest.runOnlyPendingTimers();
 
@@ -710,11 +629,9 @@ describe('PageSearchForm', () => {
     const tabs = container.querySelectorAll('[role="tab"]');
     const summary = container.querySelector('summary');
 
-    jest.useRealTimers();
-
     fireEvent.click(container.querySelector('[role="option"]') as HTMLElement);
 
-    await wait(() => {
+    await waitFor(() => {
       expect(accordionSection).toHaveAttribute('aria-expanded', 'true');
       expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
       expect(summary).toHaveAttribute('aria-expanded', 'true');

--- a/src/explore-education-statistics-frontend/src/components/Link.tsx
+++ b/src/explore-education-statistics-frontend/src/components/Link.tsx
@@ -2,10 +2,6 @@ import { OmitStrict } from '@common/types';
 import classNames from 'classnames';
 import RouterLink, { LinkProps as RouterLinkProps } from 'next/link';
 import React, { AnchorHTMLAttributes, ReactNode } from 'react';
-import {
-  AnalyticProps,
-  logEvent,
-} from '@frontend/services/googleAnalyticsService';
 
 export type LinkProps = {
   as?: RouterLinkProps['as'];
@@ -14,8 +10,7 @@ export type LinkProps = {
   prefetch?: boolean;
   to: RouterLinkProps['href'];
   unvisited?: boolean;
-} & OmitStrict<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> &
-  AnalyticProps;
+} & OmitStrict<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>;
 
 const Link = ({
   as,
@@ -23,20 +18,9 @@ const Link = ({
   className,
   prefetch,
   to,
-  analytics,
   unvisited = false,
   ...props
 }: LinkProps) => {
-  const handleAnalytics = () => {
-    if (analytics) {
-      logEvent(
-        analytics.category,
-        analytics.action,
-        analytics.label ? analytics.label : window.location.pathname,
-      );
-    }
-  };
-
   const isAbsolute = typeof to === 'string' && to.startsWith('http');
 
   const link = (
@@ -51,14 +35,6 @@ const Link = ({
         },
         className,
       )}
-      onClick={() => {
-        handleAnalytics();
-      }}
-      onKeyDown={event => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          handleAnalytics();
-        }
-      }}
     >
       {children}
     </a>

--- a/src/explore-education-statistics-frontend/src/components/PageSearchFormWithAnalytics.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageSearchFormWithAnalytics.tsx
@@ -22,6 +22,4 @@ const PageSearchFormWithAnalytics = (props: PageSearchFormProps) => {
   );
 };
 
-PageSearchFormWithAnalytics.defaultProps = PageSearchForm.defaultProps;
-
 export default PageSearchFormWithAnalytics;

--- a/src/explore-education-statistics-frontend/src/components/PageSearchFormWithAnalytics.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PageSearchFormWithAnalytics.tsx
@@ -9,11 +9,12 @@ const PageSearchFormWithAnalytics = (props: PageSearchFormProps) => {
     <PageSearchForm
       {...props}
       onSearch={(searchTerm: string) => {
-        logEvent(
-          window.location.pathname,
-          props.id || 'PageSearchForm',
-          searchTerm,
-        );
+        logEvent({
+          category: window.location.pathname,
+          action: props.id || 'PageSearchForm',
+          label: searchTerm,
+        });
+
         if (typeof props.onSearch === 'function') {
           props.onSearch(searchTerm);
         }

--- a/src/explore-education-statistics-frontend/src/components/PrintThisPage.tsx
+++ b/src/explore-education-statistics-frontend/src/components/PrintThisPage.tsx
@@ -1,17 +1,14 @@
 import Button from '@common/components/Button';
-import React from 'react';
+import React, { MouseEventHandler } from 'react';
 import classNames from 'classnames';
-import {
-  AnalyticProps,
-  logEvent,
-} from '@frontend/services/googleAnalyticsService';
 import styles from './PrintThisPage.module.scss';
 
 interface Props {
   className?: string;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-const PrintThisPage = ({ analytics, className }: AnalyticProps & Props) => {
+const PrintThisPage = ({ className, onClick }: Props) => {
   return (
     <div
       className={classNames(
@@ -23,15 +20,8 @@ const PrintThisPage = ({ analytics, className }: AnalyticProps & Props) => {
     >
       <Button
         variant="secondary"
-        onClick={() => {
-          if (analytics) {
-            logEvent(
-              analytics.category,
-              analytics.action,
-              window.location.pathname,
-            );
-          }
-
+        onClick={event => {
+          onClick?.(event);
           window.print();
         }}
       >

--- a/src/explore-education-statistics-frontend/src/modules/download/DownloadIndexPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/download/DownloadIndexPage.tsx
@@ -56,11 +56,11 @@ const DownloadIndexPage: NextPage<Props> = ({ themes = [] }) => {
         <Accordion
           id="downloads"
           onSectionOpen={accordionSection => {
-            logEvent(
-              'Download index page',
-              'Accordion opened',
-              accordionSection.title,
-            );
+            logEvent({
+              category: 'Download index page',
+              action: 'Accordion opened',
+              label: accordionSection.title,
+            });
           }}
         >
           {themes.map(theme => (

--- a/src/explore-education-statistics-frontend/src/modules/download/components/TopicDownloadList.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/download/components/TopicDownloadList.tsx
@@ -4,6 +4,7 @@ import {
   Topic,
 } from '@common/services/themeService';
 import Link from '@frontend/components/Link';
+import { logEvent } from '@frontend/services/googleAnalyticsService';
 import React from 'react';
 
 interface Props {
@@ -46,12 +47,14 @@ function TopicDownloadList({ topic }: Props) {
                     <li key={isAllFiles ? 'all' : fileId}>
                       <Link
                         to={url}
-                        analytics={{
-                          category: 'Downloads',
-                          action: `Download latest data page ${
-                            isAllFiles ? 'all files' : 'file'
-                          } downloaded`,
-                          label: `Publication: ${title}, File: ${fileName}`,
+                        onClick={() => {
+                          logEvent({
+                            category: 'Downloads',
+                            action: `Download latest data page ${
+                              isAllFiles ? 'all files' : 'file'
+                            } downloaded`,
+                            label: `Publication: ${title}, File: ${fileName}`,
+                          });
                         }}
                       >
                         {name}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/FindStatisticsPage.tsx
@@ -56,11 +56,11 @@ const FindStatisticsPage: NextPage<Props> = ({ themes = [] }) => {
         <Accordion
           id="publications"
           onSectionOpen={accordionSection => {
-            logEvent(
-              'Find statistics and data',
-              'Publications accordion opened',
-              accordionSection.title,
-            );
+            logEvent({
+              category: 'Find statistics and data',
+              action: 'Publications accordion opened',
+              label: accordionSection.title,
+            });
           }}
         >
           {themes.map(

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseHelpAndSupportSection.tsx
@@ -92,11 +92,11 @@ const AccordionComponent = ({
     <Accordion
       id={accordionId}
       onSectionOpen={accordionSection => {
-        logEvent(
-          `${publicationTitle} help and support`,
-          'Accordion opened',
-          accordionSection.title,
-        );
+        logEvent({
+          category: `${publicationTitle} help and support`,
+          action: 'Accordion opened',
+          label: accordionSection.title,
+        });
       }}
     >
       {children}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -111,11 +111,11 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                   id="releaseLastUpdates"
                   onToggle={open => {
                     if (open) {
-                      logEvent(
-                        'Last Updates',
-                        'Release page last updates dropdown opened',
-                        window.location.pathname,
-                      );
+                      logEvent({
+                        category: 'Last Updates',
+                        action: 'Release page last updates dropdown opened',
+                        label: window.location.pathname,
+                      });
                     }
                   }}
                   summary={`See all updates (${data.updates.length})`}
@@ -137,12 +137,14 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
               <Link
                 className="dfe-print-hidden govuk-!-font-weight-bold"
                 unvisited
-                analytics={{
-                  category: 'Subscribe',
-                  action: 'Email subscription',
-                }}
                 to={`/subscriptions?slug=${data.publication.slug}`}
                 data-testid={`subscription-${data.publication.slug}`}
+                onClick={() => {
+                  logEvent({
+                    category: 'Subscribe',
+                    action: 'Email subscription',
+                  });
+                }}
               >
                 Sign up for email alerts
               </Link>
@@ -240,11 +242,11 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                       summary={`See other releases (${releaseCount})`}
                       onToggle={open =>
                         open &&
-                        logEvent(
-                          'Other Releases',
-                          'Release page other releases dropdown opened',
-                          window.location.pathname,
-                        )
+                        logEvent({
+                          category: 'Other Releases',
+                          action: 'Release page other releases dropdown opened',
+                          label: window.location.pathname,
+                        })
                       }
                     >
                       <ul className="govuk-list">
@@ -312,11 +314,11 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
             id="dataDownloads"
             showOpenAll={false}
             onSectionOpen={accordionSection => {
-              logEvent(
-                `${data.publication.title} release page`,
-                `Content accordion opened`,
-                `${accordionSection.title}`,
-              );
+              logEvent({
+                category: `${data.publication.title} release page`,
+                action: `Content accordion opened`,
+                label: `${accordionSection.title}`,
+              });
             }}
           >
             <AccordionSection heading="Download data and files">
@@ -336,12 +338,14 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                       <li key={isAllFiles ? 'all' : fileId}>
                         <Link
                           to={url}
-                          analytics={{
-                            category: 'Downloads',
-                            action: `Release page ${
-                              isAllFiles ? 'all files' : 'file'
-                            } downloaded`,
-                            label: `Publication: ${data.title}, File: ${fileName}`,
+                          onClick={() => {
+                            logEvent({
+                              category: 'Downloads',
+                              action: `Release page ${
+                                isAllFiles ? 'all files' : 'file'
+                              } downloaded`,
+                              label: `Publication: ${data.title}, File: ${fileName}`,
+                            });
                           }}
                         >
                           {name}
@@ -384,11 +388,11 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
         <Accordion
           id="content"
           onSectionOpen={accordionSection => {
-            logEvent(
-              `${data.publication.title} release page`,
-              `Content accordion opened`,
-              `${accordionSection.title}`,
-            );
+            logEvent({
+              category: `${data.publication.title} release page`,
+              action: `Content accordion opened`,
+              label: `${accordionSection.title}`,
+            });
           }}
         >
           {data.content.map(({ heading, caption, order, content }) => {
@@ -422,9 +426,12 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
       </ButtonLink>
 
       <PrintThisPage
-        analytics={{
-          category: 'Page print',
-          action: 'Print this page link selected',
+        onClick={() => {
+          logEvent({
+            category: 'Page print',
+            action: 'Print this page link selected',
+            label: window.location.pathname,
+          });
         }}
       />
     </Page>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
@@ -36,11 +36,11 @@ const PublicationSectionBlocks = ({
               releaseId={release.id}
               getInfographic={getReleaseFile}
               onToggle={section => {
-                logEvent(
-                  'Publication Release Data Tabs',
-                  `${section.title} (${section.id}) tab opened`,
-                  window.location.pathname,
-                );
+                logEvent({
+                  category: 'Publication Release Data Tabs',
+                  action: `${section.title} (${section.id}) tab opened`,
+                  label: window.location.pathname,
+                });
               }}
               additionalTabContent={
                 <div className="dfe-print-hidden">
@@ -54,11 +54,11 @@ const PublicationSectionBlocks = ({
                     to="/data-tables/fast-track/[fastTrackId]"
                     as={`/data-tables/fast-track/${block.id}`}
                     onClick={() => {
-                      logEvent(
-                        `Publication Release Data Tabs`,
-                        `Explore data button clicked`,
-                        `Explore data block name: ${block.name}`,
-                      );
+                      logEvent({
+                        category: `Publication Release Data Tabs`,
+                        action: `Explore data button clicked`,
+                        label: `Explore data block name: ${block.name}`,
+                      });
                     }}
                   >
                     Explore data

--- a/src/explore-education-statistics-frontend/src/modules/glossary/GlossaryPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/glossary/GlossaryPage.tsx
@@ -48,7 +48,11 @@ function GlossaryPage({ entries }: GlossaryPageProps) {
       <Accordion
         id="glossary"
         onSectionOpen={accordionSection => {
-          logEvent('Glossary', 'Accordion opened', accordionSection.title);
+          logEvent({
+            category: 'Glossary',
+            action: 'Accordion opened',
+            label: accordionSection.title,
+          });
         }}
       >
         {entries.map(entry => (

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyIndexPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyIndexPage.tsx
@@ -50,11 +50,11 @@ const MethodologyIndexPage: NextPage<Props> = ({ themes = [] }) => {
         <Accordion
           id="publications"
           onSectionOpen={accordionSection => {
-            logEvent(
-              'Methodologies',
-              'Publications accordion opened',
-              accordionSection.title,
-            );
+            logEvent({
+              category: 'Methodologies',
+              action: 'Publications accordion opened',
+              label: accordionSection.title,
+            });
           }}
         >
           {themes.map(

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
@@ -50,9 +50,12 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
             )}
           </dl>
           <PrintThisPage
-            analytics={{
-              category: 'Page print',
-              action: 'Print this page link selected',
+            onClick={() => {
+              logEvent({
+                category: 'Page print',
+                action: 'Print this page link selected',
+                label: window.location.pathname,
+              });
             }}
           />
           <PageSearchFormWithAnalytics inputLabel="Search in this methodology page." />
@@ -92,11 +95,11 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
         <Accordion
           id="content"
           onSectionOpen={accordionSection => {
-            logEvent(
-              `${data.title} methodology`,
-              `Content accordion opened`,
-              accordionSection.title,
-            );
+            logEvent({
+              category: `${data.title} methodology`,
+              action: `Content accordion opened`,
+              label: accordionSection.title,
+            });
           }}
         >
           {data.content.map(({ heading, caption, order, content }) => {
@@ -127,11 +130,11 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
           <Accordion
             id="annexes"
             onSectionOpen={accordionSection => {
-              logEvent(
-                `${data.title} methodology`,
-                `Annexes accordion opened`,
-                accordionSection.title,
-              );
+              logEvent({
+                category: `${data.title} methodology`,
+                action: `Annexes accordion opened`,
+                label: accordionSection.title,
+              });
             }}
           >
             {data.annexes.map(({ heading, caption, order, content }) => {
@@ -150,9 +153,12 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
       )}
 
       <PrintThisPage
-        analytics={{
-          category: 'Page print',
-          action: 'Print this page link selected',
+        onClick={() => {
+          logEvent({
+            category: 'Page print',
+            action: 'Print this page link selected',
+            label: window.location.pathname,
+          });
         }}
       />
     </Page>

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -50,10 +50,13 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
         </dl>
 
         <PrintThisPage
-          analytics={{
-            category: 'Page print',
-            action: 'Print this page link selected',
-          }}
+          onClick={() =>
+            logEvent({
+              category: 'Page print',
+              action: 'Print this page link selected',
+              label: window.location.pathname,
+            })
+          }
         />
       </div>
 
@@ -78,17 +81,17 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
               fileName={`permalink-${data.id}`}
               fullTable={fullTable}
               onClick={() =>
-                logEvent(
-                  'Permalink page',
-                  'CSV download button clicked',
-                  `${fullTable.subjectMeta.publicationName} between ${
+                logEvent({
+                  category: 'Permalink page',
+                  action: 'CSV download button clicked',
+                  label: `${fullTable.subjectMeta.publicationName} between ${
                     fullTable.subjectMeta.timePeriodRange[0].label
                   } and ${
                     fullTable.subjectMeta.timePeriodRange[
                       fullTable.subjectMeta.timePeriodRange.length - 1
                     ].label
                   }`,
-                )
+                })
               }
             />
           </li>
@@ -98,17 +101,17 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
               fileName={`permalink-${data.id}`}
               subjectMeta={fullTable.subjectMeta}
               onClick={() =>
-                logEvent(
-                  'Permalink page',
-                  'Excel download button clicked',
-                  `${fullTable.subjectMeta.publicationName} between ${
+                logEvent({
+                  category: 'Permalink page',
+                  action: 'Excel download button clicked',
+                  label: `${fullTable.subjectMeta.publicationName} between ${
                     fullTable.subjectMeta.timePeriodRange[0].label
                   } and ${
                     fullTable.subjectMeta.timePeriodRange[
                       fullTable.subjectMeta.timePeriodRange.length - 1
                     ].label
                   }`,
-                )
+                })
               }
             />
           </li>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -102,10 +102,12 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
           <Link
             to="/data-tables/fast-track/[fastTrackId]"
             as={`/data-tables/fast-track/${highlight.id}`}
-            analytics={{
-              category: 'Table tool',
-              action: 'Clicked to view Table highlight',
-              label: `Table highlight name: ${highlight.name}`,
+            onClick={() => {
+              logEvent({
+                category: 'Table tool',
+                action: 'Clicked to view Table highlight',
+                label: `Table highlight name: ${highlight.name}`,
+              });
             }}
           >
             {highlight.name}
@@ -132,12 +134,16 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
           </WizardStep>
         )}
         onSubmit={table => {
-          logEvent(
-            'Table tool',
-            'Publication and subject chosen',
-            `${table.subjectMeta.publicationName}/${table.subjectMeta.subjectName}`,
-          );
-          logEvent('Table tool', 'Table created', window.location.pathname);
+          logEvent({
+            category: 'Table tool',
+            action: 'Publication and subject chosen',
+            label: `${table.subjectMeta.publicationName}/${table.subjectMeta.subjectName}`,
+          });
+          logEvent({
+            category: 'Table tool',
+            action: 'Table created',
+            label: window.location.pathname,
+          });
         }}
       />
     </Page>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
@@ -153,17 +153,17 @@ const TableToolFinalStep = ({
               fileName={`data-${publication.slug}`}
               fullTable={table}
               onClick={() =>
-                logEvent(
-                  'Table tool',
-                  'CSV download button clicked',
-                  `${table.subjectMeta.publicationName} between ${
+                logEvent({
+                  category: 'Table tool',
+                  action: 'CSV download button clicked',
+                  label: `${table.subjectMeta.publicationName} between ${
                     table.subjectMeta.timePeriodRange[0].label
                   } and ${
                     table.subjectMeta.timePeriodRange[
                       table.subjectMeta.timePeriodRange.length - 1
                     ].label
                   }`,
-                )
+                })
               }
             />
           </li>
@@ -173,17 +173,17 @@ const TableToolFinalStep = ({
               tableRef={dataTableRef}
               subjectMeta={table.subjectMeta}
               onClick={() =>
-                logEvent(
-                  'Table tool',
-                  'Excel download button clicked',
-                  `${table.subjectMeta.publicationName} between ${
+                logEvent({
+                  category: 'Table tool',
+                  action: 'Excel download button clicked',
+                  label: `${table.subjectMeta.publicationName} between ${
                     table.subjectMeta.timePeriodRange[0].label
                   } and ${
                     table.subjectMeta.timePeriodRange[
                       table.subjectMeta.timePeriodRange.length - 1
                     ].label
                   }`,
-                )
+                })
               }
             />
           </li>

--- a/src/explore-education-statistics-frontend/src/services/googleAnalyticsService.ts
+++ b/src/explore-education-statistics-frontend/src/services/googleAnalyticsService.ts
@@ -35,27 +35,28 @@ export const logPageView = () => {
   }
 };
 
-export const logEvent = (
-  category: string,
-  action: string,
-  label?: string,
-  value?: number,
-) => {
-  if (initialised) {
-    ReactGA.event({ category, action, label, value });
+export interface AnalyticsEvent {
+  category: string;
+  action: string;
+  label?: string;
+  value?: number;
+}
+
+export function logEvent({ category, action, label, value }: AnalyticsEvent) {
+  if (!initialised) {
+    return;
   }
-};
+
+  ReactGA.event({
+    category,
+    action,
+    label,
+    value,
+  });
+}
 
 export const logException = (description: string, fatal = false) => {
   if (initialised) {
     ReactGA.exception({ description, fatal });
   }
 };
-
-export interface AnalyticProps {
-  analytics?: {
-    category: string;
-    action: string;
-    label?: string;
-  };
-}


### PR DESCRIPTION
This PR just refactors all public frontend link/button components to use a combination of `onClick` handlers with `logEvent` calls.

As part of this, we've also refactored the `logEvent` function to accept a single object paramter, instead of multiple parameters. This simplifies the API and prevents potential ordering bugs with the parameters.

## Other changes

- Refactors `PageSearchForm` to a function component.