### PR TITLE
EES-2353 Include Publications granted by Publication Owner that have no Releases in the 'My Publications' result

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationRepositoryTests.cs
@@ -310,6 +310,62 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task GetPublicationsForTopicRelatedToUser_PublicationHasNoReleases()
+        {
+            var user = new User();
+            var topic = new Topic();
+
+            // Check publications granted via the owner role are still returned when they contain no releases
+            // Set up publications without any releases, one for this topic and one for a different topic
+
+            var userPublicationRoles = new List<UserPublicationRole>
+            {
+                new UserPublicationRole
+                {
+                    Publication = new Publication
+                    {
+                        Title = "Related publication 1",
+                        Releases = new List<Release>(),
+                        Topic = topic
+                    },
+                    User = user,
+                    Role = Owner
+                },
+                new UserPublicationRole
+                {
+                    Publication = new Publication
+                    {
+                        Title = "Unrelated publication 1",
+                        Releases = new List<Release>(),
+                        Topic = new Topic()
+                    },
+                    User = user,
+                    Role = Owner
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            using (var contentDbContext = InMemoryApplicationDbContext(contextId))
+            {
+                await contentDbContext.Users.AddAsync(user);
+                await contentDbContext.Topics.AddAsync(topic);
+                await contentDbContext.UserPublicationRoles.AddRangeAsync(userPublicationRoles);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            using (var contentDbContext = InMemoryApplicationDbContext(contextId))
+            {
+                var service = SetupPublicationRepository(contentDbContext);
+                var result = await service.GetPublicationsForTopicRelatedToUserAsync(topic.Id, user.Id);
+
+                // Result should contain the publication related to this topic
+                Assert.Single(result);
+                Assert.Equal("Related publication 1", result[0].Title);
+            }
+        }
+
+        [Fact]
         public async Task ReleasesCorrectlyOrdered()
         {
             var topicId = Guid.NewGuid();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationRepositoryTests.cs
@@ -24,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var userReleaseRoles = new List<UserReleaseRole>();
             var userPublicationRoles = new List<UserPublicationRole>();
-            
+
             // Set up a publication and releases related to the topic that will be granted via different release roles
 
             var relatedPublication1 = new Publication
@@ -168,7 +168,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using (var contentDbContext = InMemoryApplicationDbContext(contextId))
             {
                 var service = SetupPublicationRepository(contentDbContext);
-                var result = await service.GetPublicationsForTopicRelatedToUserAsync(topic.Id, user.Id);
+                var result = await service.GetPublicationsForTopicRelatedToUser(topic.Id, user.Id);
 
                 // Result should contain Related publication 1 and Related publication 2
                 // Related publication 3 is excluded because it's only granted via the PrereleaseViewer release role
@@ -238,7 +238,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using (var contentDbContext = InMemoryApplicationDbContext(contextId))
             {
                 var service = SetupPublicationRepository(contentDbContext);
-                var result = await service.GetPublicationsForTopicRelatedToUserAsync(topic.Id, user.Id);
+                var result = await service.GetPublicationsForTopicRelatedToUser(topic.Id, user.Id);
 
                 Assert.Empty(result);
             }
@@ -303,7 +303,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using (var contentDbContext = InMemoryApplicationDbContext(contextId))
             {
                 var service = SetupPublicationRepository(contentDbContext);
-                var result = await service.GetPublicationsForTopicRelatedToUserAsync(topic.Id, user.Id);
+                var result = await service.GetPublicationsForTopicRelatedToUser(topic.Id, user.Id);
 
                 Assert.Empty(result);
             }
@@ -357,7 +357,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             using (var contentDbContext = InMemoryApplicationDbContext(contextId))
             {
                 var service = SetupPublicationRepository(contentDbContext);
-                var result = await service.GetPublicationsForTopicRelatedToUserAsync(topic.Id, user.Id);
+                var result = await service.GetPublicationsForTopicRelatedToUser(topic.Id, user.Id);
 
                 // Result should contain the publication related to this topic
                 Assert.Single(result);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -64,7 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void GetMyPublicationsAndReleasesByTopicAsync_CanViewAllReleases()
+        public void GetMyPublicationsAndReleasesByTopic_CanViewAllReleases()
         {
             var mocks = Mocks();
             var userService = mocks.UserService;
@@ -100,7 +100,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void GetMyPublicationsAndReleasesByTopicAsync_CanViewRelatedReleases()
+        public void GetPublicationsForTopicRelatedToUser_CanViewRelatedReleases()
         {
             var mocks = Mocks();
             var userService = mocks.UserService;
@@ -125,7 +125,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 }
             };
 
-            publicationRepository.Setup(s => s.GetPublicationsForTopicRelatedToUserAsync(topicId, userId))
+            publicationRepository.Setup(s => s.GetPublicationsForTopicRelatedToUser(topicId, userId))
                 .ReturnsAsync(list);
 
             var result = publicationService.GetMyPublicationsAndReleasesByTopic(topicId).Result.Right;
@@ -136,7 +136,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             userService.Verify(s => s.GetUserId());
             userService.VerifyNoOtherCalls();
 
-            publicationRepository.Verify(s => s.GetPublicationsForTopicRelatedToUserAsync(topicId, userId));
+            publicationRepository.Verify(s => s.GetPublicationsForTopicRelatedToUser(topicId, userId));
             publicationRepository.VerifyNoOtherCalls();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -32,7 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         };
 
         [Fact]
-        public void GetMyPublicationsAndReleasesByTopicAsync_NoAccessOfSystem()
+        public void GetMyPublicationsAndReleasesByTopic_NoAccessOfSystem()
         {
             var mocks = Mocks();
             var userService = mocks.UserService;
@@ -100,7 +100,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void GetPublicationsForTopicRelatedToUser_CanViewRelatedReleases()
+        public void GetMyPublicationsAndReleasesByTopic_CanViewRelatedReleases()
         {
             var mocks = Mocks();
             var userService = mocks.UserService;
@@ -228,7 +228,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void GetViewModel()
+        public void GetPublication()
         {
             var mocks = Mocks();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationRepository.cs
@@ -9,8 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     {
         Task<List<MyPublicationViewModel>> GetAllPublicationsForTopicAsync(Guid topicId);
 
-        Task<List<MyPublicationViewModel>> GetPublicationsForTopicRelatedToUserAsync(Guid topicId, Guid userId);
+        Task<List<MyPublicationViewModel>> GetPublicationsForTopicRelatedToUser(Guid topicId, Guid userId);
+
         Task<MyPublicationViewModel> GetPublicationForUser(Guid publicationId, Guid userId);
+
         Task<MyPublicationViewModel> GetPublicationWithAllReleases(Guid publicationId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -56,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .OnSuccess(() =>
                             _publicationRepository.GetAllPublicationsForTopicAsync(topicId))
                         .OrElse(() =>
-                            _publicationRepository.GetPublicationsForTopicRelatedToUserAsync(topicId,
+                            _publicationRepository.GetPublicationsForTopicRelatedToUser(topicId,
                                 _userService.GetUserId()));
                 });
         }


### PR DESCRIPTION
This PR fixes a bug where Publications without any Releases that should be included in the 'My Publications' result because they are granted via the Publication Owner role to the user were being excluded.