### PR TITLE
EES-1236 remove validation preventing chart preview update

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -140,10 +140,8 @@ const ChartConfiguration = ({
   );
 
   const handleChange = useCallback(
-    ({ isValid, ...values }: FormValues & { isValid: boolean }) => {
-      if (isValid) {
-        onChange(normalizeValues(values));
-      }
+    ({ ...values }: FormValues) => {
+      onChange(normalizeValues(values));
     },
     [normalizeValues, onChange],
   );
@@ -175,7 +173,6 @@ const ChartConfiguration = ({
             <Effect
               value={{
                 ...form.values,
-                isValid: form.isValid,
               }}
               onChange={handleChange}
             />


### PR DESCRIPTION
Removes validation that prevents the chart preview from updating unless the required fields (title and alt) are filled.

I couldn't think of a reason the validation needed to there for the onChange event and have checked it hasn't changed how the validation works when the form is submitted or the required fields changed. Let me know if there's something I'm missing that requires it. 