### PR TITLE
EES-2059 increase cookie banner cookie expiry

### DIFF
--- a/src/explore-education-statistics-frontend/src/hooks/useCookies.ts
+++ b/src/explore-education-statistics-frontend/src/hooks/useCookies.ts
@@ -5,7 +5,7 @@ import {
   enableGoogleAnalytics,
   googleAnalyticsCookies,
 } from '@frontend/services/googleAnalyticsService';
-import { addMonths, addYears } from 'date-fns';
+import { addYears } from 'date-fns';
 import {
   destroyCookie,
   parseCookies,
@@ -30,9 +30,9 @@ interface AllowedCookies {
 export const allowedCookies: AllowedCookies = {
   bannerSeen: {
     name: 'ees_banner_seen',
-    duration: '1 month',
+    duration: '1 year',
     options: {
-      expires: addMonths(new Date(), 1),
+      expires: addYears(new Date(), 1),
     },
   },
   disableGA: {


### PR DESCRIPTION
Increases the banner seen cookie length to 1 year, this is still shorter than the analytics one but 10 years seemed to long and this makes it consistent with the gov.uk equivalent (see https://www.gov.uk/help/cookie-details).

Note for testing: this will also update the info on https://explore-education-statistics.service.gov.uk/cookies/details