### PR TITLE
EES-1995 Fix the naming of methodology file containers locally

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -60,12 +61,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                         _methodologyFileRepository.CheckFileExists(methodologyId, fileId, Image)).OnSuccessAll())
                 .OnSuccessVoid(async files =>
                 {
-                    foreach (var file in files)
+                    await files.ForEachAsync(async file =>
                     {
-                        await _methodologyFileRepository.Delete(methodologyId, file.Id);
                         await _blobStorageService.DeleteBlob(PrivateMethodologyFiles, file.Path());
+                        await _methodologyFileRepository.Delete(methodologyId, file.Id);
                         await _fileRepository.Delete(file.Id);
-                    }
+                    });
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/BlobContainers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/BlobContainers.cs
@@ -8,14 +8,14 @@
 
     public static class BlobContainers
     {
-        public static readonly BlobContainer PrivateReleaseFiles = new BlobContainer("releases");
-        public static readonly BlobContainer PublicReleaseFiles = new BlobContainer("downloads");
-        public static readonly BlobContainer PublicContentContainerName = new BlobContainer("cache");
-        public static readonly BlobContainer Permalinks = new BlobContainer("permalinks");
-        public static readonly BlobContainer PermalinkMigrations = new BlobContainer("permalink-migrations");
-        public static readonly BlobContainer PublisherLeases = new BlobContainer("leases");
-        public static readonly BlobContainer PrivateMethodologyFiles = new PrivateBlobContainer("methodologies");
-        public static readonly BlobContainer PublicMethodologyFiles = new PublicBlobContainer("methodologies");
+        public static readonly IBlobContainer PrivateReleaseFiles = new BlobContainer("releases");
+        public static readonly IBlobContainer PublicReleaseFiles = new BlobContainer("downloads");
+        public static readonly IBlobContainer PublicContentContainerName = new BlobContainer("cache");
+        public static readonly IBlobContainer Permalinks = new BlobContainer("permalinks");
+        public static readonly IBlobContainer PermalinkMigrations = new BlobContainer("permalink-migrations");
+        public static readonly IBlobContainer PublisherLeases = new BlobContainer("leases");
+        public static readonly IBlobContainer PrivateMethodologyFiles = new PrivateBlobContainer("methodologies");
+        public static readonly IBlobContainer PublicMethodologyFiles = new PublicBlobContainer("methodologies");
     }
 
     /// <summary>
@@ -32,30 +32,49 @@
 
         public string EmulatedName => Name;
 
-        public override string ToString() => Name;
+        public override string ToString()
+        {
+            return Name;
+        }
     }
 
     /// <summary>
     /// Blob container with a name prefixed by 'public-' when used with emulator storage
     /// </summary>
-    public class PublicBlobContainer : BlobContainer
+    public class PublicBlobContainer : IBlobContainer
     {
-        public PublicBlobContainer(string name) : base(name)
+        public string Name { get; }
+
+        public PublicBlobContainer(string name)
         {
+            Name = name;
         }
 
-        public new string EmulatedName => $"public-{Name}";
+        public string EmulatedName => $"public-{Name}";
+
+        public override string ToString()
+        {
+            return Name;
+        }
     }
 
     /// <summary>
     /// Blob container with a name prefixed by 'private-' when used with emulator storage
     /// </summary>
-    public class PrivateBlobContainer : BlobContainer
+    public class PrivateBlobContainer : IBlobContainer
     {
-        public PrivateBlobContainer(string name) : base(name)
+        public string Name { get; }
+
+        public PrivateBlobContainer(string name)
         {
+            Name = name;
         }
 
-        public new string EmulatedName => $"private-{Name}";
+        public string EmulatedName => $"private-{Name}";
+
+        public override string ToString()
+        {
+            return Name;
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/BlobContainers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/BlobContainers.cs
@@ -32,10 +32,7 @@
 
         public string EmulatedName => Name;
 
-        public override string ToString()
-        {
-            return Name;
-        }
+        public override string ToString() => Name;
     }
 
     /// <summary>
@@ -52,10 +49,7 @@
 
         public string EmulatedName => $"public-{Name}";
 
-        public override string ToString()
-        {
-            return Name;
-        }
+        public override string ToString() => Name;
     }
 
     /// <summary>
@@ -72,9 +66,6 @@
 
         public string EmulatedName => $"private-{Name}";
 
-        public override string ToString()
-        {
-            return Name;
-        }
+        public override string ToString() => Name;
     }
 }


### PR DESCRIPTION
Locally methodology file containers should be:

```
devstoreaccount1/private-methodologies
devstoreaccount1/public-methodologies
```
 
but they were both `devstoreaccount1/methodologies`.

With only one container locally this was hiding a problem with publishing files when being tested.

### Other changes

- Use ForEachAsync and delete blobs prior to deleting database references. This addresses comments raised  on https://github.com/dfe-analytical-services/explore-education-statistics/pull/2416