### PR TITLE
EES-941 - removed Next update section from Publication Release page if not the latest Release

### DIFF
--- a/src/explore-education-statistics-common/src/components/SummaryListItem.tsx
+++ b/src/explore-education-statistics-common/src/components/SummaryListItem.tsx
@@ -10,14 +10,26 @@ interface Props {
 const SummaryListItem = ({ actions, children, term, testId = term }: Props) => {
   return (
     <div className="govuk-summary-list__row" data-testid={testId}>
-      <dt className="govuk-summary-list__key">{term}</dt>
+      <dt className="govuk-summary-list__key" data-testid={`${testId}-key`}>
+        {term}
+      </dt>
 
       {typeof children !== 'undefined' && (
-        <dd className="govuk-summary-list__value">{children}</dd>
+        <dd
+          className="govuk-summary-list__value"
+          data-testid={`${testId}-value`}
+        >
+          {children}
+        </dd>
       )}
 
       {typeof actions !== 'undefined' && (
-        <dd className="govuk-summary-list__actions">{actions}</dd>
+        <dd
+          className="govuk-summary-list__actions"
+          data-testid={`${testId}-actions`}
+        >
+          {actions}
+        </dd>
       )}
     </div>
   );

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FiltersForm.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FiltersForm.test.tsx.snap
@@ -10,11 +10,13 @@ exports[`FiltersForm renders a read-only view of selected options when no longer
   >
     <dt
       class="govuk-summary-list__key"
+      data-testid="Indicators-key"
     >
       Indicators
     </dt>
     <dd
       class="govuk-summary-list__value"
+      data-testid="Indicators-value"
     >
       <ul
         class="govuk-list listContainer"
@@ -31,11 +33,13 @@ exports[`FiltersForm renders a read-only view of selected options when no longer
   >
     <dt
       class="govuk-summary-list__key"
+      data-testid="School type-key"
     >
       School type
     </dt>
     <dd
       class="govuk-summary-list__value"
+      data-testid="School type-value"
     >
       <ul
         class="govuk-list listContainer"
@@ -52,11 +56,13 @@ exports[`FiltersForm renders a read-only view of selected options when no longer
   >
     <dt
       class="govuk-summary-list__key"
+      data-testid="Characteristic-key"
     >
       Characteristic
     </dt>
     <dd
       class="govuk-summary-list__value"
+      data-testid="Characteristic-value"
     >
       <ul
         class="govuk-list listContainer"

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -116,7 +116,7 @@ export interface Release<
   headlinesSection: ContentSection<ContentBlockType>;
   publication: PublicationType;
   latestRelease: boolean;
-  nextReleaseDate: PartialDate;
+  nextReleaseDate?: PartialDate;
   relatedInformation: BasicLink[];
   type: {
     id: string;

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -102,11 +102,15 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
             <SummaryListItem term="Published">
               <FormattedDate>{release.published}</FormattedDate>
             </SummaryListItem>
-            {isValidPartialDate(release.nextReleaseDate) && (
-              <SummaryListItem term="Next update">
-                <time>{formatPartialDate(release.nextReleaseDate)}</time>
-              </SummaryListItem>
-            )}
+            {release.latestRelease &&
+              isValidPartialDate(release.nextReleaseDate) && (
+                <SummaryListItem
+                  term="Next update"
+                  testId="next-update-list-item"
+                >
+                  <time>{formatPartialDate(release.nextReleaseDate)}</time>
+                </SummaryListItem>
+              )}
             {release.updates && release.updates.length > 0 && (
               <SummaryListItem term="Last updated">
                 <FormattedDate>{release.updates[0].on}</FormattedDate>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
@@ -28,7 +28,7 @@ describe('PublicationReleasePage', () => {
     );
 
     expect(
-      screen.getByRole('button', { name: 'National Statistics' }),
+      screen.queryByRole('button', { name: 'National Statistics' }),
     ).toBeInTheDocument();
   });
 
@@ -55,6 +55,71 @@ describe('PublicationReleasePage', () => {
 
     expect(
       screen.queryByRole('button', { name: 'National Statistics' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders "Next update" section if this is the latest Release for a Publication and there is a valid partial date', () => {
+    render(
+      <PublicationReleasePage
+        release={{
+          ...((OfficialStats as unknown) as Release),
+          latestRelease: true,
+          nextReleaseDate: {
+            month: 2,
+            year: 2022,
+          },
+        }}
+      />,
+    );
+
+    const nextUpdateValue = screen.getByTestId('next-update-list-item-value');
+    expect(nextUpdateValue.textContent).toEqual('February 2022');
+  });
+
+  test(`doesn't render "Next update" section if there is no valid partial date`, () => {
+    render(
+      <PublicationReleasePage
+        release={{
+          ...((OfficialStats as unknown) as Release),
+          latestRelease: true,
+          nextReleaseDate: undefined,
+        }}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId('next-update-list-item-value'),
+    ).not.toBeInTheDocument();
+  });
+
+  test(`doesn't render "Next update" section if the Release is not the latest Release for the Publication`, () => {
+    const release = (OfficialStats as unknown) as Release;
+
+    render(
+      <PublicationReleasePage
+        release={{
+          ...release,
+          latestRelease: false,
+          nextReleaseDate: {
+            month: 2,
+            year: 2022,
+          },
+          publication: {
+            ...release.publication,
+            otherReleases: [
+              {
+                id: 'latest-release',
+                title: 'Latest Release Title',
+                slug: 'latest-release-slug',
+              },
+            ],
+          },
+        }}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId('next-update-list-item-value'),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/__snapshots__/TableToolPage.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/__snapshots__/TableToolPage.test.tsx.snap
@@ -65,11 +65,13 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Publication-key"
                 >
                   Publication
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Publication-value"
                 >
                   Test publication
                 </dd>
@@ -214,11 +216,13 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
                             >
                               <dt
                                 class="govuk-summary-list__key"
+                                data-testid="Geographic levels-key"
                               >
                                 Geographic levels
                               </dt>
                               <dd
                                 class="govuk-summary-list__value"
+                                data-testid="Geographic levels-value"
                               >
                                 National
                               </dd>
@@ -229,11 +233,13 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
                             >
                               <dt
                                 class="govuk-summary-list__key"
+                                data-testid="Time period-key"
                               >
                                 Time period
                               </dt>
                               <dd
                                 class="govuk-summary-list__value"
+                                data-testid="Time period-value"
                               >
                                 2020 Week 13 to 2021 Week 24
                               </dd>
@@ -244,11 +250,13 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
                             >
                               <dt
                                 class="govuk-summary-list__key"
+                                data-testid="Content-key"
                               >
                                 Content
                               </dt>
                               <dd
                                 class="govuk-summary-list__value"
+                                data-testid="Content-value"
                               >
                                 <div
                                   class="dfe-content"
@@ -373,11 +381,13 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Time period-key"
                 >
                   Time period
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Time period-value"
                 />
               </div>
             </dl>
@@ -427,11 +437,13 @@ exports[`TableToolPage renders the Table Tool page correctly when Publication is
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Indicators-key"
                 >
                   Indicators
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Indicators-value"
                 >
                   <ul
                     class="govuk-list listContainer"
@@ -729,11 +741,13 @@ exports[`TableToolPage renders the Table Tool page correctly when Theme metadata
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Subject-key"
                 >
                   Subject
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Subject-value"
                 >
                   None
                 </dd>
@@ -825,11 +839,13 @@ exports[`TableToolPage renders the Table Tool page correctly when Theme metadata
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Time period-key"
                 >
                   Time period
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Time period-value"
                 />
               </div>
             </dl>
@@ -879,11 +895,13 @@ exports[`TableToolPage renders the Table Tool page correctly when Theme metadata
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Indicators-key"
                 >
                   Indicators
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Indicators-value"
                 >
                   <ul
                     class="govuk-list listContainer"
@@ -998,11 +1016,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Subject-key"
                 >
                   Subject
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Subject-value"
                 >
                   None
                 </dd>
@@ -1071,11 +1091,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="National-key"
                 >
                   National
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="National-value"
                 >
                   <ul
                     class="govuk-list listContainer"
@@ -1150,11 +1172,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Time period-key"
                 >
                   Time period
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Time period-value"
                 >
                   2018-19 to 2018-19
                 </dd>
@@ -1223,11 +1247,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Indicators-key"
                 >
                   Indicators
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Indicators-value"
                 >
                   <ul
                     class="govuk-list listContainer"
@@ -1247,11 +1273,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Subject studied-key"
                 >
                   Subject studied
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Subject studied-value"
                 >
                   <ul
                     class="govuk-list listContainer"
@@ -1932,11 +1960,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Subject-key"
                 >
                   Subject
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Subject-value"
                 >
                   None
                 </dd>
@@ -2005,11 +2035,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="National-key"
                 >
                   National
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="National-value"
                 >
                   <ul
                     class="govuk-list listContainer"
@@ -2084,11 +2116,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Time period-key"
                 >
                   Time period
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Time period-value"
                 >
                   2018-19 to 2018-19
                 </dd>
@@ -2157,11 +2191,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Indicators-key"
                 >
                   Indicators
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Indicators-value"
                 >
                   <ul
                     class="govuk-list listContainer"
@@ -2181,11 +2217,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Subject studied-key"
                 >
                   Subject studied
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Subject studied-value"
                 >
                   <ul
                     class="govuk-list listContainer"
@@ -2849,11 +2887,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Subject-key"
                 >
                   Subject
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Subject-value"
                 >
                   None
                 </dd>
@@ -2922,11 +2962,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="National-key"
                 >
                   National
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="National-value"
                 >
                   <ul
                     class="govuk-list listContainer"
@@ -3001,11 +3043,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Time period-key"
                 >
                   Time period
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Time period-value"
                 >
                   2018-19 to 2018-19
                 </dd>
@@ -3074,11 +3118,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Indicators-key"
                 >
                   Indicators
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Indicators-value"
                 >
                   <ul
                     class="govuk-list listContainer"
@@ -3098,11 +3144,13 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               >
                 <dt
                   class="govuk-summary-list__key"
+                  data-testid="Subject studied-key"
                 >
                   Subject studied
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
+                  data-testid="Subject studied-value"
                 >
                   <ul
                     class="govuk-list listContainer"

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
@@ -10,8 +10,8 @@ import { TableDataQuery } from '@common/services/tableBuilderService';
 import TableToolFinalStep from '@frontend/modules/table-tool/components/TableToolFinalStep';
 import { within } from '@testing-library/dom';
 import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 
 describe('TableToolFinalStep', () => {
   const testQuery: TableDataQuery = {


### PR DESCRIPTION
This PR:
- removes the "Next update" section from the public Publication Release page if this is not the latest Release