### PR TITLE
EES-1983 Add Created/CreatedBy fields to File and retain existing values when migrating data files

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTest.cs
@@ -40,6 +40,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
     public class ReleaseDataFileServiceTest
     {
+        private readonly User _user = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = "test@test.com"
+        };
+
         [Fact]
         public async Task Delete()
         {
@@ -852,7 +858,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 RootPath = Guid.NewGuid(),
                 Filename = "test-data.csv",
                 Type = FileType.Data,
-                SubjectId = subject.Id
+                SubjectId = subject.Id,
+                Created = DateTime.UtcNow,
+                CreatedById = _user.Id
             };
             var metaFile = new File
             {
@@ -909,10 +917,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             meta: GetDataFileMetaValues(
                                 name: "Test data file name",
                                 metaFileName: "test-data.meta.csv",
-                                userName: "test@test.com",
                                 numberOfRows: 200
-                            ),
-                            created: DateTimeOffset.Parse("2020-09-16T12:00:00Z")
+                            )
                         )
                     );
 
@@ -945,10 +951,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataFile.Path(), fileInfo.Path);
                 Assert.Equal(metaFile.Id, fileInfo.MetaFileId);
                 Assert.Equal("test-data.meta.csv", fileInfo.MetaFileName);
-                Assert.Equal("test@test.com", fileInfo.UserName);
+                Assert.Equal(_user.Email, fileInfo.UserName);
                 Assert.Equal(200, fileInfo.Rows);
                 Assert.Equal("400 B", fileInfo.Size);
-                Assert.Equal(DateTimeOffset.Parse("2020-09-16T12:00:00Z"), fileInfo.Created);
+                Assert.Equal(dataFile.Created, fileInfo.Created);
                 Assert.Equal(COMPLETE, fileInfo.Status);
             }
         }
@@ -969,7 +975,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 RootPath = Guid.NewGuid(),
                 Filename = "Test data 1.csv",
                 Type = FileType.Data,
-                SubjectId = subject.Id
+                SubjectId = subject.Id,
+                Created = DateTime.UtcNow,
+                CreatedById = _user.Id
             };
             var metaFile = new File
             {
@@ -1028,10 +1036,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             {
                                 {BlobInfoExtensions.NameKey, "Test data file name"},
                                 {BlobInfoExtensions.MetaFileKey, "Test data 1.meta.csv"},
-                                {BlobInfoExtensions.UserNameKey, "test@test.com"},
                                 {BlobInfoExtensions.NumberOfRowsKey, "200"}
-                            },
-                            created: DateTimeOffset.Parse("2020-09-16T12:00:00Z")
+                            }
                         )
                     );
 
@@ -1064,10 +1070,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataFile.Path(), fileInfo.Path);
                 Assert.Equal(metaFile.Id, fileInfo.MetaFileId);
                 Assert.Equal("Test data 1.meta.csv", fileInfo.MetaFileName);
-                Assert.Equal("test@test.com", fileInfo.UserName);
+                Assert.Equal(_user.Email, fileInfo.UserName);
                 Assert.Equal(200, fileInfo.Rows);
                 Assert.Equal("400 B", fileInfo.Size);
-                Assert.Equal(DateTimeOffset.Parse("2020-09-16T12:00:00Z"), fileInfo.Created);
+                Assert.Equal(dataFile.Created, fileInfo.Created);
                 Assert.Equal(COMPLETE, fileInfo.Status);
             }
         }
@@ -1120,7 +1126,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 RootPath = Guid.NewGuid(),
                 Filename = "test-data.csv",
-                Type = FileType.Data
+                Type = FileType.Data,
+                CreatedById = _user.Id
             };
             var metaFile = new File
             {
@@ -1177,7 +1184,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 RootPath = Guid.NewGuid(),
                 SubjectId = subject.Id,
                 Filename = "test-data.csv",
-                Type = FileType.Data
+                Type = FileType.Data,
+                Created = DateTime.UtcNow,
+                CreatedById = _user.Id
             };
             var metaFile = new File
             {
@@ -1253,9 +1262,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("test-data.csv", fileInfo.Path);
                 Assert.Equal(metaFile.Id, fileInfo.MetaFileId);
                 Assert.Equal("test-data.meta.csv", fileInfo.MetaFileName);
-                Assert.Equal("", fileInfo.UserName);
+                Assert.Equal(_user.Email, fileInfo.UserName);
                 Assert.Equal(0, fileInfo.Rows);
                 Assert.Equal("0.00 B", fileInfo.Size);
+                Assert.Equal(dataFile.Created, fileInfo.Created);
                 Assert.Equal(STAGE_1, fileInfo.Status);
             }
         }
@@ -1269,14 +1279,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 RootPath = Guid.NewGuid(),
                 Filename = "test-data-archive.zip",
-                Type = DataZip,
+                Type = DataZip
             };
             var dataFile = new File
             {
                 RootPath = Guid.NewGuid(),
                 Filename = "test-data.csv",
                 Type = FileType.Data,
-                Source = zipFile
+                Source = zipFile,
+                Created = DateTime.UtcNow,
+                CreatedById = _user.Id
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -1334,10 +1346,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             meta: GetDataFileMetaValues(
                                 name: "Test data",
                                 metaFileName: "test-data.meta.csv",
-                                userName: "test@test.com",
                                 numberOfRows: 0
-                            ),
-                            created: DateTimeOffset.Parse("2020-09-16T12:00:00Z")
+                            )
                         )
                     );
 
@@ -1369,9 +1379,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("test-data.csv", fileInfo.Path);
                 Assert.False(fileInfo.MetaFileId.HasValue);
                 Assert.Equal("test-data.meta.csv", fileInfo.MetaFileName);
-                Assert.Equal("test@test.com", fileInfo.UserName);
+                Assert.Equal(_user.Email, fileInfo.UserName);
                 Assert.Equal(0, fileInfo.Rows);
                 Assert.Equal(PROCESSING_ARCHIVE_FILE, fileInfo.Status);
+                Assert.Equal(dataFile.Created, fileInfo.Created);
                 Assert.Equal("1 Mb", fileInfo.Size);
             }
         }
@@ -1393,7 +1404,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 RootPath = Guid.NewGuid(),
                 Filename = "test-data.csv",
                 Type = FileType.Data,
-                SubjectId = subject.Id
+                SubjectId = subject.Id,
+                Created = DateTime.UtcNow,
+                CreatedById = _user.Id
             };
             var metaFile = new File
             {
@@ -1464,10 +1477,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             meta: GetDataFileMetaValues(
                                 name: "Test data file name",
                                 metaFileName: "test-data.meta.csv",
-                                userName: "test@test.com",
                                 numberOfRows: 200
-                            ),
-                            created: DateTimeOffset.Parse("2020-09-16T12:00:00Z")
+                            )
                         )
                     );
 
@@ -1500,10 +1511,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataFile.Path(), fileInfo.Path);
                 Assert.Equal(metaFile.Id, fileInfo.MetaFileId);
                 Assert.Equal("test-data.meta.csv", fileInfo.MetaFileName);
-                Assert.Equal("test@test.com", fileInfo.UserName);
+                Assert.Equal(_user.Email, fileInfo.UserName);
                 Assert.Equal(200, fileInfo.Rows);
                 Assert.Equal("400 B", fileInfo.Size);
-                Assert.Equal(DateTimeOffset.Parse("2020-09-16T12:00:00Z"), fileInfo.Created);
+                Assert.Equal(dataFile.Created, fileInfo.Created);
                 Assert.Equal(COMPLETE, fileInfo.Status);
             }
         }
@@ -1528,7 +1539,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 RootPath = Guid.NewGuid(),
                 Filename = "test-data-1.csv",
                 Type = FileType.Data,
-                SubjectId = subject1.Id
+                SubjectId = subject1.Id,
+                Created = DateTime.UtcNow,
+                CreatedById = _user.Id
             };
             var metaFile1 = new File
             {
@@ -1542,7 +1555,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 RootPath = Guid.NewGuid(),
                 Filename = "Test data 2.csv",
                 Type = FileType.Data,
-                SubjectId = subject2.Id
+                SubjectId = subject2.Id,
+                Created = DateTime.UtcNow,
+                CreatedById = _user.Id
             };
             var metaFile2 = new File
             {
@@ -1610,7 +1625,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             GetDataFileMetaValues(
                                 name: "Test data file 1",
                                 metaFileName: "test-data-1.meta.csv",
-                                userName: "test1@test.com",
                                 numberOfRows: 200
                             )
                         )
@@ -1629,7 +1643,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             {
                                 {BlobInfoExtensions.NameKey, "Test data file 2"},
                                 {BlobInfoExtensions.MetaFileKey, "Test data 2.meta.csv"},
-                                {BlobInfoExtensions.UserNameKey, "test2@test.com"},
                                 {BlobInfoExtensions.NumberOfRowsKey, "400"}
                             }
                         )
@@ -1667,9 +1680,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataFile1.Path(), files[0].Path);
                 Assert.Equal(metaFile1.Id, files[0].MetaFileId);
                 Assert.Equal("test-data-1.meta.csv", files[0].MetaFileName);
-                Assert.Equal("test1@test.com", files[0].UserName);
+                Assert.Equal(_user.Email, files[0].UserName);
                 Assert.Equal(200, files[0].Rows);
                 Assert.Equal("400 B", files[0].Size);
+                Assert.Equal(dataFile1.Created, files[0].Created);
                 Assert.Equal(COMPLETE, files[0].Status);
 
                 Assert.Equal(dataFile2.Id, files[1].Id);
@@ -1679,9 +1693,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataFile2.Path(), files[1].Path);
                 Assert.Equal(metaFile2.Id, files[1].MetaFileId);
                 Assert.Equal("Test data 2.meta.csv", files[1].MetaFileName);
-                Assert.Equal("test2@test.com", files[1].UserName);
+                Assert.Equal(_user.Email, files[1].UserName);
                 Assert.Equal(400, files[1].Rows);
                 Assert.Equal("800 B", files[1].Size);
+                Assert.Equal(dataFile2.Created, files[1].Created);
                 Assert.Equal(STAGE_2, files[1].Status);
             }
         }
@@ -1702,7 +1717,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 RootPath = Guid.NewGuid(),
                 Filename = "test-data-1.csv",
                 Type = FileType.Data,
-                SubjectId = subject.Id
+                SubjectId = subject.Id,
+                Created = DateTime.UtcNow,
+                CreatedById = _user.Id
             };
             var metaFile = new File
             {
@@ -1738,7 +1755,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         {
                             RootPath = Guid.NewGuid(),
                             Filename = "test-data-2.csv",
-                            Type = FileType.Data
+                            Type = FileType.Data,
+                            CreatedById = _user.Id
                         }
                     },
                     new ReleaseFile
@@ -1793,7 +1811,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             GetDataFileMetaValues(
                                 name: "Test data file 1",
                                 metaFileName: "test-data-1.meta.csv",
-                                userName: "test1@test.com",
                                 numberOfRows: 200
                             )
                         )
@@ -1827,9 +1844,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataFile.Path(), files[0].Path);
                 Assert.Equal(metaFile.Id, files[0].MetaFileId);
                 Assert.Equal("test-data-1.meta.csv", files[0].MetaFileName);
-                Assert.Equal("test1@test.com", files[0].UserName);
+                Assert.Equal(_user.Email, files[0].UserName);
                 Assert.Equal(200, files[0].Rows);
                 Assert.Equal("400 B", files[0].Size);
+                Assert.Equal(dataFile.Created, files[0].Created);
                 Assert.Equal(COMPLETE, files[0].Status);
             }
         }
@@ -1856,7 +1874,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 RootPath = Guid.NewGuid(),
                 Filename = "test-data-1.csv",
                 Type = FileType.Data,
-                SubjectId = subject1.Id
+                SubjectId = subject1.Id,
+                Created = DateTime.UtcNow.AddDays(-1),
+                CreatedById = _user.Id
             };
             var metaFile1 = new File
             {
@@ -1870,7 +1890,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 RootPath = Guid.NewGuid(),
                 Filename = "test-data-2.csv",
                 Type = FileType.Data,
-                SubjectId = subject2.Id
+                SubjectId = subject2.Id,
+                Created = DateTime.UtcNow,
+                CreatedById = _user.Id
             };
             var metaFile2 = new File
             {
@@ -1951,7 +1973,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             GetDataFileMetaValues(
                                 name: "Test data file 2",
                                 metaFileName: "test-data-2.meta.csv",
-                                userName: "test2@test.com",
                                 numberOfRows: 400
                             )
                         )
@@ -1985,9 +2006,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataFile2.Path(), files[0].Path);
                 Assert.Equal(metaFile2.Id, files[0].MetaFileId);
                 Assert.Equal("test-data-2.meta.csv", files[0].MetaFileName);
-                Assert.Equal("test2@test.com", files[0].UserName);
+                Assert.Equal(_user.Email, files[0].UserName);
                 Assert.Equal(400, files[0].Rows);
                 Assert.Equal("800 B", files[0].Size);
+                Assert.Equal(dataFile2.Created, files[0].Created);
                 Assert.Equal(STAGE_2, files[0].Status);
             }
         }
@@ -2006,7 +2028,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 RootPath = Guid.NewGuid(),
                 Filename = "test-data.csv",
                 Type = FileType.Data,
-                SubjectId = subject.Id
+                SubjectId = subject.Id,
+                Created = DateTime.UtcNow,
+                CreatedById = _user.Id
             };
             var metaFile = new File
             {
@@ -2079,9 +2103,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("test-data.csv", files[0].Path);
                 Assert.Equal(metaFile.Id, files[0].MetaFileId);
                 Assert.Equal("test-data.meta.csv", files[0].MetaFileName);
-                Assert.Equal("", files[0].UserName);
+                Assert.Equal(_user.Email, files[0].UserName);
                 Assert.Equal(0, files[0].Rows);
                 Assert.Equal("0.00 B", files[0].Size);
+                Assert.Equal(dataFile.Created, files[0].Created);
                 Assert.Equal(STAGE_1, files[0].Status);
             }
         }
@@ -2102,7 +2127,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 RootPath = Guid.NewGuid(),
                 Filename = "test-data.csv",
                 Type = FileType.Data,
-                Source = zipFile
+                Source = zipFile,
+                Created = DateTime.UtcNow,
+                CreatedById = _user.Id
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -2160,10 +2187,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             meta: GetDataFileMetaValues(
                                 name: "Test data",
                                 metaFileName: "test-data.meta.csv",
-                                userName: "test@test.com",
                                 numberOfRows: 0
-                            ),
-                            created: DateTimeOffset.Parse("2020-09-16T12:00:00Z")
+                            )
                         )
                     );
 
@@ -2194,9 +2219,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("test-data.csv", files[0].Path);
                 Assert.False(files[0].MetaFileId.HasValue);
                 Assert.Equal("test-data.meta.csv", files[0].MetaFileName);
-                Assert.Equal("test@test.com", files[0].UserName);
+                Assert.Equal(_user.Email, files[0].UserName);
                 Assert.Equal(0, files[0].Rows);
                 Assert.Equal("1 Mb", files[0].Size);
+                Assert.Equal(dataFile.Created, files[0].Created);
                 Assert.Equal(PROCESSING_ARCHIVE_FILE, files[0].Status);
             }
         }
@@ -2272,7 +2298,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         It.Is<IDictionary<string, string>>(metadata =>
                             metadata[BlobInfoExtensions.NameKey] == subjectName
                             && metadata[BlobInfoExtensions.MetaFileKey] == metaFileName
-                            && metadata[BlobInfoExtensions.UserNameKey] == "test@test.com"
                             && metadata[BlobInfoExtensions.NumberOfRowsKey] == "2")
                     )).Returns(Task.CompletedTask);
 
@@ -2297,10 +2322,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             meta: GetDataFileMetaValues(
                                 subjectName,
                                 metaFileName: metaFileName,
-                                userName: "test@test.com",
                                 numberOfRows: 0
-                            ),
-                            created: DateTimeOffset.Parse("2020-09-16T12:00:00Z")
+                            )
                         )
                     );
 
@@ -2316,7 +2339,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseId: release.Id,
                     dataFormFile: dataFormFile,
                     metaFormFile: metaFormFile,
-                    userName: "test@test.com",
+                    userName: _user.Email,
                     subjectName: subjectName);
 
                 Assert.True(result.IsRight);
@@ -2330,9 +2353,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("data/file/path", result.Right.Path);
                 Assert.True(result.Right.MetaFileId.HasValue);
                 Assert.Equal(metaFileName, result.Right.MetaFileName);
-                Assert.Equal("test@test.com", result.Right.UserName);
+                Assert.Equal(_user.Email, result.Right.UserName);
                 Assert.Equal(0, result.Right.Rows);
                 Assert.Equal("1 Mb", result.Right.Size);
+                Assert.InRange(DateTime.UtcNow.Subtract(result.Right.Created.Value).Milliseconds, 0, 1500);
                 Assert.Equal(QUEUED, result.Right.Status);
             }
 
@@ -2458,7 +2482,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         It.Is<IDictionary<string, string>>(metadata =>
                             metadata[BlobInfoExtensions.NameKey] == originalSubject.Name
                             && metadata[BlobInfoExtensions.MetaFileKey] == metaFileName
-                            && metadata[BlobInfoExtensions.UserNameKey] == "test@test.com"
                             && metadata[BlobInfoExtensions.NumberOfRowsKey] == "2")
                     )).Returns(Task.CompletedTask);
 
@@ -2483,10 +2506,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             meta: GetDataFileMetaValues(
                                 originalSubject.Name,
                                 metaFileName: metaFileName,
-                                userName: "test@test.com",
                                 numberOfRows: 0
-                            ),
-                            created: DateTimeOffset.Parse("2020-09-16T12:00:00Z")
+                            )
                         )
                     );
 
@@ -2502,7 +2523,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseId: release.Id,
                     dataFormFile: dataFormFile,
                     metaFormFile: metaFormFile,
-                    userName: "test@test.com",
+                    userName: _user.Email,
                     replacingFileId: originalDataReleaseFile.File.Id);
 
                 Assert.True(result.IsRight);
@@ -2516,9 +2537,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("data/file/path", result.Right.Path);
                 Assert.True(result.Right.MetaFileId.HasValue);
                 Assert.Equal(metaFileName, result.Right.MetaFileName);
-                Assert.Equal("test@test.com", result.Right.UserName);
+                Assert.Equal(_user.Email, result.Right.UserName);
                 Assert.Equal(0, result.Right.Rows);
                 Assert.Equal("1 Mb", result.Right.Size);
+                Assert.InRange(DateTime.UtcNow.Subtract(result.Right.Created.Value).Milliseconds, 0, 1500);
                 Assert.Equal(QUEUED, result.Right.Status);
             }
 
@@ -2654,7 +2676,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         It.Is<IDictionary<string, string>>(metadata =>
                             metadata[BlobInfoExtensions.NameKey] == subjectName
                             && metadata[BlobInfoExtensions.MetaFileKey] == metaFileName
-                            && metadata[BlobInfoExtensions.UserNameKey] == "test@test.com"
                             && metadata[BlobInfoExtensions.NumberOfRowsKey] == "0")
                     )).Returns(Task.CompletedTask);
 
@@ -2671,10 +2692,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             meta: GetDataFileMetaValues(
                                 subjectName,
                                 metaFileName: metaFileName,
-                                userName: "test@test.com",
                                 numberOfRows: 0
-                            ),
-                            created: DateTimeOffset.Parse("2020-09-16T12:00:00Z")
+                            )
                         )
                     );
 
@@ -2690,7 +2709,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.UploadAsZip(
                     releaseId: release.Id,
                     zipFormFile: zipFormFile,
-                    userName: "test@test.com",
+                    userName: _user.Email,
                     subjectName: subjectName);
 
                 Assert.True(result.IsRight);
@@ -2707,9 +2726,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataFileName, result.Right.Path);
                 Assert.True(result.Right.MetaFileId.HasValue);
                 Assert.Equal(metaFileName, result.Right.MetaFileName);
-                Assert.Equal("test@test.com", result.Right.UserName);
+                Assert.Equal(_user.Email, result.Right.UserName);
                 Assert.Equal(0, result.Right.Rows);
                 Assert.Equal("1 Mb", result.Right.Size);
+                Assert.InRange(DateTime.UtcNow.Subtract(result.Right.Created.Value).Milliseconds, 0, 1500);
                 Assert.Equal(QUEUED, result.Right.Status);
             }
 
@@ -2844,7 +2864,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         It.Is<IDictionary<string, string>>(metadata =>
                             metadata[BlobInfoExtensions.NameKey] == originalSubject.Name
                             && metadata[BlobInfoExtensions.MetaFileKey] == metaFileName
-                            && metadata[BlobInfoExtensions.UserNameKey] == "test@test.com"
                             && metadata[BlobInfoExtensions.NumberOfRowsKey] == "0")
                     )).Returns(Task.CompletedTask);
 
@@ -2861,10 +2880,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             meta: GetDataFileMetaValues(
                                 name: originalSubject.Name,
                                 metaFileName: metaFileName,
-                                userName: "test@test.com",
                                 numberOfRows: 0
-                            ),
-                            created: DateTimeOffset.Parse("2020-09-16T12:00:00Z")
+                            )
                         )
                     );
 
@@ -2880,7 +2897,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.UploadAsZip(
                     release.Id,
                     zipFormFile,
-                    userName: "test@test.com",
+                    userName: _user.Email,
                     replacingFileId: originalDataReleaseFile.File.Id);
 
                 Assert.True(result.IsRight);
@@ -2897,9 +2914,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(dataFileName, result.Right.Path);
                 Assert.True(result.Right.MetaFileId.HasValue);
                 Assert.Equal(metaFileName, result.Right.MetaFileName);
-                Assert.Equal("test@test.com", result.Right.UserName);
+                Assert.Equal(_user.Email, result.Right.UserName);
                 Assert.Equal(0, result.Right.Rows);
                 Assert.Equal("1 Mb", result.Right.Size);
+                Assert.InRange(DateTime.UtcNow.Subtract(result.Right.Created.Value).Milliseconds, 0, 1500);
                 Assert.Equal(QUEUED, result.Right.Status);
             }
 
@@ -2994,7 +3012,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             return dataArchiveFile;
         }
 
-        private static ReleaseDataFileService SetupReleaseDataFileService(
+        private ReleaseDataFileService SetupReleaseDataFileService(
             ContentDbContext contentDbContext,
             StatisticsDbContext statisticsDbContext = null,
             IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
@@ -3008,8 +3026,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IDataImportService dataImportService = null,
             IUserService userService = null)
         {
+            contentDbContext.Users.Add(_user);
+            contentDbContext.SaveChanges();
+
             return new ReleaseDataFileService(
-                contentDbContext ?? new Mock<ContentDbContext>().Object,
+                contentDbContext,
                 statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
                 contentPersistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
                 blobStorageService ?? new Mock<IBlobStorageService>().Object,
@@ -3021,7 +3042,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 releaseFileRepository ?? new ReleaseFileRepository(contentDbContext),
                 releaseDataFileRepository ?? new ReleaseDataFileRepository(contentDbContext),
                 dataImportService ?? new Mock<IDataImportService>().Object,
-                userService ?? MockUtils.AlwaysTrueUserService().Object
+                userService ?? MockUtils.AlwaysTrueUserService(_user.Id).Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/MigrateFilesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/MigrateFilesController.cs
@@ -22,6 +22,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
             _migrateFilesService = migrateFilesService;
         }
 
+        [HttpPatch("api/files/private/data/migrate-created-fields")]
+        public async Task<ActionResult<Unit>> MigratePrivateDataFilesCreatedFields()
+        {
+            return await _migrateFilesService
+                .MigratePrivateFilesCreatedFields()
+                .HandleFailuresOrOk();
+        }
+
         [HttpPatch("api/files/private/data/migrate-files")]
         public async Task<ActionResult<Unit>> MigratePrivateDataFiles()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210311102805_EES1983AddCreatedFieldsToFile.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210311102805_EES1983AddCreatedFieldsToFile.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210311102805_EES1983AddCreatedFieldsToFile")]
+    partial class EES1983AddCreatedFieldsToFile
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210311102805_EES1983AddCreatedFieldsToFile.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210311102805_EES1983AddCreatedFieldsToFile.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES1983AddCreatedFieldsToFile : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Created",
+                table: "Files",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "CreatedById",
+                table: "Files",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Files_CreatedById",
+                table: "Files",
+                column: "CreatedById");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Files_Users_CreatedById",
+                table: "Files",
+                column: "CreatedById",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Files_Users_CreatedById",
+                table: "Files");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Files_CreatedById",
+                table: "Files");
+
+            migrationBuilder.DropColumn(
+                name: "Created",
+                table: "Files");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedById",
+                table: "Files");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/DataFileInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/DataFileInfo.cs
@@ -15,7 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
         public string MetaFileName { get; set; }
         public int Rows { get; set; }
         public string UserName { get; set; }
-        public DateTimeOffset? Created { get; set; }
+        public DateTime? Created { get; set; }
         public Guid? ReplacedBy { get; set; }
 
         [JsonConverter(typeof(EnumToEnumValueJsonConverter<DataImportStatus>))]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IMigrateFilesService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IMigrateFilesService.cs
@@ -6,6 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IMigrateFilesService
     {
+        Task<Either<ActionResult, Unit>> MigratePrivateFilesCreatedFields();
         Task<Either<ActionResult, Unit>> MigratePrivateFiles(params FileType[] types);
         Task<Either<ActionResult, Unit>> MigratePublicFiles(FileType type);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseDataFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseDataFileRepository.cs
@@ -13,12 +13,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             Guid subjectId,
             string filename,
             FileType type,
+            Guid createdById,
             File replacingFile = null,
             File source = null);
 
         public Task<File> CreateZip(
             Guid releaseId,
-            string filename);
+            string filename,
+            Guid createdById);
 
         public Task<IList<File>> ListDataFiles(Guid releaseId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFileRepository.cs
@@ -16,7 +16,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         public Task<File> Create(
             Guid releaseId,
             string filename,
-            FileType type);
+            FileType type,
+            Guid createdById);
 
         public Task Delete(Guid releaseId, Guid fileId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyFileRepository.cs
@@ -8,8 +8,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
     public interface IMethodologyFileRepository
     {
         public Task<File> Create(
-            Guid releaseId,
+            Guid methodologyId,
             string filename,
-            FileType type);
+            FileType type,
+            Guid createdById);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyFileRepository.cs
@@ -23,7 +23,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             _contentDbContext = contentDbContext;
         }
 
-        public async Task<File> Create(Guid methodologyId, string filename, FileType type)
+        public async Task<File> Create(Guid methodologyId,
+            string filename,
+            FileType type,
+            Guid createdById)
         {
             if (!SupportedFileTypes.Contains(type))
             {
@@ -38,6 +41,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                     // Mark any new files as already migrated while these flags temporarily exist
                     PrivateBlobPathMigrated = true,
                     PublicBlobPathMigrated = true,
+                    Created = DateTime.UtcNow,
+                    CreatedById = createdById,
                     RootPath = methodologyId,
                     Filename = filename,
                     Type = type

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
@@ -90,9 +90,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             IDictionary<string, string> metadata = null)
         {
             var file = await _methodologyFileRepository.Create(
-                methodologyId,
-                formFile.FileName,
-                type);
+                methodologyId: methodologyId,
+                filename: formFile.FileName,
+                type: type,
+                createdById: _userService.GetUserId());
 
             await _contentDbContext.SaveChangesAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MigrateFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MigrateFileService.cs
@@ -162,21 +162,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             _contentDbContext.Update(file);
 
-            // Should always be true
-            if (blob.Created.HasValue)
+            if (blob.Created.HasValue && !file.Created.HasValue)
             {
                 file.Created = blob.Created.Value.UtcDateTime;
             }
 
-            if (blob.Meta.TryGetValue("userName", out var email))
+            if (!file.CreatedById.HasValue)
             {
-                if (!email.IsNullOrEmpty())
+                if (blob.Meta.TryGetValue("userName", out var email))
                 {
-                    // Case of the email shouldn't matter here since queries are case insensitive
-                    var user = await _contentDbContext.Users
-                        .SingleOrDefaultAsync(u => u.Email == email);
+                    if (!email.IsNullOrEmpty())
+                    {
+                        // Case of the email shouldn't matter here since queries are case insensitive
+                        var user = await _contentDbContext.Users
+                            .SingleOrDefaultAsync(u => u.Email == email);
 
-                    file.CreatedById = user?.Id;
+                        file.CreatedById = user?.Id;
+                    }
                 }
             }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileRepository.cs
@@ -31,6 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             Guid subjectId,
             string filename,
             FileType type,
+            Guid createdById,
             File replacingFile = null,
             File source = null)
         {
@@ -52,6 +53,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     // Mark any new files as already migrated while these flags temporarily exist
                     PrivateBlobPathMigrated = true,
                     PublicBlobPathMigrated = true,
+                    Created = DateTime.UtcNow,
+                    CreatedById = createdById,
                     RootPath = releaseId,
                     SubjectId = subjectId,
                     Filename = filename,
@@ -71,13 +74,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return created.File;
         }
 
-        public async Task<File> CreateZip(Guid releaseId, string filename)
+        public async Task<File> CreateZip(Guid releaseId,
+            string filename,
+            Guid createdById)
         {
             var file = (await _contentDbContext.Files.AddAsync(new File
             {
                 // Mark any new files as already migrated while these flags temporarily exist
                 PrivateBlobPathMigrated = true,
                 PublicBlobPathMigrated = true,
+                Created = DateTime.UtcNow,
+                CreatedById = createdById,
                 RootPath = releaseId,
                 Filename = filename,
                 Type = DataZip

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileRepository.cs
@@ -52,7 +52,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<File> Create(
             Guid releaseId,
             string filename,
-            FileType type)
+            FileType type,
+            Guid createdById)
         {
             if (!SupportedFileTypes.Contains(type))
             {
@@ -67,6 +68,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     // Mark any new files as already migrated while these flags temporarily exist
                     PrivateBlobPathMigrated = true,
                     PublicBlobPathMigrated = true,
+                    Created = DateTime.UtcNow,
+                    CreatedById = createdById,
                     RootPath = releaseId,
                     Filename = filename,
                     Type = type

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
@@ -182,9 +182,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             replacingId.Value,
                             formFile.FileName)
                         : await _releaseFileRepository.Create(
-                            releaseId,
-                            formFile.FileName,
-                            Chart);
+                            releaseId: releaseId,
+                            filename: formFile.FileName,
+                            type: Chart,
+                            createdById: _userService.GetUserId());
 
                     await _blobStorageService.UploadFile(
                         containerName: PrivateReleaseFiles,
@@ -206,9 +207,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IDictionary<string, string> metadata = null)
         {
             var file = await _releaseFileRepository.Create(
-                releaseId,
-                formFile.FileName,
-                type);
+                releaseId: releaseId,
+                filename: formFile.FileName,
+                type: type,
+                createdById: _userService.GetUserId());
 
             await _contentDbContext.SaveChangesAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseImageService.cs
@@ -83,15 +83,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
-        private async Task<Either<ActionResult, FileInfo>> Upload(Guid methodologyId,
+        private async Task<Either<ActionResult, FileInfo>> Upload(Guid releaseId,
             FileType type,
             IFormFile formFile,
             IDictionary<string, string> metadata = null)
         {
             var file = await _releaseFileRepository.Create(
-                methodologyId,
-                formFile.FileName,
-                type);
+                releaseId: releaseId,
+                filename: formFile.FileName,
+                type: type,
+                createdById: _userService.GetUserId());
 
             await _contentDbContext.SaveChangesAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
@@ -95,12 +95,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
             };
         }
 
-        public static Mock<IUserService> AlwaysTrueUserService()
+        public static Mock<IUserService> AlwaysTrueUserService(Guid? userId = null)
         {
-            return AlwaysTrueUserService<Enum>();
+            return AlwaysTrueUserService<Enum>(userId);
         }
 
-        public static Mock<IUserService> AlwaysTrueUserService<T>()
+        public static Mock<IUserService> AlwaysTrueUserService<T>(Guid? userId = null)
             where T : Enum
         {
             var userService = new Mock<IUserService>();
@@ -112,6 +112,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
             userService
                 .Setup(s => s.MatchesPolicy(It.IsAny<object>(), It.IsAny<T>()))
                 .ReturnsAsync(true);
+
+            if (userId.HasValue)
+            {
+                userService.Setup(s => s.GetUserId())
+                    .Returns(userId.Value);
+            }
 
             return userService;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/BlobInfoExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/BlobInfoExtensions.cs
@@ -8,7 +8,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
     {
         public const string NameKey = BlobInfo.NameKey;
         public const string NumberOfRowsKey = "NumberOfRows";
-        public const string UserNameKey = "userName";
         public const string ReleaseDateTimeKey = "releasedatetime";
 
         /**
@@ -29,11 +28,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
         public static string GetMetaFileName(this BlobInfo blob)
         {
             return blob.Meta[MetaFileKey];
-        }
-
-        public static string GetUserName(this BlobInfo blob)
-        {
-            return blob.Meta.TryGetValue(UserNameKey, out var name) ? name : string.Empty;
         }
 
         public static int GetNumberOfRows(this BlobInfo blob)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStorageUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStorageUtils.cs
@@ -55,14 +55,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         public static IDictionary<string, string> GetDataFileMetaValues(
             string name,
             string metaFileName,
-            string userName,
             int numberOfRows)
         {
             return new Dictionary<string, string>
             {
                 {BlobInfoExtensions.NameKey, name},
                 {BlobInfoExtensions.MetaFileKey, metaFileName.ToLower()},
-                {BlobInfoExtensions.UserNameKey, userName},
                 {BlobInfoExtensions.NumberOfRowsKey, numberOfRows.ToString()}
             };
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -236,6 +236,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .HasForeignKey<File>(b => b.ReplacedById)
                 .IsRequired(false);
 
+            modelBuilder.Entity<File>()
+                .Property(comment => comment.Created)
+                .HasConversion(
+                    v => v,
+                    v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : (DateTime?) null);
+
             modelBuilder.Entity<Release>()
                 .HasOne(r => r.PreviousVersion)
                 .WithMany()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/File.cs
@@ -16,13 +16,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public FileType Type { get; set; }
 
         public Guid? ReplacedById { get; set; }
+
         public File ReplacedBy { get; set; }
 
         public Guid? ReplacingId { get; set; }
+
         public File Replacing { get; set; }
 
         public Guid? SourceId { get; set; }
+
         public File? Source { get; set; }
+
+        public DateTime? Created { get; set; }
+
+        public User CreatedBy { get; set; }
+
+        public Guid? CreatedById { get; set; }
 
         // EES-1704 Temporary fields that will be removed after files migration
         public bool PrivateBlobPathMigrated { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataArchiveService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataArchiveService.cs
@@ -43,7 +43,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     metadata: GetDataFileMetaValues(
                             name: blob.Name,
                             metaFileName: metadataFile.Name,
-                            userName: blob.GetUserName(),
                             numberOfRows: CalculateNumberOfRows(rowStream)
                         ));
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
@@ -188,7 +188,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     metadata: GetDataFileMetaValues(
                         name: dataBlob.Name,
                         metaFileName: dataImport.MetaFile.Filename,
-                        userName: dataBlob.GetUserName(),
                         numberOfRows: numRows
                     ));
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -602,7 +602,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                         meta: GetDataFileMetaValues(
                             name: "Data Test File",
                             metaFileName: "data.meta.csv",
-                            userName: "test@test.com",
                             numberOfRows: 200),
                         created: null
                     ));
@@ -764,7 +763,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                         meta: GetDataFileMetaValues(
                             name: "Data Test File",
                             metaFileName: "data.meta.csv",
-                            userName: "test@test.com",
                             numberOfRows: 200),
                         created: null
                     ));


### PR DESCRIPTION
This PR adds new Created and CreatedBy fields to File for auditing/debugging as well as displaying the "Uploaded on" field of data files in the Admin.

It also has a manual endpoint `PATCH http://localhost:5021/api/files/private/data/migrate-created-fields` to retain values of existing data files which it gets from their blobs in the Storage container.

This needs to be run prior to the files migration which changes their paths by moving the files where the Created value on the blob is reset due to the move operation being a copy and delete.