### PR TITLE
EES-2081 - made Highlight Description non-mandatory in front end

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableHighlightsList.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableHighlightsList.tsx
@@ -15,7 +15,7 @@ const TableHighlightsList = ({ highlights = [], renderLink }: Props) => {
     highlights.filter(
       highlight =>
         highlight.name.toLowerCase().includes(highlightSearch) ||
-        highlight.description.toLowerCase().includes(highlightSearch),
+        highlight.description?.toLowerCase().includes(highlightSearch),
     ),
     'name',
   );

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableHighlightsList.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableHighlightsList.test.tsx
@@ -170,6 +170,33 @@ describe('TableHighlightsList', () => {
     });
   });
 
+  test('handles search when some highlights have no description', async () => {
+    const highlightWithoutDescription = {
+      id: 'highlight-4',
+      name: '4 - no description',
+    };
+
+    render(
+      <TableHighlightsList
+        highlights={[highlightWithoutDescription, ...testHighlights]}
+        renderLink={renderLink}
+      />,
+    );
+
+    await userEvent.type(screen.getByRole('textbox'), 'unique description');
+
+    jest.runOnlyPendingTimers();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Found 1 matching table/)).toBeInTheDocument();
+
+      const listItems = screen.getAllByRole('listitem');
+
+      expect(listItems).toHaveLength(1);
+      expect(listItems[0]).toHaveTextContent('10 - Unique description');
+    });
+  });
+
   test('renders empty message if no results', async () => {
     render(
       <TableHighlightsList

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -88,7 +88,7 @@ export interface Subject {
 export interface TableHighlight {
   id: string;
   name: string;
-  description: string;
+  description?: string;
 }
 
 export interface Publication {


### PR DESCRIPTION
This PR:
- fixes an issue with the Highlight Table search box, whereby the highlight code expected a defined description whereas there are several hundred entries live with no description available 