### PR TITLE
EES-2311 Send email when assigning a Publication role to a user

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -281,6 +281,10 @@
       "type": "securestring",
       "defaultValue": ""
     },
+    "notifyPublicationRoleTemplateId": {
+      "type": "securestring",
+      "defaultValue": ""
+    },
     "notifyReleaseRoleTemplateId": {
       "type": "securestring",
       "defaultValue": ""
@@ -1619,6 +1623,7 @@
         "ASPNETCORE_DETAILEDERRORS": "[parameters('detailedErrors')]",
         "NotifyApiKey": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-notify-apikey-admin'), '2018-02-14').secretUriWithVersion, ')')]",
         "NotifyInviteTemplateId": "[parameters('notifyInviteTemplateId')]",
+        "NotifyPublicationRoleTemplateId": "[parameters('notifyPublicationRoleTemplateId')]",
         "NotifyReleaseRoleTemplateId": "[parameters('notifyReleaseRoleTemplateId')]",
         "NotifyPreReleaseTemplateId": "[parameters('notifyPreReleaseTemplateId')]",
         "AdminUri": "[parameters('adminUri')]",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/EmailTemplateServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/EmailTemplateServiceTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseRole;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
@@ -16,6 +17,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         [Fact]
         public void SendInviteEmail()
         {
+            const string expectedTemplateId = "invite-template-id";
+            
             var expectedValues = new Dictionary<string, dynamic>
             {
                 {"url", "https://admin-uri"}
@@ -26,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             emailService.Setup(mock =>
                 mock.SendEmail(
                     "test@test.com",
-                    "notify-invite-template-id",
+                    expectedTemplateId,
                     expectedValues
                 ));
 
@@ -37,7 +40,49 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             emailService.Verify(
                 s => s.SendEmail(
                     "test@test.com",
-                    "notify-invite-template-id",
+                    expectedTemplateId,
+                    expectedValues
+                ), Times.Once
+            );
+
+            VerifyAllMocks(emailService);
+        }
+
+        [Fact]
+        public void SendPublicationRoleEmail()
+        {
+            var publication = new Publication
+            {
+                Id = Guid.NewGuid(),
+                Title = "Test Publication"
+            };
+
+            const string expectedTemplateId = "publication-role-template-id";
+
+            var expectedValues = new Dictionary<string, dynamic>
+            {
+                {"url", $"https://admin-uri"},
+                {"role", Owner.ToString()},
+                {"publication", "Test Publication"},
+            };
+
+            var emailService = new Mock<IEmailService>(MockBehavior.Strict);
+
+            emailService.Setup(mock =>
+                mock.SendEmail(
+                    "test@test.com",
+                    expectedTemplateId,
+                    expectedValues
+                ));
+
+            var service = SetupEmailTemplateService(emailService: emailService.Object);
+
+            service.SendPublicationRoleEmail("test@test.com", publication, Owner);
+
+            emailService.Verify(
+                s => s.SendEmail(
+                    "test@test.com",
+                    expectedTemplateId,
                     expectedValues
                 ), Times.Once
             );
@@ -60,6 +105,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 TimePeriodCoverage = December
             };
 
+            const string expectedTemplateId = "release-role-template-id";
+            
             var expectedValues = new Dictionary<string, dynamic>
             {
                 {"url", $"https://admin-uri/publication/{release.Publication.Id}/release/{release.Id}/summary"},
@@ -73,7 +120,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             emailService.Setup(mock =>
                 mock.SendEmail(
                     "test@test.com",
-                    "notify-release-role-template-id",
+                    expectedTemplateId,
                     expectedValues
                 ));
 
@@ -84,7 +131,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             emailService.Verify(
                 s => s.SendEmail(
                     "test@test.com",
-                    "notify-release-role-template-id",
+                    expectedTemplateId,
                     expectedValues
                 ), Times.Once
             );
@@ -95,15 +142,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         private static Mock<IConfiguration> ConfigurationMock()
         {
             var notifyInviteTemplateSection = new Mock<IConfigurationSection>();
+            var publicationRoleTemplateSection = new Mock<IConfigurationSection>();
             var releaseRoleTemplateSection = new Mock<IConfigurationSection>();
             var adminUriSection = new Mock<IConfigurationSection>();
             var configuration = new Mock<IConfiguration>();
 
             notifyInviteTemplateSection.Setup(m => m.Value)
-                .Returns("notify-invite-template-id");
+                .Returns("invite-template-id");
+
+            publicationRoleTemplateSection.Setup(m => m.Value)
+                .Returns("publication-role-template-id");
 
             releaseRoleTemplateSection.Setup(m => m.Value)
-                .Returns("notify-release-role-template-id");
+                .Returns("release-role-template-id");
 
             adminUriSection.Setup(m => m.Value)
                 .Returns("admin-uri");
@@ -111,6 +162,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             configuration
                 .Setup(m => m.GetSection("NotifyInviteTemplateId"))
                 .Returns(notifyInviteTemplateSection.Object);
+
+            configuration
+                .Setup(m => m.GetSection("NotifyPublicationRoleTemplateId"))
+                .Returns(publicationRoleTemplateSection.Object);
 
             configuration
                 .Setup(m => m.GetSection("NotifyReleaseRoleTemplateId"))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/EmailTemplateService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/EmailTemplateService.cs
@@ -31,7 +31,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public void SendPublicationRoleEmail(string email, Publication publication, PublicationRole role)
         {
-            // TODO EES-2311
+            var uri = _configuration.GetValue<string>("AdminUri");
+            var template = _configuration.GetValue<string>("NotifyPublicationRoleTemplateId");
+
+            var emailValues = new Dictionary<string, dynamic>
+            {
+                {"url", $"https://{uri}"},
+                {"role", role.ToString()},
+                {"publication", publication.Title}
+            };
+
+            _emailService.SendEmail(email, template, emailValues);
         }
 
         public void SendReleaseRoleEmail(string email, Release release, ReleaseRole role)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -2,6 +2,7 @@
   "AdminUri": "localhost:5021",
   "NotifyApiKey": "change-me",
   "NotifyInviteTemplateId": "change-me",
+  "NotifyPublicationRoleTemplateId": "change-me",
   "NotifyReleaseRoleTemplateId": "change-me",
   "NotifyPreReleaseTemplateId": "change-me",
   "PublicAppUrl": "http://localhost:3000",


### PR DESCRIPTION
This PR completes the changes for adding a new resource role to a Publication for a User by sending an email to the user using a new Gov.Uk Notify email template that has been set up for it.

![image](https://user-images.githubusercontent.com/4147126/118976182-a58cb280-b96c-11eb-8e02-881624c36d8c.png)
