### PR TITLE
EES-1936 Remove DataImport Migrated field

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210317120015_EES1936RemoveDataImportMigratedField.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210317120015_EES1936RemoveDataImportMigratedField.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210317120015_EES1936RemoveDataImportMigratedField")]
+    partial class EES1936RemoveDataImportMigratedField
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210317120015_EES1936RemoveDataImportMigratedField.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210317120015_EES1936RemoveDataImportMigratedField.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES1936RemoveDataImportMigratedField : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Migrated",
+                table: "DataImports");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Migrated",
+                table: "DataImports",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataImportService.cs
@@ -101,8 +101,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 MetaFileId = metaFile.Id,
                 SubjectId = subjectId,
                 Rows = CalculateNumberOfRows(formFile.OpenReadStream()),
-                Status = DataImportStatus.QUEUED,
-                Migrated = false
+                Status = DataImportStatus.QUEUED
             });
 
             await _queueService.AddMessageAsync(ImportsPendingQueue, new ImportMessage(import.Id));
@@ -117,8 +116,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 MetaFileId = metaFile.Id,
                 ZipFileId = zipFile.Id,
                 SubjectId = subjectId,
-                Status = DataImportStatus.QUEUED,
-                Migrated = false
+                Status = DataImportStatus.QUEUED
             });
 
             await _queueService.AddMessageAsync(ImportsPendingQueue, new ImportMessage(import.Id));

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataImport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataImport.cs
@@ -52,9 +52,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public int TotalRows { get; set; }
 
-        // EES-1231 Temporary column to differentiate rows migrated from table storage from newer imports 
-        public bool Migrated { get; set; }
-
         public List<DataImportError> Errors { get; set; } = new List<DataImportError>();
 
         public int PercentageComplete()


### PR DESCRIPTION
This PR removes the `DataImport.Migrated` database field which was used for debugging to differentiate rows being migrated from table storage from newer imports during the migration of https://github.com/dfe-analytical-services/explore-education-statistics/pull/2323 which moved Imports from an Azure Storage Table to the Content database.