### PR TITLE
EES-1947 Add analytics event for View data and files button

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -173,6 +173,13 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                   <a
                     href="#dataDownloads-1"
                     className="govuk-button govuk-!-margin-bottom-3"
+                    onClick={() => {
+                      logEvent({
+                        category: `${data.publication.title} release page`,
+                        action: `View data and files clicked`,
+                        label: window.location.pathname,
+                      });
+                    }}
                   >
                     View data and files
                   </a>


### PR DESCRIPTION
Sends an analytics event when the 'View data and files' button is clicked.

Not sure if the label is really necessary, but a few others had it so thought it might be standard practice if there's no more meaningful label to send. 