### PR TITLE
EES-1126 show correct time period table headers in reorder list

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageReadOnlyTabs.tsx
@@ -39,7 +39,7 @@ const DataBlockPageReadOnlyTabs = ({ releaseId, dataBlock }: Props) => {
 
     const tableHeaders = mapTableHeadersConfig(
       dataBlock.table.tableHeaders,
-      table.subjectMeta,
+      table,
     );
 
     return {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -104,7 +104,7 @@ const DataBlockPageTabs = ({
     try {
       const tableHeaders = mapTableHeadersConfig(
         dataBlock.table.tableHeaders,
-        table.subjectMeta,
+        table,
       );
 
       return {

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
@@ -55,10 +55,7 @@ const PreReleaseTableToolPage = ({
       ]);
 
       const fullTable = mapFullTable(tableData);
-      const tableHeaders = mapTableHeadersConfig(
-        table.tableHeaders,
-        fullTable.subjectMeta,
-      );
+      const tableHeaders = mapTableHeadersConfig(table.tableHeaders, fullTable);
 
       return {
         initialStep: 5,

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -133,9 +133,9 @@ const DataBlockTabs = ({
                     dataBlock.table.tableHeaders
                       ? mapTableHeadersConfig(
                           dataBlock.table.tableHeaders,
-                          fullTable.subjectMeta,
+                          fullTable,
                         )
-                      : getDefaultTableHeaderConfig(fullTable.subjectMeta)
+                      : getDefaultTableHeaderConfig(fullTable)
                   }
                 />
 

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/DataBlockTabs.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/DataBlockTabs.test.tsx
@@ -311,7 +311,7 @@ describe('DataBlockTabs', () => {
           ...testDataBlock,
           table: {
             tableHeaders: mapUnmappedTableHeaders(
-              getDefaultTableHeaderConfig(fullTable.subjectMeta),
+              getDefaultTableHeaderConfig(fullTable),
             ),
             indicators: [
               'authorised-absence-rate',
@@ -377,7 +377,7 @@ describe('DataBlockTabs', () => {
           ...testDataBlock,
           table: {
             tableHeaders: mapUnmappedTableHeaders(
-              getDefaultTableHeaderConfig(fullTable.subjectMeta),
+              getDefaultTableHeaderConfig(fullTable),
             ),
             indicators: [
               'authorised-absence-rate',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -258,7 +258,7 @@ const TableToolWizard = ({
     }
 
     const table = mapFullTable(tableData);
-    const tableHeaders = getDefaultTableHeaderConfig(table.subjectMeta);
+    const tableHeaders = getDefaultTableHeaderConfig(table);
 
     if (onSubmit) {
       onSubmit(table);

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
@@ -22,7 +22,7 @@ describe('TimePeriodDataTable', () => {
         fullTable={fullTable}
         tableHeadersConfig={mapTableHeadersConfig(
           testData1.tableHeadersConfig,
-          fullTable.subjectMeta,
+          fullTable,
         )}
       />,
     );
@@ -59,7 +59,7 @@ describe('TimePeriodDataTable', () => {
         fullTable={fullTable}
         tableHeadersConfig={mapTableHeadersConfig(
           testData1.tableHeadersConfig,
-          fullTable.subjectMeta,
+          fullTable,
         )}
       />,
     );
@@ -79,7 +79,7 @@ describe('TimePeriodDataTable', () => {
         fullTable={fullTable}
         tableHeadersConfig={mapTableHeadersConfig(
           testData2.tableHeadersConfig,
-          fullTable.subjectMeta,
+          fullTable,
         )}
       />,
     );
@@ -116,7 +116,7 @@ describe('TimePeriodDataTable', () => {
         fullTable={fullTable}
         tableHeadersConfig={mapTableHeadersConfig(
           testData2.tableHeadersConfig,
-          fullTable.subjectMeta,
+          fullTable,
         )}
       />,
     );
@@ -136,7 +136,7 @@ describe('TimePeriodDataTable', () => {
         fullTable={fullTable}
         tableHeadersConfig={mapTableHeadersConfig(
           testData3.tableHeadersConfig,
-          fullTable.subjectMeta,
+          fullTable,
         )}
       />,
     );
@@ -173,7 +173,7 @@ describe('TimePeriodDataTable', () => {
         fullTable={fullTable}
         tableHeadersConfig={mapTableHeadersConfig(
           testData3.tableHeadersConfig,
-          fullTable.subjectMeta,
+          fullTable,
         )}
       />,
     );
@@ -193,7 +193,7 @@ describe('TimePeriodDataTable', () => {
         fullTable={fullTable}
         tableHeadersConfig={mapTableHeadersConfig(
           testDataNoFilters.tableHeadersConfig,
-          fullTable.subjectMeta,
+          fullTable,
         )}
       />,
     );
@@ -293,7 +293,7 @@ describe('TimePeriodDataTable', () => {
           },
         ],
       },
-      fullTable.subjectMeta,
+      fullTable,
     );
 
     const { container } = render(
@@ -379,7 +379,7 @@ describe('TimePeriodDataTable', () => {
           },
         ],
       },
-      fullTable.subjectMeta,
+      fullTable,
     );
 
     const { container } = render(
@@ -464,7 +464,7 @@ describe('TimePeriodDataTable', () => {
           },
         ],
       },
-      fullTable.subjectMeta,
+      fullTable,
     );
 
     const { container } = render(
@@ -554,7 +554,7 @@ describe('TimePeriodDataTable', () => {
         fullTable={fullTable}
         tableHeadersConfig={mapTableHeadersConfig(
           tableHeadersConfig,
-          fullTable.subjectMeta,
+          fullTable,
         )}
       />,
     );
@@ -633,7 +633,7 @@ describe('TimePeriodDataTable', () => {
         fullTable={fullTable}
         tableHeadersConfig={mapTableHeadersConfig(
           tableHeadersConfig,
-          fullTable.subjectMeta,
+          fullTable,
         )}
       />,
     );

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/getDefaultTableHeadersConfig.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/getDefaultTableHeadersConfig.test.ts
@@ -152,74 +152,79 @@ describe('getDefaultTableHeadersConfig', () => {
   });
 
   test('returns correct config using a larger number of time periods than indicators', () => {
-    const testTableDataTimePeriods = JSON.parse(JSON.stringify(testTableData));
-    testTableDataTimePeriods.subjectMeta.indicators = [
-      {
-        value: 'overall-absence-sessions',
-        label: 'Number of overall absence sessions',
-        unit: '',
-        name: 'sess_overall',
-        decimalPlaces: 2,
+    const testTableDataTimePeriods = {
+      ...testTableData,
+      subjectMeta: {
+        ...testTableData.subjectMeta,
+        indicators: [
+          {
+            value: 'overall-absence-sessions',
+            label: 'Number of overall absence sessions',
+            unit: '',
+            name: 'sess_overall',
+            decimalPlaces: 2,
+          },
+          {
+            value: 'authorised-absence-sessions',
+            label: 'Number of authorised absence sessions',
+            unit: '',
+            name: 'sess_authorised',
+            decimalPlaces: 2,
+          },
+          {
+            value: 'persistent-absentees',
+            label: 'Number of persistent absentees',
+            unit: '',
+            name: 'enrolments_pa_10_exact',
+            decimalPlaces: 2,
+          },
+        ],
+        timePeriodRange: [
+          { label: '2014/15', code: 'AY', year: 2014 },
+          { label: '2015/16', code: 'AY', year: 2015 },
+          { label: '2016/17', code: 'AY', year: 2016 },
+          { label: '2017/18', code: 'AY', year: 2017 },
+          { label: '2018/19', code: 'AY', year: 2018 },
+        ],
       },
-      {
-        value: 'authorised-absence-sessions',
-        label: 'Number of authorised absence sessions',
-        unit: '',
-        name: 'sess_authorised',
-        decimalPlaces: 2,
-      },
-      {
-        value: 'persistent-absentees',
-        label: 'Number of persistent absentees',
-        unit: '',
-        name: 'enrolments_pa_10_exact',
-        decimalPlaces: 2,
-      },
-    ];
-    testTableDataTimePeriods.subjectMeta.timePeriodRange = [
-      { label: '2014/15', code: 'AY', year: 2014 },
-      { label: '2015/16', code: 'AY', year: 2015 },
-      { label: '2016/17', code: 'AY', year: 2016 },
-      { label: '2017/18', code: 'AY', year: 2017 },
-      { label: '2018/19', code: 'AY', year: 2018 },
-    ];
-    testTableDataTimePeriods.results = [
-      {
-        filters: [],
-        geographicLevel: '',
-        location: {},
-        measures: {},
-        timePeriod: '2014_AY',
-      },
-      {
-        filters: [],
-        geographicLevel: '',
-        location: {},
-        measures: {},
-        timePeriod: '2015_AY',
-      },
-      {
-        filters: [],
-        geographicLevel: '',
-        location: {},
-        measures: {},
-        timePeriod: '2016_AY',
-      },
-      {
-        filters: [],
-        geographicLevel: '',
-        location: {},
-        measures: {},
-        timePeriod: '2017_AY',
-      },
-      {
-        filters: [],
-        geographicLevel: '',
-        location: {},
-        measures: {},
-        timePeriod: '2018_AY',
-      },
-    ];
+      results: [
+        {
+          filters: [],
+          geographicLevel: '',
+          location: {},
+          measures: {},
+          timePeriod: '2014_AY',
+        },
+        {
+          filters: [],
+          geographicLevel: '',
+          location: {},
+          measures: {},
+          timePeriod: '2015_AY',
+        },
+        {
+          filters: [],
+          geographicLevel: '',
+          location: {},
+          measures: {},
+          timePeriod: '2016_AY',
+        },
+        {
+          filters: [],
+          geographicLevel: '',
+          location: {},
+          measures: {},
+          timePeriod: '2017_AY',
+        },
+        {
+          filters: [],
+          geographicLevel: '',
+          location: {},
+          measures: {},
+          timePeriod: '2018_AY',
+        },
+      ],
+    };
 
     const testSubjectMeta = mapFullTable(testTableDataTimePeriods);
 
@@ -259,38 +264,49 @@ describe('getDefaultTableHeadersConfig', () => {
   });
 
   test('returns correct config when two options for every filter type', () => {
-    const testTableDataTwoOptions = JSON.parse(JSON.stringify(testTableData));
-    testTableDataTwoOptions.subjectMeta.filters.SchoolType.options = {
-      Default: {
-        label: 'Default',
-        options: [
+    const testTableDataTwoOptions = {
+      ...testTableData,
+      subjectMeta: {
+        ...testTableData.subjectMeta,
+        filters: {
+          ...testTableData.subjectMeta.filters,
+          SchoolType: {
+            ...testTableData.subjectMeta.filters.SchoolType,
+            options: {
+              Default: {
+                label: 'Default',
+                options: [
+                  {
+                    label: 'State-funded secondary',
+                    value: 'state-funded-secondary',
+                  },
+                  {
+                    label: 'Special',
+                    value: 'special',
+                  },
+                ],
+              },
+            },
+          },
+        },
+        indicators: [
           {
-            label: 'State-funded secondary',
-            value: 'state-funded-secondary',
+            value: 'overall-absence-sessions',
+            label: 'Number of overall absence sessions',
+            unit: '',
+            name: 'sess_overall',
+            decimalPlaces: 2,
           },
           {
-            label: 'Special',
-            value: 'special',
+            value: 'authorised-absence-sessions',
+            label: 'Number of authorised absence sessions',
+            unit: '',
+            name: 'sess_authorised',
+            decimalPlaces: 2,
           },
         ],
       },
     };
-    testTableDataTwoOptions.subjectMeta.indicators = [
-      {
-        value: 'overall-absence-sessions',
-        label: 'Number of overall absence sessions',
-        unit: '',
-        name: 'sess_overall',
-        decimalPlaces: 2,
-      },
-      {
-        value: 'authorised-absence-sessions',
-        label: 'Number of authorised absence sessions',
-        unit: '',
-        name: 'sess_authorised',
-        decimalPlaces: 2,
-      },
-    ];
 
     const testSubjectMeta = mapFullTable(testTableDataTwoOptions);
 
@@ -325,50 +341,64 @@ describe('getDefaultTableHeadersConfig', () => {
   });
 
   test('returns correct config with siblingless filters removed when one option for every filter type', () => {
-    const testTableDataSiblingless = JSON.parse(JSON.stringify(testTableData));
-    testTableDataSiblingless.subjectMeta.filters.Characteristic.options = {
-      EthnicGroupMajor: {
-        label: 'Ethnic group major',
-        options: [
+    const testTableDataSiblingless = {
+      ...testTableData,
+      subjectMeta: {
+        ...testTableData.subjectMeta,
+        filters: {
+          ...testTableData.subjectMeta.filters,
+          Characteristic: {
+            ...testTableData.subjectMeta.filters.Characteristic,
+            options: {
+              EthnicGroupMajor: {
+                label: 'Ethnic group major',
+                options: [
+                  {
+                    label: 'Ethnicity Major Black Total',
+                    value: 'ethnicity-major-black-total',
+                  },
+                ],
+              },
+            },
+          },
+          SchoolType: {
+            ...testTableData.subjectMeta.filters.SchoolType,
+            options: {
+              Default: {
+                label: 'Default',
+                options: [
+                  {
+                    label: 'State-funded secondary',
+                    value: 'state-funded-secondary',
+                  },
+                ],
+              },
+            },
+          },
+        },
+        indicators: [
           {
-            label: 'Ethnicity Major Black Total',
-            value: 'ethnicity-major-black-total',
+            value: 'overall-absence-sessions',
+            label: 'Number of overall absence sessions',
+            unit: '',
+            name: 'sess_overall',
+            decimalPlaces: 2,
           },
         ],
-      },
-    };
-    testTableDataSiblingless.subjectMeta.filters.SchoolType.options = {
-      Default: {
-        label: 'Default',
-        options: [
-          {
-            label: 'State-funded secondary',
-            value: 'state-funded-secondary',
-          },
+        locations: [
+          { value: 'barnsley', label: 'Barnsley', level: 'localAuthority' },
         ],
       },
+      results: [
+        {
+          filters: [],
+          geographicLevel: '',
+          location: {},
+          measures: {},
+          timePeriod: '2014_AY',
+        },
+      ],
     };
-    testTableDataSiblingless.subjectMeta.indicators = [
-      {
-        value: 'overall-absence-sessions',
-        label: 'Number of overall absence sessions',
-        unit: '',
-        name: 'sess_overall',
-        decimalPlaces: 2,
-      },
-    ];
-    testTableDataSiblingless.subjectMeta.locations = [
-      { value: 'barnsley', label: 'Barnsley', level: 'localAuthority' },
-    ];
-    testTableDataSiblingless.results = [
-      {
-        filters: [],
-        geographicLevel: '',
-        location: {},
-        measures: {},
-        timePeriod: '2014_AY',
-      },
-    ];
 
     const testSubjectMeta = mapFullTable(testTableDataSiblingless);
 
@@ -392,30 +422,35 @@ describe('getDefaultTableHeadersConfig', () => {
   });
 
   test('returns the correct time periods when terms are selected', () => {
-    const testTableDataTerms = JSON.parse(JSON.stringify(testTableData));
-    testTableDataTerms.results = [
-      {
-        filters: [],
-        geographicLevel: '',
-        location: {},
-        measures: {},
-        timePeriod: '2018_T1',
+    const testTableDataTerms = {
+      ...testTableData,
+      subjectMeta: {
+        ...testTableData.subjectMeta,
+        timePeriodRange: [
+          { code: 'T1', label: '2017/18 Autumn Term', year: 2017 },
+          { code: 'T1T2', label: '2017/18 Autumn and Spring Term', year: 2017 },
+          { code: 'T2', label: '2017/18 Spring Term', year: 2017 },
+          { code: 'T3', label: '2017/18 Summer Term', year: 2017 },
+          { code: 'T1', label: '2018/19 Autumn Term', year: 2018 },
+        ],
       },
-      {
-        filters: [],
-        geographicLevel: '',
-        location: {},
-        measures: {},
-        timePeriod: '2017_T1',
-      },
-    ];
-    testTableDataTerms.subjectMeta.timePeriodRange = [
-      { code: 'T1', label: '2017/18 Autumn Term', year: 2017 },
-      { code: 'T1T2', label: '2017/18 Autumn and Spring Term', year: 2017 },
-      { code: 'T2', label: '2017/18 Spring Term', year: 2017 },
-      { code: 'T3', label: '2017/18 Summer Term', year: 2017 },
-      { code: 'T1', label: '2018/19 Autumn Term', year: 2018 },
-    ];
+      results: [
+        {
+          filters: [],
+          geographicLevel: '',
+          location: {},
+          measures: {},
+          timePeriod: '2018_T1',
+        },
+        {
+          filters: [],
+          geographicLevel: '',
+          location: {},
+          measures: {},
+          timePeriod: '2017_T1',
+        },
+      ],
+    };
 
     const testSubjectMeta = mapFullTable(testTableDataTerms);
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/getDefaultTableHeadersConfig.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/getDefaultTableHeadersConfig.test.ts
@@ -3,104 +3,119 @@ import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import { TableDataResponse } from '@common/services/tableBuilderService';
 
 describe('getDefaultTableHeadersConfig', () => {
-  test('returns correct config using a variety of options for every filter type', () => {
-    const testTableData: TableDataResponse = {
-      subjectMeta: {
-        filters: {
-          Characteristic: {
-            totalValue: '',
-            hint: '',
-            legend: 'Characteristic',
-            name: 'characteristic',
-            options: {
-              EthnicGroupMajor: {
-                label: 'Ethnic group major',
-                options: [
-                  {
-                    label: 'Ethnicity Major Black Total',
-                    value: 'ethnicity-major-black-total',
-                  },
-                  {
-                    label: 'Ethnicity Major Asian Total',
-                    value: 'ethnicity-major-asian-total',
-                  },
-                ],
-              },
-            },
-          },
-          SchoolType: {
-            totalValue: '',
-            hint: 'Filter by school type',
-            legend: 'School type',
-            name: 'school_type',
-            options: {
-              Default: {
-                label: 'Default',
-                options: [
-                  {
-                    label: 'State-funded secondary',
-                    value: 'state-funded-secondary',
-                  },
-                  {
-                    label: 'Special',
-                    value: 'special',
-                  },
-                  {
-                    label: 'State-funded primary',
-                    value: 'state-funded-primary',
-                  },
-                ],
-              },
+  const testTableData: TableDataResponse = {
+    subjectMeta: {
+      filters: {
+        Characteristic: {
+          totalValue: '',
+          hint: '',
+          legend: 'Characteristic',
+          name: 'characteristic',
+          options: {
+            EthnicGroupMajor: {
+              label: 'Ethnic group major',
+              options: [
+                {
+                  label: 'Ethnicity Major Black Total',
+                  value: 'ethnicity-major-black-total',
+                },
+                {
+                  label: 'Ethnicity Major Asian Total',
+                  value: 'ethnicity-major-asian-total',
+                },
+              ],
             },
           },
         },
-        footnotes: [],
-        geoJsonAvailable: false,
-        indicators: [
-          {
-            value: 'overall-absence-sessions',
-            label: 'Number of overall absence sessions',
-            unit: '',
-            name: 'sess_overall',
-            decimalPlaces: 2,
+        SchoolType: {
+          totalValue: '',
+          hint: 'Filter by school type',
+          legend: 'School type',
+          name: 'school_type',
+          options: {
+            Default: {
+              label: 'Default',
+              options: [
+                {
+                  label: 'State-funded secondary',
+                  value: 'state-funded-secondary',
+                },
+                {
+                  label: 'Special',
+                  value: 'special',
+                },
+                {
+                  label: 'State-funded primary',
+                  value: 'state-funded-primary',
+                },
+              ],
+            },
           },
-          {
-            value: 'authorised-absence-sessions',
-            label: 'Number of authorised absence sessions',
-            unit: '',
-            name: 'sess_authorised',
-            decimalPlaces: 2,
-          },
-          {
-            value: 'persistent-absentees',
-            label: 'Number of persistent absentees',
-            unit: '',
-            name: 'enrolments_pa_10_exact',
-            decimalPlaces: 2,
-          },
-          {
-            value: 'unauthorised-absence-sessions',
-            label: 'Number of unauthorised absence sessions',
-            unit: '',
-            name: 'sess_unauthorised',
-            decimalPlaces: 2,
-          },
-        ],
-        locations: [
-          { value: 'barnsley', label: 'Barnsley', level: 'localAuthority' },
-          { value: 'barnet', label: 'Barnet', level: 'localAuthority' },
-        ],
-        boundaryLevels: [],
-        publicationName: 'Pupil absence in schools in England',
-        subjectName: 'Absence by characteristic',
-        timePeriodRange: [
-          { label: '2014/15', code: 'AY', year: 2014 },
-          { label: '2015/16', code: 'AY', year: 2015 },
-        ],
+        },
       },
-      results: [],
-    };
+      footnotes: [],
+      geoJsonAvailable: false,
+      indicators: [
+        {
+          value: 'overall-absence-sessions',
+          label: 'Number of overall absence sessions',
+          unit: '',
+          name: 'sess_overall',
+          decimalPlaces: 2,
+        },
+        {
+          value: 'authorised-absence-sessions',
+          label: 'Number of authorised absence sessions',
+          unit: '',
+          name: 'sess_authorised',
+          decimalPlaces: 2,
+        },
+        {
+          value: 'persistent-absentees',
+          label: 'Number of persistent absentees',
+          unit: '',
+          name: 'enrolments_pa_10_exact',
+          decimalPlaces: 2,
+        },
+        {
+          value: 'unauthorised-absence-sessions',
+          label: 'Number of unauthorised absence sessions',
+          unit: '',
+          name: 'sess_unauthorised',
+          decimalPlaces: 2,
+        },
+      ],
+      locations: [
+        { value: 'barnsley', label: 'Barnsley', level: 'localAuthority' },
+        { value: 'barnet', label: 'Barnet', level: 'localAuthority' },
+      ],
+      boundaryLevels: [],
+      publicationName: 'Pupil absence in schools in England',
+      subjectName: 'Absence by characteristic',
+      timePeriodRange: [
+        { label: '2014/15', code: 'AY', year: 2014 },
+        { label: '2015/16', code: 'AY', year: 2015 },
+      ],
+    },
+    results: [
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2014_AY',
+      },
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2015_AY',
+      },
+    ],
+  };
 
+  test('returns correct config using a variety of options for every filter type', () => {
     const testSubjectMeta = mapFullTable(testTableData);
 
     const {
@@ -108,7 +123,7 @@ describe('getDefaultTableHeadersConfig', () => {
       rowGroups,
       columns,
       columnGroups,
-    } = getDefaultTableHeaderConfig(testSubjectMeta.subjectMeta);
+    } = getDefaultTableHeaderConfig(testSubjectMeta);
 
     expect(columnGroups).toHaveLength(1);
     expect(columnGroups[0]).toHaveLength(2);
@@ -137,107 +152,83 @@ describe('getDefaultTableHeadersConfig', () => {
   });
 
   test('returns correct config using a larger number of time periods than indicators', () => {
-    const testTableData: TableDataResponse = {
-      subjectMeta: {
-        filters: {
-          Characteristic: {
-            totalValue: '',
-            hint: '',
-            legend: 'Characteristic',
-            name: 'characteristic',
-            options: {
-              EthnicGroupMajor: {
-                label: 'Ethnic group major',
-                options: [
-                  {
-                    label: 'Ethnicity Major Black Total',
-                    value: 'ethnicity-major-black-total',
-                  },
-                  {
-                    label: 'Ethnicity Major Asian Total',
-                    value: 'ethnicity-major-asian-total',
-                  },
-                ],
-              },
-            },
-          },
-          SchoolType: {
-            totalValue: '',
-            hint: 'Filter by school type',
-            legend: 'School type',
-            name: 'school_type',
-            options: {
-              Default: {
-                label: 'Default',
-                options: [
-                  {
-                    label: 'State-funded secondary',
-                    value: 'state-funded-secondary',
-                  },
-                  {
-                    label: 'Special',
-                    value: 'special',
-                  },
-                  {
-                    label: 'State-funded primary',
-                    value: 'state-funded-primary',
-                  },
-                ],
-              },
-            },
-          },
-        },
-        footnotes: [],
-        geoJsonAvailable: false,
-        indicators: [
-          {
-            value: 'overall-absence-sessions',
-            label: 'Number of overall absence sessions',
-            unit: '',
-            name: 'sess_overall',
-            decimalPlaces: 2,
-          },
-          {
-            value: 'authorised-absence-sessions',
-            label: 'Number of authorised absence sessions',
-            unit: '',
-            name: 'sess_authorised',
-            decimalPlaces: 2,
-          },
-          {
-            value: 'persistent-absentees',
-            label: 'Number of persistent absentees',
-            unit: '',
-            name: 'enrolments_pa_10_exact',
-            decimalPlaces: 2,
-          },
-        ],
-        locations: [
-          { value: 'barnsley', label: 'Barnsley', level: 'localAuthority' },
-          { value: 'barnet', label: 'Barnet', level: 'localAuthority' },
-        ],
-        boundaryLevels: [],
-        publicationName: 'Pupil absence in schools in England',
-        subjectName: 'Absence by characteristic',
-        timePeriodRange: [
-          { label: '2014/15', code: 'AY', year: 2014 },
-          { label: '2015/16', code: 'AY', year: 2015 },
-          { label: '2016/17', code: 'AY', year: 2016 },
-          { label: '2017/18', code: 'AY', year: 2017 },
-          { label: '2018/19', code: 'AY', year: 2018 },
-        ],
+    const testTableDataTimePeriods = JSON.parse(JSON.stringify(testTableData));
+    testTableDataTimePeriods.subjectMeta.indicators = [
+      {
+        value: 'overall-absence-sessions',
+        label: 'Number of overall absence sessions',
+        unit: '',
+        name: 'sess_overall',
+        decimalPlaces: 2,
       },
-      results: [],
-    };
+      {
+        value: 'authorised-absence-sessions',
+        label: 'Number of authorised absence sessions',
+        unit: '',
+        name: 'sess_authorised',
+        decimalPlaces: 2,
+      },
+      {
+        value: 'persistent-absentees',
+        label: 'Number of persistent absentees',
+        unit: '',
+        name: 'enrolments_pa_10_exact',
+        decimalPlaces: 2,
+      },
+    ];
+    testTableDataTimePeriods.subjectMeta.timePeriodRange = [
+      { label: '2014/15', code: 'AY', year: 2014 },
+      { label: '2015/16', code: 'AY', year: 2015 },
+      { label: '2016/17', code: 'AY', year: 2016 },
+      { label: '2017/18', code: 'AY', year: 2017 },
+      { label: '2018/19', code: 'AY', year: 2018 },
+    ];
+    testTableDataTimePeriods.results = [
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2014_AY',
+      },
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2015_AY',
+      },
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2016_AY',
+      },
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2017_AY',
+      },
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2018_AY',
+      },
+    ];
 
-    const testSubjectMeta = mapFullTable(testTableData);
+    const testSubjectMeta = mapFullTable(testTableDataTimePeriods);
 
     const {
       rows,
       rowGroups,
       columns,
       columnGroups,
-    } = getDefaultTableHeaderConfig(testSubjectMeta.subjectMeta);
+    } = getDefaultTableHeaderConfig(testSubjectMeta);
 
     expect(columnGroups).toHaveLength(1);
     expect(columnGroups[0]).toHaveLength(2);
@@ -268,93 +259,47 @@ describe('getDefaultTableHeadersConfig', () => {
   });
 
   test('returns correct config when two options for every filter type', () => {
-    const testTableData: TableDataResponse = {
-      subjectMeta: {
-        filters: {
-          Characteristic: {
-            totalValue: '',
-            hint: '',
-            legend: 'Characteristic',
-            name: 'characteristic',
-            options: {
-              EthnicGroupMajor: {
-                label: 'Ethnic group major',
-                options: [
-                  {
-                    label: 'Ethnicity Major Black Total',
-                    value: 'ethnicity-major-black-total',
-                  },
-                  {
-                    label: 'Ethnicity Major Asian Total',
-                    value: 'ethnicity-major-asian-total',
-                  },
-                ],
-              },
-            },
-          },
-          SchoolType: {
-            totalValue: '',
-            hint: 'Filter by school type',
-            legend: 'School type',
-            name: 'school_type',
-            options: {
-              Default: {
-                label: 'Default',
-                options: [
-                  {
-                    label: 'State-funded secondary',
-                    value: 'state-funded-secondary',
-                  },
-                  {
-                    label: 'Special',
-                    value: 'special',
-                  },
-                ],
-              },
-            },
-          },
-        },
-        footnotes: [],
-        geoJsonAvailable: false,
-        indicators: [
+    const testTableDataTwoOptions = JSON.parse(JSON.stringify(testTableData));
+    testTableDataTwoOptions.subjectMeta.filters.SchoolType.options = {
+      Default: {
+        label: 'Default',
+        options: [
           {
-            value: 'overall-absence-sessions',
-            label: 'Number of overall absence sessions',
-            unit: '',
-            name: 'sess_overall',
-            decimalPlaces: 2,
+            label: 'State-funded secondary',
+            value: 'state-funded-secondary',
           },
           {
-            value: 'authorised-absence-sessions',
-            label: 'Number of authorised absence sessions',
-            unit: '',
-            name: 'sess_authorised',
-            decimalPlaces: 2,
+            label: 'Special',
+            value: 'special',
           },
-        ],
-        locations: [
-          { value: 'barnsley', label: 'Barnsley', level: 'localAuthority' },
-          { value: 'barnet', label: 'Barnet', level: 'localAuthority' },
-        ],
-        boundaryLevels: [],
-        publicationName: 'Pupil absence in schools in England',
-        subjectName: 'Absence by characteristic',
-        timePeriodRange: [
-          { label: '2014/15', code: 'AY', year: 2014 },
-          { label: '2015/16', code: 'AY', year: 2015 },
         ],
       },
-      results: [],
     };
+    testTableDataTwoOptions.subjectMeta.indicators = [
+      {
+        value: 'overall-absence-sessions',
+        label: 'Number of overall absence sessions',
+        unit: '',
+        name: 'sess_overall',
+        decimalPlaces: 2,
+      },
+      {
+        value: 'authorised-absence-sessions',
+        label: 'Number of authorised absence sessions',
+        unit: '',
+        name: 'sess_authorised',
+        decimalPlaces: 2,
+      },
+    ];
 
-    const testSubjectMeta = mapFullTable(testTableData);
+    const testSubjectMeta = mapFullTable(testTableDataTwoOptions);
 
     const {
       rows,
       rowGroups,
       columns,
       columnGroups,
-    } = getDefaultTableHeaderConfig(testSubjectMeta.subjectMeta);
+    } = getDefaultTableHeaderConfig(testSubjectMeta);
 
     expect(columnGroups).toHaveLength(1);
     expect(columnGroups[0]).toHaveLength(2);
@@ -380,74 +325,59 @@ describe('getDefaultTableHeadersConfig', () => {
   });
 
   test('returns correct config with siblingless filters removed when one option for every filter type', () => {
-    const testTableData: TableDataResponse = {
-      subjectMeta: {
-        filters: {
-          Characteristic: {
-            totalValue: '',
-            hint: '',
-            legend: 'Characteristic',
-            name: 'characteristic',
-            options: {
-              EthnicGroupMajor: {
-                label: 'Ethnic group major',
-                options: [
-                  {
-                    label: 'Ethnicity Major Black Total',
-                    value: 'ethnicity-major-black-total',
-                  },
-                ],
-              },
-            },
-          },
-          SchoolType: {
-            totalValue: '',
-            hint: 'Filter by school type',
-            legend: 'School type',
-            name: 'school_type',
-            options: {
-              Default: {
-                label: 'Default',
-                options: [
-                  {
-                    label: 'State-funded secondary',
-                    value: 'state-funded-secondary',
-                  },
-                ],
-              },
-            },
-          },
-        },
-        footnotes: [],
-        geoJsonAvailable: false,
-        indicators: [
+    const testTableDataSiblingless = JSON.parse(JSON.stringify(testTableData));
+    testTableDataSiblingless.subjectMeta.filters.Characteristic.options = {
+      EthnicGroupMajor: {
+        label: 'Ethnic group major',
+        options: [
           {
-            value: 'overall-absence-sessions',
-            label: 'Number of overall absence sessions',
-            unit: '',
-            name: 'sess_overall',
-            decimalPlaces: 2,
+            label: 'Ethnicity Major Black Total',
+            value: 'ethnicity-major-black-total',
           },
         ],
-        locations: [
-          { value: 'barnsley', label: 'Barnsley', level: 'localAuthority' },
-        ],
-        boundaryLevels: [],
-        publicationName: 'Pupil absence in schools in England',
-        subjectName: 'Absence by characteristic',
-        timePeriodRange: [{ label: '2014/15', code: 'AY', year: 2014 }],
       },
-      results: [],
     };
+    testTableDataSiblingless.subjectMeta.filters.SchoolType.options = {
+      Default: {
+        label: 'Default',
+        options: [
+          {
+            label: 'State-funded secondary',
+            value: 'state-funded-secondary',
+          },
+        ],
+      },
+    };
+    testTableDataSiblingless.subjectMeta.indicators = [
+      {
+        value: 'overall-absence-sessions',
+        label: 'Number of overall absence sessions',
+        unit: '',
+        name: 'sess_overall',
+        decimalPlaces: 2,
+      },
+    ];
+    testTableDataSiblingless.subjectMeta.locations = [
+      { value: 'barnsley', label: 'Barnsley', level: 'localAuthority' },
+    ];
+    testTableDataSiblingless.results = [
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2014_AY',
+      },
+    ];
 
-    const testSubjectMeta = mapFullTable(testTableData);
+    const testSubjectMeta = mapFullTable(testTableDataSiblingless);
 
     const {
       rows,
       rowGroups,
       columns,
       columnGroups,
-    } = getDefaultTableHeaderConfig(testSubjectMeta.subjectMeta);
+    } = getDefaultTableHeaderConfig(testSubjectMeta);
 
     // Should only have indicators and time periods
     // when all other filter types are siblingless
@@ -459,5 +389,40 @@ describe('getDefaultTableHeadersConfig', () => {
 
     expect(columns).toHaveLength(1);
     expect(columns[0].label).toBe('2014/15');
+  });
+
+  test('returns the correct time periods when terms are selected', () => {
+    const testTableDataTerms = JSON.parse(JSON.stringify(testTableData));
+    testTableDataTerms.results = [
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2018_T1',
+      },
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2017_T1',
+      },
+    ];
+    testTableDataTerms.subjectMeta.timePeriodRange = [
+      { code: 'T1', label: '2017/18 Autumn Term', year: 2017 },
+      { code: 'T1T2', label: '2017/18 Autumn and Spring Term', year: 2017 },
+      { code: 'T2', label: '2017/18 Spring Term', year: 2017 },
+      { code: 'T3', label: '2017/18 Summer Term', year: 2017 },
+      { code: 'T1', label: '2018/19 Autumn Term', year: 2018 },
+    ];
+
+    const testSubjectMeta = mapFullTable(testTableDataTerms);
+
+    const { columns } = getDefaultTableHeaderConfig(testSubjectMeta);
+
+    expect(columns).toHaveLength(2);
+    expect(columns[0].label).toBe('2017/18 Autumn Term');
+    expect(columns[1].label).toBe('2018/19 Autumn Term');
   });
 });

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableHeadersConfig.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableHeadersConfig.test.ts
@@ -347,56 +347,62 @@ describe('mapTableHeadersConfig', () => {
   });
 
   test('correctly maps term time periods to only return those in the table result', () => {
-    const testHeaderConfigWithTerms = JSON.parse(
-      JSON.stringify(testHeaderConfig),
-    );
-    testHeaderConfigWithTerms.columns = [
-      {
-        value: '2017_T1',
-        type: 'TimePeriod',
-      },
-      {
-        value: '2017_T1T2',
-        type: 'TimePeriod',
-      },
-      {
-        value: '2017_T2',
-        type: 'TimePeriod',
-      },
-      {
-        value: '2017_T3',
-        type: 'TimePeriod',
-      },
-      {
-        value: '2018_T1',
-        type: 'TimePeriod',
-      },
-    ];
+    const testHeaderConfigWithTerms: UnmappedTableHeadersConfig = {
+      ...testHeaderConfig,
+      columns: [
+        {
+          value: '2017_T1',
+          type: 'TimePeriod',
+        },
+        {
+          value: '2017_T1T2',
+          type: 'TimePeriod',
+        },
+        {
+          value: '2017_T2',
+          type: 'TimePeriod',
+        },
+        {
+          value: '2017_T3',
+          type: 'TimePeriod',
+        },
+        {
+          value: '2018_T1',
+          type: 'TimePeriod',
+        },
+      ],
+    };
 
-    const testTableDataWithTerms = JSON.parse(JSON.stringify(testTableData));
-    testTableDataWithTerms.results = [
-      {
-        filters: [],
-        geographicLevel: '',
-        location: {},
-        measures: {},
-        timePeriod: '2018_T1',
+    const testTableDataWithTerms = {
+      ...testTableData,
+      subjectMeta: {
+        ...testTableData.subjectMeta,
+        timePeriodRange: [
+          { code: 'T1', label: '2017/18 Autumn Term', year: 2017 },
+          { code: 'T1T2', label: '2017/18 Autumn and Spring Term', year: 2017 },
+          { code: 'T2', label: '2017/18 Spring Term', year: 2017 },
+          { code: 'T3', label: '2017/18 Summer Term', year: 2017 },
+          { code: 'T1', label: '2018/19 Autumn Term', year: 2018 },
+        ],
       },
-      {
-        filters: [],
-        geographicLevel: '',
-        location: {},
-        measures: {},
-        timePeriod: '2017_T1',
-      },
-    ];
-    testTableDataWithTerms.subjectMeta.timePeriodRange = [
-      { code: 'T1', label: '2017/18 Autumn Term', year: 2017 },
-      { code: 'T1T2', label: '2017/18 Autumn and Spring Term', year: 2017 },
-      { code: 'T2', label: '2017/18 Spring Term', year: 2017 },
-      { code: 'T3', label: '2017/18 Summer Term', year: 2017 },
-      { code: 'T1', label: '2018/19 Autumn Term', year: 2018 },
-    ];
+      results: [
+        {
+          filters: [],
+          geographicLevel: '',
+          location: {},
+          measures: {},
+          timePeriod: '2018_T1',
+        },
+        {
+          filters: [],
+          geographicLevel: '',
+          location: {},
+          measures: {},
+          timePeriod: '2017_T1',
+        },
+      ],
+    };
+
     const table: FullTable = mapFullTable(testTableDataWithTerms);
     const headers = mapTableHeadersConfig(testHeaderConfigWithTerms, table);
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableHeadersConfig.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableHeadersConfig.test.ts
@@ -151,12 +151,27 @@ describe('mapTableHeadersConfig', () => {
         { label: '2015/16', code: 'AY', year: 2015 },
       ],
     },
-    results: [],
+    results: [
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2014_AY',
+      },
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2015_AY',
+      },
+    ],
   };
 
   test('maps headers to their classes', () => {
     const table: FullTable = mapFullTable(testTableData);
-    const headers = mapTableHeadersConfig(testHeaderConfig, table.subjectMeta);
+    const headers = mapTableHeadersConfig(testHeaderConfig, table);
 
     expect(headers.columnGroups).toEqual([
       [
@@ -299,7 +314,7 @@ describe('mapTableHeadersConfig', () => {
           },
         ],
       },
-      table.subjectMeta,
+      table,
     );
 
     expect(headers.rowGroups).toEqual([
@@ -331,6 +346,76 @@ describe('mapTableHeadersConfig', () => {
     ]);
   });
 
+  test('correctly maps term time periods to only return those in the table result', () => {
+    const testHeaderConfigWithTerms = JSON.parse(
+      JSON.stringify(testHeaderConfig),
+    );
+    testHeaderConfigWithTerms.columns = [
+      {
+        value: '2017_T1',
+        type: 'TimePeriod',
+      },
+      {
+        value: '2017_T1T2',
+        type: 'TimePeriod',
+      },
+      {
+        value: '2017_T2',
+        type: 'TimePeriod',
+      },
+      {
+        value: '2017_T3',
+        type: 'TimePeriod',
+      },
+      {
+        value: '2018_T1',
+        type: 'TimePeriod',
+      },
+    ];
+
+    const testTableDataWithTerms = JSON.parse(JSON.stringify(testTableData));
+    testTableDataWithTerms.results = [
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2018_T1',
+      },
+      {
+        filters: [],
+        geographicLevel: '',
+        location: {},
+        measures: {},
+        timePeriod: '2017_T1',
+      },
+    ];
+    testTableDataWithTerms.subjectMeta.timePeriodRange = [
+      { code: 'T1', label: '2017/18 Autumn Term', year: 2017 },
+      { code: 'T1T2', label: '2017/18 Autumn and Spring Term', year: 2017 },
+      { code: 'T2', label: '2017/18 Spring Term', year: 2017 },
+      { code: 'T3', label: '2017/18 Summer Term', year: 2017 },
+      { code: 'T1', label: '2018/19 Autumn Term', year: 2018 },
+    ];
+    const table: FullTable = mapFullTable(testTableDataWithTerms);
+    const headers = mapTableHeadersConfig(testHeaderConfigWithTerms, table);
+
+    expect(headers.columns).toEqual([
+      new TimePeriodFilter({
+        year: 2017,
+        code: 'T1',
+        label: '2017/18 Autumn Term',
+        order: 0,
+      }),
+      new TimePeriodFilter({
+        year: 2018,
+        code: 'T1',
+        label: '2018/19 Autumn Term',
+        order: 4,
+      }),
+    ]);
+  });
+
   test('throws error if there is an invalid header type', () => {
     const fullTable = mapFullTable(testTableData);
 
@@ -347,7 +432,7 @@ describe('mapTableHeadersConfig', () => {
     };
 
     expect(() => {
-      mapTableHeadersConfig(headers, fullTable.subjectMeta);
+      mapTableHeadersConfig(headers, fullTable);
     }).toThrowError(
       `Invalid header type: ${JSON.stringify(headers.columns[0])}`,
     );
@@ -369,7 +454,7 @@ describe('mapTableHeadersConfig', () => {
     };
 
     expect(() => {
-      mapTableHeadersConfig(headers, fullTable.subjectMeta);
+      mapTableHeadersConfig(headers, fullTable);
     }).toThrowError(
       `Could not find matching filter for header: ${JSON.stringify(
         headers.columns[0],
@@ -386,7 +471,7 @@ describe('mapTableHeadersConfig', () => {
         rowGroups: [],
         rows: [],
       },
-      fullTable.subjectMeta,
+      fullTable,
     );
 
     expect(headers.columnGroups).toEqual([]);

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/getDefaultTableHeadersConfig.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/getDefaultTableHeadersConfig.ts
@@ -107,7 +107,7 @@ export default function getDefaultTableHeaderConfig(
   // When terms are selected the time period range can include ones not displayed in the table,
   // filter these out to ensure the reorder headings list is correct
   const filteredTimePeriodRange = timePeriodRange.filter(period =>
-    results.find(result => result.timePeriod === period.value) ? period : null,
+    results.find(result => result.timePeriod === period.value),
   );
 
   // In the following instance, we should display the time periods in the

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/mapTableHeadersConfig.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/mapTableHeadersConfig.ts
@@ -18,14 +18,11 @@ export default function mapTableHeadersConfig(
   const mapToFilters = (headers: TableHeader[]): Filter[] => {
     // When terms are selected the time period range can include ones not displayed in the table,
     // filter these out to ensure the reorder headings list is correct
-    const filteredHeaders = headers.filter(header => {
-      if (header.type === 'TimePeriod') {
-        return results.find(result => result.timePeriod === header.value)
-          ? header
-          : null;
-      }
-      return header;
-    });
+    const filteredHeaders = headers.filter(
+      header =>
+        header.type !== 'TimePeriod' ||
+        results.find(result => result.timePeriod === header.value),
+    );
 
     return filteredHeaders.map(header => {
       let matchingFilter: Filter | undefined;

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -23,7 +23,7 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
   const fullTable = mapFullTable(data.fullTable);
   const tableHeadersConfig = mapTableHeadersConfig(
     data.configuration.tableHeaders,
-    fullTable.subjectMeta,
+    fullTable,
   );
 
   const { subjectName, publicationName } = fullTable.subjectMeta;

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -62,7 +62,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
       const fullTable = mapFullTable(fastTrack.fullTable);
       const tableHeaders = mapTableHeadersConfig(
         fastTrack.configuration.tableHeaders,
-        fullTable.subjectMeta,
+        fullTable,
       );
 
       return {


### PR DESCRIPTION
When terms were used for time periods in the table tool extra terms were shown in the reorder table headers list, this PR filters the unnecessary ones out.