### PR TITLE
EES-2051 fix excessive footer padding on some releases

### DIFF
--- a/src/explore-education-statistics-common/src/components/AccordionSection.module.scss
+++ b/src/explore-education-statistics-common/src/components/AccordionSection.module.scss
@@ -11,6 +11,7 @@
   overflow: hidden;
   padding: 0 !important;
   visibility: hidden;
+  position: relative;
 
   @media print {
     height: auto;

--- a/src/explore-education-statistics-common/src/components/AccordionSection.module.scss
+++ b/src/explore-education-statistics-common/src/components/AccordionSection.module.scss
@@ -10,8 +10,8 @@
   height: 0;
   overflow: hidden;
   padding: 0 !important;
-  visibility: hidden;
   position: relative;
+  visibility: hidden;
 
   @media print {
     height: auto;


### PR DESCRIPTION
This seems to occur because of the absolutely positioned govuk-visually-hidden elements within accordion content. These cause the accordion content to extend the height of the page, despite being in a collapsed section.

Making the collapsed sections have relative position fixes it as the govuk-visually-hidden elements are now absolutely positioned relative to their containing section (and still remain visually hidden).