### PR TITLE
EES-1936 Update emulator Release file Python script

### DIFF
--- a/useful-scripts/create-emulator-release-files.py
+++ b/useful-scripts/create-emulator-release-files.py
@@ -5,12 +5,10 @@ from datetime import datetime, timezone
 
 
 class File(ABC):
-    def __init__(self, release, id, name=None, filename=None):
+    def __init__(self, release, id, name=None):
         self.release = release
         self.id = id
         self.name = name
-        # EES-1704 Temporary field used for legacy path
-        self.filename = filename
         # Create a timestamp matching "yyyy-MM-ddTHH:mm:ss.mmmmmmmZ"
         self.published = datetime.now(
             timezone.utc).isoformat().replace("+00:00", "0Z")
@@ -23,15 +21,6 @@ class File(ABC):
     def path(self):
         pass
 
-    # EES-1704 Temporary methods in case still generating legacy file structure
-    @abstractmethod
-    def legacy_private_path(self):
-        pass
-
-    @abstractmethod
-    def legacy_public_path(self):
-        pass
-
 
 class AncillaryFile(File):
     def metadata(self):
@@ -42,12 +31,6 @@ class AncillaryFile(File):
 
     def path(self):
         return f"{self.release.id}/ancillary/{self.id}"
-
-    def legacy_private_path(self):
-        return f"{self.release.id}/ancillary/{self.id}"
-
-    def legacy_public_path(self):
-        return f"{self.release.publication_slug}/{self.release.slug}/ancillary/{self.id}"
 
 
 class DataFile(File):
@@ -62,12 +45,6 @@ class DataFile(File):
     def path(self):
         return f"{self.release.id}/data/{self.id}"
 
-    def legacy_private_path(self):
-        return f"{self.release.id}/data/{self.filename}"
-
-    def legacy_public_path(self):
-        return f"{self.release.publication_slug}/{self.release.slug}/data/{self.filename}"
-
 
 class MetadataFile(File):
     def metadata(self):
@@ -76,33 +53,22 @@ class MetadataFile(File):
     def path(self):
         return f"{self.release.id}/data/{self.id}"
 
-    def legacy_private_path(self):
-        return f"{self.release.id}/data/{self.filename}"
-
-    def legacy_public_path(self):
-        return f"{self.release.publication_slug}/{self.release.slug}/data/{self.filename}"
-
 
 class Release:
-    def __init__(self, id, slug, publication_slug):
+    def __init__(self, id):
         self.id = id
-        self.slug = slug
-        self.publication_slug = publication_slug
 
 
 class ReleaseFilesGenerator(object):
 
-    def __init__(self, legacy_structure):
-        self.legacy_structure = legacy_structure
+    def __init__(self):
 
         # Instantiate a new ContainerClient for the emulator
         self.blob_service_client = BlobServiceClient.from_connection_string(
             "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1")
 
-        exclusions_release = Release(
-            "e7774a74-1f62-4b76-b9b5-84f14dac7278", "2016-17", "permanent-and-fixed-period-exclusions-in-england")
-        pupil_absence_release = Release(
-            "4fa4fe8e-9a15-46bb-823f-49bf8e0cdec5", "2016-17", "pupil-absence-in-schools-in-england")
+        exclusions_release = Release("e7774a74-1f62-4b76-b9b5-84f14dac7278")
+        pupil_absence_release = Release("4fa4fe8e-9a15-46bb-823f-49bf8e0cdec5")
 
         self.all_files_zip_files = [
             # Exclusions
@@ -120,102 +86,76 @@ class ReleaseFilesGenerator(object):
             # Exclusions
             DataFile(exclusions_release,
                      "0ddf5b95-874b-4bcd-6a8f-08d7ec2d8168",
-                     "Duration of fixed exclusions",
-                     "exclusions_duration_of_fixed_exclusions.csv"),
+                     "Duration of fixed exclusions"),
             DataFile(exclusions_release,
                      "a5eb34a2-4615-4ee4-6a90-08d7ec2d8168",
-                     "Exclusions by characteristic",
-                     "exclusions_by_characteristic.csv"),
+                     "Exclusions by characteristic"),
             DataFile(exclusions_release,
                      "0d8b6e60-7b92-4f4d-6a91-08d7ec2d8168",
-                     "Exclusions by geographic level",
-                     "exclusions_by_geographic_level.csv"),
+                     "Exclusions by geographic level"),
             DataFile(exclusions_release,
                      "25b691c9-4d07-437f-6a93-08d7ec2d8168",
-                     "Number of fixed exclusions",
-                     "exclusions_number_of_fixed_exclusions.csv"),
+                     "Number of fixed exclusions"),
             DataFile(exclusions_release,
                      "f5c56849-f634-4fda-6a92-08d7ec2d8168",
-                     "Exclusions by reason",
-                     "exclusions_by_reason.csv"),
+                     "Exclusions by reason"),
             DataFile(exclusions_release,
                      "f0538c07-fc64-423b-6a94-08d7ec2d8168",
-                     "Total days missed due to fixed period exclusions",
-                     "exclusions_total_days_missed_fixed_exclusions.csv"),
+                     "Total days missed due to fixed period exclusions"),
 
             # Pupil absence
             DataFile(pupil_absence_release,
                      "15c05193-1b4a-4acb-6a81-08d7ec2d8168",
-                     "Absence by characteristic",
-                     "absence_by_characteristic.csv"),
+                     "Absence by characteristic"),
             DataFile(pupil_absence_release,
                      "cf0e3cb5-ea9c-45b1-6a83-08d7ec2d8168",
-                     "Absence by term",
-                     "absence_by_term.csv"),
+                     "Absence by term"),
             DataFile(pupil_absence_release,
                      "d4d72886-8921-426a-6a82-08d7ec2d8168",
-                     "Absence by geographic level",
-                     "absence_by_geographic_level.csv"),
+                     "Absence by geographic level"),
             DataFile(pupil_absence_release,
                      "bcf86eb2-4244-41aa-6a84-08d7ec2d8168",
-                     "Absence for four year olds",
-                     "absence_for_four_year_olds.csv"),
+                     "Absence for four year olds"),
             DataFile(pupil_absence_release,
                      "c1239606-300a-4782-6a85-08d7ec2d8168",
-                     "Absence in prus",
-                     "absence_in_prus.csv"),
+                     "Absence in prus"),
             DataFile(pupil_absence_release, "c8141534-d706-49d0-6a86-08d7ec2d8168",
-                     "Absence number missing at least one session by reason",
-                     "absence_number_missing_at_least_one_session_by_reason.csv"),
+                     "Absence number missing at least one session by reason"),
             DataFile(pupil_absence_release,
                      "28199189-f0b9-44f2-6a87-08d7ec2d8168",
-                     "Absence rate percent bands",
-                     "absence_rate_percent_bands.csv")
+                     "Absence rate percent bands")
         ]
 
         self.metadata_files = [
             # Exclusions
             MetadataFile(exclusions_release,
-                         "2a90141f-3331-4f00-6a98-08d7ec2d8168",
-                         filename="exclusions_duration_of_fixed_exclusions.meta.csv"),
+                         "2a90141f-3331-4f00-6a98-08d7ec2d8168"),
             MetadataFile(exclusions_release,
-                         "04b45150-0492-4b8b-6a95-08d7ec2d8168",
-                         filename="exclusions_by_characteristic.meta.csv"),
+                         "04b45150-0492-4b8b-6a95-08d7ec2d8168"),
             MetadataFile(exclusions_release,
-                         "7af9b369-1487-41f4-6a96-08d7ec2d8168",
-                         filename="exclusions_by_geographic_level.meta.csv"),
+                         "7af9b369-1487-41f4-6a96-08d7ec2d8168"),
             MetadataFile(exclusions_release,
-                         "8a7d0775-8b51-47e3-6a99-08d7ec2d8168",
-                         filename="exclusions_number_of_fixed_exclusions.meta.csv"),
+                         "8a7d0775-8b51-47e3-6a99-08d7ec2d8168"),
             MetadataFile(exclusions_release,
-                         "5a22f935-6d50-4d76-6a97-08d7ec2d8168",
-                         filename="exclusions_by_reason.meta.csv"),
+                         "5a22f935-6d50-4d76-6a97-08d7ec2d8168"),
             MetadataFile(exclusions_release,
-                         "9a917320-891c-4a00-6a9a-08d7ec2d8168",
-                         filename="exclusions_total_days_missed_fixed_exclusions.meta.csv"),
+                         "9a917320-891c-4a00-6a9a-08d7ec2d8168"),
 
             # Pupil absence
             MetadataFile(pupil_absence_release,
-                         "be141b27-0143-41b0-6a88-08d7ec2d8168",
-                         filename="absence_by_characteristic.meta.csv"),
+                         "be141b27-0143-41b0-6a88-08d7ec2d8168"),
             MetadataFile(pupil_absence_release,
-                         "c2a67d23-b135-4d84-6a8a-08d7ec2d8168",
-                         filename="absence_by_term.meta.csv"),
+                         "c2a67d23-b135-4d84-6a8a-08d7ec2d8168"),
             MetadataFile(pupil_absence_release,
-                         "5f355f7c-a6ec-481a-6a89-08d7ec2d8168",
-                         filename="absence_by_geographic_level.meta.csv"),
+                         "5f355f7c-a6ec-481a-6a89-08d7ec2d8168"),
             MetadataFile(pupil_absence_release,
-                         "f06041a4-e468-44df-6a8b-08d7ec2d8168",
-                         filename="absence_for_four_year_olds.meta.csv"),
+                         "f06041a4-e468-44df-6a8b-08d7ec2d8168"),
             MetadataFile(pupil_absence_release,
-                         "ec069435-bdc0-4c2d-6a8c-08d7ec2d8168",
-                         filename="absence_in_prus.meta.csv"),
+                         "ec069435-bdc0-4c2d-6a8c-08d7ec2d8168"),
             MetadataFile(pupil_absence_release,
-                         "f9c1eecc-e0a0-40cd-6a8d-08d7ec2d8168",
-                         filename="absence_number_missing_at_least_one_session_by_reason.meta.csv"),
+                         "f9c1eecc-e0a0-40cd-6a8d-08d7ec2d8168"),
             MetadataFile(pupil_absence_release,
-                         "36c7efeb-ffe9-4444-6a8e-08d7ec2d8168",
-                         filename="absence_rate_percent_bands.meta.csv"),
+                         "36c7efeb-ffe9-4444-6a8e-08d7ec2d8168"),
         ]
 
     def create_public_release_files(self):
@@ -227,11 +167,9 @@ class ReleaseFilesGenerator(object):
                 "downloads")
 
         self.upload_files(container_client,
-                          self.all_files_zip_files,
-                          public_storage=True)
+                          self.all_files_zip_files)
         self.upload_files(container_client,
-                          self.data_files,
-                          public_storage=True)
+                          self.data_files)
 
     def create_private_release_files(self):
         try:
@@ -242,26 +180,20 @@ class ReleaseFilesGenerator(object):
                 "releases")
 
         self.upload_files(container_client,
-                          self.data_files,
-                          public_storage=False)
+                          self.data_files)
         self.upload_files(container_client,
-                          self.metadata_files,
-                          public_storage=False)
+                          self.metadata_files)
 
-    def upload_files(self, container_client, files, public_storage):
+    def upload_files(self, container_client, files):
         data = b'abcd'*128
         for file in files:
-            path = file.path() if not self.legacy_structure else (
-                file.legacy_public_path() if public_storage else file.legacy_private_path())
+            path = file.path()
             blob_client = container_client.get_blob_client(path)
             blob_client.upload_blob(
                 data, blob_type="BlockBlob", metadata=file.metadata())
 
 
 if __name__ == '__main__':
-    # EES-1704 Release file structure migration
-    # In case database hasn't been manually migrated yet,
-    # allow setting legacy_structure to true to create the old structure
-    generator = ReleaseFilesGenerator(legacy_structure=False)
+    generator = ReleaseFilesGenerator()
     generator.create_public_release_files()
     generator.create_private_release_files()

--- a/useful-scripts/create-emulator-release-files.py
+++ b/useful-scripts/create-emulator-release-files.py
@@ -36,7 +36,6 @@ class AncillaryFile(File):
 class DataFile(File):
     def metadata(self):
         return {
-            "userName": "ees-analyst1@education.gov.uk",
             "NumberOfRows": "1000",
             "name": self.name,
             "releasedatetime": self.published


### PR DESCRIPTION
This PR updates the Python script that we use to create Release data/metdata/ancillary files in emulator storage to remove support for creating the legacy file structure, only now creating the new structure.

It also stops adding the `userName` property to the data files after the need for it was removed by https://github.com/dfe-analytical-services/explore-education-statistics/pull/2412