### PR TITLE
fix: re-add missing Stylelint plugin to admin Webpack config

### DIFF
--- a/src/explore-education-statistics-admin/config/webpack.config.js
+++ b/src/explore-education-statistics-admin/config/webpack.config.js
@@ -19,6 +19,7 @@ const ModuleNotFoundPlugin = require('react-dev-utils/ModuleNotFoundPlugin');
 const ForkTsCheckerWebpackPlugin = require('react-dev-utils/ForkTsCheckerWebpackPlugin');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
 const postCssNormalize = require('postcss-normalize');
+const StylelintPlugin = require('stylelint-webpack-plugin');
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
 
@@ -640,6 +641,7 @@ module.exports = webpackEnv => {
           // The formatter is invoked directly in WebpackDevServerUtils during development
           formatter: isEnvProduction ? typescriptFormatter : undefined,
         }),
+      new StylelintPlugin(),
     ].filter(Boolean),
     // Some libraries import Node modules but don't use them in the browser.
     // Tell webpack to provide empty mocks for them so importing them works.


### PR DESCRIPTION
This was accidentally removed in 2f15563, so we're just adding this back in to lint CSS on save.