### PR TITLE
EES-2137 - fixed remaining failing UI tests after front-end changes

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ManagePublicationsAndReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ManagePublicationsAndReleasesTab.tsx
@@ -205,7 +205,10 @@ const ManagePublicationsAndReleasesTab = () => {
           </>
         ) : (
           <>
-            <h3 className="govuk-heading-s">
+            <h3
+              className="govuk-heading-s"
+              data-testid="no-permission-to-access-releases"
+            >
               You do not currently have permission to edit any releases within
               the service. To view a prerelease, please use the link provided to
               you by email.

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/PreReleaseTableToolPage.tsx
@@ -94,7 +94,7 @@ const PreReleaseTableToolPage = ({
 
   return (
     <>
-      <PageTitle title="Create your own tables online" caption="Table Tool" />
+      <PageTitle title="Create your own tables" caption="Table Tool" />
 
       <p>
         Choose the data and area of interest you want to explore and then use

--- a/src/explore-education-statistics-admin/src/prototypes/PrototypeRelease.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/PrototypeRelease.tsx
@@ -307,7 +307,7 @@ const PrototypeRelease = () => {
                 <PrototypeDownloadAncillary viewAsList />
               </TabsSection>
             </Tabs>
-            <h3 className="govuk-heading-m">Create your own tables online</h3>
+            <h3 className="govuk-heading-m">Create your own tables</h3>
             <p>
               Use our tool to build tables using our range of national and
               regional data

--- a/src/explore-education-statistics-admin/src/prototypes/PrototypeTableHighlights.tsx
+++ b/src/explore-education-statistics-admin/src/prototypes/PrototypeTableHighlights.tsx
@@ -29,10 +29,7 @@ const PrototypeTableHighlights = () => {
       <PrototypePage wide>
         <div className="govuk-grid-row">
           <div className="govuk-grid-column-two-thirds">
-            <PageTitle
-              title="Create your own tables online"
-              caption="Table tool"
-            />
+            <PageTitle title="Create your own tables" caption="Table tool" />
             <p>
               Choose the data and area of interest you want to explore and then
               use filters to create your table.

--- a/src/explore-education-statistics-frontend/README.md
+++ b/src/explore-education-statistics-frontend/README.md
@@ -55,6 +55,10 @@ Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
+### `npm run start:prod`
+
+After building the app for production, this runs the production-ready bundle. This command can be helpful if you are experiencing flakiness or performance issues when running UI / unit tests locally, as pages will load much quicker.
+
 ### `npm run eject`
 
 **Note: this is a one-way operation. Once you `eject`, you can’t go back!**

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -372,7 +372,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                   <div className="dfe-flex dfe-justify-content--space-between dfe-align-items--center">
                     <div>
                       <h2 className="govuk-heading-m">
-                        Create your own tables online
+                        Create your own tables
                       </h2>
                       <p>
                         Explore our range of data and build your own tables from

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationList.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationList.tsx
@@ -40,7 +40,7 @@ function PublicationList({ publications }: Props) {
                   as={`/data-tables/${slug}`}
                   data-testid={`Create table link for ${title}`}
                 >
-                  Create your own tables online{' '}
+                  Create your own tables{' '}
                   <span className="govuk-visually-hidden">for {title}</span>
                 </Link>
               </div>

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -118,7 +118,7 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
         </ul>
 
         <h2 className="govuk-heading-m govuk-!-margin-top-9">
-          Create your own tables online
+          Create your own tables
         </h2>
         <p>
           Use our tool to build tables using our range of national and regional

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -115,7 +115,6 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
 
       <TableToolWizard
         key={fastTrack?.id}
-        hidePublicationSelectionStage={!!fastTrack}
         scrollOnMount
         themeMeta={themeMeta}
         initialState={initialState}

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/__snapshots__/TableToolPage.test.tsx.snap
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/__snapshots__/TableToolPage.test.tsx.snap
@@ -986,7 +986,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               <span
                 class="govuk-visually-hidden"
               >
-                Choose a subject
+                Choose a publication
               </span>
             </h2>
             <dl
@@ -994,17 +994,17 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             >
               <div
                 class="govuk-summary-list__row"
-                data-testid="Subject"
+                data-testid="Publication"
               >
                 <dt
                   class="govuk-summary-list__key"
                 >
-                  Subject
+                  Publication
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
                 >
-                  None
+                  Test publication
                 </dd>
               </div>
             </dl>
@@ -1020,7 +1020,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 data-testid="wizardStep-1-goToButton"
                 type="button"
               >
-                Change subject
+                Change publication
                  
                 <span
                   class="govuk-visually-hidden"
@@ -1055,6 +1055,79 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 class="govuk-tag govuk-tag govuk-tag--grey"
               >
                 Step 2 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose a subject
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Subject"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Subject
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  None
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-2-goToButton"
+                type="button"
+              >
+                Change subject
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 2
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li
+      class="step"
+      data-testid="wizardStep-3"
+      id="tableToolWizard-step-3"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class="stepEnabled"
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 3 
               </span>
               <span
                 class="govuk-visually-hidden"
@@ -1096,7 +1169,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             >
               <button
                 class="stepButton"
-                data-testid="wizardStep-2-goToButton"
+                data-testid="wizardStep-3-goToButton"
                 type="button"
               >
                 Edit locations
@@ -1104,7 +1177,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 <span
                   class="govuk-visually-hidden"
                 >
-                  Step 2
+                  Step 3
                 </span>
               </button>
             </div>
@@ -1114,8 +1187,8 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
     </li>
     <li
       class="step"
-      data-testid="wizardStep-3"
-      id="tableToolWizard-step-3"
+      data-testid="wizardStep-4"
+      id="tableToolWizard-step-4"
       tabindex="-1"
     >
       <div
@@ -1133,7 +1206,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               <span
                 class="govuk-tag govuk-tag govuk-tag--grey"
               >
-                Step 3 
+                Step 4 
               </span>
               <span
                 class="govuk-visually-hidden"
@@ -1169,7 +1242,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             >
               <button
                 class="stepButton"
-                data-testid="wizardStep-3-goToButton"
+                data-testid="wizardStep-4-goToButton"
                 type="button"
               >
                 Edit time period
@@ -1177,7 +1250,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 <span
                   class="govuk-visually-hidden"
                 >
-                  Step 3
+                  Step 4
                 </span>
               </button>
             </div>
@@ -1187,8 +1260,8 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
     </li>
     <li
       class="step"
-      data-testid="wizardStep-4"
-      id="tableToolWizard-step-4"
+      data-testid="wizardStep-5"
+      id="tableToolWizard-step-5"
       tabindex="-1"
     >
       <div
@@ -1206,7 +1279,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               <span
                 class="govuk-tag govuk-tag govuk-tag--grey"
               >
-                Step 4 
+                Step 5 
               </span>
               <span
                 class="govuk-visually-hidden"
@@ -1275,7 +1348,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             >
               <button
                 class="stepButton"
-                data-testid="wizardStep-4-goToButton"
+                data-testid="wizardStep-5-goToButton"
                 type="button"
               >
                 Edit filters
@@ -1283,7 +1356,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 <span
                   class="govuk-visually-hidden"
                 >
-                  Step 4
+                  Step 5
                 </span>
               </button>
             </div>
@@ -1292,9 +1365,10 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
       </div>
     </li>
     <li
-      class="step"
-      data-testid="wizardStep-5"
-      id="tableToolWizard-step-5"
+      aria-current="step"
+      class="step stepActive"
+      data-testid="wizardStep-6"
+      id="tableToolWizard-step-6"
       tabindex="-1"
     >
       <div
@@ -1306,7 +1380,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
           <span
             class="govuk-tag govuk-tag--turquoise govuk-!-margin-right-2"
           >
-            Step 5 
+            Step 6 
             <span
               class="govuk-visually-hidden"
             >
@@ -1920,7 +1994,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               <span
                 class="govuk-visually-hidden"
               >
-                Choose a subject
+                Choose a publication
               </span>
             </h2>
             <dl
@@ -1928,17 +2002,17 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             >
               <div
                 class="govuk-summary-list__row"
-                data-testid="Subject"
+                data-testid="Publication"
               >
                 <dt
                   class="govuk-summary-list__key"
                 >
-                  Subject
+                  Publication
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
                 >
-                  None
+                  Test publication
                 </dd>
               </div>
             </dl>
@@ -1954,7 +2028,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 data-testid="wizardStep-1-goToButton"
                 type="button"
               >
-                Change subject
+                Change publication
                  
                 <span
                   class="govuk-visually-hidden"
@@ -1989,6 +2063,79 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 class="govuk-tag govuk-tag govuk-tag--grey"
               >
                 Step 2 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose a subject
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Subject"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Subject
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  None
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-2-goToButton"
+                type="button"
+              >
+                Change subject
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 2
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li
+      class="step"
+      data-testid="wizardStep-3"
+      id="tableToolWizard-step-3"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class="stepEnabled"
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 3 
               </span>
               <span
                 class="govuk-visually-hidden"
@@ -2030,7 +2177,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             >
               <button
                 class="stepButton"
-                data-testid="wizardStep-2-goToButton"
+                data-testid="wizardStep-3-goToButton"
                 type="button"
               >
                 Edit locations
@@ -2038,7 +2185,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 <span
                   class="govuk-visually-hidden"
                 >
-                  Step 2
+                  Step 3
                 </span>
               </button>
             </div>
@@ -2048,8 +2195,8 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
     </li>
     <li
       class="step"
-      data-testid="wizardStep-3"
-      id="tableToolWizard-step-3"
+      data-testid="wizardStep-4"
+      id="tableToolWizard-step-4"
       tabindex="-1"
     >
       <div
@@ -2067,7 +2214,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               <span
                 class="govuk-tag govuk-tag govuk-tag--grey"
               >
-                Step 3 
+                Step 4 
               </span>
               <span
                 class="govuk-visually-hidden"
@@ -2103,7 +2250,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             >
               <button
                 class="stepButton"
-                data-testid="wizardStep-3-goToButton"
+                data-testid="wizardStep-4-goToButton"
                 type="button"
               >
                 Edit time period
@@ -2111,7 +2258,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 <span
                   class="govuk-visually-hidden"
                 >
-                  Step 3
+                  Step 4
                 </span>
               </button>
             </div>
@@ -2121,8 +2268,8 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
     </li>
     <li
       class="step"
-      data-testid="wizardStep-4"
-      id="tableToolWizard-step-4"
+      data-testid="wizardStep-5"
+      id="tableToolWizard-step-5"
       tabindex="-1"
     >
       <div
@@ -2140,7 +2287,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               <span
                 class="govuk-tag govuk-tag govuk-tag--grey"
               >
-                Step 4 
+                Step 5 
               </span>
               <span
                 class="govuk-visually-hidden"
@@ -2209,7 +2356,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             >
               <button
                 class="stepButton"
-                data-testid="wizardStep-4-goToButton"
+                data-testid="wizardStep-5-goToButton"
                 type="button"
               >
                 Edit filters
@@ -2217,7 +2364,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 <span
                   class="govuk-visually-hidden"
                 >
-                  Step 4
+                  Step 5
                 </span>
               </button>
             </div>
@@ -2226,9 +2373,10 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
       </div>
     </li>
     <li
-      class="step"
-      data-testid="wizardStep-5"
-      id="tableToolWizard-step-5"
+      aria-current="step"
+      class="step stepActive"
+      data-testid="wizardStep-6"
+      id="tableToolWizard-step-6"
       tabindex="-1"
     >
       <div
@@ -2240,7 +2388,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
           <span
             class="govuk-tag govuk-tag--turquoise govuk-!-margin-right-2"
           >
-            Step 5 
+            Step 6 
             <span
               class="govuk-visually-hidden"
             >
@@ -2837,7 +2985,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               <span
                 class="govuk-visually-hidden"
               >
-                Choose a subject
+                Choose a publication
               </span>
             </h2>
             <dl
@@ -2845,17 +2993,17 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             >
               <div
                 class="govuk-summary-list__row"
-                data-testid="Subject"
+                data-testid="Publication"
               >
                 <dt
                   class="govuk-summary-list__key"
                 >
-                  Subject
+                  Publication
                 </dt>
                 <dd
                   class="govuk-summary-list__value"
                 >
-                  None
+                  Test publication
                 </dd>
               </div>
             </dl>
@@ -2871,7 +3019,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 data-testid="wizardStep-1-goToButton"
                 type="button"
               >
-                Change subject
+                Change publication
                  
                 <span
                   class="govuk-visually-hidden"
@@ -2906,6 +3054,79 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 class="govuk-tag govuk-tag govuk-tag--grey"
               >
                 Step 2 
+              </span>
+              <span
+                class="govuk-visually-hidden"
+              >
+                Choose a subject
+              </span>
+            </h2>
+            <dl
+              class="govuk-summary-list govuk-summary-list--no-border"
+            >
+              <div
+                class="govuk-summary-list__row"
+                data-testid="Subject"
+              >
+                <dt
+                  class="govuk-summary-list__key"
+                >
+                  Subject
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                >
+                  None
+                </dd>
+              </div>
+            </dl>
+          </div>
+          <div
+            class="govuk-grid-column-one-third dfe-align--right"
+          >
+            <div
+              class="govuk-!-margin-top-2"
+            >
+              <button
+                class="stepButton"
+                data-testid="wizardStep-2-goToButton"
+                type="button"
+              >
+                Change subject
+                 
+                <span
+                  class="govuk-visually-hidden"
+                >
+                  Step 2
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+    <li
+      class="step"
+      data-testid="wizardStep-3"
+      id="tableToolWizard-step-3"
+      tabindex="-1"
+    >
+      <div
+        class="content contentSmall"
+      >
+        <div
+          class="govuk-grid-row"
+        >
+          <div
+            class="govuk-grid-column-two-thirds"
+          >
+            <h2
+              class="stepEnabled"
+            >
+              <span
+                class="govuk-tag govuk-tag govuk-tag--grey"
+              >
+                Step 3 
               </span>
               <span
                 class="govuk-visually-hidden"
@@ -2947,7 +3168,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             >
               <button
                 class="stepButton"
-                data-testid="wizardStep-2-goToButton"
+                data-testid="wizardStep-3-goToButton"
                 type="button"
               >
                 Edit locations
@@ -2955,7 +3176,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 <span
                   class="govuk-visually-hidden"
                 >
-                  Step 2
+                  Step 3
                 </span>
               </button>
             </div>
@@ -2965,8 +3186,8 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
     </li>
     <li
       class="step"
-      data-testid="wizardStep-3"
-      id="tableToolWizard-step-3"
+      data-testid="wizardStep-4"
+      id="tableToolWizard-step-4"
       tabindex="-1"
     >
       <div
@@ -2984,7 +3205,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               <span
                 class="govuk-tag govuk-tag govuk-tag--grey"
               >
-                Step 3 
+                Step 4 
               </span>
               <span
                 class="govuk-visually-hidden"
@@ -3020,7 +3241,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             >
               <button
                 class="stepButton"
-                data-testid="wizardStep-3-goToButton"
+                data-testid="wizardStep-4-goToButton"
                 type="button"
               >
                 Edit time period
@@ -3028,7 +3249,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 <span
                   class="govuk-visually-hidden"
                 >
-                  Step 3
+                  Step 4
                 </span>
               </button>
             </div>
@@ -3038,8 +3259,8 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
     </li>
     <li
       class="step"
-      data-testid="wizardStep-4"
-      id="tableToolWizard-step-4"
+      data-testid="wizardStep-5"
+      id="tableToolWizard-step-5"
       tabindex="-1"
     >
       <div
@@ -3057,7 +3278,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
               <span
                 class="govuk-tag govuk-tag govuk-tag--grey"
               >
-                Step 4 
+                Step 5 
               </span>
               <span
                 class="govuk-visually-hidden"
@@ -3126,7 +3347,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
             >
               <button
                 class="stepButton"
-                data-testid="wizardStep-4-goToButton"
+                data-testid="wizardStep-5-goToButton"
                 type="button"
               >
                 Edit filters
@@ -3134,7 +3355,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
                 <span
                   class="govuk-visually-hidden"
                 >
-                  Step 4
+                  Step 5
                 </span>
               </button>
             </div>
@@ -3143,9 +3364,10 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
       </div>
     </li>
     <li
-      class="step"
-      data-testid="wizardStep-5"
-      id="tableToolWizard-step-5"
+      aria-current="step"
+      class="step stepActive"
+      data-testid="wizardStep-6"
+      id="tableToolWizard-step-6"
       tabindex="-1"
     >
       <div
@@ -3157,7 +3379,7 @@ exports[`TableToolPage renders the Table Tool page correctly when a Fast Track i
           <span
             class="govuk-tag govuk-tag--turquoise govuk-!-margin-right-2"
           >
-            Step 5 
+            Step 6 
             <span
               class="govuk-visually-hidden"
             >

--- a/src/explore-education-statistics-frontend/src/pages/help-support.tsx
+++ b/src/explore-education-statistics-frontend/src/pages/help-support.tsx
@@ -90,8 +90,8 @@ function HelpSupportPage() {
             <p>
               To create your own tables and explore the national and regional
               data we have available via the service use the table tool
-              available in our{' '}
-              <a href="/data-tables">Create your own tables online</a> section.
+              available in our <a href="/data-tables">Create your own tables</a>{' '}
+              section.
             </p>
             <p>
               You can use our table tool to choose the data and area of

--- a/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
@@ -40,7 +40,7 @@ Navigate to Absence release
     user opens details dropdown  Academic Year 2016/17 (Live - Latest release)
     user clicks testid element   Edit release link for Pupil absence in schools in England, Academic Year 2016/17 (Live - Latest release)
     user waits until h1 is visible  Pupil absence in schools in England
-    user waits until h2 is visible  Release Summary
+    user waits until h2 is visible  Release summary
 
 
 Validate Analyst1 can see Absence release summary

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -55,14 +55,14 @@ Start creating a data block
     user waits until page contains  No data blocks have been created.
 
     user clicks link  Create data block
-    user waits until h2 is visible   Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
 
 Select subject "UI test subject"
     [Tags]  HappyPath
     user waits until page contains   UI test subject
     user clicks radio    UI test subject
     user clicks element   id:publicationSubjectForm-submit
-    user waits until h2 is visible  Choose locations    90
+    user waits until table tool wizard step is available    Choose locations    90
     user checks previous table tool step contains  1    Subject     UI test subject
 
 Select locations
@@ -76,7 +76,7 @@ Select locations
     user clicks checkbox   Nailsea Youngwood
     user clicks checkbox   Syon
     user clicks element     id:locationFiltersForm-submit
-    user waits until h2 is visible  Choose time period  90
+    user waits until table tool wizard step is available    Choose time period  90
 
 Select time period
     [Tags]   HappyPath
@@ -89,9 +89,8 @@ Select time period
     user selects from list by label  id:timePeriodForm-start  2005
     user selects from list by label  id:timePeriodForm-end  2020
     user clicks element     id:timePeriodForm-submit
-    user waits until h2 is visible  Choose your filters
-    user checks previous table tool step contains  3    Start date    2005
-    user checks previous table tool step contains  3    End date      2020
+    user waits until table tool wizard step is available    Choose your filters
+    user checks previous table tool step contains  3    Time period    2005 to 2020
 
 Select indicators
     [Tags]  HappyPath
@@ -303,7 +302,7 @@ Navigate to Chart tab
     set suite variable  ${DATABLOCK_URL}  ${url}
 
     user clicks link   Chart
-    user waits until h3 is visible  Choose chart type
+    user waits until table tool wizard step is available    Choose chart type
 
 Configure basic line chart
     [Tags]  HappyPath
@@ -416,7 +415,7 @@ Configure basic vertical bar chart
     user waits until page does not contain loading spinner
 
     user clicks link  Chart
-    user waits until h3 is visible  Choose chart type
+    user waits until table tool wizard step is available    Choose chart type
     user clicks button  Vertical bar
 
     user waits for chart preview to update
@@ -523,7 +522,7 @@ Configure basic horizontal bar chart
     user waits until page does not contain loading spinner
 
     user clicks link  Chart
-    user waits until h3 is visible  Choose chart type
+    user waits until table tool wizard step is available    Choose chart type
     user clicks button  Horizontal bar
 
     user waits for chart preview to update
@@ -617,7 +616,7 @@ Configure basic geographic chart
     user waits until page does not contain loading spinner
 
     user clicks link  Chart
-    user waits until h3 is visible  Choose chart type
+    user waits until table tool wizard step is available    Choose chart type
     user clicks button  Geographic
 
     user waits for chart preview to update
@@ -715,7 +714,7 @@ Configure basic infographic chart
     user waits until page does not contain loading spinner
 
     user clicks link  Chart
-    user waits until h3 is visible  Choose chart type
+    user waits until table tool wizard step is available    Choose chart type
     user clicks button  Choose an infographic as alternative
     user chooses file  id:chartConfigurationForm-file  ${FILES_DIR}test-infographic.png
 

--- a/tests/robot-tests/tests/admin/bau/delete_subject.robot
+++ b/tests/robot-tests/tests/admin/bau/delete_subject.robot
@@ -114,14 +114,14 @@ Navigate to 'Data blocks' page
 
     user clicks link  Create data block
     user waits until h2 is visible  Create data block
-    user waits until h2 is visible  Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
 
 Select subject "UI test subject"
     [Tags]  HappyPath
     user waits until page contains   UI test subject
     user clicks radio    UI test subject
     user clicks element   id:publicationSubjectForm-submit
-    user waits until h2 is visible   Choose locations
+    user waits until table tool wizard step is available    Choose locations
     user checks previous table tool step contains  1    Subject     UI test subject
 
 Select locations
@@ -132,7 +132,7 @@ Select locations
     user clicks checkbox   Nailsea Youngwood
     user clicks checkbox   Syon
     user clicks element     id:locationFiltersForm-submit
-    user waits until h2 is visible  Choose time period
+    user waits until table tool wizard step is available    Choose time period
 
 Select time period
     [Tags]   HappyPath
@@ -141,7 +141,7 @@ Select time period
     user selects from list by label  id:timePeriodForm-start  2019
     user selects from list by label  id:timePeriodForm-end  2019
     user clicks element     id:timePeriodForm-submit
-    user waits until h2 is visible  Choose your filters
+    user waits until table tool wizard step is available    Choose your filters
 
 Select indicators
     [Tags]  HappyPath

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -19,14 +19,14 @@ ${RELEASE_URL}
 
 *** Keywords ***
 user chooses location, time period and filters
-    user waits until h2 is visible  Choose locations    90
+    user waits until table tool wizard step is available    Choose locations    90
 
     user opens details dropdown   Ward
     user clicks checkbox   Nailsea Youngwood
     user clicks checkbox   Syon
     user clicks element     id:locationFiltersForm-submit
 
-    user waits until h2 is visible  Choose time period  90
+    user waits until table tool wizard step is available    Choose time period  90
 
     ${timePeriodStartList}=   get list items  id:timePeriodForm-start
     ${timePeriodEndList}=   get list items  id:timePeriodForm-end
@@ -38,8 +38,8 @@ user chooses location, time period and filters
     user selects from list by label  id:timePeriodForm-end  2017
     user clicks element     id:timePeriodForm-submit
 
-    user waits until h2 is visible  Choose your filters
-    user checks previous table tool step contains  3    Start date    2005
+    user waits until table tool wizard step is available    Choose your filters
+    user checks previous table tool step contains  3    Time period    2005 to 2017
 
     user clicks indicator checkbox    Admission Numbers
 
@@ -145,7 +145,7 @@ Add table highlight
     user waits until h2 is visible  Data blocks
 
     user clicks link  Create data block
-    user waits until h2 is visible   Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
 
     user waits until page contains   UI test subject
     user clicks radio    UI test subject
@@ -370,8 +370,8 @@ Go to prerelease table tool page
     [Tags]  HappyPath
     user clicks link  Table tool
 
-    user waits until h1 is visible  Create your own tables online
-    user waits until h2 is visible  View a featured table or create your own
+    user waits until h1 is visible  Create your own tables
+    user waits until table tool wizard step is available  Choose a subject
 
 Validate table highlights
     [Tags]  HappyPath
@@ -389,11 +389,10 @@ Create and validate custom table
     [Tags]  HappyPath
     user clicks link  Table tool
 
-    user waits until h1 is visible  Create your own tables online
-    user waits until h2 is visible  View a featured table or create your own
+    user waits until h1 is visible  Create your own tables
 
     user clicks link  Create your own table
-    user waits until h3 is visible  Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
 
     user waits until page contains   UI test subject
     user clicks radio    UI test subject
@@ -480,8 +479,8 @@ Go to prerelease table tool page as Analyst user
     [Tags]  HappyPath
     user clicks link  Table tool
 
-    user waits until h1 is visible  Create your own tables online
-    user waits until h2 is visible  View a featured table or create your own
+    user waits until h1 is visible  Create your own tables
+    user waits until table tool wizard step is available  Choose a subject
 
 Validate table highlights as Analyst user
     [Tags]  HappyPath
@@ -499,11 +498,10 @@ Create and validate custom table as Analyst user
     [Tags]  HappyPath
     user clicks link  Table tool
 
-    user waits until h1 is visible  Create your own tables online
-    user waits until h2 is visible  View a featured table or create your own
+    user waits until h1 is visible  Create your own tables
 
     user clicks link  Create your own table
-    user waits until h3 is visible  Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
 
     user waits until page contains   UI test subject
     user clicks radio    UI test subject

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -55,7 +55,7 @@ Check Absence in PRUs subject appears in 'Data blocks' page
     user clicks link  Create data block
 
     user waits until h2 is visible  Create data block
-    user waits until h2 is visible  Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
 
     user waits until page contains  Absence in PRUs
 

--- a/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/footnotes.robot
@@ -110,7 +110,7 @@ Navigate to 'Create data block' page
     user clicks link  Create data block
 
     user waits until h2 is visible  Create data block
-    user waits until h2 is visible  Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
 
 Select subject "${SUBJECT_NAME}" (data block)
     [Tags]  HappyPath
@@ -120,21 +120,21 @@ Select subject "${SUBJECT_NAME}" (data block)
 
 Select locations (data block)
     [Tags]   HappyPath
-    user waits until h2 is visible  Choose locations
+    user waits until table tool wizard step is available    Choose locations
     user opens details dropdown   National
     user clicks checkbox   England
     user clicks element     id:locationFiltersForm-submit
 
 Select time period
     [Tags]   HappyPath
-    user waits until h2 is visible  Choose time period
+    user waits until table tool wizard step is available    Choose time period
     user selects from list by label  id:timePeriodForm-start    2020 Week 13
     user selects from list by label  id:timePeriodForm-end      2021 Week 24
     user clicks element     id:timePeriodForm-submit
 
 Select indicators (data block)
     [Tags]  HappyPath
-    user waits until h2 is visible  Choose your filters
+    user waits until table tool wizard step is available    Choose your filters
     user clicks button  Select all 2 subgroup options
 
 Select category filters (data block)
@@ -276,7 +276,7 @@ Verify newly published release is on Find Statistics page
     user opens details dropdown  ${TOPIC_NAME}
     user waits until details dropdown contains publication    ${TOPIC_NAME}  ${PUBLICATION_NAME}   10
     user checks publication bullet contains link   ${PUBLICATION_NAME}  View statistics and data
-    user checks publication bullet contains link   ${PUBLICATION_NAME}  Create your own tables online
+    user checks publication bullet contains link   ${PUBLICATION_NAME}  Create your own tables
     user checks publication bullet does not contain link  ${PUBLICATION_NAME}   Statistics at DfE
 
 Navigate to newly published release page
@@ -314,21 +314,21 @@ Choose subject (table tool)
 
 Select locations (table tool)
     [Tags]   HappyPath
-    user waits until h2 is visible  Choose locations
+    user waits until table tool wizard step is available    Choose locations
     user opens details dropdown   National
     user clicks checkbox   England
     user clicks element     id:locationFiltersForm-submit
 
 Select time period (table tool)
     [Tags]   HappyPath
-    user waits until h2 is visible  Choose time period
+    user waits until table tool wizard step is available    Choose time period
     user selects from list by label  id:timePeriodForm-start    2020 Week 13
     user selects from list by label  id:timePeriodForm-end      2021 Week 24
     user clicks element     id:timePeriodForm-submit
 
 Select indicators (table tool)
     [Tags]  HappyPath
-    user waits until h2 is visible  Choose your filters
+    user waits until table tool wizard step is available    Choose your filters
     user clicks button  Select all 2 subgroup options
 
 Select category filters (table tool)

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -54,7 +54,8 @@ Go to 'Sign Off' page
     user clicks link  Sign off
     user waits for page to finish loading
     user waits until page contains testid  public-release-url
-    ${PUBLIC_RELEASE_LINK}=  Get Text  xpath://*[@data-testid="public-release-url"]
+    ${PUBLIC_RELEASE_LINK}=  Get Value  xpath://*[@data-testid="public-release-url"]
+    check that variable is not empty  PUBLIC_RELEASE_LINK   ${PUBLIC_RELEASE_LINK}
     Set Suite Variable  ${PUBLIC_RELEASE_LINK}
 
 Go to Public Release Link
@@ -143,7 +144,7 @@ Go to Table Tool page
     [Tags]  HappyPath
     user goes to url  %{PUBLIC_URL}/data-tables
     user waits for page to finish loading
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
 
 Check scheduled release isn't visible
     [Tags]  HappyPath

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -68,7 +68,7 @@ Return to Admin Dashboard
     [Tags]  HappyPath
     user goes to url    %{ADMIN_URL}
     user waits until h1 is visible   Dashboard
-    user waits until page contains element   id:publicationsReleases-themeTopic-themeId    180
+    user waits until page contains element   css:#publicationsReleases-themeTopic-themeId,[data-testid='no-permission-to-access-releases']    180
 
 Create another release for the same publication
     [Tags]  HappyPath
@@ -124,7 +124,7 @@ Navigate to 'Create data block' page
     user clicks link  Create data block
 
     user waits until h2 is visible  Create data block
-    user waits until h2 is visible   Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
 
 Select subject "${SUBJECT_NAME}"
     [Tags]  HappyPath
@@ -134,7 +134,7 @@ Select subject "${SUBJECT_NAME}"
 
 Select locations
     [Tags]   HappyPath
-    user waits until h2 is visible  Choose locations
+    user waits until table tool wizard step is available    Choose locations
     user opens details dropdown   Opportunity Area
     user clicks checkbox   Bolton 001 (E02000984)
     user clicks checkbox   Bolton 001 (E05000364)
@@ -147,14 +147,14 @@ Select locations
 
 Select time period
     [Tags]   HappyPath
-    user waits until h2 is visible  Choose time period
+    user waits until table tool wizard step is available    Choose time period
     user selects from list by label  id:timePeriodForm-start  2005
     user selects from list by label  id:timePeriodForm-end  2020
     user clicks element     id:timePeriodForm-submit
 
 Select indicators
     [Tags]  HappyPath
-    user waits until h2 is visible  Choose your filters
+    user waits until table tool wizard step is available    Choose your filters
     user clicks indicator checkbox    Admission Numbers
 
 Create table
@@ -236,7 +236,7 @@ Verify newly published release is on Find Statistics page
     user opens details dropdown  ${TOPIC_NAME}
     user waits until details dropdown contains publication    ${TOPIC_NAME}  ${PUBLICATION_NAME}
     user checks publication bullet contains link   ${PUBLICATION_NAME}  View statistics and data
-    user checks publication bullet contains link   ${PUBLICATION_NAME}  Create your own tables online
+    user checks publication bullet contains link   ${PUBLICATION_NAME}  Create your own tables
     user checks publication bullet does not contain link  ${PUBLICATION_NAME}   Statistics at DfE
 
 Navigate to published release page
@@ -268,7 +268,7 @@ Check other release is correct
 Go to Table Tool page
     [Tags]  HappyPath
     user goes to url  %{PUBLIC_URL}/data-tables
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
     user waits for page to finish loading
 
 Select publication in table tool
@@ -277,18 +277,18 @@ Select publication in table tool
     user opens details dropdown    ${TOPIC_NAME}
     user clicks radio      ${PUBLICATION_NAME}
     user clicks element    id:publicationForm-submit
-    user waits until h2 is visible   View a featured table or create your own
+    user waits until table tool wizard step is available  Choose a subject
     user checks previous table tool step contains  1    Publication    ${PUBLICATION_NAME}
 
 Select subject "${SUBJECT_NAME}" in table tool
     [Tags]  HappyPath
     user clicks link  Create your own table
-    user waits until h3 is visible  Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
 
     user waits until page contains   ${SUBJECT_NAME}
     user clicks radio    ${SUBJECT_NAME}
     user clicks element   id:publicationSubjectForm-submit
-    user waits until h2 is visible  Choose locations
+    user waits until table tool wizard step is available    Choose locations
     user checks previous table tool step contains  2    Subject    ${SUBJECT_NAME}
 
 Select locations in table tool
@@ -297,7 +297,7 @@ Select locations in table tool
     user clicks checkbox   Barnsley
     user clicks checkbox   Birmingham
     user clicks element     id:locationFiltersForm-submit
-    user waits until h2 is visible  Choose time period
+    user waits until table tool wizard step is available    Choose time period
     user checks previous table tool step contains  3   Local Authority    Barnsley
     user checks previous table tool step contains  3   Local Authority    Birmingham
 
@@ -309,7 +309,7 @@ Select time period in table tool
 
 Select indicators in table tool
     [Tags]  HappyPath
-    user waits until h2 is visible  Choose your filters
+    user waits until table tool wizard step is available    Choose your filters
     user clicks indicator checkbox    Admission Numbers
     user clicks element   id:filtersForm-submit
 
@@ -342,10 +342,10 @@ Select table highlight from subjects step
     user waits until h1 is visible  Go back to previous step
     user clicks button  Confirm
 
-    user waits until h3 is visible  Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
 
     user clicks link  Featured tables
-    user waits until h3 is visible  Choose a table
+    user waits until table tool wizard step is available    Choose a table
 
     user checks element count is x  css:#featuredTables li  1
     user checks element should contain  css:#featuredTables li:first-child a  Test highlight name
@@ -354,7 +354,7 @@ Select table highlight from subjects step
 
     user clicks link  Test highlight name
     user waits until results table appears  180
-    user waits until page contains element   xpath://*[@data-testid="dataTableCaption" and text()="Table showing Admission Numbers for '${SUBJECT_NAME}' from '${PUBLICATION_NAME}' in Bolton 001 (E02000984), Bolton 001 (E05000364), Bolton 004 (E02000987), Bolton 004 (E05010450), Nailsea Youngwood and Syon between 2005 and 2020"]
+    user waits until page contains element   xpath://*[@data-testid="dataTableCaption" and text()="Table showing Admission Numbers for '${SUBJECT_NAME}' in Bolton 001 (E02000984), Bolton 001 (E05000364), Bolton 004 (E02000987), Bolton 004 (E05010450), Nailsea Youngwood and Syon between 2005 and 2020"]
 
 Validate table column headings for table highlight
     [Tags]  HappyPath

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -97,23 +97,23 @@ Create data block table
     user clicks link  Create data block
 
     user waits until h2 is visible  Create data block
-    user waits until h2 is visible   Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
 
     user waits until page contains   Dates test subject
     user clicks radio    Dates test subject
     user clicks element   id:publicationSubjectForm-submit
 
-    user waits until h2 is visible  Choose locations
+    user waits until table tool wizard step is available    Choose locations
     user opens details dropdown   National
     user clicks checkbox   England
     user clicks element     id:locationFiltersForm-submit
 
-    user waits until h2 is visible  Choose time period
+    user waits until table tool wizard step is available    Choose time period
     user selects from list by label  id:timePeriodForm-start  2020 Week 13
     user selects from list by label  id:timePeriodForm-end    2020 Week 16
     user clicks element     id:timePeriodForm-submit
 
-    user waits until h2 is visible  Choose your filters
+    user waits until table tool wizard step is available    Choose your filters
     user clicks subheaded indicator checkbox  Open settings  Number of open settings
     user checks subheaded indicator checkbox is checked  Open settings  Number of open settings
     user clicks subheaded indicator checkbox  Open settings  Proportion of settings open
@@ -244,7 +244,7 @@ Verify newly published release is on Find Statistics page
     user opens details dropdown  ${TOPIC_NAME}
     user waits until details dropdown contains publication    ${TOPIC_NAME}  ${PUBLICATION_NAME}   10
     user checks publication bullet contains link   ${PUBLICATION_NAME}  View statistics and data
-    user checks publication bullet contains link   ${PUBLICATION_NAME}  Create your own tables online
+    user checks publication bullet contains link   ${PUBLICATION_NAME}  Create your own tables
     user checks publication bullet does not contain link  ${PUBLICATION_NAME}   Statistics at DfE
 
 Navigate to newly published release page
@@ -624,7 +624,7 @@ Verify amendment is on Find Statistics page again
     user opens details dropdown  ${TOPIC_NAME}
     user waits until details dropdown contains publication    ${TOPIC_NAME}  ${PUBLICATION_NAME}   10
     user checks publication bullet contains link   ${PUBLICATION_NAME}  View statistics and data
-    user checks publication bullet contains link   ${PUBLICATION_NAME}  Create your own tables online
+    user checks publication bullet contains link   ${PUBLICATION_NAME}  Create your own tables
     user checks publication bullet does not contain link  ${PUBLICATION_NAME}   Statistics at DfE
 
 Navigate to amendment release page

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -209,7 +209,7 @@ Go to Table Tool page
     [Tags]  HappyPath
     environment variable should be set  PUBLIC_URL
     user goes to url  %{PUBLIC_URL}/data-tables
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
 
 Select "Test Topic" publication
     [Tags]  HappyPath
@@ -219,14 +219,14 @@ Select "Test Topic" publication
     user opens details dropdown    %{TEST_TOPIC_NAME}
     user clicks radio      ${PUBLICATION_NAME}
     user clicks element    id:publicationForm-submit
-    user waits until h2 is visible  Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
     user checks previous table tool step contains  1   Publication   ${PUBLICATION_NAME}
 
 Select "${SUBJECT_NAME}" subject
     [Tags]  HappyPath
     user clicks radio   ${SUBJECT_NAME}
     user clicks element   id:publicationSubjectForm-submit
-    user waits until h2 is visible  Choose locations
+    user waits until table tool wizard step is available    Choose locations
     user checks previous table tool step contains  2    Subject     ${SUBJECT_NAME}
 
 Select National location
@@ -237,17 +237,16 @@ Select National location
 Click next step button
     [Tags]  HappyPath
     user clicks element     id:locationFiltersForm-submit
-    user waits until h2 is visible  Choose time period
+    user waits until table tool wizard step is available    Choose time period
 
 Select start date and end date
     [Tags]  HappyPath
     user selects from list by label  id:timePeriodForm-start   2012/13
     user selects from list by label  id:timePeriodForm-end     2012/13
     user clicks element     id:timePeriodForm-submit
-    user waits until h2 is visible  Choose your filters
+    user waits until table tool wizard step is available    Choose your filters
     user waits until page contains element   id:filtersForm-indicators
-    user checks previous table tool step contains  4    Start date    2012/13
-    user checks previous table tool step contains  4    End date      2012/13
+    user checks previous table tool step contains  4    Time period    2012/13 to 2012/13
 
 Select Indicators
     [Tags]  HappyPath
@@ -280,7 +279,7 @@ Click submit button
 
 Wait until table is generated
     [Tags]  HappyPath
-    user waits until page contains button  Generate permanent link
+    user waits until page contains button  Share your table
 
 Wait until new footnote is visible
     [Tags]  HappyPath
@@ -350,9 +349,9 @@ Validate table cells
 Generate the permalink
     [Tags]  HappyPath
     [Documentation]  EES-214
-    user clicks button  Generate permanent link
+    user clicks button  Share your table
     user waits until page contains testid  permalink-generated-url
-    ${PERMA_LOCATION_URL}=  Get Text  xpath://*[@data-testid="permalink-generated-url"]
+    ${PERMA_LOCATION_URL}=  Get Value  xpath://*[@data-testid="permalink-generated-url"]
     Set Suite Variable  ${PERMA_LOCATION_URL}
 
 Go to permalink
@@ -556,12 +555,12 @@ Check the table has the same results as original table
 Check amended release doesn't contain deleted subject
     [Tags]  HappyPath
     user goes to url  %{PUBLIC_URL}/data-tables
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
     user opens details dropdown    %{TEST_THEME_NAME}
     user opens details dropdown    %{TEST_TOPIC_NAME}
     user clicks radio      ${PUBLICATION_NAME}
     user clicks element    id:publicationForm-submit
-    user waits until h2 is visible  Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
     user checks previous table tool step contains  1   Publication   ${PUBLICATION_NAME}
     user checks page does not contain  ${SECOND_SUBJECT}
 
@@ -661,24 +660,24 @@ Wait for release process status to be Complete again
 Go to Table Tool page for amendment
     [Tags]  HappyPath
     user goes to url  %{PUBLIC_URL}/data-tables
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
 
 Go to amended release & create table
     [Tags]  HappyPath
     user goes to url  %{PUBLIC_URL}/data-tables
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
     user opens details dropdown    %{TEST_THEME_NAME}
     user opens details dropdown    %{TEST_TOPIC_NAME}
     user clicks radio      ${PUBLICATION_NAME}
     user clicks element    id:publicationForm-submit
-    user waits until h2 is visible  Choose a subject
+    user waits until table tool wizard step is available    Choose a subject
     user checks previous table tool step contains  1   Publication   ${PUBLICATION_NAME}
     #user checks page does not contain  ${SECOND_SUBJECT}   # EES-1360
 
 Select ${SUBJECT_NAME} subject
     user clicks radio   ${SUBJECT_NAME}
     user clicks element   id:publicationSubjectForm-submit
-    user waits until h2 is visible  Choose locations
+    user waits until table tool wizard step is available    Choose locations
     user checks previous table tool step contains  2    Subject     ${SUBJECT_NAME}
 
 Select National location filter
@@ -689,14 +688,14 @@ Select National location filter
 Click the next step button
     [Tags]  HappyPath
     user clicks element     id:locationFiltersForm-submit
-    user waits until h2 is visible  Choose time period
+    user waits until table tool wizard step is available    Choose time period
 
 Select start date + end date
     [Tags]  HappyPath
     user selects from list by label  id:timePeriodForm-start   2020 Week 13
     user selects from list by label  id:timePeriodForm-end     2021 Week 24
     user clicks element     id:timePeriodForm-submit
-    user waits until h2 is visible  Choose your filters
+    user waits until table tool wizard step is available    Choose your filters
     user waits until page contains element   id:filtersForm-indicators
 
 Select four indicators
@@ -721,7 +720,7 @@ Generate table
 
 Wait until the table is generated
     [Tags]  HappyPath
-    user waits until page contains button  Generate permanent link
+    user clicks button  Share your table
 
 Validate generated table
     [Tags]   HappyPath
@@ -730,9 +729,8 @@ Validate generated table
 Generate the new permalink
     [Tags]  HappyPath
     [Documentation]  EES-214
-    user clicks button  Generate permanent link
     user waits until page contains testid  permalink-generated-url
-    ${PERMA_LOCATION_URL_TWO}=  Get Text  xpath://*[@data-testid="permalink-generated-url"]
+    ${PERMA_LOCATION_URL_TWO}=  Get Value  xpath://*[@data-testid="permalink-generated-url"]
     Set Suite Variable  ${PERMA_LOCATION_URL_TWO}
 
 Go to new permalink

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -443,8 +443,7 @@ Confirm data replacement
 
 Delete second subject file
     [Tags]  HappyPath
-    user clicks link  Footnotes
-    user clicks link  Data and files
+    user clicks link  Back  # back from data replacement confirmation
     user waits until page contains accordion section  ${SECOND_SUBJECT}
     user opens accordion section  ${SECOND_SUBJECT}
     user scrolls to accordion section content  ${SECOND_SUBJECT}

--- a/tests/robot-tests/tests/general_public/fast_track.robot
+++ b/tests/robot-tests/tests/general_public/fast_track.robot
@@ -22,7 +22,7 @@ Click fast track link for 'Pupil absence rates' data block
 
 Validate Publication selected step option
     [Tags]  HappyPath
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
     user waits until page contains element    css:table
     user checks previous table tool step contains  1    Publication     Pupil absence in schools in England
 
@@ -33,10 +33,7 @@ Validate Subject selected step option
 Validate other selected step options
     [Tags]  HappyPath
     user checks previous table tool step contains  3    National        England
-
-    user checks previous table tool step contains  4    Start date      2012/13
-    user checks previous table tool step contains  4    End date        2016/17
-
+    user checks previous table tool step contains  4    Time period      2012/13 to 2016/17
     user checks previous table tool step contains  5    Indicators      Authorised absence rate
     user checks previous table tool step contains  5    Indicators      Overall absence rate
     user checks previous table tool step contains  5    Indicators      Unauthorised absence rate

--- a/tests/robot-tests/tests/general_public/permalink_prod_1.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_1.robot
@@ -11,7 +11,7 @@ Go to Table Tool page
     [Tags]  HappyPath
     environment variable should be set  PUBLIC_URL
     user goes to url  %{PUBLIC_URL}/data-tables
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
 
 Go to permalink
     [Tags]  HappyPath
@@ -57,7 +57,7 @@ Validate download files
 
 Use Create tables button
     [Tags]  HappyPath
-    user waits until h2 is visible  Create your own tables online
+    user waits until h2 is visible  Create your own tables
     user clicks link    Create tables
 
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables

--- a/tests/robot-tests/tests/general_public/permalink_prod_2.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_2.robot
@@ -11,7 +11,7 @@ Go to Table Tool page
     [Tags]  HappyPath
     environment variable should be set  PUBLIC_URL
     user goes to url  %{PUBLIC_URL}/data-tables
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
 
 Go to permalink
     [Tags]  HappyPath
@@ -69,7 +69,7 @@ Validate download files
 
 Use Create tables button
     [Tags]  HappyPath
-    user waits until h2 is visible  Create your own tables online
+    user waits until h2 is visible  Create your own tables
     user clicks link    Create tables
 
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables

--- a/tests/robot-tests/tests/general_public/permalink_prod_3.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_3.robot
@@ -11,7 +11,7 @@ Go to Table Tool page
     [Tags]  HappyPath
     environment variable should be set  PUBLIC_URL
     user goes to url  %{PUBLIC_URL}/data-tables
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables
 
 Go to permalink
     [Tags]  HappyPath
@@ -75,7 +75,7 @@ Validate download files
 
 Use Create tables button
     [Tags]  HappyPath
-    user waits until h2 is visible  Create your own tables online
+    user waits until h2 is visible  Create your own tables
     user clicks link    Create tables
 
-    user waits until h1 is visible  Create your own tables online
+    user waits until h1 is visible  Create your own tables

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -296,7 +296,7 @@ Clicking "Create tables" takes user to Table Tool page with absence publication 
     [Documentation]  DFE-898
     [Tags]  HappyPath
     user clicks link    Create tables
-    user waits until h1 is visible  Create your own tables online   60
+    user waits until h1 is visible  Create your own tables   60
     user waits for page to finish loading
 
     user waits until page contains  Choose a subject   60

--- a/tests/robot-tests/tests/general_public/statistics_page.robot
+++ b/tests/robot-tests/tests/general_public/statistics_page.robot
@@ -51,7 +51,7 @@ Validate "Pupil absence" details component
 
     user waits until details dropdown contains publication   Pupil absence   Pupil absence in schools in England
     user checks publication bullet contains link   Pupil absence in schools in England    View statistics and data
-    user checks publication bullet contains link   Pupil absence in schools in England    Create your own tables online
+    user checks publication bullet contains link   Pupil absence in schools in England    Create your own tables
     user checks publication bullet does not contain link  Pupil absence in schools in England   Statistics at DfE
 
     user waits until details dropdown contains publication   Pupil absence   Pupil absence in schools in England: autumn and spring

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -106,7 +106,7 @@ Validate Bury Number of fixed period exclusions row
 User generates a permanent link
     [Tags]   HappyPath
     user clicks button    Share your table
-    user waits until page contains element   xpath://a[text()="View share link"]   60
+    user waits until page contains testid  permalink-generated-url
     user checks generated permalink is valid
 
 User validates permanent link works correctly

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -13,7 +13,7 @@ user signs in as bau1
 
     user waits until h1 is visible   Dashboard
     user waits until page contains title caption  Welcome Bau1
-    user waits until page contains element   id:publicationsReleases-themeTopic-themeId   180
+    user waits until page contains element   css:#publicationsReleases-themeTopic-themeId,[data-testid='no-permission-to-access-releases']   180
 
     user checks breadcrumb count should be  2
     user checks nth breadcrumb contains  1   Home
@@ -29,7 +29,7 @@ user signs in as analyst1
 
     user waits until h1 is visible  Dashboard
     user waits until page contains title caption  Welcome Analyst1
-    user waits until page contains element   id:publicationsReleases-themeTopic-themeId   180
+    user waits until page contains element   css:#publicationsReleases-themeTopic-themeId,[data-testid='no-permission-to-access-releases']   180
 
     user checks breadcrumb count should be  2
     user checks nth breadcrumb contains  1   Home

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -20,8 +20,7 @@ ${release_complete_wait}   900
 
 *** Keywords ***
 do this on failure
-#    capture large screenshot and prompt to continue
-    capture large screenshot
+    capture large screenshot and html
     set selenium timeout  3
 
 user opens the browser

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -20,6 +20,7 @@ ${release_complete_wait}   900
 
 *** Keywords ***
 do this on failure
+#    capture large screenshot and prompt to continue
     capture large screenshot
     set selenium timeout  3
 
@@ -555,3 +556,11 @@ user checks page contains other release
 user checks page does not contain other release
     [Arguments]   ${other_release_title}
     user checks page does not contain element   xpath://li[@data-testid="other-release-item"]/a[text()="${other_release_title}"]
+
+check that variable is not empty
+    [Arguments]   ${variable_name}  ${variable_value}
+    Run Keyword If	'${variable_value}'=='${EMPTY}'    Variable "${variable_name}" is empty.
+
+user waits until table tool wizard step is available
+    [Arguments]   ${table_tool_step_title}   ${wait}=${timeout}
+    user waits until element is visible  xpath://h2|h3//*[contains(text(),"${table_tool_step_title}")]  ${wait}

--- a/tests/robot-tests/tests/libs/public-utilities.py
+++ b/tests/robot-tests/tests/libs/public-utilities.py
@@ -104,7 +104,7 @@ def user_checks_generated_permalink_is_valid():
     elem = sl.driver.find_element_by_css_selector('[data-testid="permalink-generated-url"]')
     url_without_basic_auth = re.sub(r'.*@', '', os.environ['PUBLIC_URL'])
     url_without_http = re.sub(r'^https?:\/\/', '', url_without_basic_auth)
-    current_url_without_http = re.sub(r'^https?:\/\/', '', elem.text)
+    current_url_without_http = re.sub(r'^https?:\/\/', '', elem.value)
     if not current_url_without_http.startswith(f"{url_without_http}/data-tables/permalink/"):
         raise_assertion_error(
             f'Generated permalink "{current_url_without_http}" is invalid! Should start with "{url_without_http}/data-tables/permalink/"')

--- a/tests/robot-tests/tests/libs/public-utilities.py
+++ b/tests/robot-tests/tests/libs/public-utilities.py
@@ -104,7 +104,7 @@ def user_checks_generated_permalink_is_valid():
     elem = sl.driver.find_element_by_css_selector('[data-testid="permalink-generated-url"]')
     url_without_basic_auth = re.sub(r'.*@', '', os.environ['PUBLIC_URL'])
     url_without_http = re.sub(r'^https?:\/\/', '', url_without_basic_auth)
-    current_url_without_http = re.sub(r'^https?:\/\/', '', elem.value)
+    current_url_without_http = re.sub(r'^https?:\/\/', '', elem.get_attribute("value"))
     if not current_url_without_http.startswith(f"{url_without_http}/data-tables/permalink/"):
         raise_assertion_error(
             f'Generated permalink "{current_url_without_http}" is invalid! Should start with "{url_without_http}/data-tables/permalink/"')

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -167,6 +167,13 @@ def user_should_be_at_top_of_page():
         raise_assertion_error(
             f"Windows position Y is {y} not 0! User should be at the top of the page!")
 
+def capture_large_screenshot_and_prompt_to_continue():
+    capture_large_screenshot()
+    warn("Failure encountered - continue? (Y/n)")
+    choice=input()
+    if (choice.lower().startsWith("n")):
+        raise_assertion_error('Test failed and you chose to stop the tests')
+
 
 def capture_large_screenshot():
     currentWindow = sl.get_window_size()
@@ -177,9 +184,10 @@ def capture_large_screenshot():
     original_height = currentWindow[1]
 
     sl.set_window_size(page_width, page_height)
-    warn("Capturing a screenshot at URL " + sl.get_location())
-    sl.capture_page_screenshot()
+    screenshot_location = sl.capture_page_screenshot()
     sl.set_window_size(page_width, original_height)
+
+    warn("Captured a screenshot at URL " + sl.get_location() + "     Screenshot saved to file://" + screenshot_location)
 
 
 def user_gets_row_number_with_heading(heading: str, table_locator: str = 'css:table'):
@@ -255,5 +263,9 @@ def remove_substring_from_right_of_string(string, substring):
 
 
 def user_clicks_element_if_exists(selector):
+    if element_finder.find(selector, required=False) is not None:
+        sl.click_element(selector)
+
+def user_chooses_what_to_do_on_step_failure(selector):
     if element_finder.find(selector, required=False) is not None:
         sl.click_element(selector)

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -175,6 +175,11 @@ def capture_large_screenshot_and_prompt_to_continue():
         raise_assertion_error('Test failed and you chose to stop the tests')
 
 
+def capture_large_screenshot_and_html():
+    capture_large_screenshot()
+    capture_html()
+
+
 def capture_large_screenshot():
     currentWindow = sl.get_window_size()
     page_height = sl.driver.execute_script(
@@ -187,8 +192,16 @@ def capture_large_screenshot():
     screenshot_location = sl.capture_page_screenshot()
     sl.set_window_size(page_width, original_height)
 
-    warn("Captured a screenshot at URL " + sl.get_location() + "     Screenshot saved to file://" + screenshot_location)
+    warn(f"Captured a screenshot at URL {sl.get_location()}     Screenshot saved to file://{screenshot_location}")
 
+
+def capture_html():
+    html = sl.get_source()
+    current_time_millis=round(datetime.datetime.timestamp(datetime.datetime.now()) * 1000)
+    html_file = open(f"test-results/captured-html-{current_time_millis}.html", "w")
+    html_file.write(html)
+    html_file.close()
+    warn(f"Captured HTML of {sl.get_location()}      HTML saved to file://{os.path.realpath(html_file.name)}")
 
 def user_gets_row_number_with_heading(heading: str, table_locator: str = 'css:table'):
     elem = get_child_element(table_locator, f'xpath:.//tbody/tr/th[text()="{heading}"]/..')


### PR DESCRIPTION
This PR:
- fixes currently-failing UI tests
- adds arguments to run_tests.py to rerun failed tests and suites and combine results with original run
- adds arguments to run_tests.py to specify own implicit and explicit wait times for Robot runs
- adds the generation of an HTML dump to accompany screenshots when failures occur.  From these it is easier to find out the cause of failures if down to difference in HTML structure.

An example usage of running with the extra options:

`pipenv run python3 run_tests.py -i robot -b chrome -e local -v --rerun-failed-suites --timeout 10 --implicit-wait 2` 

In this particular example, this is re-running only the suites that failed in the previous run, and then merging any new successes with the original run results and creating a new report.html.