### PR TITLE
EES-1954 Alter HTTP Content-Security-Policy img-src directive to allow Content API as an image source.

### DIFF
--- a/src/explore-education-statistics-admin/src/services/releaseImageService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseImageService.ts
@@ -12,7 +12,7 @@ const releaseImageService = {
     const data = new FormData();
     data.append('file', file);
 
-    return client.post(`/api/releases/${releaseId}/images`, data, {
+    return client.post(`/releases/${releaseId}/images`, data, {
       onUploadProgress(event: ProgressEvent) {
         onProgress?.(event.loaded, event.total);
       },

--- a/src/explore-education-statistics-frontend/package.json
+++ b/src/explore-education-statistics-frontend/package.json
@@ -124,6 +124,7 @@
       "src/**/*.{js,jsx,ts,tsx}",
       "!src/**/*.d.ts"
     ],
+    "setupFiles": ["dotenv/config"],
     "setupFilesAfterEnv": [
       "<rootDir>/test/setupTests.js"
     ],

--- a/src/explore-education-statistics-frontend/server.js
+++ b/src/explore-education-statistics-frontend/server.js
@@ -76,6 +76,7 @@ async function startServer(port = process.env.PORT || 3000) {
           styleSrc: ["'self'", "'unsafe-inline'"],
           imgSrc: [
             "'self'",
+            process.env.CONTENT_API_BASE_URL.replace('/api', ''),
             'data:',
             'https://www.google-analytics.com/',
             'https://insights.hotjar.com',

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
@@ -22,7 +22,7 @@ const PublicationSectionBlocks = ({
 
   const transformImageAttributes = useReleaseImageAttributeTransformer({
     releaseId: release.id,
-    rootUrl: process.env.CONTENT_API_BASE_URL,
+    rootUrl: process.env.CONTENT_API_BASE_URL.replace('/api', ''),
   });
 
   return blocks.length > 0 ? (


### PR DESCRIPTION
Alter HTTP Content-Security-Policy `img-src` directive to allow Content API as an image source.

Images were previously blocked with the error

## Other changes

- Remove additional `/api` in client POST url when uploading images.
- Remove additional `/api` in the `rootUrl` which is already in the image Url's when transforming content editor image nodes.
- Configure Jest to use the dotenv environment.