### PR TITLE
EES-1936 Rename Public Content BlobContainer field name.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/BlobContainers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/BlobContainers.cs
@@ -10,7 +10,7 @@
     {
         public static readonly IBlobContainer PrivateReleaseFiles = new BlobContainer("releases");
         public static readonly IBlobContainer PublicReleaseFiles = new BlobContainer("downloads");
-        public static readonly IBlobContainer PublicContentContainerName = new BlobContainer("cache");
+        public static readonly IBlobContainer PublicContent = new BlobContainer("cache");
         public static readonly IBlobContainer Permalinks = new BlobContainer("permalinks");
         public static readonly IBlobContainer PermalinkMigrations = new BlobContainer("permalink-migrations");
         public static readonly IBlobContainer PublisherLeases = new BlobContainer("leases");

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/FileStorageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/FileStorageServiceTests.cs
@@ -22,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
             var blobStorageService = new Mock<IBlobStorageService>();
 
             blobStorageService
-                .Setup(s => s.GetDeserializedJson<TestModel>(PublicContentContainerName, "test-path"))
+                .Setup(s => s.GetDeserializedJson<TestModel>(PublicContent, "test-path"))
                 .ReturnsAsync(new TestModel
                 {
                     Name = "Test"
@@ -42,7 +42,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
             var blobStorageService = new Mock<IBlobStorageService>();
 
             blobStorageService
-                .Setup(s => s.GetDeserializedJson<TestModel>(PublicContentContainerName, "test-path"))
+                .Setup(s => s.GetDeserializedJson<TestModel>(PublicContent, "test-path"))
                 .ThrowsAsync(new FileNotFoundException("Blob not found"));
 
             var fileStorageService = new FileStorageService(blobStorageService.Object);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/FileStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/FileStorageService.cs
@@ -1,10 +1,10 @@
 using System.IO;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
 {
@@ -22,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
             try
             {
                 return await _blobStorageService.GetDeserializedJson<T>(
-                    BlobContainers.PublicContentContainerName,
+                    PublicContent,
                     path
                 );
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServiceTests.cs
@@ -76,11 +76,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var blobStorageService = new Mock<IBlobStorageService>();
 
             blobStorageService
-                .Setup(s => s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContentContainerName, path))
+                .Setup(s => s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContent, path))
                 .ThrowsAsync(new FileNotFoundException());
 
             blobStorageService
-                .Setup(s => s.UploadAsJson(PublicContentContainerName, path, tableResult, null));
+                .Setup(s => s.UploadAsJson(PublicContent, path, tableResult, null));
 
             var tableBuilderService = new Mock<ITableBuilderService>();
 
@@ -164,11 +164,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var blobStorageService = new Mock<IBlobStorageService>();
 
             blobStorageService
-                .Setup(s => s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContentContainerName, path))
+                .Setup(s => s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContent, path))
                 .ThrowsAsync(new FileNotFoundException());
 
             blobStorageService
-                .Setup(s => s.UploadAsJson(PublicContentContainerName, path, tableResult, null));
+                .Setup(s => s.UploadAsJson(PublicContent, path, tableResult, null));
 
             var tableBuilderService = new Mock<ITableBuilderService>();
 
@@ -251,7 +251,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var blobStorageService = new Mock<IBlobStorageService>();
 
             blobStorageService
-                .Setup(s => s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContentContainerName, path))
+                .Setup(s => s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContent, path))
                 .ReturnsAsync(tableResult);
 
             var tableBuilderService = new Mock<ITableBuilderService>();
@@ -323,14 +323,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             blobStorageService
                 .Setup(s =>
-                    s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContentContainerName, path))
+                    s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContent, path))
                 .ThrowsAsync(new JsonException("Could not deserialize the JSON"));
 
             blobStorageService
-                .Setup(s => s.DeleteBlob(PublicContentContainerName, path));
+                .Setup(s => s.DeleteBlob(PublicContent, path));
 
             blobStorageService
-                .Setup(s => s.UploadAsJson(PublicContentContainerName, path, tableResult, null));
+                .Setup(s => s.UploadAsJson(PublicContent, path, tableResult, null));
 
             var tableBuilderService = new Mock<ITableBuilderService>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
@@ -71,7 +71,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
                             try
                             {
                                 return await _blobStorageService.GetDeserializedJson<TableBuilderResultViewModel>(
-                                    PublicContentContainerName,
+                                    PublicContent,
                                     path
                                 );
                             }
@@ -79,7 +79,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
                             {
                                 // If there's an error deserializing the blob, we should
                                 // assume it's not salvageable and just re-build it.
-                                await _blobStorageService.DeleteBlob(PublicContentContainerName, path);
+                                await _blobStorageService.DeleteBlob(PublicContent, path);
                             }
                             catch (FileNotFoundException)
                             {
@@ -98,7 +98,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
 
                             return await _tableBuilderService.Query(block.ReleaseId, query)
                                 .OnSuccessDo(
-                                    result => _blobStorageService.UploadAsJson(PublicContentContainerName, path, result)
+                                    result => _blobStorageService.UploadAsJson(PublicContent, path, result)
                                 );
                         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/FastTrackService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/FastTrackService.cs
@@ -73,7 +73,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             return await GetReleaseFastTrack(id)
                 .OnSuccess(async releaseFastTrack =>
                 {
-                    var text = await _blobStorageService.DownloadBlobText(PublicContentContainerName,
+                    var text = await _blobStorageService.DownloadBlobText(PublicContent,
                         PublicContentFastTrackPath(releaseFastTrack.ReleaseId.ToString(), id.ToString()));
                     return JsonConvert.DeserializeObject<FastTrack>(text);
                 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -57,7 +57,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 if (release.Slug != release.PreviousVersion.Slug)
                 {
                     await _publicBlobStorageService.DeleteBlob(
-                        PublicContentContainerName,
+                        PublicContent,
                         PublicContentReleasePath(release.Publication.Slug, release.PreviousVersion.Slug)
                     );
                 }
@@ -236,7 +236,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         private async Task DeleteAllContentAsyncExcludingStaging()
         {
             var excludePattern = $"^{PublicContentStagingPath()}/.+$";
-            await _publicBlobStorageService.DeleteBlobs(PublicContentContainerName, string.Empty, excludePattern);
+            await _publicBlobStorageService.DeleteBlobs(PublicContent, string.Empty, excludePattern);
         }
 
         private static JsonSerializerSettings GetJsonSerializerSettings(NamingStrategy namingStrategy)
@@ -257,7 +257,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         {
             var pathPrefix = context.Staging ? PublicContentStagingPath() : null;
             var blobName = pathFunction.Invoke(pathPrefix);
-            await _publicBlobStorageService.UploadAsJson(PublicContentContainerName, blobName, value, settings);
+            await _publicBlobStorageService.UploadAsJson(PublicContent, blobName, value, settings);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FastTrackService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/FastTrackService.cs
@@ -72,7 +72,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         public async Task DeleteAllFastTracksByRelease(Guid releaseId)
         {
             await _publicBlobStorageService.DeleteBlobs(
-                PublicContentContainerName,
+                PublicContent,
                 PublicContentReleaseFastTrackPath(releaseId.ToString()));
             await _tableStorageService.DeleteByPartitionKey(PublicReleaseFastTrackTableName, releaseId.ToString());
         }
@@ -82,7 +82,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             var blobName = context.Staging
                 ? PublicContentFastTrackPath(releaseId.ToString(), fastTrack.Id.ToString(), PublicContentStagingPath())
                 : PublicContentFastTrackPath(releaseId.ToString(), fastTrack.Id.ToString());
-            await _publicBlobStorageService.UploadAsJson(PublicContentContainerName, blobName, fastTrack);
+            await _publicBlobStorageService.UploadAsJson(PublicContent, blobName, fastTrack);
         }
 
         private async Task<CloudTable> GetTableAsync()

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -45,9 +45,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         public async Task PublishStagedReleaseContent(Guid releaseId)
         {
             await _publicBlobStorageService.MoveDirectory(
-                sourceContainerName: PublicContentContainerName,
+                sourceContainerName: PublicContent,
                 sourceDirectoryPath: PublicContentStagingPath(),
-                destinationContainerName: PublicContentContainerName,
+                destinationContainerName: PublicContent,
                 destinationDirectoryPath: string.Empty
             );
 


### PR DESCRIPTION
This PR is a rename of the Public Content `BlobContainer` field name from `PublicContentContainerName` to `PublicContent` which deliberately wasn't renamed in 01668bd0730f4a435675b67177d2390261e8cfa2 to reduce the visual diff needing to be reviewed in the PR for that work.

It resolves the comment when it was spotted by @ntsim https://github.com/dfe-analytical-services/explore-education-statistics/pull/2358#discussion_r582067426