### PR TITLE
EES-1941 Configure Deployment Slot in Virtual Network

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -783,7 +783,7 @@
           "httpLoggingEnabled": true,
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
-          "vnetName": "[variables('vNetRef')]",
+          "vnetName": "[variables('dataSubnetRef')]",
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
@@ -797,7 +797,7 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/Sites', variables('dataAppName'))]",
-        "[variables('vNetRef')]"
+        "[variables('dataSubnetRef')]"
       ]
     },
     {
@@ -989,7 +989,7 @@
           "httpLoggingEnabled": true,
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
-          "vnetName": "[variables('vNetRef')]",
+          "vnetName": "[variables('contentSubnetRef')]",
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
@@ -1003,7 +1003,7 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/Sites', variables('contentAppName'))]",
-        "[variables('vNetRef')]"
+        "[variables('contentSubnetRef')]"
       ]
     },
     {
@@ -1215,7 +1215,7 @@
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
           "use32BitWorkerProcess": false,
-          "vnetName": "[variables('vNetRef')]",
+          "vnetName": "[variables('adminSubnetRef')]",
           "cors": {
             "allowedOrigins": [
               "https://localhost:3000",
@@ -1226,7 +1226,7 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/Sites', variables('adminAppName'))]",
-        "[variables('vNetRef')]"
+        "[variables('adminSubnetRef')]"
       ]
     },
     {


### PR DESCRIPTION
This is an update to the previous PR https://github.com/dfe-analytical-services/explore-education-statistics/pull/2381 to correct the vnetName value to be a subnet resource id.

When we export the configuration from the app service we see that it's using subnet resource id's for this value rather than the virtual network resource id or name.

See the description of https://github.com/dfe-analytical-services/explore-education-statistics/pull/2381 for more information.