### PR TITLE
EES-2254 table tool changes

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/__tests__/ReleaseStatusPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/__tests__/ReleaseStatusPage.test.tsx
@@ -33,7 +33,7 @@ describe('ReleaseStatusPage', () => {
       expect(screen.getByText('Sign off')).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId('public-release-url')).toHaveTextContent(
+    expect(screen.getByLabelText('Url')).toHaveValue(
       'http://localhost/find-statistics/publication-1-slug/release-1-slug',
     );
   });

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseDataBlockEditPage.test.tsx
@@ -193,7 +193,8 @@ describe('ReleaseDataBlockEditPage', () => {
       ).toBeInTheDocument();
 
       expect(screen.queryByTestId('Highlight name')).not.toBeInTheDocument();
-      expect(screen.getByTestId('Fast track URL')).toHaveTextContent(
+
+      expect(screen.getByLabelText('Url')).toHaveValue(
         'http://localhost/data-tables/fast-track/block-1',
       );
     });
@@ -375,7 +376,7 @@ describe('ReleaseDataBlockEditPage', () => {
         expect(screen.getByTestId('Highlight description')).toHaveTextContent(
           'Test highlight description 1',
         );
-        expect(screen.getByTestId('Fast track URL')).toHaveTextContent(
+        expect(screen.getByLabelText('Url')).toHaveValue(
           'http://localhost/data-tables/fast-track/block-1',
         );
       });
@@ -400,7 +401,7 @@ describe('ReleaseDataBlockEditPage', () => {
           screen.queryByTestId('Highlight description'),
         ).not.toBeInTheDocument();
 
-        expect(screen.getByTestId('Fast track URL')).toHaveTextContent(
+        expect(screen.getByLabelText('Url')).toHaveValue(
           'http://localhost/data-tables/fast-track/block-1',
         );
       });

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__tests__/ReleaseTableToolPage.test.tsx
@@ -49,7 +49,7 @@ describe('ReleaseTableToolPage', () => {
 
       expect(stepHeadings).toHaveLength(1);
       expect(stepHeadings[0]).toHaveTextContent(
-        'Step 1 (current): Choose a subject',
+        'Step 1 (current) Choose a subject',
       );
     });
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -143,7 +143,7 @@ const DataBlockSourceWizard = ({
         hidePublicationSelectionStage
         initialState={tableToolState}
         finalStep={({ response, query }) => (
-          <WizardStep>
+          <WizardStep size="l">
             {wizardStepProps => (
               <>
                 <WizardStepHeading {...wizardStepProps}>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/__tests__/DataBlockPageTabs.test.tsx
@@ -78,7 +78,7 @@ describe('DataBlockPageTabs', () => {
 
       expect(stepHeadings).toHaveLength(1);
       expect(stepHeadings[0]).toHaveTextContent(
-        'Step 1 (current): Choose a subject',
+        'Step 1 (current) Choose a subject',
       );
 
       expect(screen.getAllByRole('listitem')).toHaveLength(1);
@@ -120,12 +120,12 @@ describe('DataBlockPageTabs', () => {
       const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
 
       expect(stepHeadings).toHaveLength(5);
-      expect(stepHeadings[0]).toHaveTextContent('Step 1: Choose a subject');
-      expect(stepHeadings[1]).toHaveTextContent('Step 2: Choose locations');
-      expect(stepHeadings[2]).toHaveTextContent('Step 3: Choose time period');
-      expect(stepHeadings[3]).toHaveTextContent('Step 4: Choose your filters');
+      expect(stepHeadings[0]).toHaveTextContent('Step 1 Choose a subject');
+      expect(stepHeadings[1]).toHaveTextContent('Step 2 Choose locations');
+      expect(stepHeadings[2]).toHaveTextContent('Step 3 Choose time period');
+      expect(stepHeadings[3]).toHaveTextContent('Step 4 Choose your filters');
       expect(stepHeadings[4]).toHaveTextContent(
-        'Step 5 (current): Update data block',
+        'Step 5 (current) Update data block',
       );
 
       expect(screen.getByLabelText('Name')).toHaveValue('Test data block');
@@ -189,9 +189,9 @@ describe('DataBlockPageTabs', () => {
       const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
 
       expect(stepHeadings).toHaveLength(2);
-      expect(stepHeadings[0]).toHaveTextContent('Step 1: Choose a subject');
+      expect(stepHeadings[0]).toHaveTextContent('Step 1 Choose a subject');
       expect(stepHeadings[1]).toHaveTextContent(
-        'Step 2 (current): Choose locations',
+        'Step 2 (current) Choose locations',
       );
     });
   });
@@ -234,9 +234,9 @@ describe('DataBlockPageTabs', () => {
       const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
 
       expect(stepHeadings).toHaveLength(2);
-      expect(stepHeadings[0]).toHaveTextContent('Step 1: Choose a subject');
+      expect(stepHeadings[0]).toHaveTextContent('Step 1 Choose a subject');
       expect(stepHeadings[1]).toHaveTextContent(
-        'Step 2 (current): Choose locations',
+        'Step 2 (current) Choose locations',
       );
     });
   });

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
@@ -61,7 +61,7 @@ describe('ReleasePreReleaseAccessPage', () => {
       expect(screen.queryByTestId('prerelease-url')).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId('prerelease-url')).toHaveTextContent(
+    expect(screen.getByLabelText('Url')).toHaveValue(
       'http://localhost/publication/publication-1/release/release-1/prerelease/content',
     );
   });

--- a/src/explore-education-statistics-common/src/components/UrlContainer.module.scss
+++ b/src/explore-education-statistics-common/src/components/UrlContainer.module.scss
@@ -2,8 +2,10 @@
 
 .url {
   background: govuk-colour('light-grey');
+  border: 0;
   display: inline-block;
   padding: govuk-spacing(2) govuk-spacing(4);
   user-select: all;
   white-space: pre-wrap;
+  width: 100%;
 }

--- a/src/explore-education-statistics-common/src/components/UrlContainer.tsx
+++ b/src/explore-education-statistics-common/src/components/UrlContainer.tsx
@@ -3,15 +3,30 @@ import React from 'react';
 import styles from './UrlContainer.module.scss';
 
 interface Props {
-  'data-testid'?: string;
+  'data-testid'?: string | 'url';
   className?: string;
   url: string;
 }
 
-const UrlContainer = ({ 'data-testid': dataTestId, className, url }: Props) => (
-  <span className={classNames(styles.url, className)} data-testid={dataTestId}>
-    {url}
-  </span>
-);
+const UrlContainer = ({ 'data-testid': dataTestId, className, url }: Props) => {
+  const handleFocus = (event: React.FocusEvent<HTMLInputElement>) =>
+    event.target.select();
+  return (
+    <>
+      <label htmlFor={dataTestId} className="govuk-visually-hidden">
+        Url
+      </label>
+      <input
+        type="text"
+        value={url}
+        id={dataTestId}
+        className={classNames(styles.url, className)}
+        data-testid={dataTestId}
+        onFocus={handleFocus}
+        readOnly
+      />
+    </>
+  );
+};
 
 export default UrlContainer;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -20,6 +20,7 @@ import ResetFormOnPreviousStep from './ResetFormOnPreviousStep';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 import WizardStepHeading from './WizardStepHeading';
+import WizardStepEditButton from './WizardStepEditButton';
 
 export interface FormValues {
   indicators: string[];
@@ -76,8 +77,11 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
     };
   }, [initialValues, subjectMeta]);
 
+  const stepEnabled = currentStep > stepNumber;
   const stepHeading = (
-    <WizardStepHeading {...props}>Choose your filters</WizardStepHeading>
+    <WizardStepHeading {...props} stepEnabled={stepEnabled}>
+      Choose your filters
+    </WizardStepHeading>
   );
 
   return (
@@ -195,51 +199,56 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
         }
 
         return (
-          <>
-            {stepHeading}
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+              {stepHeading}
+              <SummaryList noBorder>
+                <SummaryListItem term="Indicators">
+                  <CollapsibleList>
+                    {Object.values(subjectMeta.indicators)
+                      .flatMap(group => group.options)
+                      .filter(indicator =>
+                        form.values.indicators.includes(indicator.value),
+                      )
+                      .map(indicator => (
+                        <li key={indicator.value}>{indicator.label}</li>
+                      ))}
+                  </CollapsibleList>
+                </SummaryListItem>
 
-            <ResetFormOnPreviousStep
-              currentStep={currentStep}
-              stepNumber={stepNumber}
-            />
-
-            <SummaryList noBorder>
-              <SummaryListItem term="Indicators">
-                <CollapsibleList>
-                  {Object.values(subjectMeta.indicators)
-                    .flatMap(group => group.options)
-                    .filter(indicator =>
-                      form.values.indicators.includes(indicator.value),
-                    )
-                    .map(indicator => (
-                      <li key={indicator.value}>{indicator.label}</li>
-                    ))}
-                </CollapsibleList>
-              </SummaryListItem>
-
-              {Object.entries(subjectMeta.filters)
-                .filter(([groupKey]) => !!form.values.filters[groupKey])
-                .map(([filterGroupKey, filterGroup]) => (
-                  <SummaryListItem
-                    key={filterGroupKey}
-                    term={filterGroup.legend}
-                  >
-                    <CollapsibleList>
-                      {Object.values(filterGroup.options)
-                        .flatMap(group => group.options)
-                        .filter(option =>
-                          form.values.filters[filterGroupKey].includes(
-                            option.value,
-                          ),
-                        )
-                        .map(option => (
-                          <li key={option.value}>{option.label}</li>
-                        ))}
-                    </CollapsibleList>
-                  </SummaryListItem>
-                ))}
-            </SummaryList>
-          </>
+                {Object.entries(subjectMeta.filters)
+                  .filter(([groupKey]) => !!form.values.filters[groupKey])
+                  .map(([filterGroupKey, filterGroup]) => (
+                    <SummaryListItem
+                      key={filterGroupKey}
+                      term={filterGroup.legend}
+                    >
+                      <CollapsibleList>
+                        {Object.values(filterGroup.options)
+                          .flatMap(group => group.options)
+                          .filter(option =>
+                            form.values.filters[filterGroupKey].includes(
+                              option.value,
+                            ),
+                          )
+                          .map(option => (
+                            <li key={option.value}>{option.label}</li>
+                          ))}
+                      </CollapsibleList>
+                    </SummaryListItem>
+                  ))}
+              </SummaryList>
+            </div>
+            <div className="govuk-grid-column-one-third dfe-align--right">
+              {stepEnabled && (
+                <WizardStepEditButton {...props} editTitle="Edit filters" />
+              )}
+              <ResetFormOnPreviousStep
+                currentStep={currentStep}
+                stepNumber={stepNumber}
+              />
+            </div>
+          </div>
         );
       }}
     </Formik>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -17,6 +17,7 @@ import FormFieldCheckboxMenu from './FormFieldCheckboxMenu';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 import WizardStepHeading from './WizardStepHeading';
+import WizardStepEditButton from './WizardStepEditButton';
 
 interface FormValues {
   locations: Dictionary<string[]>;
@@ -46,14 +47,14 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
   } = props;
 
   const formOptions = useMemo(() => options, [options]);
-
+  const stepEnabled = currentStep > stepNumber;
   const stepHeading = useMemo(
     () => (
-      <WizardStepHeading {...props} fieldsetHeading>
+      <WizardStepHeading {...props} fieldsetHeading stepEnabled={stepEnabled}>
         Choose locations
       </WizardStepHeading>
     ),
-    [props],
+    [props, stepEnabled],
   );
 
   return (
@@ -150,34 +151,39 @@ const LocationFiltersForm = (props: Props & InjectedWizardProps) => {
         );
 
         return (
-          <>
-            {stepHeading}
-
-            <ResetFormOnPreviousStep
-              currentStep={currentStep}
-              stepNumber={stepNumber}
-            />
-
-            <SummaryList noBorder>
-              {Object.entries(locationLevels)
-                .filter(
-                  ([levelKey, levelOptions]) =>
-                    levelOptions.length > 0 && formOptions[levelKey],
-                )
-                .map(([levelKey, levelOptions]) => (
-                  <SummaryListItem
-                    term={formOptions[levelKey].legend}
-                    key={levelKey}
-                  >
-                    <CollapsibleList>
-                      {sortBy(levelOptions, ['label']).map(level => (
-                        <li key={level.value}>{level.label}</li>
-                      ))}
-                    </CollapsibleList>
-                  </SummaryListItem>
-                ))}
-            </SummaryList>
-          </>
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+              {stepHeading}
+              <SummaryList noBorder>
+                {Object.entries(locationLevels)
+                  .filter(
+                    ([levelKey, levelOptions]) =>
+                      levelOptions.length > 0 && formOptions[levelKey],
+                  )
+                  .map(([levelKey, levelOptions]) => (
+                    <SummaryListItem
+                      term={formOptions[levelKey].legend}
+                      key={levelKey}
+                    >
+                      <CollapsibleList>
+                        {sortBy(levelOptions, ['label']).map(level => (
+                          <li key={level.value}>{level.label}</li>
+                        ))}
+                      </CollapsibleList>
+                    </SummaryListItem>
+                  ))}
+              </SummaryList>
+            </div>
+            <div className="govuk-grid-column-one-third dfe-align--right">
+              {stepEnabled && (
+                <WizardStepEditButton {...props} editTitle="Edit locations" />
+              )}
+              <ResetFormOnPreviousStep
+                currentStep={currentStep}
+                stepNumber={stepNumber}
+              />
+            </div>
+          </div>
         );
       }}
     </Formik>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/PublicationForm.tsx
@@ -16,6 +16,7 @@ import React, { useState } from 'react';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 import WizardStepHeading from './WizardStepHeading';
+import WizardStepEditButton from './WizardStepEditButton';
 
 export interface PublicationFormValues {
   publicationId: string;
@@ -45,13 +46,16 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
     initialValues = {
       publicationId: '',
     },
+    currentStep,
+    stepNumber,
   } = props;
 
   const [searchTerm, setSearchTerm] = useState('');
   const lowercaseSearchTerm = searchTerm.toLowerCase();
+  const stepEnabled = currentStep > stepNumber;
 
   const stepHeading = (
-    <WizardStepHeading {...props} fieldsetHeading>
+    <WizardStepHeading {...props} fieldsetHeading stepEnabled={stepEnabled}>
       Choose a publication
     </WizardStepHeading>
   );
@@ -216,14 +220,24 @@ const PublicationForm = (props: Props & InjectedWizardProps) => {
           .find(option => option.id === form.values.publicationId);
 
         return (
-          <>
-            {stepHeading}
-            <SummaryList noBorder>
-              <SummaryListItem term="Publication">
-                {publication?.title}
-              </SummaryListItem>
-            </SummaryList>
-          </>
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+              {stepHeading}
+              <SummaryList noBorder>
+                <SummaryListItem term="Publication">
+                  {publication?.title}
+                </SummaryListItem>
+              </SummaryList>
+            </div>
+            <div className="govuk-grid-column-one-third dfe-align--right">
+              {stepEnabled && (
+                <WizardStepEditButton
+                  {...props}
+                  editTitle="Change publication"
+                />
+              )}
+            </div>
+          </div>
         );
       }}
     </Formik>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectStep.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/SubjectStep.tsx
@@ -11,6 +11,7 @@ import WizardStepHeading from '@common/modules/table-tool/components/WizardStepH
 import { Subject, TableHighlight } from '@common/services/tableBuilderService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import React, { ReactNode } from 'react';
+import WizardStepEditButton from './WizardStepEditButton';
 
 const subjectTabsId = 'subjectTabs';
 const subjectTabIds = {
@@ -36,12 +37,16 @@ const SubjectStep = ({
   onSubmit,
   ...stepProps
 }: Props & InjectedWizardProps) => {
-  const { isActive } = stepProps;
+  const { isActive, currentStep, stepNumber } = stepProps;
 
   const hasHighlights = renderHighlightLink && highlights.length > 0;
-
-  const heading = (
-    <WizardStepHeading {...stepProps} fieldsetHeading={!hasHighlights}>
+  const stepEnabled = currentStep > stepNumber;
+  const stepHeading = (
+    <WizardStepHeading
+      {...stepProps}
+      fieldsetHeading={!hasHighlights}
+      stepEnabled={stepEnabled}
+    >
       {hasHighlights
         ? 'View a featured table or create your own'
         : 'Choose a subject'}
@@ -62,7 +67,7 @@ const SubjectStep = ({
           hasHighlights ? (
             <h3 className="govuk-fieldset__heading">Choose a subject</h3>
           ) : (
-            heading
+            stepHeading
           )
         }
         legendHint="Choose a subject to create your table from, more information on the data coverage can be found by viewing more details"
@@ -71,7 +76,7 @@ const SubjectStep = ({
 
     return hasHighlights ? (
       <>
-        {heading}
+        {stepHeading}
 
         <Tabs id={subjectTabsId}>
           <TabsSection
@@ -121,13 +126,19 @@ const SubjectStep = ({
     subjects.find(({ id }) => subjectId === id)?.name ?? 'None';
 
   return (
-    <>
-      {heading}
-
-      <SummaryList noBorder>
-        <SummaryListItem term="Subject">{subjectName}</SummaryListItem>
-      </SummaryList>
-    </>
+    <div className="govuk-grid-row">
+      <div className="govuk-grid-column-two-thirds">
+        {stepHeading}
+        <SummaryList noBorder>
+          <SummaryListItem term="Subject">{subjectName}</SummaryListItem>
+        </SummaryList>
+      </div>
+      <div className="govuk-grid-column-one-third dfe-align--right">
+        {stepEnabled && (
+          <WizardStepEditButton {...stepProps} editTitle="Change subject" />
+        )}
+      </div>
+    </div>
   );
 };
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -30,7 +30,7 @@ import tableBuilderService, {
   TableHighlight,
   Theme,
 } from '@common/services/tableBuilderService';
-import React, { ReactElement, ReactNode, useMemo } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { useImmer } from 'use-immer';
 
 export interface InitialTableToolState {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
@@ -13,6 +13,7 @@ import React, { useMemo } from 'react';
 import { InjectedWizardProps } from './Wizard';
 import WizardStepFormActions from './WizardStepFormActions';
 import WizardStepHeading from './WizardStepHeading';
+import WizardStepEditButton from './WizardStepEditButton';
 
 interface FormValues {
   start: string;
@@ -76,8 +77,9 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
     return matchingOption ? matchingOption.label : '';
   };
 
+  const stepEnabled = currentStep > stepNumber;
   const stepHeading = (
-    <WizardStepHeading {...props} fieldsetHeading>
+    <WizardStepHeading {...props} fieldsetHeading stepEnabled={stepEnabled}>
       Choose time period
     </WizardStepHeading>
   );
@@ -171,23 +173,29 @@ const TimePeriodForm = (props: Props & InjectedWizardProps) => {
             <WizardStepFormActions {...props} />
           </Form>
         ) : (
-          <>
-            {stepHeading}
-
-            <ResetFormOnPreviousStep
-              currentStep={currentStep}
-              stepNumber={stepNumber}
-            />
-
-            <SummaryList noBorder>
-              <SummaryListItem term="Start date">
-                {form.values.start && getOptionLabel(form.values.start)}
-              </SummaryListItem>
-              <SummaryListItem term="End date">
-                {form.values.end && getOptionLabel(form.values.end)}
-              </SummaryListItem>
-            </SummaryList>
-          </>
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+              {stepHeading}
+              <SummaryList noBorder>
+                <SummaryListItem term="Time period">
+                  {form.values.start &&
+                    form.values.end &&
+                    `${getOptionLabel(form.values.start)} to ${getOptionLabel(
+                      form.values.end,
+                    )}`}
+                </SummaryListItem>
+              </SummaryList>
+            </div>
+            <div className="govuk-grid-column-one-third dfe-align--right">
+              {stepEnabled && (
+                <WizardStepEditButton {...props} editTitle="Edit time period" />
+              )}
+              <ResetFormOnPreviousStep
+                currentStep={currentStep}
+                stepNumber={stepNumber}
+              />
+            </div>
+          </div>
         );
       }}
     </Formik>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/Wizard.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/Wizard.module.scss
@@ -1,6 +1,8 @@
 @import '~govuk-frontend/govuk/base';
 
 .stepNav {
+  display: flex;
+  flex-direction: column;
   list-style: none;
   padding-left: 0;
   @include govuk-media-query($until: tablet) {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.module.scss
@@ -1,45 +1,23 @@
 @import '~govuk-frontend/govuk/base';
 
-$circle-size: 40px;
-$circle-border-size: 4px;
-$step-padding-top: govuk-spacing(6);
-$step-padding-top-mobile: govuk-spacing(7);
-
 .step {
   align-items: flex-start;
   display: flex;
-  padding-left: govuk-spacing(8);
   position: relative;
-  @include govuk-media-query($until: tablet) {
-    padding-left: govuk-spacing(4);
-  }
 
   &.stepHidden {
     display: none;
   }
 
-  &::before {
-    border-left: $circle-border-size solid $govuk-border-colour;
-    content: '';
-    height: 100%;
-    left: ($circle-size / 2) - ($circle-border-size / 2);
-    position: absolute;
-    top: $circle-size - (2 * $circle-border-size);
-    z-index: 2;
-  }
-
-  &:last-child::after {
-    border-bottom: $circle-border-size solid $govuk-border-colour;
-    bottom: -($circle-size - (2 * $circle-border-size));
-    content: '';
-    left: 0;
-    position: absolute;
-    width: $circle-size;
-    z-index: 3;
-  }
-
   &:focus {
     outline: 0;
+  }
+
+  :global(.govuk-summary-list) {
+    margin-bottom: 0;
+    @include govuk-media-query($from: tablet) {
+      margin-left: govuk-spacing(9) + govuk-spacing(5);
+    }
   }
 }
 
@@ -48,39 +26,28 @@ $step-padding-top-mobile: govuk-spacing(7);
   &:last-child::after {
     border-color: govuk-colour('black');
   }
-
-  .number {
-    border-color: govuk-colour('black');
-  }
-}
-
-.number {
-  align-items: center;
-  background: #fff;
-  border: $circle-border-size solid $govuk-border-colour;
-  border-radius: 50%;
-  display: inline-flex;
-  height: $circle-size;
-  justify-content: center;
-  left: 0;
-  position: absolute;
-  top: $step-padding-top;
-  width: $circle-size;
-  z-index: 3;
-}
-
-.numberInner {
-  font-size: 1rem;
-  font-weight: $govuk-font-weight-bold;
 }
 
 .content {
-  border-top: 2px solid govuk-colour('light-grey');
+  border-bottom: 2px solid govuk-colour('light-grey');
   display: block;
-  padding-left: govuk-spacing(6);
-  padding-top: $step-padding-top;
+  position: relative;
   width: 100%;
+
   @include govuk-media-query($until: tablet) {
-    padding-top: $step-padding-top-mobile;
+    padding-top: govuk-spacing(2);
+  }
+
+  &.contentSmall {
+    max-width: 980px;
+  }
+
+  :global(.govuk-tabs) & {
+    max-width: 100%;
+  }
+
+  .stepActive & {
+    border-bottom: 0;
+    max-width: 100%;
   }
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.tsx
@@ -7,9 +7,15 @@ export interface WizardStepProps {
   children: ((props: InjectedWizardProps) => ReactNode) | ReactNode;
   onBack?: () => void;
   id?: string;
+  size?: 's' | 'l';
 }
 
-const WizardStep = ({ children, id, ...restProps }: WizardStepProps) => {
+const WizardStep = ({
+  children,
+  id,
+  size = 's',
+  ...restProps
+}: WizardStepProps) => {
   // Hide injected props from public API
   const injectedWizardProps = restProps as InjectedWizardProps;
 
@@ -49,11 +55,11 @@ const WizardStep = ({ children, id, ...restProps }: WizardStepProps) => {
       tabIndex={-1}
       hidden={stepNumber > currentStep}
     >
-      <div className={styles.content}>
-        <span className={styles.number} aria-hidden>
-          <span className={styles.numberInner}>{stepNumber}</span>
-        </span>
-
+      <div
+        className={classNames(styles.content, {
+          [styles.contentSmall]: size === 's',
+        })}
+      >
         {typeof children === 'function'
           ? children(injectedWizardProps)
           : children}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepEditButton.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepEditButton.module.scss
@@ -1,0 +1,27 @@
+@import '~govuk-frontend/govuk/base';
+
+.stepButton {
+  @include govuk-typography-common;
+  background: none;
+  border: $govuk-focus-width solid transparent;
+  color: $govuk-link-colour;
+  cursor: text;
+  margin: 0;
+  outline: 0;
+  padding: 0;
+  text-align: left;
+  text-decoration: underline;
+}
+
+.stepButton {
+  cursor: pointer;
+}
+
+.stepButton:hover {
+  color: $govuk-link-hover-colour;
+}
+
+.stepButton:focus {
+  border: $govuk-focus-width solid #000;
+  outline: $govuk-focus-colour solid $govuk-focus-width;
+}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepEditButton.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepEditButton.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { InjectedWizardProps } from './Wizard';
+import styles from './WizardStepEditButton.module.scss';
+
+interface Props {
+  editTitle: string;
+}
+
+const WizardStepEditButton = ({
+  editTitle,
+  stepNumber,
+  setCurrentStep,
+}: Props & InjectedWizardProps) => {
+  return (
+    <div className="govuk-!-margin-top-2">
+      <button
+        type="button"
+        data-testid={`wizardStep-${stepNumber}-goToButton`}
+        onClick={() => setCurrentStep(stepNumber)}
+        className={styles.stepButton}
+      >
+        {editTitle}{' '}
+        <span className="govuk-visually-hidden">{`Step ${stepNumber}`}</span>
+      </button>
+    </div>
+  );
+};
+
+export default WizardStepEditButton;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.module.scss
@@ -1,47 +1,11 @@
 @import '~govuk-frontend/govuk/base';
 
-$circle-size: 40px;
-$circle-border-size: 4px;
-$step-padding-top: govuk-spacing(6);
-
-.stepButton {
-  @include govuk-typography-common;
-
-  background: none;
-  border: 0;
-  cursor: text;
-  font-weight: $govuk-font-weight-bold;
-  margin: 0;
-  outline: 0;
-  padding: 0;
-  text-align: left;
-}
-
-.toggleText {
-  @include govuk-link-common;
-
-  color: $govuk-link-colour;
-  cursor: pointer;
-  display: block;
-  font-size: 1.1rem;
-  font-weight: $govuk-font-weight-regular;
-}
-
 .stepEnabled {
-  .stepButton {
-    cursor: pointer;
-  }
-
-  .stepButton:hover {
-    color: $govuk-link-hover-colour;
-  }
-
-  .stepButton:focus {
-    border: $govuk-focus-width solid #000;
-    outline: $govuk-focus-colour solid $govuk-focus-width;
-  }
-
-  .stepButton:hover .toggleText {
-    text-decoration: underline;
+  @include govuk-media-query($from: tablet) {
+    left: 0;
+    line-height: 1;
+    margin: 0;
+    position: absolute;
+    top: -2px;
   }
 }

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.tsx
@@ -6,55 +6,37 @@ import styles from './WizardStepHeading.module.scss';
 interface Props {
   children: ReactNode;
   fieldsetHeading?: boolean;
-  size?: 'xl' | 'l' | 'm' | 's';
+  stepEnabled?: boolean;
 }
 
 const WizardStepHeading = ({
   children,
-  currentStep,
   fieldsetHeading = false,
   isActive,
-  size = 'l',
   stepNumber,
-  setCurrentStep,
+  stepEnabled,
 }: Props & InjectedWizardProps) => {
-  const stepEnabled = currentStep > stepNumber;
-
   return (
-    <>
-      {isActive ? (
-        <h2
-          className={classNames(`govuk-heading-${size}`, {
-            'govuk-fieldset__heading': fieldsetHeading,
-          })}
-        >
-          <span className="govuk-visually-hidden">{`Step ${stepNumber} (current): `}</span>
-          {children}
-        </h2>
-      ) : (
-        <h2
-          className={classNames(`govuk-heading-${size}`, {
-            [styles.stepEnabled]: stepEnabled,
-          })}
-        >
-          <button
-            data-testid={`wizardStep-${stepNumber}-goToButton`}
-            type="button"
-            onClick={() => setCurrentStep(stepNumber)}
-            className={styles.stepButton}
-          >
-            <span className="govuk-visually-hidden">{`Step ${stepNumber}: `}</span>
-            {children}
-
-            {stepEnabled && (
-              <span className={styles.toggleText} aria-hidden>
-                Go to this step
-              </span>
-            )}
-          </button>
-        </h2>
-      )}
-    </>
+    <h2
+      className={classNames({
+        'govuk-heading-l dfe-flex dfe-align-items--center govuk-!-margin-top-6': isActive,
+        'govuk-fieldset__heading': fieldsetHeading && isActive,
+        [styles.stepEnabled]: stepEnabled && !isActive,
+      })}
+    >
+      <span
+        className={classNames('govuk-tag', {
+          'govuk-tag--turquoise govuk-!-margin-right-2': isActive,
+          'govuk-tag govuk-tag--grey': !isActive,
+        })}
+      >
+        {`Step ${stepNumber} `}
+        {isActive && <span className="govuk-visually-hidden">(current) </span>}
+      </span>
+      <span className={classNames({ 'govuk-visually-hidden': !isActive })}>
+        {children}
+      </span>
+    </h2>
   );
 };
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/SubjectStep.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/SubjectStep.test.tsx
@@ -197,7 +197,7 @@ describe('SubjectStep', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: 'Step 1 (current): Choose a subject',
+        name: 'Step 1 (current) Choose a subject',
       }),
     ).toBeInTheDocument();
   });
@@ -216,7 +216,7 @@ describe('SubjectStep', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: 'Step 1 (current): View a featured table or create your own',
+        name: 'Step 1 (current) View a featured table or create your own',
       }),
     ).toBeInTheDocument();
   });
@@ -285,7 +285,7 @@ describe('SubjectStep', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: 'Step 1: Choose a subject',
+        name: 'Step 1 Choose a subject',
       }),
     ).toBeInTheDocument();
   });
@@ -305,7 +305,7 @@ describe('SubjectStep', () => {
 
     expect(
       screen.getByRole('heading', {
-        name: 'Step 1: View a featured table or create your own',
+        name: 'Step 1 View a featured table or create your own',
       }),
     ).toBeInTheDocument();
   });

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -145,7 +145,7 @@ describe('TableToolWizard', () => {
 
     expect(stepHeadings).toHaveLength(1);
     expect(stepHeadings[0]).toHaveTextContent(
-      'Step 1 (current): Choose a publication',
+      'Step 1 (current) Choose a publication',
     );
 
     expect(screen.getAllByRole('listitem')).toHaveLength(1);
@@ -198,7 +198,7 @@ describe('TableToolWizard', () => {
 
       expect(stepHeadings).toHaveLength(1);
       expect(stepHeadings[0]).toHaveTextContent(
-        'Step 1 (current): Choose a subject',
+        'Step 1 (current) Choose a subject',
       );
     });
   });
@@ -235,12 +235,12 @@ describe('TableToolWizard', () => {
       const stepHeadings = screen.queryAllByRole('heading', { name: /Step/ });
 
       expect(stepHeadings).toHaveLength(5);
-      expect(stepHeadings[0]).toHaveTextContent('Step 1: Choose a publication');
-      expect(stepHeadings[1]).toHaveTextContent('Step 2: Choose a subject');
-      expect(stepHeadings[2]).toHaveTextContent('Step 3: Choose locations');
-      expect(stepHeadings[3]).toHaveTextContent('Step 4: Choose time period');
+      expect(stepHeadings[0]).toHaveTextContent('Step 1 Choose a publication');
+      expect(stepHeadings[1]).toHaveTextContent('Step 2 Choose a subject');
+      expect(stepHeadings[2]).toHaveTextContent('Step 3 Choose locations');
+      expect(stepHeadings[3]).toHaveTextContent('Step 4 Choose time period');
       expect(stepHeadings[4]).toHaveTextContent(
-        'Step 5 (current): Choose your filters',
+        'Step 5 (current) Choose your filters',
       );
 
       // Step 1
@@ -280,16 +280,10 @@ describe('TableToolWizard', () => {
       const step4 = within(screen.getByTestId('wizardStep-4'));
 
       expect(
-        step4.getByText('Start date', { selector: 'dt' }),
+        step4.getByText('Time period', { selector: 'dt' }),
       ).toBeInTheDocument();
       expect(
-        step4.getByText('End date', { selector: 'dt' }),
-      ).toBeInTheDocument();
-      expect(
-        step4.getByText('2013/14', { selector: 'dd' }),
-      ).toBeInTheDocument();
-      expect(
-        step4.getByText('2014/15', { selector: 'dd' }),
+        step4.getByText('2013/14 to 2014/15', { selector: 'dd' }),
       ).toBeInTheDocument();
 
       // Step 5

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -104,13 +104,11 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
   ]);
 
   return (
-    <Page title="Create your own tables online" caption="Table Tool" wide>
+    <Page title="Create your own tables" caption="Table Tool" wide>
       <p>
         Choose the data and area of interest you want to explore and then use
         filters to create your table.
-      </p>
-
-      <p>
+        <br />
         Once you've created your table, you can download the data it contains
         for your own offline analysis.
       </p>
@@ -143,10 +141,10 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
           response,
           selectedPublication: selectedPublicationDetails,
         }) => (
-          <WizardStep>
+          <WizardStep size="l">
             {wizardStepProps => (
               <>
-                <WizardStepHeading {...wizardStepProps}>
+                <WizardStepHeading {...wizardStepProps} isActive>
                   Explore data
                 </WizardStepHeading>
 

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/__snapshots__/TableToolPage.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/__snapshots__/TableToolPage.test.tsx.snap
@@ -14,14 +14,13 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
   </span>
   <h1
     class="govuk-heading-xl"
-    data-testid="page-title Create your own tables online"
+    data-testid="page-title Create your own tables"
   >
-    Create your own tables online
+    Create your own tables
   </h1>
   <p>
     Choose the data and area of interest you want to explore and then use filters to create your table.
-  </p>
-  <p>
+    <br />
     Once you've created your table, you can download the data it contains for your own offline analysis.
   </p>
   <ol
@@ -35,59 +34,70 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
       tabindex="-1"
     >
       <div
-        class="content"
+        class="content contentSmall"
       >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            1
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-1-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 1: 
-            </span>
-            Choose a publication
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
+        <div
+          class="govuk-grid-row"
         >
           <div
-            class="govuk-summary-list__row"
-            data-testid="Publication"
+            class="govuk-grid-column-two-thirds"
           >
-            <dt
-              class="govuk-summary-list__key"
+            <h2
+              class="stepEnabled"
             >
-              Publication
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 1 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose a publication
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
             >
-              Test publication
-            </dd>
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Publication"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Publication
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  Test publication
+                </dd>
+              </div>
+            </dl>
           </div>
-        </dl>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-1-goToButton"
+                type="button"
+              >
+                Change publication
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 1
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </li>
     <li
@@ -98,18 +108,8 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
       tabindex="-1"
     >
       <div
-        class="content"
+        class="content contentSmall"
       >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            2
-          </span>
-        </span>
         <form
           id="publicationSubjectForm"
         >
@@ -128,14 +128,23 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
                   class="govuk-fieldset__legend govuk-fieldset__legend--l"
                 >
                   <h2
-                    class="govuk-heading-l govuk-fieldset__heading"
+                    class="govuk-heading-l dfe-flex dfe-align-items--center govuk-!-margin-top-6 govuk-fieldset__heading"
                   >
                     <span
-                      class="govuk-visually-hidden"
+                      class="govuk-tag govuk-tag--turquoise govuk-!-margin-right-2"
                     >
-                      Step 2 (current): 
+                      Step 2 
+                      <span
+                        class="govuk-visually-hidden"
+                      >
+                        (current) 
+                      </span>
                     </span>
-                    Choose a subject
+                    <span
+                      class=""
+                    >
+                      Choose a subject
+                    </span>
                   </h2>
                 </legend>
                 <span
@@ -293,37 +302,36 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
       tabindex="-1"
     >
       <div
-        class="content"
+        class="content contentSmall"
       >
-        <span
-          aria-hidden="true"
-          class="number"
+        <div
+          class="govuk-grid-row"
         >
-          <span
-            class="numberInner"
+          <div
+            class="govuk-grid-column-two-thirds"
           >
-            3
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-3-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
+            <h2
+              class=""
             >
-              Step 3: 
-            </span>
-            Choose locations
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        />
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 3 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose locations
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            />
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          />
+        </div>
       </div>
     </li>
     <li
@@ -334,64 +342,50 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
       tabindex="-1"
     >
       <div
-        class="content"
+        class="content contentSmall"
       >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            4
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-4-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 4: 
-            </span>
-            Choose time period
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
+        <div
+          class="govuk-grid-row"
         >
           <div
-            class="govuk-summary-list__row"
-            data-testid="Start date"
+            class="govuk-grid-column-two-thirds"
           >
-            <dt
-              class="govuk-summary-list__key"
+            <h2
+              class=""
             >
-              Start date
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            />
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 4 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose time period
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Time period"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Time period
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                />
+              </div>
+            </dl>
           </div>
           <div
-            class="govuk-summary-list__row"
-            data-testid="End date"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              End date
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            />
-          </div>
-        </dl>
+            class="govuk-grid-column-one-third dfe-align--right"
+          />
+        </div>
       </div>
     </li>
     <li
@@ -402,55 +396,54 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
       tabindex="-1"
     >
       <div
-        class="content"
+        class="content contentSmall"
       >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            5
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-5-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 5: 
-            </span>
-            Choose your filters
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
+        <div
+          class="govuk-grid-row"
         >
           <div
-            class="govuk-summary-list__row"
-            data-testid="Indicators"
+            class="govuk-grid-column-two-thirds"
           >
-            <dt
-              class="govuk-summary-list__key"
+            <h2
+              class=""
             >
-              Indicators
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 5 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose your filters
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
             >
-              <ul
-                class="govuk-list listContainer"
-              />
-            </dd>
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Indicators"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Indicators
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  <ul
+                    class="govuk-list listContainer"
+                  />
+                </dd>
+              </div>
+            </dl>
           </div>
-        </dl>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          />
+        </div>
       </div>
     </li>
     <li
@@ -463,32 +456,2328 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
       <div
         class="content"
       >
-        <span
-          aria-hidden="true"
-          class="number"
+        <h2
+          class="govuk-heading-l dfe-flex dfe-align-items--center govuk-!-margin-top-6"
         >
           <span
-            class="numberInner"
+            class="govuk-tag govuk-tag--turquoise govuk-!-margin-right-2"
           >
-            6
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-6-goToButton"
-            type="button"
-          >
+            Step 6 
             <span
               class="govuk-visually-hidden"
             >
-              Step 6: 
+              (current) 
             </span>
+          </span>
+          <span
+            class=""
+          >
             Explore data
-          </button>
+          </span>
         </h2>
+      </div>
+    </li>
+  </ol>
+</main>
+`;
+
+exports[`TableToolPage renders the Table Tool page correctly when Theme metadata is provided, giving the user a choice of Publications 1`] = `
+<main
+  class="govuk-main-wrapper app-main-class"
+  id="main-content"
+  role="main"
+>
+  <span
+    class="govuk-caption-xl"
+    data-testid="page-title-caption"
+  >
+    Table Tool
+  </span>
+  <h1
+    class="govuk-heading-xl"
+    data-testid="page-title Create your own tables"
+  >
+    Create your own tables
+  </h1>
+  <p>
+    Choose the data and area of interest you want to explore and then use filters to create your table.
+    <br />
+    Once you've created your table, you can download the data it contains for your own offline analysis.
+  </p>
+  <ol
+    class="stepNav"
+    id="tableToolWizard"
+  >
+    <li
+      aria-current="step"
+      class="step stepActive"
+      data-testid="wizardStep-1"
+      id="tableToolWizard-step-1"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <form
+          id="publicationForm"
+        >
+          <div
+            class="govuk-form-group"
+          >
+            <fieldset
+              class="govuk-fieldset"
+              id="publicationForm-publicationId"
+            >
+              <legend
+                class="govuk-fieldset__legend govuk-fieldset__legend--l"
+              >
+                <h2
+                  class="govuk-heading-l dfe-flex dfe-align-items--center govuk-!-margin-top-6 govuk-fieldset__heading"
+                >
+                  <span
+                    class="govuk-tag govuk-tag--turquoise govuk-!-margin-right-2"
+                  >
+                    Step 1 
+                    <span
+                      class="govuk-visually-hidden"
+                    >
+                      (current) 
+                    </span>
+                  </span>
+                  <span
+                    class=""
+                  >
+                    Choose a publication
+                  </span>
+                </h2>
+              </legend>
+              
+              <div
+                class="govuk-form-group"
+              >
+                <label
+                  class="govuk-label"
+                  for="publicationForm-publicationIdSearch"
+                >
+                  Search publications
+                </label>
+                <input
+                  class="govuk-input searchInput govuk-input--width-20"
+                  id="publicationForm-publicationIdSearch"
+                  name="publicationSearch"
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                class="govuk-form-group"
+              >
+                <div
+                  aria-live="assertive"
+                >
+                  <details
+                    class="govuk-details details"
+                    role="group"
+                  >
+                    <summary
+                      aria-controls="publicationForm-theme-ee1855ca-d1e1-4f04-a795-cbd61d326a1f"
+                      aria-expanded="false"
+                      class="govuk-details__summary"
+                      role="button"
+                      tabindex="0"
+                    >
+                      <span
+                        class="summaryText govuk-details__summary-text"
+                        data-testid="Expand Details Section Pupils and schools"
+                      >
+                        Pupils and schools
+                      </span>
+                    </summary>
+                    <div
+                      aria-hidden="true"
+                      class="govuk-details__text"
+                      id="publicationForm-theme-ee1855ca-d1e1-4f04-a795-cbd61d326a1f"
+                      style=""
+                    >
+                      <details
+                        class="govuk-details details"
+                        role="group"
+                      >
+                        <summary
+                          aria-controls="publicationForm-topic-c9f0b897-d58a-42b0-9d12-ca874cc7c810"
+                          aria-expanded="false"
+                          class="govuk-details__summary"
+                          role="button"
+                          tabindex="0"
+                        >
+                          <span
+                            class="summaryText govuk-details__summary-text"
+                            data-testid="Expand Details Section Admission appeals"
+                          >
+                            Admission appeals
+                          </span>
+                        </summary>
+                        <div
+                          aria-hidden="true"
+                          class="govuk-details__text"
+                          id="publicationForm-topic-c9f0b897-d58a-42b0-9d12-ca874cc7c810"
+                        >
+                          <div
+                            class="govuk-form-group"
+                          >
+                            <div
+                              class="govuk-form-group"
+                            >
+                              <fieldset
+                                class="govuk-fieldset"
+                                id="publicationForm-publicationId"
+                              >
+                                <legend
+                                  class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden"
+                                >
+                                  Choose option from Admission appeals
+                                </legend>
+                                
+                                <div
+                                  class="govuk-radios govuk-radios--small"
+                                >
+                                  <div
+                                    class="govuk-radios__item"
+                                    data-testid="Radio item for Test publication"
+                                  >
+                                    <input
+                                      class="govuk-radios__input"
+                                      id="publicationForm-publicationId-536154f5-7f82-4dc7-060a-08d9097c1945"
+                                      name="publicationId"
+                                      type="radio"
+                                      value="536154f5-7f82-4dc7-060a-08d9097c1945"
+                                    />
+                                    <label
+                                      class="govuk-label govuk-radios__label"
+                                      for="publicationForm-publicationId-536154f5-7f82-4dc7-060a-08d9097c1945"
+                                    >
+                                      Test publication
+                                    </label>
+                                  </div>
+                                </div>
+                              </fieldset>
+                            </div>
+                          </div>
+                        </div>
+                      </details>
+                    </div>
+                  </details>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+          <div
+            class="govuk-form-group"
+          >
+            <div
+              class="group"
+            >
+              <button
+                aria-disabled="false"
+                class="govuk-button"
+                id="publicationForm-submit"
+                type="submit"
+              >
+                Next step
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </li>
+    <li
+      class="step stepHidden"
+      data-testid="wizardStep-2"
+      hidden=""
+      id="tableToolWizard-step-2"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class=""
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 2 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose a subject
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Subject"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Subject
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  None
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          />
+        </div>
+      </div>
+    </li>
+    <li
+      class="step stepHidden"
+      data-testid="wizardStep-3"
+      hidden=""
+      id="tableToolWizard-step-3"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class=""
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 3 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose locations
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            />
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          />
+        </div>
+      </div>
+    </li>
+    <li
+      class="step stepHidden"
+      data-testid="wizardStep-4"
+      hidden=""
+      id="tableToolWizard-step-4"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class=""
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 4 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose time period
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Time period"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Time period
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                />
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          />
+        </div>
+      </div>
+    </li>
+    <li
+      class="step stepHidden"
+      data-testid="wizardStep-5"
+      hidden=""
+      id="tableToolWizard-step-5"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class=""
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 5 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose your filters
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Indicators"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Indicators
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  <ul
+                    class="govuk-list listContainer"
+                  />
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          />
+        </div>
+      </div>
+    </li>
+    <li
+      class="step stepHidden"
+      data-testid="wizardStep-6"
+      hidden=""
+      id="tableToolWizard-step-6"
+      tabindex="-1"
+    >
+      <div
+        class="content"
+      >
+        <h2
+          class="govuk-heading-l dfe-flex dfe-align-items--center govuk-!-margin-top-6"
+        >
+          <span
+            class="govuk-tag govuk-tag--turquoise govuk-!-margin-right-2"
+          >
+            Step 6 
+            <span
+              class="govuk-visually-hidden"
+            >
+              (current) 
+            </span>
+          </span>
+          <span
+            class=""
+          >
+            Explore data
+          </span>
+        </h2>
+      </div>
+    </li>
+  </ol>
+</main>
+`;
+
+exports[`TableToolPage renders the Table Tool page correctly when a Fast Track is provided and this is not the latest data 1`] = `
+<main
+  class="govuk-main-wrapper app-main-class"
+  id="main-content"
+  role="main"
+>
+  <span
+    class="govuk-caption-xl"
+    data-testid="page-title-caption"
+  >
+    Table Tool
+  </span>
+  <h1
+    class="govuk-heading-xl"
+    data-testid="page-title Create your own tables"
+  >
+    Create your own tables
+  </h1>
+  <p>
+    Choose the data and area of interest you want to explore and then use filters to create your table.
+    <br />
+    Once you've created your table, you can download the data it contains for your own offline analysis.
+  </p>
+  <ol
+    class="stepNav"
+    id="tableToolWizard"
+  >
+    <li
+      class="step"
+      data-testid="wizardStep-1"
+      id="tableToolWizard-step-1"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class="stepEnabled"
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 1 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose a subject
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Subject"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Subject
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  None
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-1-goToButton"
+                type="button"
+              >
+                Change subject
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 1
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li
+      class="step"
+      data-testid="wizardStep-2"
+      id="tableToolWizard-step-2"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class="stepEnabled"
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 2 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose locations
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="National"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  National
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  <ul
+                    class="govuk-list listContainer"
+                  >
+                    <li>
+                      Great Britain
+                    </li>
+                  </ul>
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-2-goToButton"
+                type="button"
+              >
+                Edit locations
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 2
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li
+      class="step"
+      data-testid="wizardStep-3"
+      id="tableToolWizard-step-3"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class="stepEnabled"
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 3 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose time period
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Time period"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Time period
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  2018-19 to 2018-19
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-3-goToButton"
+                type="button"
+              >
+                Edit time period
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 3
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li
+      class="step"
+      data-testid="wizardStep-4"
+      id="tableToolWizard-step-4"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class="stepEnabled"
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 4 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose your filters
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Indicators"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Indicators
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  <ul
+                    class="govuk-list listContainer"
+                  >
+                    <li>
+                      Gender gap
+                    </li>
+                    <li>
+                      Graduates included in earnings figures
+                    </li>
+                  </ul>
+                </dd>
+              </div>
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Subject studied"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Subject studied
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  <ul
+                    class="govuk-list listContainer"
+                  >
+                    <li>
+                      1 .  PGCE
+                    </li>
+                    <li>
+                      10 .  Psychology
+                    </li>
+                  </ul>
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-4-goToButton"
+                type="button"
+              >
+                Edit filters
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 4
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li
+      class="step"
+      data-testid="wizardStep-5"
+      id="tableToolWizard-step-5"
+      tabindex="-1"
+    >
+      <div
+        class="content"
+      >
+        <h2
+          class="govuk-heading-l dfe-flex dfe-align-items--center govuk-!-margin-top-6"
+        >
+          <span
+            class="govuk-tag govuk-tag--turquoise govuk-!-margin-right-2"
+          >
+            Step 5 
+            <span
+              class="govuk-visually-hidden"
+            >
+              (current) 
+            </span>
+          </span>
+          <span
+            class=""
+          >
+            Explore data
+          </span>
+        </h2>
+        <div
+          class="govuk-!-margin-bottom-4"
+          data-testid="Table tool final step container"
+        >
+          <details
+            class="govuk-details"
+            role="group"
+          >
+            <summary
+              aria-controls="details-content-11"
+              aria-expanded="false"
+              class="govuk-details__summary"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="summaryText govuk-details__summary-text"
+                data-testid="Expand Details Section Re-order table headers"
+              >
+                Re-order table headers
+              </span>
+            </summary>
+            <div
+              aria-hidden="true"
+              class="govuk-details__text"
+              id="details-content-11"
+            >
+              <p
+                class="govuk-hint"
+              >
+                Drag and drop the options below to re-order the table headers. For keyboard users, select and deselect a draggable item with space and use the arrow keys to move a selected item.
+              </p>
+              <div
+                class="govuk-visually-hidden"
+              >
+                To move a draggable item, select and deselect the item with space and use the arrow keys to move a selected item. If you are using a screen reader disable scan mode.
+              </div>
+              <form
+                action="#"
+                id="tableHeadersForm"
+              >
+                <div
+                  class="govuk-form-group"
+                >
+                  <div
+                    class="govuk-!-margin-bottom-2"
+                  >
+                    <div
+                      class="groupsFieldset"
+                      data-rbd-droppable-context-id="8"
+                      data-rbd-droppable-id="rowGroups"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <fieldset
+                          class="govuk-fieldset"
+                          id="rowGroups"
+                        >
+                          <legend
+                            class="govuk-fieldset__legend govuk-fieldset__legend--m"
+                          >
+                            Row groups
+                          </legend>
+                          <div
+                            class="listsContainer"
+                          >
+                            <div
+                              aria-describedby="rbd-hidden-text-8-hidden-text-34"
+                              class="list"
+                              data-rbd-drag-handle-context-id="8"
+                              data-rbd-drag-handle-draggable-id="rowGroups-0"
+                              data-rbd-draggable-context-id="8"
+                              data-rbd-draggable-id="rowGroups-0"
+                              draggable="false"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <div
+                                class="govuk-form-group"
+                              >
+                                <fieldset
+                                  class="govuk-fieldset"
+                                  id="rowGroups-0"
+                                >
+                                  <legend
+                                    class="govuk-fieldset__legend govuk-fieldset__legend--s"
+                                  >
+                                    Row group 1
+                                  </legend>
+                                  <div
+                                    class="list"
+                                    data-rbd-droppable-context-id="9"
+                                    data-rbd-droppable-id="rowGroups-0"
+                                  >
+                                    <div
+                                      aria-describedby="rbd-hidden-text-9-hidden-text-37"
+                                      class="optionRow"
+                                      data-rbd-drag-handle-context-id="9"
+                                      data-rbd-drag-handle-draggable-id="72303947-27a4-4ea2-a708-dfeb7bb31efb"
+                                      data-rbd-draggable-context-id="9"
+                                      data-rbd-draggable-id="72303947-27a4-4ea2-a708-dfeb7bb31efb"
+                                      draggable="false"
+                                      role="button"
+                                      tabindex="0"
+                                    >
+                                      <div
+                                        class="optionText"
+                                      >
+                                        <strong>
+                                          1 .  PGCE
+                                        </strong>
+                                        <span>
+                                          ⇅
+                                        </span>
+                                      </div>
+                                    </div>
+                                    <div
+                                      aria-describedby="rbd-hidden-text-9-hidden-text-37"
+                                      class="optionRow"
+                                      data-rbd-drag-handle-context-id="9"
+                                      data-rbd-drag-handle-draggable-id="0164a10e-c041-49f8-b44d-daa6f0c1fbfd"
+                                      data-rbd-draggable-context-id="9"
+                                      data-rbd-draggable-id="0164a10e-c041-49f8-b44d-daa6f0c1fbfd"
+                                      draggable="false"
+                                      role="button"
+                                      tabindex="0"
+                                    >
+                                      <div
+                                        class="optionText"
+                                      >
+                                        <strong>
+                                          2 .  MBA
+                                        </strong>
+                                        <span>
+                                          ⇅
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                              </div>
+                            </div>
+                            <div
+                              aria-describedby="rbd-hidden-text-8-hidden-text-34"
+                              class="list"
+                              data-rbd-drag-handle-context-id="8"
+                              data-rbd-drag-handle-draggable-id="rowGroups-1"
+                              data-rbd-draggable-context-id="8"
+                              data-rbd-draggable-id="rowGroups-1"
+                              draggable="false"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <div
+                                class="govuk-form-group"
+                              >
+                                <fieldset
+                                  class="govuk-fieldset"
+                                  id="rowGroups-1"
+                                >
+                                  <legend
+                                    class="govuk-fieldset__legend govuk-fieldset__legend--s"
+                                  >
+                                    Row group 2
+                                  </legend>
+                                  <div
+                                    class="list"
+                                    data-rbd-droppable-context-id="11"
+                                    data-rbd-droppable-id="rowGroups-1"
+                                  >
+                                    <div
+                                      aria-describedby="rbd-hidden-text-11-hidden-text-46"
+                                      class="optionRow"
+                                      data-rbd-drag-handle-context-id="11"
+                                      data-rbd-drag-handle-draggable-id="e5174cb8-02f6-48d3-662e-08d9097c4255"
+                                      data-rbd-draggable-context-id="11"
+                                      data-rbd-draggable-id="e5174cb8-02f6-48d3-662e-08d9097c4255"
+                                      draggable="false"
+                                      role="button"
+                                      tabindex="0"
+                                    >
+                                      <div
+                                        class="optionText"
+                                      >
+                                        <strong>
+                                          Gender gap
+                                        </strong>
+                                        <span>
+                                          ⇅
+                                        </span>
+                                      </div>
+                                    </div>
+                                    <div
+                                      aria-describedby="rbd-hidden-text-11-hidden-text-46"
+                                      class="optionRow"
+                                      data-rbd-drag-handle-context-id="11"
+                                      data-rbd-drag-handle-draggable-id="0e8f9198-ce65-40ac-662a-08d9097c4255"
+                                      data-rbd-draggable-context-id="11"
+                                      data-rbd-draggable-id="0e8f9198-ce65-40ac-662a-08d9097c4255"
+                                      draggable="false"
+                                      role="button"
+                                      tabindex="0"
+                                    >
+                                      <div
+                                        class="optionText"
+                                      >
+                                        <strong>
+                                          Graduates included in earnings figures
+                                        </strong>
+                                        <span>
+                                          ⇅
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                              </div>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="govuk-!-margin-bottom-2"
+                  >
+                    <div
+                      class="groupsFieldset"
+                      data-rbd-droppable-context-id="8"
+                      data-rbd-droppable-id="columnGroups"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <fieldset
+                          class="govuk-fieldset"
+                          id="columnGroups"
+                        >
+                          <legend
+                            class="govuk-fieldset__legend govuk-fieldset__legend--m"
+                          >
+                            Column groups
+                          </legend>
+                          <div
+                            class="listsContainer"
+                          >
+                            <div
+                              aria-describedby="rbd-hidden-text-8-hidden-text-34"
+                              class="list"
+                              data-rbd-drag-handle-context-id="8"
+                              data-rbd-drag-handle-draggable-id="columnGroups-0"
+                              data-rbd-draggable-context-id="8"
+                              data-rbd-draggable-id="columnGroups-0"
+                              draggable="false"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <div
+                                class="govuk-form-group"
+                              >
+                                <fieldset
+                                  class="govuk-fieldset"
+                                  id="columnGroups-0"
+                                >
+                                  <legend
+                                    class="govuk-fieldset__legend govuk-fieldset__legend--s"
+                                  >
+                                    Column group 1
+                                  </legend>
+                                  <div
+                                    class="list"
+                                    data-rbd-droppable-context-id="10"
+                                    data-rbd-droppable-id="columnGroups-0"
+                                  >
+                                    <div
+                                      aria-describedby="rbd-hidden-text-10-hidden-text-41"
+                                      class="optionRow"
+                                      data-rbd-drag-handle-context-id="10"
+                                      data-rbd-drag-handle-draggable-id="2018_TY"
+                                      data-rbd-draggable-context-id="10"
+                                      data-rbd-draggable-id="2018_TY"
+                                      draggable="false"
+                                      role="button"
+                                      tabindex="0"
+                                    >
+                                      <div
+                                        class="optionText"
+                                      >
+                                        <strong>
+                                          2018-19
+                                        </strong>
+                                        <span>
+                                          ⇅
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                              </div>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <button
+                  aria-disabled="false"
+                  class="govuk-button"
+                  type="submit"
+                >
+                  Re-order table
+                </button>
+              </form>
+            </div>
+          </details>
+          <div
+            class="govuk-!-margin-bottom-3"
+          >
+            <div
+              class="govuk-!-margin-bottom-3"
+            >
+              <strong
+                class="govuk-tag govuk-tag--orange"
+              >
+                This data is not from the latest release
+              </strong>
+            </div>
+            <a
+              class="govuk-link govuk-link--no-visited-state dfe-print-hidden"
+              data-testid="View latest data link"
+              href="/find-statistics/test-publication"
+            >
+              View latest data:
+               
+              <span
+                class="govuk-!-font-weight-bold"
+              >
+                Latest Release Title
+              </span>
+            </a>
+          </div>
+          <figure
+            class="figure"
+          >
+            <figcaption>
+              <strong
+                data-testid="dataTableCaption"
+                id="dataTableCaption"
+              >
+                Table showing 'data 1' for 1 .  PGCE and 2 .  MBA in Great Britain for 2018-19
+              </strong>
+            </figcaption>
+            <div
+              class="container"
+              role="region"
+              tabindex="0"
+            >
+              <table
+                aria-labelledby="dataTableCaption"
+                class="govuk-table table"
+                data-testid="dataTableCaption-table"
+              >
+                <thead
+                  class="tableHead"
+                >
+                  <tr>
+                    <td
+                      class="borderBottom"
+                      colspan="2"
+                      rowspan="1"
+                    />
+                    <th
+                      colspan="1"
+                      rowspan="1"
+                      scope="col"
+                    >
+                      2018-19
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th
+                      class="borderBottom"
+                      colspan="1"
+                      rowspan="2"
+                      scope="rowgroup"
+                    >
+                      1 .  PGCE
+                    </th>
+                    <th
+                      class=""
+                      colspan="1"
+                      rowspan="1"
+                      scope="row"
+                    >
+                      Gender gap
+                    </th>
+                    <td
+                      class="govuk-table__cell--numeric"
+                    >
+                      20.00%
+                    </td>
+                  </tr>
+                  <tr>
+                    <th
+                      class=""
+                      colspan="1"
+                      rowspan="1"
+                      scope="row"
+                    >
+                      Graduates included in earnings figures
+                    </th>
+                    <td
+                      class="govuk-table__cell--numeric borderBottom"
+                    >
+                      2
+                    </td>
+                  </tr>
+                  <tr>
+                    <th
+                      class="borderBottom"
+                      colspan="1"
+                      rowspan="2"
+                      scope="rowgroup"
+                    >
+                      2 .  MBA
+                    </th>
+                    <th
+                      class=""
+                      colspan="1"
+                      rowspan="1"
+                      scope="row"
+                    >
+                      Gender gap
+                    </th>
+                    <td
+                      class="govuk-table__cell--numeric"
+                    >
+                      60.00%
+                    </td>
+                  </tr>
+                  <tr>
+                    <th
+                      class=""
+                      colspan="1"
+                      rowspan="1"
+                      scope="row"
+                    >
+                      Graduates included in earnings figures
+                    </th>
+                    <td
+                      class="govuk-table__cell--numeric borderBottom"
+                    >
+                      2
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </figure>
+          <div
+            class="govuk-grid-row"
+          >
+            <div
+              class="govuk-grid-column-one-half"
+            >
+              <details
+                class="govuk-details"
+                role="group"
+              >
+                <summary
+                  aria-controls="details-content-12"
+                  aria-expanded="false"
+                  class="govuk-details__summary"
+                  role="button"
+                  tabindex="0"
+                >
+                  <span
+                    class="summaryText govuk-details__summary-text"
+                    data-testid="Expand Details Section Additional options"
+                  >
+                    Additional options
+                  </span>
+                </summary>
+                <div
+                  aria-hidden="true"
+                  class="govuk-details__text"
+                  id="details-content-12"
+                >
+                  <ul
+                    class="govuk-list"
+                  >
+                    <li>
+                      <a
+                        class="govuk-link"
+                        href="/find-statistics/test-publication/selected-release-slug"
+                      >
+                        View the release for this data
+                      </a>
+                    </li>
+                    <li>
+                      <button
+                        class="button"
+                        type="button"
+                      >
+                        Download the data of this table (CSV)
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        class="button"
+                        type="button"
+                      >
+                        Download table as Excel spreadsheet (XLSX)
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+              </details>
+            </div>
+            <div
+              class="govuk-grid-column-one-half dfe-align--right"
+            >
+              <button
+                class="button"
+                type="button"
+              >
+                Share your table
+              </button>
+            </div>
+          </div>
+          <div
+            class="govuk-inset-text"
+          >
+            <p>
+              If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
+            </p>
+          </div>
+        </div>
+      </div>
+    </li>
+  </ol>
+</main>
+`;
+
+exports[`TableToolPage renders the Table Tool page correctly when a Fast Track is provided and this is the latest data 1`] = `
+<main
+  class="govuk-main-wrapper app-main-class"
+  id="main-content"
+  role="main"
+>
+  <span
+    class="govuk-caption-xl"
+    data-testid="page-title-caption"
+  >
+    Table Tool
+  </span>
+  <h1
+    class="govuk-heading-xl"
+    data-testid="page-title Create your own tables"
+  >
+    Create your own tables
+  </h1>
+  <p>
+    Choose the data and area of interest you want to explore and then use filters to create your table.
+    <br />
+    Once you've created your table, you can download the data it contains for your own offline analysis.
+  </p>
+  <ol
+    class="stepNav"
+    id="tableToolWizard"
+  >
+    <li
+      class="step"
+      data-testid="wizardStep-1"
+      id="tableToolWizard-step-1"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class="stepEnabled"
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 1 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose a subject
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Subject"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Subject
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  None
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-1-goToButton"
+                type="button"
+              >
+                Change subject
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 1
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li
+      class="step"
+      data-testid="wizardStep-2"
+      id="tableToolWizard-step-2"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class="stepEnabled"
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 2 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose locations
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="National"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  National
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  <ul
+                    class="govuk-list listContainer"
+                  >
+                    <li>
+                      Great Britain
+                    </li>
+                  </ul>
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-2-goToButton"
+                type="button"
+              >
+                Edit locations
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 2
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li
+      class="step"
+      data-testid="wizardStep-3"
+      id="tableToolWizard-step-3"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class="stepEnabled"
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 3 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose time period
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Time period"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Time period
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  2018-19 to 2018-19
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-3-goToButton"
+                type="button"
+              >
+                Edit time period
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 3
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li
+      class="step"
+      data-testid="wizardStep-4"
+      id="tableToolWizard-step-4"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class="stepEnabled"
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 4 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose your filters
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Indicators"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Indicators
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  <ul
+                    class="govuk-list listContainer"
+                  >
+                    <li>
+                      Gender gap
+                    </li>
+                    <li>
+                      Graduates included in earnings figures
+                    </li>
+                  </ul>
+                </dd>
+              </div>
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Subject studied"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Subject studied
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  <ul
+                    class="govuk-list listContainer"
+                  >
+                    <li>
+                      1 .  PGCE
+                    </li>
+                    <li>
+                      10 .  Psychology
+                    </li>
+                  </ul>
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-4-goToButton"
+                type="button"
+              >
+                Edit filters
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 4
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li
+      class="step"
+      data-testid="wizardStep-5"
+      id="tableToolWizard-step-5"
+      tabindex="-1"
+    >
+      <div
+        class="content"
+      >
+        <h2
+          class="govuk-heading-l dfe-flex dfe-align-items--center govuk-!-margin-top-6"
+        >
+          <span
+            class="govuk-tag govuk-tag--turquoise govuk-!-margin-right-2"
+          >
+            Step 5 
+            <span
+              class="govuk-visually-hidden"
+            >
+              (current) 
+            </span>
+          </span>
+          <span
+            class=""
+          >
+            Explore data
+          </span>
+        </h2>
+        <div
+          class="govuk-!-margin-bottom-4"
+          data-testid="Table tool final step container"
+        >
+          <details
+            class="govuk-details"
+            role="group"
+          >
+            <summary
+              aria-controls="details-content-7"
+              aria-expanded="false"
+              class="govuk-details__summary"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="summaryText govuk-details__summary-text"
+                data-testid="Expand Details Section Re-order table headers"
+              >
+                Re-order table headers
+              </span>
+            </summary>
+            <div
+              aria-hidden="true"
+              class="govuk-details__text"
+              id="details-content-7"
+            >
+              <p
+                class="govuk-hint"
+              >
+                Drag and drop the options below to re-order the table headers. For keyboard users, select and deselect a draggable item with space and use the arrow keys to move a selected item.
+              </p>
+              <div
+                class="govuk-visually-hidden"
+              >
+                To move a draggable item, select and deselect the item with space and use the arrow keys to move a selected item. If you are using a screen reader disable scan mode.
+              </div>
+              <form
+                action="#"
+                id="tableHeadersForm"
+              >
+                <div
+                  class="govuk-form-group"
+                >
+                  <div
+                    class="govuk-!-margin-bottom-2"
+                  >
+                    <div
+                      class="groupsFieldset"
+                      data-rbd-droppable-context-id="4"
+                      data-rbd-droppable-id="rowGroups"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <fieldset
+                          class="govuk-fieldset"
+                          id="rowGroups"
+                        >
+                          <legend
+                            class="govuk-fieldset__legend govuk-fieldset__legend--m"
+                          >
+                            Row groups
+                          </legend>
+                          <div
+                            class="listsContainer"
+                          >
+                            <div
+                              aria-describedby="rbd-hidden-text-4-hidden-text-17"
+                              class="list"
+                              data-rbd-drag-handle-context-id="4"
+                              data-rbd-drag-handle-draggable-id="rowGroups-0"
+                              data-rbd-draggable-context-id="4"
+                              data-rbd-draggable-id="rowGroups-0"
+                              draggable="false"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <div
+                                class="govuk-form-group"
+                              >
+                                <fieldset
+                                  class="govuk-fieldset"
+                                  id="rowGroups-0"
+                                >
+                                  <legend
+                                    class="govuk-fieldset__legend govuk-fieldset__legend--s"
+                                  >
+                                    Row group 1
+                                  </legend>
+                                  <div
+                                    class="list"
+                                    data-rbd-droppable-context-id="5"
+                                    data-rbd-droppable-id="rowGroups-0"
+                                  >
+                                    <div
+                                      aria-describedby="rbd-hidden-text-5-hidden-text-20"
+                                      class="optionRow"
+                                      data-rbd-drag-handle-context-id="5"
+                                      data-rbd-drag-handle-draggable-id="72303947-27a4-4ea2-a708-dfeb7bb31efb"
+                                      data-rbd-draggable-context-id="5"
+                                      data-rbd-draggable-id="72303947-27a4-4ea2-a708-dfeb7bb31efb"
+                                      draggable="false"
+                                      role="button"
+                                      tabindex="0"
+                                    >
+                                      <div
+                                        class="optionText"
+                                      >
+                                        <strong>
+                                          1 .  PGCE
+                                        </strong>
+                                        <span>
+                                          ⇅
+                                        </span>
+                                      </div>
+                                    </div>
+                                    <div
+                                      aria-describedby="rbd-hidden-text-5-hidden-text-20"
+                                      class="optionRow"
+                                      data-rbd-drag-handle-context-id="5"
+                                      data-rbd-drag-handle-draggable-id="0164a10e-c041-49f8-b44d-daa6f0c1fbfd"
+                                      data-rbd-draggable-context-id="5"
+                                      data-rbd-draggable-id="0164a10e-c041-49f8-b44d-daa6f0c1fbfd"
+                                      draggable="false"
+                                      role="button"
+                                      tabindex="0"
+                                    >
+                                      <div
+                                        class="optionText"
+                                      >
+                                        <strong>
+                                          2 .  MBA
+                                        </strong>
+                                        <span>
+                                          ⇅
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                              </div>
+                            </div>
+                            <div
+                              aria-describedby="rbd-hidden-text-4-hidden-text-17"
+                              class="list"
+                              data-rbd-drag-handle-context-id="4"
+                              data-rbd-drag-handle-draggable-id="rowGroups-1"
+                              data-rbd-draggable-context-id="4"
+                              data-rbd-draggable-id="rowGroups-1"
+                              draggable="false"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <div
+                                class="govuk-form-group"
+                              >
+                                <fieldset
+                                  class="govuk-fieldset"
+                                  id="rowGroups-1"
+                                >
+                                  <legend
+                                    class="govuk-fieldset__legend govuk-fieldset__legend--s"
+                                  >
+                                    Row group 2
+                                  </legend>
+                                  <div
+                                    class="list"
+                                    data-rbd-droppable-context-id="7"
+                                    data-rbd-droppable-id="rowGroups-1"
+                                  >
+                                    <div
+                                      aria-describedby="rbd-hidden-text-7-hidden-text-29"
+                                      class="optionRow"
+                                      data-rbd-drag-handle-context-id="7"
+                                      data-rbd-drag-handle-draggable-id="e5174cb8-02f6-48d3-662e-08d9097c4255"
+                                      data-rbd-draggable-context-id="7"
+                                      data-rbd-draggable-id="e5174cb8-02f6-48d3-662e-08d9097c4255"
+                                      draggable="false"
+                                      role="button"
+                                      tabindex="0"
+                                    >
+                                      <div
+                                        class="optionText"
+                                      >
+                                        <strong>
+                                          Gender gap
+                                        </strong>
+                                        <span>
+                                          ⇅
+                                        </span>
+                                      </div>
+                                    </div>
+                                    <div
+                                      aria-describedby="rbd-hidden-text-7-hidden-text-29"
+                                      class="optionRow"
+                                      data-rbd-drag-handle-context-id="7"
+                                      data-rbd-drag-handle-draggable-id="0e8f9198-ce65-40ac-662a-08d9097c4255"
+                                      data-rbd-draggable-context-id="7"
+                                      data-rbd-draggable-id="0e8f9198-ce65-40ac-662a-08d9097c4255"
+                                      draggable="false"
+                                      role="button"
+                                      tabindex="0"
+                                    >
+                                      <div
+                                        class="optionText"
+                                      >
+                                        <strong>
+                                          Graduates included in earnings figures
+                                        </strong>
+                                        <span>
+                                          ⇅
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                              </div>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="govuk-!-margin-bottom-2"
+                  >
+                    <div
+                      class="groupsFieldset"
+                      data-rbd-droppable-context-id="4"
+                      data-rbd-droppable-id="columnGroups"
+                    >
+                      <div
+                        class="govuk-form-group"
+                      >
+                        <fieldset
+                          class="govuk-fieldset"
+                          id="columnGroups"
+                        >
+                          <legend
+                            class="govuk-fieldset__legend govuk-fieldset__legend--m"
+                          >
+                            Column groups
+                          </legend>
+                          <div
+                            class="listsContainer"
+                          >
+                            <div
+                              aria-describedby="rbd-hidden-text-4-hidden-text-17"
+                              class="list"
+                              data-rbd-drag-handle-context-id="4"
+                              data-rbd-drag-handle-draggable-id="columnGroups-0"
+                              data-rbd-draggable-context-id="4"
+                              data-rbd-draggable-id="columnGroups-0"
+                              draggable="false"
+                              role="button"
+                              tabindex="0"
+                            >
+                              <div
+                                class="govuk-form-group"
+                              >
+                                <fieldset
+                                  class="govuk-fieldset"
+                                  id="columnGroups-0"
+                                >
+                                  <legend
+                                    class="govuk-fieldset__legend govuk-fieldset__legend--s"
+                                  >
+                                    Column group 1
+                                  </legend>
+                                  <div
+                                    class="list"
+                                    data-rbd-droppable-context-id="6"
+                                    data-rbd-droppable-id="columnGroups-0"
+                                  >
+                                    <div
+                                      aria-describedby="rbd-hidden-text-6-hidden-text-24"
+                                      class="optionRow"
+                                      data-rbd-drag-handle-context-id="6"
+                                      data-rbd-drag-handle-draggable-id="2018_TY"
+                                      data-rbd-draggable-context-id="6"
+                                      data-rbd-draggable-id="2018_TY"
+                                      draggable="false"
+                                      role="button"
+                                      tabindex="0"
+                                    >
+                                      <div
+                                        class="optionText"
+                                      >
+                                        <strong>
+                                          2018-19
+                                        </strong>
+                                        <span>
+                                          ⇅
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </div>
+                                </fieldset>
+                              </div>
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <button
+                  aria-disabled="false"
+                  class="govuk-button"
+                  type="submit"
+                >
+                  Re-order table
+                </button>
+              </form>
+            </div>
+          </details>
+          <div
+            class="govuk-!-margin-bottom-3"
+          >
+            <strong
+              class="govuk-tag"
+            >
+              This is the latest data
+            </strong>
+          </div>
+          <figure
+            class="figure"
+          >
+            <figcaption>
+              <strong
+                data-testid="dataTableCaption"
+                id="dataTableCaption"
+              >
+                Table showing 'data 1' for 1 .  PGCE and 2 .  MBA in Great Britain for 2018-19
+              </strong>
+            </figcaption>
+            <div
+              class="container"
+              role="region"
+              tabindex="0"
+            >
+              <table
+                aria-labelledby="dataTableCaption"
+                class="govuk-table table"
+                data-testid="dataTableCaption-table"
+              >
+                <thead
+                  class="tableHead"
+                >
+                  <tr>
+                    <td
+                      class="borderBottom"
+                      colspan="2"
+                      rowspan="1"
+                    />
+                    <th
+                      colspan="1"
+                      rowspan="1"
+                      scope="col"
+                    >
+                      2018-19
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th
+                      class="borderBottom"
+                      colspan="1"
+                      rowspan="2"
+                      scope="rowgroup"
+                    >
+                      1 .  PGCE
+                    </th>
+                    <th
+                      class=""
+                      colspan="1"
+                      rowspan="1"
+                      scope="row"
+                    >
+                      Gender gap
+                    </th>
+                    <td
+                      class="govuk-table__cell--numeric"
+                    >
+                      20.00%
+                    </td>
+                  </tr>
+                  <tr>
+                    <th
+                      class=""
+                      colspan="1"
+                      rowspan="1"
+                      scope="row"
+                    >
+                      Graduates included in earnings figures
+                    </th>
+                    <td
+                      class="govuk-table__cell--numeric borderBottom"
+                    >
+                      2
+                    </td>
+                  </tr>
+                  <tr>
+                    <th
+                      class="borderBottom"
+                      colspan="1"
+                      rowspan="2"
+                      scope="rowgroup"
+                    >
+                      2 .  MBA
+                    </th>
+                    <th
+                      class=""
+                      colspan="1"
+                      rowspan="1"
+                      scope="row"
+                    >
+                      Gender gap
+                    </th>
+                    <td
+                      class="govuk-table__cell--numeric"
+                    >
+                      60.00%
+                    </td>
+                  </tr>
+                  <tr>
+                    <th
+                      class=""
+                      colspan="1"
+                      rowspan="1"
+                      scope="row"
+                    >
+                      Graduates included in earnings figures
+                    </th>
+                    <td
+                      class="govuk-table__cell--numeric borderBottom"
+                    >
+                      2
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </figure>
+          <div
+            class="govuk-grid-row"
+          >
+            <div
+              class="govuk-grid-column-one-half"
+            >
+              <details
+                class="govuk-details"
+                role="group"
+              >
+                <summary
+                  aria-controls="details-content-8"
+                  aria-expanded="false"
+                  class="govuk-details__summary"
+                  role="button"
+                  tabindex="0"
+                >
+                  <span
+                    class="summaryText govuk-details__summary-text"
+                    data-testid="Expand Details Section Additional options"
+                  >
+                    Additional options
+                  </span>
+                </summary>
+                <div
+                  aria-hidden="true"
+                  class="govuk-details__text"
+                  id="details-content-8"
+                >
+                  <ul
+                    class="govuk-list"
+                  >
+                    <li>
+                      <a
+                        class="govuk-link"
+                        href="/find-statistics/test-publication"
+                      >
+                        View the release for this data
+                      </a>
+                    </li>
+                    <li>
+                      <button
+                        class="button"
+                        type="button"
+                      >
+                        Download the data of this table (CSV)
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        class="button"
+                        type="button"
+                      >
+                        Download table as Excel spreadsheet (XLSX)
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+              </details>
+            </div>
+            <div
+              class="govuk-grid-column-one-half dfe-align--right"
+            >
+              <button
+                class="button"
+                type="button"
+              >
+                Share your table
+              </button>
+            </div>
+          </div>
+          <div
+            class="govuk-inset-text"
+          >
+            <p>
+              If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
+            </p>
+          </div>
+        </div>
       </div>
     </li>
   </ol>
@@ -509,14 +2798,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
   </span>
   <h1
     class="govuk-heading-xl"
-    data-testid="page-title Create your own tables online"
+    data-testid="page-title Create your own tables"
   >
-    Create your own tables online
+    Create your own tables
   </h1>
   <p>
     Choose the data and area of interest you want to explore and then use filters to create your table.
-  </p>
-  <p>
+    <br />
     Once you've created your table, you can download the data it contains for your own offline analysis.
   </p>
   <ol
@@ -530,59 +2818,70 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
       tabindex="-1"
     >
       <div
-        class="content"
+        class="content contentSmall"
       >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            1
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-1-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 1: 
-            </span>
-            Choose a subject
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
+        <div
+          class="govuk-grid-row"
         >
           <div
-            class="govuk-summary-list__row"
-            data-testid="Subject"
+            class="govuk-grid-column-two-thirds"
           >
-            <dt
-              class="govuk-summary-list__key"
+            <h2
+              class="stepEnabled"
             >
-              Subject
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 1 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose a subject
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
             >
-              None
-            </dd>
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Subject"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Subject
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  None
+                </dd>
+              </div>
+            </dl>
           </div>
-        </dl>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-1-goToButton"
+                type="button"
+              >
+                Change subject
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 1
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </li>
     <li
@@ -592,65 +2891,76 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
       tabindex="-1"
     >
       <div
-        class="content"
+        class="content contentSmall"
       >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            2
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-2-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 2: 
-            </span>
-            Choose locations
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
+        <div
+          class="govuk-grid-row"
         >
           <div
-            class="govuk-summary-list__row"
-            data-testid="National"
+            class="govuk-grid-column-two-thirds"
           >
-            <dt
-              class="govuk-summary-list__key"
+            <h2
+              class="stepEnabled"
             >
-              National
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              <ul
-                class="govuk-list listContainer"
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
               >
-                <li>
-                  Great Britain
-                </li>
-              </ul>
-            </dd>
+                Step 2 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose locations
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="National"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  National
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  <ul
+                    class="govuk-list listContainer"
+                  >
+                    <li>
+                      Great Britain
+                    </li>
+                  </ul>
+                </dd>
+              </div>
+            </dl>
           </div>
-        </dl>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-2-goToButton"
+                type="button"
+              >
+                Edit locations
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 2
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </li>
     <li
@@ -660,74 +2970,70 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
       tabindex="-1"
     >
       <div
-        class="content"
+        class="content contentSmall"
       >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            3
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-3-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 3: 
-            </span>
-            Choose time period
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
+        <div
+          class="govuk-grid-row"
         >
           <div
-            class="govuk-summary-list__row"
-            data-testid="Start date"
+            class="govuk-grid-column-two-thirds"
           >
-            <dt
-              class="govuk-summary-list__key"
+            <h2
+              class="stepEnabled"
             >
-              Start date
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 3 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose time period
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
             >
-              2018-19
-            </dd>
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Time period"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Time period
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  2018-19 to 2018-19
+                </dd>
+              </div>
+            </dl>
           </div>
           <div
-            class="govuk-summary-list__row"
-            data-testid="End date"
+            class="govuk-grid-column-one-third dfe-align--right"
           >
-            <dt
-              class="govuk-summary-list__key"
+            <div
+              class="govuk-!-margin-top-2"
             >
-              End date
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              2018-19
-            </dd>
+              <button
+                class="stepButton"
+                data-testid="wizardStep-3-goToButton"
+                type="button"
+              >
+                Edit time period
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 3
+                </span>
+              </button>
+            </div>
           </div>
-        </dl>
+        </div>
       </div>
     </li>
     <li
@@ -737,92 +3043,103 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
       tabindex="-1"
     >
       <div
-        class="content"
+        class="content contentSmall"
       >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            4
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-4-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 4: 
-            </span>
-            Choose your filters
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
+        <div
+          class="govuk-grid-row"
         >
           <div
-            class="govuk-summary-list__row"
-            data-testid="Indicators"
+            class="govuk-grid-column-two-thirds"
           >
-            <dt
-              class="govuk-summary-list__key"
+            <h2
+              class="stepEnabled"
             >
-              Indicators
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              <ul
-                class="govuk-list listContainer"
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
               >
-                <li>
-                  Gender gap
-                </li>
-                <li>
-                  Graduates included in earnings figures
-                </li>
-              </ul>
-            </dd>
+                Step 4 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose your filters
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Indicators"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Indicators
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  <ul
+                    class="govuk-list listContainer"
+                  >
+                    <li>
+                      Gender gap
+                    </li>
+                    <li>
+                      Graduates included in earnings figures
+                    </li>
+                  </ul>
+                </dd>
+              </div>
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Subject studied"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Subject studied
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  <ul
+                    class="govuk-list listContainer"
+                  >
+                    <li>
+                      1 .  PGCE
+                    </li>
+                    <li>
+                      10 .  Psychology
+                    </li>
+                  </ul>
+                </dd>
+              </div>
+            </dl>
           </div>
           <div
-            class="govuk-summary-list__row"
-            data-testid="Subject studied"
+            class="govuk-grid-column-one-third dfe-align--right"
           >
-            <dt
-              class="govuk-summary-list__key"
+            <div
+              class="govuk-!-margin-top-2"
             >
-              Subject studied
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              <ul
-                class="govuk-list listContainer"
+              <button
+                class="stepButton"
+                data-testid="wizardStep-4-goToButton"
+                type="button"
               >
-                <li>
-                  1 .  PGCE
-                </li>
-                <li>
-                  10 .  Psychology
-                </li>
-              </ul>
-            </dd>
+                Edit filters
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 4
+                </span>
+              </button>
+            </div>
           </div>
-        </dl>
+        </div>
       </div>
     </li>
     <li
@@ -834,37 +3151,24 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
       <div
         class="content"
       >
-        <span
-          aria-hidden="true"
-          class="number"
+        <h2
+          class="govuk-heading-l dfe-flex dfe-align-items--center govuk-!-margin-top-6"
         >
           <span
-            class="numberInner"
+            class="govuk-tag govuk-tag--turquoise govuk-!-margin-right-2"
           >
-            5
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-5-goToButton"
-            type="button"
-          >
+            Step 5 
             <span
               class="govuk-visually-hidden"
             >
-              Step 5: 
+              (current) 
             </span>
+          </span>
+          <span
+            class=""
+          >
             Explore data
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
+          </span>
         </h2>
         <div
           class="govuk-!-margin-bottom-4"
@@ -1312,2302 +3616,84 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               </table>
             </div>
           </figure>
-          <h3>
-            Share your table
-          </h3>
-          <ul
-            class="govuk-list"
-          >
-            <li>
-              <button
-                class="button"
-                type="button"
-              >
-                Generate permanent link
-              </button>
-            </li>
-          </ul>
-          <h3>
-            Additional options
-          </h3>
-          <ul
-            class="govuk-list"
-          >
-            <li>
-              <a
-                class="govuk-link"
-                href="/find-statistics/test-publication"
-              >
-                View the release for this data
-              </a>
-            </li>
-            <li>
-              <button
-                class="button"
-                type="button"
-              >
-                Download the data of this table (CSV)
-              </button>
-            </li>
-            <li>
-              <button
-                class="button"
-                type="button"
-              >
-                Download table as Excel spreadsheet (XLSX)
-              </button>
-            </li>
-          </ul>
-          <p
-            class="govuk-body"
-          >
-            If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
-          </p>
-        </div>
-      </div>
-    </li>
-  </ol>
-</main>
-`;
-
-exports[`TableToolPage renders the Table Tool page correctly when Theme metadata is provided, giving the user a choice of Publications 1`] = `
-<main
-  class="govuk-main-wrapper app-main-class"
-  id="main-content"
-  role="main"
->
-  <span
-    class="govuk-caption-xl"
-    data-testid="page-title-caption"
-  >
-    Table Tool
-  </span>
-  <h1
-    class="govuk-heading-xl"
-    data-testid="page-title Create your own tables online"
-  >
-    Create your own tables online
-  </h1>
-  <p>
-    Choose the data and area of interest you want to explore and then use filters to create your table.
-  </p>
-  <p>
-    Once you've created your table, you can download the data it contains for your own offline analysis.
-  </p>
-  <ol
-    class="stepNav"
-    id="tableToolWizard"
-  >
-    <li
-      aria-current="step"
-      class="step stepActive"
-      data-testid="wizardStep-1"
-      id="tableToolWizard-step-1"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            1
-          </span>
-        </span>
-        <form
-          id="publicationForm"
-        >
           <div
-            class="govuk-form-group"
+            class="govuk-grid-row"
           >
-            <fieldset
-              class="govuk-fieldset"
-              id="publicationForm-publicationId"
+            <div
+              class="govuk-grid-column-one-half"
             >
-              <legend
-                class="govuk-fieldset__legend govuk-fieldset__legend--l"
+              <details
+                class="govuk-details"
+                role="group"
               >
-                <h2
-                  class="govuk-heading-l govuk-fieldset__heading"
+                <summary
+                  aria-controls="details-content-4"
+                  aria-expanded="false"
+                  class="govuk-details__summary"
+                  role="button"
+                  tabindex="0"
                 >
                   <span
-                    class="govuk-visually-hidden"
+                    class="summaryText govuk-details__summary-text"
+                    data-testid="Expand Details Section Additional options"
                   >
-                    Step 1 (current): 
+                    Additional options
                   </span>
-                  Choose a publication
-                </h2>
-              </legend>
-              
-              <div
-                class="govuk-form-group"
-              >
-                <label
-                  class="govuk-label"
-                  for="publicationForm-publicationIdSearch"
-                >
-                  Search publications
-                </label>
-                <input
-                  class="govuk-input searchInput govuk-input--width-20"
-                  id="publicationForm-publicationIdSearch"
-                  name="publicationSearch"
-                  type="text"
-                  value=""
-                />
-              </div>
-              <div
-                class="govuk-form-group"
-              >
+                </summary>
                 <div
-                  aria-live="assertive"
+                  aria-hidden="true"
+                  class="govuk-details__text"
+                  id="details-content-4"
                 >
-                  <details
-                    class="govuk-details details"
-                    role="group"
+                  <ul
+                    class="govuk-list"
                   >
-                    <summary
-                      aria-controls="publicationForm-theme-ee1855ca-d1e1-4f04-a795-cbd61d326a1f"
-                      aria-expanded="false"
-                      class="govuk-details__summary"
-                      role="button"
-                      tabindex="0"
-                    >
-                      <span
-                        class="summaryText govuk-details__summary-text"
-                        data-testid="Expand Details Section Pupils and schools"
+                    <li>
+                      <a
+                        class="govuk-link"
+                        href="/find-statistics/test-publication"
                       >
-                        Pupils and schools
-                      </span>
-                    </summary>
-                    <div
-                      aria-hidden="true"
-                      class="govuk-details__text"
-                      id="publicationForm-theme-ee1855ca-d1e1-4f04-a795-cbd61d326a1f"
-                      style=""
-                    >
-                      <details
-                        class="govuk-details details"
-                        role="group"
+                        View the release for this data
+                      </a>
+                    </li>
+                    <li>
+                      <button
+                        class="button"
+                        type="button"
                       >
-                        <summary
-                          aria-controls="publicationForm-topic-c9f0b897-d58a-42b0-9d12-ca874cc7c810"
-                          aria-expanded="false"
-                          class="govuk-details__summary"
-                          role="button"
-                          tabindex="0"
-                        >
-                          <span
-                            class="summaryText govuk-details__summary-text"
-                            data-testid="Expand Details Section Admission appeals"
-                          >
-                            Admission appeals
-                          </span>
-                        </summary>
-                        <div
-                          aria-hidden="true"
-                          class="govuk-details__text"
-                          id="publicationForm-topic-c9f0b897-d58a-42b0-9d12-ca874cc7c810"
-                        >
-                          <div
-                            class="govuk-form-group"
-                          >
-                            <div
-                              class="govuk-form-group"
-                            >
-                              <fieldset
-                                class="govuk-fieldset"
-                                id="publicationForm-publicationId"
-                              >
-                                <legend
-                                  class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden"
-                                >
-                                  Choose option from Admission appeals
-                                </legend>
-                                
-                                <div
-                                  class="govuk-radios govuk-radios--small"
-                                >
-                                  <div
-                                    class="govuk-radios__item"
-                                    data-testid="Radio item for Test publication"
-                                  >
-                                    <input
-                                      class="govuk-radios__input"
-                                      id="publicationForm-publicationId-536154f5-7f82-4dc7-060a-08d9097c1945"
-                                      name="publicationId"
-                                      type="radio"
-                                      value="536154f5-7f82-4dc7-060a-08d9097c1945"
-                                    />
-                                    <label
-                                      class="govuk-label govuk-radios__label"
-                                      for="publicationForm-publicationId-536154f5-7f82-4dc7-060a-08d9097c1945"
-                                    >
-                                      Test publication
-                                    </label>
-                                  </div>
-                                </div>
-                              </fieldset>
-                            </div>
-                          </div>
-                        </div>
-                      </details>
-                    </div>
-                  </details>
+                        Download the data of this table (CSV)
+                      </button>
+                    </li>
+                    <li>
+                      <button
+                        class="button"
+                        type="button"
+                      >
+                        Download table as Excel spreadsheet (XLSX)
+                      </button>
+                    </li>
+                  </ul>
                 </div>
-              </div>
-            </fieldset>
-          </div>
-          <div
-            class="govuk-form-group"
-          >
-            <div
-              class="group"
-            >
-              <button
-                aria-disabled="false"
-                class="govuk-button"
-                id="publicationForm-submit"
-                type="submit"
-              >
-                Next step
-              </button>
+              </details>
             </div>
-          </div>
-        </form>
-      </div>
-    </li>
-    <li
-      class="step stepHidden"
-      data-testid="wizardStep-2"
-      hidden=""
-      id="tableToolWizard-step-2"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            2
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-2-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 2: 
-            </span>
-            Choose a subject
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        >
-          <div
-            class="govuk-summary-list__row"
-            data-testid="Subject"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              Subject
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              None
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </li>
-    <li
-      class="step stepHidden"
-      data-testid="wizardStep-3"
-      hidden=""
-      id="tableToolWizard-step-3"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            3
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-3-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 3: 
-            </span>
-            Choose locations
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        />
-      </div>
-    </li>
-    <li
-      class="step stepHidden"
-      data-testid="wizardStep-4"
-      hidden=""
-      id="tableToolWizard-step-4"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            4
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-4-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 4: 
-            </span>
-            Choose time period
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        >
-          <div
-            class="govuk-summary-list__row"
-            data-testid="Start date"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              Start date
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            />
-          </div>
-          <div
-            class="govuk-summary-list__row"
-            data-testid="End date"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              End date
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            />
-          </div>
-        </dl>
-      </div>
-    </li>
-    <li
-      class="step stepHidden"
-      data-testid="wizardStep-5"
-      hidden=""
-      id="tableToolWizard-step-5"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            5
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-5-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 5: 
-            </span>
-            Choose your filters
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        >
-          <div
-            class="govuk-summary-list__row"
-            data-testid="Indicators"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              Indicators
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              <ul
-                class="govuk-list listContainer"
-              />
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </li>
-    <li
-      class="step stepHidden"
-      data-testid="wizardStep-6"
-      hidden=""
-      id="tableToolWizard-step-6"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            6
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-6-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 6: 
-            </span>
-            Explore data
-          </button>
-        </h2>
-      </div>
-    </li>
-  </ol>
-</main>
-`;
-
-exports[`TableToolPage renders the Table Tool page correctly when a Fast Track is provided and this is not the latest data 1`] = `
-<main
-  class="govuk-main-wrapper app-main-class"
-  id="main-content"
-  role="main"
->
-  <span
-    class="govuk-caption-xl"
-    data-testid="page-title-caption"
-  >
-    Table Tool
-  </span>
-  <h1
-    class="govuk-heading-xl"
-    data-testid="page-title Create your own tables online"
-  >
-    Create your own tables online
-  </h1>
-  <p>
-    Choose the data and area of interest you want to explore and then use filters to create your table.
-  </p>
-  <p>
-    Once you've created your table, you can download the data it contains for your own offline analysis.
-  </p>
-  <ol
-    class="stepNav"
-    id="tableToolWizard"
-  >
-    <li
-      class="step"
-      data-testid="wizardStep-1"
-      id="tableToolWizard-step-1"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            1
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-1-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 1: 
-            </span>
-            Choose a subject
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        >
-          <div
-            class="govuk-summary-list__row"
-            data-testid="Subject"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              Subject
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              None
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </li>
-    <li
-      class="step"
-      data-testid="wizardStep-2"
-      id="tableToolWizard-step-2"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            2
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-2-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 2: 
-            </span>
-            Choose locations
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        >
-          <div
-            class="govuk-summary-list__row"
-            data-testid="National"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              National
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              <ul
-                class="govuk-list listContainer"
-              >
-                <li>
-                  Great Britain
-                </li>
-              </ul>
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </li>
-    <li
-      class="step"
-      data-testid="wizardStep-3"
-      id="tableToolWizard-step-3"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            3
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-3-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 3: 
-            </span>
-            Choose time period
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        >
-          <div
-            class="govuk-summary-list__row"
-            data-testid="Start date"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              Start date
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              2018-19
-            </dd>
-          </div>
-          <div
-            class="govuk-summary-list__row"
-            data-testid="End date"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              End date
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              2018-19
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </li>
-    <li
-      class="step"
-      data-testid="wizardStep-4"
-      id="tableToolWizard-step-4"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            4
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-4-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 4: 
-            </span>
-            Choose your filters
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        >
-          <div
-            class="govuk-summary-list__row"
-            data-testid="Indicators"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              Indicators
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              <ul
-                class="govuk-list listContainer"
-              >
-                <li>
-                  Gender gap
-                </li>
-                <li>
-                  Graduates included in earnings figures
-                </li>
-              </ul>
-            </dd>
-          </div>
-          <div
-            class="govuk-summary-list__row"
-            data-testid="Subject studied"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              Subject studied
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              <ul
-                class="govuk-list listContainer"
-              >
-                <li>
-                  1 .  PGCE
-                </li>
-                <li>
-                  10 .  Psychology
-                </li>
-              </ul>
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </li>
-    <li
-      class="step"
-      data-testid="wizardStep-5"
-      id="tableToolWizard-step-5"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            5
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-5-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 5: 
-            </span>
-            Explore data
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <div
-          class="govuk-!-margin-bottom-4"
-          data-testid="Table tool final step container"
-        >
-          <details
-            class="govuk-details"
-            role="group"
-          >
-            <summary
-              aria-controls="details-content-7"
-              aria-expanded="false"
-              class="govuk-details__summary"
-              role="button"
-              tabindex="0"
-            >
-              <span
-                class="summaryText govuk-details__summary-text"
-                data-testid="Expand Details Section Re-order table headers"
-              >
-                Re-order table headers
-              </span>
-            </summary>
             <div
-              aria-hidden="true"
-              class="govuk-details__text"
-              id="details-content-7"
+              class="govuk-grid-column-one-half dfe-align--right"
             >
-              <p
-                class="govuk-hint"
-              >
-                Drag and drop the options below to re-order the table headers. For keyboard users, select and deselect a draggable item with space and use the arrow keys to move a selected item.
-              </p>
-              <div
-                class="govuk-visually-hidden"
-              >
-                To move a draggable item, select and deselect the item with space and use the arrow keys to move a selected item. If you are using a screen reader disable scan mode.
-              </div>
-              <form
-                action="#"
-                id="tableHeadersForm"
-              >
-                <div
-                  class="govuk-form-group"
-                >
-                  <div
-                    class="govuk-!-margin-bottom-2"
-                  >
-                    <div
-                      class="groupsFieldset"
-                      data-rbd-droppable-context-id="8"
-                      data-rbd-droppable-id="rowGroups"
-                    >
-                      <div
-                        class="govuk-form-group"
-                      >
-                        <fieldset
-                          class="govuk-fieldset"
-                          id="rowGroups"
-                        >
-                          <legend
-                            class="govuk-fieldset__legend govuk-fieldset__legend--m"
-                          >
-                            Row groups
-                          </legend>
-                          <div
-                            class="listsContainer"
-                          >
-                            <div
-                              aria-describedby="rbd-hidden-text-8-hidden-text-34"
-                              class="list"
-                              data-rbd-drag-handle-context-id="8"
-                              data-rbd-drag-handle-draggable-id="rowGroups-0"
-                              data-rbd-draggable-context-id="8"
-                              data-rbd-draggable-id="rowGroups-0"
-                              draggable="false"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="govuk-form-group"
-                              >
-                                <fieldset
-                                  class="govuk-fieldset"
-                                  id="rowGroups-0"
-                                >
-                                  <legend
-                                    class="govuk-fieldset__legend govuk-fieldset__legend--s"
-                                  >
-                                    Row group 1
-                                  </legend>
-                                  <div
-                                    class="list"
-                                    data-rbd-droppable-context-id="9"
-                                    data-rbd-droppable-id="rowGroups-0"
-                                  >
-                                    <div
-                                      aria-describedby="rbd-hidden-text-9-hidden-text-37"
-                                      class="optionRow"
-                                      data-rbd-drag-handle-context-id="9"
-                                      data-rbd-drag-handle-draggable-id="72303947-27a4-4ea2-a708-dfeb7bb31efb"
-                                      data-rbd-draggable-context-id="9"
-                                      data-rbd-draggable-id="72303947-27a4-4ea2-a708-dfeb7bb31efb"
-                                      draggable="false"
-                                      role="button"
-                                      tabindex="0"
-                                    >
-                                      <div
-                                        class="optionText"
-                                      >
-                                        <strong>
-                                          1 .  PGCE
-                                        </strong>
-                                        <span>
-                                          ⇅
-                                        </span>
-                                      </div>
-                                    </div>
-                                    <div
-                                      aria-describedby="rbd-hidden-text-9-hidden-text-37"
-                                      class="optionRow"
-                                      data-rbd-drag-handle-context-id="9"
-                                      data-rbd-drag-handle-draggable-id="0164a10e-c041-49f8-b44d-daa6f0c1fbfd"
-                                      data-rbd-draggable-context-id="9"
-                                      data-rbd-draggable-id="0164a10e-c041-49f8-b44d-daa6f0c1fbfd"
-                                      draggable="false"
-                                      role="button"
-                                      tabindex="0"
-                                    >
-                                      <div
-                                        class="optionText"
-                                      >
-                                        <strong>
-                                          2 .  MBA
-                                        </strong>
-                                        <span>
-                                          ⇅
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </fieldset>
-                              </div>
-                            </div>
-                            <div
-                              aria-describedby="rbd-hidden-text-8-hidden-text-34"
-                              class="list"
-                              data-rbd-drag-handle-context-id="8"
-                              data-rbd-drag-handle-draggable-id="rowGroups-1"
-                              data-rbd-draggable-context-id="8"
-                              data-rbd-draggable-id="rowGroups-1"
-                              draggable="false"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="govuk-form-group"
-                              >
-                                <fieldset
-                                  class="govuk-fieldset"
-                                  id="rowGroups-1"
-                                >
-                                  <legend
-                                    class="govuk-fieldset__legend govuk-fieldset__legend--s"
-                                  >
-                                    Row group 2
-                                  </legend>
-                                  <div
-                                    class="list"
-                                    data-rbd-droppable-context-id="11"
-                                    data-rbd-droppable-id="rowGroups-1"
-                                  >
-                                    <div
-                                      aria-describedby="rbd-hidden-text-11-hidden-text-46"
-                                      class="optionRow"
-                                      data-rbd-drag-handle-context-id="11"
-                                      data-rbd-drag-handle-draggable-id="e5174cb8-02f6-48d3-662e-08d9097c4255"
-                                      data-rbd-draggable-context-id="11"
-                                      data-rbd-draggable-id="e5174cb8-02f6-48d3-662e-08d9097c4255"
-                                      draggable="false"
-                                      role="button"
-                                      tabindex="0"
-                                    >
-                                      <div
-                                        class="optionText"
-                                      >
-                                        <strong>
-                                          Gender gap
-                                        </strong>
-                                        <span>
-                                          ⇅
-                                        </span>
-                                      </div>
-                                    </div>
-                                    <div
-                                      aria-describedby="rbd-hidden-text-11-hidden-text-46"
-                                      class="optionRow"
-                                      data-rbd-drag-handle-context-id="11"
-                                      data-rbd-drag-handle-draggable-id="0e8f9198-ce65-40ac-662a-08d9097c4255"
-                                      data-rbd-draggable-context-id="11"
-                                      data-rbd-draggable-id="0e8f9198-ce65-40ac-662a-08d9097c4255"
-                                      draggable="false"
-                                      role="button"
-                                      tabindex="0"
-                                    >
-                                      <div
-                                        class="optionText"
-                                      >
-                                        <strong>
-                                          Graduates included in earnings figures
-                                        </strong>
-                                        <span>
-                                          ⇅
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </fieldset>
-                              </div>
-                            </div>
-                          </div>
-                        </fieldset>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="govuk-!-margin-bottom-2"
-                  >
-                    <div
-                      class="groupsFieldset"
-                      data-rbd-droppable-context-id="8"
-                      data-rbd-droppable-id="columnGroups"
-                    >
-                      <div
-                        class="govuk-form-group"
-                      >
-                        <fieldset
-                          class="govuk-fieldset"
-                          id="columnGroups"
-                        >
-                          <legend
-                            class="govuk-fieldset__legend govuk-fieldset__legend--m"
-                          >
-                            Column groups
-                          </legend>
-                          <div
-                            class="listsContainer"
-                          >
-                            <div
-                              aria-describedby="rbd-hidden-text-8-hidden-text-34"
-                              class="list"
-                              data-rbd-drag-handle-context-id="8"
-                              data-rbd-drag-handle-draggable-id="columnGroups-0"
-                              data-rbd-draggable-context-id="8"
-                              data-rbd-draggable-id="columnGroups-0"
-                              draggable="false"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="govuk-form-group"
-                              >
-                                <fieldset
-                                  class="govuk-fieldset"
-                                  id="columnGroups-0"
-                                >
-                                  <legend
-                                    class="govuk-fieldset__legend govuk-fieldset__legend--s"
-                                  >
-                                    Column group 1
-                                  </legend>
-                                  <div
-                                    class="list"
-                                    data-rbd-droppable-context-id="10"
-                                    data-rbd-droppable-id="columnGroups-0"
-                                  >
-                                    <div
-                                      aria-describedby="rbd-hidden-text-10-hidden-text-41"
-                                      class="optionRow"
-                                      data-rbd-drag-handle-context-id="10"
-                                      data-rbd-drag-handle-draggable-id="2018_TY"
-                                      data-rbd-draggable-context-id="10"
-                                      data-rbd-draggable-id="2018_TY"
-                                      draggable="false"
-                                      role="button"
-                                      tabindex="0"
-                                    >
-                                      <div
-                                        class="optionText"
-                                      >
-                                        <strong>
-                                          2018-19
-                                        </strong>
-                                        <span>
-                                          ⇅
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </fieldset>
-                              </div>
-                            </div>
-                          </div>
-                        </fieldset>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <button
-                  aria-disabled="false"
-                  class="govuk-button"
-                  type="submit"
-                >
-                  Re-order table
-                </button>
-              </form>
-            </div>
-          </details>
-          <div
-            class="govuk-!-margin-bottom-3"
-          >
-            <div
-              class="govuk-!-margin-bottom-3"
-            >
-              <strong
-                class="govuk-tag govuk-tag--orange"
-              >
-                This data is not from the latest release
-              </strong>
-            </div>
-            <a
-              class="govuk-link govuk-link--no-visited-state dfe-print-hidden"
-              data-testid="View latest data link"
-              href="/find-statistics/test-publication"
-            >
-              View latest data:
-               
-              <span
-                class="govuk-!-font-weight-bold"
-              >
-                Latest Release Title
-              </span>
-            </a>
-          </div>
-          <figure
-            class="figure"
-          >
-            <figcaption>
-              <strong
-                data-testid="dataTableCaption"
-                id="dataTableCaption"
-              >
-                Table showing 'data 1' for 1 .  PGCE and 2 .  MBA in Great Britain for 2018-19
-              </strong>
-            </figcaption>
-            <div
-              class="container"
-              role="region"
-              tabindex="0"
-            >
-              <table
-                aria-labelledby="dataTableCaption"
-                class="govuk-table table"
-                data-testid="dataTableCaption-table"
-              >
-                <thead
-                  class="tableHead"
-                >
-                  <tr>
-                    <td
-                      class="borderBottom"
-                      colspan="2"
-                      rowspan="1"
-                    />
-                    <th
-                      colspan="1"
-                      rowspan="1"
-                      scope="col"
-                    >
-                      2018-19
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <th
-                      class="borderBottom"
-                      colspan="1"
-                      rowspan="2"
-                      scope="rowgroup"
-                    >
-                      1 .  PGCE
-                    </th>
-                    <th
-                      class=""
-                      colspan="1"
-                      rowspan="1"
-                      scope="row"
-                    >
-                      Gender gap
-                    </th>
-                    <td
-                      class="govuk-table__cell--numeric"
-                    >
-                      20.00%
-                    </td>
-                  </tr>
-                  <tr>
-                    <th
-                      class=""
-                      colspan="1"
-                      rowspan="1"
-                      scope="row"
-                    >
-                      Graduates included in earnings figures
-                    </th>
-                    <td
-                      class="govuk-table__cell--numeric borderBottom"
-                    >
-                      2
-                    </td>
-                  </tr>
-                  <tr>
-                    <th
-                      class="borderBottom"
-                      colspan="1"
-                      rowspan="2"
-                      scope="rowgroup"
-                    >
-                      2 .  MBA
-                    </th>
-                    <th
-                      class=""
-                      colspan="1"
-                      rowspan="1"
-                      scope="row"
-                    >
-                      Gender gap
-                    </th>
-                    <td
-                      class="govuk-table__cell--numeric"
-                    >
-                      60.00%
-                    </td>
-                  </tr>
-                  <tr>
-                    <th
-                      class=""
-                      colspan="1"
-                      rowspan="1"
-                      scope="row"
-                    >
-                      Graduates included in earnings figures
-                    </th>
-                    <td
-                      class="govuk-table__cell--numeric borderBottom"
-                    >
-                      2
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </figure>
-          <h3>
-            Share your table
-          </h3>
-          <ul
-            class="govuk-list"
-          >
-            <li>
               <button
                 class="button"
                 type="button"
               >
-                Generate permanent link
+                Share your table
               </button>
-            </li>
-          </ul>
-          <h3>
-            Additional options
-          </h3>
-          <ul
-            class="govuk-list"
-          >
-            <li>
-              <a
-                class="govuk-link"
-                href="/find-statistics/test-publication/selected-release-slug"
-              >
-                View the release for this data
-              </a>
-            </li>
-            <li>
-              <button
-                class="button"
-                type="button"
-              >
-                Download the data of this table (CSV)
-              </button>
-            </li>
-            <li>
-              <button
-                class="button"
-                type="button"
-              >
-                Download table as Excel spreadsheet (XLSX)
-              </button>
-            </li>
-          </ul>
-          <p
-            class="govuk-body"
-          >
-            If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
-          </p>
-        </div>
-      </div>
-    </li>
-  </ol>
-</main>
-`;
-
-exports[`TableToolPage renders the Table Tool page correctly when a Fast Track is provided and this is the latest data 1`] = `
-<main
-  class="govuk-main-wrapper app-main-class"
-  id="main-content"
-  role="main"
->
-  <span
-    class="govuk-caption-xl"
-    data-testid="page-title-caption"
-  >
-    Table Tool
-  </span>
-  <h1
-    class="govuk-heading-xl"
-    data-testid="page-title Create your own tables online"
-  >
-    Create your own tables online
-  </h1>
-  <p>
-    Choose the data and area of interest you want to explore and then use filters to create your table.
-  </p>
-  <p>
-    Once you've created your table, you can download the data it contains for your own offline analysis.
-  </p>
-  <ol
-    class="stepNav"
-    id="tableToolWizard"
-  >
-    <li
-      class="step"
-      data-testid="wizardStep-1"
-      id="tableToolWizard-step-1"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            1
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-1-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 1: 
-            </span>
-            Choose a subject
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        >
-          <div
-            class="govuk-summary-list__row"
-            data-testid="Subject"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              Subject
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              None
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </li>
-    <li
-      class="step"
-      data-testid="wizardStep-2"
-      id="tableToolWizard-step-2"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            2
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-2-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 2: 
-            </span>
-            Choose locations
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        >
-          <div
-            class="govuk-summary-list__row"
-            data-testid="National"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              National
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              <ul
-                class="govuk-list listContainer"
-              >
-                <li>
-                  Great Britain
-                </li>
-              </ul>
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </li>
-    <li
-      class="step"
-      data-testid="wizardStep-3"
-      id="tableToolWizard-step-3"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            3
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-3-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 3: 
-            </span>
-            Choose time period
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        >
-          <div
-            class="govuk-summary-list__row"
-            data-testid="Start date"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              Start date
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              2018-19
-            </dd>
-          </div>
-          <div
-            class="govuk-summary-list__row"
-            data-testid="End date"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              End date
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              2018-19
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </li>
-    <li
-      class="step"
-      data-testid="wizardStep-4"
-      id="tableToolWizard-step-4"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            4
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-4-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 4: 
-            </span>
-            Choose your filters
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <dl
-          class="govuk-summary-list govuk-summary-list--no-border"
-        >
-          <div
-            class="govuk-summary-list__row"
-            data-testid="Indicators"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              Indicators
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              <ul
-                class="govuk-list listContainer"
-              >
-                <li>
-                  Gender gap
-                </li>
-                <li>
-                  Graduates included in earnings figures
-                </li>
-              </ul>
-            </dd>
-          </div>
-          <div
-            class="govuk-summary-list__row"
-            data-testid="Subject studied"
-          >
-            <dt
-              class="govuk-summary-list__key"
-            >
-              Subject studied
-            </dt>
-            <dd
-              class="govuk-summary-list__value"
-            >
-              <ul
-                class="govuk-list listContainer"
-              >
-                <li>
-                  1 .  PGCE
-                </li>
-                <li>
-                  10 .  Psychology
-                </li>
-              </ul>
-            </dd>
-          </div>
-        </dl>
-      </div>
-    </li>
-    <li
-      class="step"
-      data-testid="wizardStep-5"
-      id="tableToolWizard-step-5"
-      tabindex="-1"
-    >
-      <div
-        class="content"
-      >
-        <span
-          aria-hidden="true"
-          class="number"
-        >
-          <span
-            class="numberInner"
-          >
-            5
-          </span>
-        </span>
-        <h2
-          class="govuk-heading-l stepEnabled"
-        >
-          <button
-            class="stepButton"
-            data-testid="wizardStep-5-goToButton"
-            type="button"
-          >
-            <span
-              class="govuk-visually-hidden"
-            >
-              Step 5: 
-            </span>
-            Explore data
-            <span
-              aria-hidden="true"
-              class="toggleText"
-            >
-              Go to this step
-            </span>
-          </button>
-        </h2>
-        <div
-          class="govuk-!-margin-bottom-4"
-          data-testid="Table tool final step container"
-        >
-          <details
-            class="govuk-details"
-            role="group"
-          >
-            <summary
-              aria-controls="details-content-5"
-              aria-expanded="false"
-              class="govuk-details__summary"
-              role="button"
-              tabindex="0"
-            >
-              <span
-                class="summaryText govuk-details__summary-text"
-                data-testid="Expand Details Section Re-order table headers"
-              >
-                Re-order table headers
-              </span>
-            </summary>
-            <div
-              aria-hidden="true"
-              class="govuk-details__text"
-              id="details-content-5"
-            >
-              <p
-                class="govuk-hint"
-              >
-                Drag and drop the options below to re-order the table headers. For keyboard users, select and deselect a draggable item with space and use the arrow keys to move a selected item.
-              </p>
-              <div
-                class="govuk-visually-hidden"
-              >
-                To move a draggable item, select and deselect the item with space and use the arrow keys to move a selected item. If you are using a screen reader disable scan mode.
-              </div>
-              <form
-                action="#"
-                id="tableHeadersForm"
-              >
-                <div
-                  class="govuk-form-group"
-                >
-                  <div
-                    class="govuk-!-margin-bottom-2"
-                  >
-                    <div
-                      class="groupsFieldset"
-                      data-rbd-droppable-context-id="4"
-                      data-rbd-droppable-id="rowGroups"
-                    >
-                      <div
-                        class="govuk-form-group"
-                      >
-                        <fieldset
-                          class="govuk-fieldset"
-                          id="rowGroups"
-                        >
-                          <legend
-                            class="govuk-fieldset__legend govuk-fieldset__legend--m"
-                          >
-                            Row groups
-                          </legend>
-                          <div
-                            class="listsContainer"
-                          >
-                            <div
-                              aria-describedby="rbd-hidden-text-4-hidden-text-17"
-                              class="list"
-                              data-rbd-drag-handle-context-id="4"
-                              data-rbd-drag-handle-draggable-id="rowGroups-0"
-                              data-rbd-draggable-context-id="4"
-                              data-rbd-draggable-id="rowGroups-0"
-                              draggable="false"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="govuk-form-group"
-                              >
-                                <fieldset
-                                  class="govuk-fieldset"
-                                  id="rowGroups-0"
-                                >
-                                  <legend
-                                    class="govuk-fieldset__legend govuk-fieldset__legend--s"
-                                  >
-                                    Row group 1
-                                  </legend>
-                                  <div
-                                    class="list"
-                                    data-rbd-droppable-context-id="5"
-                                    data-rbd-droppable-id="rowGroups-0"
-                                  >
-                                    <div
-                                      aria-describedby="rbd-hidden-text-5-hidden-text-20"
-                                      class="optionRow"
-                                      data-rbd-drag-handle-context-id="5"
-                                      data-rbd-drag-handle-draggable-id="72303947-27a4-4ea2-a708-dfeb7bb31efb"
-                                      data-rbd-draggable-context-id="5"
-                                      data-rbd-draggable-id="72303947-27a4-4ea2-a708-dfeb7bb31efb"
-                                      draggable="false"
-                                      role="button"
-                                      tabindex="0"
-                                    >
-                                      <div
-                                        class="optionText"
-                                      >
-                                        <strong>
-                                          1 .  PGCE
-                                        </strong>
-                                        <span>
-                                          ⇅
-                                        </span>
-                                      </div>
-                                    </div>
-                                    <div
-                                      aria-describedby="rbd-hidden-text-5-hidden-text-20"
-                                      class="optionRow"
-                                      data-rbd-drag-handle-context-id="5"
-                                      data-rbd-drag-handle-draggable-id="0164a10e-c041-49f8-b44d-daa6f0c1fbfd"
-                                      data-rbd-draggable-context-id="5"
-                                      data-rbd-draggable-id="0164a10e-c041-49f8-b44d-daa6f0c1fbfd"
-                                      draggable="false"
-                                      role="button"
-                                      tabindex="0"
-                                    >
-                                      <div
-                                        class="optionText"
-                                      >
-                                        <strong>
-                                          2 .  MBA
-                                        </strong>
-                                        <span>
-                                          ⇅
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </fieldset>
-                              </div>
-                            </div>
-                            <div
-                              aria-describedby="rbd-hidden-text-4-hidden-text-17"
-                              class="list"
-                              data-rbd-drag-handle-context-id="4"
-                              data-rbd-drag-handle-draggable-id="rowGroups-1"
-                              data-rbd-draggable-context-id="4"
-                              data-rbd-draggable-id="rowGroups-1"
-                              draggable="false"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="govuk-form-group"
-                              >
-                                <fieldset
-                                  class="govuk-fieldset"
-                                  id="rowGroups-1"
-                                >
-                                  <legend
-                                    class="govuk-fieldset__legend govuk-fieldset__legend--s"
-                                  >
-                                    Row group 2
-                                  </legend>
-                                  <div
-                                    class="list"
-                                    data-rbd-droppable-context-id="7"
-                                    data-rbd-droppable-id="rowGroups-1"
-                                  >
-                                    <div
-                                      aria-describedby="rbd-hidden-text-7-hidden-text-29"
-                                      class="optionRow"
-                                      data-rbd-drag-handle-context-id="7"
-                                      data-rbd-drag-handle-draggable-id="e5174cb8-02f6-48d3-662e-08d9097c4255"
-                                      data-rbd-draggable-context-id="7"
-                                      data-rbd-draggable-id="e5174cb8-02f6-48d3-662e-08d9097c4255"
-                                      draggable="false"
-                                      role="button"
-                                      tabindex="0"
-                                    >
-                                      <div
-                                        class="optionText"
-                                      >
-                                        <strong>
-                                          Gender gap
-                                        </strong>
-                                        <span>
-                                          ⇅
-                                        </span>
-                                      </div>
-                                    </div>
-                                    <div
-                                      aria-describedby="rbd-hidden-text-7-hidden-text-29"
-                                      class="optionRow"
-                                      data-rbd-drag-handle-context-id="7"
-                                      data-rbd-drag-handle-draggable-id="0e8f9198-ce65-40ac-662a-08d9097c4255"
-                                      data-rbd-draggable-context-id="7"
-                                      data-rbd-draggable-id="0e8f9198-ce65-40ac-662a-08d9097c4255"
-                                      draggable="false"
-                                      role="button"
-                                      tabindex="0"
-                                    >
-                                      <div
-                                        class="optionText"
-                                      >
-                                        <strong>
-                                          Graduates included in earnings figures
-                                        </strong>
-                                        <span>
-                                          ⇅
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </fieldset>
-                              </div>
-                            </div>
-                          </div>
-                        </fieldset>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    class="govuk-!-margin-bottom-2"
-                  >
-                    <div
-                      class="groupsFieldset"
-                      data-rbd-droppable-context-id="4"
-                      data-rbd-droppable-id="columnGroups"
-                    >
-                      <div
-                        class="govuk-form-group"
-                      >
-                        <fieldset
-                          class="govuk-fieldset"
-                          id="columnGroups"
-                        >
-                          <legend
-                            class="govuk-fieldset__legend govuk-fieldset__legend--m"
-                          >
-                            Column groups
-                          </legend>
-                          <div
-                            class="listsContainer"
-                          >
-                            <div
-                              aria-describedby="rbd-hidden-text-4-hidden-text-17"
-                              class="list"
-                              data-rbd-drag-handle-context-id="4"
-                              data-rbd-drag-handle-draggable-id="columnGroups-0"
-                              data-rbd-draggable-context-id="4"
-                              data-rbd-draggable-id="columnGroups-0"
-                              draggable="false"
-                              role="button"
-                              tabindex="0"
-                            >
-                              <div
-                                class="govuk-form-group"
-                              >
-                                <fieldset
-                                  class="govuk-fieldset"
-                                  id="columnGroups-0"
-                                >
-                                  <legend
-                                    class="govuk-fieldset__legend govuk-fieldset__legend--s"
-                                  >
-                                    Column group 1
-                                  </legend>
-                                  <div
-                                    class="list"
-                                    data-rbd-droppable-context-id="6"
-                                    data-rbd-droppable-id="columnGroups-0"
-                                  >
-                                    <div
-                                      aria-describedby="rbd-hidden-text-6-hidden-text-24"
-                                      class="optionRow"
-                                      data-rbd-drag-handle-context-id="6"
-                                      data-rbd-drag-handle-draggable-id="2018_TY"
-                                      data-rbd-draggable-context-id="6"
-                                      data-rbd-draggable-id="2018_TY"
-                                      draggable="false"
-                                      role="button"
-                                      tabindex="0"
-                                    >
-                                      <div
-                                        class="optionText"
-                                      >
-                                        <strong>
-                                          2018-19
-                                        </strong>
-                                        <span>
-                                          ⇅
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </div>
-                                </fieldset>
-                              </div>
-                            </div>
-                          </div>
-                        </fieldset>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <button
-                  aria-disabled="false"
-                  class="govuk-button"
-                  type="submit"
-                >
-                  Re-order table
-                </button>
-              </form>
             </div>
-          </details>
-          <div
-            class="govuk-!-margin-bottom-3"
-          >
-            <strong
-              class="govuk-tag"
-            >
-              This is the latest data
-            </strong>
           </div>
-          <figure
-            class="figure"
+          <div
+            class="govuk-inset-text"
           >
-            <figcaption>
-              <strong
-                data-testid="dataTableCaption"
-                id="dataTableCaption"
-              >
-                Table showing 'data 1' for 1 .  PGCE and 2 .  MBA in Great Britain for 2018-19
-              </strong>
-            </figcaption>
-            <div
-              class="container"
-              role="region"
-              tabindex="0"
-            >
-              <table
-                aria-labelledby="dataTableCaption"
-                class="govuk-table table"
-                data-testid="dataTableCaption-table"
-              >
-                <thead
-                  class="tableHead"
-                >
-                  <tr>
-                    <td
-                      class="borderBottom"
-                      colspan="2"
-                      rowspan="1"
-                    />
-                    <th
-                      colspan="1"
-                      rowspan="1"
-                      scope="col"
-                    >
-                      2018-19
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <th
-                      class="borderBottom"
-                      colspan="1"
-                      rowspan="2"
-                      scope="rowgroup"
-                    >
-                      1 .  PGCE
-                    </th>
-                    <th
-                      class=""
-                      colspan="1"
-                      rowspan="1"
-                      scope="row"
-                    >
-                      Gender gap
-                    </th>
-                    <td
-                      class="govuk-table__cell--numeric"
-                    >
-                      20.00%
-                    </td>
-                  </tr>
-                  <tr>
-                    <th
-                      class=""
-                      colspan="1"
-                      rowspan="1"
-                      scope="row"
-                    >
-                      Graduates included in earnings figures
-                    </th>
-                    <td
-                      class="govuk-table__cell--numeric borderBottom"
-                    >
-                      2
-                    </td>
-                  </tr>
-                  <tr>
-                    <th
-                      class="borderBottom"
-                      colspan="1"
-                      rowspan="2"
-                      scope="rowgroup"
-                    >
-                      2 .  MBA
-                    </th>
-                    <th
-                      class=""
-                      colspan="1"
-                      rowspan="1"
-                      scope="row"
-                    >
-                      Gender gap
-                    </th>
-                    <td
-                      class="govuk-table__cell--numeric"
-                    >
-                      60.00%
-                    </td>
-                  </tr>
-                  <tr>
-                    <th
-                      class=""
-                      colspan="1"
-                      rowspan="1"
-                      scope="row"
-                    >
-                      Graduates included in earnings figures
-                    </th>
-                    <td
-                      class="govuk-table__cell--numeric borderBottom"
-                    >
-                      2
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </figure>
-          <h3>
-            Share your table
-          </h3>
-          <ul
-            class="govuk-list"
-          >
-            <li>
-              <button
-                class="button"
-                type="button"
-              >
-                Generate permanent link
-              </button>
-            </li>
-          </ul>
-          <h3>
-            Additional options
-          </h3>
-          <ul
-            class="govuk-list"
-          >
-            <li>
-              <a
-                class="govuk-link"
-                href="/find-statistics/test-publication"
-              >
-                View the release for this data
-              </a>
-            </li>
-            <li>
-              <button
-                class="button"
-                type="button"
-              >
-                Download the data of this table (CSV)
-              </button>
-            </li>
-            <li>
-              <button
-                class="button"
-                type="button"
-              >
-                Download table as Excel spreadsheet (XLSX)
-              </button>
-            </li>
-          </ul>
-          <p
-            class="govuk-body"
-          >
-            If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
-          </p>
+            <p>
+              If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
+            </p>
+          </div>
         </div>
       </div>
     </li>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
@@ -10,6 +10,7 @@ import TimePeriodDataTable from '@common/modules/table-tool/components/TimePerio
 import { FullTable } from '@common/modules/table-tool/types/fullTable';
 import { TableHeadersConfig } from '@common/modules/table-tool/types/tableHeaders';
 import mapUnmappedTableHeaders from '@common/modules/table-tool/utils/mapUnmappedTableHeaders';
+import Details from '@common/components/Details';
 import permalinkService from '@common/services/permalinkService';
 import publicationService from '@common/services/publicationService';
 import {
@@ -71,6 +72,14 @@ const TableToolFinalStep = ({
     setPermalinkLoading(false);
   };
 
+  const handleCopyClick = () => {
+    const el = document.querySelector(
+      "[data-testid='permalink-generated-url']",
+    ) as HTMLInputElement;
+    el?.select();
+    document.execCommand('copy');
+  };
+
   return (
     <div
       className="govuk-!-margin-bottom-4"
@@ -128,14 +137,100 @@ const TableToolFinalStep = ({
         </>
       )}
 
-      <h3>Share your table</h3>
-      <ul className="govuk-list">
-        <li>
+      <div className="govuk-grid-row">
+        <div className="govuk-grid-column-one-half">
+          {table && (
+            <Details summary="Additional options">
+              <ul className="govuk-list">
+                <li>
+                  {selectedPublication.selectedRelease.latestData ? (
+                    <Link
+                      to="/find-statistics/[publication]"
+                      as={`/find-statistics/${selectedPublication.slug}`}
+                    >
+                      View the release for this data
+                    </Link>
+                  ) : (
+                    <Link
+                      to="/find-statistics/[publication]/[releaseSlug]"
+                      as={`/find-statistics/${selectedPublication.slug}/${selectedPublication.selectedRelease.slug}`}
+                    >
+                      View the release for this data
+                    </Link>
+                  )}
+                </li>
+                <li>
+                  <DownloadCsvButton
+                    fileName={`data-${selectedPublication.slug}`}
+                    fullTable={table}
+                    onClick={() =>
+                      logEvent({
+                        category: 'Table tool',
+                        action: 'CSV download button clicked',
+                        label: `${table.subjectMeta.publicationName} between ${
+                          table.subjectMeta.timePeriodRange[0].label
+                        } and ${
+                          table.subjectMeta.timePeriodRange[
+                            table.subjectMeta.timePeriodRange.length - 1
+                          ].label
+                        }`,
+                      })
+                    }
+                  />
+                </li>
+
+                <li>
+                  <DownloadExcelButton
+                    fileName={`data-${selectedPublication.slug}`}
+                    tableRef={dataTableRef}
+                    subjectMeta={table.subjectMeta}
+                    onClick={() =>
+                      logEvent({
+                        category: 'Table tool',
+                        action: 'Excel download button clicked',
+                        label: `${table.subjectMeta.publicationName} between ${
+                          table.subjectMeta.timePeriodRange[0].label
+                        } and ${
+                          table.subjectMeta.timePeriodRange[
+                            table.subjectMeta.timePeriodRange.length - 1
+                          ].label
+                        }`,
+                      })
+                    }
+                  />
+                </li>
+                {pubMethodology?.methodology?.slug && (
+                  <li>
+                    <Link
+                      to="/methodology/[methodology]"
+                      as={`/methodology/${pubMethodology.methodology.slug}`}
+                    >
+                      Go to methodology
+                    </Link>
+                  </li>
+                )}
+                {pubMethodology?.externalMethodology?.url && (
+                  <li>
+                    <a href={pubMethodology.externalMethodology.url}>
+                      Go to methodology
+                    </a>
+                  </li>
+                )}
+              </ul>
+            </Details>
+          )}
+        </div>
+
+        <div className="govuk-grid-column-one-half dfe-align--right">
           {permalinkId ? (
-            <>
-              <p className="govuk-!-margin-bottom-2">
-                Generated permanent link:
-              </p>
+            <div className="dfe-align--left">
+              <h3 className="govuk-heading-s">Generated share link</h3>
+
+              <div className="govuk-inset-text">
+                Use the link below to see a version of this page that you can
+                bookmark for future reference, or copy the link to send on to
+                somebody else to view.
+              </div>
 
               <p className="govuk-!-margin-top-0 govuk-!-margin-bottom-2">
                 <UrlContainer
@@ -144,17 +239,25 @@ const TableToolFinalStep = ({
                 />
               </p>
 
+              <button
+                type="button"
+                className="govuk-button govuk-button--secondary govuk-!-margin-right-3"
+                onClick={handleCopyClick}
+              >
+                Copy link
+              </button>
+
               <Link
-                className="govuk-!-margin-top-0"
+                className="govuk-!-margin-top-0 govuk-button"
                 to="/data-tables/permalink/[permalink]"
                 as={`/data-tables/permalink/${permalinkId}`}
                 title="View created table permalink"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                View permanent link
+                View share link
               </Link>
-            </>
+            </div>
           ) : (
             <LoadingSpinner
               alert
@@ -164,95 +267,19 @@ const TableToolFinalStep = ({
               text="Generating permanent link"
             >
               <ButtonText onClick={handlePermalinkClick}>
-                Generate permanent link
+                Share your table
               </ButtonText>
             </LoadingSpinner>
           )}
-        </li>
-      </ul>
+        </div>
+      </div>
 
-      <h3>Additional options</h3>
-      {table && (
-        <ul className="govuk-list">
-          <li>
-            {selectedPublication.selectedRelease.latestData ? (
-              <Link
-                to="/find-statistics/[publication]"
-                as={`/find-statistics/${selectedPublication.slug}`}
-              >
-                View the release for this data
-              </Link>
-            ) : (
-              <Link
-                to="/find-statistics/[publication]/[releaseSlug]"
-                as={`/find-statistics/${selectedPublication.slug}/${selectedPublication.selectedRelease.slug}`}
-              >
-                View the release for this data
-              </Link>
-            )}
-          </li>
-          <li>
-            <DownloadCsvButton
-              fileName={`data-${selectedPublication.slug}`}
-              fullTable={table}
-              onClick={() =>
-                logEvent({
-                  category: 'Table tool',
-                  action: 'CSV download button clicked',
-                  label: `${table.subjectMeta.publicationName} between ${
-                    table.subjectMeta.timePeriodRange[0].label
-                  } and ${
-                    table.subjectMeta.timePeriodRange[
-                      table.subjectMeta.timePeriodRange.length - 1
-                    ].label
-                  }`,
-                })
-              }
-            />
-          </li>
-          <li>
-            <DownloadExcelButton
-              fileName={`data-${selectedPublication.slug}`}
-              tableRef={dataTableRef}
-              subjectMeta={table.subjectMeta}
-              onClick={() =>
-                logEvent({
-                  category: 'Table tool',
-                  action: 'Excel download button clicked',
-                  label: `${table.subjectMeta.publicationName} between ${
-                    table.subjectMeta.timePeriodRange[0].label
-                  } and ${
-                    table.subjectMeta.timePeriodRange[
-                      table.subjectMeta.timePeriodRange.length - 1
-                    ].label
-                  }`,
-                })
-              }
-            />
-          </li>
-          {pubMethodology?.methodology?.slug && (
-            <li>
-              <Link
-                to="/methodology/[methodology]"
-                as={`/methodology/${pubMethodology.methodology.slug}`}
-              >
-                Go to methodology
-              </Link>
-            </li>
-          )}
-          {pubMethodology?.externalMethodology?.url && (
-            <li>
-              <a href={pubMethodology.externalMethodology.url}>
-                Go to methodology
-              </a>
-            </li>
-          )}
-        </ul>
-      )}
-      <p className="govuk-body">
-        If you have a question about the data or methods used to create this
-        table contact the named statistician via the relevant release page.
-      </p>
+      <div className="govuk-inset-text">
+        <p>
+          If you have a question about the data or methods used to create this
+          table contact the named statistician via the relevant release page.
+        </p>
+      </div>
     </div>
   );
 };

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
@@ -1,4 +1,3 @@
-import { FinalStepRenderProps } from '@common/modules/table-tool/components/TableToolWizard';
 import {
   CategoryFilter,
   Indicator,
@@ -249,7 +248,7 @@ describe('TableToolFinalStep', () => {
 
     // test the reordering controls for the table headers are present
     const groups = screen.queryAllByRole('group');
-    expect(groups).toHaveLength(1);
+    expect(groups).toHaveLength(2);
     const reorderTableHeadersGroup = groups[0];
     expect(
       within(reorderTableHeadersGroup).queryByRole('button', {
@@ -268,26 +267,34 @@ describe('TableToolFinalStep', () => {
     expect(table).toMatchSnapshot();
 
     // test the permalink controls are present
-    expect(screen.queryByText('Share your table')).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: 'Generate permanent link' }),
+      screen.queryByRole('button', { name: 'Share your table' }),
     ).toBeInTheDocument();
 
     // test that the additional options are rendered correctly
-    expect(screen.queryByText('Additional options')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('link', { name: 'View the release for this data' }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', {
-        name: 'Download the data of this table (CSV)',
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', {
-        name: 'Download table as Excel spreadsheet (XLSX)',
-      }),
-    ).toBeInTheDocument();
+    const additionalOptionsRevealButton = screen.getByRole('button', {
+      name: 'Additional options',
+    });
+
+    expect(additionalOptionsRevealButton).toBeInTheDocument();
+
+    userEvent.click(additionalOptionsRevealButton);
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('link', { name: 'View the release for this data' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {
+          name: 'Download the data of this table (CSV)',
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {
+          name: 'Download table as Excel spreadsheet (XLSX)',
+        }),
+      ).toBeInTheDocument();
+    });
 
     expect(
       screen.getByTestId('Table tool final step container'),
@@ -335,13 +342,21 @@ describe('TableToolFinalStep', () => {
       />,
     );
 
-    const viewReleaseLink = screen.getByRole('link', {
-      name: 'View the release for this data',
-    }) as HTMLAnchorElement;
+    const additionalOptionsRevealButton = screen.getByRole('button', {
+      name: 'Additional options',
+    });
 
-    expect(viewReleaseLink.href).toEqual(
-      'http://localhost/find-statistics/test-publication/selected-release-slug',
-    );
+    userEvent.click(additionalOptionsRevealButton);
+
+    await waitFor(() => {
+      const viewReleaseLink = screen.getByRole('link', {
+        name: 'View the release for this data',
+      }) as HTMLAnchorElement;
+
+      expect(viewReleaseLink.href).toEqual(
+        'http://localhost/find-statistics/test-publication/selected-release-slug',
+      );
+    });
 
     expect(
       screen.getByTestId('Table tool final step container'),
@@ -358,13 +373,21 @@ describe('TableToolFinalStep', () => {
       />,
     );
 
-    const viewReleaseLink = screen.getByRole('link', {
-      name: 'View the release for this data',
-    }) as HTMLAnchorElement;
+    const additionalOptionsRevealButton = screen.getByRole('button', {
+      name: 'Additional options',
+    });
 
-    expect(viewReleaseLink.href).toEqual(
-      'http://localhost/find-statistics/test-publication',
-    );
+    userEvent.click(additionalOptionsRevealButton);
+
+    await waitFor(() => {
+      const viewReleaseLink = screen.getByRole('link', {
+        name: 'View the release for this data',
+      }) as HTMLAnchorElement;
+
+      expect(viewReleaseLink.href).toEqual(
+        'http://localhost/find-statistics/test-publication',
+      );
+    });
 
     expect(
       screen.getByTestId('Table tool final step container'),
@@ -393,7 +416,6 @@ describe('TableToolFinalStep', () => {
       screen.getByTestId('Table tool final step container'),
     ).toMatchSnapshot();
   });
-
   test(`renders the Table Tool final step correctly if this is not the latest data`, async () => {
     render(
       <TableToolFinalStep
@@ -402,14 +424,6 @@ describe('TableToolFinalStep', () => {
         tableHeaders={testTableHeaders}
         selectedPublication={testSelectedPublicationWithNonLatestRelease}
       />,
-    );
-
-    const viewReleaseLink = screen.getByRole('link', {
-      name: 'View the release for this data',
-    }) as HTMLAnchorElement;
-
-    expect(viewReleaseLink.href).toEqual(
-      'http://localhost/find-statistics/test-publication/selected-release-slug',
     );
 
     expect(
@@ -428,6 +442,22 @@ describe('TableToolFinalStep', () => {
     );
     expect(latestDataLink.text).toContain('View latest data');
     expect(latestDataLink.text).toContain('Latest Release Title');
+
+    const additionalOptionsRevealButton = screen.getByRole('button', {
+      name: 'Additional options',
+    });
+
+    userEvent.click(additionalOptionsRevealButton);
+
+    await waitFor(() => {
+      const viewReleaseLink = screen.getByRole('link', {
+        name: 'View the release for this data',
+      }) as HTMLAnchorElement;
+
+      expect(viewReleaseLink.href).toEqual(
+        'http://localhost/find-statistics/test-publication/selected-release-slug',
+      );
+    });
 
     expect(
       screen.getByTestId('Table tool final step container'),

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__snapshots__/TableToolFinalStep.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/__snapshots__/TableToolFinalStep.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`TableToolFinalStep renders the 'View the release for this data' URL wit
     role="group"
   >
     <summary
-      aria-controls="details-content-8"
+      aria-controls="details-content-16"
       aria-expanded="false"
       class="govuk-details__summary"
       role="button"
@@ -26,7 +26,7 @@ exports[`TableToolFinalStep renders the 'View the release for this data' URL wit
     <div
       aria-hidden="true"
       class="govuk-details__text"
-      id="details-content-8"
+      id="details-content-16"
     >
       <p
         class="govuk-hint"
@@ -483,57 +483,85 @@ exports[`TableToolFinalStep renders the 'View the release for this data' URL wit
       </table>
     </div>
   </figure>
-  <h3>
-    Share your table
-  </h3>
-  <ul
-    class="govuk-list"
+  <div
+    class="govuk-grid-row"
   >
-    <li>
+    <div
+      class="govuk-grid-column-one-half"
+    >
+      <details
+        class="govuk-details"
+        open=""
+        role="group"
+      >
+        <summary
+          aria-controls="details-content-17"
+          aria-expanded="true"
+          class="govuk-details__summary"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="summaryText govuk-details__summary-text"
+            data-testid="Expand Details Section Additional options"
+          >
+            Additional options
+          </span>
+        </summary>
+        <div
+          aria-hidden="false"
+          class="govuk-details__text"
+          id="details-content-17"
+        >
+          <ul
+            class="govuk-list"
+          >
+            <li>
+              <a
+                class="govuk-link"
+                href="/find-statistics/test-publication"
+              >
+                View the release for this data
+              </a>
+            </li>
+            <li>
+              <button
+                class="button"
+                type="button"
+              >
+                Download the data of this table (CSV)
+              </button>
+            </li>
+            <li>
+              <button
+                class="button"
+                type="button"
+              >
+                Download table as Excel spreadsheet (XLSX)
+              </button>
+            </li>
+          </ul>
+        </div>
+      </details>
+    </div>
+    <div
+      class="govuk-grid-column-one-half dfe-align--right"
+    >
       <button
         class="button"
         type="button"
       >
-        Generate permanent link
+        Share your table
       </button>
-    </li>
-  </ul>
-  <h3>
-    Additional options
-  </h3>
-  <ul
-    class="govuk-list"
+    </div>
+  </div>
+  <div
+    class="govuk-inset-text"
   >
-    <li>
-      <a
-        class="govuk-link"
-        href="/find-statistics/test-publication"
-      >
-        View the release for this data
-      </a>
-    </li>
-    <li>
-      <button
-        class="button"
-        type="button"
-      >
-        Download the data of this table (CSV)
-      </button>
-    </li>
-    <li>
-      <button
-        class="button"
-        type="button"
-      >
-        Download table as Excel spreadsheet (XLSX)
-      </button>
-    </li>
-  </ul>
-  <p
-    class="govuk-body"
-  >
-    If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
-  </p>
+    <p>
+      If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
+    </p>
+  </div>
 </div>
 `;
 
@@ -547,7 +575,7 @@ exports[`TableToolFinalStep renders the 'View the release for this data' URL wit
     role="group"
   >
     <summary
-      aria-controls="details-content-6"
+      aria-controls="details-content-11"
       aria-expanded="false"
       class="govuk-details__summary"
       role="button"
@@ -563,7 +591,7 @@ exports[`TableToolFinalStep renders the 'View the release for this data' URL wit
     <div
       aria-hidden="true"
       class="govuk-details__text"
-      id="details-content-6"
+      id="details-content-11"
     >
       <p
         class="govuk-hint"
@@ -1037,57 +1065,85 @@ exports[`TableToolFinalStep renders the 'View the release for this data' URL wit
       </table>
     </div>
   </figure>
-  <h3>
-    Share your table
-  </h3>
-  <ul
-    class="govuk-list"
+  <div
+    class="govuk-grid-row"
   >
-    <li>
+    <div
+      class="govuk-grid-column-one-half"
+    >
+      <details
+        class="govuk-details"
+        open=""
+        role="group"
+      >
+        <summary
+          aria-controls="details-content-12"
+          aria-expanded="true"
+          class="govuk-details__summary"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="summaryText govuk-details__summary-text"
+            data-testid="Expand Details Section Additional options"
+          >
+            Additional options
+          </span>
+        </summary>
+        <div
+          aria-hidden="false"
+          class="govuk-details__text"
+          id="details-content-12"
+        >
+          <ul
+            class="govuk-list"
+          >
+            <li>
+              <a
+                class="govuk-link"
+                href="/find-statistics/test-publication/selected-release-slug"
+              >
+                View the release for this data
+              </a>
+            </li>
+            <li>
+              <button
+                class="button"
+                type="button"
+              >
+                Download the data of this table (CSV)
+              </button>
+            </li>
+            <li>
+              <button
+                class="button"
+                type="button"
+              >
+                Download table as Excel spreadsheet (XLSX)
+              </button>
+            </li>
+          </ul>
+        </div>
+      </details>
+    </div>
+    <div
+      class="govuk-grid-column-one-half dfe-align--right"
+    >
       <button
         class="button"
         type="button"
       >
-        Generate permanent link
+        Share your table
       </button>
-    </li>
-  </ul>
-  <h3>
-    Additional options
-  </h3>
-  <ul
-    class="govuk-list"
+    </div>
+  </div>
+  <div
+    class="govuk-inset-text"
   >
-    <li>
-      <a
-        class="govuk-link"
-        href="/find-statistics/test-publication/selected-release-slug"
-      >
-        View the release for this data
-      </a>
-    </li>
-    <li>
-      <button
-        class="button"
-        type="button"
-      >
-        Download the data of this table (CSV)
-      </button>
-    </li>
-    <li>
-      <button
-        class="button"
-        type="button"
-      >
-        Download table as Excel spreadsheet (XLSX)
-      </button>
-    </li>
-  </ul>
-  <p
-    class="govuk-body"
-  >
-    If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
-  </p>
+    <p>
+      If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
+    </p>
+  </div>
 </div>
 `;
 
@@ -1101,7 +1157,7 @@ exports[`TableToolFinalStep renders the Table Tool final step correctly if this 
     role="group"
   >
     <summary
-      aria-controls="details-content-12"
+      aria-controls="details-content-25"
       aria-expanded="false"
       class="govuk-details__summary"
       role="button"
@@ -1117,7 +1173,7 @@ exports[`TableToolFinalStep renders the Table Tool final step correctly if this 
     <div
       aria-hidden="true"
       class="govuk-details__text"
-      id="details-content-12"
+      id="details-content-25"
     >
       <p
         class="govuk-hint"
@@ -1591,57 +1647,85 @@ exports[`TableToolFinalStep renders the Table Tool final step correctly if this 
       </table>
     </div>
   </figure>
-  <h3>
-    Share your table
-  </h3>
-  <ul
-    class="govuk-list"
+  <div
+    class="govuk-grid-row"
   >
-    <li>
+    <div
+      class="govuk-grid-column-one-half"
+    >
+      <details
+        class="govuk-details"
+        open=""
+        role="group"
+      >
+        <summary
+          aria-controls="details-content-26"
+          aria-expanded="true"
+          class="govuk-details__summary"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="summaryText govuk-details__summary-text"
+            data-testid="Expand Details Section Additional options"
+          >
+            Additional options
+          </span>
+        </summary>
+        <div
+          aria-hidden="false"
+          class="govuk-details__text"
+          id="details-content-26"
+        >
+          <ul
+            class="govuk-list"
+          >
+            <li>
+              <a
+                class="govuk-link"
+                href="/find-statistics/test-publication/selected-release-slug"
+              >
+                View the release for this data
+              </a>
+            </li>
+            <li>
+              <button
+                class="button"
+                type="button"
+              >
+                Download the data of this table (CSV)
+              </button>
+            </li>
+            <li>
+              <button
+                class="button"
+                type="button"
+              >
+                Download table as Excel spreadsheet (XLSX)
+              </button>
+            </li>
+          </ul>
+        </div>
+      </details>
+    </div>
+    <div
+      class="govuk-grid-column-one-half dfe-align--right"
+    >
       <button
         class="button"
         type="button"
       >
-        Generate permanent link
+        Share your table
       </button>
-    </li>
-  </ul>
-  <h3>
-    Additional options
-  </h3>
-  <ul
-    class="govuk-list"
+    </div>
+  </div>
+  <div
+    class="govuk-inset-text"
   >
-    <li>
-      <a
-        class="govuk-link"
-        href="/find-statistics/test-publication/selected-release-slug"
-      >
-        View the release for this data
-      </a>
-    </li>
-    <li>
-      <button
-        class="button"
-        type="button"
-      >
-        Download the data of this table (CSV)
-      </button>
-    </li>
-    <li>
-      <button
-        class="button"
-        type="button"
-      >
-        Download table as Excel spreadsheet (XLSX)
-      </button>
-    </li>
-  </ul>
-  <p
-    class="govuk-body"
-  >
-    If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
-  </p>
+    <p>
+      If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
+    </p>
+  </div>
 </div>
 `;
 
@@ -1655,7 +1739,7 @@ exports[`TableToolFinalStep renders the Table Tool final step correctly when thi
     role="group"
   >
     <summary
-      aria-controls="details-content-10"
+      aria-controls="details-content-21"
       aria-expanded="false"
       class="govuk-details__summary"
       role="button"
@@ -1671,7 +1755,7 @@ exports[`TableToolFinalStep renders the Table Tool final step correctly when thi
     <div
       aria-hidden="true"
       class="govuk-details__text"
-      id="details-content-10"
+      id="details-content-21"
     >
       <p
         class="govuk-hint"
@@ -2128,57 +2212,84 @@ exports[`TableToolFinalStep renders the Table Tool final step correctly when thi
       </table>
     </div>
   </figure>
-  <h3>
-    Share your table
-  </h3>
-  <ul
-    class="govuk-list"
+  <div
+    class="govuk-grid-row"
   >
-    <li>
+    <div
+      class="govuk-grid-column-one-half"
+    >
+      <details
+        class="govuk-details"
+        role="group"
+      >
+        <summary
+          aria-controls="details-content-22"
+          aria-expanded="false"
+          class="govuk-details__summary"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="summaryText govuk-details__summary-text"
+            data-testid="Expand Details Section Additional options"
+          >
+            Additional options
+          </span>
+        </summary>
+        <div
+          aria-hidden="true"
+          class="govuk-details__text"
+          id="details-content-22"
+        >
+          <ul
+            class="govuk-list"
+          >
+            <li>
+              <a
+                class="govuk-link"
+                href="/find-statistics/test-publication"
+              >
+                View the release for this data
+              </a>
+            </li>
+            <li>
+              <button
+                class="button"
+                type="button"
+              >
+                Download the data of this table (CSV)
+              </button>
+            </li>
+            <li>
+              <button
+                class="button"
+                type="button"
+              >
+                Download table as Excel spreadsheet (XLSX)
+              </button>
+            </li>
+          </ul>
+        </div>
+      </details>
+    </div>
+    <div
+      class="govuk-grid-column-one-half dfe-align--right"
+    >
       <button
         class="button"
         type="button"
       >
-        Generate permanent link
+        Share your table
       </button>
-    </li>
-  </ul>
-  <h3>
-    Additional options
-  </h3>
-  <ul
-    class="govuk-list"
+    </div>
+  </div>
+  <div
+    class="govuk-inset-text"
   >
-    <li>
-      <a
-        class="govuk-link"
-        href="/find-statistics/test-publication"
-      >
-        View the release for this data
-      </a>
-    </li>
-    <li>
-      <button
-        class="button"
-        type="button"
-      >
-        Download the data of this table (CSV)
-      </button>
-    </li>
-    <li>
-      <button
-        class="button"
-        type="button"
-      >
-        Download table as Excel spreadsheet (XLSX)
-      </button>
-    </li>
-  </ul>
-  <p
-    class="govuk-body"
-  >
-    If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
-  </p>
+    <p>
+      If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
+    </p>
+  </div>
 </div>
 `;
 
@@ -2740,57 +2851,85 @@ exports[`TableToolFinalStep renders the final step successfully 2`] = `
       </table>
     </div>
   </figure>
-  <h3>
-    Share your table
-  </h3>
-  <ul
-    class="govuk-list"
+  <div
+    class="govuk-grid-row"
   >
-    <li>
+    <div
+      class="govuk-grid-column-one-half"
+    >
+      <details
+        class="govuk-details"
+        open=""
+        role="group"
+      >
+        <summary
+          aria-controls="details-content-2"
+          aria-expanded="true"
+          class="govuk-details__summary"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="summaryText govuk-details__summary-text"
+            data-testid="Expand Details Section Additional options"
+          >
+            Additional options
+          </span>
+        </summary>
+        <div
+          aria-hidden="false"
+          class="govuk-details__text"
+          id="details-content-2"
+        >
+          <ul
+            class="govuk-list"
+          >
+            <li>
+              <a
+                class="govuk-link"
+                href="/find-statistics/test-publication"
+              >
+                View the release for this data
+              </a>
+            </li>
+            <li>
+              <button
+                class="button"
+                type="button"
+              >
+                Download the data of this table (CSV)
+              </button>
+            </li>
+            <li>
+              <button
+                class="button"
+                type="button"
+              >
+                Download table as Excel spreadsheet (XLSX)
+              </button>
+            </li>
+          </ul>
+        </div>
+      </details>
+    </div>
+    <div
+      class="govuk-grid-column-one-half dfe-align--right"
+    >
       <button
         class="button"
         type="button"
       >
-        Generate permanent link
+        Share your table
       </button>
-    </li>
-  </ul>
-  <h3>
-    Additional options
-  </h3>
-  <ul
-    class="govuk-list"
+    </div>
+  </div>
+  <div
+    class="govuk-inset-text"
   >
-    <li>
-      <a
-        class="govuk-link"
-        href="/find-statistics/test-publication"
-      >
-        View the release for this data
-      </a>
-    </li>
-    <li>
-      <button
-        class="button"
-        type="button"
-      >
-        Download the data of this table (CSV)
-      </button>
-    </li>
-    <li>
-      <button
-        class="button"
-        type="button"
-      >
-        Download table as Excel spreadsheet (XLSX)
-      </button>
-    </li>
-  </ul>
-  <p
-    class="govuk-body"
-  >
-    If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
-  </p>
+    <p>
+      If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
+    </p>
+  </div>
 </div>
 `;
 
@@ -2805,7 +2944,7 @@ exports[`TableToolFinalStep shows and hides table header re-ordering controls su
     role="group"
   >
     <summary
-      aria-controls="details-content-3"
+      aria-controls="details-content-6"
       aria-expanded="true"
       class="govuk-details__summary"
       role="button"
@@ -2821,7 +2960,7 @@ exports[`TableToolFinalStep shows and hides table header re-ordering controls su
     <div
       aria-hidden="false"
       class="govuk-details__text"
-      id="details-content-3"
+      id="details-content-6"
     >
       <p
         class="govuk-hint"
@@ -3278,56 +3417,83 @@ exports[`TableToolFinalStep shows and hides table header re-ordering controls su
       </table>
     </div>
   </figure>
-  <h3>
-    Share your table
-  </h3>
-  <ul
-    class="govuk-list"
+  <div
+    class="govuk-grid-row"
   >
-    <li>
+    <div
+      class="govuk-grid-column-one-half"
+    >
+      <details
+        class="govuk-details"
+        role="group"
+      >
+        <summary
+          aria-controls="details-content-7"
+          aria-expanded="false"
+          class="govuk-details__summary"
+          role="button"
+          tabindex="0"
+        >
+          <span
+            class="summaryText govuk-details__summary-text"
+            data-testid="Expand Details Section Additional options"
+          >
+            Additional options
+          </span>
+        </summary>
+        <div
+          aria-hidden="true"
+          class="govuk-details__text"
+          id="details-content-7"
+        >
+          <ul
+            class="govuk-list"
+          >
+            <li>
+              <a
+                class="govuk-link"
+                href="/find-statistics/test-publication"
+              >
+                View the release for this data
+              </a>
+            </li>
+            <li>
+              <button
+                class="button"
+                type="button"
+              >
+                Download the data of this table (CSV)
+              </button>
+            </li>
+            <li>
+              <button
+                class="button"
+                type="button"
+              >
+                Download table as Excel spreadsheet (XLSX)
+              </button>
+            </li>
+          </ul>
+        </div>
+      </details>
+    </div>
+    <div
+      class="govuk-grid-column-one-half dfe-align--right"
+    >
       <button
         class="button"
         type="button"
       >
-        Generate permanent link
+        Share your table
       </button>
-    </li>
-  </ul>
-  <h3>
-    Additional options
-  </h3>
-  <ul
-    class="govuk-list"
+    </div>
+  </div>
+  <div
+    class="govuk-inset-text"
   >
-    <li>
-      <a
-        class="govuk-link"
-        href="/find-statistics/test-publication"
-      >
-        View the release for this data
-      </a>
-    </li>
-    <li>
-      <button
-        class="button"
-        type="button"
-      >
-        Download the data of this table (CSV)
-      </button>
-    </li>
-    <li>
-      <button
-        class="button"
-        type="button"
-      >
-        Download table as Excel spreadsheet (XLSX)
-      </button>
-    </li>
-  </ul>
-  <p
-    class="govuk-body"
-  >
-    If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
-  </p>
+    <p>
+      If you have a question about the data or methods used to create this table contact the named statistician via the relevant release page.
+    </p>
+  </div>
 </div>
 `;

--- a/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
@@ -11,7 +11,7 @@ Go to Table Tool page
     [Tags]  HappyPath
     environment variable should be set  PUBLIC_URL
     user goes to url  %{PUBLIC_URL}/data-tables
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
     user waits for page to finish loading
 
 Select "Pupil absence" publication
@@ -20,7 +20,7 @@ Select "Pupil absence" publication
     user opens details dropdown    Pupil absence
     user clicks radio      Pupil absence in schools in England
     user clicks element    id:publicationForm-submit
-    user waits until h2 is visible  Choose a subject
+    user waits until element is visible  xpath://span[text()="Choose a subject"]
     user checks previous table tool step contains  1   Publication   Pupil absence in schools in England
 
 Validate "Absence by characteristic" subject details
@@ -34,7 +34,7 @@ Select subject "Absence by characteristic"
     [Tags]  HappyPath
     user clicks radio   Absence by characteristic
     user clicks element   id:publicationSubjectForm-submit
-    user waits until h2 is visible  Choose locations
+    user waits until element is visible  xpath://span[text()="Choose locations"]
     user checks previous table tool step contains  2    Subject     Absence by characteristic
 
 Select Location Country, England
@@ -43,7 +43,7 @@ Select Location Country, England
     user clicks checkbox    England
     user clicks element     id:locationFiltersForm-submit
     # Extra timeout until EES-315/316
-    user waits until h2 is visible  Choose time period
+    user waits until element is visible  xpath://span[text()="Choose time period"]
     user checks previous table tool step contains  3    National    England
 
 Select Start date and End date
@@ -51,10 +51,9 @@ Select Start date and End date
     user selects from list by label  id:timePeriodForm-start   2012/13
     user selects from list by label  id:timePeriodForm-end   2015/16
     user clicks element     id:timePeriodForm-submit
-    user waits until h2 is visible  Choose your filters
+    user waits until element is visible  xpath://span[text()="Choose your filters"]
     user waits until page contains element   id:filtersForm-indicators
-    user checks previous table tool step contains  4    Start date    2012/13
-    user checks previous table tool step contains  4    End date      2015/16
+    user checks previous table tool step contains  4    Time period    2012/13 to 2015/16
 
 Select Indicators - Authorised absence rate
     [Tags]  HappyPath
@@ -244,13 +243,13 @@ Validate rows after reordering
 
 User generates a permanent link
     [Tags]   HappyPath
-    user clicks element    xpath://*[text()="Generate permanent link"]
-    user waits until page contains element   xpath://a[text()="View permanent link"]   60
+    user clicks element    xpath://*[text()="Share your table"]
+    user waits until page contains element   xpath://a[text()="View share link"]   60
     user checks generated permalink is valid
 
 User validates permanent link works correctly
     [Tags]   HappyPath
-    user clicks link   View permanent link
+    user clicks link   View share link
     select window    NEW
     user waits until h1 is visible  'Absence by characteristic' from 'Pupil absence in schools in England'
 
@@ -300,3 +299,5 @@ User validates permalink table
     user checks results table cell contains  3    6     3.6%
     user checks results table cell contains  3    7     3.5%
     user checks results table cell contains  3    8     4.2%
+
+

--- a/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
@@ -11,7 +11,7 @@ Go to Table Tool page
     [Tags]  HappyPath
     environment variable should be set  PUBLIC_URL
     user goes to url  %{PUBLIC_URL}/data-tables
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
     user waits for page to finish loading
 
 Select "Pupil absence" publication
@@ -20,7 +20,7 @@ Select "Pupil absence" publication
     user opens details dropdown    Pupil absence
     user clicks radio      Pupil absence in schools in England
     user clicks element    id:publicationForm-submit
-    user waits until h2 is visible  Choose a subject
+    user waits until element is visible  xpath://span[text()="Choose a subject"]
     user checks previous table tool step contains  1   Publication   Pupil absence in schools in England
 
 Validate "Absence in prus" subject details
@@ -34,7 +34,7 @@ Select subject "Absence in prus"
     [Tags]  HappyPath
     user clicks radio   Absence in prus
     user clicks element   id:publicationSubjectForm-submit
-    user waits until h2 is visible  Choose locations
+    user waits until element is visible  xpath://span[text()="Choose locations"]
     user checks previous table tool step contains  2    Subject     Absence in prus
 
 Select Location Country, England
@@ -42,7 +42,7 @@ Select Location Country, England
     user opens details dropdown     National
     user clicks checkbox    England
     user clicks element     id:locationFiltersForm-submit
-    user waits until h2 is visible  Choose time period
+    user waits until element is visible  xpath://span[text()="Choose time period"]
     user checks previous table tool step contains  3   National     England
 
 Select Start date and End date
@@ -50,10 +50,9 @@ Select Start date and End date
     user selects from list by label  id:timePeriodForm-start   2013/14
     user selects from list by label  id:timePeriodForm-end     2016/17
     user clicks element     id:timePeriodForm-submit
-    user waits until h2 is visible  Choose your filters
+    user waits until element is visible  xpath://span[text()="Choose your filters"]
     user waits until page contains element   id:filtersForm-indicators
-    user checks previous table tool step contains  4    Start date    2013/14
-    user checks previous table tool step contains  4    End date      2016/17
+    user checks previous table tool step contains  4    Time period    2013/14 to 2016/17
 
 Select Indicators
     [Tags]  HappyPath
@@ -64,7 +63,7 @@ Create table
     [Tags]  HappyPath
     user clicks element     id:filtersForm-submit
     user waits until results table appears     60
-    user waits until page contains element   xpath://*[@data-testid="dataTableCaption" and text()="Table showing Number of schools for 'Absence in prus' from 'Pupil absence in schools in England' in England between 2013/14 and 2016/17"]
+    user waits until page contains element   xpath://*[@data-testid="dataTableCaption" and text()="Table showing Number of schools for 'Absence in prus' in England between 2013/14 and 2016/17"]
 
 Validate results table column headings
     [Tags]  HappyPath
@@ -86,7 +85,7 @@ Validate Number of schools row results
 
 Go back to Locations step
     [Tags]  HappyPath
-    user clicks element  xpath://button[contains(text(), "Choose locations")]
+    user clicks element  xpath://button[contains(text(), "Edit locations")]
     user waits until page contains element  xpath://h1[text()="Go back to previous step"]
     user clicks element  xpath://button[text()="Confirm"]
 
@@ -111,7 +110,7 @@ Select locations LAs Barnet, Barnsley, Bedford
     user clicks checkbox            Bedford
 
     user clicks element   id:locationFiltersForm-submit
-    user waits until h2 is visible  Choose time period
+    user waits until element is visible  xpath://span[text()="Choose time period"]
     user checks previous table tool step contains  3    Local Authority    Barnet
     user checks previous table tool step contains  3    Local Authority    Barnsley
     user checks previous table tool step contains  3    Local Authority    Bedford
@@ -121,10 +120,9 @@ Select new start and end date
     user selects from list by label  id:timePeriodForm-start   2014/15
     user selects from list by label  id:timePeriodForm-end     2015/16
     user clicks element     id:timePeriodForm-submit
-    user waits until h2 is visible  Choose your filters
+    user waits until element is visible  xpath://span[text()="Choose your filters"]
     user waits until page contains element   id:filtersForm-indicators
-    user checks previous table tool step contains  4    Start date    2014/15
-    user checks previous table tool step contains  4    End date      2015/16
+    user checks previous table tool step contains  4    Time period    2014/15 to 2015/16
 
 Select indicator Number of pupil enrolments
     [Tags]   HappyPath
@@ -144,7 +142,7 @@ Create table again
     [Tags]   HappyPath
     user clicks element    id:filtersForm-submit
     user waits until results table appears    60
-    user waits until page contains element   xpath://*[@data-testid="dataTableCaption" and text()="Table showing 'Absence in prus' from 'Pupil absence in schools in England' in Barnet, Barnsley and Bedford between 2014/15 and 2015/16"]
+    user waits until page contains element   xpath://*[@data-testid="dataTableCaption" and text()="Table showing 'Absence in prus' in Barnet, Barnsley and Bedford between 2014/15 and 2015/16"]
 
 Validate new table column headings
     [Tags]   HappyPath

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -11,7 +11,7 @@ Go to Table Tool page
     [Tags]  HappyPath
     environment variable should be set  PUBLIC_URL
     user goes to url  %{PUBLIC_URL}/data-tables
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
     user waits for page to finish loading
 
 Select Exclusions publication
@@ -20,7 +20,7 @@ Select Exclusions publication
     user opens details dropdown    Exclusions
     user clicks radio      Permanent and fixed-period exclusions in England
     user clicks element    id:publicationForm-submit
-    user waits until h2 is visible  Choose a subject
+    user waits until element is visible  xpath://span[text()="Choose a subject"]
     user checks previous table tool step contains  1   Publication   Permanent and fixed-period exclusions in England
 
 Validate "Exclusions by geographic level" subject details
@@ -34,7 +34,7 @@ Select subject "Exclusions by geographic level"
     [Tags]  HappyPath
     user clicks radio   Exclusions by geographic level
     user clicks element   id:publicationSubjectForm-submit
-    user waits until h2 is visible  Choose locations
+    user waits until element is visible  xpath://span[text()="Choose locations"]
     user checks previous table tool step contains  2    Subject     Exclusions by geographic level
 
 Select Locations LA, Bury, Sheffield, York
@@ -45,7 +45,7 @@ Select Locations LA, Bury, Sheffield, York
     user clicks checkbox    York
     user clicks element     id:locationFiltersForm-submit
     # Extra timeout until EES-315/316
-    user waits until h2 is visible  Choose time period
+    user waits until element is visible  xpath://span[text()="Choose time period"]
     user checks previous table tool step contains  3    Local Authority    Bury
     user checks previous table tool step contains  3    Local Authority    Sheffield
     user checks previous table tool step contains  3    Local Authority    York
@@ -55,10 +55,9 @@ Select Start date and End date
     user selects from list by label  id:timePeriodForm-start   2006/07
     user selects from list by label  id:timePeriodForm-end     2008/09
     user clicks element     id:timePeriodForm-submit
-    user waits until h2 is visible  Choose your filters
+    user waits until element is visible  xpath://span[text()="Choose your filters"]
     user waits until page contains element   id:filtersForm-indicators
-    user checks previous table tool step contains  4    Start date    2006/07
-    user checks previous table tool step contains  4    End date      2008/09
+    user checks previous table tool step contains  4    Time period    2006/07 to 2008/09
 
 Select Indicator - Number of pupils
     [Tags]  HappyPath
@@ -106,13 +105,13 @@ Validate Bury Number of fixed period exclusions row
 
 User generates a permanent link
     [Tags]   HappyPath
-    user clicks button    Generate permanent link
-    user waits until page contains element   xpath://a[text()="View permanent link"]   60
+    user clicks button    Share your table
+    user waits until page contains element   xpath://a[text()="View share link"]   60
     user checks generated permalink is valid
 
 User validates permanent link works correctly
     [Tags]   HappyPath
-    user clicks link   View permanent link
+    user clicks link   View share link
     select window    NEW
     user waits until h1 is visible  'Exclusions by geographic level' from 'Permanent and fixed-period exclusions in England'
 

--- a/tests/robot-tests/tests/libs/table_tool.robot
+++ b/tests/robot-tests/tests/libs/table_tool.robot
@@ -37,7 +37,7 @@ user clicks select all for category
 
 user checks previous table tool step contains
     [Arguments]  ${step}   ${key}   ${value}   ${wait}=10
-    wait until page contains element  xpath://*[@id="tableToolWizard-step-${step}"]//*[text()="Go to this step"]
+    wait until page contains element  xpath://*[@id="tableToolWizard-step-${step}"]
     ...   timeout=${wait}
     ...   error=Previous step wasn't found!
     wait until page contains element  xpath://*[@id="tableToolWizard-step-${step}"]//dt[text()="${key}"]/..//*[text()="${value}"]


### PR DESCRIPTION
Changes the table tool styling to reduce the vertical space, this includes
- hiding the step headings on inactive steps
- moving and changing the edit step links
- changing the format of the displayed time period
- moving the additional options into an collapsed section
- moving and changing the wording for generating a permalink, plus adding a copy link button
- updating loads of tests

![tabletool](https://user-images.githubusercontent.com/81572860/119532906-3b657a80-bd7d-11eb-84ac-bb148c33b829.png)
