### PR TITLE
EES-1512 Add ability to rename Data and Ancillary files

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
@@ -1498,6 +1498,39 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task UpdateName()
+        {
+            var releaseFile = new ReleaseFile
+            {
+                Release = new Release(),
+                Name = "Test PDF File",
+                File = new File()
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupReleaseFileService(contentDbContext: contentDbContext);
+
+                var result = await service.UpdateName(releaseFile.ReleaseId, releaseFile.FileId, "New file title");
+
+                Assert.True(result.IsRight);
+                Assert.IsType<Unit>(result.Right);
+
+                var updatedReleaseFile = await contentDbContext.ReleaseFiles.FirstAsync(rf =>
+                    rf.ReleaseId == releaseFile.ReleaseId
+                    && rf.FileId == releaseFile.FileId);
+                Assert.Equal("New file title", updatedReleaseFile.Name);
+            }
+        }
+
+        [Fact]
         public async Task UploadAncillary()
         {
             const string filename = "ancillary.pdf";

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
@@ -1197,7 +1197,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
             var blob = new BlobInfo(
                 path: null,
-                size: "93",
+                size: "93 Kb",
                 contentType: "application/pdf",
                 contentLength: 0L,
                 meta: null,
@@ -1222,7 +1222,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(releaseFile.FileId, fileInfo.Id);
                 Assert.Equal("pdf", fileInfo.Extension);
                 Assert.Equal("ancillary.pdf", fileInfo.FileName);
-                Assert.Equal("93", fileInfo.Size);
+                Assert.Equal("93 Kb", fileInfo.Size);
                 Assert.Equal(Ancillary, fileInfo.Type);
             }
             MockUtils.VerifyAllMocks(blobStorageService);
@@ -1233,12 +1233,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
 
-            await using (var contentDbContext = InMemoryApplicationDbContext(Guid.NewGuid().ToString()))
+            await using (var contentDbContext = InMemoryApplicationDbContext())
             {
                 var service = SetupReleaseFileService(contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = await service.GetFile(Guid.Empty, Guid.Empty);
+                var result = await service.GetFile(Guid.NewGuid(), Guid.NewGuid());
                 Assert.True(result.IsLeft);
                 Assert.IsType<NotFoundResult>(result.Left);
             }
@@ -1516,13 +1516,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var service = SetupReleaseFileService(contentDbContext: contentDbContext);
+                var service = SetupReleaseFileService(contentDbContext);
 
                 var result = await service.UpdateName(releaseFile.ReleaseId, releaseFile.FileId, "New file title");
 
                 Assert.True(result.IsRight);
                 Assert.IsType<Unit>(result.Right);
+            }
 
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
                 var updatedReleaseFile = await contentDbContext.ReleaseFiles.FirstAsync(rf =>
                     rf.ReleaseId == releaseFile.ReleaseId
                     && rf.FileId == releaseFile.FileId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseFileController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseFileController.cs
@@ -44,7 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrNoContent();
         }
 
-        [HttpGet("release/{releaseId}/file/{id}")]
+        [HttpGet("release/{releaseId}/file/{id}/download")]
         public async Task<ActionResult> Stream(Guid releaseId, Guid id)
         {
             return await _releaseFileService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseFileController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseFileController.cs
@@ -44,6 +44,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrNoContent();
         }
 
+        [HttpGet("release/{releaseId}/file/{fileId}")]
+        public async Task<ActionResult<FileInfo>> GetFile(Guid releaseId, Guid fileId)
+        {
+            return await _releaseFileService
+                .GetFile(releaseId, fileId)
+                .HandleFailuresOrOk();
+        }
+
         [HttpGet("release/{releaseId}/file/{id}/download")]
         public async Task<ActionResult> Stream(Guid releaseId, Guid id)
         {
@@ -66,14 +74,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         {
             return await _releaseFileService
                 .ListAll(releaseId, Ancillary)
-                .HandleFailuresOrOk();
-        }
-
-        [HttpGet("release/{releaseId}/ancillary/{fileId}")]
-        public async Task<ActionResult<FileInfo>> GetFile(Guid releaseId, Guid fileId)
-        {
-            return await _releaseFileService
-                .GetFile(releaseId, fileId)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseFileController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseFileController.cs
@@ -69,6 +69,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
+        [HttpGet("release/{releaseId}/ancillary/{fileId}")]
+        public async Task<ActionResult<FileInfo>> GetFile(Guid releaseId, Guid fileId)
+        {
+            return await _releaseFileService
+                .GetFile(releaseId, fileId)
+                .HandleFailuresOrOk();
+        }
+
         [HttpPut("release/{releaseId}/chart/{id}")]
         [RequestSizeLimit(int.MaxValue)]
         [RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseFileController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleaseFileController.cs
@@ -52,6 +52,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailures();
         }
 
+        [HttpPost("release/{releaseId}/file/{fileId}/rename")]
+        public async Task<ActionResult<Unit>> Rename(Guid releaseId, Guid fileId,
+            [FromQuery(Name = "name"), Required] string name)
+        {
+            return await _releaseFileService
+                .UpdateName(releaseId: releaseId, fileId: fileId, name: name)
+                .HandleFailuresOrOk();
+        }
+
         [HttpGet("release/{releaseId}/ancillary")]
         public async Task<ActionResult<IEnumerable<FileInfo>>> GetAncillaryFiles(Guid releaseId)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFileRepository.cs
@@ -32,5 +32,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
             Guid releaseId,
             Guid fileId,
             string filename);
+
+        public Task UpdateName(
+            Guid releaseId,
+            Guid fileId,
+            string name);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFileService.cs
@@ -25,6 +25,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, FileStreamResult>> Stream(Guid releaseId, Guid id);
 
+        Task<Either<ActionResult, Unit>> UpdateName(Guid releaseId, Guid fileId, string name);
+
         Task<Either<ActionResult, FileInfo>> UploadAncillary(Guid releaseId,
             IFormFile formFile,
             string name);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseFileService.cs
@@ -23,6 +23,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, IEnumerable<FileInfo>>> ListAll(Guid releaseId, params FileType[] types);
 
+        Task<Either<ActionResult, FileInfo>> GetFile(Guid releaseId, Guid fileId);
+
         Task<Either<ActionResult, FileStreamResult>> Stream(Guid releaseId, Guid id);
 
         Task<Either<ActionResult, Unit>> UpdateName(Guid releaseId, Guid fileId, string name);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileRepository.cs
@@ -136,5 +136,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             return releaseFile;
         }
+
+        public async Task UpdateName(Guid releaseId,
+            Guid fileId,
+            string name)
+        {
+            var releaseFile = await _contentDbContext.ReleaseFiles
+                .Include(rf => rf.File)
+                .SingleAsync(rf =>
+                    rf.ReleaseId == releaseId
+                    && rf.FileId == fileId
+                    && (rf.File.Type == FileType.Data || rf.File.Type == Ancillary));
+
+            _contentDbContext.Update(releaseFile);
+            releaseFile.Name = name;
+
+            await _contentDbContext.SaveChangesAsync();
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
@@ -132,6 +132,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
+        public async Task<Either<ActionResult, FileInfo>> GetFile(Guid releaseId, Guid fileId)
+        {
+            return await _persistenceHelper
+                .CheckEntityExists<ReleaseFile>(
+                    q => q.Include(rf => rf.File)
+                        .Where(rf =>
+                            rf.ReleaseId == releaseId
+                            && rf.FileId == fileId))
+                .OnSuccess(async releaseFile =>
+                {
+                    var blobExists = await _blobStorageService.CheckBlobExists(
+                        PrivateReleaseFiles,
+                        releaseFile.Path());
+                    if (!blobExists)
+                    {
+                        return releaseFile.File.ToFileInfoNotFound();
+                    }
+                    var blob = await _blobStorageService.GetBlob(PrivateReleaseFiles, releaseFile.Path());
+                    return releaseFile.ToFileInfo(blob);
+                });
+        }
+
         public async Task<Either<ActionResult, FileStreamResult>> Stream(Guid releaseId, Guid id)
         {
             return await _persistenceHelper

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
@@ -14,6 +14,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using FileInfo = GovUk.Education.ExploreEducationStatistics.Common.Model.FileInfo;
@@ -149,6 +150,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     {
                         FileDownloadName = file.Filename
                     };
+                });
+        }
+
+        public Task<Either<ActionResult, Unit>> UpdateName(Guid releaseId, Guid fileId, string name)
+        {
+            return _persistenceHelper
+                .CheckEntityExists<Release>(releaseId)
+                .OnSuccess(_userService.CheckCanUpdateRelease)
+                .OnSuccessVoid(async () =>
+                {
+                    await _releaseFileRepository.UpdateName(releaseId, fileId, name);
                 });
         }
 

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -11,7 +11,7 @@ import {
   releaseDataBlockEditRoute,
   releaseDataBlocksRoute,
   releaseDataFileReplacementCompleteRoute,
-  releaseDataFileRoute,
+  releaseDataFileReplaceRoute,
   releaseDataRoute,
   releaseFootnotesCreateRoute,
   releaseFootnotesEditRoute,
@@ -43,7 +43,7 @@ const navRoutes = [
 
 const routes = [
   ...navRoutes,
-  releaseDataFileRoute,
+  releaseDataFileReplaceRoute,
   releaseDataFileReplacementCompleteRoute,
   releaseSummaryEditRoute,
   releaseFootnotesCreateRoute,

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -11,9 +11,11 @@ import {
   releaseDataBlockEditRoute,
   releaseDataBlocksRoute,
   releaseDataFileReplacementCompleteRoute,
+  releaseDataRoute,
+  releaseDataAncillaryRoute,
+  releaseAncillaryFileRoute,
   releaseDataFileRoute,
   releaseDataFileReplaceRoute,
-  releaseDataRoute,
   releaseFootnotesCreateRoute,
   releaseFootnotesEditRoute,
   releaseFootnotesRoute,
@@ -44,6 +46,8 @@ const navRoutes = [
 
 const routes = [
   ...navRoutes,
+  releaseDataAncillaryRoute,
+  releaseAncillaryFileRoute,
   releaseDataFileRoute,
   releaseDataFileReplaceRoute,
   releaseDataFileReplacementCompleteRoute,

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -11,6 +11,7 @@ import {
   releaseDataBlockEditRoute,
   releaseDataBlocksRoute,
   releaseDataFileReplacementCompleteRoute,
+  releaseDataFileRoute,
   releaseDataFileReplaceRoute,
   releaseDataRoute,
   releaseFootnotesCreateRoute,
@@ -43,6 +44,7 @@ const navRoutes = [
 
 const routes = [
   ...navRoutes,
+  releaseDataFileRoute,
   releaseDataFileReplaceRoute,
   releaseDataFileReplacementCompleteRoute,
   releaseSummaryEditRoute,

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseAncillaryFilePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseAncillaryFilePage.tsx
@@ -1,0 +1,85 @@
+import {
+  ReleaseAncillaryFileRouteParams,
+  ReleaseRouteParams,
+  releaseDataAncillaryRoute,
+} from '@admin/routes/releaseRoutes';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import React from 'react';
+import Link from '@admin/components/Link';
+import { generatePath, RouteComponentProps } from 'react-router';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import Yup from '@common/validation/yup';
+import { Formik } from 'formik';
+import { Form, FormFieldTextInput } from '@common/components/form';
+import Button from '@common/components/Button';
+import releaseAncillaryFileService from '@admin/services/releaseAncillaryFileService';
+
+interface EditFormValues {
+  title: string;
+}
+
+const ReleaseAncillaryFilePage = ({
+  history,
+  match: {
+    params: { publicationId, releaseId, fileId },
+  },
+}: RouteComponentProps<ReleaseAncillaryFileRouteParams>) => {
+  const {
+    value: ancillaryFile,
+    isLoading: ancillaryFileLoading,
+  } = useAsyncHandledRetry(
+    () => releaseAncillaryFileService.getAncillaryFile(releaseId, fileId),
+    [releaseId, fileId],
+  );
+
+  return (
+    <>
+      <Link
+        className="govuk-!-margin-bottom-6"
+        back
+        to={generatePath<ReleaseRouteParams>(releaseDataAncillaryRoute.path, {
+          publicationId,
+          releaseId,
+        })}
+      >
+        Back
+      </Link>
+      <LoadingSpinner loading={ancillaryFileLoading}>
+        {ancillaryFile && (
+          <section>
+            <h2>Edit ancillary file details</h2>
+            <Formik<EditFormValues>
+              initialValues={{ title: ancillaryFile.title }}
+              validationSchema={Yup.object<EditFormValues>({
+                title: Yup.string().required('Enter a ancillary title'),
+              })}
+              onSubmit={values => {
+                releaseAncillaryFileService
+                  .renameFile(releaseId, fileId, values.title)
+                  .then();
+                history.push(
+                  generatePath<ReleaseRouteParams>(
+                    releaseDataAncillaryRoute.path,
+                    {
+                      publicationId,
+                      releaseId,
+                    },
+                  ),
+                );
+              }}
+            >
+              {form => (
+                <Form {...form} id="edit-data-file-form">
+                  <FormFieldTextInput id="title" label="Title" name="title" />
+                  <Button type="submit">Save changes</Button>
+                </Form>
+              )}
+            </Formik>
+          </section>
+        )}
+      </LoadingSpinner>
+    </>
+  );
+};
+
+export default ReleaseAncillaryFilePage;

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
@@ -1,0 +1,82 @@
+import {
+  ReleaseDataFileRouteParams,
+  ReleaseRouteParams,
+  releaseDataRoute,
+} from '@admin/routes/releaseRoutes';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import React from 'react';
+import releaseDataFileService from '@admin/services/releaseDataFileService';
+import Link from '@admin/components/Link';
+import { generatePath, RouteComponentProps } from 'react-router';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import Yup from '@common/validation/yup';
+import { Formik } from 'formik';
+import { Form, FormFieldTextInput } from '@common/components/form';
+import Button from '@common/components/Button';
+
+interface EditSubjectFormValues {
+  title: string;
+}
+
+const ReleaseDataFilePage = ({
+  history,
+  match: {
+    params: { publicationId, releaseId, fileId },
+  },
+}: RouteComponentProps<ReleaseDataFileRouteParams>) => {
+  const {
+    value: dataFile,
+    isLoading: dataFileLoading,
+  } = useAsyncHandledRetry(
+    () => releaseDataFileService.getDataFile(releaseId, fileId),
+    [releaseId, fileId],
+  );
+
+  return (
+    <>
+      <Link
+        className="govuk-!-margin-bottom-6"
+        back
+        to={generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
+          publicationId,
+          releaseId,
+        })}
+      >
+        Back
+      </Link>
+      <LoadingSpinner loading={dataFileLoading}>
+        {dataFile && (
+          <section>
+            <h2>Edit data file details</h2>
+            <Formik<EditSubjectFormValues>
+              initialValues={{ title: dataFile.title }}
+              validationSchema={Yup.object<EditSubjectFormValues>({
+                title: Yup.string().required('Enter a subject title'),
+              })}
+              onSubmit={values => {
+                releaseDataFileService
+                  .renameFile(releaseId, fileId, values.title)
+                  .then();
+                history.push(
+                  generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
+                    publicationId,
+                    releaseId,
+                  }),
+                );
+              }}
+            >
+              {form => (
+                <Form {...form} id="edit-data-file-form">
+                  <FormFieldTextInput id="title" label="Title" name="title" />
+                  <Button type="submit">Save changes</Button>
+                </Form>
+              )}
+            </Formik>
+          </section>
+        )}
+      </LoadingSpinner>
+    </>
+  );
+};
+
+export default ReleaseDataFilePage;

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacePage.tsx
@@ -4,7 +4,7 @@ import DataFileReplacementPlan from '@admin/pages/release/data/components/DataFi
 import DataFileUploadForm from '@admin/pages/release/data/components/DataFileUploadForm';
 import {
   releaseDataFileReplacementCompleteRoute,
-  ReleaseDataFileRouteParams,
+  ReleaseDataFileReplaceRouteParams,
   releaseDataRoute,
   ReleaseRouteParams,
 } from '@admin/routes/releaseRoutes';
@@ -22,12 +22,12 @@ import useToggle from '@common/hooks/useToggle';
 import React from 'react';
 import { generatePath, RouteComponentProps } from 'react-router';
 
-const ReleaseDataFilePage = ({
+const ReleaseDataFileReplacePage = ({
   history,
   match: {
     params: { publicationId, releaseId, fileId },
   },
-}: RouteComponentProps<ReleaseDataFileRouteParams>) => {
+}: RouteComponentProps<ReleaseDataFileReplaceRouteParams>) => {
   const [isCancelling, toggleCancelling] = useToggle(false);
   const {
     value: dataFile,
@@ -209,7 +209,7 @@ const ReleaseDataFilePage = ({
                     onCancel={toggleCancelling.on}
                     onReplacement={() => {
                       history.push(
-                        generatePath<ReleaseDataFileRouteParams>(
+                        generatePath<ReleaseDataFileReplaceRouteParams>(
                           releaseDataFileReplacementCompleteRoute.path,
                           {
                             publicationId,
@@ -252,4 +252,4 @@ const ReleaseDataFilePage = ({
   );
 };
 
-export default ReleaseDataFilePage;
+export default ReleaseDataFileReplacePage;

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacementCompletePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFileReplacementCompletePage.tsx
@@ -2,8 +2,8 @@ import Link from '@admin/components/Link';
 import {
   ReleaseDataBlockRouteParams,
   releaseDataBlocksRoute,
-  releaseDataFileRoute,
-  ReleaseDataFileRouteParams,
+  releaseDataFileReplaceRoute,
+  ReleaseDataFileReplaceRouteParams,
   ReleaseFootnoteRouteParams,
 } from '@admin/routes/releaseRoutes';
 import dataReplacementService from '@admin/services/dataReplacementService';
@@ -15,7 +15,7 @@ import { generatePath, RouteComponentProps } from 'react-router';
 
 const ReleaseDataFileReplacementCompletePage = ({
   match,
-}: RouteComponentProps<ReleaseDataFileRouteParams>) => {
+}: RouteComponentProps<ReleaseDataFileReplaceRouteParams>) => {
   const { publicationId, releaseId, fileId } = match.params;
 
   // Run the replacement plan against itself so we can just get the
@@ -25,8 +25,8 @@ const ReleaseDataFileReplacementCompletePage = ({
     [releaseId, fileId],
   );
 
-  const dataFilePath = generatePath<ReleaseDataFileRouteParams>(
-    releaseDataFileRoute.path,
+  const dataFilePath = generatePath<ReleaseDataFileReplaceRouteParams>(
+    releaseDataFileReplaceRoute.path,
     {
       publicationId,
       releaseId,

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataPage.tsx
@@ -47,6 +47,7 @@ const ReleaseDataPage = () => {
           title="Ancillary file uploads"
         >
           <ReleaseFileUploadsSection
+            publicationId={release.publicationId}
             releaseId={releaseId}
             canUpdateRelease={canUpdateRelease}
           />

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
@@ -94,11 +94,14 @@ describe('ReleaseDataFileReplacePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
-            releaseId: 'release-1',
-            publicationId: 'publication-1',
-            fileId: 'file-1',
-          }),
+          generatePath<ReleaseDataFileReplaceRouteParams>(
+            releaseDataFileReplaceRoute.path,
+            {
+              releaseId: 'release-1',
+              publicationId: 'publication-1',
+              fileId: 'file-1',
+            },
+          ),
         ]}
       >
         <Route
@@ -143,11 +146,14 @@ describe('ReleaseDataFileReplacePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
-            releaseId: 'release-1',
-            publicationId: 'publication-1',
-            fileId: 'file-1',
-          }),
+          generatePath<ReleaseDataFileReplaceRouteParams>(
+            releaseDataFileReplaceRoute.path,
+            {
+              releaseId: 'release-1',
+              publicationId: 'publication-1',
+              fileId: 'file-1',
+            },
+          ),
         ]}
       >
         <Route
@@ -191,11 +197,14 @@ describe('ReleaseDataFileReplacePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
-            releaseId: 'release-1',
-            publicationId: 'publication-1',
-            fileId: 'file-1',
-          }),
+          generatePath<ReleaseDataFileReplaceRouteParams>(
+            releaseDataFileReplaceRoute.path,
+            {
+              releaseId: 'release-1',
+              publicationId: 'publication-1',
+              fileId: 'file-1',
+            },
+          ),
         ]}
       >
         <Route
@@ -272,11 +281,14 @@ describe('ReleaseDataFileReplacePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
-            releaseId: 'release-1',
-            publicationId: 'publication-1',
-            fileId: 'file-1',
-          }),
+          generatePath<ReleaseDataFileReplaceRouteParams>(
+            releaseDataFileReplaceRoute.path,
+            {
+              releaseId: 'release-1',
+              publicationId: 'publication-1',
+              fileId: 'file-1',
+            },
+          ),
         ]}
       >
         <Route
@@ -345,11 +357,14 @@ describe('ReleaseDataFileReplacePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
-            releaseId: 'release-1',
-            publicationId: 'publication-1',
-            fileId: 'file-1',
-          }),
+          generatePath<ReleaseDataFileReplaceRouteParams>(
+            releaseDataFileReplaceRoute.path,
+            {
+              releaseId: 'release-1',
+              publicationId: 'publication-1',
+              fileId: 'file-1',
+            },
+          ),
         ]}
       >
         <Route
@@ -399,11 +414,14 @@ describe('ReleaseDataFileReplacePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
-            releaseId: 'release-1',
-            publicationId: 'publication-1',
-            fileId: 'file-1',
-          }),
+          generatePath<ReleaseDataFileReplaceRouteParams>(
+            releaseDataFileReplaceRoute.path,
+            {
+              releaseId: 'release-1',
+              publicationId: 'publication-1',
+              fileId: 'file-1',
+            },
+          ),
         ]}
       >
         <Route
@@ -448,11 +466,14 @@ describe('ReleaseDataFileReplacePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
-            releaseId: 'release-1',
-            publicationId: 'publication-1',
-            fileId: 'file-1',
-          }),
+          generatePath<ReleaseDataFileReplaceRouteParams>(
+            releaseDataFileReplaceRoute.path,
+            {
+              releaseId: 'release-1',
+              publicationId: 'publication-1',
+              fileId: 'file-1',
+            },
+          ),
         ]}
       >
         <Route
@@ -493,11 +514,14 @@ describe('ReleaseDataFileReplacePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
-            releaseId: 'release-1',
-            publicationId: 'publication-1',
-            fileId: 'file-1',
-          }),
+          generatePath<ReleaseDataFileReplaceRouteParams>(
+            releaseDataFileReplaceRoute.path,
+            {
+              releaseId: 'release-1',
+              publicationId: 'publication-1',
+              fileId: 'file-1',
+            },
+          ),
         ]}
       >
         <Route
@@ -563,11 +587,14 @@ describe('ReleaseDataFileReplacePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
-            releaseId: 'release-1',
-            publicationId: 'publication-1',
-            fileId: 'file-1',
-          }),
+          generatePath<ReleaseDataFileReplaceRouteParams>(
+            releaseDataFileReplaceRoute.path,
+            {
+              releaseId: 'release-1',
+              publicationId: 'publication-1',
+              fileId: 'file-1',
+            },
+          ),
         ]}
       >
         <Route
@@ -649,11 +676,14 @@ describe('ReleaseDataFileReplacePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
-            releaseId: 'release-1',
-            publicationId: 'publication-1',
-            fileId: 'file-1',
-          }),
+          generatePath<ReleaseDataFileReplaceRouteParams>(
+            releaseDataFileReplaceRoute.path,
+            {
+              releaseId: 'release-1',
+              publicationId: 'publication-1',
+              fileId: 'file-1',
+            },
+          ),
         ]}
       >
         <Route

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFileReplacePage.test.tsx
@@ -1,7 +1,7 @@
-import ReleaseDataFilePage from '@admin/pages/release/data/ReleaseDataFilePage';
+import ReleaseDataFileReplacePage from '@admin/pages/release/data/ReleaseDataFileReplacePage';
 import {
-  releaseDataFileRoute,
-  ReleaseDataFileRouteParams,
+  releaseDataFileReplaceRoute,
+  ReleaseDataFileReplaceRouteParams,
 } from '@admin/routes/releaseRoutes';
 import _dataReplacementService, {
   DataReplacementPlan,
@@ -29,7 +29,7 @@ const permissionService = _permissionService as jest.Mocked<
   typeof _permissionService
 >;
 
-describe('ReleaseDataFilePage', () => {
+describe('ReleaseDataFileReplacePage', () => {
   beforeEach(() => {
     permissionService.getDataFilePermissions.mockResolvedValue({
       canCancelImport: false,
@@ -94,7 +94,7 @@ describe('ReleaseDataFilePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
+          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
             releaseId: 'release-1',
             publicationId: 'publication-1',
             fileId: 'file-1',
@@ -102,8 +102,8 @@ describe('ReleaseDataFilePage', () => {
         ]}
       >
         <Route
-          path={releaseDataFileRoute.path}
-          component={ReleaseDataFilePage}
+          path={releaseDataFileReplaceRoute.path}
+          component={ReleaseDataFileReplacePage}
         />
       </MemoryRouter>,
     );
@@ -143,7 +143,7 @@ describe('ReleaseDataFilePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
+          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
             releaseId: 'release-1',
             publicationId: 'publication-1',
             fileId: 'file-1',
@@ -151,8 +151,8 @@ describe('ReleaseDataFilePage', () => {
         ]}
       >
         <Route
-          path={releaseDataFileRoute.path}
-          component={ReleaseDataFilePage}
+          path={releaseDataFileReplaceRoute.path}
+          component={ReleaseDataFileReplacePage}
         />
       </MemoryRouter>,
     );
@@ -191,7 +191,7 @@ describe('ReleaseDataFilePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
+          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
             releaseId: 'release-1',
             publicationId: 'publication-1',
             fileId: 'file-1',
@@ -199,8 +199,8 @@ describe('ReleaseDataFilePage', () => {
         ]}
       >
         <Route
-          path={releaseDataFileRoute.path}
-          component={ReleaseDataFilePage}
+          path={releaseDataFileReplaceRoute.path}
+          component={ReleaseDataFileReplacePage}
         />
       </MemoryRouter>,
     );
@@ -272,7 +272,7 @@ describe('ReleaseDataFilePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
+          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
             releaseId: 'release-1',
             publicationId: 'publication-1',
             fileId: 'file-1',
@@ -280,8 +280,8 @@ describe('ReleaseDataFilePage', () => {
         ]}
       >
         <Route
-          path={releaseDataFileRoute.path}
-          component={ReleaseDataFilePage}
+          path={releaseDataFileReplaceRoute.path}
+          component={ReleaseDataFileReplacePage}
         />
       </MemoryRouter>,
     );
@@ -345,7 +345,7 @@ describe('ReleaseDataFilePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
+          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
             releaseId: 'release-1',
             publicationId: 'publication-1',
             fileId: 'file-1',
@@ -353,8 +353,8 @@ describe('ReleaseDataFilePage', () => {
         ]}
       >
         <Route
-          path={releaseDataFileRoute.path}
-          component={ReleaseDataFilePage}
+          path={releaseDataFileReplaceRoute.path}
+          component={ReleaseDataFileReplacePage}
         />
       </MemoryRouter>,
     );
@@ -399,7 +399,7 @@ describe('ReleaseDataFilePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
+          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
             releaseId: 'release-1',
             publicationId: 'publication-1',
             fileId: 'file-1',
@@ -407,8 +407,8 @@ describe('ReleaseDataFilePage', () => {
         ]}
       >
         <Route
-          path={releaseDataFileRoute.path}
-          component={ReleaseDataFilePage}
+          path={releaseDataFileReplaceRoute.path}
+          component={ReleaseDataFileReplacePage}
         />
       </MemoryRouter>,
     );
@@ -448,7 +448,7 @@ describe('ReleaseDataFilePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
+          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
             releaseId: 'release-1',
             publicationId: 'publication-1',
             fileId: 'file-1',
@@ -456,8 +456,8 @@ describe('ReleaseDataFilePage', () => {
         ]}
       >
         <Route
-          path={releaseDataFileRoute.path}
-          component={ReleaseDataFilePage}
+          path={releaseDataFileReplaceRoute.path}
+          component={ReleaseDataFileReplacePage}
         />
       </MemoryRouter>,
     );
@@ -493,7 +493,7 @@ describe('ReleaseDataFilePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
+          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
             releaseId: 'release-1',
             publicationId: 'publication-1',
             fileId: 'file-1',
@@ -501,8 +501,8 @@ describe('ReleaseDataFilePage', () => {
         ]}
       >
         <Route
-          path={releaseDataFileRoute.path}
-          component={ReleaseDataFilePage}
+          path={releaseDataFileReplaceRoute.path}
+          component={ReleaseDataFileReplacePage}
         />
       </MemoryRouter>,
     );
@@ -563,7 +563,7 @@ describe('ReleaseDataFilePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
+          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
             releaseId: 'release-1',
             publicationId: 'publication-1',
             fileId: 'file-1',
@@ -571,8 +571,8 @@ describe('ReleaseDataFilePage', () => {
         ]}
       >
         <Route
-          path={releaseDataFileRoute.path}
-          component={ReleaseDataFilePage}
+          path={releaseDataFileReplaceRoute.path}
+          component={ReleaseDataFileReplacePage}
         />
       </MemoryRouter>,
     );
@@ -649,7 +649,7 @@ describe('ReleaseDataFilePage', () => {
     render(
       <MemoryRouter
         initialEntries={[
-          generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
+          generatePath<ReleaseDataFileReplaceRouteParams>(releaseDataFileReplaceRoute.path, {
             releaseId: 'release-1',
             publicationId: 'publication-1',
             fileId: 'file-1',
@@ -657,8 +657,8 @@ describe('ReleaseDataFilePage', () => {
         ]}
       >
         <Route
-          path={releaseDataFileRoute.path}
-          component={ReleaseDataFilePage}
+          path={releaseDataFileReplaceRoute.path}
+          component={ReleaseDataFileReplacePage}
         />
       </MemoryRouter>,
     );

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -6,7 +6,8 @@ import DataFileUploadForm, {
 import { terminalImportStatuses } from '@admin/pages/release/data/components/ImporterStatus';
 import {
   releaseDataFileReplaceRoute,
-  ReleaseDataFileReplaceRouteParams,
+  ReleaseDataFileReplaceRouteParams, releaseDataFileRoute,
+  ReleaseDataFileRouteParams,
 } from '@admin/routes/releaseRoutes';
 import permissionService from '@admin/services/permissionService';
 import releaseDataFileService, {
@@ -262,19 +263,33 @@ const ReleaseDataUploadsSection = ({
                       terminalImportStatuses.includes(dataFile.status) && (
                         <>
                           {dataFile.status === 'COMPLETE' && (
-                            <Link
-                              className="govuk-!-margin-right-4"
-                              to={generatePath<ReleaseDataFileReplaceRouteParams>(
-                                releaseDataFileReplaceRoute.path,
-                                {
+                            <>
+                              <Link
+                                className="govuk-!-margin-right-4"
+                                to={generatePath<ReleaseDataFileRouteParams>(
+                                  releaseDataFileRoute.path,
+                                  {
+                                    publicationId,
+                                    releaseId,
+                                    fileId: dataFile.id,
+                                  },
+                                )}
+                              >
+                                Edit title
+                              </Link>
+                              <Link
+                                className="govuk-!-margin-right-4"
+                                to={generatePath<
+                                  ReleaseDataFileReplaceRouteParams
+                                >(releaseDataFileReplaceRoute.path, {
                                   publicationId,
                                   releaseId,
                                   fileId: dataFile.id,
-                                },
-                              )}
-                            >
-                              Replace data
-                            </Link>
+                                })}
+                              >
+                                Replace data
+                              </Link>
+                            </>
                           )}
 
                           <ButtonText

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -6,7 +6,8 @@ import DataFileUploadForm, {
 import { terminalImportStatuses } from '@admin/pages/release/data/components/ImporterStatus';
 import {
   releaseDataFileReplaceRoute,
-  ReleaseDataFileReplaceRouteParams, releaseDataFileRoute,
+  ReleaseDataFileReplaceRouteParams,
+  releaseDataFileRoute,
   ReleaseDataFileRouteParams,
 } from '@admin/routes/releaseRoutes';
 import permissionService from '@admin/services/permissionService';

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -5,8 +5,8 @@ import DataFileUploadForm, {
 } from '@admin/pages/release/data/components/DataFileUploadForm';
 import { terminalImportStatuses } from '@admin/pages/release/data/components/ImporterStatus';
 import {
-  releaseDataFileRoute,
-  ReleaseDataFileRouteParams,
+  releaseDataFileReplaceRoute,
+  ReleaseDataFileReplaceRouteParams,
 } from '@admin/routes/releaseRoutes';
 import permissionService from '@admin/services/permissionService';
 import releaseDataFileService, {
@@ -264,8 +264,8 @@ const ReleaseDataUploadsSection = ({
                           {dataFile.status === 'COMPLETE' && (
                             <Link
                               className="govuk-!-margin-right-4"
-                              to={generatePath<ReleaseDataFileRouteParams>(
-                                releaseDataFileRoute.path,
+                              to={generatePath<ReleaseDataFileReplaceRouteParams>(
+                                releaseDataFileReplaceRoute.path,
                                 {
                                   publicationId,
                                   releaseId,

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -22,6 +22,12 @@ import { mapFieldErrors } from '@common/validation/serverValidations';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
 import React, { useState } from 'react';
+import Link from '@admin/components/Link';
+import { generatePath } from 'react-router';
+import {
+  releaseAncillaryFileRoute,
+  ReleaseDataFileRouteParams,
+} from '@admin/routes/releaseRoutes';
 
 interface FormValues {
   name: string;
@@ -49,13 +55,18 @@ const errorMappings = [
 ];
 
 interface Props {
+  publicationId: string;
   releaseId: string;
   canUpdateRelease: boolean;
 }
 
 const formId = 'fileUploadForm';
 
-const ReleaseFileUploadsSection = ({ releaseId, canUpdateRelease }: Props) => {
+const ReleaseFileUploadsSection = ({
+  publicationId,
+  releaseId,
+  canUpdateRelease,
+}: Props) => {
   const [deleteFile, setDeleteFile] = useState<AncillaryFile>();
   const [isUploading, setIsUploading] = useState(false);
 
@@ -237,9 +248,24 @@ const ReleaseFileUploadsSection = ({ releaseId, canUpdateRelease }: Props) => {
                       <SummaryListItem
                         term="Actions"
                         actions={
-                          <ButtonText onClick={() => setDeleteFile(file)}>
-                            Delete file
-                          </ButtonText>
+                          <>
+                            <Link
+                              className="govuk-!-margin-right-4"
+                              to={generatePath<ReleaseDataFileRouteParams>(
+                                releaseAncillaryFileRoute.path,
+                                {
+                                  publicationId,
+                                  releaseId,
+                                  fileId: file.id,
+                                },
+                              )}
+                            >
+                              Edit title
+                            </Link>
+                            <ButtonText onClick={() => setDeleteFile(file)}>
+                              Delete file
+                            </ButtonText>
+                          </>
                         }
                       />
                     )}

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseDataUploadsSection.test.tsx
@@ -478,7 +478,7 @@ describe('ReleaseDataUploadsSection', () => {
           section2.getByRole('link', { name: 'Replace data' }),
         ).toHaveAttribute(
           'href',
-          '/publication/publication-1/release/release-1/data/data-2',
+          '/publication/publication-1/release/release-1/data/data-2/replace',
         );
       });
     });

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseFileUploadsSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/ReleaseFileUploadsSection.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { MemoryRouter } from 'react-router';
 
 jest.mock('@admin/services/releaseAncillaryFileService');
 
@@ -41,12 +42,22 @@ describe('ReleaseFileUploadsSection', () => {
     },
   ];
 
+  function renderPage() {
+    return render(
+      <MemoryRouter>
+        <ReleaseFileUploadsSection
+          publicationId="publication-1"
+          releaseId="release-1"
+          canUpdateRelease
+        />
+      </MemoryRouter>,
+    );
+  }
+
   test('renders list of uploaded files', async () => {
     releaseAncillaryFileService.getAncillaryFiles.mockResolvedValue(testFiles);
 
-    render(
-      <ReleaseFileUploadsSection releaseId="release-1" canUpdateRelease />,
-    );
+    renderPage();
 
     await waitFor(() => {
       expect(
@@ -82,9 +93,7 @@ describe('ReleaseFileUploadsSection', () => {
   test('renders empty message when there are no files', async () => {
     releaseAncillaryFileService.getAncillaryFiles.mockResolvedValue([]);
 
-    render(
-      <ReleaseFileUploadsSection releaseId="release-1" canUpdateRelease />,
-    );
+    renderPage();
 
     await waitFor(() => {
       const sections = screen.queryAllByTestId('accordionSection');
@@ -102,9 +111,7 @@ describe('ReleaseFileUploadsSection', () => {
         testFiles,
       );
 
-      render(
-        <ReleaseFileUploadsSection releaseId="release-1" canUpdateRelease />,
-      );
+      renderPage();
 
       let sections: HTMLElement[] = [];
 
@@ -139,9 +146,7 @@ describe('ReleaseFileUploadsSection', () => {
         testFiles,
       );
 
-      render(
-        <ReleaseFileUploadsSection releaseId="release-1" canUpdateRelease />,
-      );
+      renderPage();
 
       let sections: HTMLElement[] = [];
 
@@ -191,9 +196,7 @@ describe('ReleaseFileUploadsSection', () => {
     });
 
     test('show validation message when no subject title', async () => {
-      render(
-        <ReleaseFileUploadsSection releaseId="release-1" canUpdateRelease />,
-      );
+      renderPage();
 
       userEvent.click(screen.getByLabelText('Name'));
       userEvent.tab();
@@ -208,9 +211,7 @@ describe('ReleaseFileUploadsSection', () => {
     });
 
     test('shows validation message when non-unique name', async () => {
-      render(
-        <ReleaseFileUploadsSection releaseId="release-1" canUpdateRelease />,
-      );
+      renderPage();
 
       await userEvent.type(screen.getByLabelText('Name'), 'Test file 1');
       userEvent.tab();
@@ -225,9 +226,7 @@ describe('ReleaseFileUploadsSection', () => {
     });
 
     test('shows validation message when no file selected', async () => {
-      render(
-        <ReleaseFileUploadsSection releaseId="release-1" canUpdateRelease />,
-      );
+      renderPage();
 
       userEvent.click(screen.getByLabelText('Upload file'));
       fireEvent.change(screen.getByLabelText('Upload file'), {
@@ -247,9 +246,7 @@ describe('ReleaseFileUploadsSection', () => {
     });
 
     test('shows validation message when file is empty', async () => {
-      render(
-        <ReleaseFileUploadsSection releaseId="release-1" canUpdateRelease />,
-      );
+      renderPage();
 
       const file = new File([''], 'test.txt', {
         type: 'text/plain',
@@ -268,9 +265,7 @@ describe('ReleaseFileUploadsSection', () => {
     });
 
     test('cannot submit with invalid values', async () => {
-      render(
-        <ReleaseFileUploadsSection releaseId="release-1" canUpdateRelease />,
-      );
+      renderPage();
 
       userEvent.click(
         screen.getByRole('button', {
@@ -308,9 +303,7 @@ describe('ReleaseFileUploadsSection', () => {
         },
       });
 
-      render(
-        <ReleaseFileUploadsSection releaseId="release-1" canUpdateRelease />,
-      );
+      renderPage();
 
       const file = new File(['test'], 'test-file.txt');
 
@@ -344,9 +337,7 @@ describe('ReleaseFileUploadsSection', () => {
         },
       });
 
-      render(
-        <ReleaseFileUploadsSection releaseId="release-1" canUpdateRelease />,
-      );
+      renderPage();
 
       const file = new File(['test'], 'test-file.docx');
 

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -1,5 +1,6 @@
 import ReleaseContentPage from '@admin/pages/release/content/ReleaseContentPage';
 import ReleaseDataFilePage from '@admin/pages/release/data/ReleaseDataFilePage';
+import ReleaseAncillaryFilePage from '@admin/pages/release/data/ReleaseAncillaryFilePage';
 import ReleaseDataFileReplacePage from '@admin/pages/release/data/ReleaseDataFileReplacePage';
 import ReleaseDataFileReplacementCompletePage from '@admin/pages/release/data/ReleaseDataFileReplacementCompletePage';
 import ReleaseDataPage from '@admin/pages/release/data/ReleaseDataPage';
@@ -26,6 +27,10 @@ export type ReleaseDataBlockRouteParams = ReleaseRouteParams & {
 };
 
 export type ReleaseDataFileRouteParams = ReleaseRouteParams & {
+  fileId: string;
+};
+
+export type ReleaseAncillaryFileRouteParams = ReleaseRouteParams & {
   fileId: string;
 };
 
@@ -58,6 +63,18 @@ export const releaseDataRoute: ReleaseRouteProps = {
   path: '/publication/:publicationId/release/:releaseId/data',
   title: 'Data and files',
   component: ReleaseDataPage,
+};
+
+export const releaseDataAncillaryRoute: ReleaseRouteProps = {
+  path: '/publication/:publicationId/release/:releaseId/data#file-uploads',
+  title: 'Data and files',
+  component: ReleaseDataPage,
+};
+
+export const releaseAncillaryFileRoute: ReleaseRouteProps = {
+  path: '/publication/:publicationId/release/:releaseId/ancillary/:fileId',
+  title: 'Ancillary file',
+  component: ReleaseAncillaryFilePage,
 };
 
 export const releaseDataFileRoute: ReleaseRouteProps = {

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -1,5 +1,5 @@
 import ReleaseContentPage from '@admin/pages/release/content/ReleaseContentPage';
-import ReleaseDataFilePage from '@admin/pages/release/data/ReleaseDataFilePage';
+import ReleaseDataFileReplacePage from '@admin/pages/release/data/ReleaseDataFileReplacePage';
 import ReleaseDataFileReplacementCompletePage from '@admin/pages/release/data/ReleaseDataFileReplacementCompletePage';
 import ReleaseDataPage from '@admin/pages/release/data/ReleaseDataPage';
 import ReleaseDataBlockCreatePage from '@admin/pages/release/datablocks/ReleaseDataBlockCreatePage';
@@ -24,7 +24,7 @@ export type ReleaseDataBlockRouteParams = ReleaseRouteParams & {
   dataBlockId: string;
 };
 
-export type ReleaseDataFileRouteParams = ReleaseRouteParams & {
+export type ReleaseDataFileReplaceRouteParams = ReleaseRouteParams & {
   fileId: string;
 };
 
@@ -55,10 +55,10 @@ export const releaseDataRoute: ReleaseRouteProps = {
   component: ReleaseDataPage,
 };
 
-export const releaseDataFileRoute: ReleaseRouteProps = {
-  path: '/publication/:publicationId/release/:releaseId/data/:fileId',
-  title: 'Data file',
-  component: ReleaseDataFilePage,
+export const releaseDataFileReplaceRoute: ReleaseRouteProps = {
+  path: '/publication/:publicationId/release/:releaseId/data/:fileId/replace',
+  title: 'Replace data file',
+  component: ReleaseDataFileReplacePage,
 };
 
 export const releaseDataFileReplacementCompleteRoute: ReleaseRouteProps = {

--- a/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/releaseRoutes.ts
@@ -1,4 +1,5 @@
 import ReleaseContentPage from '@admin/pages/release/content/ReleaseContentPage';
+import ReleaseDataFilePage from '@admin/pages/release/data/ReleaseDataFilePage';
 import ReleaseDataFileReplacePage from '@admin/pages/release/data/ReleaseDataFileReplacePage';
 import ReleaseDataFileReplacementCompletePage from '@admin/pages/release/data/ReleaseDataFileReplacementCompletePage';
 import ReleaseDataPage from '@admin/pages/release/data/ReleaseDataPage';
@@ -22,6 +23,10 @@ export type ReleaseRouteParams = {
 
 export type ReleaseDataBlockRouteParams = ReleaseRouteParams & {
   dataBlockId: string;
+};
+
+export type ReleaseDataFileRouteParams = ReleaseRouteParams & {
+  fileId: string;
 };
 
 export type ReleaseDataFileReplaceRouteParams = ReleaseRouteParams & {
@@ -53,6 +58,12 @@ export const releaseDataRoute: ReleaseRouteProps = {
   path: '/publication/:publicationId/release/:releaseId/data',
   title: 'Data and files',
   component: ReleaseDataPage,
+};
+
+export const releaseDataFileRoute: ReleaseRouteProps = {
+  path: '/publication/:publicationId/release/:releaseId/data/:fileId',
+  title: 'Data file',
+  component: ReleaseDataFilePage,
 };
 
 export const releaseDataFileReplaceRoute: ReleaseRouteProps = {

--- a/src/explore-education-statistics-admin/src/services/releaseAncillaryFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseAncillaryFileService.ts
@@ -47,7 +47,7 @@ const releaseAncillaryFileService = {
   },
   getAncillaryFile(releaseId: string, fileId: string): Promise<AncillaryFile> {
     return client
-      .get<AncillaryFileInfo>(`/release/${releaseId}/ancillary/${fileId}`)
+      .get<AncillaryFileInfo>(`/release/${releaseId}/file/${fileId}`)
       .then(mapFile);
   },
   async uploadAncillaryFile(

--- a/src/explore-education-statistics-admin/src/services/releaseAncillaryFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseAncillaryFileService.ts
@@ -74,7 +74,7 @@ const releaseAncillaryFileService = {
   },
   downloadFile(releaseId: string, id: string, fileName: string): Promise<void> {
     return client
-      .get<Blob>(`/release/${releaseId}/file/${id}`, {
+      .get<Blob>(`/release/${releaseId}/file/${id}/download`, {
         responseType: 'blob',
       })
       .then(response => downloadFile(response, fileName));

--- a/src/explore-education-statistics-admin/src/services/releaseAncillaryFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseAncillaryFileService.ts
@@ -45,6 +45,11 @@ const releaseAncillaryFileService = {
       .get<AncillaryFileInfo[]>(`/release/${releaseId}/ancillary`)
       .then(response => response.map(mapFile));
   },
+  getAncillaryFile(releaseId: string, fileId: string): Promise<AncillaryFile> {
+    return client
+      .get<AncillaryFileInfo>(`/release/${releaseId}/ancillary/${fileId}`)
+      .then(mapFile);
+  },
   async uploadAncillaryFile(
     releaseId: string,
     request: UploadAncillaryFileRequest,
@@ -73,6 +78,17 @@ const releaseAncillaryFileService = {
         responseType: 'blob',
       })
       .then(response => downloadFile(response, fileName));
+  },
+  renameFile(releaseId: string, fileId: string, name: string): Promise<void> {
+    return client.post(
+      `/release/${releaseId}/file/${fileId}/rename`,
+      {},
+      {
+        params: {
+          name,
+        },
+      },
+    );
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/releaseChartFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseChartFileService.ts
@@ -50,7 +50,7 @@ const releaseChartFileService = {
   },
 
   getChartFile(releaseId: string, id: string): Promise<Blob> {
-    return client.get<Blob>(`/release/${releaseId}/file/${id}`, {
+    return client.get<Blob>(`/release/${releaseId}/file/${id}/download`, {
       responseType: 'blob',
     });
   },

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -173,7 +173,7 @@ const releaseDataFileService = {
   },
   downloadFile(releaseId: string, id: string, fileName: string): Promise<void> {
     return client
-      .get<Blob>(`/release/${releaseId}/file/${id}`, {
+      .get<Blob>(`/release/${releaseId}/file/${id}/download`, {
         responseType: 'blob',
       })
       .then(response => downloadFile(response, fileName));

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -178,6 +178,17 @@ const releaseDataFileService = {
       })
       .then(response => downloadFile(response, fileName));
   },
+  renameFile(releaseId: string, fileId: string, name: string): Promise<void> {
+    return client.post(
+      `/release/${releaseId}/file/${fileId}/rename`,
+      {},
+      {
+        params: {
+          name,
+        },
+      },
+    );
+  },
   cancelImport(releaseId: string, fileId: string): Promise<void> {
     return client.post(`/release/${releaseId}/data/${fileId}/import/cancel`);
   },


### PR DESCRIPTION
On the backend, this PR adds two endpoints, one to rename ReleaseFiles.Name for Data or Ancillary files. The other gets a single Ancillary file's FileInfo.

On the frontend, this adds two pages for editing data file and ancillary file details, and links to those pages.