### PR TITLE
EES-1953 - fix importer.py & publisher.py local SSL errors

### DIFF
--- a/useful-scripts/importer-tests/importer.py
+++ b/useful-scripts/importer-tests/importer.py
@@ -192,7 +192,7 @@ def rename_csv_file(random_identifier):
 
 if __name__ == "__main__":
     # To prevent InsecureRequestWarning
-    requests.packages.urllib3.disable_warnings()
+    requests.packages.urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     class colors:
         WARNING = '\033[93m' 
         FAIL = '\033[91m' 

--- a/useful-scripts/publisher-tests/publisher.py
+++ b/useful-scripts/publisher-tests/publisher.py
@@ -220,6 +220,7 @@ def get_final_release_details(api_url, release_id):
     response = requests.request(
         "GET",
         url=f'{api_url}/api/releases/{release_id}',
+        verify=False, 
         headers={
         "Authorization": f'Bearer {jwt_token}',
         "Content-Type": "application/json",
@@ -325,7 +326,7 @@ def get_release_status(api_url, release_id):
 
 if __name__ == "__main__":
     # To prevent InsecureRequestWarning
-    requests.packages.urllib3.disable_warnings()
+    requests.packages.urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     class colors:
         WARNING = '\033[93m' 
         FAIL = '\033[91m' 


### PR DESCRIPTION
This PR: 

Fixes SSL errors that occur from the requests library when running these scripts locally.  Originally both these scripts used: `requests.packages.urllib3.disable_warnings()` to disable warnings however is seems that the library still complains about SSL errors. In order to prevent this from occurring I've added `    requests.packages.urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)` which seems to work when running these scripts against a local environment  