### PR TITLE
EES-197 unsaved changes warning

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentBlock.tsx
@@ -22,6 +22,8 @@ interface EditableContentBlockProps {
   label: string;
   hideLabel?: boolean;
   value: string;
+  handleBlur?: (isDirty: boolean) => void;
+  onCancel?: () => void;
   onImageUpload?: ImageUploadHandler;
   onImageUploadCancel?: ImageUploadCancelHandler;
   onSave: (value: string) => void;
@@ -38,6 +40,8 @@ const EditableContentBlock = ({
   label,
   hideLabel = false,
   value,
+  handleBlur,
+  onCancel,
   onImageUpload,
   onImageUploadCancel,
   onSave,
@@ -81,7 +85,7 @@ const EditableContentBlock = ({
     [onSave, toggleEditing],
   );
 
-  if (onSave && isEditing) {
+  if (isEditing) {
     return (
       <EditableContentForm
         id={id}
@@ -90,8 +94,14 @@ const EditableContentBlock = ({
         content={content ? sanitizeHtml(content, sanitizeOptions) : ''} // NOTE: Sanitize to transform img src attribs
         onImageUpload={onImageUpload}
         onImageUploadCancel={onImageUploadCancel}
-        onCancel={toggleEditing.off}
+        onCancel={() => {
+          toggleEditing.off();
+          if (onCancel) {
+            onCancel();
+          }
+        }}
         onSubmit={handleSave}
+        handleBlur={handleBlur}
       />
     );
   }

--- a/src/explore-education-statistics-admin/src/components/editable/EditableContentForm.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableContentForm.tsx
@@ -20,6 +20,7 @@ export interface Props {
   content: string;
   id: string;
   hideLabel?: boolean;
+  handleBlur?: (isDirty: boolean) => void;
   onImageUpload?: ImageUploadHandler;
   onImageUploadCancel?: ImageUploadCancelHandler;
   onCancel: () => void;
@@ -31,6 +32,7 @@ const EditableContentForm = ({
   content,
   label,
   hideLabel = false,
+  handleBlur,
   onImageUpload,
   onImageUploadCancel,
   onCancel,
@@ -73,6 +75,7 @@ const EditableContentForm = ({
           validateElements={validateElements}
           onImageUpload={onImageUpload}
           onImageUploadCancel={onImageUploadCancel}
+          handleBlur={handleBlur}
         />
 
         <ButtonGroup>

--- a/src/explore-education-statistics-admin/src/components/form/FormFieldEditor.tsx
+++ b/src/explore-education-statistics-admin/src/components/form/FormFieldEditor.tsx
@@ -21,6 +21,7 @@ type Props<FormValues> = {
   validateElements?: (
     elements: Element[],
   ) => string | undefined | Promise<string | undefined>;
+  handleBlur?: (isDirty: boolean) => void;
 } & OmitStrict<FormEditorProps, 'id' | 'value' | 'onChange'>;
 
 function FormFieldEditor<T>({
@@ -31,6 +32,7 @@ function FormFieldEditor<T>({
   formGroupClass,
   testId,
   validateElements,
+  handleBlur,
   ...props
 }: Props<T>) {
   const { prefixFormId, fieldId } = useFormContext();
@@ -65,6 +67,9 @@ function FormFieldEditor<T>({
               id={id ? prefixFormId(id) : fieldId(name as string)}
               onBlur={() => {
                 form.setFieldTouched(name as string, true);
+                if (handleBlur) {
+                  handleBlur(form.dirty);
+                }
               }}
               onElementsChange={handleElements}
               onElementsReady={handleElements}

--- a/src/explore-education-statistics-admin/src/contexts/EditingContext.tsx
+++ b/src/explore-education-statistics-admin/src/contexts/EditingContext.tsx
@@ -7,14 +7,23 @@ import React, {
 } from 'react';
 import noop from 'lodash/noop';
 
+export interface UnSavedEdit {
+  sectionId: string;
+  blockIds: string[];
+}
+
 export interface EditingContextState {
   isEditing: boolean;
   setEditing: (isEditing: boolean) => void;
+  unSavedEdits: UnSavedEdit[];
+  setUnSavedEdits: (unSavedEdits: UnSavedEdit[]) => void;
 }
 
 export const EditingContext = createContext<EditingContextState>({
   isEditing: false,
   setEditing: noop,
+  unSavedEdits: [],
+  setUnSavedEdits: noop,
 });
 
 export function useEditingContext() {
@@ -25,6 +34,7 @@ interface EditingContextProviderProps {
   children: ReactNode | ((state: EditingContextState) => ReactNode);
   value?: {
     isEditing: boolean;
+    unSavedEdits?: UnSavedEdit[];
   };
 }
 
@@ -35,13 +45,16 @@ export const EditingContextProvider = ({
   },
 }: EditingContextProviderProps) => {
   const [isEditing, setEditing] = useState<boolean>(value.isEditing);
+  const [unSavedEdits, setUnSavedEdits] = useState<UnSavedEdit[]>([]);
 
   const state = useMemo<EditingContextState>(() => {
     return {
       isEditing,
       setEditing,
+      unSavedEdits,
+      setUnSavedEdits,
     };
-  }, [isEditing]);
+  }, [isEditing, unSavedEdits]);
 
   return (
     <EditingContext.Provider value={state}>

--- a/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
@@ -17,6 +17,7 @@ import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import { ContentSection } from '@common/services/publicationService';
+import { getNumberOfUnSavedBlocks } from '@admin/pages/release/content/components/utils/unSavedEdits';
 import classNames from 'classnames';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
@@ -34,52 +35,62 @@ const ReleaseContentPageLoaded = () => {
         isEditing: canUpdateRelease,
       }}
     >
-      {({ isEditing }) => (
-        <>
-          {isEditing && (
-            <BrowserWarning>
-              <ul>
-                <li>Editing key statistic guidance text</li>
-                <li>Editing headline text</li>
-                <li>Editing text blocks</li>
-              </ul>
-            </BrowserWarning>
-          )}
+      {({ isEditing, unSavedEdits }) => {
+        const numOfEdits = getNumberOfUnSavedBlocks(unSavedEdits);
+        return (
+          <>
+            {isEditing && (
+              <BrowserWarning>
+                <ul>
+                  <li>Editing key statistic guidance text</li>
+                  <li>Editing headline text</li>
+                  <li>Editing text blocks</li>
+                </ul>
+              </BrowserWarning>
+            )}
 
-          {canUpdateRelease && (
-            <div className="govuk-form-group">
-              {unresolvedComments.length > 0 &&
-              unresolvedComments.length > 1 ? (
-                <WarningMessage>
-                  There are {unresolvedComments.length} unresolved comments
-                </WarningMessage>
-              ) : (
-                <WarningMessage>There is 1 unresolved comment</WarningMessage>
-              )}
+            {canUpdateRelease && (
+              <div className="govuk-form-group">
+                {numOfEdits > 0 && (
+                  <WarningMessage>
+                    {numOfEdits === 1
+                      ? 'One content block has unsaved changes. Clicking away from this tab will result in the changes being lost.'
+                      : `${numOfEdits} content blocks have unsaved changes. Clicking away from this tab will result in the changes being lost.`}
+                  </WarningMessage>
+                )}
+                {unresolvedComments.length > 0 &&
+                unresolvedComments.length > 1 ? (
+                  <WarningMessage>
+                    There are {unresolvedComments.length} unresolved comments
+                  </WarningMessage>
+                ) : (
+                  <WarningMessage>There is 1 unresolved comment</WarningMessage>
+                )}
 
-              <EditablePageModeToggle />
-            </div>
-          )}
+                <EditablePageModeToggle />
+              </div>
+            )}
 
-          <div
-            className={classNames('govuk-width-container', {
-              'govuk-!-margin-right-0': isEditing,
-            })}
-          >
             <div
-              className={isEditing ? 'dfe-page-editing' : 'dfe-page-preview'}
+              className={classNames('govuk-width-container', {
+                'govuk-!-margin-right-0': isEditing,
+              })}
             >
-              <span className="govuk-caption-l">{release.title}</span>
+              <div
+                className={isEditing ? 'dfe-page-editing' : 'dfe-page-preview'}
+              >
+                <span className="govuk-caption-l">{release.title}</span>
 
-              <h2 className="govuk-heading-l dfe-print-break-before">
-                {release.publication.title}
-              </h2>
+                <h2 className="govuk-heading-l dfe-print-break-before">
+                  {release.publication.title}
+                </h2>
 
-              <ReleaseContent />
+                <ReleaseContent />
+              </div>
             </div>
-          </div>
-        </>
-      )}
+          </>
+        );
+      }}
     </EditingContextProvider>
   );
 };

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -127,6 +127,7 @@ const ReleaseContent = () => {
                     <ReleaseEditableBlock
                       block={block}
                       releaseId={release.id}
+                      sectionId={release.summarySection.id}
                       onSave={updateBlock}
                       onDelete={removeBlock}
                     />

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -26,7 +26,7 @@ const ReleaseContentAccordionSection = ({
   section: { id: sectionId, caption, heading, content: sectionContent = [] },
   ...props
 }: ReleaseContentAccordionSectionProps) => {
-  const { isEditing } = useEditingContext();
+  const { isEditing, unSavedEdits } = useEditingContext();
 
   const actions = useReleaseContentActions();
 
@@ -34,6 +34,11 @@ const ReleaseContentAccordionSection = ({
   const [showDataBlockForm, toggleDataBlockForm] = useToggle(false);
 
   const [blocks, setBlocks] = useState<EditableBlock[]>(sectionContent);
+
+  const updatedHeading =
+    unSavedEdits.findIndex(edit => edit.sectionId === sectionId) === -1
+      ? heading
+      : `${heading} (Unsaved changes)`;
 
   useEffect(() => {
     setBlocks(sectionContent);
@@ -139,7 +144,7 @@ const ReleaseContentAccordionSection = ({
   return (
     <EditableAccordionSection
       {...props}
-      heading={heading || ''}
+      heading={updatedHeading || ''}
       caption={caption}
       onHeadingChange={handleHeadingChange}
       onRemoveSection={handleRemoveSection}
@@ -173,6 +178,7 @@ const ReleaseContentAccordionSection = ({
           <ReleaseEditableBlock
             allowImages
             block={block}
+            sectionId={sectionId}
             editable={!isReordering}
             releaseId={release.id}
             onSave={updateBlock}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHeadlines.tsx
@@ -91,6 +91,7 @@ const ReleaseHeadlines = ({ release }: Props) => {
           renderEditableBlock={block => (
             <ReleaseEditableBlock
               block={block}
+              sectionId={release.headlinesSection.id}
               releaseId={release.id}
               onSave={updateBlock}
               onDelete={removeBlock}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseEditableBlock.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/__tests__/ReleaseEditableBlock.test.tsx
@@ -18,6 +18,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         releaseId="release-1"
+        sectionId="section-1"
         block={testHtmlBlock}
         onSave={noop}
         onDelete={noop}
@@ -47,6 +48,7 @@ describe('ReleaseEditableBlock', () => {
     render(
       <ReleaseEditableBlock
         releaseId="release-1"
+        sectionId="section-1"
         block={{
           ...testHtmlBlock,
           body: `

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/utils/__tests__/unSavedEdits.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/utils/__tests__/unSavedEdits.test.ts
@@ -1,0 +1,136 @@
+import {
+  addUnSavedEdit,
+  removeUnSavedEdit,
+} from '@admin/pages/release/content/components/utils/unSavedEdits';
+
+describe('Unsaved edits', () => {
+  describe('Adding an unsaved edit', () => {
+    test('Adding a new unsaved edit', () => {
+      const result = addUnSavedEdit([], 'section-1', 'block-1');
+      expect(result).toEqual([
+        {
+          sectionId: 'section-1',
+          blockIds: ['block-1'],
+        },
+      ]);
+    });
+
+    test('Adding a new unsaved edit for a section with other unsaved edits', () => {
+      const edits = [
+        {
+          sectionId: 'section-1',
+          blockIds: ['block-1', 'block-2'],
+        },
+        {
+          sectionId: 'section-2',
+          blockIds: ['block-4'],
+        },
+      ];
+      const result = addUnSavedEdit(edits, 'section-1', 'block-3');
+      expect(result).toEqual([
+        {
+          sectionId: 'section-1',
+          blockIds: ['block-1', 'block-2', 'block-3'],
+        },
+        {
+          sectionId: 'section-2',
+          blockIds: ['block-4'],
+        },
+      ]);
+    });
+
+    test('Duplicate edits are not added', () => {
+      const edits = [
+        {
+          sectionId: 'section-1',
+          blockIds: ['block-1', 'block-2'],
+        },
+        {
+          sectionId: 'section-2',
+          blockIds: ['block-4'],
+        },
+      ];
+      const result = addUnSavedEdit(edits, 'section-1', 'block-2');
+      expect(result).toEqual([
+        {
+          sectionId: 'section-1',
+          blockIds: ['block-1', 'block-2'],
+        },
+        {
+          sectionId: 'section-2',
+          blockIds: ['block-4'],
+        },
+      ]);
+    });
+  });
+
+  describe('Removing an unsaved edit', () => {
+    test('Removing an unsaved edit', () => {
+      const edits = [
+        {
+          sectionId: 'section-1',
+          blockIds: ['block-1', 'block-2'],
+        },
+        {
+          sectionId: 'section-2',
+          blockIds: ['block-4'],
+        },
+      ];
+      const result = removeUnSavedEdit(edits, 'section-2', 'block-4');
+      expect(result).toEqual([
+        {
+          sectionId: 'section-1',
+          blockIds: ['block-1', 'block-2'],
+        },
+      ]);
+    });
+
+    test('Removing an unsaved edit from a section with multiple unsaved edits', () => {
+      const edits = [
+        {
+          sectionId: 'section-1',
+          blockIds: ['block-1', 'block-2'],
+        },
+        {
+          sectionId: 'section-2',
+          blockIds: ['block-4'],
+        },
+      ];
+      const result = removeUnSavedEdit(edits, 'section-1', 'block-1');
+      expect(result).toEqual([
+        {
+          sectionId: 'section-1',
+          blockIds: ['block-2'],
+        },
+        {
+          sectionId: 'section-2',
+          blockIds: ['block-4'],
+        },
+      ]);
+    });
+
+    test('Do nothing if the unsaved edit does not exist', () => {
+      const edits = [
+        {
+          sectionId: 'section-1',
+          blockIds: ['block-1', 'block-2'],
+        },
+        {
+          sectionId: 'section-2',
+          blockIds: ['block-4'],
+        },
+      ];
+      const result = removeUnSavedEdit(edits, 'section-3', 'block-5');
+      expect(result).toEqual([
+        {
+          sectionId: 'section-1',
+          blockIds: ['block-1', 'block-2'],
+        },
+        {
+          sectionId: 'section-2',
+          blockIds: ['block-4'],
+        },
+      ]);
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/utils/unSavedEdits.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/utils/unSavedEdits.ts
@@ -1,0 +1,51 @@
+import { UnSavedEdit } from '@admin/contexts/EditingContext';
+
+export const addUnSavedEdit = (
+  edits: UnSavedEdit[],
+  sectionId: string,
+  blockId: string,
+) => {
+  if (edits.findIndex(edit => edit.sectionId === sectionId) === -1) {
+    return [
+      ...edits,
+      {
+        sectionId,
+        blockIds: [blockId],
+      },
+    ];
+  }
+
+  return edits.map(edit =>
+    edit.sectionId === sectionId
+      ? {
+          ...edit,
+          blockIds:
+            edit.blockIds.indexOf(blockId) === -1
+              ? [...edit.blockIds, blockId]
+              : edit.blockIds,
+        }
+      : edit,
+  );
+};
+
+export const removeUnSavedEdit = (
+  edits: UnSavedEdit[],
+  sectionId: string,
+  blockId: string,
+) => {
+  return edits
+    .map(edit =>
+      edit.sectionId === sectionId
+        ? { ...edit, blockIds: edit.blockIds.filter(id => id !== blockId) }
+        : edit,
+    )
+    .filter(edit => edit.blockIds.length);
+};
+
+export const getNumberOfUnSavedBlocks = (edits: UnSavedEdit[]) => {
+  let count = 0;
+  edits.forEach(edit => {
+    count += edit.blockIds.length;
+  });
+  return count;
+};


### PR DESCRIPTION
- Shows a warning at the top if there are unsaved text block changes on the content tab
- If the changes are in an accordion section it shows '(Unsaved changes)' in the heading

![unsaved1](https://user-images.githubusercontent.com/81572860/120463623-02885f80-c394-11eb-9514-7d418e05ab69.png)
![unsaved2](https://user-images.githubusercontent.com/81572860/120463627-0320f600-c394-11eb-928b-482fc6b79fa5.png)
