### PR TITLE
EES-1814 add confirmation text to data upload delete modal

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -331,6 +331,7 @@ const ReleaseDataUploadsSection = ({
             }
           }}
         >
+          <p>Are you sure you want to delete {deleteDataFile.file.title}?</p>
           <p>This data will no longer be available for use in this release.</p>
 
           {deleteDataFile.plan.deleteDataBlockPlan.dependentDataBlocks.length >


### PR DESCRIPTION
Adds a confirmation line including the subject title to the delete modal.

![Screenshot from 2021-04-01 14-34-44](https://user-images.githubusercontent.com/81572860/113306960-87a3b980-92fc-11eb-92e7-957ed7a8602b.png)
