### PR TITLE
EES-1815 Retrieve file names from releaseFile.Name where possible

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -49,7 +49,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var dataFileInfo = new DataFileInfo
             {
                 Name = "Subject name",
-                Path = "datafile.csv"
             };
 
             mocks.ReleaseDataFilesService
@@ -70,7 +69,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 metaFile: metaFile);
             var dataFileInfoResult = AssertOkResult(result);
             Assert.Equal("Subject name", dataFileInfoResult.Name);
-            Assert.Equal("datafile.csv", dataFileInfoResult.Path);
         }
 
         [Fact]
@@ -109,14 +107,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 {
                     FileName = "file1.csv",
                     Name = "Release a file 1",
-                    Path = "file1.csv",
                     Size = "1 Kb"
                 },
                 new DataFileInfo
                 {
                     FileName = "file2.csv",
                     Name = "Release a file 2",
-                    Path = "file2.csv",
                     Size = "1 Kb"
                 }
             };

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
@@ -123,7 +123,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
                     Id = ancillaryFileId,
                     FileName = "ancillary.pdf",
                     Name = "Ancillary File",
-                    Path = "ancillary/file/path",
                     Size = "10 Kb",
                     Type = Ancillary
                 },
@@ -132,7 +131,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
                     Id = dataFileId,
                     FileName = "data.csv",
                     Name = "Subject File",
-                    Path = "data/file/path",
                     Size = "20 Kb",
                     Type = FileType.Data
                 }
@@ -249,14 +247,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
                 Assert.Equal("pdf", contentDownloadFiles[0].Extension);
                 Assert.Equal("ancillary.pdf", contentDownloadFiles[0].FileName);
                 Assert.Equal("Ancillary File", contentDownloadFiles[0].Name);
-                Assert.Equal(files[0].Path, contentDownloadFiles[0].Path);
                 Assert.Equal("10 Kb", contentDownloadFiles[0].Size);
                 Assert.Equal(Ancillary, contentDownloadFiles[0].Type);
                 Assert.Equal(files[1].Id, contentDownloadFiles[1].Id);
                 Assert.Equal("csv", contentDownloadFiles[1].Extension);
                 Assert.Equal("data.csv", contentDownloadFiles[1].FileName);
                 Assert.Equal("Subject File", contentDownloadFiles[1].Name);
-                Assert.Equal(files[1].Path, contentDownloadFiles[1].Path);
                 Assert.Equal("20 Kb", contentDownloadFiles[1].Size);
                 Assert.Equal(FileType.Data, contentDownloadFiles[1].Type);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServiceTest.cs
@@ -908,7 +908,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             contentType: "text/csv",
                             contentLength: 400L,
                             meta: GetDataFileMetaValues(
-                                name: "Test data file name",
                                 metaFileName: "test-data.meta.csv",
                                 numberOfRows: 200
                             )
@@ -941,7 +940,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test data", fileInfo.Name);
                 Assert.Equal("test-data.csv", fileInfo.FileName);
                 Assert.Equal("csv", fileInfo.Extension);
-                Assert.Equal(dataReleaseFile.Path(), fileInfo.Path);
                 Assert.Equal(metaReleaseFile.File.Id, fileInfo.MetaFileId);
                 Assert.Equal("test-data.meta.csv", fileInfo.MetaFileName);
                 Assert.Equal(_user.Email, fileInfo.UserName);
@@ -1054,7 +1052,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test data", fileInfo.Name);
                 Assert.Equal("Test data 1.csv", fileInfo.FileName);
                 Assert.Equal("csv", fileInfo.Extension);
-                Assert.Equal(dataReleaseFile.Path(), fileInfo.Path);
                 Assert.Equal(metaReleaseFile.File.Id, fileInfo.MetaFileId);
                 Assert.Equal("Test data 1.meta.csv", fileInfo.MetaFileName);
                 Assert.Equal(_user.Email, fileInfo.UserName);
@@ -1238,7 +1235,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test data", fileInfo.Name);
                 Assert.Equal("test-data.csv", fileInfo.FileName);
                 Assert.Equal("csv", fileInfo.Extension);
-                Assert.Equal("test-data.csv", fileInfo.Path);
                 Assert.Equal(metaReleaseFile.File.Id, fileInfo.MetaFileId);
                 Assert.Equal("test-data.meta.csv", fileInfo.MetaFileName);
                 Assert.Equal(_user.Email, fileInfo.UserName);
@@ -1318,7 +1314,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             contentType: "application/zip",
                             contentLength: 1000L,
                             meta: GetDataFileMetaValues(
-                                name: "Test data",
                                 metaFileName: "test-data.meta.csv",
                                 numberOfRows: 0
                             )
@@ -1350,7 +1345,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test data", fileInfo.Name);
                 Assert.Equal("test-data.csv", fileInfo.FileName);
                 Assert.Equal("csv", fileInfo.Extension);
-                Assert.Equal("test-data.csv", fileInfo.Path);
                 Assert.False(fileInfo.MetaFileId.HasValue);
                 Assert.Equal("test-data.meta.csv", fileInfo.MetaFileName);
                 Assert.Equal(_user.Email, fileInfo.UserName);
@@ -1447,7 +1441,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             contentType: "text/csv",
                             contentLength: 400L,
                             meta: GetDataFileMetaValues(
-                                name: "Test data file name",
                                 metaFileName: "test-data.meta.csv",
                                 numberOfRows: 200
                             )
@@ -1480,7 +1473,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test data amended", fileInfo.Name);
                 Assert.Equal("test-data.csv", fileInfo.FileName);
                 Assert.Equal("csv", fileInfo.Extension);
-                Assert.Equal(dataFile.Path(), fileInfo.Path);
                 Assert.Equal(metaFile.Id, fileInfo.MetaFileId);
                 Assert.Equal("test-data.meta.csv", fileInfo.MetaFileName);
                 Assert.Equal(_user.Email, fileInfo.UserName);
@@ -1586,7 +1578,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             contentType: "text/csv",
                             contentLength: 400L,
                             GetDataFileMetaValues(
-                                name: "Test data file 1",
                                 metaFileName: "test-data-1.meta.csv",
                                 numberOfRows: 200
                             )
@@ -1604,7 +1595,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             // Don't use GetDataFileMetaValues here as it forces the filename to lower case
                             meta: new Dictionary<string, string>
                             {
-                                {BlobInfoExtensions.NameKey, "Test data file 2"},
                                 {BlobInfoExtensions.MetaFileKey, "Test data 2.meta.csv"},
                                 {BlobInfoExtensions.NumberOfRowsKey, "400"}
                             }
@@ -1640,7 +1630,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test subject 1", files[0].Name);
                 Assert.Equal("test-data-1.csv", files[0].FileName);
                 Assert.Equal("csv", files[0].Extension);
-                Assert.Equal(dataReleaseFile1.Path(), files[0].Path);
                 Assert.Equal(metaReleaseFile1.File.Id, files[0].MetaFileId);
                 Assert.Equal("test-data-1.meta.csv", files[0].MetaFileName);
                 Assert.Equal(_user.Email, files[0].UserName);
@@ -1653,7 +1642,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test subject 2", files[1].Name);
                 Assert.Equal("Test data 2.csv", files[1].FileName);
                 Assert.Equal("csv", files[1].Extension);
-                Assert.Equal(dataReleaseFile2.Path(), files[1].Path);
                 Assert.Equal(metaReleaseFile2.File.Id, files[1].MetaFileId);
                 Assert.Equal("Test data 2.meta.csv", files[1].MetaFileName);
                 Assert.Equal(_user.Email, files[1].UserName);
@@ -1770,7 +1758,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             contentType: "text/csv",
                             contentLength: 400L,
                             GetDataFileMetaValues(
-                                name: "Test data file 1",
                                 metaFileName: "test-data-1.meta.csv",
                                 numberOfRows: 200
                             )
@@ -1802,7 +1789,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test data", files[0].Name);
                 Assert.Equal("test-data-1.csv", files[0].FileName);
                 Assert.Equal("csv", files[0].Extension);
-                Assert.Equal(dataRelease1File.Path(), files[0].Path);
                 Assert.Equal(metaRelease1File.File.Id, files[0].MetaFileId);
                 Assert.Equal("test-data-1.meta.csv", files[0].MetaFileName);
                 Assert.Equal(_user.Email, files[0].UserName);
@@ -1927,7 +1913,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             contentType: "text/csv",
                             contentLength: 800L,
                             GetDataFileMetaValues(
-                                name: "Test data file 2",
                                 metaFileName: "test-data-2.meta.csv",
                                 numberOfRows: 400
                             )
@@ -1959,7 +1944,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test subject 2 name change", files[0].Name);
                 Assert.Equal("test-data-2.csv", files[0].FileName);
                 Assert.Equal("csv", files[0].Extension);
-                Assert.Equal(dataFile2.Path(), files[0].Path);
                 Assert.Equal(metaFile2.Id, files[0].MetaFileId);
                 Assert.Equal("test-data-2.meta.csv", files[0].MetaFileName);
                 Assert.Equal(_user.Email, files[0].UserName);
@@ -2049,7 +2033,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test subject name", files[0].Name);
                 Assert.Equal("test-data.csv", files[0].FileName);
                 Assert.Equal("csv", files[0].Extension);
-                Assert.Equal("test-data.csv", files[0].Path);
                 Assert.Equal(metaReleaseFile.File.Id, files[0].MetaFileId);
                 Assert.Equal("test-data.meta.csv", files[0].MetaFileName);
                 Assert.Equal(_user.Email, files[0].UserName);
@@ -2130,7 +2113,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             contentType: "application/zip",
                             contentLength: 1000L,
                             meta: GetDataFileMetaValues(
-                                name: "Test data",
                                 metaFileName: "test-data.meta.csv",
                                 numberOfRows: 0
                             )
@@ -2161,7 +2143,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("Test data", files[0].Name);
                 Assert.Equal("test-data.csv", files[0].FileName);
                 Assert.Equal("csv", files[0].Extension);
-                Assert.Equal("test-data.csv", files[0].Path);
                 Assert.False(files[0].MetaFileId.HasValue);
                 Assert.Equal("test-data.meta.csv", files[0].MetaFileName);
                 Assert.Equal(_user.Email, files[0].UserName);
@@ -2241,8 +2222,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             path.Contains(FilesPath(release.Id, FileType.Data))),
                         dataFormFile,
                         It.Is<IDictionary<string, string>>(metadata =>
-                            metadata[BlobInfoExtensions.NameKey] == subjectName
-                            && metadata[BlobInfoExtensions.MetaFileKey] == metaFileName
+                            metadata[BlobInfoExtensions.MetaFileKey] == metaFileName
                             && metadata[BlobInfoExtensions.NumberOfRowsKey] == "2")
                     )).Returns(Task.CompletedTask);
 
@@ -2265,7 +2245,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             contentType: "application/zip",
                             contentLength: 1000L,
                             meta: GetDataFileMetaValues(
-                                subjectName,
                                 metaFileName: metaFileName,
                                 numberOfRows: 0
                             )
@@ -2295,7 +2274,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(subjectName, result.Right.Name);
                 Assert.Equal(dataFileName, result.Right.FileName);
                 Assert.Equal("csv", result.Right.Extension);
-                Assert.Equal("data/file/path", result.Right.Path);
                 Assert.True(result.Right.MetaFileId.HasValue);
                 Assert.Equal(metaFileName, result.Right.MetaFileName);
                 Assert.Equal(_user.Email, result.Right.UserName);
@@ -2425,8 +2403,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             path.Contains(FilesPath(release.Id, FileType.Data))),
                         dataFormFile,
                         It.Is<IDictionary<string, string>>(metadata =>
-                            metadata[BlobInfoExtensions.NameKey] == originalDataReleaseFile.Name
-                            && metadata[BlobInfoExtensions.MetaFileKey] == metaFileName
+                            metadata[BlobInfoExtensions.MetaFileKey] == metaFileName
                             && metadata[BlobInfoExtensions.NumberOfRowsKey] == "2")
                     )).Returns(Task.CompletedTask);
 
@@ -2449,7 +2426,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             contentType: "application/zip",
                             contentLength: 1000L,
                             meta: GetDataFileMetaValues(
-                                originalSubject.Name,
                                 metaFileName: metaFileName,
                                 numberOfRows: 0
                             )
@@ -2479,7 +2455,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(originalDataReleaseFile.Name, result.Right.Name);
                 Assert.Equal(dataFileName, result.Right.FileName);
                 Assert.Equal("csv", result.Right.Extension);
-                Assert.Equal("data/file/path", result.Right.Path);
                 Assert.True(result.Right.MetaFileId.HasValue);
                 Assert.Equal(metaFileName, result.Right.MetaFileName);
                 Assert.Equal(_user.Email, result.Right.UserName);
@@ -2619,8 +2594,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             path.Contains(FilesPath(release.Id, DataZip))),
                         zipFormFile,
                         It.Is<IDictionary<string, string>>(metadata =>
-                            metadata[BlobInfoExtensions.NameKey] == subjectName
-                            && metadata[BlobInfoExtensions.MetaFileKey] == metaFileName
+                            metadata[BlobInfoExtensions.MetaFileKey] == metaFileName
                             && metadata[BlobInfoExtensions.NumberOfRowsKey] == "0")
                     )).Returns(Task.CompletedTask);
 
@@ -2635,7 +2609,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             contentType: "application/zip",
                             contentLength: 1000L,
                             meta: GetDataFileMetaValues(
-                                subjectName,
                                 metaFileName: metaFileName,
                                 numberOfRows: 0
                             )
@@ -2668,7 +2641,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(subjectName, result.Right.Name);
                 Assert.Equal(dataFileName, result.Right.FileName);
                 Assert.Equal("csv", result.Right.Extension);
-                Assert.Equal(dataFileName, result.Right.Path);
                 Assert.True(result.Right.MetaFileId.HasValue);
                 Assert.Equal(metaFileName, result.Right.MetaFileName);
                 Assert.Equal(_user.Email, result.Right.UserName);
@@ -2807,8 +2779,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             path.Contains(FilesPath(release.Id, DataZip))),
                         zipFormFile,
                         It.Is<IDictionary<string, string>>(metadata =>
-                            metadata[BlobInfoExtensions.NameKey] == originalDataReleaseFile.Name
-                            && metadata[BlobInfoExtensions.MetaFileKey] == metaFileName
+                            metadata[BlobInfoExtensions.MetaFileKey] == metaFileName
                             && metadata[BlobInfoExtensions.NumberOfRowsKey] == "0")
                     )).Returns(Task.CompletedTask);
 
@@ -2823,7 +2794,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             contentType: "application/zip",
                             contentLength: 1000L,
                             meta: GetDataFileMetaValues(
-                                name: originalDataReleaseFile.Name,
                                 metaFileName: metaFileName,
                                 numberOfRows: 0
                             )
@@ -2856,7 +2826,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(originalDataReleaseFile.Name, result.Right.Name);
                 Assert.Equal(dataFileName, result.Right.FileName);
                 Assert.Equal("csv", result.Right.Extension);
-                Assert.Equal(dataFileName, result.Right.Path);
                 Assert.True(result.Right.MetaFileId.HasValue);
                 Assert.Equal(metaFileName, result.Right.MetaFileName);
                 Assert.Equal(_user.Email, result.Right.UserName);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
@@ -1145,7 +1145,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("pdf", fileInfoList[0].Extension);
                 Assert.Equal("ancillary_1.pdf", fileInfoList[0].FileName);
                 Assert.Equal("Ancillary Test File 1", fileInfoList[0].Name);
-                Assert.Equal(ancillaryFile1.Path(), fileInfoList[0].Path);
                 Assert.Equal("10 Kb", fileInfoList[0].Size);
                 Assert.Equal(Ancillary, fileInfoList[0].Type);
 
@@ -1153,7 +1152,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("pdf", fileInfoList[1].Extension);
                 Assert.Equal("Ancillary 2.pdf", fileInfoList[1].FileName);
                 Assert.Equal("Ancillary Test File 2", fileInfoList[1].Name);
-                Assert.Equal(ancillaryFile2.Path(), fileInfoList[1].Path);
                 Assert.Equal("10 Kb", fileInfoList[1].Size);
                 Assert.Equal(Ancillary, fileInfoList[1].Type);
 
@@ -1161,7 +1159,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("png", fileInfoList[2].Extension);
                 Assert.Equal("chart.png", fileInfoList[2].FileName);
                 Assert.Equal("chart.png", fileInfoList[2].Name);
-                Assert.Equal(chartFile.Path(), fileInfoList[2].Path);
                 Assert.Equal("20 Kb", fileInfoList[2].Size);
                 Assert.Equal(Chart, fileInfoList[2].Type);
 
@@ -1169,7 +1166,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("png", fileInfoList[3].Extension);
                 Assert.Equal("image.png", fileInfoList[3].FileName);
                 Assert.Equal("image.png", fileInfoList[3].Name);
-                Assert.Equal(imageFile.Path(), fileInfoList[3].Path);
                 Assert.Equal("30 Kb", fileInfoList[3].Size);
                 Assert.Equal(Image, fileInfoList[3].Type);
             }
@@ -1461,7 +1457,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("pdf", result.Right.Extension);
                 Assert.Equal("ancillary.pdf", result.Right.FileName);
                 Assert.Equal("Ancillary Test File", result.Right.Name);
-                Assert.Contains(FilesPath(release.Id, Ancillary), result.Right.Path);
                 Assert.Equal("10 Kb", result.Right.Size);
                 Assert.Equal(Ancillary, result.Right.Type);
             }
@@ -1558,7 +1553,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("png", result.Right.Extension);
                 Assert.Equal("chart.png", result.Right.FileName);
                 Assert.Equal("chart.png", result.Right.Name);
-                Assert.Contains(FilesPath(release.Id, Chart), result.Right.Path);
                 Assert.Equal("20 Kb", result.Right.Size);
                 Assert.Equal(Chart, result.Right.Type);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFileRepository.cs
@@ -13,7 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             Guid id,
             params FileType[] allowedFileTypes);
 
-        public Task<File> Create(
+        public Task<ReleaseFile> Create(
             Guid releaseId,
             string filename,
             FileType type,
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         public Task<bool> FileIsLinkedToOtherReleases(Guid releaseId, Guid fileId);
 
-        public Task<File> UpdateFilename(
+        public Task<ReleaseFile> UpdateFilename(
             Guid releaseId,
             Guid fileId,
             string filename);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyFileRepository.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 {
     public interface IMethodologyFileRepository
     {
-        public Task<File> Create(
+        public Task<MethodologyFile> Create(
             Guid methodologyId,
             string filename,
             FileType type,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyFileRepository.cs
@@ -28,7 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             _contentDbContext = contentDbContext;
         }
 
-        public async Task<File> Create(Guid methodologyId,
+        public async Task<MethodologyFile> Create(Guid methodologyId,
             string filename,
             FileType type,
             Guid createdById)
@@ -53,7 +53,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
             var created = (await _contentDbContext.MethodologyFiles.AddAsync(methodologyFile)).Entity;
             await _contentDbContext.SaveChangesAsync();
-            return created.File;
+            return created;
         }
 
         public async Task<Either<ActionResult, File>> CheckFileExists(Guid methodologyId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
@@ -113,7 +113,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             IFormFile formFile,
             IDictionary<string, string> metadata = null)
         {
-            var file = await _methodologyFileRepository.Create(
+            var methodologyFile = await _methodologyFileRepository.Create(
                 methodologyId: methodologyId,
                 filename: formFile.FileName,
                 type: type,
@@ -123,15 +123,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
             await _blobStorageService.UploadFile(
                 containerName: PrivateMethodologyFiles,
-                path: file.Path(),
+                path: methodologyFile.Path(),
                 file: formFile,
                 metadata: metadata);
 
             var blob = await _blobStorageService.GetBlob(
                 PrivateMethodologyFiles,
-                file.Path());
+                methodologyFile.Path());
 
-            return file.ToFileInfo(blob);
+            return methodologyFile.ToFileInfo(blob);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseDataFileService.cs
@@ -233,7 +233,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                             createdById: _userService.GetUserId());
 
                                         var dataInfo = GetDataFileMetaValues(
-                                            name: validSubjectName,
                                             metaFileName: metaFile.Filename,
                                             numberOfRows: CalculateNumberOfRows(dataFormFile.OpenReadStream())
                                         );
@@ -261,7 +260,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                             Id = dataFile.Id,
                                             FileName = dataFile.Filename,
                                             Name = validSubjectName,
-                                            Path = blob.Path,
                                             Size = blob.Size,
                                             MetaFileId = metaFile.Id,
                                             MetaFileName = metaFile.Filename,
@@ -296,7 +294,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                         .OnSuccess(async archiveFile =>
                                         {
                                             var dataInfo = GetDataFileMetaValues(
-                                                name: validSubjectName,
                                                 metaFileName: archiveFile.MetaFileName,
                                                 numberOfRows: 0
                                             );
@@ -356,7 +353,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                                         Id = dataFile.Id,
                                                         FileName = dataFile.Filename,
                                                         Name = validSubjectName,
-                                                        Path = dataFile.Filename,
                                                         Size = blob.Size,
                                                         MetaFileId = metaFile.Id,
                                                         MetaFileName = metaFile.Filename,
@@ -396,7 +392,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 Id = dataFile.Id,
                 FileName = dataFile.Filename,
                 Name = await GetSubjectName(releaseId, dataFile),
-                Path = blob.Path,
                 Size = blob.Size,
                 MetaFileId = metaFile.Id,
                 MetaFileName = metaFile.Filename,
@@ -429,7 +424,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         Id = dataFile.Id,
                         FileName = dataFile.Filename,
                         Name = await GetSubjectName(releaseId, dataFile),
-                        Path = dataFile.Filename,
                         Size = zipBlob.Size,
                         MetaFileId = null,
                         MetaFileName = zipBlob.GetMetaFileName(),
@@ -449,7 +443,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 Id = dataFile.Id,
                 FileName = dataFile.Filename,
                 Name = await GetSubjectName(releaseId, dataFile),
-                Path = dataFile.Filename,
                 Size = "0.00 B",
                 MetaFileId = metaFile.Id,
                 MetaFileName = metaFile.Filename ?? "",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileRepository.cs
@@ -49,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return releaseFile.File;
         }
 
-        public async Task<File> Create(
+        public async Task<ReleaseFile> Create(
             Guid releaseId,
             string filename,
             FileType type,
@@ -75,7 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             var created = (await _contentDbContext.ReleaseFiles.AddAsync(releaseFile)).Entity;
             await _contentDbContext.SaveChangesAsync();
-            return created.File;
+            return created;
         }
 
         public async Task Delete(Guid releaseId, Guid fileId)
@@ -115,7 +115,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     && releaseFile.FileId == fileId);
         }
 
-        public async Task<File> UpdateFilename(Guid releaseId,
+        public async Task<ReleaseFile> UpdateFilename(Guid releaseId,
             Guid fileId,
             string filename)
         {
@@ -132,7 +132,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             await _contentDbContext.SaveChangesAsync();
 
-            return file;
+            return releaseFile;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
@@ -123,7 +123,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                             }
 
                             var blob = await _blobStorageService.GetBlob(PrivateReleaseFiles, file.Path());
-                            return file.ToFileInfo(blob);
+                            return releaseFile.ToFileInfo(blob);
                         });
 
                     return (await Task.WhenAll(filesWithMetadata))
@@ -176,7 +176,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(async () => await _fileUploadsValidatorService.ValidateFileForUpload(formFile, Chart))
                 .OnSuccess(async () =>
                 {
-                    var file = replacingId.HasValue
+                    var releaseFile = replacingId.HasValue
                         ? await _releaseFileRepository.UpdateFilename(
                             releaseId,
                             replacingId.Value,
@@ -189,15 +189,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     await _blobStorageService.UploadFile(
                         containerName: PrivateReleaseFiles,
-                        path: file.Path(),
+                        path: releaseFile.Path(),
                         file: formFile
                     );
 
                     var blob = await _blobStorageService.GetBlob(
                         PrivateReleaseFiles,
-                        file.Path());
+                        releaseFile.Path());
 
-                    return file.ToFileInfo(blob);
+                    return releaseFile.ToFileInfo(blob);
                 });
         }
 
@@ -206,7 +206,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IFormFile formFile,
             IDictionary<string, string> metadata = null)
         {
-            var file = await _releaseFileRepository.Create(
+            var releaseFile = await _releaseFileRepository.Create(
                 releaseId: releaseId,
                 filename: formFile.FileName,
                 type: type,
@@ -216,15 +216,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             await _blobStorageService.UploadFile(
                 containerName: PrivateReleaseFiles,
-                path: file.Path(),
+                path: releaseFile.Path(),
                 file: formFile,
                 metadata: metadata);
 
             var blob = await _blobStorageService.GetBlob(
                 PrivateReleaseFiles,
-                file.Path());
+                releaseFile.Path());
 
-            return file.ToFileInfo(blob);
+            return releaseFile.ToFileInfo(blob);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseImageService.cs
@@ -88,7 +88,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IFormFile formFile,
             IDictionary<string, string> metadata = null)
         {
-            var file = await _releaseFileRepository.Create(
+            var releaseFile = await _releaseFileRepository.Create(
                 releaseId: releaseId,
                 filename: formFile.FileName,
                 type: type,
@@ -98,15 +98,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             await _blobStorageService.UploadFile(
                 containerName: PrivateReleaseFiles,
-                path: file.Path(),
+                path: releaseFile.Path(),
                 file: formFile,
                 metadata: metadata);
 
             var blob = await _blobStorageService.GetBlob(
                 PrivateReleaseFiles,
-                file.Path());
+                releaseFile.Path());
 
-            return file.ToFileInfo(blob);
+            return releaseFile.ToFileInfo(blob);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/FileInfo.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/FileInfo.cs
@@ -13,9 +13,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         public string Name { get; set; }
         public string Size { get; set; }
 
-        [JsonIgnore]
-        public string Path { get; set; }
-
         [JsonConverter(typeof(EnumToEnumValueJsonConverter<FileType>))]
         public FileType Type { get; set; }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStorageUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStorageUtils.cs
@@ -20,14 +20,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         }
 
         public static IDictionary<string, string> GetAllFilesZipMetaValues(
-            string name,
             DateTime releaseDateTime)
         {
             return new Dictionary<string, string>
             {
-                {
-                    BlobInfoExtensions.NameKey, name
-                },
                 {
                     BlobInfoExtensions.ReleaseDateTimeKey, releaseDateTime.ToString("o", CultureInfo.InvariantCulture)
                 }
@@ -53,13 +49,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         }
 
         public static IDictionary<string, string> GetDataFileMetaValues(
-            string name,
             string metaFileName,
             int numberOfRows)
         {
             return new Dictionary<string, string>
             {
-                {BlobInfoExtensions.NameKey, name},
                 {BlobInfoExtensions.MetaFileKey, metaFileName.ToLower()},
                 {BlobInfoExtensions.NumberOfRowsKey, numberOfRows.ToString()}
             };

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/FileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/FileExtensionTests.cs
@@ -9,6 +9,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
 {
     public class FileExtensionTests
     {
+        private readonly File _file = new File
+        {
+            Id = Guid.NewGuid(),
+            RootPath = Guid.NewGuid(),
+            Filename = "ancillary.pdf",
+            Type = Ancillary
+        };
+
         [Fact]
         public void BatchesPath()
         {
@@ -169,6 +177,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
                     Assert.Throws<ArgumentOutOfRangeException>(() => file.PublicPath(release));
                 }
             });
+        }
+
+        [Fact]
+        public void ToFileInfoNotFound()
+        {
+            var result = _file.ToFileInfoNotFound();
+
+            Assert.Equal(_file.Id, result.Id);
+            Assert.Equal("pdf", result.Extension);
+            Assert.Equal("ancillary.pdf", result.FileName);
+            Assert.Equal("Unknown", result.Name);
+            Assert.Equal("0.00 B", result.Size);
+            Assert.Equal(Ancillary, result.Type);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/FileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/FileExtensionTests.cs
@@ -14,12 +14,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
         private const string PublicationSlug = "publication-slug";
         private const string ReleaseSlug = "release-slug";
 
-        private readonly File _file = new File
+        private readonly ReleaseFile _releaseFile = new ReleaseFile
         {
-            Id = Guid.NewGuid(),
-            RootPath = Guid.NewGuid(),
-            Filename = "ancillary.pdf",
-            Type = Ancillary
+            Release = new Release(),
+            File = new File
+            {
+                Id = Guid.NewGuid(),
+                RootPath = Guid.NewGuid(),
+                Filename = "ancillary.pdf",
+                Type = Ancillary
+            }
         };
 
         [Fact]
@@ -187,7 +191,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
         [Fact]
         public void ToFileInfo()
         {
-            var result = _file.ToFileInfo(new BlobInfo
+            var result = _releaseFile.ToFileInfo(new BlobInfo
             (
                 path: "Ignored",
                 size: "400 B",
@@ -199,11 +203,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
                 }
             ));
 
-            Assert.Equal(_file.Id, result.Id);
+            Assert.Equal(_releaseFile.FileId, result.Id);
             Assert.Equal("pdf", result.Extension);
             Assert.Equal("ancillary.pdf", result.FileName);
             Assert.Equal("Test ancillary file", result.Name);
-            Assert.Equal(_file.Path(), result.Path);
             Assert.Equal("400 B", result.Size);
             Assert.Equal(Ancillary, result.Type);
         }
@@ -216,7 +219,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
             // Chart files don't have any meta properties added to avoid duplicating data unnecessarily since nothing requires the filename or name of them
             // Nevertheless test that we populate the name from the database File as a fallback when the blob name property is missing
 
-            var result = _file.ToFileInfo(new BlobInfo
+            var result = _releaseFile.ToFileInfo(new BlobInfo
             (
                 path: "Ignored",
                 size: "400 B",
@@ -225,11 +228,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
                 meta: new Dictionary<string, string>()
             ));
 
-            Assert.Equal(_file.Id, result.Id);
+            Assert.Equal(_releaseFile.FileId, result.Id);
             Assert.Equal("pdf", result.Extension);
             Assert.Equal("ancillary.pdf", result.FileName);
             Assert.Equal("ancillary.pdf", result.Name);
-            Assert.Equal(_file.Path(), result.Path);
             Assert.Equal("400 B", result.Size);
             Assert.Equal(Ancillary, result.Type);
         }
@@ -237,47 +239,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
         [Fact]
         public void ToFileInfoNotFound()
         {
-            var result = _file.ToFileInfoNotFound();
+            var result = _releaseFile.File.ToFileInfoNotFound();
 
-            Assert.Equal(_file.Id, result.Id);
+            Assert.Equal(_releaseFile.File.Id, result.Id);
             Assert.Equal("pdf", result.Extension);
             Assert.Equal("ancillary.pdf", result.FileName);
             Assert.Equal("Unknown", result.Name);
-            Assert.Null(result.Path);
             Assert.Equal("0.00 B", result.Size);
-            Assert.Equal(Ancillary, result.Type);
-        }
-
-        [Fact]
-        public void ToPublicFileInfo()
-        {
-            var release = new Release
-            {
-                Publication = new Publication
-                {
-                    Slug = PublicationSlug
-                },
-                Slug = ReleaseSlug
-            };
-
-            var result = _file.ToPublicFileInfo(new BlobInfo
-            (
-                path: _file.PublicPath(release),
-                size: "400 B",
-                contentType: "Ignored",
-                contentLength: -1L,
-                meta: new Dictionary<string, string>
-                {
-                    {NameKey, "Test ancillary file"}
-                }
-            ));
-
-            Assert.Equal(_file.Id, result.Id);
-            Assert.Equal("pdf", result.Extension);
-            Assert.Equal("ancillary.pdf", result.FileName);
-            Assert.Equal("Test ancillary file", result.Name);
-            Assert.Equal(_file.PublicPath(release), result.Path);
-            Assert.Equal("400 B", result.Size);
             Assert.Equal(Ancillary, result.Type);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/FileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/FileExtensionTests.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Common.Model.BlobInfo;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions.FileExtensions;
 
@@ -11,21 +9,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
 {
     public class FileExtensionTests
     {
-        private const string PublicationSlug = "publication-slug";
-        private const string ReleaseSlug = "release-slug";
-
-        private readonly ReleaseFile _releaseFile = new ReleaseFile
-        {
-            Release = new Release(),
-            File = new File
-            {
-                Id = Guid.NewGuid(),
-                RootPath = Guid.NewGuid(),
-                Filename = "ancillary.pdf",
-                Type = Ancillary
-            }
-        };
-
         [Fact]
         public void BatchesPath()
         {
@@ -186,67 +169,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
                     Assert.Throws<ArgumentOutOfRangeException>(() => file.PublicPath(release));
                 }
             });
-        }
-
-        [Fact]
-        public void ToFileInfo()
-        {
-            var result = _releaseFile.ToFileInfo(new BlobInfo
-            (
-                path: "Ignored",
-                size: "400 B",
-                contentType: "Ignored",
-                contentLength: -1L,
-                meta: new Dictionary<string, string>
-                {
-                    {NameKey, "Test ancillary file"}
-                }
-            ));
-
-            Assert.Equal(_releaseFile.FileId, result.Id);
-            Assert.Equal("pdf", result.Extension);
-            Assert.Equal("ancillary.pdf", result.FileName);
-            Assert.Equal("Test ancillary file", result.Name);
-            Assert.Equal("400 B", result.Size);
-            Assert.Equal(Ancillary, result.Type);
-        }
-
-        [Fact]
-        // TODO EES-1815 Remove this when the name is changed to use the database Subject name
-        public void ToFileInfo_BlobWithNoNameKey()
-        {
-            // Name is retrieved from the blob meta properties due to EES-1637 (Subject didn't exist early on and Name on Data files is Subject name persisted on blob)
-            // Chart files don't have any meta properties added to avoid duplicating data unnecessarily since nothing requires the filename or name of them
-            // Nevertheless test that we populate the name from the database File as a fallback when the blob name property is missing
-
-            var result = _releaseFile.ToFileInfo(new BlobInfo
-            (
-                path: "Ignored",
-                size: "400 B",
-                contentType: "Ignored",
-                contentLength: -1L,
-                meta: new Dictionary<string, string>()
-            ));
-
-            Assert.Equal(_releaseFile.FileId, result.Id);
-            Assert.Equal("pdf", result.Extension);
-            Assert.Equal("ancillary.pdf", result.FileName);
-            Assert.Equal("ancillary.pdf", result.Name);
-            Assert.Equal("400 B", result.Size);
-            Assert.Equal(Ancillary, result.Type);
-        }
-
-        [Fact]
-        public void ToFileInfoNotFound()
-        {
-            var result = _releaseFile.File.ToFileInfoNotFound();
-
-            Assert.Equal(_releaseFile.File.Id, result.Id);
-            Assert.Equal("pdf", result.Extension);
-            Assert.Equal("ancillary.pdf", result.FileName);
-            Assert.Equal("Unknown", result.Name);
-            Assert.Equal("0.00 B", result.Size);
-            Assert.Equal(Ancillary, result.Type);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/MethodologyFileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/MethodologyFileExtensionTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
@@ -22,6 +24,37 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
             };
 
             Assert.Equal(methodologyFile.File.Path(), methodologyFile.Path());
+        }
+
+        [Fact]
+        public void ToFileInfo()
+        {
+            var methodologyFile = new MethodologyFile
+            {
+                Methodology = new Methodology(),
+                File = new File
+                {
+                    Id = Guid.NewGuid(),
+                    RootPath = Guid.NewGuid(),
+                    Filename = "image.png",
+                    Type = Image
+                }
+            };
+
+            var result = methodologyFile.ToFileInfo(new BlobInfo
+            (
+                path: "Ignored",
+                size: "500 B",
+                contentType: "Ignored",
+                contentLength: -1L,
+                meta: new Dictionary<string, string>()
+            ));
+
+            Assert.Equal(methodologyFile.File.Id, result.Id);
+            Assert.Equal("png", result.Extension);
+            Assert.Equal("image.png", result.FileName);
+            Assert.Equal("500 B", result.Size);
+            Assert.Equal(Image, result.Type);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseFileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseFileExtensionTests.cs
@@ -1,12 +1,27 @@
 ﻿using System;
+using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Model.BlobInfo;
+using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensions
 {
     public class ReleaseFileExtensionTests
     {
+        private readonly ReleaseFile _releaseFile = new ReleaseFile
+        {
+            Release = new Release(),
+            File = new File
+            {
+                Id = Guid.NewGuid(),
+                RootPath = Guid.NewGuid(),
+                Filename = "ancillary.pdf",
+                Type = Ancillary
+            }
+        };
+
         [Fact]
         public void BatchesPath()
         {
@@ -17,7 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
                     Id = Guid.NewGuid(),
                     RootPath = Guid.NewGuid(),
                     Filename = "data.csv",
-                    Type = FileType.Data
+                    Type = Data
                 }
             };
 
@@ -34,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
                     Id = Guid.NewGuid(),
                     RootPath = Guid.NewGuid(),
                     Filename = "ancillary.pdf",
-                    Type = FileType.Ancillary
+                    Type = Ancillary
                 }
             };
 
@@ -57,11 +72,72 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
                     Id = Guid.NewGuid(),
                     RootPath = Guid.NewGuid(),
                     Filename = "ancillary.pdf",
-                    Type = FileType.Ancillary
+                    Type = Ancillary
                 }
             };
 
             Assert.Equal(releaseFile.File.PublicPath(release), releaseFile.PublicPath());
+        }
+
+        [Fact]
+        public void ToFileInfo()
+        {
+            var result = _releaseFile.ToFileInfo(new BlobInfo
+            (
+                path: "Ignored",
+                size: "400 B",
+                contentType: "Ignored",
+                contentLength: -1L,
+                meta: new Dictionary<string, string>
+                {
+                    {NameKey, "Test ancillary file"}
+                }
+            ));
+
+            Assert.Equal(_releaseFile.FileId, result.Id);
+            Assert.Equal("pdf", result.Extension);
+            Assert.Equal("ancillary.pdf", result.FileName);
+            Assert.Equal("Test ancillary file", result.Name);
+            Assert.Equal("400 B", result.Size);
+            Assert.Equal(Ancillary, result.Type);
+        }
+
+        [Fact]
+        // TODO EES-1815 Remove this when the name is changed to use the database Subject name
+        public void ToFileInfo_BlobWithNoNameKey()
+        {
+            // Name is retrieved from the blob meta properties due to EES-1637 (Subject didn't exist early on and Name on Data files is Subject name persisted on blob)
+            // Chart files don't have any meta properties added to avoid duplicating data unnecessarily since nothing requires the filename or name of them
+            // Nevertheless test that we populate the name from the database File as a fallback when the blob name property is missing
+
+            var result = _releaseFile.ToFileInfo(new BlobInfo
+            (
+                path: "Ignored",
+                size: "400 B",
+                contentType: "Ignored",
+                contentLength: -1L,
+                meta: new Dictionary<string, string>()
+            ));
+
+            Assert.Equal(_releaseFile.FileId, result.Id);
+            Assert.Equal("pdf", result.Extension);
+            Assert.Equal("ancillary.pdf", result.FileName);
+            Assert.Equal("ancillary.pdf", result.Name);
+            Assert.Equal("400 B", result.Size);
+            Assert.Equal(Ancillary, result.Type);
+        }
+
+        [Fact]
+        public void ToFileInfoNotFound()
+        {
+            var result = _releaseFile.File.ToFileInfoNotFound();
+
+            Assert.Equal(_releaseFile.File.Id, result.Id);
+            Assert.Equal("pdf", result.Extension);
+            Assert.Equal("ancillary.pdf", result.FileName);
+            Assert.Equal("Unknown", result.Name);
+            Assert.Equal("0.00 B", result.Size);
+            Assert.Equal(Ancillary, result.Type);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseFileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseFileExtensionTests.cs
@@ -127,18 +127,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
             Assert.Equal("400 B", result.Size);
             Assert.Equal(Ancillary, result.Type);
         }
-
-        [Fact]
-        public void ToFileInfoNotFound()
-        {
-            var result = _releaseFile.File.ToFileInfoNotFound();
-
-            Assert.Equal(_releaseFile.File.Id, result.Id);
-            Assert.Equal("pdf", result.Extension);
-            Assert.Equal("ancillary.pdf", result.FileName);
-            Assert.Equal("Unknown", result.Name);
-            Assert.Equal("0.00 B", result.Size);
-            Assert.Equal(Ancillary, result.Type);
-        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseFileExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Extensions/ReleaseFileExtensionTests.cs
@@ -103,13 +103,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Extensi
         }
 
         [Fact]
-        // TODO EES-1815 Remove this when the name is changed to use the database Subject name
+        // TODO EES-2052
+        // As part of the subtasks of EES-1512, subject names are no longer added to and access via blob files, but 
+        // via the ReleaseFile table. At the time of writing, this hasn't been done for ancillary files, and
+        // therefore there is still some logic in BlobInfo and releaseFile.ToFileInfo() to handle getting names from
+        // blob files. Once ancillary files also add and access their names from the ReleaseFiles table, this logic 
+        // can be removed and this test removed.
         public void ToFileInfo_BlobWithNoNameKey()
         {
-            // Name is retrieved from the blob meta properties due to EES-1637 (Subject didn't exist early on and Name on Data files is Subject name persisted on blob)
-            // Chart files don't have any meta properties added to avoid duplicating data unnecessarily since nothing requires the filename or name of them
-            // Nevertheless test that we populate the name from the database File as a fallback when the blob name property is missing
-
             var result = _releaseFile.ToFileInfo(new BlobInfo
             (
                 path: "Ignored",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/FileExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/FileExtensions.cs
@@ -52,17 +52,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
             return $"{FilesPath(releaseId, file.Type)}{file.Id}";
         }
 
-        public static FileInfo ToFileInfo(this File file, BlobInfo blobInfo)
+        public static FileInfo ToFileInfo(this ReleaseFile releaseFile, BlobInfo blobInfo)
         {
             return new FileInfo
             {
-                Id = file.Id,
-                FileName = file.Filename,
-                // EES-1815 Change to use Subject name rather than BlobInfo.Name
-                Name = blobInfo.Name.IsNullOrEmpty() ? file.Filename : blobInfo.Name,
-                Path = file.Path(),
+                Id = releaseFile.FileId,
+                FileName = releaseFile.File.Filename,
+                Name = releaseFile.Name ?? 
+                       (blobInfo.Name.IsNullOrEmpty() ? releaseFile.File.Filename : blobInfo.Name),
                 Size = blobInfo.Size,
-                Type = file.Type
+                Type = releaseFile.File.Type
+            };
+        }
+
+        public static FileInfo ToFileInfo(this MethodologyFile methodologyFile, BlobInfo blobInfo)
+        {
+            return new FileInfo
+            {
+                Id = methodologyFile.File.Id,
+                FileName = methodologyFile.File.Filename,
+                Name = null,
+                Size = blobInfo.Size,
+                Type = methodologyFile.File.Type
             };
         }
 
@@ -73,21 +84,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
                 Id = file.Id,
                 FileName = file.Filename,
                 Name = "Unknown",
-                Path = null,
                 Size = "0.00 B",
-                Type = file.Type
-            };
-        }
-
-        public static FileInfo ToPublicFileInfo(this File file, BlobInfo blobInfo)
-        {
-            return new FileInfo
-            {
-                Id = file.Id,
-                FileName = file.Filename,
-                Name = blobInfo.Name,
-                Path = blobInfo.Path,
-                Size = blobInfo.Size,
                 Type = file.Type
             };
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/FileExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/FileExtensions.cs
@@ -52,18 +52,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
             return $"{FilesPath(releaseId, file.Type)}{file.Id}";
         }
 
-        public static FileInfo ToFileInfo(this MethodologyFile methodologyFile, BlobInfo blobInfo)
-        {
-            return new FileInfo
-            {
-                Id = methodologyFile.File.Id,
-                FileName = methodologyFile.File.Filename,
-                Name = null,
-                Size = blobInfo.Size,
-                Type = methodologyFile.File.Type
-            };
-        }
-
         public static FileInfo ToFileInfoNotFound(this File file)
         {
             return new FileInfo

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/FileExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/FileExtensions.cs
@@ -52,19 +52,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
             return $"{FilesPath(releaseId, file.Type)}{file.Id}";
         }
 
-        public static FileInfo ToFileInfo(this ReleaseFile releaseFile, BlobInfo blobInfo)
-        {
-            return new FileInfo
-            {
-                Id = releaseFile.FileId,
-                FileName = releaseFile.File.Filename,
-                Name = releaseFile.Name ?? 
-                       (blobInfo.Name.IsNullOrEmpty() ? releaseFile.File.Filename : blobInfo.Name),
-                Size = blobInfo.Size,
-                Type = releaseFile.File.Type
-            };
-        }
-
         public static FileInfo ToFileInfo(this MethodologyFile methodologyFile, BlobInfo blobInfo)
         {
             return new FileInfo

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/MethodologyFileExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/MethodologyFileExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
 {
     public static class MethodologyFileExtensions
     {
@@ -6,5 +8,18 @@
         {
             return methodologyFile.File.Path();
         }
+
+        public static FileInfo ToFileInfo(this MethodologyFile methodologyFile, BlobInfo blobInfo)
+        {
+            return new FileInfo
+            {
+                Id = methodologyFile.File.Id,
+                FileName = methodologyFile.File.Filename,
+                Name = null,
+                Size = blobInfo.Size,
+                Type = methodologyFile.File.Type
+            };
+        }
+
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseFileExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Extensions/ReleaseFileExtensions.cs
@@ -1,4 +1,7 @@
-﻿namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions
 {
     public static class ReleaseFileExtensions
     {
@@ -15,6 +18,19 @@
         public static string PublicPath(this ReleaseFile releaseFile)
         {
             return releaseFile.File.PublicPath(releaseFile.Release);
+        }
+
+        public static FileInfo ToFileInfo(this ReleaseFile releaseFile, BlobInfo blobInfo)
+        {
+            return new FileInfo
+            {
+                Id = releaseFile.FileId,
+                FileName = releaseFile.File.Filename,
+                Name = releaseFile.Name ??
+                       (blobInfo.Name.IsNullOrEmpty() ? releaseFile.File.Filename : blobInfo.Name),
+                Size = blobInfo.Size,
+                Type = releaseFile.File.Type
+            };
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataArchiveService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataArchiveService.cs
@@ -1,6 +1,5 @@
 using System.IO.Compression;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
@@ -22,7 +21,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         public async Task ExtractDataFiles(DataImport import)
         {
             var path = import.ZipFile.Path();
-            var blob = await _blobStorageService.GetBlob(PrivateReleaseFiles, path);
 
             await using var zipBlobFileStream = await _blobStorageService.StreamBlob(PrivateReleaseFiles, path);
             using var archive = new ZipArchive(zipBlobFileStream);
@@ -41,7 +39,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     stream: stream,
                     contentType: "text/csv",
                     metadata: GetDataFileMetaValues(
-                            name: blob.Name,
                             metaFileName: metadataFile.Name,
                             numberOfRows: CalculateNumberOfRows(rowStream)
                         ));

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
@@ -178,15 +178,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
                 stream.Seek(0, SeekOrigin.Begin);
 
-                var dataBlob = await _blobStorageService.GetBlob(PrivateReleaseFiles, dataImport.File.Path());
-
                 await _blobStorageService.UploadStream(
                     containerName: PrivateReleaseFiles,
                     path: dataImport.File.BatchPath(batchCount),
                     stream: stream,
                     contentType: "text/csv",
                     metadata: GetDataFileMetaValues(
-                        name: dataBlob.Name,
                         metaFileName: dataImport.MetaFile.Filename,
                         numberOfRows: numRows
                     ));

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -522,6 +522,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         private static readonly ReleaseFile PublicationARelease2DataReleaseFile = new ReleaseFile
         {
             Release = PublicationARelease2,
+            Name = "Data Test File",
             File = new File
             {
                 Filename = "data.csv",
@@ -601,7 +602,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                         contentType: "text/csv",
                         contentLength: 0L,
                         meta: GetDataFileMetaValues(
-                            name: "Data Test File",
                             metaFileName: "data.meta.csv",
                             numberOfRows: 200),
                         created: null
@@ -616,7 +616,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                         contentType: "application/x-zip-compressed",
                         contentLength: 0L,
                         meta: GetAllFilesZipMetaValues(
-                            name: "All files",
                             releaseDateTime: DateTime.Now),
                         created: null
                     ));
@@ -633,21 +632,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Assert.Equal("zip", result[0].Extension);
                 Assert.Equal("publication-a_2018-19-q2.zip", result[0].FileName);
                 Assert.Equal("All files", result[0].Name);
-                Assert.Equal(PublicationARelease2.AllFilesZipPath(), result[0].Path);
                 Assert.Equal("3 Mb", result[0].Size);
                 Assert.Equal(Ancillary, result[0].Type);
                 Assert.Equal(PublicationARelease2AncillaryReleaseFile.File.Id, result[1].Id);
                 Assert.Equal("pdf", result[1].Extension);
                 Assert.Equal("ancillary.pdf", result[1].FileName);
                 Assert.Equal("Ancillary Test File", result[1].Name);
-                Assert.Equal(PublicationARelease2AncillaryReleaseFile.PublicPath(), result[1].Path);
                 Assert.Equal("15 Kb", result[1].Size);
                 Assert.Equal(Ancillary, result[1].Type);
                 Assert.Equal(PublicationARelease2DataReleaseFile.File.Id, result[2].Id);
                 Assert.Equal("csv", result[2].Extension);
                 Assert.Equal("data.csv", result[2].FileName);
                 Assert.Equal("Data Test File", result[2].Name);
-                Assert.Equal(PublicationARelease2DataReleaseFile.PublicPath(), result[2].Path);
                 Assert.Equal("10 Mb", result[2].Size);
                 Assert.Equal(FileType.Data, result[2].Type);
             }
@@ -762,7 +758,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                         contentType: "text/csv",
                         contentLength: 0L,
                         meta: GetDataFileMetaValues(
-                            name: "Data Test File",
                             metaFileName: "data.meta.csv",
                             numberOfRows: 200),
                         created: null
@@ -777,7 +772,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                         contentType: "application/x-zip-compressed",
                         contentLength: 0L,
                         meta: GetAllFilesZipMetaValues(
-                            name: "All files",
                             releaseDateTime: DateTime.Now),
                         created: null
                     ));
@@ -846,21 +840,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Assert.Equal("zip", result.DownloadFiles[0].Extension);
                 Assert.Equal("publication-a_2018-19-q2.zip", result.DownloadFiles[0].FileName);
                 Assert.Equal("All files", result.DownloadFiles[0].Name);
-                Assert.Equal(PublicationARelease2.AllFilesZipPath(), result.DownloadFiles[0].Path);
                 Assert.Equal("3 Mb", result.DownloadFiles[0].Size);
                 Assert.Equal(Ancillary, result.DownloadFiles[0].Type);
                 Assert.Equal(PublicationARelease2AncillaryReleaseFile.File.Id, result.DownloadFiles[1].Id);
                 Assert.Equal("pdf", result.DownloadFiles[1].Extension);
                 Assert.Equal("ancillary.pdf", result.DownloadFiles[1].FileName);
                 Assert.Equal("Ancillary Test File", result.DownloadFiles[1].Name);
-                Assert.Equal(PublicationARelease2AncillaryReleaseFile.PublicPath(), result.DownloadFiles[1].Path);
                 Assert.Equal("15 Kb", result.DownloadFiles[1].Size);
                 Assert.Equal(Ancillary, result.DownloadFiles[1].Type);
                 Assert.Equal(PublicationARelease2DataReleaseFile.File.Id, result.DownloadFiles[2].Id);
                 Assert.Equal("csv", result.DownloadFiles[2].Extension);
                 Assert.Equal("data.csv", result.DownloadFiles[2].FileName);
                 Assert.Equal("Data Test File", result.DownloadFiles[2].Name);
-                Assert.Equal(PublicationARelease2DataReleaseFile.PublicPath(), result.DownloadFiles[2].Path);
                 Assert.Equal("10 Mb", result.DownloadFiles[2].Size);
                 Assert.Equal(FileType.Data, result.DownloadFiles[2].Type);
 
@@ -903,7 +894,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                     contentType: "application/x-zip-compressed",
                     contentLength: 0L,
                     meta: GetAllFilesZipMetaValues(
-                        name: "All files",
                         releaseDateTime: DateTime.Now),
                     created: null
                 ));
@@ -971,7 +961,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Assert.Equal("zip", result.DownloadFiles[0].Extension);
                 Assert.Equal("publication-a_2018-19-q1.zip", result.DownloadFiles[0].FileName);
                 Assert.Equal("All files", result.DownloadFiles[0].Name);
-                Assert.Equal(PublicationARelease1V1.AllFilesZipPath(), result.DownloadFiles[0].Path);
                 Assert.Equal("0 b", result.DownloadFiles[0].Size);
                 Assert.Equal(Ancillary, result.DownloadFiles[0].Type);
 
@@ -1014,7 +1003,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                     contentType: "application/x-zip-compressed",
                     contentLength: 0L,
                     meta: GetAllFilesZipMetaValues(
-                        name: "All files",
                         releaseDateTime: DateTime.Now),
                     created: null
                 ));
@@ -1041,7 +1029,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Assert.Equal("zip", result.DownloadFiles[0].Extension);
                 Assert.Equal("publication-a_2018-19-q3.zip", result.DownloadFiles[0].FileName);
                 Assert.Equal("All files", result.DownloadFiles[0].Name);
-                Assert.Equal(PublicationARelease3.AllFilesZipPath(), result.DownloadFiles[0].Path);
                 Assert.Equal("0 b", result.DownloadFiles[0].Size);
                 Assert.Equal(Ancillary, result.DownloadFiles[0].Type);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ZipFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ZipFileServiceTests.cs
@@ -63,8 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                     It.IsAny<MemoryStream>(),
                     "application/x-zip-compressed",
                     It.Is<IDictionary<string, string>>(metadata =>
-                        metadata[BlobInfoExtensions.NameKey] == "All files"
-                        && metadata[BlobInfoExtensions.ReleaseDateTimeKey] ==
+                        metadata[BlobInfoExtensions.ReleaseDateTimeKey] ==
                         release.PublishScheduled.Value.ToString("o", CultureInfo.InvariantCulture))))
                 .Returns(Task.CompletedTask);
 
@@ -73,7 +72,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             await service.UploadZippedFiles(
                 containerName: PublicReleaseFiles,
                 destinationPath: "destination/path/test.zip",
-                zipFileName: "All files",
                 files: files,
                 releaseId: release.Id,
                 publishScheduled: release.PublishScheduled.Value);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IZipFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IZipFileService.cs
@@ -11,7 +11,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
         Task UploadZippedFiles(
             IBlobContainer containerName,
             string destinationPath,
-            string zipFileName,
             IEnumerable<File> files,
             Guid releaseId,
             DateTime publishScheduled);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -146,7 +146,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             await _zipFileService.UploadZippedFiles(
                 PublicReleaseFiles,
                 destinationPath: release.AllFilesZipPath(),
-                zipFileName: "All files",
                 files: filesToZip,
                 releaseId: release.Id,
                 publishScheduled: release.PublishScheduled.Value

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ZipFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ZipFileService.cs
@@ -23,7 +23,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         public async Task UploadZippedFiles(IBlobContainer containerName,
             string destinationPath,
-            string zipFileName,
             IEnumerable<File> files,
             Guid releaseId,
             DateTime publishScheduled)
@@ -52,7 +51,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 memoryStream,
                 contentType: "application/x-zip-compressed",
                 metadata: GetAllFilesZipMetaValues(
-                    name: zipFileName,
                     releaseDateTime: publishScheduled));
         }
     }


### PR DESCRIPTION
Now that we have releaseFile.Name, we don't need to store subject names
in blob file metadata and can retrieve subject names from releaseFile.Name instead.

This currently is only happening with data files, not ancillary files.