### PR TITLE
EES-2074 Remove Name field from Copy activity mapping in Data Factory config

### DIFF
--- a/infrastructure/templates/datafactory/components/template.json
+++ b/infrastructure/templates/datafactory/components/template.json
@@ -2071,16 +2071,6 @@
                                             "name": "Filename",
                                             "type": "String"
                                         }
-                                    },
-                                    {
-                                        "source": {
-                                            "name": "Name",
-                                            "type": "String"
-                                        },
-                                        "sink": {
-                                            "name": "Name",
-                                            "type": "String"
-                                        }
                                     }
                                 ]
                             }


### PR DESCRIPTION
This PR removes the Subject `Name` field from a copy activity mapping in Data Factory config after it was removed by https://github.com/dfe-analytical-services/explore-education-statistics/pull/2480