### PR TITLE
Hotfix/EES-2020 Adding CIN and EDA to the glossary

### DIFF
--- a/src/explore-education-statistics-frontend/src/html/glossary/C.html
+++ b/src/explore-education-statistics-frontend/src/html/glossary/C.html
@@ -28,6 +28,14 @@
     <li>immediately before he ceased to be looked-after at age 18, was an eligible child.</li>
 </ul>
 
+<h3 id="child-in-need">Child in need</h3>
+
+<p>A child in need is defined under the Children Act 1989 as a child who is unlikely to reach or maintain a satisfactory level of health or development, or their health or development will be significantly impaired without the provision of children's social care services, or the child is disabled.</p>
+
+<h3 id="child-protection-plan">Child protection plan</h3>
+
+<p>A <a href="/glossary#child-in-need">child in need</a> becomes the subject of a child protection plan if they are assessed as being at risk of harm, at an initial child protection conference.</p>
+
 <h3 id="cla">CLA</h3>
 
 <p>See <a href="/glossary#looked-after-child">Looked-after child</a></p>

--- a/src/explore-education-statistics-frontend/src/html/glossary/E.html
+++ b/src/explore-education-statistics-frontend/src/html/glossary/E.html
@@ -2,6 +2,51 @@
 
 <p>English as an Additional Language (EAL) refers to pupils whose first language is not English.</p>
 
+<h3 id="english-devolved-area">English devolved area</h3>
+
+<p>Used to refer to combined authorities, mayoral combined authorities, and the Greater London Authority. Full list of authorities included below:</p>
+
+<p>Mayoral combined authorities</p>
+<ul>
+  <li>
+    Cambridgeshire and Peterborough
+  </li>
+  <li>
+    Greater Manchester
+  </li>
+  <li>
+    Liverpool City Region
+  </li>
+  <li>
+    North of Tyne
+  </li>
+  <li>
+    Sheffield City Region
+  </li>
+  <li>
+    Tees Valley
+  </li>
+  <li>
+    West Midlands
+  </li>
+  <li>
+    West of England
+  </li>
+</ul>
+
+<p>Non-mayoral combined authorities</p>
+<ul>
+  <li>
+    Great London Authority
+  </li>
+  <li>
+    North East
+  </li>
+  <li>
+    West Yorkshire
+  </li>
+</ul>
+
 <h3 id="exclusion">Exclusion</h3>
 
 <p>When a pupil is not allowed to attend (or is excluded from) a school.</p>


### PR DESCRIPTION
Adding the following definitions to the glossary as a hotfix so they appear on Production before the CIN Outcomes publication on the 25th March.

1. **Child in need**

A child in need is defined under the Children Act 1989 as a child who is unlikely to reach or maintain a satisfactory level of health or development, or their health or development will be significantly impaired without the provision of children's social care services, or the child is disabled.

On production, this definition should show at - https://explore-education-statistics.service.gov.uk/glossary#child-in-need.

2. **Child protection plan**

A [child in need](link to above definition) becomes the subject of a child protection plan if they are assessed as being at risk of harm, at an initial child protection conference.

On production this definition should show at - https://explore-education-statistics.service.gov.uk/glossary#child-protection-plan

3. **English devolved area**

Used to refer to combined authorities, mayoral combined authorities, and the Greater London Authority. Full list of authorities included below:

Mayoral Combined Authorities

- Cambridge and Peterborough 
- Greater Manchester
- Liverpool City Region
- North of Tyne
- Sheffield City Region
- Tees Valley
- West Midlands
- West of England

Non-mayoral combined authorities

- North East
- West Yorkshire
- Greater London Authority