### PR TITLE
EES-1998 Publish the files of the Methodology if it's not already live

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusState.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ReleaseStatusState.cs
@@ -176,7 +176,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model
         Invalid,
         Scheduled,
         Started,
-        Superseded 
+        Superseded
     }
 
     public enum ReleaseStatusPublishingStage

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/LegacyReleaseViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/LegacyReleaseViewModel.cs
@@ -5,7 +5,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels
     public class LegacyReleaseViewModel
     {
         public Guid Id { get; set; }
-        
+
         public string Description { get; set; }
 
         public string Url { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/LinkViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/LinkViewModel.cs
@@ -5,7 +5,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels
     public class LinkViewModel
     {
         public Guid Id { get; set; }
-        
+
         public string Description { get; set; }
 
         public string Url { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 using Xunit;
@@ -16,123 +17,87 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 {
     public class MethodologyServiceTests
     {
-        private static readonly Theme Theme = new Theme
-        {
-            Id = Guid.NewGuid(),
-            Title = "Theme A",
-            Slug = "theme-a",
-            Summary = "The first theme"
-        };
-
-        private static readonly Topic Topic = new Topic
-        {
-            Id = Guid.NewGuid(),
-            Title = "Topic A",
-            ThemeId = Theme.Id,
-            Slug = "topic-a",
-        };
-
-        private static readonly Methodology MethodologyA = new Methodology
-        {
-            Id = Guid.NewGuid(),
-            Slug = "methodology-a",
-            Title = "Methodology A",
-            Summary = "first methodology",
-            Published = new DateTime(2019, 1, 01),
-            Updated = new DateTime(2019, 1, 15),
-            Annexes = new List<ContentSection>(),
-            Content = new List<ContentSection>()
-        };
-
-        private static readonly Methodology MethodologyB = new Methodology
-        {
-            Id = Guid.NewGuid(),
-            Slug = "methodology-b",
-            Title = "Methodology B",
-            Summary = "second methodology",
-            Published = new DateTime(2019, 3, 01),
-            Updated = new DateTime(2019, 3, 15),
-            Annexes = new List<ContentSection>(),
-            Content = new List<ContentSection>()
-        };
-
-        private static readonly Methodology MethodologyC = new Methodology
-        {
-            Id = Guid.NewGuid(),
-            Slug = "methodology-c",
-            Title = "Methodology C",
-            Summary = "third methodology",
-            Published = null,
-            Updated = new DateTime(2019, 6, 15),
-            Annexes = new List<ContentSection>(),
-            Content = new List<ContentSection>()
-        };
-
-        private static readonly Publication PublicationA = new Publication
-        {
-            Id = Guid.NewGuid(),
-            Title = "Publication A",
-            TopicId = Topic.Id,
-            Slug = "publication-a",
-            Summary = "first publication",
-            MethodologyId = MethodologyA.Id
-        };
-
-        private static readonly Publication PublicationB = new Publication
-        {
-            Id = Guid.NewGuid(),
-            Title = "Publication B",
-            TopicId = Topic.Id,
-            Slug = "publication-b",
-            Summary = "second publication",
-            MethodologyId = MethodologyB.Id
-        };
-
-        private static readonly Release PublicationARelease1 = new Release
-        {
-            Id = Guid.NewGuid(),
-            PublicationId = PublicationA.Id,
-            ReleaseName = "2018",
-            TimePeriodCoverage = AcademicYearQ1,
-            Published = new DateTime(2019, 1, 01),
-            Status = Approved
-        };
-
-        private static readonly Release PublicationBRelease1 = new Release
-        {
-            Id = Guid.NewGuid(),
-            PublicationId = PublicationB.Id,
-            ReleaseName = "2018",
-            TimePeriodCoverage = AcademicYearQ1,
-            Published = null,
-            Status = Draft
-        };
-
         [Fact]
         public async Task GetTree()
         {
+            var topicA = new Topic
+            {
+                Title = "Topic A",
+                Theme = new Theme
+                {
+                    Title = "Theme A",
+                    Slug = "theme-a",
+                    Summary = "The first theme"
+                },
+                Slug = "topic-a"
+            };
+
+            var methodologyA = new Methodology
+            {
+                Slug = "methodology-a",
+                Title = "Methodology A",
+                Summary = "first methodology",
+                Published = new DateTime(2019, 1, 01),
+                Updated = new DateTime(2019, 1, 15),
+                Annexes = new List<ContentSection>(),
+                Content = new List<ContentSection>()
+            };
+
+            var methodologyB = new Methodology
+            {
+                Slug = "methodology-b",
+                Title = "Methodology B",
+                Summary = "second methodology",
+                Published = new DateTime(2019, 3, 01),
+                Updated = new DateTime(2019, 3, 15),
+                Annexes = new List<ContentSection>(),
+                Content = new List<ContentSection>()
+            };
+
+            var publicationA = new Publication
+            {
+                Title = "Publication A",
+                Topic = topicA,
+                Slug = "publication-a",
+                Summary = "first publication",
+                Methodology = methodologyA
+            };
+
+            var publicationB = new Publication
+            {
+                Title = "Publication B",
+                Topic = topicA,
+                Slug = "publication-b",
+                Summary = "second publication",
+                Methodology = methodologyB
+            };
+
+            var publicationARelease1 = new Release
+            {
+                Publication = publicationA,
+                ReleaseName = "2018",
+                TimePeriodCoverage = AcademicYearQ1,
+                Published = new DateTime(2019, 1, 01),
+                Status = Approved
+            };
+
+            var publicationBRelease1 = new Release
+            {
+                Publication = publicationB,
+                ReleaseName = "2018",
+                TimePeriodCoverage = AcademicYearQ1,
+                Published = null,
+                Status = Draft
+            };
+
             var contentDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                await contentDbContext.AddRangeAsync(new List<Methodology>
-                {
-                    MethodologyA, MethodologyB
-                });
-
-                await contentDbContext.AddAsync(Theme);
-                await contentDbContext.AddAsync(Topic);
-
-                await contentDbContext.AddRangeAsync(new List<Publication>
-                {
-                    PublicationA, PublicationB
-                });
-
-                await contentDbContext.AddRangeAsync(new List<Release>
-                {
-                    PublicationARelease1, PublicationBRelease1
-                });
-
+                await contentDbContext.Topics.AddAsync(topicA);
+                await contentDbContext.Methodologies.AddRangeAsync(methodologyA, methodologyB);
+                await contentDbContext.Publications.AddRangeAsync(publicationA, publicationB);
+                await contentDbContext.Releases.AddRangeAsync(publicationARelease1, publicationBRelease1);
                 await contentDbContext.SaveChangesAsync();
             }
 
@@ -207,7 +172,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = new MethodologyService(contentDbContext, MapperForProfile<MappingProfiles>());
+                var service = SetupMethodologyService(contentDbContext);
 
                 var result = await service.GetFiles(methodology.Id, Image);
 
@@ -218,27 +183,39 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         }
 
         [Fact]
-        public async Task GetViewModelAsync()
+        public async Task GetViewModel()
         {
+            var methodology = new Methodology
+            {
+                Id = Guid.NewGuid(),
+                Slug = "methodology-slug",
+                Title = "Methodology",
+                Summary = "Methodology summary",
+                Published = new DateTime(2019, 1, 01),
+                Updated = new DateTime(2019, 1, 15),
+                Annexes = new List<ContentSection>(),
+                Content = new List<ContentSection>()
+            };
+            
             var contentDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                await contentDbContext.AddAsync(MethodologyA);
+                await contentDbContext.Methodologies.AddAsync(methodology);
                 await contentDbContext.SaveChangesAsync();
             }
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = new MethodologyService(contentDbContext, MapperForProfile<MappingProfiles>());
+                var service = SetupMethodologyService(contentDbContext);
 
-                var result = await service.GetViewModelAsync(MethodologyA.Id, PublishContext());
+                var result = await service.GetViewModelAsync(methodology.Id, PublishContext());
 
-                Assert.Equal(MethodologyA.Id, result.Id);
-                Assert.Equal("Methodology A", result.Title);
+                Assert.Equal(methodology.Id, result.Id);
+                Assert.Equal("Methodology", result.Title);
                 Assert.Equal(new DateTime(2019, 1, 01), result.Published);
                 Assert.Equal(new DateTime(2019, 1, 15), result.Updated);
-                Assert.Equal("first methodology", result.Summary);
+                Assert.Equal("Methodology summary", result.Summary);
 
                 var annexes = result.Annexes;
                 Assert.NotNull(annexes);
@@ -251,28 +228,39 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         }
 
         [Fact]
-        public async Task GetViewModelAsync_NotYetPublished()
+        public async Task GetViewModel_NotYetPublished()
         {
+            var methodology = new Methodology
+            {
+                Slug = "methodology-slug",
+                Title = "Methodology",
+                Summary = "Methodology summary",
+                Published = null,
+                Updated = new DateTime(2019, 6, 15),
+                Annexes = new List<ContentSection>(),
+                Content = new List<ContentSection>()
+            };
+            
             var contentDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                await contentDbContext.AddAsync(MethodologyC);
+                await contentDbContext.Methodologies.AddAsync(methodology);
                 await contentDbContext.SaveChangesAsync();
             }
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                var service = new MethodologyService(contentDbContext, MapperForProfile<MappingProfiles>());
+                var service = SetupMethodologyService(contentDbContext);
 
                 var context = PublishContext();
-                var result = await service.GetViewModelAsync(MethodologyC.Id, context);
+                var result = await service.GetViewModelAsync(methodology.Id, context);
 
-                Assert.Equal(MethodologyC.Id, result.Id);
-                Assert.Equal("Methodology C", result.Title);
+                Assert.Equal(methodology.Id, result.Id);
+                Assert.Equal("Methodology", result.Title);
                 Assert.Equal(context.Published, result.Published);
                 Assert.Equal(new DateTime(2019, 6, 15), result.Updated);
-                Assert.Equal("third methodology", result.Summary);
+                Assert.Equal("Methodology summary", result.Summary);
 
                 var annexes = result.Annexes;
                 Assert.NotNull(annexes);
@@ -284,10 +272,86 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             }
         }
 
+        [Fact]
+        public async Task GetByRelease()
+        {
+            var methodology = new Methodology();
+
+            var release = new Release
+            {
+                Publication = new Publication
+                {
+                    Title = "Publication",
+                    Slug = "publication-slug",
+                    Methodology = methodology
+                },
+                ReleaseName = "2018",
+                TimePeriodCoverage = AcademicYearQ1,
+                Status = Approved
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+        
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Methodologies.AddAsync(methodology);
+                await contentDbContext.Releases.AddAsync(release);
+                await contentDbContext.SaveChangesAsync();
+            }
+            
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyService(contentDbContext);
+
+                var result = await service.GetByRelease(release.Id);
+                Assert.Equal(methodology.Id, result.Id);
+            }
+        }
+
+        [Fact]
+        public async Task GetByRelease_PublicationHasNoMethodology()
+        {
+            var release = new Release
+            {
+                Publication = new Publication
+                {
+                    Title = "Publication",
+                    Slug = "publication-slug",
+                    Methodology = null
+                },
+                ReleaseName = "2018",
+                TimePeriodCoverage = AcademicYearQ1,
+                Status = Approved
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+        
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Releases.AddAsync(release);
+                await contentDbContext.SaveChangesAsync();
+            }
+            
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyService(contentDbContext);
+
+                var result = await service.GetByRelease(release.Id);
+                Assert.Null(result);
+            }
+        }
+
         private static PublishContext PublishContext()
         {
             var published = DateTime.Today.Add(new TimeSpan(9, 30, 0));
             return new PublishContext(published, true);
+        }
+
+        private MethodologyService SetupMethodologyService(ContentDbContext contentDbContext)
+        {
+            return new MethodologyService(
+                contentDbContext,
+                MapperForProfile<MappingProfiles>());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleasesFunction.cs
@@ -33,7 +33,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         /// <param name="logger"></param>
         [FunctionName("PublishReleases")]
         // ReSharper disable once UnusedMember.Global
-        public void PublishReleases([TimerTrigger("%PublishReleasesCronSchedule%")]
+        public async Task PublishReleases([TimerTrigger("%PublishReleasesCronSchedule%")]
             TimerInfo timer,
             ExecutionContext executionContext,
             ILogger logger)
@@ -41,7 +41,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             logger.LogInformation("{0} triggered at: {1}",
                 executionContext.FunctionName,
                 DateTime.Now);
-            PublishReleases().Wait();
+
+            await PublishReleases();
+
             logger.LogInformation(
                 "{0} completed. {1}",
                 executionContext.FunctionName,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -131,6 +131,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 }
             }
 
+            // Include Methodologies of the Publications if they are not already live
             foreach (var methodologyId in methodologyIds)
             {
                 var methodology = await _methodologyService.Get(methodologyId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
@@ -12,6 +12,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
     {
         Task<Methodology> Get(Guid id);
 
+        Task<Methodology> GetByRelease(Guid releaseId);
+
         Task<List<File>> GetFiles(Guid methodologyId, params FileType[] types);
 
         Task<MethodologyViewModel> GetViewModelAsync(Guid id, PublishContext context);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IQueueService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IQueueService.cs
@@ -15,7 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
         Task QueuePublishReleaseDataMessagesAsync(IEnumerable<(Guid ReleaseId, Guid ReleaseStatusId)> releases);
 
         Task QueuePublishReleaseFilesMessageAsync(Guid releaseId, Guid releaseStatusId);
-        
+
         Task QueuePublishReleaseFilesMessageAsync(IEnumerable<(Guid ReleaseId, Guid ReleaseStatusId)> releases);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
@@ -31,6 +31,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             return await _context.Methodologies.FindAsync(id);
         }
 
+        public async Task<Methodology> GetByRelease(Guid releaseId)
+        {
+            return await _context.Releases
+                .Include(release => release.Publication)
+                .ThenInclude(publication => publication.Methodology)
+                .Select(release => release.Publication.Methodology)
+                .SingleAsync();
+        }
+
         public async Task<List<File>> GetFiles(Guid methodologyId, params FileType[] types)
         {
             return await _context.MethodologyFiles

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
@@ -34,10 +34,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         public async Task<Methodology> GetByRelease(Guid releaseId)
         {
             return await _context.Releases
-                .Include(release => release.Publication)
-                .ThenInclude(publication => publication.Methodology)
+                .Where(release => release.Id == releaseId)
                 .Select(release => release.Publication.Methodology)
-                .SingleAsync();
+                .SingleOrDefaultAsync();
         }
 
         public async Task<List<File>> GetFiles(Guid methodologyId, params FileType[] types)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -76,7 +76,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 {
                     DestinationConnectionString = _publicStorageConnectionString,
                     SetAttributesCallbackAsync = destination =>
-                        SetPublishedBlobAttributesCallback(destination, methodology.Published.Value),
+                        SetPublishedBlobAttributesCallback(destination, DateTime.UtcNow),
                     ShouldTransferCallbackAsync = (source, _) =>
                         // Filter by blobs with matching file paths
                         TransferBlobIfFileExistsCallback(

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -12,11 +12,11 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
-using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
-using IReleaseService = GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces.IReleaseService;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Extensions.PublisherExtensions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ValidationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ValidationService.cs
@@ -114,7 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         private static IEnumerable<ReleaseStatusLogMessage> CollateMessages(
             params Either<IEnumerable<ReleaseStatusLogMessage>, Unit>[] results)
         {
-            return results.SelectMany(either => either.IsLeft ? either.Left : new ReleaseStatusLogMessage[] {});
+            return results.SelectMany(either => either.IsLeft ? either.Left : new ReleaseStatusLogMessage[] { });
         }
 
         private enum ValidationStage


### PR DESCRIPTION
A Methodolgy is deliberately not published when first created and approved until it's used by a Publication/Release that is published.

This PR makes a change so that when a Release is published, as well as publishing the methodology content, it's methodology files will be published too. The files were previously missed.

On further methodology approvals, the files are already being published.