### PR TITLE
EES-2008 - fix various UI tests

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -137,6 +137,7 @@ Go to Public release page and ensure release isn't visible
 Go to Table Tool page
     [Tags]  HappyPath
     user goes to url  %{PUBLIC_URL}/data-tables
+    user waits for page to finish loading
     user waits until h1 is visible  Create your own tables online
 
 Check scheduled release isn't visible

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -395,7 +395,7 @@ Create amendment
     user waits until h1 is visible  Confirm you want to amend this live release
     user clicks button   Confirm
     user waits until h1 is visible  ${PUBLICATION_NAME}
-    user waits until page contains title caption  Amend release
+    user waits until page contains title caption  Amend release  90
 
 Navigate to data replacement page
     [Tags]  HappyPath

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -206,7 +206,8 @@ Validate Regional and local authority (LA) breakdown table
     [Tags]  HappyPath   Failing
     [Documentation]  BAU-540
     user opens accordion section  Regional and local authority (LA) breakdown  id:content
-    user waits until element contains  css:#content_9_datablock-tables [data-testid="dataTableCaption"]    Table showing 'Absence by characteristic' from 'Pupil absence in schools in England' in
+    user waits until element contains  css:#content_9_datablock-tables [data-testid="dataTableCaption"]
+    ...  Table showing 'Absence by characteristic' from 'Pupil absence in schools in England' in  90
 
     user checks table column heading contains  1   1   2016/17  css:#content_9_datablock-tables table
 


### PR DESCRIPTION
This PR: 
- Fixes various UI tests that are currently failing on the UI testing pipeline. This is mainly due to tests timing out due to not finding elements after a certain period of time. In order to prevent this I've added more generous timeouts to the tests that are failing 