### PR TITLE
EES-2190 display chart indicator units, warning for mixed units

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
@@ -227,6 +227,7 @@ const ChartAxisConfiguration = ({
       max: Yup.number(),
       min: Yup.number(),
       visible: Yup.boolean(),
+      unit: Yup.string(),
     });
 
     if (type === 'major' && !definition.axes.major?.constants?.groupBy) {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
@@ -13,6 +13,7 @@ import { LocationFilter } from '@common/modules/table-tool/types/filters';
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import { Dictionary } from '@common/types';
 import Yup from '@common/validation/yup';
+import WarningMessage from '@common/components/WarningMessage';
 import { Formik } from 'formik';
 import difference from 'lodash/difference';
 import mapValues from 'lodash/mapValues';
@@ -55,6 +56,19 @@ const ChartDataSetsConfiguration = ({
     [meta.locations],
   );
 
+  const hasMixedUnits = useMemo(() => {
+    const units: string[] = [];
+    dataSets.forEach(dataSet => {
+      const foundIndicator = meta.indicators.find(
+        indicator => indicator.value === dataSet.indicator,
+      );
+      if (foundIndicator) {
+        units.push(foundIndicator.unit);
+      }
+    });
+    return !units.every(unit => unit === units[0]);
+  }, [dataSets, meta.indicators]);
+
   useEffect(() => {
     updateForm({
       formKey: 'dataSets',
@@ -64,6 +78,11 @@ const ChartDataSetsConfiguration = ({
 
   return (
     <>
+      {hasMixedUnits && (
+        <WarningMessage>
+          Selected data sets have different indicator units.
+        </WarningMessage>
+      )}
       <Formik<FormValues>
         initialValues={{
           filters: mapValues(meta.filters, filterGroup =>

--- a/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/HorizontalBarBlock.tsx
@@ -17,6 +17,7 @@ import {
 } from '@common/modules/charts/util/domainTicks';
 import getDataSetCategoryConfigs from '@common/modules/charts/util/getDataSetCategoryConfigs';
 import getCategoryLabel from '@common/modules/charts/util/getCategoryLabel';
+import getUnit from '@common/modules/charts/util/getUnit';
 import getMinorAxisDecimalPlaces from '@common/modules/charts/util/getMinorAxisDecimalPlaces';
 import parseNumber from '@common/utils/number/parseNumber';
 import React, { memo } from 'react';
@@ -117,7 +118,7 @@ const HorizontalBarBlock = ({
             {...minorDomainTicks}
             type="number"
             hide={!axes.minor.visible}
-            unit={axes.minor.unit}
+            unit={getUnit(axes.minor.unit, dataSetCategoryConfigs)}
             height={xAxisHeight}
             padding={{ left: 0, right: 20 }}
             tickMargin={10}

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -21,6 +21,7 @@ import getMinorAxisDecimalPlaces from '@common/modules/charts/util/getMinorAxisD
 import { Dictionary } from '@common/types';
 import formatPretty from '@common/utils/number/formatPretty';
 import parseNumber from '@common/utils/number/parseNumber';
+import getUnit from '@common/modules/charts/util/getUnit';
 import React, { memo } from 'react';
 import {
   CartesianGrid,
@@ -160,7 +161,7 @@ const LineChartBlock = ({
             {...minorDomainTicks}
             type="number"
             hide={!axes.minor.visible}
-            unit={axes.minor.unit}
+            unit={getUnit(axes.minor.unit, dataSetCategoryConfigs)}
             width={yAxisWidth}
             tickFormatter={tick => formatPretty(tick, '', minorAxisDecimals)}
           />

--- a/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/VerticalBarBlock.tsx
@@ -19,6 +19,7 @@ import getDataSetCategoryConfigs from '@common/modules/charts/util/getDataSetCat
 import getCategoryLabel from '@common/modules/charts/util/getCategoryLabel';
 import getMinorAxisDecimalPlaces from '@common/modules/charts/util/getMinorAxisDecimalPlaces';
 import parseNumber from '@common/utils/number/parseNumber';
+import getUnit from '@common/modules/charts/util/getUnit';
 import React, { memo } from 'react';
 import {
   Bar,
@@ -115,7 +116,7 @@ const VerticalBarBlock = ({
             {...minorDomainTicks}
             type="number"
             hide={!axes.minor.visible}
-            unit={axes.minor.unit}
+            unit={getUnit(axes.minor.unit, dataSetCategoryConfigs)}
             width={parseNumber(axes.minor.size)}
             tickFormatter={tick => formatPretty(tick, '', minorAxisDecimals)}
           />

--- a/src/explore-education-statistics-common/src/modules/charts/util/getUnit.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/getUnit.ts
@@ -1,0 +1,23 @@
+import { DataSetCategoryConfig } from '@common/modules/charts/util/getDataSetCategoryConfigs';
+
+const getUnit = (
+  configUnit: string | undefined,
+  dataSetCategoryConfigs: DataSetCategoryConfig[],
+) => {
+  if (configUnit) {
+    return configUnit;
+  }
+
+  const units = dataSetCategoryConfigs.map(config => {
+    return config.dataSet.indicator.unit;
+  });
+
+  // Check if all units are the same, leave blank if not.
+  // Don't display £ as unable to position them before the value. (EES-2278)
+  if (units.every(unit => unit === units[0])) {
+    return units[0] === '£' ? '' : units[0];
+  }
+
+  return '';
+};
+export default getUnit;


### PR DESCRIPTION
- EES-2277 Show indicator units from the meta data, if no override set
- EES-2278 Leave unit blank if £ as unable to change position of the indicator (issue raised with recharts library for this)
- EES-2281 If data sets with different units are added to the same chart, leave the units blank and show a warning message on the data sets tab
- EES-2279 Fixes saving a blank override unit 
- EES-2280 Fixes displaying the override unit in the form