### PR TITLE
EES-1997 Release containers should have been methodologies containers.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -68,9 +68,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
             // Copy the blobs from private to public storage
             await _privateBlobStorageService.CopyDirectory(
-                sourceContainerName: PrivateReleaseFiles,
+                sourceContainerName: PrivateMethodologyFiles,
                 sourceDirectoryPath: directoryPath,
-                destinationContainerName: PublicReleaseFiles,
+                destinationContainerName: PublicMethodologyFiles,
                 destinationDirectoryPath: directoryPath,
                 new IBlobStorageService.CopyDirectoryOptions
                 {


### PR DESCRIPTION
This fixes a problem where after publishing a methodology we saw no files being copied from private to public storage.