### PR TITLE
EES-2021 - Fix publish_release_and_amend.robot

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -371,6 +371,7 @@ Verify Test text accordion section contains correct text
     ${section}=  user gets accordion section content element  Test text  id:content
     user waits until parent contains element  ${section}   xpath:.//p[text()="Some test text!"]
     user closes accordion section  Test text  id:content
+    user clicks link  Summary
 
 Return to Admin to start creating an amendment
     [Tags]  HappyPath


### PR DESCRIPTION
This PR: 
- Fixes publish_release_and_amend.robot from failing. For some reason the focus seemed to be in a frozen state (focus was set to the footnotes link) which caused the test to fail after timing out. After forcing this test case to click a Summary link the test seemed to continue with other test cases and pass. 