### PR TITLE
EES-2025 Use package GovukNotify

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
@@ -4,6 +4,8 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="GovukNotify" Version="4.0.0" />
+    <PackageReference Include="JWT" Version="7.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
     <!-- EES-1205 Temporarily downgrading dependency Microsoft.NET.Sdk.Functions to 3.0.3
@@ -11,8 +13,7 @@
     'Could not load file or assembly 'Microsoft.IdentityModel.Tokens, Version=6.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified'
     See https://github.com/Azure/azure-functions-host/issues/5894 --> 
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
-    <PackageReference Include="Notify" Version="2.8.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.9.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Notifier.Model\GovUk.Education.ExploreEducationStatistics.Notifier.Model.csproj" />


### PR DESCRIPTION
This PR switches the GOV.UK Notify client from Bintray https://bintray.com/gov-uk-notify/nuget/Notify/2.8.0 to Nuget Gallery https://www.nuget.org/packages/GovukNotify 4.0.0 due to the upcoming Bintray sunset on 1st May.

It adds a dependency on [Jwt.Net](https://github.com/jwt-dotnet/jwt) which is required by GOV.UK Notify >= 7.0.0 && < 8.0.0.

See https://docs.notifications.service.gov.uk/net.html#net-client-documentation
and https://github.com/alphagov/notifications-net-client/blob/master/CHANGELOG.md

It also takes the opportunity to upgrade dependency `System.IdentityModel.Tokens.Jwt` to the latest version 6.9.0.