### PR TITLE
EES-1323 add none selected option to map location select

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -349,13 +349,15 @@ export const MapBlockInternal = ({
   }, [dataSetCategoryConfigs]);
 
   const locationOptions = useMemo(() => {
-    return orderBy(
+    const locations = orderBy(
       dataSetCategories.map(dataSetCategory => ({
         label: dataSetCategory.filter.label,
         value: dataSetCategory.filter.id,
       })),
       ['label'],
     );
+    locations.unshift({ label: 'None selected', value: '' });
+    return locations;
   }, [dataSetCategories]);
 
   const [selectedDataSetKey, setSelectedDataSetKey] = useState<string>(
@@ -470,6 +472,22 @@ export const MapBlockInternal = ({
     [selectedFeature],
   );
 
+  const resetSelectedFeature = useCallback(() => {
+    if (selectedFeature) {
+      const element = selectedFeature?.properties.layer?.getElement();
+
+      if (element) {
+        element.classList.remove(styles.selected);
+        element.removeAttribute('data-testid');
+      }
+      if (mapRef.current) {
+        mapRef.current.leafletElement.setZoom(5);
+      }
+
+      setSelectedFeature(undefined);
+    }
+  }, [selectedFeature]);
+
   // We have to assign our `onEachFeature` callback to a ref
   // as `onEachFeature` forms an internal closure which
   // prevents us from updating the callback's dependencies.
@@ -554,17 +572,16 @@ export const MapBlockInternal = ({
               id={`${id}-selectedLocation`}
               label="2. Select a location"
               value={selectedFeature?.id?.toString()}
-              placeholder="Select location"
               options={locationOptions}
               order={FormSelect.unordered}
               onChange={e => {
                 const feature = geometry?.features.find(
                   feat => feat.id === e.currentTarget.value,
                 );
-
                 if (feature) {
-                  updateSelectedFeature(feature);
+                  return updateSelectedFeature(feature);
                 }
+                return resetSelectedFeature();
               }}
             />
           </FormGroup>

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlock.test.tsx
@@ -120,7 +120,7 @@ describe('MapBlock', () => {
       expect(select).toBeVisible();
 
       expect(select.children).toHaveLength(4);
-      expect(select.children[0]).toHaveTextContent('Select location');
+      expect(select.children[0]).toHaveTextContent('None selected');
       expect(select.children[1]).toHaveTextContent('Leeds');
       expect(select.children[2]).toHaveTextContent('Manchester');
       expect(select.children[3]).toHaveTextContent('Sheffield');
@@ -282,5 +282,26 @@ describe('MapBlock', () => {
     expect(tile3.getByTestId('mapBlock-indicatorTile-value')).toHaveTextContent(
       '4.01%',
     );
+  });
+
+  test('reseting the map when select None Selected', async () => {
+    const { container } = render(<MapBlock {...testBlockProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('2. Select a location')).toBeInTheDocument();
+    });
+
+    const select = screen.getByLabelText('2. Select a location');
+
+    userEvent.selectOptions(select, select.children[1] as HTMLElement);
+
+    const paths = container.querySelectorAll<HTMLElement>(
+      '.leaflet-container svg path',
+    );
+
+    expect(paths[3]).toHaveClass('selected');
+
+    userEvent.selectOptions(select, select.children[0] as HTMLElement);
+    expect(paths[3]).not.toHaveClass('selected');
   });
 });


### PR DESCRIPTION
Allow users to reset the map by selecting 'Non selected' in the location dropdown. clicking this de-selects the selected area and zooms the map back out.

![map](https://user-images.githubusercontent.com/81572860/115426790-c096c600-a1f8-11eb-8a81-f11a56966a71.png)
