### PR TITLE
EES-1397 show correct file size and rows when upload zips

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileDetailsTable.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileDetailsTable.tsx
@@ -113,21 +113,33 @@ const DataFileDetailsTable = ({
         <tr>
           <th scope="row">Data file size</th>
           <td data-testid="Data file size">
-            {dataFile.fileSize.size.toLocaleString()} {dataFile.fileSize.unit}
+            {!dataFile.isQueuedZipUpload && (
+              <>
+                {dataFile.fileSize.size.toLocaleString()}{' '}
+                {dataFile.fileSize.unit}
+              </>
+            )}
           </td>
           {replacementDataFile && (
             <td data-testid="Replacement Data file size">
-              {replacementDataFile.fileSize.size.toLocaleString()}{' '}
-              {replacementDataFile.fileSize.unit}
+              {!replacementDataFile.isQueuedZipUpload && (
+                <>
+                  {replacementDataFile.fileSize.size.toLocaleString()}{' '}
+                  {replacementDataFile.fileSize.unit}
+                </>
+              )}
             </td>
           )}
         </tr>
         <tr>
           <th scope="row">Number of rows</th>
-          <td data-testid="Number of rows">{dataFile.rows.toLocaleString()}</td>
+          <td data-testid="Number of rows">
+            {!dataFile.isQueuedZipUpload && dataFile.rows.toLocaleString()}
+          </td>
           {replacementDataFile && (
             <td data-testid="Replacement Number of rows">
-              {replacementDataFile.rows.toLocaleString()}
+              {!replacementDataFile.isQueuedZipUpload &&
+                replacementDataFile.rows.toLocaleString()}
             </td>
           )}
         </tr>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileReplacementPlan.tsx
@@ -26,6 +26,7 @@ import VisuallyHidden from '@common/components/VisuallyHidden';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import useToggle from '@common/hooks/useToggle';
+import useMountedRef from '@common/hooks/useMountedRef';
 import React, { useMemo, useState } from 'react';
 import { generatePath } from 'react-router';
 
@@ -54,6 +55,8 @@ const DataFileReplacementPlan = ({
   const [deleteFootnote, setDeleteFootnote] = useState<
     FootnoteReplacementPlan
   >();
+
+  const isMounted = useMountedRef();
 
   const {
     value: plan,
@@ -392,8 +395,9 @@ const DataFileReplacementPlan = ({
                   if (onReplacement) {
                     onReplacement();
                   }
-
-                  toggleSubmitting.off();
+                  if (isMounted.current) {
+                    toggleSubmitting.off();
+                  }
                 }}
               >
                 Confirm data replacement

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -9,6 +9,7 @@ import {
   FieldMessageMapper,
   mapFieldErrors,
 } from '@common/validation/serverValidations';
+import useMountedRef from '@common/hooks/useMountedRef';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
 import React, { ReactNode } from 'react';
@@ -107,10 +108,14 @@ const DataFileUploadForm = <FormValues extends DataFileUploadFormValues>({
   validationSchema,
   onSubmit,
 }: Props<FormValues>) => {
+  const isMounted = useMountedRef();
+
   const handleSubmit = useFormSubmit<FormValues>(
     async (values, actions) => {
       await onSubmit(values);
-      actions.resetForm();
+      if (isMounted.current) {
+        actions.resetForm();
+      }
     },
     values => {
       return [...baseErrorMappings(values), ...errorMappings];

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -120,6 +120,18 @@ const ReleaseDataUploadsSection = ({
     dataFile: DataFile,
     { status }: DataFileImportStatus,
   ) => {
+    // Update data file if uploading a zip so get the correct size and rows.
+    let updatedDataFile = dataFile;
+    if (
+      dataFile.isQueuedZipUpload &&
+      ['UPLOADING', 'QUEUED'].indexOf(status) === -1
+    ) {
+      updatedDataFile = await releaseDataFileService.getDataFile(
+        releaseId,
+        dataFile.id,
+      );
+    }
+
     const permissions = await permissionService.getDataFilePermissions(
       releaseId,
       dataFile.id,
@@ -130,7 +142,7 @@ const ReleaseDataUploadsSection = ({
         file.fileName !== dataFile.fileName
           ? file
           : {
-              ...file,
+              ...updatedDataFile,
               status,
               permissions,
             },
@@ -153,6 +165,7 @@ const ReleaseDataUploadsSection = ({
           name: values.subjectTitle.trim(),
           zipFile: values.zipFile as File,
         });
+        file.isQueuedZipUpload = true;
       }
 
       setDataFiles(orderBy([...dataFiles, file], dataFile => dataFile.title));

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -38,6 +38,8 @@ export interface DataFile {
   created?: string;
   isDeleting?: boolean;
   isCancelling?: boolean;
+  isQueuedZipUpload?: boolean;
+  isReplacedByZipFile?: boolean;
   permissions: DataFilePermissions;
 }
 


### PR DESCRIPTION
When a zip file is uploaded leave the file size and number of rows blanks until the file is being processed and that information is available.

Noticed a couple of related places where state was trying to update on an unmounted component so have fixed those by checking if the component us mounted in the relevant places.