### PR TITLE
EES-2195 EES-2196 Schema, model changes and data migration to support methodology versions, and publications that can have multiple Methodologies

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
@@ -13,37 +12,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
     public class MethodologyControllerTests
     {
         private readonly Guid _methodologyId = Guid.NewGuid();
-
-        [Fact]
-        public async void CreateMethodologyAsync_Returns_Ok()
-        {
-            var request = new MethodologyCreateRequest();
-
-            var methodologyService = new Mock<IMethodologyService>();
-
-            methodologyService.Setup(s => s.CreateMethodologyAsync(request))
-                .ReturnsAsync(new Either<ActionResult, MethodologySummaryViewModel>(new MethodologySummaryViewModel()));
-            var controller = new MethodologyController(methodologyService.Object);
-
-            // Method under test
-            var result = await controller.CreateMethodologyAsync(request);
-            AssertOkResult(result);
-        }
-
-        [Fact]
-        public async void GetMethodologiesAsync_Returns_Ok()
-        {
-            var methodologyService = new Mock<IMethodologyService>();
-
-            methodologyService.Setup(s => s.ListAsync())
-                .ReturnsAsync(
-                    new Either<ActionResult, List<MethodologySummaryViewModel>>(new List<MethodologySummaryViewModel>()));
-            var controller = new MethodologyController(methodologyService.Object);
-
-            // Method under test
-            var result = await controller.GetMethodologiesAsync();
-            AssertOkResult(result);
-        }
 
         [Fact]
         public async void GetMethodologySummaryAsync_Returns_Ok()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -133,8 +133,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             TeamName = "Test team",
                             TeamEmail = "john.smith@test.com",
                         },
-                        TopicId = topic.Id,
-                        MethodologyId = methodology.Id
+                        TopicId = topic.Id
                     }
                 );
 
@@ -188,129 +187,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             Assert.True(result.IsLeft);
             AssertValidationProblem(result.Left, TopicDoesNotExist);
-        }
-
-        [Fact]
-        public async void CreatePublication_FailsWithNonExistingMethodology()
-        {
-            var topic = new Topic
-            {
-                Title = "Test topic"
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(topic);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context, Mocks());
-
-                // Service method under test
-                var result = await publicationService.CreatePublication(
-                    new PublicationSaveViewModel()
-                    {
-                        Title = "Test title",
-                        TopicId = topic.Id,
-                        MethodologyId = Guid.NewGuid(),
-                    }
-                );
-
-                Assert.True(result.IsLeft);
-                AssertValidationProblem(result.Left, MethodologyDoesNotExist);
-            }
-        }
-
-        [Fact]
-        public async void CreatePublication_FailsWithMethodologyAndExternalMethodology()
-        {
-            var topic = new Topic
-            {
-                Title = "Test topic"
-            };
-            var methodology = new Methodology
-            {
-                Title = "Test methodology",
-                Status = MethodologyStatus.Approved,
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(topic);
-                context.Add(methodology);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context, Mocks());
-
-                // Service method under test
-                var result = await publicationService.CreatePublication(
-                    new PublicationSaveViewModel()
-                    {
-                        Title = "Test title",
-                        TopicId = topic.Id,
-                        MethodologyId = methodology.Id,
-                        ExternalMethodology = new ExternalMethodology
-                        {
-                            Title = "Test external",
-                            Url = "http://test.com"
-                        }
-                    }
-                );
-
-                Assert.True(result.IsLeft);
-                AssertValidationProblem(result.Left, CannotSpecifyMethodologyAndExternalMethodology);
-            }
-        }
-
-
-        [Fact]
-        public async void CreatePublication_FailsWithUnapprovedMethodology()
-        {
-            var topic = new Topic
-            {
-                Title = "Test topic"
-            };
-            var methodology = new Methodology
-            {
-                Title = "Test methodology",
-                Status = MethodologyStatus.Draft,
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(topic);
-                context.Add(methodology);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context, Mocks());
-
-                // Service method under test
-                var result = await publicationService.CreatePublication(
-                    new PublicationSaveViewModel()
-                    {
-                        Title = "Test title",
-                        TopicId = topic.Id,
-                        MethodologyId = methodology.Id,
-                    }
-                );
-
-                Assert.True(result.IsLeft);
-                AssertValidationProblem(result.Left, MethodologyMustBeApproved);
-            }
         }
 
         [Fact]
@@ -416,8 +292,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             TeamName = "Test team",
                             TeamEmail = "john.smith@test.com",
                         },
-                        TopicId = topic.Id,
-                        MethodologyId = methodology.Id,
+                        TopicId = topic.Id
                     }
                 );
 
@@ -516,8 +391,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             TeamName = "Test team",
                             TeamEmail = "john.smith@test.com",
                         },
-                        TopicId = topic.Id,
-                        MethodologyId = methodology.Id,
+                        TopicId = topic.Id
                     }
                 );
 
@@ -597,8 +471,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             TeamName = "Test team",
                             TeamEmail = "john.smith@test.com",
                         },
-                        TopicId = publication.TopicId,
-                        MethodologyId = publication.MethodologyId,
+                        TopicId = publication.TopicId
                     }
                 );
 
@@ -667,8 +540,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             TeamName = "Test team",
                             TeamEmail = "john.smith@test.com",
                         },
-                        TopicId = publication.TopicId,
-                        MethodologyId = publication.MethodologyId,
+                        TopicId = publication.TopicId
                     }
                 );
 
@@ -722,135 +594,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.True(result.IsLeft);
                 AssertValidationProblem(result.Left, TopicDoesNotExist);
-            }
-        }
-
-        [Fact]
-        public async void UpdatePublication_FailsWithNonExistingMethodology()
-        {
-            var publication = new Publication
-            {
-                Topic = new Topic
-                {
-                    Title = "Old topic"
-                }
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(publication);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context, Mocks());
-
-                // Service method under test
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveViewModel()
-                    {
-                        Title = "Test publication",
-                        TopicId = publication.TopicId,
-                        MethodologyId = Guid.NewGuid(),
-                    }
-                );
-
-                Assert.True(result.IsLeft);
-                AssertValidationProblem(result.Left, MethodologyDoesNotExist);
-            }
-        }
-
-        [Fact]
-        public async void UpdatePublication_FailsWithMethodologyAndExternalMethodology()
-        {
-            var publication = new Publication
-            {
-                Topic = new Topic
-                {
-                    Title = "Test topic"
-                }
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(publication);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var publicationService = BuildPublicationService(context, Mocks());
-
-                // Service method under test
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveViewModel()
-                    {
-                        Title = "Test publication",
-                        TopicId = publication.TopicId,
-                        MethodologyId = Guid.NewGuid(),
-                        ExternalMethodology = new ExternalMethodology
-                        {
-                            Title = "Test external",
-                            Url = "http://test.com"
-                        }
-                    }
-                );
-
-                Assert.True(result.IsLeft);
-                AssertValidationProblem(result.Left, CannotSpecifyMethodologyAndExternalMethodology);
-            }
-        }
-
-        [Fact]
-        public async void UpdatePublication_FailsWithUnapprovedMethodology()
-        {
-            var methodology = new Methodology
-            {
-                Title = "Test methodology",
-                Status = MethodologyStatus.Draft,
-            };
-            var publication = new Publication
-            {
-                Topic = new Topic
-                {
-                    Title = "Test topic"
-                },
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                context.Add(methodology);
-                context.Add(publication);
-                await context.SaveChangesAsync();
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-
-                var publicationService = BuildPublicationService(context, Mocks());
-
-                // Service method under test
-                var result = await publicationService.UpdatePublication(
-                    publication.Id,
-                    new PublicationSaveViewModel()
-                    {
-                        Title = "Test publication",
-                        TopicId = publication.TopicId,
-                        MethodologyId = methodology.Id,
-                    }
-                );
-
-                Assert.True(result.IsLeft);
-                AssertValidationProblem(result.Left, MethodologyMustBeApproved);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyController.cs
@@ -21,27 +21,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
         }
 
         [Produces("application/json")]
-        [HttpGet("api/methodologies")]
-        public Task<ActionResult<List<MethodologySummaryViewModel>>> GetMethodologiesAsync()
-        {
-            return _methodologyService
-                .ListAsync()
-                .HandleFailuresOrOk();
-        }
-
-        [Produces("application/json")]
-        [ProducesResponseType(typeof(MethodologySummaryViewModel), 200)]
-        [ProducesResponseType(typeof(ValidationProblemDetails), 400)]
-        [HttpPost("api/methodologies")]
-        public Task<ActionResult<MethodologySummaryViewModel>> CreateMethodologyAsync(
-            MethodologyCreateRequest methodology)
-        {
-            return _methodologyService
-                .CreateMethodologyAsync(methodology)
-                .HandleFailuresOrOk();
-        }
-
-        [Produces("application/json")]
         [HttpGet("api/methodology/{methodologyId}/summary")]
         public async Task<ActionResult<MethodologySummaryViewModel>> GetMethodologySummaryAsync(Guid methodologyId)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -70,7 +70,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
             CreateMap<Methodology, MethodologySummaryViewModel>();
 
             CreateMap<Methodology, MethodologyTitleViewModel>();
-            CreateMap<Methodology, MethodologyPublicationsViewModel>();
 
             CreateMap<Publication, IdTitlePair>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210601153005_EES2195AddPublicationMethodology.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210601153005_EES2195AddPublicationMethodology.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210601153005_EES2195AddPublicationMethodology")]
+    partial class EES2195AddPublicationMethodology
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -306,7 +308,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<string>("InternalReleaseNote")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<Guid>("MethodologyParentId")
+                    b.Property<Guid?>("MethodologyParentId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid?>("PreviousVersionId")
@@ -949,9 +951,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyParent", "MethodologyParent")
                         .WithMany()
-                        .HasForeignKey("MethodologyParentId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                        .HasForeignKey("MethodologyParentId");
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", "PreviousVersion")
                         .WithMany()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210601153005_EES2195AddPublicationMethodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210601153005_EES2195AddPublicationMethodology.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES2195AddPublicationMethodology : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("UPDATE Methodologies SET Annexes = '[]' WHERE Annexes IS NULL");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Slug",
+                table: "Methodologies",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Content",
+                table: "Methodologies",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Annexes",
+                table: "Methodologies",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Created",
+                table: "Methodologies",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "CreatedById",
+                table: "Methodologies",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "MethodologyParentId",
+                table: "Methodologies",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "PreviousVersionId",
+                table: "Methodologies",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Version",
+                table: "Methodologies",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "MethodologyParents",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MethodologyParents", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PublicationMethodologies",
+                columns: table => new
+                {
+                    PublicationId = table.Column<Guid>(nullable: false),
+                    MethodologyParentId = table.Column<Guid>(nullable: false),
+                    Owner = table.Column<bool>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PublicationMethodologies", x => new { x.PublicationId, x.MethodologyParentId });
+                    table.ForeignKey(
+                        name: "FK_PublicationMethodologies_MethodologyParents_MethodologyParentId",
+                        column: x => x.MethodologyParentId,
+                        principalTable: "MethodologyParents",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_PublicationMethodologies_Publications_PublicationId",
+                        column: x => x.PublicationId,
+                        principalTable: "Publications",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Methodologies_CreatedById",
+                table: "Methodologies",
+                column: "CreatedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Methodologies_MethodologyParentId",
+                table: "Methodologies",
+                column: "MethodologyParentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Methodologies_PreviousVersionId",
+                table: "Methodologies",
+                column: "PreviousVersionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PublicationMethodologies_MethodologyParentId",
+                table: "PublicationMethodologies",
+                column: "MethodologyParentId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Methodologies_Users_CreatedById",
+                table: "Methodologies",
+                column: "CreatedById",
+                principalTable: "Users",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Methodologies_MethodologyParents_MethodologyParentId",
+                table: "Methodologies",
+                column: "MethodologyParentId",
+                principalTable: "MethodologyParents",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Methodologies_Methodologies_PreviousVersionId",
+                table: "Methodologies",
+                column: "PreviousVersionId",
+                principalTable: "Methodologies",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Methodologies_Users_CreatedById",
+                table: "Methodologies");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Methodologies_MethodologyParents_MethodologyParentId",
+                table: "Methodologies");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Methodologies_Methodologies_PreviousVersionId",
+                table: "Methodologies");
+
+            migrationBuilder.DropTable(
+                name: "PublicationMethodologies");
+
+            migrationBuilder.DropTable(
+                name: "MethodologyParents");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Methodologies_CreatedById",
+                table: "Methodologies");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Methodologies_MethodologyParentId",
+                table: "Methodologies");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Methodologies_PreviousVersionId",
+                table: "Methodologies");
+
+            migrationBuilder.DropColumn(
+                name: "Created",
+                table: "Methodologies");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedById",
+                table: "Methodologies");
+
+            migrationBuilder.DropColumn(
+                name: "MethodologyParentId",
+                table: "Methodologies");
+
+            migrationBuilder.DropColumn(
+                name: "PreviousVersionId",
+                table: "Methodologies");
+
+            migrationBuilder.DropColumn(
+                name: "Version",
+                table: "Methodologies");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Slug",
+                table: "Methodologies",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Content",
+                table: "Methodologies",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Annexes",
+                table: "Methodologies",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string));
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210601153649_EES2195InitPublicationMethodology.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210601153649_EES2195InitPublicationMethodology.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210601153649_EES2195InitPublicationMethodology")]
+    partial class EES2195InitPublicationMethodology
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210601153649_EES2195InitPublicationMethodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210601153649_EES2195InitPublicationMethodology.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES2195InitPublicationMethodology : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Methodologies_MethodologyParents_MethodologyParentId",
+                table: "Methodologies");
+
+            // Each existing Methodology will become the first version of a new parent Methodology
+            // In preparation for this new parent, set a new random parent Id
+            migrationBuilder.Sql(
+                "UPDATE Methodologies SET MethodologyParentId = NEWID() WHERE MethodologyParentId IS NULL");
+
+            // Insert a new parent for each existing Methodology using the new random parent Id's
+            migrationBuilder.Sql(
+                "INSERT INTO MethodologyParents (Id) SELECT MethodologyParentId FROM Methodologies WHERE MethodologyParentId IS NOT NULL");
+
+            // Make the parent Id column not null
+            migrationBuilder.AlterColumn<Guid>(
+                name: "MethodologyParentId",
+                table: "Methodologies",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Methodologies_MethodologyParents_MethodologyParentId",
+                table: "Methodologies",
+                column: "MethodologyParentId",
+                principalTable: "MethodologyParents",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            // Link all the Publications that are using Methodologies to the new parent Methodology
+            migrationBuilder.Sql(@"
+INSERT INTO PublicationMethodologies (PublicationId, MethodologyParentId, Owner)
+SELECT P.Id, M.MethodologyParentId, 0
+FROM Publications P
+JOIN Methodologies M ON P.MethodologyId = M.Id
+");
+
+            // Where a Methodology is used by a single Publication, make that Publication the owner of the Methodology
+            migrationBuilder.Sql(@"
+UPDATE PublicationMethodologies SET Owner = 1
+WHERE MethodologyParentId IN (
+  SELECT MethodologyParentId
+  FROM PublicationMethodologies PM
+  GROUP BY PM.MethodologyParentId
+  HAVING COUNT(PublicationId) = 1
+)
+");
+
+            // Where a Methodology is used by more than one Publication, no owner is set automatically
+            // After the migration we will need to check these cases, choose one Publication as the owner and set it
+            // Existing orphaned Methodologies will remain orphaned and will need deleting after investigation
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Methodologies_MethodologyParents_MethodologyParentId",
+                table: "Methodologies");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "MethodologyParentId",
+                table: "Methodologies",
+                type: "uniqueidentifier",
+                nullable: true,
+                oldClrType: typeof(Guid));
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Methodologies_MethodologyParents_MethodologyParentId",
+                table: "Methodologies",
+                column: "MethodologyParentId",
+                principalTable: "MethodologyParents",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
@@ -9,14 +9,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 {
     public interface IMethodologyService
     {
-        Task<Either<ActionResult, List<MethodologySummaryViewModel>>> ListAsync();
-
         Task<Either<ActionResult, List<MethodologyPublicationsViewModel>>> ListWithPublicationsAsync();
 
         Task<Either<ActionResult, MethodologySummaryViewModel>> GetSummaryAsync(Guid id);
-
-        Task<Either<ActionResult, MethodologySummaryViewModel>>
-            CreateMethodologyAsync(MethodologyCreateRequest request);
 
         Task<Either<ActionResult, MethodologySummaryViewModel>> UpdateMethodologyAsync(Guid id,
             MethodologyUpdateRequest request);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -80,10 +80,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             PublicationSaveViewModel publication)
         {
             return await ValidateSelectedTopic(publication.TopicId)
-                .OnSuccess(_ => ValidateSelectedMethodology(
-                    publication.MethodologyId,
-                    publication.ExternalMethodology
-                ))
                 .OnSuccess(async _ =>
                 {
                     if (_context.Publications.Any(p => p.Slug == publication.Slug))
@@ -96,7 +92,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         ContactName = publication.Contact.ContactName,
                         ContactTelNo = publication.Contact.ContactTelNo,
                         TeamName = publication.Contact.TeamName,
-                        TeamEmail = publication.Contact.TeamEmail,
+                        TeamEmail = publication.Contact.TeamEmail
                     });
 
                     var saved = await _context.Publications.AddAsync(new Publication
@@ -104,7 +100,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         Contact = contact.Entity,
                         Title = publication.Title,
                         TopicId = publication.TopicId,
-                        MethodologyId = publication.MethodologyId,
                         Slug = publication.Slug,
                         ExternalMethodology = publication.ExternalMethodology
                     });
@@ -130,10 +125,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     }
                     return Unit.Instance;
                 })
-                .OnSuccessDo(_ => ValidateSelectedMethodology(
-                    updatedPublication.MethodologyId,
-                    updatedPublication.ExternalMethodology
-                ))
                 .OnSuccess(async publication =>
                 {
                     if (publication.Live)
@@ -152,7 +143,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 {
                     publication.Title = updatedPublication.Title;
                     publication.TopicId = updatedPublication.TopicId;
-                    publication.MethodologyId = updatedPublication.MethodologyId;
                     publication.ExternalMethodology = updatedPublication.ExternalMethodology;
                     publication.Updated = DateTime.UtcNow;
 
@@ -195,34 +185,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             return await _userService.CheckCanCreatePublicationForTopic(topic)
                 .OnSuccess(_ => Unit.Instance);
-        }
-
-        private async Task<Either<ActionResult, Unit>> ValidateSelectedMethodology(
-            Guid? methodologyId,
-            ExternalMethodology? externalMethodology)
-        {
-            if (methodologyId != null && externalMethodology != null)
-            {
-                return ValidationActionResult(CannotSpecifyMethodologyAndExternalMethodology);
-            }
-
-            if (methodologyId != null)
-            {
-                var methodology = await _context.Methodologies.FindAsync(methodologyId);
-
-                if (methodology == null)
-                {
-                    return ValidationActionResult(MethodologyDoesNotExist);
-                }
-
-                // TODO: this will want updating when methodology status is fully implemented
-                if (methodology.Status != MethodologyStatus.Approved)
-                {
-                    return ValidationActionResult(MethodologyMustBeApproved);
-                }
-            }
-
-            return Unit.Instance;
         }
 
         public async Task<Either<ActionResult, PublicationViewModel>> GetPublication(Guid publicationId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -95,10 +95,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         InvalidUserRole,
 
         // Methodology
-        MethodologyDoesNotExist,
         MethodologyMustBeDraft,
         MethodologyMustBeApproved,
-        CannotSpecifyMethodologyAndExternalMethodology,
 
         // Theme
         ThemeDoesNotExist,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyCreateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyCreateRequest.cs
@@ -1,9 +1,0 @@
-using System.ComponentModel.DataAnnotations;
-
-namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology
-{
-    public class MethodologyCreateRequest
-    {
-        [Required] public string Title { get; set; }
-    }
-}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModels.cs
@@ -37,8 +37,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         [Required] public Guid TopicId { get; set; }
 
-        public Guid? MethodologyId { get; set; }
-
         public ExternalMethodology ExternalMethodology { get; set; }
 
         [Required] public ContactSaveViewModel Contact { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -24,6 +24,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
         }
 
         public DbSet<Methodology> Methodologies { get; set; }
+        public DbSet<MethodologyParent> MethodologyParents { get; set; }
+        public DbSet<PublicationMethodology> PublicationMethodologies { get; set; }
         public DbSet<MethodologyFile> MethodologyFiles { get; set; }
         public DbSet<Theme> Themes { get; set; }
         public DbSet<Topic> Topics { get; set; }
@@ -106,6 +108,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .Property(b => b.Status)
                 .HasConversion(new EnumToStringConverter<MethodologyStatus>());
 
+            modelBuilder.Entity<Methodology>()
+                .Property(r => r.Created)
+                .HasConversion(
+                    v => v, 
+                    v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : (DateTime?) null);
+
+            modelBuilder.Entity<Methodology>()
+                .HasOne(r => r.CreatedBy)
+                .WithMany()
+                .OnDelete(DeleteBehavior.NoAction);
+
             modelBuilder.Entity<MethodologyFile>()
                 .HasOne(mf => mf.Methodology)
                 .WithMany()
@@ -124,6 +137,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
 
             modelBuilder.Entity<Publication>()
                 .OwnsOne(p => p.ExternalMethodology).ToTable("ExternalMethodology");
+
+            modelBuilder.Entity<PublicationMethodology>()
+                .HasKey(pm => new {pm.PublicationId, pm.MethodologyParentId});
+
+            modelBuilder.Entity<PublicationMethodology>()
+                .HasOne(pm => pm.Publication)
+                .WithMany()
+                .HasForeignKey(pm => pm.PublicationId)
+                .OnDelete(DeleteBehavior.NoAction);
+
+            modelBuilder.Entity<PublicationMethodology>()
+                .HasOne(pm => pm.MethodologyParent)
+                .WithMany()
+                .HasForeignKey(pm => pm.MethodologyParentId)
+                .OnDelete(DeleteBehavior.NoAction);
 
             modelBuilder.Entity<Release>()
                 .Property(r => r.TimePeriodCoverage)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -21,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public string Slug { get; set; }
 
-        public string Summary { get; set; }
+        public string? Summary { get; set; }
 
         public MethodologyStatus Status { get; set; }
 
@@ -29,13 +30,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public DateTime? Updated { get; set; }
 
-        public List<ContentSection> Content { get; set; }
+        public List<ContentSection> Content { get; set; } = new List<ContentSection>();
 
-        public List<ContentSection> Annexes { get; set; }
+        public List<ContentSection> Annexes { get; set; } = new List<ContentSection>();
 
-        public List<Publication> Publications { get; set; }
+        public string? InternalReleaseNote { get; set; }
 
-        public string InternalReleaseNote { get; set; }
+        public MethodologyParent MethodologyParent { get; set; }
+
+        public Guid MethodologyParentId { get; set; }
+
+        public DateTime? Created { get; set; }
+
+        public User? CreatedBy { get; set; }
+
+        public Guid? CreatedById { get; set; }
+
+        public Methodology? PreviousVersion { get; set; }
+
+        public Guid? PreviousVersionId { get; set; }
+
+        public int Version { get; set; }
 
         public bool Live => Published.HasValue && DateTime.Compare(DateTime.UtcNow, Published.Value) > 0;
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyParent.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyParent.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model
+{
+    public class MethodologyParent
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/PublicationMethodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/PublicationMethodology.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model
+{
+    public class PublicationMethodology
+    {
+        public Publication Publication { get; set; }
+
+        public Guid PublicationId { get; set; }
+
+        public MethodologyParent MethodologyParent { get; set; }
+
+        public Guid MethodologyParentId { get; set; }
+
+        public bool Owner { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -14,7 +14,7 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Model.PartialDate
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
-    public class Release : Versioned
+    public class Release : Versioned<Release>
     {
         public Guid Id { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Versioned.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Versioned.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
-    public abstract class Versioned
+    public abstract class Versioned<T> where T : Versioned<T>
     {
         public DateTime Created { get; set; }
 
@@ -11,7 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public Guid CreatedById { get; set; }
 
-        public Versioned? PreviousVersion { get; set; }
+        public T? PreviousVersion { get; set; }
 
         public Guid? PreviousVersionId { get; set; }
 

--- a/src/explore-education-statistics-admin/src/pages/methodology/MethodologiesPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/MethodologiesPage.tsx
@@ -113,12 +113,6 @@ const MethodologiesPage = () => {
         </div>
       </div>
 
-      <Link
-        to="/methodologies/create"
-        className="govuk-button govuk-!-margin-bottom-5"
-      >
-        Create new methodology
-      </Link>
       <Tabs id="methodologyTabs">
         <TabsSection
           id="draft-methodologies"

--- a/src/explore-education-statistics-admin/src/pages/methodology/MethodologyCreatePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/MethodologyCreatePage.tsx
@@ -4,6 +4,7 @@ import methodologyService from '@admin/services/methodologyService';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
+// TODO EES-2153 Remove this page
 const MethodologyCreatePage = ({ history }: RouteComponentProps) => {
   return (
     <Page

--- a/src/explore-education-statistics-admin/src/routes/routes.ts
+++ b/src/explore-education-statistics-admin/src/routes/routes.ts
@@ -114,6 +114,7 @@ export const methodologiesIndexRoute: ProtectedRouteProps = {
   exact: true,
 };
 
+// TODO EES-2153 Remove this route to the Create Methodology page
 export const methodologyCreateRoute: ProtectedRouteProps = {
   path: '/methodologies/create',
   component: MethodologyCreatePage,

--- a/src/explore-education-statistics-admin/src/services/methodologyService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyService.ts
@@ -30,7 +30,9 @@ export interface BasicMethodology {
 
 const methodologyService = {
   getMethodologies(): Promise<BasicMethodology[]> {
-    return client.get<BasicMethodology[]>('/methodologies');
+    // TODO EES-2153 This was returning a list of all methodologies but will need removing
+    // when the Manage Publication page no longer offers that list
+    return Promise.resolve([]);
   },
 
   getMyMethodologies(): Promise<MethodologyStatusListItem[]> {


### PR DESCRIPTION
This PR adds two database migrations which in order:

`EES2195AddPublicationMethodology`:

- Alter existing fields  Slug, Content and Annexes of Methodology making them not nullable. This is a side effect of adding the `nullable` directive to `Methodology.cs` which was done to make it clearer that certain fields like the new `CreatedBy` and `PreviousVersion` fields are optional. Unless we decide to also make Slug, Content and Annexes optional, they are now `not null` in the database after generating this migration. Fields Summary and InternalReleaseNote remain as nullable by now marking them as optional in the code.
- Add versionable fields CreatedBy, CreatedById, PreviousVersionId, and Version to Methodology. It wasn't possible to use the existing `Versionable` abstract class as the fields need to be optional to support existing Methodologies.
- Create a new parent container entity for Methodology called MethodologyParent. In future this parent will have non-versionable fields of the Methodology, e.g. "Slug" is a candidate for a non-versionable field. Having this parent container makes it easy for a Publication to link to a Methodology without caring about versions. Creating or removing a version won't alter the Publication-MethodologyParent link. It's envisaged that this parent entity will eventually be renamed "Methodology" and the "Methodology" that already exists  will be renamed something else such as "MethodologyVersion". For the ease of creating the migration and to limit code changes on this PR the renaming hasn't been done yet.
- Add a new many-to-many relationship between Publication and MethodologyParent. We use many-to-many because we expect that in future a Publication will link to global methodologies as well as a single one of its own or a single adopted methodology of a different publication.

`EES2195InitPublicationMethodology`:

- Give each existing Methodology (now all version 0's) a new random parent id.
- Create new parent for each existing Methodology using the new random parent Id's
- Make the parent Id column not null
- Link all the Publications that are using Methodologies to the new corresponding parent Methodology
- Where Methodologies are only used by a single Publication, flag those Publication as the owner of the Methodology

  Where a Methodology is used by more than one Publication, no owner is set automatically.
After the migrations run we will need to check these cases, choose one Publication as the owner and set it.
Existing orphaned Methodologies will remain orphaned and can be tidied up by deleting them after investigation if we choose to.

### Other changes

- Remove the create methodology button from the methodologies dashboard.
- Remove the ability to create methodologies. This will be reinstated later on beginning with the ability to create the first  methodology version with a parent methodology, linked with the context of a Publication.
- Remove `MethodologyId` from the create and update Publication requests to keep the manage publication page working.
- Remove `GetMethodologiesAsync` from `MethodologyController` which provided the list of methodologies on the manage publication page.
