### PR TITLE
EES-907 don't order chart data by name

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartLegendConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartLegendConfiguration.test.tsx
@@ -418,17 +418,17 @@ describe('ChartLegendConfiguration', () => {
 
     const legendItem1 = within(legendItems[0]);
 
-    expect(legendItem1.getByLabelText('Label')).toHaveValue('Legend item 1');
-    expect(legendItem1.getByLabelText('Colour')).toHaveValue('#ff0000');
-    expect(legendItem1.getByLabelText('Symbol')).toHaveValue('square');
-    expect(legendItem1.getByLabelText('Style')).toHaveValue('dotted');
+    expect(legendItem1.getByLabelText('Label')).toHaveValue('Legend item 2');
+    expect(legendItem1.getByLabelText('Colour')).toHaveValue('#00ff00');
+    expect(legendItem1.getByLabelText('Symbol')).toHaveValue('star');
+    expect(legendItem1.getByLabelText('Style')).toHaveValue('dashed');
 
     const legendItem2 = within(legendItems[1]);
 
-    expect(legendItem2.getByLabelText('Label')).toHaveValue('Legend item 2');
-    expect(legendItem2.getByLabelText('Colour')).toHaveValue('#00ff00');
-    expect(legendItem2.getByLabelText('Symbol')).toHaveValue('star');
-    expect(legendItem2.getByLabelText('Style')).toHaveValue('dashed');
+    expect(legendItem2.getByLabelText('Label')).toHaveValue('Legend item 1');
+    expect(legendItem2.getByLabelText('Colour')).toHaveValue('#ff0000');
+    expect(legendItem2.getByLabelText('Symbol')).toHaveValue('square');
+    expect(legendItem2.getByLabelText('Style')).toHaveValue('dotted');
   });
 
   test('does not render Symbol field if chart does not have capability', () => {

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/HorizontalBarBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/HorizontalBarBlock.test.tsx
@@ -58,9 +58,9 @@ describe('HorizontalBarBlock', () => {
 
       const legendItems = container.querySelectorAll('.recharts-legend-item');
 
-      expect(legendItems[0]).toHaveTextContent('Authorised absence rate');
+      expect(legendItems[0]).toHaveTextContent('Unauthorised absence rate');
       expect(legendItems[1]).toHaveTextContent('Overall absence rate');
-      expect(legendItems[2]).toHaveTextContent('Unauthorised absence rate');
+      expect(legendItems[2]).toHaveTextContent('Authorised absence rate');
 
       expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(
         15,

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/LineChartBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/LineChartBlock.test.tsx
@@ -56,9 +56,9 @@ describe('LineChartBlock', () => {
       ).toBeInTheDocument();
 
       const legendItems = container.querySelectorAll('.recharts-legend-item');
-      expect(legendItems[0]).toHaveTextContent('Authorised absence rate');
+      expect(legendItems[0]).toHaveTextContent('Unauthorised absence rate');
       expect(legendItems[1]).toHaveTextContent('Overall absence rate');
-      expect(legendItems[2]).toHaveTextContent('Unauthorised absence rate');
+      expect(legendItems[2]).toHaveTextContent('Authorised absence rate');
 
       // expect there to be lines for all 3 data sets
       expect(container.querySelectorAll('.recharts-line')).toHaveLength(3);

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/VerticalBarBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/VerticalBarBlock.test.tsx
@@ -57,9 +57,9 @@ describe('VerticalBarBlock', () => {
 
       const legendItems = container.querySelectorAll('.recharts-legend-item');
 
-      expect(legendItems[0]).toHaveTextContent('Authorised absence rate');
+      expect(legendItems[0]).toHaveTextContent('Unauthorised absence rate');
       expect(legendItems[1]).toHaveTextContent('Overall absence rate');
-      expect(legendItems[2]).toHaveTextContent('Unauthorised absence rate');
+      expect(legendItems[2]).toHaveTextContent('Authorised absence rate');
 
       expect(container.querySelectorAll('.recharts-rectangle')).toHaveLength(
         15,

--- a/src/explore-education-statistics-common/src/modules/charts/util/getDataSetCategoryConfigs.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/getDataSetCategoryConfigs.ts
@@ -14,7 +14,6 @@ import generateDefaultDataSetLabel from '@common/modules/charts/util/generateDef
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import keyBy from 'lodash/keyBy';
 import omit from 'lodash/omit';
-import orderBy from 'lodash/orderBy';
 import uniqBy from 'lodash/uniqBy';
 
 export interface DataSetCategoryConfig {
@@ -77,9 +76,5 @@ export default function getDataSetCategoryConfigs(
     );
   });
 
-  return orderBy(
-    uniqBy(dataSets, dataSet => dataSet.dataKey),
-    dataSet => dataSet.config.label,
-    ['asc'],
-  );
+  return uniqBy(dataSets, dataSet => dataSet.dataKey);
 }


### PR DESCRIPTION
- Removes the ordering of datasets by name so the order can be controlled by adding them in the desired order
- Updates some tests that were expecting alphabetical order