### PR TITLE
EES-2352 Remove Methodology from Publication after previous migration to associate them with Publication via MethodologyParent.

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ManageContent/ManageContentPageServiceTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.ManageContent
 {
@@ -51,11 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
                         Description = "Legacy 2018/19",
                         Order = 1,
                         Url = "http://legacy-2018-19"
-                    },
-                },
-                Methodology = new Methodology
-                {
-                    Title = "Methodology"
+                    }
                 },
                 Slug = "test-publication",
                 Summary = "Summary",
@@ -276,8 +271,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Manage
                 Assert.Equal("Data Source", contentPublication.DataSource);
                 Assert.Equal("Description", contentPublication.Description);
                 Assert.Null(contentPublication.ExternalMethodology);
-                Assert.Equal(publication.Methodology.Id, contentPublication.Methodology.Id);
-                Assert.Equal("Methodology", contentPublication.Methodology.Title);
+                // TODO SOW4 EES-2395 Test Manage Content page view model has linked Methodology
                 Assert.Equal("test-publication", contentPublication.Slug);
                 Assert.Equal("Summary", contentPublication.Summary);
                 Assert.Equal("Publication", contentPublication.Title);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyRepositoryTests.cs
@@ -4,220 +4,37 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies
 {
     public class MethodologyRepositoryTests
     {
         [Fact]
-        public async Task GetMethodologiesForUser_ReleaseRoleLead()
+        public async Task GetLatestMethodologiesByRelease()
         {
-            var userId = Guid.NewGuid();
-            var methodology = new Methodology
-            {
-                Title = "Test methodology",
-            };
-            var publication = new Publication
-            {
-                Methodology = methodology
-            };
-            var release = new Release
-            {
-                Publication = publication
-            };
-            var userReleaseRole = new UserReleaseRole
-            {
-                UserId = userId,
-                Release = release,
-                Role = ReleaseRole.Lead,
-            };
+            var release = new Release();
 
             var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                await contentDbContext.AddAsync(userReleaseRole);
+                await contentDbContext.Releases.AddAsync(release);
                 await contentDbContext.SaveChangesAsync();
             }
 
-            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var methodologyRepository = BuildMethodologyRepository(contentDbContext);
-                var methodologies = await methodologyRepository.GetMethodologiesForUser(userId);
+                var service = BuildMethodologyRepository(contentDbContext);
 
-                Assert.Single(methodologies);
-                Assert.Equal(methodology.Id, methodologies[0].Id);
-                Assert.Equal(methodology.Title, methodologies[0].Title);
+                var result = await service.GetLatestMethodologiesByRelease(release.Id);
+
+                // TODO SOW4 EES-2379 Test getting latest methodologies for a Release for approval checklist
+                Assert.Empty(result);
             }
         }
 
-        [Fact]
-        public async Task GetMethodologiesForUser_ReleaseRoleWithNullMethodology()
-        {
-            var userId = Guid.NewGuid();
-            var publication = new Publication
-            {
-                MethodologyId = null
-            };
-            var release = new Release
-            {
-                Publication = publication
-            };
-            var userReleaseRole = new UserReleaseRole
-            {
-                UserId = userId,
-                Release = release,
-                Role = ReleaseRole.Lead,
-            };
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.AddAsync(userReleaseRole);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var methodologyRepository = BuildMethodologyRepository(contentDbContext);
-                var methodologies = await methodologyRepository.GetMethodologiesForUser(userId);
-
-                Assert.Empty(methodologies);
-            }
-        }
-
-        [Fact]
-        public async Task GetMethodologiesForUser_ReleaseRolePrerelease()
-        {
-            var userId = Guid.NewGuid();
-            var methodology = new Methodology();
-            var publication = new Publication
-            {
-                Methodology = methodology
-            };
-            var release = new Release
-            {
-                Publication = publication
-            };
-            var userReleaseRole = new UserReleaseRole
-            {
-                UserId = userId,
-                Release = release,
-                Role = ReleaseRole.PrereleaseViewer,
-            };
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.AddAsync(userReleaseRole);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var methodologyRepository = BuildMethodologyRepository(contentDbContext);
-                var methodologies = await methodologyRepository.GetMethodologiesForUser(userId);
-
-                Assert.Empty(methodologies);
-            }
-        }
-
-        [Fact]
-        public async Task GetMethodologiesForUser_Multiple()
-        {
-            var userId = Guid.NewGuid();
-
-            // Associated with userId
-            var methodology1 = new Methodology
-            {
-                Title = "Test methodology 1",
-            };
-            var publication1 = new Publication
-            {
-                Title = "Test pub 1",
-                Methodology = methodology1
-            };
-            var release1 = new Release
-            {
-                Publication = publication1
-            };
-            var userReleaseRole1 = new UserReleaseRole
-            {
-                UserId = userId,
-                Release = release1,
-                Role = ReleaseRole.Lead,
-            };
-
-            var methodology2 = new Methodology
-            {
-                Title = "Test methodology 2",
-            };
-            var publication2 = new Publication
-            {
-                Title = "Test pub 2",
-                Methodology = methodology2
-            };
-            var release2 = new Release
-            {
-                Publication = publication2
-            };
-            var userReleaseRole2 = new UserReleaseRole
-            {
-                UserId = userId,
-                Release = release2,
-                Role = ReleaseRole.Contributor,
-            };
-
-            // Not associated with userId
-            var methodology3 = new Methodology
-            {
-                Title = "Ignored methodology 3",
-            };
-            var publication3 = new Publication
-            {
-                Title = "Test pub 3",
-                Methodology = methodology3
-            };
-            var release3 = new Release
-            {
-                Publication = publication3
-            };
-            var userReleaseRole3 = new UserReleaseRole
-            {
-                UserId = Guid.NewGuid(),
-                Release = release3,
-                Role = ReleaseRole.Lead,
-            };
-
-            var methodology4 = new Methodology
-            {
-                Title = "Ignored methodology 4",
-            };
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await contentDbContext.AddRangeAsync(
-                    userReleaseRole1,
-                    userReleaseRole2,
-                    userReleaseRole3,
-                    methodology4);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = DbUtils.InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var methodologyRepository = BuildMethodologyRepository(contentDbContext);
-                var methodologies = await methodologyRepository.GetMethodologiesForUser(userId);
-
-                Assert.Equal(2, methodologies.Count);
-                Assert.Contains(methodologies, m => m.Id == methodology1.Id);
-                Assert.Contains(methodologies, m => m.Id == methodology2.Id);
-                Assert.DoesNotContain(methodologies, m => m.Id == methodology3.Id);
-                Assert.DoesNotContain(methodologies, m => m.Id == methodology4.Id);
-            }
-        }
-
-        private MethodologyRepository BuildMethodologyRepository(ContentDbContext contentDbContext)
+        private static MethodologyRepository BuildMethodologyRepository(ContentDbContext contentDbContext)
         {
             return new MethodologyRepository(contentDbContext);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServiceTests.cs
@@ -35,11 +35,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Title = "Test theme"
                     }
                 },
-                Methodology = new Methodology
-                {
-                    Title = "Test methodology",
-                    Status = MethodologyStatus.Approved,
-                },
                 Contact = new Contact
                 {
                     ContactName = "Test contact",
@@ -72,9 +67,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(publication.Topic.Id, result.Right.TopicId);
                 Assert.Equal(publication.Topic.ThemeId, result.Right.ThemeId);
 
-                Assert.Equal(publication.Methodology.Id, result.Right.Methodology.Id);
-                Assert.Equal(publication.Methodology.Title, result.Right.Methodology.Title);
-
                 Assert.Equal(publication.Contact.Id, result.Right.Contact.Id);
                 Assert.Equal(publication.Contact.ContactName, result.Right.Contact.ContactName);
                 Assert.Equal(publication.Contact.ContactTelNo, result.Right.Contact.ContactTelNo);
@@ -102,18 +94,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "Test topic"
             };
-            var methodology = new Methodology
-            {
-                Title = "Test methodology",
-                Status = MethodologyStatus.Approved,
-            };
 
             var contextId = Guid.NewGuid().ToString();
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 context.Add(topic);
-                context.Add(methodology);
                 await context.SaveChangesAsync();
             }
 
@@ -147,9 +133,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(topic.Id, publicationViewModel.TopicId);
 
-                Assert.Equal(methodology.Id, publicationViewModel.Methodology.Id);
-                Assert.Equal("Test methodology", publicationViewModel.Methodology.Title);
-
                 // Do an in depth check of the saved release
                 var createdPublication = await context.Publications.FindAsync(publicationViewModel.Id);
                 Assert.False(createdPublication.Live);
@@ -164,9 +147,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(topic.Id, createdPublication.TopicId);
                 Assert.Equal("Test topic", createdPublication.Topic.Title);
-
-                Assert.Equal(methodology.Id, createdPublication.Methodology.Id);
-                Assert.Equal("Test methodology", createdPublication.Methodology.Title);
             }
         }
 
@@ -239,21 +219,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "New topic"
             };
-            var methodology = new Methodology
-            {
-                Title = "New methodology",
-                Status = MethodologyStatus.Approved,
-            };
+
             var publication = new Publication
             {
                 Title = "Old title",
                 Topic = new Topic
                 {
                     Title = "Old topic"
-                },
-                Methodology = new Methodology
-                {
-                    Title = "Old methodology"
                 },
                 Contact = new Contact
                 {
@@ -269,7 +241,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 context.Add(topic);
-                context.Add(methodology);
                 context.Add(publication);
 
                 await context.SaveChangesAsync();
@@ -304,9 +275,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("john.smith@test.com", result.Right.Contact.TeamEmail);
 
                 Assert.Equal(topic.Id, result.Right.TopicId);
-
-                Assert.Equal(methodology.Id, result.Right.Methodology.Id);
-                Assert.Equal("New methodology", result.Right.Methodology.Title);
 
                 // Do an in depth check of the saved release
                 var updatedPublication = await context.Publications.FindAsync(result.Right.Id);
@@ -323,9 +291,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(topic.Id, updatedPublication.TopicId);
                 Assert.Equal("New topic", updatedPublication.Topic.Title);
-
-                Assert.Equal(methodology.Id, updatedPublication.MethodologyId);
-                Assert.Equal("New methodology", updatedPublication.Methodology.Title);
             }
         }
 
@@ -336,11 +301,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Title = "New topic"
             };
-            var methodology = new Methodology
-            {
-                Title = "New methodology",
-                Status = MethodologyStatus.Approved,
-            };
+
             var publication = new Publication
             {
                 Slug = "old-title",
@@ -348,10 +309,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Topic = new Topic
                 {
                     Title = "Old topic"
-                },
-                Methodology = new Methodology
-                {
-                    Title = "Old methodology"
                 },
                 Contact = new Contact
                 {
@@ -368,7 +325,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 context.Add(topic);
-                context.Add(methodology);
                 context.Add(publication);
 
                 await context.SaveChangesAsync();
@@ -403,9 +359,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("john.smith@test.com", result.Right.Contact.TeamEmail);
 
                 Assert.Equal(topic.Id, result.Right.TopicId);
-
-                Assert.Equal(methodology.Id, result.Right.Methodology.Id);
-                Assert.Equal("New methodology", result.Right.Methodology.Title);
 
                 // Do an in depth check of the saved release
                 var updatedPublication = await context.Publications.FindAsync(result.Right.Id);
@@ -423,9 +376,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(topic.Id, updatedPublication.TopicId);
                 Assert.Equal("New topic", updatedPublication.Topic.Title);
-
-                Assert.Equal(methodology.Id, updatedPublication.MethodologyId);
-                Assert.Equal("New methodology", updatedPublication.Methodology.Title);
             }
         }
 
@@ -438,12 +388,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Topic = new Topic
                 {
                     Title = "Test topic"
-                },
-                Methodology = new Methodology
-                {
-                    Title = "Test methodology",
-                    Status = MethodologyStatus.Approved
-                },
+                }
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -502,11 +447,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 {
                     Title = "Test topic"
                 },
-                Methodology = new Methodology
-                {
-                    Title = "Test methodology",
-                    Status = MethodologyStatus.Approved
-                },
                 Contact = sharedContact
             };
             var otherPublication = new Publication
@@ -563,10 +503,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Topic = new Topic
                 {
                     Title = "Test topic"
-                },
-                Methodology = new Methodology
-                {
-                    Title = "Test methodology"
                 }
             };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseChecklistServicePermissionTests.cs
@@ -1,6 +1,7 @@
 using System;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -44,6 +45,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IUserService userService = null,
             IMetaGuidanceService metaGuidanceService = null,
             IReleaseDataFileRepository releaseDataFileRepository = null,
+            IMethodologyRepository methodologyRepository = null,
             IFootnoteRepository footnoteRepository = null,
             IDataBlockService dataBlockService = null)
         {
@@ -55,6 +57,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 userService ?? MockUtils.AlwaysTrueUserService().Object,
                 metaGuidanceService ?? new Mock<IMetaGuidanceService>().Object,
                 releaseDataFileRepository ?? new Mock<IReleaseDataFileRepository>().Object,
+                methodologyRepository ?? new Mock<IMethodologyRepository>().Object,
                 footnoteRepository ?? new Mock<IFootnoteRepository>().Object,
                 dataBlockService ?? new Mock<IDataBlockService>().Object
             );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -175,13 +175,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                                 Title = r.Publication.ExternalMethodology.Title,
                                 Url = r.Publication.ExternalMethodology.Url
                             }
-                            : null,
-                        Methodology = r.Publication.Methodology != null
-                            ? new MethodologyTitleViewModel
-                                {
-                                    Id = r.Publication.Methodology.Id,
-                                    Title = r.Publication.Methodology.Title
-                                }
                             : null
                     }))
                 .ForMember(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210608113655_EES2352_RemoveMethodologyFromPublication.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210608113655_EES2352_RemoveMethodologyFromPublication.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210608113655_EES2352_RemoveMethodologyFromPublication")]
+    partial class EES2352_RemoveMethodologyFromPublication
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210608113655_EES2352_RemoveMethodologyFromPublication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210608113655_EES2352_RemoveMethodologyFromPublication.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES2352_RemoveMethodologyFromPublication : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Publications_Methodologies_MethodologyId",
+                table: "Publications");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Publications_MethodologyId",
+                table: "Publications");
+
+            migrationBuilder.DropColumn(
+                name: "MethodologyId",
+                table: "Publications");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "MethodologyId",
+                table: "Publications",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Publications_MethodologyId",
+                table: "Publications",
+                column: "MethodologyId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Publications_Methodologies_MethodologyId",
+                table: "Publications",
+                column: "MethodologyId",
+                principalTable: "Methodologies",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyRepository.cs
@@ -7,6 +7,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 {
     public interface IMethodologyRepository
     {
-        Task<List<Methodology>> GetMethodologiesForUser(Guid userId);
+        Task<List<Methodology>> GetLatestMethodologiesByRelease(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
@@ -74,8 +74,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                 .Include(r => r.Publication)
                 .ThenInclude(publication => publication.LegacyReleases)
                 .Include(r => r.Publication)
-                .ThenInclude(publication => publication.Methodology)
-                .Include(r => r.Publication)
                 .ThenInclude(publication => publication.Topic.Theme)
                 .Include(r => r.Type)
                 .Include(r => r.Content)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyRepository.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies
 {
@@ -19,19 +17,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             _contentDbContext = contentDbContext;
         }
 
-        public async Task<List<Methodology>> GetMethodologiesForUser(Guid userId)
+        public async Task<List<Methodology>> GetLatestMethodologiesByRelease(Guid releaseId)
         {
-            return await _contentDbContext.UserReleaseRoles
-                .Include(urr => urr.Release)
-                .ThenInclude(r => r.Publication)
-                .ThenInclude(p => p.Methodology)
-                .Where(urr =>
-                    urr.UserId == userId
-                    && urr.Release.Publication.MethodologyId != null
-                    && urr.Role != ReleaseRole.PrereleaseViewer)
-                .Select(urr => urr.Release.Publication.Methodology)
-                .Distinct()
-                .ToListAsync();
+            // TODO SOW4 EES-2379 Get latest methodologies for a Release for approval checklist
+            return await Task.FromResult(new List<Methodology>());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -253,7 +253,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .Include(p => p.Releases)
                 .ThenInclude(r => r.Type)
                 .Include(p => p.LegacyReleases)
-                .Include(p => p.Methodology)
                 .Include(p => p.Topic);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ManageContent/ManageContentPageViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ManageContent/ManageContentPageViewModel.cs
@@ -99,6 +99,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageCont
 
             public Contact Contact { get; set; }
 
+            // TODO SOW4 EES-2395 Update Manage Content page to show linked Methodology
             public MethodologyTitleViewModel Methodology { get; set; }
 
             public ExternalMethodology ExternalMethodology { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/PublicationViewModels.cs
@@ -20,6 +20,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public List<LegacyReleaseViewModel> LegacyReleases { get; set; }
 
+        // TODO SOW4 EES-2220 Update this after Publication is created with Methodology
         public MethodologyTitleViewModel Methodology { get; set; }
 
         public ExternalMethodology ExternalMethodology { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -22,11 +22,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return $"{AppendPathSeparator(prefix)}fast-track";
         }
 
-        private static string PublicContentMethodologiesPath(string prefix = null)
-        {
-            return $"{AppendPathSeparator(prefix)}methodology";
-        }
-
         private static string PublicContentPublicationsPath(string prefix = null)
         {
             return $"{AppendPathSeparator(prefix)}publications";
@@ -47,19 +42,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return $"{PublicContentReleaseFastTrackPath(releaseId, prefix)}/{id}.json";
         }
 
-        public static string PublicContentMethodologyTreePath(string prefix = null)
-        {
-            return $"{PublicContentMethodologiesPath(prefix)}/tree.json";
-        }
-
         public static string PublicContentPublicationsTreePath(string prefix = null)
         {
             return $"{PublicContentPublicationsPath(prefix)}/tree.json";
-        }
-
-        public static string PublicContentMethodologyPath(string slug, string prefix = null)
-        {
-            return $"{PublicContentMethodologiesPath(prefix)}/methodologies/{slug}.json";
         }
 
         public static string PublicContentPublicationParentPath(string slug, string prefix = null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/MethodologyControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/MethodologyControllerTests.cs
@@ -1,10 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
-using GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using Microsoft.AspNetCore.Mvc;
-using Moq;
 using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers
@@ -14,48 +10,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         [Fact]
         public async Task Get()
         {
-            var fileStorageService = new Mock<IFileStorageService>();
+            // TODO SOW4 EES-2375 Update tests after change to return methodology from content database
 
-            fileStorageService.Setup(
-                    s =>
-                        s.GetDeserialized<MethodologyViewModel>("methodology/methodologies/test-slug.json"
-                    )
-                )
-                .ReturnsAsync(
-                    new MethodologyViewModel
-                    {
-                        Content = new List<ContentSectionViewModel>
-                        {
-                            new ContentSectionViewModel()
-                        },
-                        Annexes = new List<ContentSectionViewModel>
-                        {
-                            new ContentSectionViewModel()
-                        }
-                    }
-                );
-
-            var controller = new MethodologyController(fileStorageService.Object);
+            var controller = new MethodologyController();
 
             var result = await controller.Get("test-slug");
-            var methodologyViewModel = result.Value;
 
-            Assert.IsType<MethodologyViewModel>(methodologyViewModel);
-
-            Assert.Single(methodologyViewModel.Content);
-            Assert.Single(methodologyViewModel.Annexes);
+            Assert.IsType<NotFoundResult>(result.Result);
         }
 
         [Fact]
         public async Task Get_NotFound()
         {
-            var fileStorageService = new Mock<IFileStorageService>();
-
-            fileStorageService
-                .Setup(s => s.GetDeserialized<MethodologyViewModel>(It.IsAny<string>()))
-                .ReturnsAsync(new NotFoundResult());
-
-            var controller = new MethodologyController(fileStorageService.Object);
+            var controller = new MethodologyController();
 
             var result = await controller.Get("unknown-slug");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
@@ -113,47 +114,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         [Fact]
         public async Task GetMethodologyThemes()
         {
-            var fileStorageService = new Mock<IFileStorageService>();
-
-            fileStorageService
-                .Setup(
-                    s => s.GetDeserialized<IEnumerable<ThemeTree<MethodologyTreeNode>>>(
-                        "methodology/tree.json"
-                    )
-                )
-                .ReturnsAsync(
-                    new List<ThemeTree<MethodologyTreeNode>>
-                    {
-                        new ThemeTree<MethodologyTreeNode>
-                        {
-                            Topics = new List<TopicTree<MethodologyTreeNode>>
-                            {
-                                new TopicTree<MethodologyTreeNode>
-                                {
-                                    Publications = new List<MethodologyTreeNode>
-                                    {
-                                        new MethodologyTreeNode()
-                                    }
-                                }
-                            }
-                        }
-                    }
-                );
+            var fileStorageService = new Mock<IFileStorageService>(MockBehavior.Strict);
 
             var controller = new ThemeController(fileStorageService.Object);
 
             var result = await controller.GetMethodologyThemes();
 
-            Assert.IsAssignableFrom<IEnumerable<ThemeTree<MethodologyTreeNode>>>(result.Value);
-            Assert.Single(result.Value);
+            // TODO SOW4 EES-2378 Return all public methodologies from content database
+            // Assert.IsAssignableFrom<IEnumerable<ThemeTree<MethodologyTreeNode>>>(result.Value);
+            Assert.Empty(result.Value);
+            // Assert.Single(result.Value);
+            //
+            // var theme = result.Value.First();
+            //
+            // Assert.IsType<ThemeTree<MethodologyTreeNode>>(theme);
+            // Assert.Single(theme.Topics);
+            //
+            // var topic = theme.Topics.First();
+            // Assert.Single(topic.Publications);
 
-            var theme = result.Value.First();
-
-            Assert.IsType<ThemeTree<MethodologyTreeNode>>(theme);
-            Assert.Single(theme.Topics);
-
-            var topic = theme.Topics.First();
-            Assert.Single(topic.Publications);
+            MockUtils.VerifyAllMocks(fileStorageService);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/MethodologyController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/MethodologyController.cs
@@ -1,10 +1,7 @@
 ﻿using System.Net.Mime;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using Microsoft.AspNetCore.Mvc;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
 {
@@ -12,18 +9,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
     [Produces(MediaTypeNames.Application.Json)]
     public class MethodologyController : ControllerBase
     {
-        private readonly IFileStorageService _fileStorageService;
-
-        public MethodologyController(IFileStorageService fileStorageService)
+        public MethodologyController()
         {
-            _fileStorageService = fileStorageService;
         }
 
         [HttpGet("methodologies/{slug}")]
         public async Task<ActionResult<MethodologyViewModel>> Get(string slug)
         {
-            return await _fileStorageService.GetDeserialized<MethodologyViewModel>(PublicContentMethodologyPath(slug))
-                .HandleFailuresOrOk();
+            // TODO SOW4 EES-2375 Return methodology from content database
+            return new NotFoundResult();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ThemeController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ThemeController.cs
@@ -41,9 +41,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         [HttpGet("methodology-themes")]
         public async Task<ActionResult<IEnumerable<ThemeTree<MethodologyTreeNode>>>> GetMethodologyThemes()
         {
-            return await _fileStorageService
-                .GetDeserialized<IEnumerable<ThemeTree<MethodologyTreeNode>>>(PublicContentMethodologyTreePath())
-                .HandleFailuresOrOk();
+            // TODO SOW4 EES-2378 Return all public methodologies from content database
+            return await Task.FromResult(new List<ThemeTree<MethodologyTreeNode>>());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Publication.cs
@@ -21,10 +21,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<Release> Releases { get; set; } = new List<Release>();
 
-        public Guid? MethodologyId { get; set; }
-
-        public Methodology Methodology { get; set; }
-
         public ExternalMethodology ExternalMethodology { get; set; }
 
         public Uri LegacyPublicationUrl { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/CachedPublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/CachedPublicationViewModel.cs
@@ -27,6 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels
 
         public ContactViewModel Contact { get; set; }
 
+        // TODO SOW4 EES-2375 Remove this when Content API returns methodology from Content database
         public MethodologySummaryViewModel Methodology { get; set; }
 
         public ExternalMethodologyViewModel ExternalMethodology { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -17,114 +16,115 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 {
     public class MethodologyServiceTests
     {
-        [Fact]
-        public async Task GetTree()
-        {
-            var topicA = new Topic
-            {
-                Title = "Topic A",
-                Theme = new Theme
-                {
-                    Title = "Theme A",
-                    Slug = "theme-a",
-                    Summary = "The first theme"
-                },
-                Slug = "topic-a"
-            };
-
-            var methodologyA = new Methodology
-            {
-                Slug = "methodology-a",
-                Title = "Methodology A",
-                Summary = "first methodology",
-                Published = new DateTime(2019, 1, 01),
-                Updated = new DateTime(2019, 1, 15),
-                Annexes = new List<ContentSection>(),
-                Content = new List<ContentSection>()
-            };
-
-            var methodologyB = new Methodology
-            {
-                Slug = "methodology-b",
-                Title = "Methodology B",
-                Summary = "second methodology",
-                Published = new DateTime(2019, 3, 01),
-                Updated = new DateTime(2019, 3, 15),
-                Annexes = new List<ContentSection>(),
-                Content = new List<ContentSection>()
-            };
-
-            var publicationA = new Publication
-            {
-                Title = "Publication A",
-                Topic = topicA,
-                Slug = "publication-a",
-                Summary = "first publication",
-                Methodology = methodologyA
-            };
-
-            var publicationB = new Publication
-            {
-                Title = "Publication B",
-                Topic = topicA,
-                Slug = "publication-b",
-                Summary = "second publication",
-                Methodology = methodologyB
-            };
-
-            var publicationARelease1 = new Release
-            {
-                Publication = publicationA,
-                ReleaseName = "2018",
-                TimePeriodCoverage = AcademicYearQ1,
-                Published = new DateTime(2019, 1, 01),
-                Status = Approved
-            };
-
-            var publicationBRelease1 = new Release
-            {
-                Publication = publicationB,
-                ReleaseName = "2018",
-                TimePeriodCoverage = AcademicYearQ1,
-                Published = null,
-                Status = Draft
-            };
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            {
-                await contentDbContext.Topics.AddAsync(topicA);
-                await contentDbContext.Methodologies.AddRangeAsync(methodologyA, methodologyB);
-                await contentDbContext.Publications.AddRangeAsync(publicationA, publicationB);
-                await contentDbContext.Releases.AddRangeAsync(publicationARelease1, publicationBRelease1);
-                await contentDbContext.SaveChangesAsync();
-            }
-
-            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            {
-                var service = new MethodologyService(contentDbContext, MapperForProfile<MappingProfiles>());
-
-                var result = service.GetTree(Enumerable.Empty<Guid>());
-
-                Assert.Single(result);
-                var theme = result.First();
-                Assert.Equal("Theme A", theme.Title);
-
-                Assert.Single(theme.Topics);
-                var topic = theme.Topics.First();
-                Assert.Equal("Topic A", topic.Title);
-
-                Assert.Single(topic.Publications);
-                var publication = topic.Publications.First();
-                Assert.Equal("Publication A", publication.Title);
-
-                var methodology = publication.Methodology;
-                Assert.Equal("methodology-a", methodology.Slug);
-                Assert.Equal("first methodology", methodology.Summary);
-                Assert.Equal("Methodology A", methodology.Title);
-            }
-        }
+        // TODO SOW4 EES-2375 Update for new model after moving to Content API
+        // [Fact]
+        // public async Task GetTree()
+        // {
+        //     var topicA = new Topic
+        //     {
+        //         Title = "Topic A",
+        //         Theme = new Theme
+        //         {
+        //             Title = "Theme A",
+        //             Slug = "theme-a",
+        //             Summary = "The first theme"
+        //         },
+        //         Slug = "topic-a"
+        //     };
+        //
+        //     var methodologyA = new Methodology
+        //     {
+        //         Slug = "methodology-a",
+        //         Title = "Methodology A",
+        //         Summary = "first methodology",
+        //         Published = new DateTime(2019, 1, 01),
+        //         Updated = new DateTime(2019, 1, 15),
+        //         Annexes = new List<ContentSection>(),
+        //         Content = new List<ContentSection>()
+        //     };
+        //
+        //     var methodologyB = new Methodology
+        //     {
+        //         Slug = "methodology-b",
+        //         Title = "Methodology B",
+        //         Summary = "second methodology",
+        //         Published = new DateTime(2019, 3, 01),
+        //         Updated = new DateTime(2019, 3, 15),
+        //         Annexes = new List<ContentSection>(),
+        //         Content = new List<ContentSection>()
+        //     };
+        //
+        //     var publicationA = new Publication
+        //     {
+        //         Title = "Publication A",
+        //         Topic = topicA,
+        //         Slug = "publication-a",
+        //         Summary = "first publication",
+        //         Methodology = methodologyA
+        //     };
+        //
+        //     var publicationB = new Publication
+        //     {
+        //         Title = "Publication B",
+        //         Topic = topicA,
+        //         Slug = "publication-b",
+        //         Summary = "second publication",
+        //         Methodology = methodologyB
+        //     };
+        //
+        //     var publicationARelease1 = new Release
+        //     {
+        //         Publication = publicationA,
+        //         ReleaseName = "2018",
+        //         TimePeriodCoverage = AcademicYearQ1,
+        //         Published = new DateTime(2019, 1, 01),
+        //         Status = Approved
+        //     };
+        //
+        //     var publicationBRelease1 = new Release
+        //     {
+        //         Publication = publicationB,
+        //         ReleaseName = "2018",
+        //         TimePeriodCoverage = AcademicYearQ1,
+        //         Published = null,
+        //         Status = Draft
+        //     };
+        //
+        //     var contentDbContextId = Guid.NewGuid().ToString();
+        //
+        //     await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        //     {
+        //         await contentDbContext.Topics.AddAsync(topicA);
+        //         await contentDbContext.Methodologies.AddRangeAsync(methodologyA, methodologyB);
+        //         await contentDbContext.Publications.AddRangeAsync(publicationA, publicationB);
+        //         await contentDbContext.Releases.AddRangeAsync(publicationARelease1, publicationBRelease1);
+        //         await contentDbContext.SaveChangesAsync();
+        //     }
+        //
+        //     await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+        //     {
+        //         var service = new MethodologyService(contentDbContext, MapperForProfile<MappingProfiles>());
+        //
+        //         var result = service.GetTree(Enumerable.Empty<Guid>());
+        //
+        //         Assert.Single(result);
+        //         var theme = result.First();
+        //         Assert.Equal("Theme A", theme.Title);
+        //
+        //         Assert.Single(theme.Topics);
+        //         var topic = theme.Topics.First();
+        //         Assert.Equal("Topic A", topic.Title);
+        //
+        //         Assert.Single(topic.Publications);
+        //         var publication = topic.Publications.First();
+        //         Assert.Equal("Publication A", publication.Title);
+        //
+        //         var methodology = publication.Methodology;
+        //         Assert.Equal("methodology-a", methodology.Slug);
+        //         Assert.Equal("first methodology", methodology.Summary);
+        //         Assert.Equal("Methodology A", methodology.Title);
+        //     }
+        // }
 
         [Fact]
         public async Task GetFiles()
@@ -275,15 +275,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         [Fact]
         public async Task GetByRelease()
         {
-            var methodology = new Methodology();
-
             var release = new Release
             {
                 Publication = new Publication
                 {
                     Title = "Publication",
-                    Slug = "publication-slug",
-                    Methodology = methodology
+                    Slug = "publication-slug"
                 },
                 ReleaseName = "2018",
                 TimePeriodCoverage = AcademicYearQ1,
@@ -294,17 +291,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
-                await contentDbContext.Methodologies.AddAsync(methodology);
                 await contentDbContext.Releases.AddAsync(release);
                 await contentDbContext.SaveChangesAsync();
             }
-            
+
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = SetupMethodologyService(contentDbContext);
 
                 var result = await service.GetByRelease(release.Id);
-                Assert.Equal(methodology.Id, result.Id);
+                //TODO SOW4 EES-2385 Get the latest methodologies related to this release
+                Assert.Empty(result);
             }
         }
 
@@ -317,7 +314,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 {
                     Title = "Publication",
                     Slug = "publication-slug",
-                    Methodology = null
                 },
                 ReleaseName = "2018",
                 TimePeriodCoverage = AcademicYearQ1,
@@ -337,7 +333,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 var service = SetupMethodologyService(contentDbContext);
 
                 var result = await service.GetByRelease(release.Id);
-                Assert.Null(result);
+                Assert.Empty(result);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublicationServiceTests.cs
@@ -61,16 +61,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             TeamName = "third contact team name"
         };
 
-        private static readonly Methodology Methodology = new Methodology
-        {
-            Id = Guid.NewGuid(),
-            Title = "methodology title",
-            Slug = "methodology-slug",
-            Summary = "methodology summary",
-            Published = new DateTime(2020, 2, 10),
-            Updated = new DateTime(2020, 2, 11)
-        };
-
         private static readonly Publication PublicationA = new Publication
         {
             Id = Guid.NewGuid(),
@@ -108,7 +98,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                   Url = "http://link.two/"
               }
             },
-            MethodologyId = Methodology.Id,
             Slug = "publication-a",
             Summary = "first publication summary",
             LegacyPublicationUrl = new Uri("http://legacy.url/")
@@ -295,7 +284,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
             {
-                context.Add(Methodology);
                 context.Add(Theme);
                 context.Add(Topic);
                 context.AddRange(Publications);
@@ -356,13 +344,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 Assert.Equal("http://link.two/", legacyReleases[1].Url);
                 Assert.Equal("Academic Year 2008/09", legacyReleases[2].Description);
                 Assert.Equal("http://link.one/", legacyReleases[2].Url);
-
-                Assert.NotNull(viewModel.Methodology);
-                var methodology = viewModel.Methodology;
-                Assert.Equal(Methodology.Id, methodology.Id);
-                Assert.Equal("methodology-slug", methodology.Slug);
-                Assert.Equal("methodology summary", methodology.Summary);
-                Assert.Equal("methodology title", methodology.Title);
 
                 Assert.NotNull(viewModel.Releases);
                 var releases = viewModel.Releases;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishMethodologyFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishMethodologyFunction.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
-using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
@@ -12,13 +10,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
     // ReSharper disable once UnusedType.Global
     public class PublishMethodologyFunction
     {
-        private readonly IContentService _contentService;
         private readonly IPublishingService _publishingService;
 
-        public PublishMethodologyFunction(IContentService contentService,
-            IPublishingService publishingService)
+        public PublishMethodologyFunction(IPublishingService publishingService)
         {
-            _contentService = contentService;
             _publishingService = publishingService;
         }
 
@@ -34,9 +29,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 executionContext.FunctionName,
                 message);
 
-            var context = new PublishContext(DateTime.UtcNow, false);
-
-            await _contentService.UpdateMethodology(context, message.MethodologyId);
             await _publishingService.PublishMethodologyFiles(message.MethodologyId);
 
             logger.LogInformation("{0} completed",

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
@@ -60,10 +60,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 await UpdateStage(releaseId, releaseStatusId, Started);
                 try
                 {
-                    var methodology = await _methodologyService.GetByRelease(releaseId);
-                    // Publish the files of the Methodology if it's not already live
-                    // Since the Methodology will be published for the first time with this Release
-                    if (methodology != null && !methodology.Live)
+                    var methodologies = await _methodologyService.GetByRelease(releaseId);
+                    // TODO SOW4 EES-2385 Publish the files of the latest methodologies of this release that
+                    // aren't already live but depended on this release being published,
+                    // since those methodologies will be published for the first time with this release
+                    foreach (var methodology in methodologies)
                     {
                         await _publishingService.PublishMethodologyFiles(methodology.Id);
                     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
@@ -14,8 +14,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task UpdateContent(PublishContext context, params Guid[] releaseIds);
 
-        Task UpdateMethodology(PublishContext context, Guid methodologyId);
-
         Task UpdatePublication(PublishContext context, Guid publicationId);
 
         Task UpdateTaxonomy(PublishContext context);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
@@ -12,14 +12,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
     {
         Task<Methodology> Get(Guid id);
 
-        Task<Methodology> GetByRelease(Guid releaseId);
+        Task<List<Methodology>> GetByRelease(Guid releaseId);
 
         Task<List<File>> GetFiles(Guid methodologyId, params FileType[] types);
 
+        // TODO SOW4 EES-2375 Move to Content API
         Task<MethodologyViewModel> GetViewModelAsync(Guid id, PublishContext context);
 
+        // TODO SOW4 EES-2378 Move to Content API
         List<ThemeTree<MethodologyTreeNode>> GetTree(IEnumerable<Guid> includedReleaseIds);
-
-        Task SetPublishedDate(Guid id, DateTime published);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublicationService.cs
@@ -43,7 +43,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             var publication = await _contentDbContext.Publications
                 .Include(p => p.Contact)
                 .Include(p => p.LegacyReleases)
-                .Include(p => p.Methodology)
                 .Include(p => p.Topic)
                 .ThenInclude(topic => topic.Theme)
                 .SingleOrDefaultAsync(p => p.Id == id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -140,7 +140,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         {
             var contentRelease = await _contentDbContext.Releases
                 .Include(release => release.Publication)
-                .ThenInclude(publication => publication.Methodology)
                 .SingleOrDefaultAsync(r => r.Id == id);
 
             var statisticsRelease = await _statisticsDbContext.Release
@@ -171,13 +170,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
             // Update the Publication published date since we always generate the Publication when generating Release Content
             contentRelease.Publication.Published = published;
-
-            // Update the Methodology published date if it's the first time it's published
-            var methodology = contentRelease.Publication.Methodology;
-            if (methodology != null)
-            {
-                methodology.Published ??= published;
-            }
 
             await _contentDbContext.SaveChangesAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -48,7 +48,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                         publicBlobStorageService: GetBlobStorageService(provider, "PublicStorage"),
                         fastTrackService: provider.GetService<IFastTrackService>(),
                         downloadService: provider.GetRequiredService<IDownloadService>(),
-                        methodologyService: provider.GetRequiredService<IMethodologyService>(),
                         releaseService: provider.GetRequiredService<IReleaseService>(),
                         publicationService: provider.GetRequiredService<IPublicationService>()
                     ))


### PR DESCRIPTION
Methodology has a parent currently called `MethodologyParent`.

Publications can be linked to many `MethodologyParent`s through the `PublicationMethodologies` many-to-many relationship, allowing a Publication to adopt potentially many methodologies in future, including 'owning' one of its own.

This PR removes the `Methodology` and `MethodologyId` fields from `Publication` which is now possible after the previous migration in https://github.com/dfe-analytical-services/explore-education-statistics/pull/2560 to associate them with `Publication` via new parent `MethodologyParent` linked in `PublicationMethodologies`.

It adds many placeholder `TODO` comments for future work to determine the latest related versions of methodologies and for a change to publishing where the Content API will be responsible for returning methodologies from the database rather than from a storage account.