### PR TITLE
EES-1914 Log exceptions before failing imports and handle null error

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
@@ -124,10 +124,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
 
                 var ex = GetInnerException(e);
 
-                await _dataImportService.FailImport(message.Id, ex.Message);
-
                 _logger.LogError(ex, $"{GetType().Name} function FAILED for : Import: " +
                                      $"{message.Id} : {ex.Message}");
+
+                await _dataImportService.FailImport(message.Id, ex.Message);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
@@ -96,11 +96,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
             {
                 var ex = GetInnerException(e);
 
-                await _dataImportService.FailImport(message.Id, ex.Message);
-
                 _logger.LogError(ex, $"{GetType().Name} function FAILED for Import: " +
                                      $"{message.Id} : {ex.Message}");
                 _logger.LogError(ex.StackTrace);
+
+                await _dataImportService.FailImport(message.Id, ex.Message);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -33,14 +33,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             {
                 contentDbContext.Update(import);
                 import.Status = FAILED;
-                import.Errors.AddRange(errors);
+                if (errors != null)
+                {
+                    import.Errors.AddRange(errors);                    
+                }
                 await contentDbContext.SaveChangesAsync();
             }
         }
 
         public async Task FailImport(Guid id, params string[] errors)
         {
-            await FailImport(id, errors.Select(error => new DataImportError(error)).ToList());
+            await FailImport(id, errors?
+                .Select(error => new DataImportError(error ?? "An unknown error occurred"))
+                .ToList());
         }
 
         public async Task<DataImport> GetImport(Guid id)


### PR DESCRIPTION
This PR makes a change to log exceptions before attempting to fail the imports which could in itself fail,
leaving us without any trace of the exception in Application Insights.

It also handles being called with a null errors array or a null error string.