### PR TITLE
EES-2044 send correct data when edit footnote

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnoteForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/footnotes/components/FootnoteForm.tsx
@@ -107,16 +107,7 @@ const FootnoteForm = ({
           );
         }
 
-        // Remove unused subjects when type is NA.
-        const newValues = { ...values };
-        Object.keys(newValues.subjects).map(subjectId => {
-          if (newValues.subjects[subjectId].selectionType === 'NA') {
-            delete newValues.subjects[subjectId];
-          }
-          return subjectId;
-        });
-
-        await onSubmit(newValues);
+        await onSubmit(values);
       }}
     >
       {form => (

--- a/src/explore-education-statistics-admin/src/services/utils/footnote/__tests__/footnoteToFlatFootnote.test.ts
+++ b/src/explore-education-statistics-admin/src/services/utils/footnote/__tests__/footnoteToFlatFootnote.test.ts
@@ -1,0 +1,287 @@
+import footnoteToFlatFootnote from '@admin/services/utils/footnote/footnoteToFlatFootnote';
+import { BaseFootnote } from '@admin/services/footnoteService';
+
+describe('footnoteToFlatFootnote', () => {
+  test('only include the subject id if All data is selected for a subject', () => {
+    const footnote: BaseFootnote = {
+      content: '',
+      subjects: {
+        'subject-id-1': {
+          selected: true,
+          selectionType: 'All',
+          indicatorGroups: {},
+          filters: {},
+        },
+      },
+    };
+
+    const expectedFlatFootnote = {
+      content: '',
+      subjects: ['subject-id-1'],
+      indicators: [],
+      indicatorGroups: [],
+      filters: [],
+      filterItems: [],
+      filterGroups: [],
+    };
+
+    const flatFootnote = footnoteToFlatFootnote(footnote);
+    expect(flatFootnote).toEqual(expectedFlatFootnote);
+  });
+
+  test('only include the subject id if All data is selected for a subject when indicators/filters have previously been selected', () => {
+    const footnote: BaseFootnote = {
+      content: '',
+      subjects: {
+        'subject-id-1': {
+          selected: true,
+          selectionType: 'All',
+          indicatorGroups: {
+            'indicator-group-id': {
+              selected: false,
+              indicators: ['indicator-id'],
+            },
+          },
+          filters: {
+            'filter-id': {
+              selected: false,
+              filterGroups: {
+                'filter-group-id': {
+                  selected: false,
+                  filterItems: ['filter-item-id'],
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const expectedFlatFootnote = {
+      content: '',
+      subjects: ['subject-id-1'],
+      indicators: [],
+      indicatorGroups: [],
+      filters: [],
+      filterItems: [],
+      filterGroups: [],
+    };
+
+    const flatFootnote = footnoteToFlatFootnote(footnote);
+    expect(flatFootnote).toEqual(expectedFlatFootnote);
+  });
+
+  test('does not include the subject if type NA is selected', () => {
+    const footnote: BaseFootnote = {
+      content: '',
+      subjects: {
+        'subject-id-1': {
+          selected: false,
+          selectionType: 'NA',
+          indicatorGroups: {
+            'indicator-group-id': {
+              selected: false,
+              indicators: ['indicator-id'],
+            },
+          },
+
+          filters: {},
+        },
+        'subject-id-2': {
+          selected: true,
+          selectionType: 'All',
+          indicatorGroups: {},
+          filters: {},
+        },
+      },
+    };
+
+    const expectedFlatFootnote = {
+      content: '',
+      subjects: ['subject-id-2'],
+      indicators: [],
+      indicatorGroups: [],
+      filters: [],
+      filterItems: [],
+      filterGroups: [],
+    };
+
+    const flatFootnote = footnoteToFlatFootnote(footnote);
+    expect(flatFootnote).toEqual(expectedFlatFootnote);
+  });
+
+  test('includes only the filter id if all filters are selected', () => {
+    const footnote: BaseFootnote = {
+      content: '',
+      subjects: {
+        'subject-id-1': {
+          selected: true,
+          selectionType: 'Specific',
+          indicatorGroups: {},
+          filters: {
+            'filter-id': {
+              selected: true,
+              filterGroups: {
+                'filter-group-id': {
+                  selected: false,
+                  filterItems: ['filter-item-id'],
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const expectedFlatFootnote = {
+      content: '',
+      subjects: [],
+      indicators: [],
+      indicatorGroups: [],
+      filters: ['filter-id'],
+      filterItems: [],
+      filterGroups: [],
+    };
+
+    const flatFootnote = footnoteToFlatFootnote(footnote);
+    expect(flatFootnote).toEqual(expectedFlatFootnote);
+  });
+
+  test('includes only filter group id if group selected', () => {
+    const footnote: BaseFootnote = {
+      content: '',
+      subjects: {
+        'subject-id-1': {
+          selected: true,
+          selectionType: 'Specific',
+          indicatorGroups: {},
+          filters: {
+            'filter-id': {
+              selected: false,
+              filterGroups: {
+                'filter-group-id': {
+                  selected: true,
+                  filterItems: ['filter-item-id'],
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const expectedFlatFootnote = {
+      content: '',
+      subjects: [],
+      indicators: [],
+      indicatorGroups: [],
+      filters: [],
+      filterItems: [],
+      filterGroups: ['filter-group-id'],
+    };
+
+    const flatFootnote = footnoteToFlatFootnote(footnote);
+    expect(flatFootnote).toEqual(expectedFlatFootnote);
+  });
+
+  test('includes selected filter items', () => {
+    const footnote: BaseFootnote = {
+      content: '',
+      subjects: {
+        'subject-id-1': {
+          selected: true,
+          selectionType: 'Specific',
+          indicatorGroups: {},
+          filters: {
+            'filter-id': {
+              selected: false,
+              filterGroups: {
+                'filter-group-id': {
+                  selected: false,
+                  filterItems: ['filter-item-id-1', 'filter-item-id-2'],
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const expectedFlatFootnote = {
+      content: '',
+      subjects: [],
+      indicators: [],
+      indicatorGroups: [],
+      filters: [],
+      filterItems: ['filter-item-id-1', 'filter-item-id-2'],
+      filterGroups: [],
+    };
+
+    const flatFootnote = footnoteToFlatFootnote(footnote);
+    expect(flatFootnote).toEqual(expectedFlatFootnote);
+  });
+
+  test('includes only indicator group id if group selected', () => {
+    const footnote: BaseFootnote = {
+      content: '',
+      subjects: {
+        'subject-id-1': {
+          selected: true,
+          selectionType: 'Specific',
+          indicatorGroups: {
+            'indicator-group-id': {
+              selected: false,
+              indicators: ['indicator-id-1', 'indicator-id-2'],
+            },
+          },
+          filters: {},
+        },
+      },
+    };
+
+    const expectedFlatFootnote = {
+      content: '',
+      subjects: [],
+      indicators: ['indicator-id-1', 'indicator-id-2'],
+      indicatorGroups: [],
+      filters: [],
+      filterItems: [],
+      filterGroups: [],
+    };
+
+    const flatFootnote = footnoteToFlatFootnote(footnote);
+    expect(flatFootnote).toEqual(expectedFlatFootnote);
+  });
+
+  test('includes selected indicator items', () => {
+    const footnote: BaseFootnote = {
+      content: '',
+      subjects: {
+        'subject-id-1': {
+          selected: true,
+          selectionType: 'Specific',
+          indicatorGroups: {
+            'indicator-group-id': {
+              selected: true,
+              indicators: ['indicator-id'],
+            },
+          },
+          filters: {},
+        },
+      },
+    };
+
+    const expectedFlatFootnote = {
+      content: '',
+      subjects: [],
+      indicators: [],
+      indicatorGroups: ['indicator-group-id'],
+      filters: [],
+      filterItems: [],
+      filterGroups: [],
+    };
+
+    const flatFootnote = footnoteToFlatFootnote(footnote);
+    expect(flatFootnote).toEqual(expectedFlatFootnote);
+  });
+});

--- a/src/explore-education-statistics-admin/src/services/utils/footnote/footnoteToFlatFootnote.ts
+++ b/src/explore-education-statistics-admin/src/services/utils/footnote/footnoteToFlatFootnote.ts
@@ -24,33 +24,33 @@ const footnoteToFlatFootnote = (footnote: BaseFootnote): FlatFootnote => {
   Object.entries(footnote.subjects).forEach(([subjectId, subject]) => {
     if (subject.selectionType === 'All') {
       flatFootnote.subjects.push(subjectId);
-    }
+    } else if (subject.selectionType !== 'NA') {
+      Object.entries(subject.indicatorGroups).forEach(
+        ([indicatorGroupId, indicatorGroup]) => {
+          if (indicatorGroup.selected) {
+            flatFootnote.indicatorGroups.push(indicatorGroupId);
+          } else {
+            flatFootnote.indicators.push(...indicatorGroup.indicators);
+          }
+        },
+      );
 
-    Object.entries(subject.indicatorGroups).forEach(
-      ([indicatorGroupId, indicatorGroup]) => {
-        if (indicatorGroup.selected) {
-          flatFootnote.indicatorGroups.push(indicatorGroupId);
+      Object.entries(subject.filters).forEach(([filterId, filter]) => {
+        if (filter.selected) {
+          flatFootnote.filters.push(filterId);
         } else {
-          flatFootnote.indicators.push(...indicatorGroup.indicators);
+          Object.entries(filter.filterGroups).forEach(
+            ([filterGroupId, filterGroup]) => {
+              if (filterGroup.selected) {
+                flatFootnote.filterGroups.push(filterGroupId);
+              } else {
+                flatFootnote.filterItems.push(...filterGroup.filterItems);
+              }
+            },
+          );
         }
-      },
-    );
-
-    Object.entries(subject.filters).forEach(([filterId, filter]) => {
-      if (filter.selected) {
-        flatFootnote.filters.push(filterId);
-      } else {
-        Object.entries(filter.filterGroups).forEach(
-          ([filterGroupId, filterGroup]) => {
-            if (filterGroup.selected) {
-              flatFootnote.filterGroups.push(filterGroupId);
-            } else {
-              flatFootnote.filterItems.push(...filterGroup.filterItems);
-            }
-          },
-        );
-      }
-    });
+      });
+    }
   });
 
   return flatFootnote;


### PR DESCRIPTION
Makes sure that previously selected indicators and filters aren't submitted when a footnote is changed to be for all data.

Also, handles changing a footnote subject to 'Does not apply' in footnoteToFlatFootnote instead of when the form is submitted.