### PR TITLE
EES-1958 - Fix admin / public UI tests

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
@@ -196,7 +196,7 @@ Edit footnote
 Check footnote was updated
     [Tags]  HappyPath
     user clicks link  Content
-    user waits until page contains element  id:releaseHeadlines
+    user waits until page contains element  id:releaseHeadlines  120
     user scrolls to element  id:releaseHeadlines
     user waits until page contains link  Table  180
     user clicks link  Table

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -78,7 +78,7 @@ Create publication
 
 Create new release
     [Tags]  HappyPath
-    user waits until page contains accordion section   ${PUBLICATION_NAME}
+    user waits until page contains accordion section   ${PUBLICATION_NAME}  120
     user opens accordion section  ${PUBLICATION_NAME}
     user clicks link  Create new release
     user creates release for publication  ${PUBLICATION_NAME}  Academic Year Q1  2020

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -50,7 +50,7 @@ user signs out
 
 user selects theme and topic from admin dashboard
     [Arguments]  ${theme}  ${topic}
-    user waits until page contains link  Manage publications and releases  60
+    user waits until page contains link  Manage publications and releases  120
     user clicks link   Manage publications and releases
     user waits until page contains element   id:publicationsReleases-themeTopic-themeId
     user selects from list by label  id:publicationsReleases-themeTopic-themeId  ${theme}


### PR DESCRIPTION
This PR: 
- Fixes various Admin / public UI tests failures (when ran on the pipeline). The majority of failures seem to be around not finding specific elements after x amount of seconds. In order to try to fix this I've added more generous timeouts / wait assertions for the tests that are currently failing. 