### PR TITLE
EES-51 published and scheduled tags

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
@@ -6,7 +6,6 @@ import {
 import { Release } from '@admin/services/releaseService';
 import Details from '@common/components/Details';
 import FormattedDate from '@common/components/FormattedDate';
-import LoadingSpinner from '@common/components/LoadingSpinner';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import Tag from '@common/components/Tag';
@@ -16,7 +15,6 @@ import {
   isValidPartialDate,
 } from '@common/utils/date/partialDate';
 import React, { ReactNode } from 'react';
-import LazyLoad from 'react-lazyload';
 
 interface Props {
   release: Release;
@@ -40,21 +38,17 @@ const ReleaseSummary = ({
       summary={getReleaseSummaryLabel(release)}
       summaryAfter={
         <TagGroup className="govuk-!-margin-left-2">
-          <Tag>{getReleaseStatusLabel(release.status)}</Tag>
-
-          {release.amendment && <Tag>Amendment</Tag>}
-
-          {release.status === 'Approved' && (
-            <LazyLoad
-              once
-              scroll={false}
-              placeholder={
-                <LoadingSpinner className="govuk-!-margin-0" inline size="sm" />
-              }
-            >
-              <ReleaseServiceStatus exclude="details" releaseId={release.id} />
-            </LazyLoad>
+          {release.status !== 'Approved' && (
+            <Tag>{getReleaseStatusLabel(release.status)}</Tag>
           )}
+          {release.status === 'Approved' && (
+            <ReleaseServiceStatus
+              exclude="details"
+              releaseId={release.id}
+              isApproved
+            />
+          )}
+          {release.amendment && <Tag>Amendment</Tag>}
         </TagGroup>
       }
     >

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
@@ -15,6 +15,8 @@ import {
   isValidPartialDate,
 } from '@common/utils/date/partialDate';
 import React, { ReactNode } from 'react';
+import LazyLoad from 'react-lazyload';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 
 interface Props {
   release: Release;
@@ -42,11 +44,18 @@ const ReleaseSummary = ({
             <Tag>{getReleaseStatusLabel(release.status)}</Tag>
           )}
           {release.status === 'Approved' && (
-            <ReleaseServiceStatus
-              exclude="details"
-              releaseId={release.id}
-              isApproved
-            />
+            <LazyLoad
+              once
+              placeholder={
+                <LoadingSpinner className="govuk-!-margin-0" inline size="sm" />
+              }
+            >
+              <ReleaseServiceStatus
+                exclude="details"
+                releaseId={release.id}
+                isApproved
+              />
+            </LazyLoad>
           )}
           {release.amendment && <Tag>Amendment</Tag>}
         </TagGroup>


### PR DESCRIPTION
Updates the release tags on the admin dashboard:
- if a release is approved and complete show green 'Published' tag
- if a release is approved and scheduled show blue 'Scheduled' tag (this includes on the Scheduled releases tab)

This PR should also fix the issue raised in https://dfedigital.atlassian.net/browse/EES-791 of the loading spinner always showing. The lazy loader seems unnecessary here as it's not used in other places the release status is shown, and wasn't working, so I've removed it.

I couldn't recreate the other issue on EES-791 where not all the scheduled releases showed and there was a chunk error in the console, so it may have been fixed since this ticket was raised.