### PR TITLE
Ees 2203 make methodology amendment auth handler

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfMethodologyAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfMethodologyAuthorizationHandlersTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Microsoft.AspNetCore.Authorization;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public class MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests
+    {
+        public class MakeAmendmentOfSpecificMethodologyAuthorizationHandlerClaimTests
+        {
+            private static readonly Guid UserId = Guid.NewGuid();
+            
+            private static readonly Publication Publication = new Publication
+            {
+                Id = Guid.NewGuid()
+            };
+
+            private static readonly Methodology PublicMethodology = new Methodology
+            {
+                Status = Approved,
+                PublishingStrategy = MethodologyPublishingStrategy.Immediately
+            };
+                
+            private static readonly Methodology PrivateMethodology = new Methodology
+            {
+                Status = Draft
+            };
+            
+            private static readonly Methodology PublicMethodologyWithPublication = new Methodology
+            {
+                Status = Approved,
+                PublishingStrategy = MethodologyPublishingStrategy.Immediately,
+                Publications = AsList(Publication)
+            };
+            
+            private static readonly Methodology PrivateMethodologyWithPublication = new Methodology
+            {
+                Status = Draft,
+                Publications = AsList(Publication)
+            };
+            
+            [Fact]
+            public async void UserWithCorrectClaimCanCreateAmendmentOfPubliclyAccessibleMethodology()
+            {
+                await ForEachSecurityClaimAsync(async claim => {
+                    
+                    var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();
+                    
+                    var user = CreateClaimsPrincipal(UserId, claim);
+                    var authContext = CreateAuthContext(user, PublicMethodology);
+                    
+                    await handler.HandleAsync(authContext);
+                    VerifyAllMocks(publicationRoleRepository);
+
+                    // Verify that only the combination of the "MakeAmendmentsOfAllMethodologies" Claim
+                    // alongside the publicly-accessible Methodology will pass the handler test
+                    var expectedToPass = claim == MakeAmendmentsOfAllMethodologies;
+                    Assert.Equal(expectedToPass, authContext.HasSucceeded);
+                });
+            }
+            
+            [Fact]
+            public async void UserWithCorrectClaimCannotCreateAmendmentOfPrivateMethodology()
+            {
+                await ForEachSecurityClaimAsync(async claim => 
+                {
+                    var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();
+                    
+                    var user = CreateClaimsPrincipal(UserId, claim);
+                    var authContext = CreateAuthContext(user, PrivateMethodology);
+                    
+                    await handler.HandleAsync(authContext);
+                    VerifyAllMocks(publicationRoleRepository);
+
+                    // Verify that no Claims can allow a user to create an Amendment of a non-publicly-accessible
+                    // Methodology. 
+                    Assert.False(authContext.HasSucceeded);
+                });
+            }
+            
+            [Fact]
+            public async void UserWithLinkedPublicationOwnerRoleCanCreateAmendmentOfPubliclyAccessibleMethodology()
+            {
+                var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();
+                    
+                var user = CreateClaimsPrincipal(UserId);
+                var authContext = CreateAuthContext(user, PublicMethodologyWithPublication);
+                
+                publicationRoleRepository.Setup(s => 
+                        s.GetAllRolesByUser(UserId, Publication.Id))
+                    .ReturnsAsync(AsList(PublicationRole.Owner));
+
+                await handler.HandleAsync(authContext);
+                VerifyAllMocks(publicationRoleRepository);
+
+                // Verify that the user can create an Amendment, as they have a Publication Owner role on a Publication
+                // that uses this Methodology.
+                Assert.True(authContext.HasSucceeded);
+            }
+            
+            [Fact]
+            public async void UserWithoutLinkedPublicationOwnerRoleCannotCreateAmendmentOfPubliclyAccessibleMethodology()
+            {
+                var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();
+                    
+                var user = CreateClaimsPrincipal(UserId);
+                var authContext = CreateAuthContext(user, PublicMethodologyWithPublication);
+                
+                publicationRoleRepository.Setup(s => 
+                        s.GetAllRolesByUser(UserId, Publication.Id))
+                    .ReturnsAsync(new List<PublicationRole>());
+
+                await handler.HandleAsync(authContext);
+                VerifyAllMocks(publicationRoleRepository);
+
+                // Verify that the user cannot create an Amendment, as they don't have a Publication Owner role on a
+                // Publication that uses this Methodology.
+                Assert.False(authContext.HasSucceeded);
+            }
+            
+            [Fact]
+            public async void UserWithLinkedPublicationOwnerRoleCannotCreateAmendmentOfPrivateMethodology()
+            {
+                var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();
+                    
+                var user = CreateClaimsPrincipal(UserId);
+                var authContext = CreateAuthContext(user, PrivateMethodologyWithPublication);
+                
+                await handler.HandleAsync(authContext);
+                VerifyAllMocks(publicationRoleRepository);
+
+                // Verify that the user cannot create an Amendment, as even though they have the Publication Owner role
+                // on one of the Publications that use this Methodology, this Methodology is not yet publicly
+                // accessible.
+                Assert.False(authContext.HasSucceeded);
+            }
+
+            private static AuthorizationHandlerContext CreateAuthContext(ClaimsPrincipal user, Methodology methodology)
+            {
+                return CreateAuthorizationHandlerContext<MakeAmendmentOfSpecificMethodologyRequirement, Methodology>
+                    (user, methodology);
+            }
+
+            private static (MakeAmendmentOfSpecificMethodologyAuthorizationHandler, Mock<IUserPublicationRoleRepository>)
+                CreateHandlerAndDependencies()
+            {
+                var publicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
+
+                var handler = new MakeAmendmentOfSpecificMethodologyAuthorizationHandler(
+                    publicationRoleRepository.Object);
+
+                return (handler, publicationRoleRepository);
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -53,7 +54,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             };
             
             [Fact]
-            public async void UserWithCorrectClaimCanCreateAmendmentOfPubliclyAccessibleMethodology()
+            public async Task UserWithCorrectClaimCanCreateAmendmentOfPubliclyAccessibleMethodology()
             {
                 await ForEachSecurityClaimAsync(async claim => {
                     
@@ -73,7 +74,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
             
             [Fact]
-            public async void UserWithCorrectClaimCannotCreateAmendmentOfPrivateMethodology()
+            public async Task UserWithCorrectClaimCannotCreateAmendmentOfPrivateMethodology()
             {
                 await ForEachSecurityClaimAsync(async claim => 
                 {
@@ -92,15 +93,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
             
             [Fact]
-            public async void UserWithLinkedPublicationOwnerRoleCanCreateAmendmentOfPubliclyAccessibleMethodology()
+            public async Task UserWithLinkedPublicationOwnerRoleCanCreateAmendmentOfPubliclyAccessibleMethodology()
             {
                 var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();
                     
                 var user = CreateClaimsPrincipal(UserId);
                 var authContext = CreateAuthContext(user, PublicMethodologyWithPublication);
                 
-                publicationRoleRepository.Setup(s => 
-                        s.GetAllRolesByUser(UserId, Publication.Id))
+                publicationRoleRepository.Setup(s => s.GetAllRolesByUser(UserId, Publication.Id))
                     .ReturnsAsync(AsList(PublicationRole.Owner));
 
                 await handler.HandleAsync(authContext);
@@ -112,15 +112,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
             
             [Fact]
-            public async void UserWithoutLinkedPublicationOwnerRoleCannotCreateAmendmentOfPubliclyAccessibleMethodology()
+            public async Task UserWithoutLinkedPublicationOwnerRoleCannotCreateAmendmentOfPubliclyAccessibleMethodology()
             {
                 var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();
                     
                 var user = CreateClaimsPrincipal(UserId);
                 var authContext = CreateAuthContext(user, PublicMethodologyWithPublication);
                 
-                publicationRoleRepository.Setup(s => 
-                        s.GetAllRolesByUser(UserId, Publication.Id))
+                publicationRoleRepository.Setup(s => s.GetAllRolesByUser(UserId, Publication.Id))
                     .ReturnsAsync(new List<PublicationRole>());
 
                 await handler.HandleAsync(authContext);
@@ -132,7 +131,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
             
             [Fact]
-            public async void UserWithLinkedPublicationOwnerRoleCannotCreateAmendmentOfPrivateMethodology()
+            public async Task UserWithLinkedPublicationOwnerRoleCannotCreateAmendmentOfPrivateMethodology()
             {
                 var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();
                     

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlersTests.cs
@@ -1,19 +1,41 @@
 ﻿using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
     public class UpdateSpecificMethodologyAuthorizationHandlersTests
     {
         [Fact]
-        public async Task UpdateAllSpecificMethodologies()
+        public async Task UpdateAllSpecificMethodologies_DraftMethodology()
         {
-            await AssertHandlerSucceedsWithCorrectClaims<UpdateSpecificMethodologyRequirement>(
+            var draftMethodology = new Methodology
+            {
+                Status = Draft
+            };
+            
+            await AssertHandlerSucceedsWithCorrectClaims<Methodology, UpdateSpecificMethodologyRequirement>(
                 new UpdateSpecificMethodologyAuthorizationHandler(),
+                draftMethodology,
                 UpdateAllMethodologies
+            );
+        }
+
+        [Fact]
+        public async Task UpdateAllSpecificMethodologies_ApprovedMethodologyFails()
+        {
+            var approvedMethodology = new Methodology
+            {
+                Status = Approved
+            };
+            
+            await AssertHandlerSucceedsWithCorrectClaims<Methodology, UpdateSpecificMethodologyRequirement>(
+                new UpdateSpecificMethodologyAuthorizationHandler(),
+                approvedMethodology
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlersTests.cs
@@ -1,41 +1,19 @@
-﻿using System.Threading.Tasks;
+﻿﻿using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
     public class UpdateSpecificMethodologyAuthorizationHandlersTests
     {
         [Fact]
-        public async Task UpdateAllSpecificMethodologies_DraftMethodology()
+        public async Task UpdateAllSpecificMethodologies()
         {
-            var draftMethodology = new Methodology
-            {
-                Status = Draft
-            };
-            
-            await AssertHandlerSucceedsWithCorrectClaims<Methodology, UpdateSpecificMethodologyRequirement>(
+            await AssertHandlerSucceedsWithCorrectClaims<UpdateSpecificMethodologyRequirement>(
                 new UpdateSpecificMethodologyAuthorizationHandler(),
-                draftMethodology,
                 UpdateAllMethodologies
-            );
-        }
-
-        [Fact]
-        public async Task UpdateAllSpecificMethodologies_ApprovedMethodologyFails()
-        {
-            var approvedMethodology = new Methodology
-            {
-                Status = Approved
-            };
-            
-            await AssertHandlerSucceedsWithCorrectClaims<Methodology, UpdateSpecificMethodologyRequirement>(
-                new UpdateSpecificMethodologyAuthorizationHandler(),
-                approvedMethodology
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/AuthorizationHandlersTestUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/AuthorizationHandlersTestUtil.cs
@@ -151,7 +151,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             ClaimsPrincipal user, TEntity entity) where TRequirement : IAuthorizationRequirement
         {
             return new AuthorizationHandlerContext(
-                new IAuthorizationRequirement[] {default(TRequirement)},
+                new IAuthorizationRequirement[] {Activator.CreateInstance<TRequirement>()},
                 user, entity);
 
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/AuthorizationHandlersTestUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/AuthorizationHandlersTestUtil.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
 using Xunit;
@@ -116,6 +117,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
         }
 
+        public static ClaimsPrincipal CreateClaimsPrincipal(Guid userId)
+        {
+            return CreateClaimsPrincipal(userId, new Claim[] {});
+        }
+
         public static ClaimsPrincipal CreateClaimsPrincipal(Guid userId, params Claim[] additionalClaims)
         {
             var identity = new ClaimsIdentity();
@@ -123,6 +129,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             identity.AddClaims(additionalClaims);
             var user = new ClaimsPrincipal(identity);
             return user;
+        }
+
+        public static ClaimsPrincipal CreateClaimsPrincipal(Guid userId, params SecurityClaimTypes[] additionalClaims)
+        {
+            return CreateClaimsPrincipal(userId, 
+                additionalClaims.Select(c => new Claim(c.ToString(), "")).ToArray());
+        }
+
+        public static void ForEachSecurityClaim(Action<SecurityClaimTypes> action)
+        {
+            GetEnumValues<SecurityClaimTypes>().ForEach(action.Invoke);
+        }
+        
+        public static Task ForEachSecurityClaimAsync(Func<SecurityClaimTypes, Task> action)
+        {
+            return GetEnumValues<SecurityClaimTypes>().ForEachAsync(action.Invoke);
+        }
+
+        public static AuthorizationHandlerContext CreateAuthorizationHandlerContext<TRequirement, TEntity>(
+            ClaimsPrincipal user, TEntity entity) where TRequirement : IAuthorizationRequirement
+        {
+            return new AuthorizationHandlerContext(
+                new IAuthorizationRequirement[] {default(TRequirement)},
+                user, entity);
+
         }
 
         public class HandlerTestScenario

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServicePermissionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
@@ -15,6 +16,7 @@ using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -31,10 +33,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         };
 
         [Fact]
-        public void Get()
+        public async Task Get()
         {
-            PermissionTestUtils.PolicyCheckBuilder<ContentSecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
+            await PolicyCheckBuilder<ContentSecurityPolicies>()
+                .SetupResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -44,10 +46,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void GetDeletePlan()
+        public async Task GetDeletePlan()
         {
-            PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -57,10 +59,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void Create()
+        public async Task Create()
         {
-            PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -70,10 +72,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void Update()
+        public async Task Update()
         {
-            PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -83,10 +85,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void Delete()
+        public async Task Delete()
         {
-            PermissionTestUtils.PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ImportStatusBauServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ImportStatusBauServicePermissionTests.cs
@@ -12,7 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void GetAllIncompleteImports()
         {
             PolicyCheckBuilder()
-                .ExpectCheck(SecurityPolicies.CanAccessAllImports)
+                .SetupCheck(SecurityPolicies.CanAccessAllImports)
                 .AssertSuccess(
                     async userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ContentServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ContentServicePermissionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageContent;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
@@ -53,10 +54,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         };
 
         [Fact]
-        public void AddComment()
+        public async Task AddComment()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -71,10 +72,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void DeleteComment()
+        public async Task DeleteComment()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_comment, CanUpdateSpecificComment)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_comment, CanUpdateSpecificComment)
                 .AssertForbidden(
                     userService =>
                     {
@@ -86,10 +87,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void UpdateComment()
+        public async Task UpdateComment()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_comment, CanUpdateSpecificComment)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_comment, CanUpdateSpecificComment)
                 .AssertForbidden(
                     userService =>
                     {
@@ -102,10 +103,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void AddContentBlock()
+        public async Task AddContentBlock()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -119,10 +120,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void AddContentSection()
+        public async Task AddContentSection()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -135,10 +136,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void AttachDataBlock()
+        public async Task AttachDataBlock()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -152,10 +153,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void GetContentBlocks()
+        public async Task GetContentBlocks()
         {
-            PolicyCheckBuilder<ContentSecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanViewRelease)
+            await PolicyCheckBuilder<ContentSecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -166,10 +167,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void RemoveContentBlock()
+        public async Task RemoveContentBlock()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -183,10 +184,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void RemoveContentSection()
+        public async Task RemoveContentSection()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -199,10 +200,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void ReorderContentBlocks()
+        public async Task ReorderContentBlocks()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -216,10 +217,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void ReorderContentSections()
+        public async Task ReorderContentSections()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -232,10 +233,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void UpdateContentSectionHeading()
+        public async Task UpdateContentSectionHeading()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -249,10 +250,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void UpdateTextBasedContentBlock()
+        public async Task UpdateTextBasedContentBlock()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -267,10 +268,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
         }
 
         [Fact]
-        public void UpdateDataBlock()
+        public async Task UpdateDataBlock()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServicePermissionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
@@ -26,10 +27,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         };
 
         [Fact]
-        public void Get()
+        public async Task Get()
         {
-            PolicyCheckBuilder<ContentSecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
+            await PolicyCheckBuilder<ContentSecurityPolicies>()
+                .SetupResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -40,10 +41,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void Update()
+        public async Task Update()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, SecurityPolicies.CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, SecurityPolicies.CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServicePermissionTests.cs
@@ -8,6 +8,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies
@@ -23,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         public async void CreateMethodologyAmendment()
         {
             await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheckToFail(_methodology, SecurityPolicies.CanMakeAmendmentOfSpecificMethodology)
+                .SetupResourceCheckToFail(_methodology, CanMakeAmendmentOfSpecificMethodology)
                 .AssertForbidden(
                     userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServicePermissionTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies
+{
+    public class MethodologyAmendmentServicePermissionTests
+    {
+        private readonly Methodology _methodology = new Methodology
+        {
+            Id = Guid.NewGuid()
+        };
+
+        [Fact]
+        public async void CreateMethodologyAmendment()
+        {
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_methodology, SecurityPolicies.CanMakeAmendmentOfSpecificMethodology)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = SetupMethodologyAmendmentService(userService: userService.Object);
+                        return service.CreateMethodologyAmendment(_methodology.Id);
+                    }
+                );
+        }
+
+        private MethodologyAmendmentService SetupMethodologyAmendmentService(
+            IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
+            IUserService userService = null)
+        {
+            return new MethodologyAmendmentService(
+                contentPersistenceHelper ?? DefaultPersistenceHelperMock().Object,
+                userService ?? new Mock<IUserService>().Object,
+                MapperUtils.AdminMapper()
+            );
+        }
+
+        private Mock<IPersistenceHelper<ContentDbContext>> DefaultPersistenceHelperMock()
+        {
+            return MockUtils.MockPersistenceHelper<ContentDbContext, Methodology>(_methodology.Id, _methodology);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyContentServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyContentServicePermissionTests.cs
@@ -10,7 +10,9 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
@@ -32,12 +34,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyContentService = SetupMethodologyContentService(contentDbContext);
-                PolicyCheckBuilder<SecurityPolicies>()
-                    .ExpectResourceCheckToFail(methodology, SecurityPolicies.CanViewAllMethodologies)
+                await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupResourceCheckToFailWithMatcher<Methodology>(m => m.Id == methodology.Id,
+                        CanViewSpecificMethodology)
                     .AssertForbidden(
                         userService =>
-                            methodologyContentService.GetContent(methodology.Id));
+                        {
+                            var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
+
+                            return methodologyContentService.GetContent(methodology.Id);
+                        });
             }
         }
         
@@ -54,12 +60,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyContentService = SetupMethodologyContentService(contentDbContext);
-                PolicyCheckBuilder<SecurityPolicies>()
-                    .ExpectResourceCheckToFail(methodology, SecurityPolicies.CanViewAllMethodologies)
+                await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupResourceCheckToFailWithMatcher<Methodology>(m => m.Id == methodology.Id,
+                        CanViewSpecificMethodology)
                     .AssertForbidden(
-                        userService => 
-                            methodologyContentService.GetContentBlocks<ContentBlock>(methodology.Id));
+                        userService =>
+                        {
+                            var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
+
+                            return methodologyContentService.GetContentBlocks<ContentBlock>(methodology.Id);
+                        });
             }
         }
         
@@ -76,12 +86,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyContentService = SetupMethodologyContentService(contentDbContext);
-                PolicyCheckBuilder<SecurityPolicies>()
-                    .ExpectResourceCheckToFail(methodology, SecurityPolicies.CanViewAllMethodologies)
+                await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupResourceCheckToFailWithMatcher<Methodology>(m => m.Id == methodology.Id,
+                        CanViewSpecificMethodology)
                     .AssertForbidden(
-                        userService => 
-                            methodologyContentService.GetContentSections(methodology.Id, MethodologyContentService.ContentListType.Content));
+                        userService =>
+                        {
+                            var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
+
+                            return methodologyContentService.GetContentSections(methodology.Id,
+                                MethodologyContentService.ContentListType.Content);
+                        });
             }
         }
         
@@ -104,12 +119,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyContentService = SetupMethodologyContentService(contentDbContext);
-                PolicyCheckBuilder<SecurityPolicies>()
-                    .ExpectResourceCheckToFail(methodology, SecurityPolicies.CanViewAllMethodologies)
+                await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupResourceCheckToFailWithMatcher<Methodology>(m => m.Id == methodology.Id,
+                        CanViewSpecificMethodology)
                     .AssertForbidden(
-                        userService => 
-                            methodologyContentService.GetContentSection(methodology.Id, methodology.Content.First().Id));
+                        userService =>
+                        {
+                            var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
+
+                            return methodologyContentService.GetContentSection(methodology.Id,
+                                methodology.Content.First().Id);
+                        });
             }
         }
         
@@ -126,12 +146,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyContentService = SetupMethodologyContentService(contentDbContext);
-                PolicyCheckBuilder<SecurityPolicies>()
-                    .ExpectResourceCheckToFail(methodology, SecurityPolicies.CanUpdateSpecificMethodology)
+                await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupResourceCheckToFailWithMatcher<Methodology>(m => m.Id == methodology.Id,
+                        CanUpdateSpecificMethodology)
                     .AssertForbidden(
-                        userService => 
-                            methodologyContentService.ReorderContentSections(methodology.Id,new Dictionary<Guid, int>()));
+                        userService =>
+                        {
+                            var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
+
+                            return methodologyContentService.ReorderContentSections(methodology.Id,
+                                new Dictionary<Guid, int>());
+                        });
             }
         }
 
@@ -148,15 +173,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyContentService = SetupMethodologyContentService(contentDbContext);
-                PolicyCheckBuilder<SecurityPolicies>()
-                    .ExpectResourceCheckToFail(methodology, SecurityPolicies.CanUpdateSpecificMethodology)
+                await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupResourceCheckToFailWithMatcher<Methodology>(m => m.Id == methodology.Id,
+                        CanUpdateSpecificMethodology)
                     .AssertForbidden(
                         userService =>
-                            methodologyContentService.AddContentSection(
+                        {
+                            var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
+
+                            return methodologyContentService.AddContentSection(
                                 methodology.Id,
                                 new ContentSectionAddRequest(),
-                                MethodologyContentService.ContentListType.Content));
+                                MethodologyContentService.ContentListType.Content);
+                        });
             }
         }
 
@@ -180,15 +209,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyContentService = SetupMethodologyContentService(contentDbContext);
-                PolicyCheckBuilder<SecurityPolicies>()
-                    .ExpectResourceCheckToFail(methodology, SecurityPolicies.CanUpdateSpecificMethodology)
+                await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupResourceCheckToFailWithMatcher<Methodology>(m => m.Id == methodology.Id,
+                        CanUpdateSpecificMethodology)
                     .AssertForbidden(
                         userService =>
-                            methodologyContentService.UpdateContentSectionHeading(
+                        {
+                            var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
+
+                            return methodologyContentService.UpdateContentSectionHeading(
                                 methodology.Id,
                                 methodology.Content.First().Id,
-                                "New heading"));
+                                "New heading");
+                        });
             }
         }
 
@@ -212,14 +245,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyContentService = SetupMethodologyContentService(contentDbContext);
-                PolicyCheckBuilder<SecurityPolicies>()
-                    .ExpectResourceCheckToFail(methodology, SecurityPolicies.CanUpdateSpecificMethodology)
+                await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupResourceCheckToFailWithMatcher<Methodology>(m => m.Id == methodology.Id,
+                        CanUpdateSpecificMethodology)
                     .AssertForbidden(
                         userService =>
-                            methodologyContentService.RemoveContentSection(
+                        {
+                            var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
+
+                            return methodologyContentService.RemoveContentSection(
                                 methodology.Id,
-                                methodology.Content.First().Id));
+                                methodology.Content.First().Id);
+                        });
             }
         }
         
@@ -243,16 +280,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyContentService = SetupMethodologyContentService(contentDbContext);
-                PolicyCheckBuilder<SecurityPolicies>()
-                    .ExpectResourceCheckToFail(methodology, SecurityPolicies.CanUpdateSpecificMethodology)
+                await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupResourceCheckToFailWithMatcher<Methodology>(m => m.Id == methodology.Id,
+                        CanUpdateSpecificMethodology)
                     .AssertForbidden(
                         userService =>
-                            methodologyContentService.ReorderContentBlocks(
+                        {
+                            var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
+
+                            return methodologyContentService.ReorderContentBlocks(
                                 methodology.Id,
                                 methodology.Content.First().Id,
                                 new Dictionary<Guid, int>()
-                                ));
+                            );
+                        });
             }
         }
         
@@ -263,7 +304,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 Content = new List<ContentSection>
                 {
-                    new ContentSection()
+                    new ContentSection
+                    {
+                        Id = Guid.NewGuid()
+                    }
                 }
 
             };
@@ -276,16 +320,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyContentService = SetupMethodologyContentService(contentDbContext);
-                PolicyCheckBuilder<SecurityPolicies>()
-                    .ExpectResourceCheckToFail(methodology, SecurityPolicies.CanUpdateSpecificMethodology)
+                await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupResourceCheckToFailWithMatcher<Methodology>(m => m.Id == methodology.Id,
+                        CanUpdateSpecificMethodology)
                     .AssertForbidden(
                         userService =>
-                            methodologyContentService.AddContentBlock(
+                        {
+                            var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
+
+                            return methodologyContentService.AddContentBlock(
                                 methodology.Id,
                                 methodology.Content.First().Id,
                                 new ContentBlockAddRequest()
-                                ));
+                            );
+                        });
             }
         }
         
@@ -315,16 +363,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyContentService = SetupMethodologyContentService(contentDbContext);
-                PolicyCheckBuilder<SecurityPolicies>()
-                    .ExpectResourceCheckToFail(methodology, SecurityPolicies.CanUpdateSpecificMethodology)
+                await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupResourceCheckToFailWithMatcher<Methodology>(m => m.Id == methodology.Id,
+                        CanUpdateSpecificMethodology)
                     .AssertForbidden(
                         userService =>
-                            methodologyContentService.RemoveContentBlock(
+                        {
+                            var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
+
+                            return methodologyContentService.RemoveContentBlock(
                                 methodology.Id,
                                 methodology.Content.First().Id,
                                 methodology.Content.First().Content.First().Id
-                                ));
+                            );
+                        });
             }
         }
         
@@ -354,17 +406,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyContentService = SetupMethodologyContentService(contentDbContext);
-                PolicyCheckBuilder<SecurityPolicies>()
-                    .ExpectResourceCheckToFail(methodology, SecurityPolicies.CanUpdateSpecificMethodology)
+                await PolicyCheckBuilder<SecurityPolicies>()
+                    .SetupResourceCheckToFailWithMatcher<Methodology>(m => m.Id == methodology.Id,
+                        CanUpdateSpecificMethodology)
                     .AssertForbidden(
                         userService =>
-                            methodologyContentService.UpdateTextBasedContentBlock(
+                        {
+                            var methodologyContentService = SetupMethodologyContentService(contentDbContext, userService: userService.Object);
+
+                            return methodologyContentService.UpdateTextBasedContentBlock(
                                 methodology.Id,
                                 methodology.Content.First().Id,
                                 methodology.Content.First().Content.First().Id,
                                 new ContentBlockUpdateRequest()
-                                ));
+                            );
+                        });
             }
         }
         

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyImageServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyImageServicePermissionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
@@ -26,10 +27,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         };
 
         [Fact]
-        public void Delete()
+        public async Task Delete()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_methodology, SecurityPolicies.CanUpdateSpecificMethodology)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_methodology, SecurityPolicies.CanUpdateSpecificMethodology)
                 .AssertForbidden(
                     userService =>
                     {
@@ -41,10 +42,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         }
 
         [Fact]
-        public void Upload()
+        public async Task Upload()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_methodology, SecurityPolicies.CanUpdateSpecificMethodology)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_methodology, SecurityPolicies.CanUpdateSpecificMethodology)
                 .AssertForbidden(
                     userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServicePermissionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -24,10 +25,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
 
         [Fact]
-        public void GetChecklist()
+        public async Task GetChecklist()
         {
-            PolicyCheckBuilder<ContentSecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
+            await PolicyCheckBuilder<ContentSecurityPolicies>()
+                .SetupResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseDataFileServicePermissionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Mappings;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
@@ -31,10 +32,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         };
 
         [Fact]
-        public void Delete()
+        public async Task Delete()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -45,10 +46,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void Delete_MultipleFiles()
+        public async Task Delete_MultipleFiles()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -62,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void DeleteAll()
+        public async Task DeleteAll()
         {
             var releaseFile = new ReleaseFile
             {
@@ -78,12 +79,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
             {
-                contentDbContext.AddAsync(releaseFile);
-                contentDbContext.SaveChangesAsync();
+                await contentDbContext.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -96,10 +97,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void GetInfo()
+        public async Task GetInfo()
         {
-            PolicyCheckBuilder<ContentSecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
+            await PolicyCheckBuilder<ContentSecurityPolicies>()
+                .SetupResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -110,10 +111,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void ListAll()
+        public async Task ListAll()
         {
-            PolicyCheckBuilder<ContentSecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
+            await PolicyCheckBuilder<ContentSecurityPolicies>()
+                .SetupResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -124,10 +125,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void Upload()
+        public async Task Upload()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -143,10 +144,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void UploadAsZip()
+        public async Task UploadAsZip()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServicePermissionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
@@ -27,10 +28,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         };
 
         [Fact]
-        public void Delete()
+        public async Task Delete()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -42,10 +43,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void Delete_MultipleFiles()
+        public async Task Delete_MultipleFiles()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -60,7 +61,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void DeleteAll()
+        public async Task DeleteAll()
         {
             var releaseFile = new ReleaseFile
             {
@@ -76,12 +77,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
             {
-                contentDbContext.AddAsync(releaseFile);
-                contentDbContext.SaveChangesAsync();
+                await contentDbContext.AddAsync(releaseFile);
+                await contentDbContext.SaveChangesAsync();
             }
 
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -94,10 +95,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void ListAll()
+        public async Task ListAll()
         {
-            PolicyCheckBuilder<ContentSecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
+            await PolicyCheckBuilder<ContentSecurityPolicies>()
+                .SetupResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -108,10 +109,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void Stream()
+        public async Task Stream()
         {
-            PolicyCheckBuilder<ContentSecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
+            await PolicyCheckBuilder<ContentSecurityPolicies>()
+                .SetupResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -123,10 +124,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void UploadAncillary()
+        public async Task UploadAncillary()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -139,10 +140,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void UploadChart()
+        public async Task UploadChart()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseImageServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseImageServicePermissionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
@@ -24,10 +25,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         };
 
         [Fact]
-        public void Upload()
+        public async Task Upload()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
@@ -44,10 +45,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         private readonly Guid _userId = Guid.NewGuid();
 
         [Fact]
-        public void GetRelease()
+        public async Task GetRelease()
         {
-            PolicyCheckBuilder<ContentSecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
+            await PolicyCheckBuilder<ContentSecurityPolicies>()
+                .SetupResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -58,10 +59,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void CreateReleaseAsync()
+        public async Task CreateReleaseAsync()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(Publication, CanCreateReleaseForSpecificPublication)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(Publication, CanCreateReleaseForSpecificPublication)
                 .AssertForbidden(
                     userService =>
                     {
@@ -77,10 +78,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void UpdateRelease()
+        public async Task UpdateRelease()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -94,11 +95,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void UpdateRelease_Draft()
+        public async Task UpdateRelease_Draft()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheck(_release, CanUpdateSpecificRelease)
-                .ExpectResourceCheckToFail(_release, CanMarkSpecificReleaseAsDraft)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheck(_release, CanUpdateSpecificRelease)
+                .SetupResourceCheckToFail(_release, CanMarkSpecificReleaseAsDraft)
                 .AssertForbidden(
                     userService =>
                     {
@@ -115,11 +116,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void UpdateRelease_SubmitForHigherLevelReview()
+        public async Task UpdateRelease_SubmitForHigherLevelReview()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheck(_release, CanUpdateSpecificRelease)
-                .ExpectResourceCheckToFail(_release, CanSubmitSpecificReleaseToHigherReview)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheck(_release, CanUpdateSpecificRelease)
+                .SetupResourceCheckToFail(_release, CanSubmitSpecificReleaseToHigherReview)
                 .AssertForbidden(
                     userService =>
                     {
@@ -136,11 +137,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void UpdateRelease_Approve()
+        public async Task UpdateRelease_Approve()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheck(_release, CanUpdateSpecificRelease)
-                .ExpectResourceCheckToFail(_release, CanApproveSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheck(_release, CanUpdateSpecificRelease)
+                .SetupResourceCheckToFail(_release, CanApproveSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -157,10 +158,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void GetLatestReleaseAsync()
+        public async Task GetLatestReleaseAsync()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(Publication, CanViewSpecificPublication)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(Publication, CanViewSpecificPublication)
                 .AssertForbidden(
                     userService =>
                     {
@@ -171,10 +172,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void CreateReleaseAmendmentAsync()
+        public async Task CreateReleaseAmendmentAsync()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanMakeAmendmentOfSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanMakeAmendmentOfSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -185,10 +186,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void DeleteRelease()
+        public async Task DeleteRelease()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanDeleteSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanDeleteSpecificRelease)
                 .AssertForbidden(
                     userService =>
                     {
@@ -199,7 +200,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void GetMyReleasesForReleaseStatusesAsync_CanViewAllReleases()
+        public async Task GetMyReleasesForReleaseStatusesAsync_CanViewAllReleases()
         {
             var repository = new Mock<IReleaseRepository>();
 
@@ -215,9 +216,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Setup(s => s.GetAllReleasesForReleaseStatusesAsync(ReleaseStatus.Approved))
                 .ReturnsAsync(list);
 
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectCheck(CanAccessSystem)
-                .ExpectCheck(CanViewAllReleases)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupCheck(CanAccessSystem)
+                .SetupCheck(CanViewAllReleases)
                 .AssertSuccess(
                     async userService =>
                     {
@@ -238,7 +239,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void GetMyReleasesForReleaseStatusesAsync_CanViewRelatedReleases()
+        public async Task GetMyReleasesForReleaseStatusesAsync_CanViewRelatedReleases()
         {
             var repository = new Mock<IReleaseRepository>();
 
@@ -254,8 +255,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Setup(s => s.GetReleasesForReleaseStatusRelatedToUserAsync(_userId, ReleaseStatus.Approved))
                 .ReturnsAsync(list);
 
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectCheck(CanAccessSystem)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupCheck(CanAccessSystem)
                 .ExpectCheckToFail(CanViewAllReleases)
                 .AssertSuccess(
                     async userService =>
@@ -281,9 +282,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void GetMyReleasesForReleaseStatusesAsync_NoAccessToSystem()
+        public async Task GetMyReleasesForReleaseStatusesAsync_NoAccessToSystem()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
+            await PolicyCheckBuilder<SecurityPolicies>()
                 .ExpectCheckToFail(CanAccessSystem)
                 .AssertForbidden(
                     async userService =>
@@ -295,10 +296,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public void RemoveDataFiles()
+        public async Task RemoveDataFiles()
         {
-            PolicyCheckBuilder<SecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, CanUpdateSpecificRelease)
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
                 .AssertForbidden(
                     async userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseStatusServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseStatusServicePermissionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -10,6 +11,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Security;
 using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -21,10 +23,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         };
 
         [Fact]
-        public void GetReleaseStatusesAsync()
+        public async Task GetReleaseStatusesAsync()
         {
-            PermissionTestUtils.PolicyCheckBuilder<ContentSecurityPolicies>()
-                .ExpectResourceCheck(_release, ContentSecurityPolicies.CanViewRelease, false)
+            await PolicyCheckBuilder<ContentSecurityPolicies>()
+                .SetupResourceCheck(_release, ContentSecurityPolicies.CanViewRelease, false)
                 .AssertForbidden(
                     async userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
@@ -41,8 +41,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             }
 
             PolicyCheckBuilder()
-                .ExpectCheck(SecurityPolicies.CanAccessSystem)
-                .ExpectCheck(SecurityPolicies.CanManageAllTaxonomy)
+                .SetupCheck(SecurityPolicies.CanAccessSystem)
+                .SetupCheck(SecurityPolicies.CanManageAllTaxonomy)
                 .AssertSuccess(
                     async userService =>
                     {
@@ -110,8 +110,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             }
 
             PolicyCheckBuilder()
-                .ExpectCheck(SecurityPolicies.CanAccessSystem)
-                .ExpectCheck(SecurityPolicies.CanManageAllTaxonomy, false)
+                .SetupCheck(SecurityPolicies.CanAccessSystem)
+                .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
                 .AssertSuccess(
                     async userService =>
                     {
@@ -139,7 +139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void GetMyThemes_NoAccessToSystem()
         {
             PolicyCheckBuilder()
-                .ExpectCheck(SecurityPolicies.CanAccessSystem, false)
+                .SetupCheck(SecurityPolicies.CanAccessSystem, false)
                 .AssertForbidden(
                     async userService =>
                     {
@@ -154,7 +154,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void CreateTheme()
         {
             PolicyCheckBuilder()
-                .ExpectCheck(SecurityPolicies.CanManageAllTaxonomy, false)
+                .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
                 .AssertForbidden(
                     async userService =>
                     {
@@ -175,7 +175,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void UpdateTheme()
         {
             PolicyCheckBuilder()
-                .ExpectCheck(SecurityPolicies.CanManageAllTaxonomy, false)
+                .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
                 .AssertForbidden(
                     async userService =>
                     {
@@ -197,7 +197,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void GetTheme()
         {
             PolicyCheckBuilder()
-                .ExpectResourceCheck(_theme, SecurityPolicies.CanManageAllTaxonomy, false)
+                .SetupResourceCheck(_theme, SecurityPolicies.CanManageAllTaxonomy, false)
                 .AssertForbidden(
                     async userService =>
                     {
@@ -212,7 +212,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void DeleteTheme()
         {
             PolicyCheckBuilder()
-                .ExpectCheck(SecurityPolicies.CanManageAllTaxonomy, false)
+                .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
                 .AssertForbidden(
                     async userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServicePermissionTests.cs
@@ -29,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void CreateTopic()
         {
             PolicyCheckBuilder()
-                .ExpectCheck(SecurityPolicies.CanManageAllTaxonomy, false)
+                .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
                 .AssertForbidden(
                     async userService =>
                     {
@@ -49,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void UpdateTopic()
         {
             PolicyCheckBuilder()
-                .ExpectCheck(SecurityPolicies.CanManageAllTaxonomy, false)
+                .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
                 .AssertForbidden(
                     async userService =>
                     {
@@ -70,7 +70,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void GetTopic()
         {
             PolicyCheckBuilder()
-                .ExpectResourceCheck(_topic, SecurityPolicies.CanManageAllTaxonomy, false)
+                .SetupResourceCheck(_topic, SecurityPolicies.CanManageAllTaxonomy, false)
                 .AssertForbidden(
                     async userService =>
                     {
@@ -85,7 +85,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public void DeleteTopic()
         {
             PolicyCheckBuilder()
-                .ExpectCheck(SecurityPolicies.CanManageAllTaxonomy, false)
+                .SetupCheck(SecurityPolicies.CanManageAllTaxonomy, false)
                 .AssertForbidden(
                     async userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlers.cs
@@ -50,6 +50,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 return;
             }
 
+            // TODO: this will need changing in the future to only allow owning Publications the permission to make
+            // Amendments, rather than just any linked Methodologies
             foreach (var publication in methodology.Publications)
             {
                 var publicationRoles =

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlers.cs
@@ -1,0 +1,72 @@
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using IdentityServer4.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
+{
+    public class MakeAmendmentOfSpecificMethodologyRequirement : IAuthorizationRequirement
+    {
+    }
+
+    public class MakeAmendmentOfSpecificMethodologyAuthorizationHandler
+        : AuthorizationHandler<MakeAmendmentOfSpecificMethodologyRequirement, Methodology>
+    {
+        private readonly IUserPublicationRoleRepository _userPublicationRoleRepository;
+
+        public MakeAmendmentOfSpecificMethodologyAuthorizationHandler(
+            IUserPublicationRoleRepository userPublicationRoleRepository)
+        {
+            _userPublicationRoleRepository = userPublicationRoleRepository;
+        }
+
+        protected override async Task HandleRequirementAsync(
+            AuthorizationHandlerContext context,
+            MakeAmendmentOfSpecificMethodologyRequirement requirement,
+            Methodology methodology)
+        {
+            // Amendments can only be created from Methodologies that are already publicly-accessible.
+            if (!methodology.PubliclyAccessible)
+            {
+                return;
+            }
+
+            // Any user with the "MakeAmendmentsOfAllMethodologies" Claim can create an amendment of a
+            // publicly-accessible Methodology.
+            
+            // TODO - need to check there's not already an existing Amendment
+            if (SecurityUtils.HasClaim(context.User, MakeAmendmentsOfAllMethodologies))
+            {
+                context.Succeed(requirement);
+                return;
+            }
+
+            // If the user has a Publication Owner role on a Publication that uses this Methodology, they can create 
+            // an Amendment of this Methodology.
+            if (methodology.Publications.IsNullOrEmpty())
+            {
+                return;
+            }
+
+            foreach (var publication in methodology.Publications)
+            {
+                var publicationRoles =
+                    await _userPublicationRoleRepository.GetAllRolesByUser(context.User.GetUserId(),
+                        publication.Id);
+
+                if (ContainPublicationOwnerRole(publicationRoles))
+                {
+                    context.Succeed(requirement);
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlers.cs
@@ -1,12 +1,9 @@
-using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using IdentityServer4.Extensions;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 
@@ -40,8 +37,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
 
             // Any user with the "MakeAmendmentsOfAllMethodologies" Claim can create an amendment of a
             // publicly-accessible Methodology.
-            
-            // TODO - need to check there's not already an existing Amendment
             if (SecurityUtils.HasClaim(context.User, MakeAmendmentsOfAllMethodologies))
             {
                 context.Succeed(requirement);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlers.cs
@@ -1,4 +1,8 @@
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Authorization;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
@@ -7,10 +11,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
     }
 
     public class UpdateSpecificMethodologyAuthorizationHandler :
-        HasClaimAuthorizationHandler<UpdateSpecificMethodologyRequirement>
+        AuthorizationHandler<UpdateSpecificMethodologyRequirement, Methodology>
     {
-        public UpdateSpecificMethodologyAuthorizationHandler() : base(SecurityClaimTypes.UpdateAllMethodologies)
+        protected override Task HandleRequirementAsync(
+            AuthorizationHandlerContext context,
+            UpdateSpecificMethodologyRequirement requirement,
+            Methodology methodology)
         {
+            if (methodology.Status == Draft && HasClaim(context.User, SecurityClaimTypes.UpdateAllMethodologies))
+            {
+                context.Succeed(requirement);
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlers.cs
@@ -1,8 +1,4 @@
-using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Authorization;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
@@ -11,19 +7,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
     }
 
     public class UpdateSpecificMethodologyAuthorizationHandler :
-        AuthorizationHandler<UpdateSpecificMethodologyRequirement, Methodology>
+        HasClaimAuthorizationHandler<UpdateSpecificMethodologyRequirement>
     {
-        protected override Task HandleRequirementAsync(
-            AuthorizationHandlerContext context,
-            UpdateSpecificMethodologyRequirement requirement,
-            Methodology methodology)
+        // TODO: when adding in Publication Owner permissions here:
+        //
+        // In future the approver of the latest release of the publication which the methodology belongs to should be
+        // able to unapprove the methodology as long as it's not publicly accessible yet
+        public UpdateSpecificMethodologyAuthorizationHandler() : base(SecurityClaimTypes.UpdateAllMethodologies)
         {
-            if (methodology.Status == Draft && HasClaim(context.User, SecurityClaimTypes.UpdateAllMethodologies))
-            {
-                context.Succeed(requirement);
-            }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityClaimTypes.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityClaimTypes.cs
@@ -50,6 +50,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
         UpdateAllMethodologies,
         ApproveAllMethodologies,
         MarkAllMethodologiesDraft,
-        MakeAmendmentsOfAllMethodologies,
+        MakeAmendmentsOfAllMethodologies
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityClaimTypes.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityClaimTypes.cs
@@ -50,5 +50,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
         UpdateAllMethodologies,
         ApproveAllMethodologies,
         MarkAllMethodologiesDraft,
+        MakeAmendmentsOfAllMethodologies,
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityPolicies.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityPolicies.cs
@@ -62,6 +62,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
         CanViewSpecificMethodology,
         CanUpdateSpecificMethodology,
         CanMarkSpecificMethodologyAsDraft,
-        CanApproveSpecificMethodology
+        CanApproveSpecificMethodology,
+        CanMakeAmendmentOfSpecificMethodology
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
@@ -180,6 +180,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
                 // does this user have permission to approve a specific Methodology?
                 options.AddPolicy(SecurityPolicies.CanApproveSpecificMethodology.ToString(), policy =>
                     policy.Requirements.Add(new ApproveSpecificMethodologyRequirement()));
+
+                // does this user have permission to create an Amendment of a specific Methodology?
+                options.AddPolicy(SecurityPolicies.CanMakeAmendmentOfSpecificMethodology.ToString(), policy =>
+                    policy.Requirements.Add(new MakeAmendmentOfSpecificMethodologyRequirement()));
             });
         }
 
@@ -235,6 +239,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
             services.AddTransient<IAuthorizationHandler, UpdateSpecificMethodologyAuthorizationHandler>();
             services.AddTransient<IAuthorizationHandler, MarkSpecificMethodologyAsDraftAuthorizationHandler>();
             services.AddTransient<IAuthorizationHandler, ApproveSpecificMethodologyAuthorizationHandler>();
+            services.AddTransient<IAuthorizationHandler, MakeAmendmentOfSpecificMethodologyAuthorizationHandler>();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyAmendmentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyAmendmentService.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies
+{
+    public interface IMethodologyAmendmentService
+    {
+        Task<Either<ActionResult, MethodologyViewModel>> CreateMethodologyAmendment(Guid originalMethodologyId);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
@@ -70,6 +70,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
             return userService.CheckPolicy(methodology, SecurityPolicies.CanApproveSpecificMethodology);
         }
 
+        public static Task<Either<ActionResult, Methodology>> CheckCanMakeAmendmentOfMethodology(
+            this IUserService userService, Methodology methodology)
+        {
+            return userService.CheckPolicy(methodology, SecurityPolicies.CanMakeAmendmentOfSpecificMethodology);
+        }
+
         public static Task<Either<ActionResult, Unit>> CheckCanViewAllReleases(this IUserService userService)
         {
             return userService.CheckPolicy(SecurityPolicies.CanViewAllReleases);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyAmendmentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyAmendmentService.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading.Tasks;
+using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies
+{
+    public class MethodologyAmendmentService : IMethodologyAmendmentService
+    {
+        private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
+        private readonly IUserService _userService;
+        private readonly IMapper _mapper;
+
+        public MethodologyAmendmentService(
+            IPersistenceHelper<ContentDbContext> persistenceHelper, 
+            IUserService userService,
+            IMapper mapper)
+        {
+            _persistenceHelper = persistenceHelper;
+            _userService = userService;
+            _mapper = mapper;
+        }
+
+        public async Task<Either<ActionResult, MethodologyViewModel>> CreateMethodologyAmendment(
+            Guid originalMethodologyId)
+        {
+            return await _persistenceHelper.CheckEntityExists<Methodology>(originalMethodologyId)
+                .OnSuccess(_userService.CheckCanMakeAmendmentOfMethodology)
+                .OnSuccessDo(() => throw new NotImplementedException())
+                .OnSuccess(_mapper.Map<MethodologyViewModel>);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -430,6 +430,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         private Task<Either<ActionResult, Tuple<Methodology, ContentSection>>> CheckCanUpdateMethodology(
             Tuple<Methodology, ContentSection> tuple)
         {
+            if (tuple.Item1.Status != MethodologyStatus.Draft)
+            {
+                return Task.FromResult<Either<ActionResult, Tuple<Methodology, ContentSection>>>(
+                    ValidationActionResult(ValidationErrorMessages.MethodologyMustBeDraft));
+            }
+
             return _userService
                 .CheckCanUpdateMethodology(tuple.Item1)
                 .OnSuccess(_ => tuple);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
@@ -430,12 +430,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         private Task<Either<ActionResult, Tuple<Methodology, ContentSection>>> CheckCanUpdateMethodology(
             Tuple<Methodology, ContentSection> tuple)
         {
-            if (tuple.Item1.Status != MethodologyStatus.Draft)
-            {
-                return Task.FromResult<Either<ActionResult, Tuple<Methodology, ContentSection>>>(
-                    ValidationActionResult(ValidationErrorMessages.MethodologyMustBeDraft));
-            }
-
             return _userService
                 .CheckCanUpdateMethodology(tuple.Item1)
                 .OnSuccess(_ => tuple);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/AssertExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/AssertExtensions.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
          * Calling this method causes a Test to fail with the given message.  The equivalent of `Assert.Fail()` in
          * other testing frameworks.
          */
-        public static T AssertFail<T>(string message) 
+        public static void AssertFail(string message) 
         {
             throw new XunitException(message);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/EitherTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/EitherTest.cs
@@ -283,8 +283,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model
         public async void OnSuccessCombineWith_FirstFails()
         {
             var either = await Task.FromResult(new Either<int, string>(500))
-                .OnSuccessCombineWith(firstSuccess => AssertFail<Task<Either<int, string>>>(
-                    "Second call should not be called if the first failed"));
+                .OnSuccessCombineWith(firstSuccess =>
+                {
+                    AssertFail("Second call should not be called if the first failed");
+                    return Task.FromResult(new Either<int, string>("this should not be called"));
+                });
 
             Assert.True(either.IsLeft);
             Assert.Equal(500, either.Left);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
@@ -122,14 +122,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
             return userService;
         }
 
-        public static void VerifyAllMocks(params object[] mocks)
+        public static void VerifyAllMocks(params Mock[] mocks)
         {
             mocks
                 .ToList()
-                .ForEach(m =>
+                .ForEach(mock =>
                 {
-                    m.GetType().GetMethod("VerifyAll", Type.EmptyTypes).Invoke(m, null);
-                    m.GetType().GetMethod("VerifyNoOtherCalls", Type.EmptyTypes).Invoke(m, null);
+                    mock.VerifyAll();
+
+                    // We can't cast from the non-generic Mock Type to the generic Mock<?> Type which has the
+                    // VerifyNoOtherCalls() method on it, so we need to look it up with reflection.
+                    var verifyNoOtherCallsMethod = mock.GetType().GetMethod("VerifyNoOtherCalls", Type.EmptyTypes);
+
+                    if (verifyNoOtherCallsMethod != null)
+                    {
+                        verifyNoOtherCallsMethod.Invoke(mock, null);
+                    }
                 });
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/CollectionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/CollectionUtils.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services
+{
+    public static class CollectionUtils
+    {
+        public static List<T> AsList<T>(params T[] objects)
+        {
+            return new List<T>(objects);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyTests.cs
@@ -1,0 +1,86 @@
+using System;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
+{
+    public class MethodologyTests
+    {
+        [Fact]
+        public void PubliclyVisible_ApprovedAndPublishedImmediately()
+        {
+            var methodology = new Methodology
+            {
+                Status = Approved,
+                PublishingStrategy = Immediately,
+            };
+            
+            Assert.True(methodology.PubliclyAccessible);
+        }
+        
+        [Fact]
+        public void PubliclyVisible_ApprovedAndScheduledWithLiveRelease()
+        {
+            var liveRelease = new Release
+            {
+                Id = Guid.NewGuid(),
+                Published = DateTime.UtcNow
+            };
+            
+            var methodology = new Methodology
+            {
+                Status = Approved,
+                PublishingStrategy = WithRelease,
+                ScheduledWithRelease = liveRelease,
+                ScheduledWithReleaseId = liveRelease.Id
+            };
+            
+            Assert.True(methodology.PubliclyAccessible);
+        }
+        
+        [Fact]
+        public void PubliclyVisible_NotApprovedSoNotVisible()
+        {
+            var methodology = new Methodology
+            {
+                Status = Draft,
+                PublishingStrategy = Immediately,
+            };
+            
+            Assert.False(methodology.PubliclyAccessible);
+        }
+        
+        [Fact]
+        public void PubliclyVisible_ApprovedButScheduledWithNonLiveReleaseSoNotVisible()
+        {
+            var nonLiveRelease = new Release
+            {
+                Id = Guid.NewGuid()
+            };
+            
+            var methodology = new Methodology
+            {
+                Status = Approved,
+                PublishingStrategy = WithRelease,
+                ScheduledWithRelease = nonLiveRelease,
+                ScheduledWithReleaseId = nonLiveRelease.Id
+            };
+            
+            Assert.False(methodology.PubliclyAccessible);
+        }
+
+        [Fact] 
+        public void PubliclyVisible_ScheduledWithReleaseNotIncluded()
+        {
+            var methodology = new Methodology
+            {
+                Status = Approved,
+                PublishingStrategy = WithRelease,
+                ScheduledWithReleaseId = Guid.NewGuid()
+            };
+            
+            Assert.Throws<InvalidOperationException>(() => methodology.PubliclyAccessible);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
@@ -54,8 +54,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public bool Live => Published.HasValue && DateTime.Compare(DateTime.UtcNow, Published.Value) > 0;
 
         public bool ScheduledForPublishingImmediately => PublishingStrategy == MethodologyPublishingStrategy.Immediately;
-        public bool ScheduledForPublishingWithPublishedRelease => PublishingStrategy == MethodologyPublishingStrategy.WithRelease
-            && ScheduledWithRelease.Live;
+        
+        public bool ScheduledForPublishingWithPublishedRelease
+        {
+            get
+            {
+                if (ScheduledWithReleaseId != null && ScheduledWithRelease == null)
+                {
+                    throw new InvalidOperationException("ScheduledWithRelease field not included in Methodology");
+                }
+                return PublishingStrategy == MethodologyPublishingStrategy.WithRelease
+                       && ScheduledWithRelease.Live;
+            }
+        }
 
         public bool PubliclyAccessible => Approved &&
                                           (ScheduledForPublishingImmediately ||

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
@@ -9,6 +9,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         Draft,
         Approved
     }
+    
+    public enum MethodologyPublishingStrategy
+    {
+        Immediately,
+        WithRelease
+    }
 
     public class Methodology
     {
@@ -36,7 +42,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public List<Publication> Publications { get; set; }
 
         public string InternalReleaseNote { get; set; }
+        
+        public MethodologyPublishingStrategy PublishingStrategy { get; set; }
+
+        public Release ScheduledWithRelease { get; set; }
+        
+        public Guid ScheduledWithReleaseId { get; set; }
+
+        public bool Approved => Status == MethodologyStatus.Approved;
 
         public bool Live => Published.HasValue && DateTime.Compare(DateTime.UtcNow, Published.Value) > 0;
+
+        public bool ScheduledForPublishingImmediately => PublishingStrategy == MethodologyPublishingStrategy.Immediately;
+        public bool ScheduledForPublishingWithPublishedRelease => PublishingStrategy == MethodologyPublishingStrategy.WithRelease
+            && ScheduledWithRelease.Live;
+
+        public bool PubliclyAccessible => Approved &&
+                                          (ScheduledForPublishingImmediately ||
+                                           ScheduledForPublishingWithPublishedRelease);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
@@ -45,8 +46,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         
         public MethodologyPublishingStrategy PublishingStrategy { get; set; }
 
+        [NotMapped]
         public Release ScheduledWithRelease { get; set; }
         
+        [NotMapped]
         public Guid ScheduledWithReleaseId { get; set; }
 
         public bool Approved => Status == MethodologyStatus.Approved;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
@@ -44,6 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public string InternalReleaseNote { get; set; }
         
+        [NotMapped]
         public MethodologyPublishingStrategy PublishingStrategy { get; set; }
 
         [NotMapped]

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Security/DefaultAuthenticationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Security/DefaultAuthenticationHandler.cs
@@ -16,9 +16,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Security
         {
         }
 
-        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
-            return AuthenticateResult.NoResult();
+            return Task.FromResult(AuthenticateResult.NoResult());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServicePermissionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -9,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 {
@@ -20,10 +22,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         };
 
         [Fact]
-        public void GetSubjectsMeta()
+        public async Task GetSubjectsMeta()
         {
-            PermissionTestUtils.PolicyCheckBuilder<ContentSecurityPolicies>()
-                .ExpectResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
+            await PolicyCheckBuilder<ContentSecurityPolicies>()
+                .SetupResourceCheckToFail(_release, ContentSecurityPolicies.CanViewRelease)
                 .AssertForbidden(
                     userService =>
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServicePermissionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
@@ -12,6 +13,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 {
@@ -31,10 +33,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         };
 
         [Fact]
-        public void Query_LatestRelease_CanViewSubjectData()
+        public async Task Query_LatestRelease_CanViewSubjectData()
         {
-            PermissionTestUtils.PolicyCheckBuilder<DataSecurityPolicies>()
-                .ExpectResourceCheckToFail(_subject, DataSecurityPolicies.CanViewSubjectData)
+            await PolicyCheckBuilder<DataSecurityPolicies>()
+                .SetupResourceCheckToFail(_subject, DataSecurityPolicies.CanViewSubjectData)
                 .AssertForbidden(
                     async userService =>
                     {
@@ -81,10 +83,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         }
 
         [Fact]
-        public void Query_ReleaseId_CanViewSubjectData()
+        public async Task Query_ReleaseId_CanViewSubjectData()
         {
-            PermissionTestUtils.PolicyCheckBuilder<DataSecurityPolicies>()
-                .ExpectResourceCheckToFail(_subject, DataSecurityPolicies.CanViewSubjectData)
+            await PolicyCheckBuilder<DataSecurityPolicies>()
+                .SetupResourceCheckToFail(_subject, DataSecurityPolicies.CanViewSubjectData)
                 .AssertForbidden(
                     async userService =>
                     {


### PR DESCRIPTION
This PR:
- adds a new `MakeAmendmentOfSpecificMethodologyAuthorizationHandler` class with associated permission checks
- adds new fields to `Methodology` to check if a given Methodology is publicly accessible
- adds a new stub `MethodologyAmendmentService` with permissions wired in and tested, but currently not wired into DI
- corrects various tests currently using the `PolicyCheckBuilder` that were not awaiting the results of their tests, and therefore always passing
- performs some slight `PolicyCheckBuilder` method renames to better reflect what they're doing
- creates a new `PolicyCheckBuilder.SetupResourceCheckToFailWithMatcher()` method that takes an argument-matching expression rather than an instance of an object, to match successfully against objects retrieved from the InMemory...DbContexts
- does some slight refactoring of the `MethodologyContentService`, `MethodologyContentServicePermissionTests` and `UpdateSpecificMetholodgyAuthorizationHandler` classes to push a Methodology Status check into the handler itself rather than the Service 