### PR TITLE
Ees 2247 display old release subjects and in create tables path

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseController.cs
@@ -28,10 +28,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
             );
         }
 
+        [HttpGet("publications/{publicationSlug}/releases/latest/summary")]
+        public async Task<ActionResult<ReleaseSummaryViewModel>> GetLatestReleaseSummary(string publicationSlug)
+        {
+            return await GetReleaseSummaryViewModel(
+                PublicContentPublicationPath(publicationSlug),
+                PublicContentLatestReleasePath(publicationSlug)
+            );
+        }
+
         [HttpGet("publications/{publicationSlug}/releases/{releaseSlug}")]
         public async Task<ActionResult<ReleaseViewModel>> GetRelease(string publicationSlug, string releaseSlug)
         {
             return await GetReleaseViewModel(
+                PublicContentPublicationPath(publicationSlug),
+                PublicContentReleasePath(publicationSlug, releaseSlug)
+            );
+        }
+
+        [HttpGet("publications/{publicationSlug}/releases/{releaseSlug}/summary")]
+        public async Task<ActionResult<ReleaseSummaryViewModel>> GetReleaseSummary(string publicationSlug, string releaseSlug)
+        {
+            return await GetReleaseSummaryViewModel(
                 PublicContentPublicationPath(publicationSlug),
                 PublicContentReleasePath(publicationSlug, releaseSlug)
             );
@@ -49,6 +67,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
             if (releaseTask.Result.IsRight && publicationTask.Result.IsRight)
             {
                 return new ReleaseViewModel(releaseTask.Result.Right, publicationTask.Result.Right);
+            }
+
+            return NotFound();
+        }
+        
+        private async Task<ActionResult<ReleaseSummaryViewModel>> GetReleaseSummaryViewModel(
+            string publicationPath,
+            string releasePath)
+        {
+            var publicationTask = _fileStorageService.GetDeserialized<CachedPublicationViewModel>(publicationPath);
+            var releaseTask = _fileStorageService.GetDeserialized<CachedReleaseViewModel>(releasePath);
+
+            await Task.WhenAll(publicationTask, releaseTask);
+
+            if (releaseTask.Result.IsRight && publicationTask.Result.IsRight)
+            {
+                return new ReleaseSummaryViewModel(releaseTask.Result.Right, publicationTask.Result.Right);
             }
 
             return NotFound();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/PublicationController.cs
@@ -20,11 +20,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
             var publicationService = new Mock<IPublicationService>();
 
             publicationService
-                .Setup(s => s.GetPublication(_publicationId))
-                .ReturnsAsync(new PublicationViewModel());
+                .Setup(s => s.GetLatestPublicationSubjectsAndHighlights(_publicationId))
+                .ReturnsAsync(new SubjectsAndHighlightsViewModel());
 
             publicationService
-                .Setup(s => s.GetPublication(It.Is<Guid>(guid => guid != _publicationId)))
+                .Setup(s => s.GetLatestPublicationSubjectsAndHighlights(It.Is<Guid>(guid => guid != _publicationId)))
                 .ReturnsAsync(new NotFoundResult());
 
             _controller = new PublicationController(publicationService.Object);
@@ -33,14 +33,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
         [Fact]
         public async Task GetPublication_Ok()
         {
-            var result = await _controller.GetPublication(_publicationId);
-            Assert.IsAssignableFrom<PublicationViewModel>(result.Value);
+            var result = await _controller.GetLatestPublicationSubjectsAndHighlights(_publicationId);
+            Assert.IsAssignableFrom<SubjectsAndHighlightsViewModel>(result.Value);
         }
 
         [Fact]
         public async Task GetPublication_NotFound()
         {
-            var result = await _controller.GetPublication(Guid.NewGuid());
+            var result = await _controller.GetLatestPublicationSubjectsAndHighlights(Guid.NewGuid());
             Assert.IsAssignableFrom<NotFoundResult>(result.Result);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/PublicationController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Controllers/PublicationController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
 {
-    [Route("api/publications")]
+    [Route("api")]
     [ApiController]
     public class PublicationController : ControllerBase
     {
@@ -18,10 +18,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Controllers
             _publicationService = publicationService;
         }
 
-        [HttpGet("{id}")]
-        public async Task<ActionResult<PublicationViewModel>> GetPublication(Guid id)
+        [HttpGet("publications/{publicationId}")]
+        public async Task<ActionResult<SubjectsAndHighlightsViewModel>> GetLatestPublicationSubjectsAndHighlights(Guid publicationId)
         {
-            return await _publicationService.GetPublication(id).HandleFailuresOrOk();
+            return await _publicationService
+                .GetLatestPublicationSubjectsAndHighlights(publicationId)
+                .HandleFailuresOrOk();
+        }
+
+        [HttpGet("releases/{releaseId}")]
+        public async Task<ActionResult<SubjectsAndHighlightsViewModel>> GetReleaseSubjectsAndHighlights(Guid releaseId)
+        {
+            return await _publicationService
+                .GetReleaseSubjectsAndHighlights(releaseId)
+                .HandleFailuresOrOk();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/PublicationServiceTests.cs
@@ -105,7 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var service = BuildPublicationService(context, releaseService: releaseService.Object);
 
-                var result = (await service.GetPublication(publication.Id)).Right;
+                var result = (await service.GetLatestPublicationSubjectsAndHighlights(publication.Id)).Right;
 
                 var highlights = result.Highlights.ToList();
                 var subjects = result.Subjects.ToList();
@@ -131,7 +131,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             await using var context = StatisticsDbUtils.InMemoryStatisticsDbContext();
             var service = BuildPublicationService(context);
 
-            var result = await service.GetPublication(Guid.NewGuid());
+            var result = await service.GetLatestPublicationSubjectsAndHighlights(Guid.NewGuid());
             Assert.IsType<NotFoundResult>(result.Left);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/PublicationServiceTests.cs
@@ -110,9 +110,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 var highlights = result.Highlights.ToList();
                 var subjects = result.Subjects.ToList();
 
-                Assert.Equal(publication.Id, result.Id);
-                Assert.Equal(release1.Id, result.LatestReleaseId);
-
                 Assert.Equal(2, highlights.Count);
                 Assert.Equal(highlight1, highlights[0]);
                 Assert.Equal(highlight2, highlights[1]);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IPublicationService.cs
@@ -8,6 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
 {
     public interface IPublicationService
     {
-        Task<Either<ActionResult, PublicationViewModel>> GetPublication(Guid publicationId);
+        Task<Either<ActionResult, SubjectsAndHighlightsViewModel>> GetLatestPublicationSubjectsAndHighlights(Guid publicationId);
+        Task<Either<ActionResult, SubjectsAndHighlightsViewModel>> GetReleaseSubjectsAndHighlights(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/PublicationService.cs
@@ -22,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             _releaseService = releaseService;
         }
 
-        public async Task<Either<ActionResult, PublicationViewModel>> GetPublication(
+        public async Task<Either<ActionResult, SubjectsAndHighlightsViewModel>> GetLatestPublicationSubjectsAndHighlights(
             Guid publicationId)
         {
             var release = _releaseRepository.GetLatestPublishedRelease(publicationId);
@@ -32,12 +32,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 return new NotFoundResult();
             }
 
-            return await _releaseService.GetRelease(release.Id)
-                .OnSuccess(
-                    viewModel => new PublicationViewModel
+            return await GetReleaseSubjectsAndHighlights(release.Id);
+        }
+
+        public async Task<Either<ActionResult, SubjectsAndHighlightsViewModel>> GetReleaseSubjectsAndHighlights(
+            Guid releaseId)
+        {
+            return await _releaseService.GetRelease(releaseId)
+                .OnSuccess(viewModel => new SubjectsAndHighlightsViewModel
                     {
-                        Id = publicationId,
-                        LatestReleaseId = release.Id,
                         Highlights = viewModel.Highlights,
                         Subjects = viewModel.Subjects,
                     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/SubjectsAndHighlightsViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/SubjectsAndHighlightsViewModel.cs
@@ -3,12 +3,8 @@ using System.Collections.Generic;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
 {
-    public class PublicationViewModel
+    public class SubjectsAndHighlightsViewModel
     {
-        public Guid Id { get; set; }
-
-        public Guid LatestReleaseId { get; set; }
-
         public List<TableHighlightViewModel> Highlights { get; set; }
 
         public List<SubjectViewModel> Subjects { get; set; }

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
@@ -99,7 +99,7 @@ const PublicationForm = ({
     }
 
     return initialValues ? 'none' : 'existing';
-  }, [initialValues, approvedMethodologies]);
+  }, [initialValues]);
 
   const validationSchema = useMemo(() => {
     const schema = Yup.object<FormValues>({

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/ReleaseTableToolPage.tsx
@@ -70,7 +70,9 @@ const ReleaseTableToolPage = ({
   const { value: initialState, isLoading } = useAsyncHandledRetry<
     InitialTableToolState | undefined
   >(async () => {
-    const { subjects } = await tableBuilderService.getRelease(releaseId);
+    const {
+      subjects,
+    } = await tableBuilderService.getReleaseSubjectsAndHighlights(releaseId);
 
     return {
       initialStep: 1,
@@ -106,6 +108,7 @@ const ReleaseTableToolPage = ({
 
             <TableToolWizard
               themeMeta={[]}
+              hidePublicationSelectionStage
               initialState={initialState}
               finalStep={({ response, query }) => (
                 <WizardStep>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
@@ -14,7 +14,7 @@ import _dataBlockService, {
 } from '@admin/services/dataBlockService';
 import _permissionService from '@admin/services/permissionService';
 import _tableBuilderService, {
-  Release,
+  SubjectsAndHighlights,
 } from '@common/services/tableBuilderService';
 import { waitFor } from '@testing-library/dom';
 import { render, screen, within } from '@testing-library/react';
@@ -137,8 +137,7 @@ describe('ReleaseDataBlockEditPage', () => {
     },
   ];
 
-  const testRelease: Release = {
-    id: 'release-1',
+  const testReleaseSubjectsAndHighlights: SubjectsAndHighlights = {
     subjects: [
       {
         id: 'subject-1',
@@ -165,21 +164,23 @@ describe('ReleaseDataBlockEditPage', () => {
   });
 
   test('renders page elements correctly', async () => {
-    tableBuilderService.getRelease.mockResolvedValue(testRelease);
+    tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue(
+      testReleaseSubjectsAndHighlights,
+    );
 
     renderPage();
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Edit data block' }),
-      ).toBeInTheDocument();
-
-      const tabs = screen.getAllByRole('tab');
-
-      expect(tabs).toHaveLength(3);
-      expect(tabs[0]).toHaveTextContent('Data source');
-      expect(tabs[1]).toHaveTextContent('Table');
-      expect(tabs[2]).toHaveTextContent('Chart');
+      // expect(
+      //   screen.getByRole('heading', { name: 'Edit data block' }),
+      // ).toBeInTheDocument();
+      //
+      // const tabs = screen.getAllByRole('tab');
+      //
+      // expect(tabs).toHaveLength(3);
+      // expect(tabs[0]).toHaveTextContent('Data source');
+      // expect(tabs[1]).toHaveTextContent('Table');
+      // expect(tabs[2]).toHaveTextContent('Chart');
     });
   });
 
@@ -339,7 +340,9 @@ describe('ReleaseDataBlockEditPage', () => {
     });
 
     test('renders page elements correctly', async () => {
-      tableBuilderService.getRelease.mockResolvedValue(testRelease);
+      tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue(
+        testReleaseSubjectsAndHighlights,
+      );
 
       renderPage();
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
@@ -171,16 +171,16 @@ describe('ReleaseDataBlockEditPage', () => {
     renderPage();
 
     await waitFor(() => {
-      // expect(
-      //   screen.getByRole('heading', { name: 'Edit data block' }),
-      // ).toBeInTheDocument();
-      //
-      // const tabs = screen.getAllByRole('tab');
-      //
-      // expect(tabs).toHaveLength(3);
-      // expect(tabs[0]).toHaveTextContent('Data source');
-      // expect(tabs[1]).toHaveTextContent('Table');
-      // expect(tabs[2]).toHaveTextContent('Chart');
+      expect(
+        screen.getByRole('heading', { name: 'Edit data block' }),
+      ).toBeInTheDocument();
+
+      const tabs = screen.getAllByRole('tab');
+
+      expect(tabs).toHaveLength(3);
+      expect(tabs[0]).toHaveTextContent('Data source');
+      expect(tabs[1]).toHaveTextContent('Table');
+      expect(tabs[2]).toHaveTextContent('Chart');
     });
   });
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
@@ -16,8 +16,7 @@ const tableBuilderService = _tableBuilderService as jest.Mocked<
 
 describe('ReleaseTableToolPage', () => {
   test('renders correctly on step 1', async () => {
-    tableBuilderService.getRelease.mockResolvedValue({
-      id: 'release-1',
+    tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue({
       subjects: [
         {
           id: 'subject-1',

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -56,7 +56,9 @@ const DataBlockPageTabs = ({
     error,
     isLoading,
   } = useAsyncRetry<InitialTableToolState>(async () => {
-    const { subjects } = await tableBuilderService.getRelease(releaseId);
+    const {
+      subjects,
+    } = await tableBuilderService.getReleaseSubjectsAndHighlights(releaseId);
 
     if (!dataBlock) {
       return {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -140,6 +140,7 @@ const DataBlockSourceWizard = ({
 
       <TableToolWizard
         themeMeta={[]}
+        hidePublicationSelectionStage
         initialState={tableToolState}
         finalStep={({ response, query }) => (
           <WizardStep>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
@@ -7,7 +7,7 @@ import _dataBlockService, {
   ReleaseDataBlock,
 } from '@admin/services/dataBlockService';
 import _tableBuilderService, {
-  Release,
+  SubjectsAndHighlights,
 } from '@common/services/tableBuilderService';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -61,14 +61,15 @@ describe('DataBlockPageTabs', () => {
     charts: [],
   };
 
-  const testRelease: Release = {
-    id: 'release-1',
+  const testRelease: SubjectsAndHighlights = {
     subjects: [],
     highlights: [],
   };
 
   test('renders uninitialised table tool when no data block is selected', async () => {
-    tableBuilderService.getRelease.mockResolvedValue(testRelease);
+    tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue(
+      testRelease,
+    );
 
     render(<DataBlockPageTabs releaseId="release-1" onDataBlockSave={noop} />);
 
@@ -85,7 +86,9 @@ describe('DataBlockPageTabs', () => {
   });
 
   test('does not render table or chart tabs when no data block is selected', async () => {
-    tableBuilderService.getRelease.mockResolvedValue(testRelease);
+    tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue(
+      testRelease,
+    );
 
     render(<DataBlockPageTabs releaseId="release-1" onDataBlockSave={noop} />);
 
@@ -98,7 +101,9 @@ describe('DataBlockPageTabs', () => {
   });
 
   test('renders fully initialised table tool when data block is selected', async () => {
-    tableBuilderService.getRelease.mockResolvedValue(testRelease);
+    tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue(
+      testRelease,
+    );
 
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     tableBuilderService.getTableData.mockResolvedValue(testTableData);
@@ -130,7 +135,9 @@ describe('DataBlockPageTabs', () => {
   });
 
   test('renders table and chart tabs when data block is selected', async () => {
-    tableBuilderService.getRelease.mockResolvedValue(testRelease);
+    tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue(
+      testRelease,
+    );
 
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     tableBuilderService.getTableData.mockResolvedValue(testTableData);
@@ -154,7 +161,9 @@ describe('DataBlockPageTabs', () => {
   });
 
   test('renders partially initialised table tool when there are no table results', async () => {
-    tableBuilderService.getRelease.mockResolvedValue(testRelease);
+    tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue(
+      testRelease,
+    );
 
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     tableBuilderService.getTableData.mockResolvedValue({
@@ -188,7 +197,9 @@ describe('DataBlockPageTabs', () => {
   });
 
   test('renders partially initialised table tool when table header configuration would be invalid', async () => {
-    tableBuilderService.getRelease.mockResolvedValue(testRelease);
+    tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue(
+      testRelease,
+    );
 
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     tableBuilderService.getTableData.mockResolvedValue(testTableData);
@@ -232,7 +243,9 @@ describe('DataBlockPageTabs', () => {
 
   describe('updating data block', () => {
     test('submitting data source form calls correct service to update data block', async () => {
-      tableBuilderService.getRelease.mockResolvedValue(testRelease);
+      tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue(
+        testRelease,
+      );
 
       tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
       tableBuilderService.getTableData.mockResolvedValue(testTableData);

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
@@ -34,9 +34,10 @@ const PreReleaseTableToolPage = ({
   const { value: tableToolState, isLoading } = useAsyncHandledRetry<
     InitialTableToolState | undefined
   >(async () => {
-    const { subjects, ...release } = await tableBuilderService.getRelease(
-      releaseId,
-    );
+    const {
+      subjects,
+      ...release
+    } = await tableBuilderService.getReleaseSubjectsAndHighlights(releaseId);
 
     const highlights = release.highlights.filter(
       highlight => highlight.id !== dataBlockId,
@@ -109,6 +110,7 @@ const PreReleaseTableToolPage = ({
         {tableToolState && (
           <TableToolWizard
             scrollOnMount
+            hidePublicationSelectionStage
             themeMeta={[]}
             initialState={tableToolState}
             renderHighlightLink={highlight => (

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
@@ -109,9 +109,9 @@ const PreReleaseTableToolPage = ({
       <LoadingSpinner loading={isLoading}>
         {tableToolState && (
           <TableToolWizard
-            scrollOnMount
-            hidePublicationSelectionStage
             themeMeta={[]}
+            hidePublicationSelectionStage
+            scrollOnMount
             initialState={tableToolState}
             renderHighlightLink={highlight => (
               <Link

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -10,7 +10,7 @@ import _publicationService, {
   BasicPublicationDetails,
 } from '@admin/services/publicationService';
 import _tableBuilderService, {
-  Release,
+  SubjectsAndHighlights,
   SubjectMeta,
   TableDataResponse,
 } from '@common/services/tableBuilderService';
@@ -188,8 +188,7 @@ describe('PreReleaseTableToolPage', () => {
     legacyReleases: [],
   };
 
-  const testRelease: Release = {
-    id: 'release-1',
+  const testRelease: SubjectsAndHighlights = {
     highlights: [
       {
         id: 'block-1',
@@ -255,7 +254,9 @@ describe('PreReleaseTableToolPage', () => {
 
   test('renders correctly on step 1 with subjects and highlights', async () => {
     publicationService.getPublication.mockResolvedValue(testPublication);
-    tableBuilderService.getRelease.mockResolvedValue(testRelease);
+    tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue(
+      testRelease,
+    );
 
     renderPage();
 
@@ -291,7 +292,7 @@ describe('PreReleaseTableToolPage', () => {
 
   test('renders correctly on step 1 without highlights', async () => {
     publicationService.getPublication.mockResolvedValue(testPublication);
-    tableBuilderService.getRelease.mockResolvedValue({
+    tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue({
       ...testRelease,
       highlights: [],
     });
@@ -320,7 +321,9 @@ describe('PreReleaseTableToolPage', () => {
     publicationService.getPublication.mockResolvedValue(testPublication);
     dataBlockService.getDataBlock.mockResolvedValue(testDataBlock);
 
-    tableBuilderService.getRelease.mockResolvedValue(testRelease);
+    tableBuilderService.getReleaseSubjectsAndHighlights.mockResolvedValue(
+      testRelease,
+    );
     tableBuilderService.getTableData.mockResolvedValue(testTableData);
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
 

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseTableToolFinalStep.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseTableToolFinalStep.tsx
@@ -4,7 +4,6 @@ import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
 import DownloadCsvButton from '@common/modules/table-tool/components/DownloadCsvButton';
 import DownloadExcelButton from '@common/modules/table-tool/components/DownloadExcelButton';
 import TableHeadersForm from '@common/modules/table-tool/components/TableHeadersForm';
-import { FinalStepRenderProps } from '@common/modules/table-tool/components/TableToolWizard';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
@@ -12,7 +11,10 @@ import React, { memo, useEffect, useRef, useState } from 'react';
 import { generatePath } from 'react-router-dom';
 
 interface TableToolFinalStepProps {
-  publication: FinalStepRenderProps['publication'];
+  publication?: {
+    id: string;
+    slug: string;
+  };
   releaseId: string;
   table: FullTable;
   tableHeaders: TableHeadersConfig;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -22,7 +22,9 @@ export interface PublicationFormValues {
 }
 
 export type PublicationFormSubmitHandler = (
-  values: PublicationFormValues,
+  values: PublicationFormValues & {
+    publicationSlug: string;
+  },
 ) => void;
 
 interface Props {
@@ -63,7 +65,23 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
         publicationId: Yup.string().required('Choose publication'),
       })}
       onSubmit={async values => {
-        await onSubmit(values);
+        const { publicationId } = values;
+        const publications = options.flatMap(theme =>
+          theme.topics.flatMap(topic => topic.publications),
+        );
+        const selectedPublication = publications.find(
+          publication => publication.id === publicationId,
+        );
+
+        if (!selectedPublication) {
+          throw new Error('Selected publication not found');
+        }
+
+        await onSubmit({
+          publicationId,
+          publicationSlug: selectedPublication.slug,
+        });
+
         goToNextStep();
       }}
     >

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -24,6 +24,7 @@ export interface PublicationFormValues {
 export type PublicationFormSubmitHandler = (
   values: PublicationFormValues & {
     publicationSlug: string;
+    publicationTitle: string;
   },
 ) => void;
 
@@ -80,6 +81,7 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
         await onSubmit({
           publicationId,
           publicationSlug: selectedPublication.slug,
+          publicationTitle: selectedPublication.title,
         });
 
         goToNextStep();

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -24,6 +24,7 @@ import parseYearCodeTuple from '@common/modules/table-tool/utils/parseYearCodeTu
 import publicationService from '@common/services/publicationService';
 import tableBuilderService, {
   ReleaseTableDataQuery,
+  SelectedPublication,
   Subject,
   SubjectMeta,
   TableHighlight,
@@ -40,14 +41,7 @@ interface Publication {
 
 export interface InitialTableToolState {
   initialStep: number;
-  selectedRelease?: {
-    id: string;
-    slug: string;
-    latestRelease: boolean;
-  };
-  latestRelease?: {
-    title: string;
-  };
+  selectedPublication?: SelectedPublication;
   subjects?: Subject[];
   highlights?: TableHighlight[];
   subjectMeta?: SubjectMeta;
@@ -72,14 +66,7 @@ export interface FinalStepRenderProps {
     table: FullTable;
     tableHeaders: TableHeadersConfig;
   };
-  selectedRelease?: {
-    id: string;
-    slug: string;
-    latestRelease: boolean;
-  };
-  latestRelease?: {
-    title: string;
-  };
+  selectedPublication?: SelectedPublication;
 }
 
 export interface TableToolWizardProps {
@@ -150,13 +137,16 @@ const TableToolWizard = ({
       draft.highlights = subjectsAndHighlights.highlights;
 
       draft.query.publicationId = selectedPublicationId;
-      draft.selectedRelease = {
-        id: latestRelease.id,
-        latestRelease: latestRelease.latestRelease,
-        slug: latestRelease.slug,
-      };
-      draft.latestRelease = {
-        title: latestRelease.title,
+      draft.selectedPublication = {
+        id: selectedPublicationId,
+        selectedRelease: {
+          id: latestRelease.id,
+          latestData: latestRelease.latestRelease,
+          slug: latestRelease.slug,
+        },
+        latestRelease: {
+          title: latestRelease.title,
+        },
       };
     });
   };
@@ -378,8 +368,7 @@ const TableToolWizard = ({
                 query: state.query,
                 response: state.response,
                 publication,
-                selectedRelease: state.selectedRelease,
-                latestRelease: state.latestRelease,
+                selectedPublication: state.selectedPublication,
               })}
           </Wizard>
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -33,12 +33,6 @@ import tableBuilderService, {
 import React, { ReactElement, ReactNode, useMemo } from 'react';
 import { useImmer } from 'use-immer';
 
-interface Publication {
-  id: string;
-  title: string;
-  slug: string;
-}
-
 export interface InitialTableToolState {
   initialStep: number;
   selectedPublication?: SelectedPublication;
@@ -60,7 +54,6 @@ interface TableToolState extends InitialTableToolState {
 }
 
 export interface FinalStepRenderProps {
-  publication?: Publication;
   query?: ReleaseTableDataQuery;
   response?: {
     table: FullTable;
@@ -113,16 +106,10 @@ const TableToolWizard = ({
     ...initialState,
   });
 
-  const publication = useMemo<Publication | undefined>(() => {
-    return themeMeta
-      .flatMap(option => option.topics)
-      .flatMap(option => option.publications)
-      .find(option => option.id === state.query.publicationId);
-  }, [state.query.publicationId, themeMeta]);
-
   const handlePublicationFormSubmit: PublicationFormSubmitHandler = async ({
     publicationId: selectedPublicationId,
     publicationSlug,
+    publicationTitle,
   }) => {
     const subjectsAndHighlights = await tableBuilderService.getPublicationSubjectsAndHighlights(
       selectedPublicationId,
@@ -139,6 +126,8 @@ const TableToolWizard = ({
       draft.query.publicationId = selectedPublicationId;
       draft.selectedPublication = {
         id: selectedPublicationId,
+        slug: publicationSlug,
+        title: publicationTitle,
         selectedRelease: {
           id: latestRelease.id,
           latestData: latestRelease.latestRelease,
@@ -367,7 +356,6 @@ const TableToolWizard = ({
               finalStep({
                 query: state.query,
                 response: state.response,
-                publication,
                 selectedPublication: state.selectedPublication,
               })}
           </Wizard>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/PublicationForm.test.tsx
@@ -398,9 +398,11 @@ describe('PublicationForm', () => {
 
     const expected: PublicationFormValues & {
       publicationSlug: string;
+      publicationTitle: string;
     } = {
       publicationId: 'publication-5',
       publicationSlug: 'pupil-absence-in-schools-in-england',
+      publicationTitle: 'Pupil absence in schools in England',
     };
 
     await waitFor(() => {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/PublicationForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/PublicationForm.test.tsx
@@ -396,8 +396,11 @@ describe('PublicationForm', () => {
     );
     userEvent.click(screen.getByRole('button', { name: 'Next step' }));
 
-    const expected: PublicationFormValues = {
+    const expected: PublicationFormValues & {
+      publicationSlug: string;
+    } = {
       publicationId: 'publication-5',
+      publicationSlug: 'pupil-absence-in-schools-in-england',
     };
 
     await waitFor(() => {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -175,9 +175,10 @@ describe('TableToolWizard', () => {
     });
   });
 
-  test('does not render publication step if `initialState.query.releaseId` is set', async () => {
+  test('does not render publication step if instructed to hide it', async () => {
     render(
       <TableToolWizard
+        hidePublicationSelectionStage
         themeMeta={testThemeMeta}
         initialState={{
           initialStep: 1,

--- a/src/explore-education-statistics-common/src/services/fastTrackService.ts
+++ b/src/explore-education-statistics-common/src/services/fastTrackService.ts
@@ -6,6 +6,9 @@ export type FastTrackTable = ConfiguredTable & {
   query: TableDataQuery & {
     publicationId: string;
   };
+};
+
+export type FastTrackTableAndReleaseMeta = FastTrackTable & {
   releaseId: string;
   releaseSlug: string;
   latestData: boolean;
@@ -13,7 +16,9 @@ export type FastTrackTable = ConfiguredTable & {
 };
 
 const fastTrackService = {
-  getFastTrackTable(id: string): Promise<FastTrackTable> {
+  getFastTrackTableAndReleaseMeta(
+    id: string,
+  ): Promise<FastTrackTableAndReleaseMeta> {
     return dataApi.get(`/fasttrack/${id}`);
   },
 };

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -164,12 +164,27 @@ export default {
   getLatestPublicationRelease(publicationSlug: string): Promise<Release> {
     return contentApi.get(`/publications/${publicationSlug}/releases/latest`);
   },
+  getLatestPublicationReleaseSummary(
+    publicationSlug: string,
+  ): Promise<ReleaseSummary> {
+    return contentApi.get(
+      `/publications/${publicationSlug}/releases/latest/summary`,
+    );
+  },
   getPublicationRelease(
     publicationSlug: string,
     releaseSlug: string,
   ): Promise<Release> {
     return contentApi.get(
       `/publications/${publicationSlug}/releases/${releaseSlug}`,
+    );
+  },
+  getPublicationReleaseSummary(
+    publicationSlug: string,
+    releaseSlug: string,
+  ): Promise<ReleaseSummary> {
+    return contentApi.get(
+      `/publications/${publicationSlug}/releases/${releaseSlug}/summary`,
     );
   },
   getLatestPreReleaseAccessList(

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -182,6 +182,8 @@ export interface TableDataResponse {
 
 export interface SelectedPublication {
   id: string;
+  title: string;
+  slug: string;
   selectedRelease: {
     id: string;
     slug: string;

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -180,6 +180,18 @@ export interface TableDataResponse {
   subjectMeta: TableDataSubjectMeta;
 }
 
+export interface SelectedPublication {
+  id: string;
+  selectedRelease: {
+    id: string;
+    slug: string;
+    latestData: boolean;
+  };
+  latestRelease: {
+    title: string;
+  };
+}
+
 const tableBuilderService = {
   getThemes(): Promise<Theme[]> {
     return dataApi.get('/themes');

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -91,14 +91,7 @@ export interface TableHighlight {
   description?: string;
 }
 
-export interface Publication {
-  id: string;
-  subjects: Subject[];
-  highlights: TableHighlight[];
-}
-
-export interface Release {
-  id: string;
+export interface SubjectsAndHighlights {
   subjects: Subject[];
   highlights: TableHighlight[];
 }
@@ -191,10 +184,14 @@ const tableBuilderService = {
   getThemes(): Promise<Theme[]> {
     return dataApi.get('/themes');
   },
-  getPublication(publicationId: string): Promise<Publication> {
+  getPublicationSubjectsAndHighlights(
+    publicationId: string,
+  ): Promise<SubjectsAndHighlights> {
     return dataApi.get(`/publications/${publicationId}`);
   },
-  getRelease(releaseId: string): Promise<Release> {
+  getReleaseSubjectsAndHighlights(
+    releaseId: string,
+  ): Promise<SubjectsAndHighlights> {
     return dataApi.get(`/releases/${releaseId}`);
   },
   getSubjectMeta(subjectId: string): Promise<SubjectMeta> {

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -11,6 +11,7 @@ import publicationService, {
   Release,
   ReleaseType,
 } from '@common/services/publicationService';
+import { Dictionary } from '@common/types';
 import {
   formatPartialDate,
   isValidPartialDate,
@@ -31,30 +32,31 @@ import PublicationReleaseHeadlinesSection from './components/PublicationReleaseH
 import styles from './PublicationReleasePage.module.scss';
 
 interface Props {
-  data: Release;
+  release: Release;
 }
 
-const PublicationReleasePage: NextPage<Props> = ({ data }) => {
+const PublicationReleasePage: NextPage<Props> = ({ release }) => {
   const releaseCount =
-    data.publication.otherReleases.length +
-    data.publication.legacyReleases.length;
+    release.publication.otherReleases.length +
+    release.publication.legacyReleases.length;
 
   let methodologyUrl = '';
   let methodologySummary = '';
-  if (data.publication.methodology) {
-    methodologyUrl = `/methodology/${data.publication.methodology.slug}`;
-    methodologySummary = data.publication.methodology.summary;
-  } else if (data.publication.externalMethodology) {
-    methodologyUrl = data.publication.externalMethodology.url;
+  if (release.publication.methodology) {
+    methodologyUrl = `/methodology/${release.publication.methodology.slug}`;
+    methodologySummary = release.publication.methodology.summary;
+  } else if (release.publication.externalMethodology) {
+    methodologyUrl = release.publication.externalMethodology.url;
   }
 
   return (
     <Page
-      title={data.publication.title}
-      caption={data.title}
+      title={release.publication.title}
+      caption={release.title}
       description={
-        data.summarySection.content && data.summarySection.content.length > 0
-          ? data.summarySection.content[0].body
+        release.summarySection.content &&
+        release.summarySection.content.length > 0
+          ? release.summarySection.content[0].body
           : ''
       }
       breadcrumbs={[
@@ -65,7 +67,7 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
         <div className="govuk-grid-column-two-thirds">
           <div className="dfe-flex dfe-align-items--center dfe-justify-content--space-between">
             <div className="dfe-flex govuk-!-margin-bottom-3">
-              {data.latestRelease ? (
+              {release.latestRelease ? (
                 <Tag strong className="govuk-!-margin-right-6">
                   This is the latest data
                 </Tag>
@@ -74,18 +76,18 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                   className="dfe-print-hidden"
                   unvisited
                   to="/find-statistics/[publication]"
-                  as={`/find-statistics/${data.publication.slug}`}
+                  as={`/find-statistics/${release.publication.slug}`}
                 >
                   View latest data:{' '}
                   <span className="govuk-!-font-weight-bold">
-                    {data.publication.otherReleases[0].title}
+                    {release.publication.otherReleases[0].title}
                   </span>
                 </Link>
               )}
             </div>
             <div className="dfe-flex">
-              {data.type &&
-                data.type.title === ReleaseType.NationalStatistics && (
+              {release.type &&
+                release.type.title === ReleaseType.NationalStatistics && (
                   <img
                     src="/assets/images/UKSA-quality-mark2.jpg"
                     alt="UK statistics authority quality mark"
@@ -98,16 +100,16 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
 
           <SummaryList>
             <SummaryListItem term="Published">
-              <FormattedDate>{data.published}</FormattedDate>
+              <FormattedDate>{release.published}</FormattedDate>
             </SummaryListItem>
-            {isValidPartialDate(data.nextReleaseDate) && (
+            {isValidPartialDate(release.nextReleaseDate) && (
               <SummaryListItem term="Next update">
-                <time>{formatPartialDate(data.nextReleaseDate)}</time>
+                <time>{formatPartialDate(release.nextReleaseDate)}</time>
               </SummaryListItem>
             )}
-            {data.updates && data.updates.length > 0 && (
+            {release.updates && release.updates.length > 0 && (
               <SummaryListItem term="Last updated">
-                <FormattedDate>{data.updates[0].on}</FormattedDate>
+                <FormattedDate>{release.updates[0].on}</FormattedDate>
 
                 <Details
                   id="releaseLastUpdates"
@@ -120,10 +122,10 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                       });
                     }
                   }}
-                  summary={`See all updates (${data.updates.length})`}
+                  summary={`See all updates (${release.updates.length})`}
                 >
                   <ol className="govuk-list">
-                    {orderBy(data.updates, 'on', 'desc').map(update => (
+                    {orderBy(release.updates, 'on', 'desc').map(update => (
                       <li key={update.id}>
                         <FormattedDate className="govuk-body govuk-!-font-weight-bold">
                           {update.on}
@@ -139,8 +141,8 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
               <Link
                 className="dfe-print-hidden govuk-!-font-weight-bold"
                 unvisited
-                to={`/subscriptions?slug=${data.publication.slug}`}
-                data-testid={`subscription-${data.publication.slug}`}
+                to={`/subscriptions?slug=${release.publication.slug}`}
+                data-testid={`subscription-${release.publication.slug}`}
                 onClick={() => {
                   logEvent({
                     category: 'Subscribe',
@@ -153,7 +155,7 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
             </SummaryListItem>
           </SummaryList>
 
-          {data.summarySection.content.map(block => (
+          {release.summarySection.content.map(block => (
             <ContentBlockRenderer key={block.id} block={block} />
           ))}
 
@@ -176,7 +178,7 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                     className="govuk-button govuk-!-margin-bottom-3"
                     onClick={() => {
                       logEvent({
-                        category: `${data.publication.title} release page`,
+                        category: `${release.publication.title} release page`,
                         action: `View data and files clicked`,
                         label: window.location.pathname,
                       });
@@ -185,57 +187,57 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                     View data and files
                   </a>
                 </li>
-                {data.publication.methodology && (
+                {release.publication.methodology && (
                   <li>
                     <Link
                       to="/methodology/[methodology]"
-                      as={`/methodology/${data.publication.methodology.slug}`}
+                      as={`/methodology/${release.publication.methodology.slug}`}
                     >
                       Methodology
                     </Link>
                   </li>
                 )}
-                {data.publication.externalMethodology && (
+                {release.publication.externalMethodology && (
                   <li>
                     <a
-                      href={data.publication.externalMethodology.url}
+                      href={release.publication.externalMethodology.url}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      {data.publication.externalMethodology.title}
+                      {release.publication.externalMethodology.title}
                     </a>
                   </li>
                 )}
-                {data.hasMetaGuidance && (
+                {release.hasMetaGuidance && (
                   <li>
                     <Link
                       to={
-                        data.latestRelease
+                        release.latestRelease
                           ? '/find-statistics/[publication]/meta-guidance'
                           : '/find-statistics/[publication]/[release]/meta-guidance'
                       }
                       as={
-                        data.latestRelease
-                          ? `/find-statistics/${data.publication.slug}/meta-guidance`
-                          : `/find-statistics/${data.publication.slug}/${data.slug}/meta-guidance`
+                        release.latestRelease
+                          ? `/find-statistics/${release.publication.slug}/meta-guidance`
+                          : `/find-statistics/${release.publication.slug}/${release.slug}/meta-guidance`
                       }
                     >
                       Metadata guidance document
                     </Link>
                   </li>
                 )}
-                {data.hasPreReleaseAccessList && (
+                {release.hasPreReleaseAccessList && (
                   <li>
                     <Link
                       to={
-                        data.latestRelease
+                        release.latestRelease
                           ? '/find-statistics/[publication]/prerelease-access-list'
                           : '/find-statistics/[publication]/[release]/prerelease-access-list'
                       }
                       as={
-                        data.latestRelease
-                          ? `/find-statistics/${data.publication.slug}/prerelease-access-list`
-                          : `/find-statistics/${data.publication.slug}/${data.slug}/prerelease-access-list`
+                        release.latestRelease
+                          ? `/find-statistics/${release.publication.slug}/prerelease-access-list`
+                          : `/find-statistics/${release.publication.slug}/${release.slug}/prerelease-access-list`
                       }
                     >
                       Pre-release access list
@@ -245,7 +247,8 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                 {!!releaseCount && (
                   <>
                     <p className="govuk-!-margin-bottom-0">
-                      {data.coverageTitle} <strong>{data.yearTitle}</strong>
+                      {release.coverageTitle}{' '}
+                      <strong>{release.yearTitle}</strong>
                     </p>
                     <Details
                       summary={`See other releases (${releaseCount})`}
@@ -260,19 +263,19 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                     >
                       <ul className="govuk-list">
                         {[
-                          ...data.publication.otherReleases.map(
+                          ...release.publication.otherReleases.map(
                             ({ id, slug, title }) => (
                               <li key={id} data-testid="other-release-item">
                                 <Link
                                   to="/find-statistics/[publication]/[release]"
-                                  as={`/find-statistics/${data.publication.slug}/${slug}`}
+                                  as={`/find-statistics/${release.publication.slug}/${slug}`}
                                 >
                                   {title}
                                 </Link>
                               </li>
                             ),
                           ),
-                          ...data.publication.legacyReleases.map(
+                          ...release.publication.legacyReleases.map(
                             ({ id, description, url }) => (
                               <li key={id} data-testid="other-release-item">
                                 <a href={url}>{description}</a>
@@ -286,7 +289,7 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                 )}
               </ul>
             </nav>
-            {data.relatedInformation.length !== 0 && (
+            {release.relatedInformation.length !== 0 && (
               <>
                 <h2
                   className="govuk-heading-s govuk-!-margin-top-6"
@@ -296,8 +299,8 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                 </h2>
                 <nav role="navigation" aria-labelledby="related-pages">
                   <ul className="govuk-list">
-                    {data.relatedInformation &&
-                      data.relatedInformation.map(link => (
+                    {release.relatedInformation &&
+                      release.relatedInformation.map(link => (
                         <li key={link.id}>
                           <a href={link.url}>{link.description}</a>
                         </li>
@@ -312,19 +315,19 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
       <hr />
 
       <h2 className="dfe-print-break-before">
-        Headline facts and figures - {data.yearTitle}
+        Headline facts and figures - {release.yearTitle}
       </h2>
 
-      <PublicationReleaseHeadlinesSection release={data} />
+      <PublicationReleaseHeadlinesSection release={release} />
 
-      {data.downloadFiles && (
+      {release.downloadFiles && (
         <div className="dfe-download-section">
           <Accordion
             id="dataDownloads"
             showOpenAll={false}
             onSectionOpen={accordionSection => {
               logEvent({
-                category: `${data.publication.title} release page`,
+                category: `${release.publication.title} release page`,
                 action: `Content accordion opened`,
                 label: `${accordionSection.title}`,
               });
@@ -335,12 +338,12 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                 Find and download files used in the production of this release.
               </p>
               <ul className="govuk-list govuk-!-width-full">
-                {data.downloadFiles.map(
+                {release.downloadFiles.map(
                   ({ id: fileId, fileName, extension, name, size }) => {
                     const isAllFiles = !fileId && name === 'All files';
 
                     const url = `${process.env.CONTENT_API_BASE_URL}/releases/${
-                      data.id
+                      release.id
                     }/files/${isAllFiles ? 'all' : fileId}`;
 
                     return (
@@ -353,7 +356,7 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                               action: `Release page ${
                                 isAllFiles ? 'all files' : 'file'
                               } downloaded`,
-                              label: `Publication: ${data.title}, File: ${fileName}`,
+                              label: `Publication: ${release.title}, File: ${fileName}`,
                             });
                           }}
                         >
@@ -377,13 +380,10 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
                       </p>
                     </div>
                     <p className="govuk-!-width-one-quarter dfe-flex-shrink--0">
-                      <ButtonLink
+                      <CreateTablesButton
                         className="govuk-!-width-full"
-                        to="/data-tables/[publication]"
-                        as={`/data-tables/${data.publication.slug}`}
-                      >
-                        Create tables
-                      </ButtonLink>
+                        release={release}
+                      />
                     </p>
                   </div>
                 </li>
@@ -393,21 +393,21 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
         </div>
       )}
 
-      {data.content.length > 0 && (
+      {release.content.length > 0 && (
         <Accordion
           id="content"
           onSectionOpen={accordionSection => {
             logEvent({
-              category: `${data.publication.title} release page`,
+              category: `${release.publication.title} release page`,
               action: `Content accordion opened`,
               label: `${accordionSection.title}`,
             });
           }}
         >
-          {data.content.map(({ heading, caption, order, content }) => {
+          {release.content.map(({ heading, caption, order, content }) => {
             return (
               <AccordionSection heading={heading} caption={caption} key={order}>
-                <PublicationSectionBlocks blocks={content} release={data} />
+                <PublicationSectionBlocks blocks={content} release={release} />
               </AccordionSection>
             );
           })}
@@ -416,23 +416,18 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
 
       <PublicationReleaseHelpAndSupportSection
         accordionId="help-and-support"
-        publicationTitle={data.publication.title}
+        publicationTitle={release.publication.title}
         methodologyUrl={methodologyUrl}
         methodologySummary={methodologySummary}
-        publicationContact={data.publication.contact}
-        releaseType={data.type.title}
+        publicationContact={release.publication.contact}
+        releaseType={release.type.title}
       />
 
       <h2 className="govuk-heading-m govuk-!-margin-top-9">
         Create your own tables
       </h2>
       <p>Explore our range of data and build your own tables from it.</p>
-      <ButtonLink
-        to="/data-tables/[publication]"
-        as={`/data-tables/${data.publication.slug}`}
-      >
-        Create tables
-      </ButtonLink>
+      <CreateTablesButton release={release} />
 
       <PrintThisPage
         onClick={() => {
@@ -447,21 +442,46 @@ const PublicationReleasePage: NextPage<Props> = ({ data }) => {
   );
 };
 
+interface CreateTableButtonProps {
+  release: Release;
+  className?: string;
+}
+
+const CreateTablesButton = ({ release, className }: CreateTableButtonProps) => {
+  return release.latestRelease ? (
+    <ButtonLink
+      className={className}
+      to="/data-tables/[publication]"
+      as={`/data-tables/${release.publication.slug}`}
+    >
+      Create tables
+    </ButtonLink>
+  ) : (
+    <ButtonLink
+      className={className}
+      to="/data-tables/[publication]/[release]"
+      as={`/data-tables/${release.publication.slug}/${release.slug}`}
+    >
+      Create tables
+    </ButtonLink>
+  );
+};
+
 export const getServerSideProps: GetServerSideProps<Props> = async ({
   query,
 }) => {
-  const { publication, release } = query as {
-    publication: string;
-    release: string;
-  };
+  const {
+    publication: publicationSlug,
+    release: releaseSlug,
+  } = query as Dictionary<string>;
 
-  const data = await (release
-    ? publicationService.getPublicationRelease(publication, release)
-    : publicationService.getLatestPublicationRelease(publication));
+  const release = await (releaseSlug
+    ? publicationService.getPublicationRelease(publicationSlug, releaseSlug)
+    : publicationService.getLatestPublicationRelease(publicationSlug));
 
   return {
     props: {
-      data,
+      release,
     },
   };
 };

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
@@ -8,7 +8,9 @@ import OfficialStats from './__data__/content.api.response.official.stats.json';
 describe('PublicationReleasePage', () => {
   test('renders national statistics image', () => {
     const { container } = render(
-      <PublicationReleasePage data={(NationalStats as unknown) as Release} />,
+      <PublicationReleasePage
+        release={(NationalStats as unknown) as Release}
+      />,
     );
 
     expect(
@@ -20,7 +22,9 @@ describe('PublicationReleasePage', () => {
 
   test('renders national statistics section', () => {
     render(
-      <PublicationReleasePage data={(NationalStats as unknown) as Release} />,
+      <PublicationReleasePage
+        release={(NationalStats as unknown) as Release}
+      />,
     );
 
     expect(
@@ -30,7 +34,9 @@ describe('PublicationReleasePage', () => {
 
   test('renders official statistics image', () => {
     const { container } = render(
-      <PublicationReleasePage data={(OfficialStats as unknown) as Release} />,
+      <PublicationReleasePage
+        release={(OfficialStats as unknown) as Release}
+      />,
     );
 
     expect(
@@ -42,7 +48,9 @@ describe('PublicationReleasePage', () => {
 
   test('renders official statistics section', () => {
     render(
-      <PublicationReleasePage data={(OfficialStats as unknown) as Release} />,
+      <PublicationReleasePage
+        release={(OfficialStats as unknown) as Release}
+      />,
     );
 
     expect(

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -8,6 +8,7 @@ import mapTableHeadersConfig from '@common/modules/table-tool/utils/mapTableHead
 import { FastTrackTable } from '@common/services/fastTrackService';
 import publicationService from '@common/services/publicationService';
 import tableBuilderService, {
+  SelectedPublication,
   SubjectMeta,
   SubjectsAndHighlights,
   Theme,
@@ -25,15 +26,7 @@ const TableToolFinalStep = dynamic(
 );
 
 export interface TableToolPageProps {
-  publicationId?: string;
-  initiallySelectedRelease?: {
-    id: string;
-    slug: string;
-    latestRelease: boolean;
-  };
-  initialLatestRelease?: {
-    title: string;
-  };
+  selectedPublication?: SelectedPublication;
   subjectsAndHighlights?: SubjectsAndHighlights;
   fastTrack?: FastTrackTable;
   subjectMeta?: SubjectMeta;
@@ -41,9 +34,7 @@ export interface TableToolPageProps {
 }
 
 const TableToolPage: NextPage<TableToolPageProps> = ({
-  publicationId,
-  initiallySelectedRelease,
-  initialLatestRelease,
+  selectedPublication,
   subjectsAndHighlights: initialSubjectsAndHighlights,
   fastTrack,
   subjectMeta,
@@ -80,10 +71,9 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
         highlights,
         query: {
           ...fastTrack.query,
-          releaseId: fastTrack.releaseId,
+          releaseId: selectedPublication?.selectedRelease.id,
         },
-        selectedRelease: initiallySelectedRelease,
-        latestRelease: initialLatestRelease,
+        selectedPublication,
         subjectMeta,
         response: {
           table: fullTable,
@@ -97,20 +87,17 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
       subjects,
       highlights,
       query: {
-        publicationId,
-        releaseId: initiallySelectedRelease?.id,
+        publicationId: selectedPublication?.id,
+        releaseId: selectedPublication?.selectedRelease.id,
         subjectId: '',
         indicators: [],
         filters: [],
         locations: {},
       },
-      selectedRelease: initiallySelectedRelease,
-      latestRelease: initialLatestRelease,
+      selectedPublication,
     };
   }, [
-    publicationId,
-    initiallySelectedRelease,
-    initialLatestRelease,
+    selectedPublication,
     fastTrack,
     initialSubjectsAndHighlights,
     subjectMeta,
@@ -155,8 +142,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
           publication,
           query,
           response,
-          selectedRelease,
-          latestRelease,
+          selectedPublication: selectedPublicationDetails,
         }) => (
           <WizardStep>
             {wizardStepProps => (
@@ -165,14 +151,13 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
                   Explore data
                 </WizardStepHeading>
 
-                {response && query && selectedRelease && latestRelease && (
+                {response && query && selectedPublicationDetails && (
                   <TableToolFinalStep
                     publication={publication}
                     query={query}
                     table={response.table}
                     tableHeaders={response.tableHeaders}
-                    selectedRelease={selectedRelease}
-                    latestRelease={latestRelease}
+                    selectedPublication={selectedPublicationDetails}
                   />
                 )}
               </>
@@ -238,14 +223,16 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
   return {
     props: {
       themeMeta,
-      publicationId,
-      initiallySelectedRelease: {
-        id: selectedRelease.id,
-        latestRelease: selectedRelease.latestRelease,
-        slug: selectedRelease.slug,
-      },
-      initialLatestRelease: {
-        title: latestRelease.title,
+      selectedPublication: {
+        id: publicationId,
+        selectedRelease: {
+          id: selectedRelease.id,
+          latestData: selectedRelease.latestRelease,
+          slug: selectedRelease.slug,
+        },
+        latestRelease: {
+          title: latestRelease.title,
+        },
       },
       subjectsAndHighlights,
     },

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -139,7 +139,6 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
           </Link>
         )}
         finalStep={({
-          publication,
           query,
           response,
           selectedPublication: selectedPublicationDetails,
@@ -153,7 +152,6 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
 
                 {response && query && selectedPublicationDetails && (
                   <TableToolFinalStep
-                    publication={publication}
                     query={query}
                     table={response.table}
                     tableHeaders={response.tableHeaders}
@@ -190,13 +188,12 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
 
   const themeMeta = await tableBuilderService.getThemes();
 
-  const publicationId =
-    themeMeta
-      .flatMap(option => option.topics)
-      .flatMap(option => option.publications)
-      .find(option => option.slug === publicationSlug)?.id ?? '';
+  const selectedPublication = themeMeta
+    .flatMap(option => option.topics)
+    .flatMap(option => option.publications)
+    .find(option => option.slug === publicationSlug);
 
-  if (!publicationId) {
+  if (!selectedPublication) {
     return {
       props: {
         themeMeta,
@@ -224,7 +221,9 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
     props: {
       themeMeta,
       selectedPublication: {
-        id: publicationId,
+        id: selectedPublication.id,
+        slug: selectedPublication.slug,
+        title: selectedPublication.title,
         selectedRelease: {
           id: selectedRelease.id,
           latestData: selectedRelease.latestRelease,

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
@@ -1,6 +1,6 @@
 import { FastTrackTable } from '@common/services/fastTrackService';
 import {
-  Publication,
+  SubjectsAndHighlights,
   SubjectMeta,
   Theme,
 } from '@common/services/tableBuilderService';
@@ -12,6 +12,10 @@ import preloadAll from 'jest-next-dynamic';
 import TableToolPage from '@frontend/modules/table-tool/TableToolPage';
 
 describe('TableToolPage', () => {
+  const testPublicationId = '536154f5-7f82-4dc7-060a-08d9097c1945';
+
+  const testReleaseId = '47a39fb5-1fed-4820-8906-5b54192524d7';
+
   const testFastTrack: FastTrackTable = {
     id: 'a08bd50a-7814-4e43-b152-2f7464d566ff',
     created: '2021-04-27T15:17:05.7530941Z',
@@ -116,7 +120,7 @@ describe('TableToolPage', () => {
       ],
     },
     query: {
-      publicationId: '536154f5-7f82-4dc7-060a-08d9097c1945',
+      publicationId: testPublicationId,
       subjectId: 'ef95f53e-2b91-417e-b32f-08d9097c40f5',
       timePeriod: {
         startYear: 2018,
@@ -135,14 +139,13 @@ describe('TableToolPage', () => {
       locations: { country: ['K03000001'] },
       includeGeoJson: false,
     },
-    releaseId: '47a39fb5-1fed-4820-8906-5b54192524d7',
+    releaseId: testReleaseId,
     releaseSlug: '2000-01',
     latestData: true,
     latestReleaseTitle: 'Tax Year 2018/2019',
   };
 
-  const testPublication: Publication = {
-    id: '536154f5-7f82-4dc7-060a-08d9097c1945',
+  const testPublicationSubjectsAndHighlights: SubjectsAndHighlights = {
     highlights: [],
     subjects: [
       {
@@ -289,7 +292,7 @@ describe('TableToolPage', () => {
           slug: 'admission-appeals',
           publications: [
             {
-              id: '536154f5-7f82-4dc7-060a-08d9097c1945',
+              id: testPublicationId,
               title: 'Test publication',
               slug: 'test-publication',
             },
@@ -301,7 +304,7 @@ describe('TableToolPage', () => {
 
   beforeEach(preloadAll);
 
-  test('renders the Table Tool page correctly when a Theme is chosen, giving the user a choice of Publications', async () => {
+  test('renders the Table Tool page correctly when Theme metadata is provided, giving the user a choice of Publications', async () => {
     render(<TableToolPage themeMeta={testThemeMeta} />);
 
     expect(screen.getByRole('main')).toMatchSnapshot();
@@ -309,7 +312,19 @@ describe('TableToolPage', () => {
 
   test('renders the Table Tool page correctly when Publication is chosen, giving the user a choice of Subjects', async () => {
     render(
-      <TableToolPage publication={testPublication} themeMeta={testThemeMeta} />,
+      <TableToolPage
+        publicationId={testPublicationId}
+        initiallySelectedRelease={{
+          id: testReleaseId,
+          latestRelease: true,
+          slug: 'latest-release-slug',
+        }}
+        initialLatestRelease={{
+          title: 'Latest Release Title',
+        }}
+        subjectsAndHighlights={testPublicationSubjectsAndHighlights}
+        themeMeta={testThemeMeta}
+      />,
     );
 
     expect(screen.getByRole('main')).toMatchSnapshot();
@@ -318,23 +333,41 @@ describe('TableToolPage', () => {
   test('renders the Table Tool page correctly when a Fast Track is provided, rendering a previously configured table', async () => {
     render(
       <TableToolPage
-        fastTrack={testFastTrack}
-        publication={testPublication}
+        publicationId={testPublicationId}
+        initiallySelectedRelease={{
+          id: testReleaseId,
+          latestRelease: true,
+          slug: 'latest-release-slug',
+        }}
+        initialLatestRelease={{
+          title: 'Latest Release Title',
+        }}
+        subjectsAndHighlights={testPublicationSubjectsAndHighlights}
         themeMeta={testThemeMeta}
         subjectMeta={testSubjectMeta}
+        fastTrack={testFastTrack}
       />,
     );
 
     expect(screen.getByRole('main')).toMatchSnapshot();
   });
 
-  test('renders the Table Tool page correctly when this is the latest data', async () => {
+  test('renders the Table Tool page correctly when a Fast Track is provided and this is the latest data', async () => {
     render(
       <TableToolPage
-        fastTrack={testFastTrack}
-        publication={testPublication}
+        publicationId={testPublicationId}
+        subjectsAndHighlights={testPublicationSubjectsAndHighlights}
         themeMeta={testThemeMeta}
         subjectMeta={testSubjectMeta}
+        fastTrack={testFastTrack}
+        initiallySelectedRelease={{
+          id: testReleaseId,
+          latestRelease: true,
+          slug: 'latest-release-slug',
+        }}
+        initialLatestRelease={{
+          title: 'Latest Release Title',
+        }}
       />,
     );
 
@@ -349,17 +382,26 @@ describe('TableToolPage', () => {
     expect(screen.getByRole('main')).toMatchSnapshot();
   });
 
-  test('renders the Table Tool page correctly when this is not the latest data', async () => {
+  test('renders the Table Tool page correctly when a Fast Track is provided and this is not the latest data', async () => {
     render(
       <TableToolPage
+        publicationId={testPublicationId}
+        subjectsAndHighlights={testPublicationSubjectsAndHighlights}
+        themeMeta={testThemeMeta}
+        subjectMeta={testSubjectMeta}
         fastTrack={{
           ...testFastTrack,
           latestData: false,
           latestReleaseTitle: 'Tax Year 2019/2020',
         }}
-        publication={testPublication}
-        themeMeta={testThemeMeta}
-        subjectMeta={testSubjectMeta}
+        initiallySelectedRelease={{
+          id: testReleaseId,
+          latestRelease: false,
+          slug: 'selected-release-slug',
+        }}
+        initialLatestRelease={{
+          title: 'Tax Year 2019/2020',
+        }}
       />,
     );
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
@@ -139,10 +139,6 @@ describe('TableToolPage', () => {
       locations: { country: ['K03000001'] },
       includeGeoJson: false,
     },
-    releaseId: testReleaseId,
-    releaseSlug: '2000-01',
-    latestData: true,
-    latestReleaseTitle: 'Tax Year 2018/2019',
   };
 
   const testPublicationSubjectsAndHighlights: SubjectsAndHighlights = {
@@ -302,6 +298,30 @@ describe('TableToolPage', () => {
     },
   ];
 
+  const testSelectedPublicationWithLatestRelease = {
+    id: testPublicationId,
+    selectedRelease: {
+      id: 'latest-release-id',
+      latestData: true,
+      slug: 'latest-release-slug',
+    },
+    latestRelease: {
+      title: 'Latest Release Title',
+    },
+  };
+
+  const testSelectedPublicationWithNonLatestRelease = {
+    id: testPublicationId,
+    selectedRelease: {
+      id: 'selected-release-id',
+      latestData: false,
+      slug: 'selected-release-slug',
+    },
+    latestRelease: {
+      title: 'Latest Release Title',
+    },
+  };
+
   beforeEach(preloadAll);
 
   test('renders the Table Tool page correctly when Theme metadata is provided, giving the user a choice of Publications', async () => {
@@ -313,15 +333,7 @@ describe('TableToolPage', () => {
   test('renders the Table Tool page correctly when Publication is chosen, giving the user a choice of Subjects', async () => {
     render(
       <TableToolPage
-        publicationId={testPublicationId}
-        initiallySelectedRelease={{
-          id: testReleaseId,
-          latestRelease: true,
-          slug: 'latest-release-slug',
-        }}
-        initialLatestRelease={{
-          title: 'Latest Release Title',
-        }}
+        selectedPublication={testSelectedPublicationWithLatestRelease}
         subjectsAndHighlights={testPublicationSubjectsAndHighlights}
         themeMeta={testThemeMeta}
       />,
@@ -333,15 +345,7 @@ describe('TableToolPage', () => {
   test('renders the Table Tool page correctly when a Fast Track is provided, rendering a previously configured table', async () => {
     render(
       <TableToolPage
-        publicationId={testPublicationId}
-        initiallySelectedRelease={{
-          id: testReleaseId,
-          latestRelease: true,
-          slug: 'latest-release-slug',
-        }}
-        initialLatestRelease={{
-          title: 'Latest Release Title',
-        }}
+        selectedPublication={testSelectedPublicationWithLatestRelease}
         subjectsAndHighlights={testPublicationSubjectsAndHighlights}
         themeMeta={testThemeMeta}
         subjectMeta={testSubjectMeta}
@@ -355,19 +359,11 @@ describe('TableToolPage', () => {
   test('renders the Table Tool page correctly when a Fast Track is provided and this is the latest data', async () => {
     render(
       <TableToolPage
-        publicationId={testPublicationId}
+        selectedPublication={testSelectedPublicationWithLatestRelease}
         subjectsAndHighlights={testPublicationSubjectsAndHighlights}
         themeMeta={testThemeMeta}
         subjectMeta={testSubjectMeta}
         fastTrack={testFastTrack}
-        initiallySelectedRelease={{
-          id: testReleaseId,
-          latestRelease: true,
-          slug: 'latest-release-slug',
-        }}
-        initialLatestRelease={{
-          title: 'Latest Release Title',
-        }}
       />,
     );
 
@@ -385,23 +381,11 @@ describe('TableToolPage', () => {
   test('renders the Table Tool page correctly when a Fast Track is provided and this is not the latest data', async () => {
     render(
       <TableToolPage
-        publicationId={testPublicationId}
+        selectedPublication={testSelectedPublicationWithNonLatestRelease}
         subjectsAndHighlights={testPublicationSubjectsAndHighlights}
         themeMeta={testThemeMeta}
         subjectMeta={testSubjectMeta}
-        fastTrack={{
-          ...testFastTrack,
-          latestData: false,
-          latestReleaseTitle: 'Tax Year 2019/2020',
-        }}
-        initiallySelectedRelease={{
-          id: testReleaseId,
-          latestRelease: false,
-          slug: 'selected-release-slug',
-        }}
-        initialLatestRelease={{
-          title: 'Tax Year 2019/2020',
-        }}
+        fastTrack={testFastTrack}
       />,
     );
 
@@ -420,7 +404,7 @@ describe('TableToolPage', () => {
       'http://localhost/find-statistics/test-publication',
     );
     expect(latestDataLink.text).toContain('View latest data');
-    expect(latestDataLink.text).toContain('Tax Year 2019/2020');
+    expect(latestDataLink.text).toContain('Latest Release Title');
 
     expect(screen.getByRole('main')).toMatchSnapshot();
   });

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
@@ -1,20 +1,18 @@
 import { FastTrackTable } from '@common/services/fastTrackService';
 import {
-  SubjectsAndHighlights,
   SubjectMeta,
+  SubjectsAndHighlights,
   Theme,
 } from '@common/services/tableBuilderService';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import preloadAll from 'jest-next-dynamic';
 import TableToolPage from '@frontend/modules/table-tool/TableToolPage';
+import React from 'react';
 
 describe('TableToolPage', () => {
   const testPublicationId = '536154f5-7f82-4dc7-060a-08d9097c1945';
-
-  const testReleaseId = '47a39fb5-1fed-4820-8906-5b54192524d7';
 
   const testFastTrack: FastTrackTable = {
     id: 'a08bd50a-7814-4e43-b152-2f7464d566ff',
@@ -300,6 +298,8 @@ describe('TableToolPage', () => {
 
   const testSelectedPublicationWithLatestRelease = {
     id: testPublicationId,
+    title: 'Test Publication',
+    slug: 'test-publication',
     selectedRelease: {
       id: 'latest-release-id',
       latestData: true,
@@ -312,6 +312,8 @@ describe('TableToolPage', () => {
 
   const testSelectedPublicationWithNonLatestRelease = {
     id: testPublicationId,
+    title: 'Test Publication',
+    slug: 'test-publication',
     selectedRelease: {
       id: 'selected-release-id',
       latestData: false,

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/__snapshots__/TableToolPage.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/__snapshots__/TableToolPage.test.tsx.snap
@@ -1336,7 +1336,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             <li>
               <a
                 class="govuk-link"
-                href="/find-statistics/test-publication/2000-01"
+                href="/find-statistics/test-publication"
               >
                 View the release for this data
               </a>
@@ -1370,7 +1370,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
 </main>
 `;
 
-exports[`TableToolPage renders the Table Tool page correctly when a Theme is chosen, giving the user a choice of Publications 1`] = `
+exports[`TableToolPage renders the Table Tool page correctly when Theme metadata is provided, giving the user a choice of Publications 1`] = `
 <main
   class="govuk-main-wrapper app-main-class"
   id="main-content"
@@ -1848,7 +1848,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Theme is cho
 </main>
 `;
 
-exports[`TableToolPage renders the Table Tool page correctly when this is not the latest data 1`] = `
+exports[`TableToolPage renders the Table Tool page correctly when a Fast Track is provided and this is not the latest data 1`] = `
 <main
   class="govuk-main-wrapper app-main-class"
   id="main-content"
@@ -2706,7 +2706,7 @@ exports[`TableToolPage renders the Table Tool page correctly when this is not th
             <li>
               <a
                 class="govuk-link"
-                href="/find-statistics/test-publication/2000-01"
+                href="/find-statistics/test-publication/selected-release-slug"
               >
                 View the release for this data
               </a>
@@ -2740,7 +2740,7 @@ exports[`TableToolPage renders the Table Tool page correctly when this is not th
 </main>
 `;
 
-exports[`TableToolPage renders the Table Tool page correctly when this is the latest data 1`] = `
+exports[`TableToolPage renders the Table Tool page correctly when a Fast Track is provided and this is the latest data 1`] = `
 <main
   class="govuk-main-wrapper app-main-class"
   id="main-content"
@@ -3581,7 +3581,7 @@ exports[`TableToolPage renders the Table Tool page correctly when this is the la
             <li>
               <a
                 class="govuk-link"
-                href="/find-statistics/test-publication/2000-01"
+                href="/find-statistics/test-publication"
               >
                 View the release for this data
               </a>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/__snapshots__/TableToolPage.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/__snapshots__/TableToolPage.test.tsx.snap
@@ -2558,7 +2558,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               <span
                 class="govuk-!-font-weight-bold"
               >
-                Tax Year 2019/2020
+                Latest Release Title
               </span>
             </a>
           </div>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
@@ -1,10 +1,11 @@
 import ButtonText from '@common/components/ButtonText';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 import Tag from '@common/components/Tag';
 import UrlContainer from '@common/components/UrlContainer';
-import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import DownloadCsvButton from '@common/modules/table-tool/components/DownloadCsvButton';
+import DownloadExcelButton from '@common/modules/table-tool/components/DownloadExcelButton';
 import TableHeadersForm from '@common/modules/table-tool/components/TableHeadersForm';
-import { FinalStepRenderProps } from '@common/modules/table-tool/components/TableToolWizard';
 import TimePeriodDataTable from '@common/modules/table-tool/components/TimePeriodDataTable';
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
@@ -16,13 +17,10 @@ import {
   TableDataQuery,
 } from '@common/services/tableBuilderService';
 import Link from '@frontend/components/Link';
-import React, { memo, useEffect, useRef, useState } from 'react';
-import DownloadCsvButton from '@common/modules/table-tool/components/DownloadCsvButton';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
-import DownloadExcelButton from '@common/modules/table-tool/components/DownloadExcelButton';
+import React, { memo, useEffect, useRef, useState } from 'react';
 
 interface TableToolFinalStepProps {
-  publication: FinalStepRenderProps['publication'];
   query: TableDataQuery;
   table: FullTable;
   tableHeaders: TableHeadersConfig;
@@ -32,7 +30,6 @@ interface TableToolFinalStepProps {
 const TableToolFinalStep = ({
   table,
   tableHeaders,
-  publication,
   query,
   selectedPublication,
 }: TableToolFinalStepProps) => {
@@ -48,12 +45,11 @@ const TableToolFinalStep = ({
     setPermalinkId('');
   }, [tableHeaders]);
 
-  const { value: pubMethodology } = useAsyncRetry(async () => {
-    if (publication) {
-      return publicationService.getPublicationMethodology(publication.slug);
-    }
-    return undefined;
-  }, [publication]);
+  const { value: pubMethodology } = useAsyncRetry(
+    async () =>
+      publicationService.getPublicationMethodology(selectedPublication.slug),
+    [selectedPublication],
+  );
 
   const handlePermalinkClick = async () => {
     if (!currentTableHeaders) {
@@ -100,7 +96,7 @@ const TableToolFinalStep = ({
               <Tag strong>This is the latest data</Tag>
             )}
 
-            {!selectedPublication.selectedRelease.latestData && publication && (
+            {!selectedPublication.selectedRelease.latestData && (
               <>
                 <div className="govuk-!-margin-bottom-3">
                   <Tag strong colour="orange">
@@ -112,7 +108,7 @@ const TableToolFinalStep = ({
                   className="dfe-print-hidden"
                   unvisited
                   to="/find-statistics/[publication]"
-                  as={`/find-statistics/${publication.slug}`}
+                  as={`/find-statistics/${selectedPublication.slug}`}
                   testId="View latest data link"
                 >
                   View latest data:{' '}
@@ -176,20 +172,20 @@ const TableToolFinalStep = ({
       </ul>
 
       <h3>Additional options</h3>
-      {publication && table && (
+      {table && (
         <ul className="govuk-list">
           <li>
             {selectedPublication.selectedRelease.latestData ? (
               <Link
                 to="/find-statistics/[publication]"
-                as={`/find-statistics/${publication.slug}`}
+                as={`/find-statistics/${selectedPublication.slug}`}
               >
                 View the release for this data
               </Link>
             ) : (
               <Link
                 to="/find-statistics/[publication]/[releaseSlug]"
-                as={`/find-statistics/${publication.slug}/${selectedPublication.selectedRelease.slug}`}
+                as={`/find-statistics/${selectedPublication.slug}/${selectedPublication.selectedRelease.slug}`}
               >
                 View the release for this data
               </Link>
@@ -197,7 +193,7 @@ const TableToolFinalStep = ({
           </li>
           <li>
             <DownloadCsvButton
-              fileName={`data-${publication.slug}`}
+              fileName={`data-${selectedPublication.slug}`}
               fullTable={table}
               onClick={() =>
                 logEvent({
@@ -216,7 +212,7 @@ const TableToolFinalStep = ({
           </li>
           <li>
             <DownloadExcelButton
-              fileName={`data-${publication.slug}`}
+              fileName={`data-${selectedPublication.slug}`}
               tableRef={dataTableRef}
               subjectMeta={table.subjectMeta}
               onClick={() =>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
@@ -23,10 +23,14 @@ interface TableToolFinalStepProps {
   query: TableDataQuery;
   table: FullTable;
   tableHeaders: TableHeadersConfig;
-  releaseId?: string;
-  releaseSlug?: string;
-  latestData?: boolean;
-  latestReleaseTitle?: string;
+  selectedRelease: {
+    id: string;
+    slug: string;
+    latestRelease: boolean;
+  };
+  latestRelease: {
+    title: string;
+  };
 }
 
 const TableToolFinalStep = ({
@@ -34,10 +38,8 @@ const TableToolFinalStep = ({
   tableHeaders,
   publication,
   query,
-  releaseId,
-  releaseSlug,
-  latestData = true,
-  latestReleaseTitle,
+  selectedRelease,
+  latestRelease,
 }: TableToolFinalStepProps) => {
   const dataTableRef = useRef<HTMLElement>(null);
   const [permalinkId, setPermalinkId] = useState<string>('');
@@ -71,7 +73,7 @@ const TableToolFinalStep = ({
           tableHeaders: mapUnmappedTableHeaders(currentTableHeaders),
         },
       },
-      releaseId,
+      selectedRelease.id,
     );
 
     setPermalinkId(id);
@@ -99,30 +101,34 @@ const TableToolFinalStep = ({
       {table && currentTableHeaders && (
         <>
           <div className="govuk-!-margin-bottom-3">
-            {latestData && <Tag strong>This is the latest data</Tag>}
-
-            {!latestData && publication && latestReleaseTitle && (
-              <>
-                <div className="govuk-!-margin-bottom-3">
-                  <Tag strong colour="orange">
-                    This data is not from the latest release
-                  </Tag>
-                </div>
-
-                <Link
-                  className="dfe-print-hidden"
-                  unvisited
-                  to="/find-statistics/[publication]"
-                  as={`/find-statistics/${publication.slug}`}
-                  testId="View latest data link"
-                >
-                  View latest data:{' '}
-                  <span className="govuk-!-font-weight-bold">
-                    {latestReleaseTitle}
-                  </span>
-                </Link>
-              </>
+            {selectedRelease.latestRelease && (
+              <Tag strong>This is the latest data</Tag>
             )}
+
+            {!selectedRelease.latestRelease &&
+              publication &&
+              latestRelease.title && (
+                <>
+                  <div className="govuk-!-margin-bottom-3">
+                    <Tag strong colour="orange">
+                      This data is not from the latest release
+                    </Tag>
+                  </div>
+
+                  <Link
+                    className="dfe-print-hidden"
+                    unvisited
+                    to="/find-statistics/[publication]"
+                    as={`/find-statistics/${publication.slug}`}
+                    testId="View latest data link"
+                  >
+                    View latest data:{' '}
+                    <span className="govuk-!-font-weight-bold">
+                      {latestRelease.title}
+                    </span>
+                  </Link>
+                </>
+              )}
           </div>
 
           <TimePeriodDataTable
@@ -180,17 +186,17 @@ const TableToolFinalStep = ({
       {publication && table && (
         <ul className="govuk-list">
           <li>
-            {releaseSlug ? (
+            {selectedRelease.latestRelease ? (
               <Link
-                to="/find-statistics/[publication]/[releaseSlug]"
-                as={`/find-statistics/${publication.slug}/${releaseSlug}`}
+                to="/find-statistics/[publication]"
+                as={`/find-statistics/${publication.slug}`}
               >
                 View the release for this data
               </Link>
             ) : (
               <Link
-                to="/find-statistics/[publication]"
-                as={`/find-statistics/${publication.slug}`}
+                to="/find-statistics/[publication]/[releaseSlug]"
+                as={`/find-statistics/${publication.slug}/${selectedRelease.slug}`}
               >
                 View the release for this data
               </Link>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
@@ -11,7 +11,10 @@ import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeader
 import mapUnmappedTableHeaders from '@common/modules/table-tool/utils/mapUnmappedTableHeaders';
 import permalinkService from '@common/services/permalinkService';
 import publicationService from '@common/services/publicationService';
-import { TableDataQuery } from '@common/services/tableBuilderService';
+import {
+  SelectedPublication,
+  TableDataQuery,
+} from '@common/services/tableBuilderService';
 import Link from '@frontend/components/Link';
 import React, { memo, useEffect, useRef, useState } from 'react';
 import DownloadCsvButton from '@common/modules/table-tool/components/DownloadCsvButton';
@@ -23,14 +26,7 @@ interface TableToolFinalStepProps {
   query: TableDataQuery;
   table: FullTable;
   tableHeaders: TableHeadersConfig;
-  selectedRelease: {
-    id: string;
-    slug: string;
-    latestRelease: boolean;
-  };
-  latestRelease: {
-    title: string;
-  };
+  selectedPublication: SelectedPublication;
 }
 
 const TableToolFinalStep = ({
@@ -38,8 +34,7 @@ const TableToolFinalStep = ({
   tableHeaders,
   publication,
   query,
-  selectedRelease,
-  latestRelease,
+  selectedPublication,
 }: TableToolFinalStepProps) => {
   const dataTableRef = useRef<HTMLElement>(null);
   const [permalinkId, setPermalinkId] = useState<string>('');
@@ -73,7 +68,7 @@ const TableToolFinalStep = ({
           tableHeaders: mapUnmappedTableHeaders(currentTableHeaders),
         },
       },
-      selectedRelease.id,
+      selectedPublication.selectedRelease.id,
     );
 
     setPermalinkId(id);
@@ -101,34 +96,32 @@ const TableToolFinalStep = ({
       {table && currentTableHeaders && (
         <>
           <div className="govuk-!-margin-bottom-3">
-            {selectedRelease.latestRelease && (
+            {selectedPublication.selectedRelease.latestData && (
               <Tag strong>This is the latest data</Tag>
             )}
 
-            {!selectedRelease.latestRelease &&
-              publication &&
-              latestRelease.title && (
-                <>
-                  <div className="govuk-!-margin-bottom-3">
-                    <Tag strong colour="orange">
-                      This data is not from the latest release
-                    </Tag>
-                  </div>
+            {!selectedPublication.selectedRelease.latestData && publication && (
+              <>
+                <div className="govuk-!-margin-bottom-3">
+                  <Tag strong colour="orange">
+                    This data is not from the latest release
+                  </Tag>
+                </div>
 
-                  <Link
-                    className="dfe-print-hidden"
-                    unvisited
-                    to="/find-statistics/[publication]"
-                    as={`/find-statistics/${publication.slug}`}
-                    testId="View latest data link"
-                  >
-                    View latest data:{' '}
-                    <span className="govuk-!-font-weight-bold">
-                      {latestRelease.title}
-                    </span>
-                  </Link>
-                </>
-              )}
+                <Link
+                  className="dfe-print-hidden"
+                  unvisited
+                  to="/find-statistics/[publication]"
+                  as={`/find-statistics/${publication.slug}`}
+                  testId="View latest data link"
+                >
+                  View latest data:{' '}
+                  <span className="govuk-!-font-weight-bold">
+                    {selectedPublication.latestRelease.title}
+                  </span>
+                </Link>
+              </>
+            )}
           </div>
 
           <TimePeriodDataTable
@@ -186,7 +179,7 @@ const TableToolFinalStep = ({
       {publication && table && (
         <ul className="govuk-list">
           <li>
-            {selectedRelease.latestRelease ? (
+            {selectedPublication.selectedRelease.latestData ? (
               <Link
                 to="/find-statistics/[publication]"
                 as={`/find-statistics/${publication.slug}`}
@@ -196,7 +189,7 @@ const TableToolFinalStep = ({
             ) : (
               <Link
                 to="/find-statistics/[publication]/[releaseSlug]"
-                as={`/find-statistics/${publication.slug}/${selectedRelease.slug}`}
+                as={`/find-statistics/${publication.slug}/${selectedPublication.selectedRelease.slug}`}
               >
                 View the release for this data
               </Link>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
@@ -222,6 +222,14 @@ describe('TableToolFinalStep', () => {
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
+        selectedRelease={{
+          id: 'latest-release-id',
+          latestRelease: true,
+          slug: 'latest-release-slug',
+        }}
+        latestRelease={{
+          title: 'Latest Release Title',
+        }}
       />,
     );
 
@@ -279,6 +287,14 @@ describe('TableToolFinalStep', () => {
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
+        selectedRelease={{
+          id: 'latest-release-id',
+          latestRelease: true,
+          slug: 'latest-release-slug',
+        }}
+        latestRelease={{
+          title: 'Latest Release Title',
+        }}
       />,
     );
 
@@ -303,15 +319,21 @@ describe('TableToolFinalStep', () => {
     ).toMatchSnapshot();
   });
 
-  test(`renders the 'View the release for this data' URL with the Release's slug, if supplied`, async () => {
+  test(`renders the 'View the release for this data' URL with the Release's slug, if the selected Release is not the latest for the Publication`, async () => {
     render(
       <TableToolFinalStep
         publication={testPublication}
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
-        releaseId="test-release-id"
-        releaseSlug="test-release-slug"
+        selectedRelease={{
+          id: 'selected-release-id',
+          latestRelease: false,
+          slug: 'selected-release-slug',
+        }}
+        latestRelease={{
+          title: 'Latest Release Title',
+        }}
       />,
     );
 
@@ -320,7 +342,7 @@ describe('TableToolFinalStep', () => {
     }) as HTMLAnchorElement;
 
     expect(viewReleaseLink.href).toEqual(
-      'http://localhost/find-statistics/test-publication/test-release-slug',
+      'http://localhost/find-statistics/test-publication/selected-release-slug',
     );
 
     expect(
@@ -328,13 +350,21 @@ describe('TableToolFinalStep', () => {
     ).toMatchSnapshot();
   });
 
-  test(`renders the 'View the release for this data' URL with only the Publication slug, if the Release slug is not supplied`, async () => {
+  test(`renders the 'View the release for this data' URL with only the Publication slug, if the selected Release is the latest Release for that Publication`, async () => {
     render(
       <TableToolFinalStep
         publication={testPublication}
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
+        selectedRelease={{
+          id: 'latest-release-id',
+          latestRelease: true,
+          slug: 'latest-release-slug',
+        }}
+        latestRelease={{
+          title: 'Latest Release Title',
+        }}
       />,
     );
 
@@ -358,7 +388,14 @@ describe('TableToolFinalStep', () => {
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
-        latestData
+        selectedRelease={{
+          id: 'latest-release-id',
+          latestRelease: true,
+          slug: 'latest-release-slug',
+        }}
+        latestRelease={{
+          title: 'Latest Release Title',
+        }}
       />,
     );
 
@@ -382,8 +419,14 @@ describe('TableToolFinalStep', () => {
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
-        latestData={false}
-        latestReleaseTitle="Latest Release Title"
+        selectedRelease={{
+          id: 'selected-release-id',
+          latestRelease: false,
+          slug: 'selected-release-slug',
+        }}
+        latestRelease={{
+          title: 'Latest Release Title',
+        }}
       />,
     );
 
@@ -392,7 +435,7 @@ describe('TableToolFinalStep', () => {
     }) as HTMLAnchorElement;
 
     expect(viewReleaseLink.href).toEqual(
-      'http://localhost/find-statistics/test-publication',
+      'http://localhost/find-statistics/test-publication/selected-release-slug',
     );
 
     expect(

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
@@ -215,6 +215,30 @@ describe('TableToolFinalStep', () => {
     ],
   };
 
+  const testSelectedPublicationWithLatestRelease = {
+    id: testPublication.id,
+    selectedRelease: {
+      id: 'latest-release-id',
+      latestData: true,
+      slug: 'latest-release-slug',
+    },
+    latestRelease: {
+      title: 'Latest Release Title',
+    },
+  };
+
+  const testSelectedPublicationWithNonLatestRelease = {
+    id: testPublication.id,
+    selectedRelease: {
+      id: 'selected-release-id',
+      latestData: false,
+      slug: 'selected-release-slug',
+    },
+    latestRelease: {
+      title: 'Latest Release Title',
+    },
+  };
+
   test('renders the final step successfully', async () => {
     render(
       <TableToolFinalStep
@@ -222,13 +246,16 @@ describe('TableToolFinalStep', () => {
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
-        selectedRelease={{
-          id: 'latest-release-id',
-          latestRelease: true,
-          slug: 'latest-release-slug',
-        }}
-        latestRelease={{
-          title: 'Latest Release Title',
+        selectedPublication={{
+          id: testPublication.id,
+          selectedRelease: {
+            id: 'latest-release-id',
+            latestData: true,
+            slug: 'latest-release-slug',
+          },
+          latestRelease: {
+            title: 'Latest Release Title',
+          },
         }}
       />,
     );
@@ -287,14 +314,7 @@ describe('TableToolFinalStep', () => {
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
-        selectedRelease={{
-          id: 'latest-release-id',
-          latestRelease: true,
-          slug: 'latest-release-slug',
-        }}
-        latestRelease={{
-          title: 'Latest Release Title',
-        }}
+        selectedPublication={testSelectedPublicationWithLatestRelease}
       />,
     );
 
@@ -326,14 +346,7 @@ describe('TableToolFinalStep', () => {
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
-        selectedRelease={{
-          id: 'selected-release-id',
-          latestRelease: false,
-          slug: 'selected-release-slug',
-        }}
-        latestRelease={{
-          title: 'Latest Release Title',
-        }}
+        selectedPublication={testSelectedPublicationWithNonLatestRelease}
       />,
     );
 
@@ -357,14 +370,7 @@ describe('TableToolFinalStep', () => {
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
-        selectedRelease={{
-          id: 'latest-release-id',
-          latestRelease: true,
-          slug: 'latest-release-slug',
-        }}
-        latestRelease={{
-          title: 'Latest Release Title',
-        }}
+        selectedPublication={testSelectedPublicationWithLatestRelease}
       />,
     );
 
@@ -388,14 +394,7 @@ describe('TableToolFinalStep', () => {
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
-        selectedRelease={{
-          id: 'latest-release-id',
-          latestRelease: true,
-          slug: 'latest-release-slug',
-        }}
-        latestRelease={{
-          title: 'Latest Release Title',
-        }}
+        selectedPublication={testSelectedPublicationWithLatestRelease}
       />,
     );
 
@@ -419,14 +418,7 @@ describe('TableToolFinalStep', () => {
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
-        selectedRelease={{
-          id: 'selected-release-id',
-          latestRelease: false,
-          slug: 'selected-release-slug',
-        }}
-        latestRelease={{
-          title: 'Latest Release Title',
-        }}
+        selectedPublication={testSelectedPublicationWithNonLatestRelease}
       />,
     );
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
@@ -15,12 +15,6 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 
 describe('TableToolFinalStep', () => {
-  const testPublication: FinalStepRenderProps['publication'] = {
-    id: '536154f5-7f82-4dc7-060a-08d9097c1945',
-    title: 'Test publication',
-    slug: 'test-publication',
-  };
-
   const testQuery: TableDataQuery = {
     publicationId: '536154f5-7f82-4dc7-060a-08d9097c1945',
     subjectId: '1f1b1780-a607-454e-b331-08d9097c40f5',
@@ -216,7 +210,9 @@ describe('TableToolFinalStep', () => {
   };
 
   const testSelectedPublicationWithLatestRelease = {
-    id: testPublication.id,
+    id: '536154f5-7f82-4dc7-060a-08d9097c1945',
+    title: 'Test publication',
+    slug: 'test-publication',
     selectedRelease: {
       id: 'latest-release-id',
       latestData: true,
@@ -228,7 +224,9 @@ describe('TableToolFinalStep', () => {
   };
 
   const testSelectedPublicationWithNonLatestRelease = {
-    id: testPublication.id,
+    id: '536154f5-7f82-4dc7-060a-08d9097c1945',
+    title: 'Test publication',
+    slug: 'test-publication',
     selectedRelease: {
       id: 'selected-release-id',
       latestData: false,
@@ -242,21 +240,10 @@ describe('TableToolFinalStep', () => {
   test('renders the final step successfully', async () => {
     render(
       <TableToolFinalStep
-        publication={testPublication}
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
-        selectedPublication={{
-          id: testPublication.id,
-          selectedRelease: {
-            id: 'latest-release-id',
-            latestData: true,
-            slug: 'latest-release-slug',
-          },
-          latestRelease: {
-            title: 'Latest Release Title',
-          },
-        }}
+        selectedPublication={testSelectedPublicationWithLatestRelease}
       />,
     );
 
@@ -310,7 +297,6 @@ describe('TableToolFinalStep', () => {
   test('shows and hides table header re-ordering controls successfully', async () => {
     render(
       <TableToolFinalStep
-        publication={testPublication}
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
@@ -342,7 +328,6 @@ describe('TableToolFinalStep', () => {
   test(`renders the 'View the release for this data' URL with the Release's slug, if the selected Release is not the latest for the Publication`, async () => {
     render(
       <TableToolFinalStep
-        publication={testPublication}
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
@@ -366,7 +351,6 @@ describe('TableToolFinalStep', () => {
   test(`renders the 'View the release for this data' URL with only the Publication slug, if the selected Release is the latest Release for that Publication`, async () => {
     render(
       <TableToolFinalStep
-        publication={testPublication}
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
@@ -390,7 +374,6 @@ describe('TableToolFinalStep', () => {
   test('renders the Table Tool final step correctly when this is the latest data', async () => {
     render(
       <TableToolFinalStep
-        publication={testPublication}
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}
@@ -414,7 +397,6 @@ describe('TableToolFinalStep', () => {
   test(`renders the Table Tool final step correctly if this is not the latest data`, async () => {
     render(
       <TableToolFinalStep
-        publication={testPublication}
         query={testQuery}
         table={testTable}
         tableHeaders={testTableHeaders}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__snapshots__/TableToolFinalStep.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__snapshots__/TableToolFinalStep.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableToolFinalStep renders the 'View the release for this data' URL with only the Publication slug, if the Release slug is not supplied 1`] = `
+exports[`TableToolFinalStep renders the 'View the release for this data' URL with only the Publication slug, if the selected Release is the latest Release for that Publication 1`] = `
 <div
   class="govuk-!-margin-bottom-4"
   data-testid="Table tool final step container"
@@ -537,7 +537,7 @@ exports[`TableToolFinalStep renders the 'View the release for this data' URL wit
 </div>
 `;
 
-exports[`TableToolFinalStep renders the 'View the release for this data' URL with the Release's slug, if supplied 1`] = `
+exports[`TableToolFinalStep renders the 'View the release for this data' URL with the Release's slug, if the selected Release is not the latest for the Publication 1`] = `
 <div
   class="govuk-!-margin-bottom-4"
   data-testid="Table tool final step container"
@@ -924,11 +924,28 @@ exports[`TableToolFinalStep renders the 'View the release for this data' URL wit
   <div
     class="govuk-!-margin-bottom-3"
   >
-    <strong
-      class="govuk-tag"
+    <div
+      class="govuk-!-margin-bottom-3"
     >
-      This is the latest data
-    </strong>
+      <strong
+        class="govuk-tag govuk-tag--orange"
+      >
+        This data is not from the latest release
+      </strong>
+    </div>
+    <a
+      class="govuk-link govuk-link--no-visited-state dfe-print-hidden"
+      data-testid="View latest data link"
+      href="/find-statistics/test-publication"
+    >
+      View latest data:
+       
+      <span
+        class="govuk-!-font-weight-bold"
+      >
+        Latest Release Title
+      </span>
+    </a>
   </div>
   <figure
     class="figure"
@@ -1044,7 +1061,7 @@ exports[`TableToolFinalStep renders the 'View the release for this data' URL wit
     <li>
       <a
         class="govuk-link"
-        href="/find-statistics/test-publication/test-release-slug"
+        href="/find-statistics/test-publication/selected-release-slug"
       >
         View the release for this data
       </a>
@@ -1598,7 +1615,7 @@ exports[`TableToolFinalStep renders the Table Tool final step correctly if this 
     <li>
       <a
         class="govuk-link"
-        href="/find-statistics/test-publication"
+        href="/find-statistics/test-publication/selected-release-slug"
       >
         View the release for this data
       </a>

--- a/src/explore-education-statistics-frontend/src/pages/data-tables/[publicationSlug]/[releaseSlug].tsx
+++ b/src/explore-education-statistics-frontend/src/pages/data-tables/[publicationSlug]/[releaseSlug].tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  getServerSideProps,
+} from '@frontend/modules/table-tool/TableToolPage';

--- a/src/explore-education-statistics-frontend/src/pages/data-tables/fast-track/[fastTrackId].tsx
+++ b/src/explore-education-statistics-frontend/src/pages/data-tables/fast-track/[fastTrackId].tsx
@@ -18,24 +18,37 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
     tableBuilderService.getThemes(),
   ]);
 
-  if (!fastTrack?.query.publicationId) {
+  if (!fastTrack) {
+    throw new Error('Fast track not found');
+  }
+
+  if (!fastTrack.query.publicationId) {
     throw new Error('Fast track table does not have `query.publicationId`');
   }
 
-  if (!fastTrack?.query.subjectId) {
+  if (!fastTrack.query.subjectId) {
     throw new Error('Fast track table does not have `query.subjectId`');
   }
 
-  const [publication, subjectMeta] = await Promise.all([
-    tableBuilderService.getPublication(fastTrack.query.publicationId),
+  const [subjectsAndHighlights, subjectMeta] = await Promise.all([
+    tableBuilderService.getReleaseSubjectsAndHighlights(fastTrack.releaseId),
     tableBuilderService.getSubjectMeta(fastTrack.query.subjectId),
   ]);
 
   return {
     props: {
+      publicationId: fastTrack.query.publicationId,
       fastTrack,
+      initiallySelectedRelease: {
+        id: fastTrack.releaseId,
+        slug: fastTrack.releaseSlug,
+        latestRelease: fastTrack.latestData,
+      },
+      initialLatestRelease: {
+        title: fastTrack.latestReleaseTitle,
+      },
       subjectMeta,
-      publication,
+      subjectsAndHighlights,
       themeMeta,
     },
   };

--- a/src/explore-education-statistics-frontend/src/pages/data-tables/fast-track/[fastTrackId].tsx
+++ b/src/explore-education-statistics-frontend/src/pages/data-tables/fast-track/[fastTrackId].tsx
@@ -30,6 +30,17 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
     throw new Error('Fast track table does not have `query.subjectId`');
   }
 
+  const selectedPublication = themeMeta
+    .flatMap(option => option.topics)
+    .flatMap(option => option.publications)
+    .find(option => option.id === fastTrack.query.publicationId);
+
+  if (!selectedPublication) {
+    throw new Error(
+      'Fast track `query.publicationId` is not found in the themeMeta list',
+    );
+  }
+
   const [subjectsAndHighlights, subjectMeta] = await Promise.all([
     tableBuilderService.getReleaseSubjectsAndHighlights(fastTrack.releaseId),
     tableBuilderService.getSubjectMeta(fastTrack.query.subjectId),
@@ -39,7 +50,9 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
     props: {
       fastTrack,
       selectedPublication: {
-        id: fastTrack.query.publicationId,
+        id: selectedPublication.id,
+        title: selectedPublication.title,
+        slug: selectedPublication.slug,
         selectedRelease: {
           id: fastTrack.releaseId,
           slug: fastTrack.releaseSlug,

--- a/src/explore-education-statistics-frontend/src/pages/data-tables/fast-track/[fastTrackId].tsx
+++ b/src/explore-education-statistics-frontend/src/pages/data-tables/fast-track/[fastTrackId].tsx
@@ -14,7 +14,7 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
   const { fastTrackId } = query as Dictionary<string>;
 
   const [fastTrack, themeMeta] = await Promise.all([
-    fastTrackService.getFastTrackTable(fastTrackId),
+    fastTrackService.getFastTrackTableAndReleaseMeta(fastTrackId),
     tableBuilderService.getThemes(),
   ]);
 
@@ -37,15 +37,17 @@ export const getServerSideProps: GetServerSideProps<TableToolPageProps> = async 
 
   return {
     props: {
-      publicationId: fastTrack.query.publicationId,
       fastTrack,
-      initiallySelectedRelease: {
-        id: fastTrack.releaseId,
-        slug: fastTrack.releaseSlug,
-        latestRelease: fastTrack.latestData,
-      },
-      initialLatestRelease: {
-        title: fastTrack.latestReleaseTitle,
+      selectedPublication: {
+        id: fastTrack.query.publicationId,
+        selectedRelease: {
+          id: fastTrack.releaseId,
+          slug: fastTrack.releaseSlug,
+          latestData: fastTrack.latestData,
+        },
+        latestRelease: {
+          title: fastTrack.latestReleaseTitle,
+        },
       },
       subjectMeta,
       subjectsAndHighlights,


### PR DESCRIPTION
This PR:
- corrects an error whereby navigating to an old release Fast Track would be displaying "Subject: None" in the "Choose Subject" step
- corrects an error whereby navigating to an old release Fast Track's "Choose Subject" step would not provide any Subjects to choose from
- changes the "Create tables" button when clicked from an old Release's Fast Track page to take the user to the Table Tool with that Release's Subjects available, rather than those from the latest Release for the same Publication

As part of this work, a few related properties around `TableToolPage.tsx`, `TableToolWizard.tsx` and `TableToolWizardFinalStep.tsx` have been combined together as they are always supplied together.  They have been combined into a single `selectedPublication` property, which represents either the Publication that the user has manually chosen in the Table Tool, or the one saved in a Fast Track, and always contains data about the `selectedRelease` (the latest for the chosen Publication or the specific owner of the Fast Track) and the chosen Publication's `latestRelease`.

By having these 2 properties (`selectedRelease` and `latestRelease`) consistently available, it helps to simplify the navigation code to determine where actions like "Create table" or "View the release for this data" should take the user at any given time.

It also helps to simplify which optional props should be provided to the TableTool components. 