### PR TITLE
EES-2084 Cached Release view model for amendments should use published date of previous release.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -988,7 +988,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         }
 
         [Fact]
-        public async Task GetReleaseViewModel_ReleaseNotYetPublishedHasCorrectPublishedDate()
+        public async Task GetReleaseViewModel_NotYetPublished()
         {
             var contentDbContextId = Guid.NewGuid().ToString();
 


### PR DESCRIPTION
When we create the cache Release content view model, we do that at midnight (or just before publishing when the publishing mode is immediate) and so the published date in the database isn't set yet, since it's only set once we actually complete publishing.

This means we have to set a published date in the view model otherwise it would be empty if just mapped from the database values.

If it's already been published (i.e. we are republishing for some reason), it will already be set.

Otherwise, it was previously set based on the expected publishing time worked out when the function execution beings.

This PR makes a change so that if it's an amendment, it's set to the value of the previous version so that amended releases continue to show the original published date rather than the date they are being published on.