### PR TITLE
EES-2400 Rename ReleaseStatus / Status to ReleaseApprovalStatus / ApprovalStatus

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/AssignPrereleaseContactsToSpecificReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/AssignPrereleaseContactsToSpecificReleaseAuthorizationHandlerTests.cs
@@ -29,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                                 new UserReleaseRoleRepository(contentDbContext)),
                         new Release
                         {
-                            Status = ReleaseStatus.Draft
+                            ApprovalStatus = ReleaseApprovalStatus.Draft
                         });
             }
 
@@ -45,7 +45,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                                 new UserReleaseRoleRepository(contentDbContext)),
                         new Release
                         {
-                            Status = ReleaseStatus.Approved
+                            ApprovalStatus = ReleaseApprovalStatus.Approved
                         },
                         UpdateAllReleases);
             }
@@ -62,7 +62,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     {
                         Id = Guid.NewGuid()
                     },
-                    Status = ReleaseStatus.Draft
+                    ApprovalStatus = ReleaseApprovalStatus.Draft
                 };
                 
                 // Assert that no User Publication roles will allow assigning pre release contacts to a release that's not approved
@@ -88,7 +88,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     {
                         Id = Guid.NewGuid()
                     },
-                    Status = ReleaseStatus.Approved
+                    ApprovalStatus = ReleaseApprovalStatus.Approved
                 };
 
                 // Assert that users with the Publication Owner role can assign pre release contacts to a release that's approved
@@ -120,7 +120,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             new UserReleaseRoleRepository(contentDbContext)),
                     new Release
                     {
-                        Status = ReleaseStatus.Draft
+                        ApprovalStatus = ReleaseApprovalStatus.Draft
                     });
             }
 
@@ -135,7 +135,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             new UserReleaseRoleRepository(contentDbContext)),
                     new Release
                     {
-                        Status = ReleaseStatus.Approved
+                        ApprovalStatus = ReleaseApprovalStatus.Approved
                     },
                     Approver, Contributor, Lead);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificReleaseAuthorizationHandlerTests.cs
@@ -26,7 +26,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             new UserPublicationRoleRepository(contentDbContext)),
                     new Release
                     {
-                        Status = ReleaseStatus.Draft,
+                        ApprovalStatus = ReleaseApprovalStatus.Draft,
                         Version = 0
                     });
             }
@@ -41,7 +41,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             new UserPublicationRoleRepository(contentDbContext)),
                     new Release
                     {
-                        Status = ReleaseStatus.Approved,
+                        ApprovalStatus = ReleaseApprovalStatus.Approved,
                         Version = 1
                     });
             }
@@ -57,7 +57,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             new UserPublicationRoleRepository(contentDbContext)),
                     new Release
                     {
-                        Status = ReleaseStatus.Draft,
+                        ApprovalStatus = ReleaseApprovalStatus.Draft,
                         Version = 1
                     },
                     DeleteAllReleaseAmendments);
@@ -75,7 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     {
                         Id = Guid.NewGuid()
                     },
-                    Status = ReleaseStatus.Draft,
+                    ApprovalStatus = ReleaseApprovalStatus.Draft,
                     Version = 0
                 };
                 
@@ -101,7 +101,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     {
                         Id = Guid.NewGuid()
                     },
-                    Status = ReleaseStatus.Approved,
+                    ApprovalStatus = ReleaseApprovalStatus.Approved,
                     Version = 1
                 };
 
@@ -127,7 +127,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     {
                         Id = Guid.NewGuid()
                     },
-                    Status = ReleaseStatus.Draft,
+                    ApprovalStatus = ReleaseApprovalStatus.Draft,
                     Version = 1
                 };
 
@@ -162,7 +162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         {
                             Id = Guid.NewGuid()
                         },
-                        Status = ReleaseStatus.Draft,
+                        ApprovalStatus = ReleaseApprovalStatus.Draft,
                         Version = 0
                     });
             }
@@ -181,7 +181,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         {
                             Id = Guid.NewGuid()
                         },
-                        Status = ReleaseStatus.Approved,
+                        ApprovalStatus = ReleaseApprovalStatus.Approved,
                         Version = 1
                     });
             }
@@ -200,7 +200,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         {
                             Id = Guid.NewGuid()
                         },
-                        Status = ReleaseStatus.Draft,
+                        ApprovalStatus = ReleaseApprovalStatus.Draft,
                         Version = 1
                     });
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfReleaseAuthorizationHandlersTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.ReleaseAuthorizationHandlersTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
@@ -23,7 +23,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 {
                     Id = Guid.NewGuid(),
                     Publication = new Publication(),
-                    Status = Draft
+                    ApprovalStatus = Draft
                 };
 
                 // Assert that no users can amend a draft Release that is the only version
@@ -46,7 +46,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 {
                     Id = Guid.NewGuid(),
                     Publication = new Publication(),
-                    Status = Approved,
+                    ApprovalStatus = Approved,
                     Published = DateTime.UtcNow
                 };
 
@@ -81,7 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     Id = Guid.NewGuid(),
                     Publication = publication,
                     PreviousVersionId = previousVersion.Id,
-                    Status = Draft
+                    ApprovalStatus = Draft
                 };
 
                 // Assert that no users can amend an amendment Release if it is not yet approved
@@ -180,7 +180,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     {
                         Id = Guid.NewGuid()
                     },
-                    Status = Draft
+                    ApprovalStatus = Draft
                 };
 
                 // Assert that no User Publication roles will allow a draft Release that is the only version to be amended
@@ -206,7 +206,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     {
                         Id = Guid.NewGuid()
                     },
-                    Status = Approved,
+                    ApprovalStatus = Approved,
                     Published = DateTime.UtcNow
                 };
 
@@ -244,7 +244,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     Id = Guid.NewGuid(),
                     Publication = publication,
                     PreviousVersionId = previousVersion.Id,
-                    Status = Draft
+                    ApprovalStatus = Draft
                 };
 
                 // Assert that no User Publication roles will allow an amendment Release that is not yet approved to be amended
@@ -349,7 +349,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     {
                         Id = Guid.NewGuid()
                     },
-                    Status = Draft
+                    ApprovalStatus = Draft
                 };
 
                 // Assert that no User Release roles will allow a draft Release that is the only version to be amended
@@ -375,7 +375,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     {
                         Id = Guid.NewGuid()
                     },
-                    Status = Approved,
+                    ApprovalStatus = Approved,
                     Published = DateTime.UtcNow
                 };
 
@@ -412,7 +412,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     Id = Guid.NewGuid(),
                     Publication = publication,
                     PreviousVersionId = previousVersion.Id,
-                    Status = Draft
+                    ApprovalStatus = Draft
                 };
 
                 // Assert that no User Release roles will allow an amendment Release that is not yet approved to be amended

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/PublishSpecificReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/PublishSpecificReleaseAuthorizationHandlerTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.ReleaseAuthorizationHandlersTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseRole;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
@@ -24,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         new PublishSpecificReleaseAuthorizationHandler(new UserReleaseRoleRepository(contentDbContext)),
                     new Release
                     {
-                        Status = Draft
+                        ApprovalStatus = Draft
                     }
                 );
             }
@@ -38,7 +38,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         new PublishSpecificReleaseAuthorizationHandler(new UserReleaseRoleRepository(contentDbContext)),
                     new Release
                     {
-                        Status = Approved
+                        ApprovalStatus = Approved
                     },
                     PublishAllReleases
                 );
@@ -56,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         new PublishSpecificReleaseAuthorizationHandler(new UserReleaseRoleRepository(contentDbContext)),
                     new Release
                     {
-                        Status = Draft
+                        ApprovalStatus = Draft
                     }
                 );
             }
@@ -70,7 +70,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         new PublishSpecificReleaseAuthorizationHandler(new UserReleaseRoleRepository(contentDbContext)),
                     new Release
                     {
-                        Status = Approved
+                        ApprovalStatus = Approved
                     },
                     Approver);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ReleaseStatusAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ReleaseStatusAuthorizationHandlersTests.cs
@@ -17,7 +17,6 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Aut
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 using PublisherReleaseStatus = GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatus;
-using ReleaseStatus = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
@@ -54,7 +53,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task ReleaseRoleSuccess_EditorOrApprover_ReleaseUnpublished()
             {
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
@@ -64,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             {
                                 Id = Guid.NewGuid()
                             },
-                            Status = status
+                            ApprovalStatus = status
                         };
 
                         var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
@@ -80,7 +79,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
                         // Assert that a user who has the "Contributor", "Lead" or "Approver"
                         // role on a Release can update its status if it is not Approved
-                        if (status != ReleaseStatus.Approved)
+                        if (status != ReleaseApprovalStatus.Approved)
                         {
                             await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<MarkReleaseAsDraftRequirement>(
                                 context =>
@@ -127,7 +126,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task PublicationRoleSuccess_Owner_ReleaseUnpublished()
             {
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
@@ -137,7 +136,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             {
                                 Id = Guid.NewGuid()
                             },
-                            Status = status
+                            ApprovalStatus = status
                         };
 
                         var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
@@ -153,7 +152,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
                         // Assert that a User who has the Publication Owner role on a
                         // Release can update its status if it is not Approved
-                        if (status != ReleaseStatus.Approved)
+                        if (status != ReleaseApprovalStatus.Approved)
                         {
                             await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<MarkReleaseAsDraftRequirement>(
                                 context =>
@@ -241,7 +240,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task ReleaseRoleSuccess_EditorOrApprover_ReleaseUnpublished()
             {
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
@@ -251,7 +250,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             {
                                 Id = Guid.NewGuid()
                             },
-                            Status = status
+                            ApprovalStatus = status
                         };
 
                         var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
@@ -267,7 +266,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
                         // Assert that a user who has the "Contributor", "Lead" or "Approver"
                         // role on a Release can update its status if it is not Approved
-                        if (status != ReleaseStatus.Approved)
+                        if (status != ReleaseApprovalStatus.Approved)
                         {
                             await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<
                                 MarkReleaseAsHigherLevelReviewRequirement>(
@@ -316,7 +315,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task PublicationRoleSuccess_Owner_ReleaseUnpublished()
             {
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
@@ -326,7 +325,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             {
                                 Id = Guid.NewGuid()
                             },
-                            Status = status
+                            ApprovalStatus = status
                         };
 
                         var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
@@ -342,7 +341,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
                         // Assert that a User who has the Publication Owner role on a
                         // Release can update its status if it is not Approved
-                        if (status != ReleaseStatus.Approved)
+                        if (status != ReleaseApprovalStatus.Approved)
                         {
                             await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<MarkReleaseAsHigherLevelReviewRequirement>(
                                 context =>
@@ -430,7 +429,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task ReleaseRoleSuccess_Approver_ReleaseUnpublished()
             {
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
@@ -440,7 +439,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             {
                                 Id = Guid.NewGuid()
                             },
-                            Status = status
+                            ApprovalStatus = status
                         };
 
                         var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
@@ -498,7 +497,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             params SecurityClaimTypes[] claims)
             where TRequirement : IAuthorizationRequirement
         {
-            await GetEnumValues<ReleaseStatus>().ForEachAsync(
+            await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                 async status =>
                 {
                     var release = new Release
@@ -508,7 +507,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         {
                             Id = Guid.NewGuid()
                         },
-                        Status = status
+                        ApprovalStatus = status
                     };
 
                     var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
@@ -535,7 +534,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             Func<IReleaseStatusRepository, IUserPublicationRoleRepository, IUserReleaseRoleRepository, IAuthorizationHandler> authorizationHandler)
             where TRequirement : IAuthorizationRequirement
         {
-            await GetEnumValues<ReleaseStatus>().ForEachAsync(
+            await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                 async status =>
                 {
                     var release = new Release
@@ -545,7 +544,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         {
                             Id = Guid.NewGuid()
                         },
-                        Status = status
+                        ApprovalStatus = status
                     };
 
                     var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
@@ -584,7 +583,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             Func<IReleaseStatusRepository, IUserPublicationRoleRepository, IUserReleaseRoleRepository, IAuthorizationHandler> authorizationHandler)
             where TRequirement : IAuthorizationRequirement
         {
-            await GetEnumValues<ReleaseStatus>().ForEachAsync(
+            await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                 async status =>
                 {
                     var release = new Release
@@ -594,7 +593,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         {
                             Id = Guid.NewGuid()
                         },
-                        Status = status,
+                        ApprovalStatus = status,
                         Published = DateTime.Now
                     };
 
@@ -629,7 +628,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             Func<IReleaseStatusRepository, IUserPublicationRoleRepository, IUserReleaseRoleRepository, IAuthorizationHandler> authorizationHandler)
             where TRequirement : IAuthorizationRequirement
         {
-            await GetEnumValues<ReleaseStatus>().ForEachAsync(
+            await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                 async status =>
                 {
                     var release = new Release
@@ -639,7 +638,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         {
                             Id = Guid.NewGuid()
                         },
-                        Status = status
+                        ApprovalStatus = status
                     };
 
                     var releaseStatusRepository = new Mock<IReleaseStatusRepository>();
@@ -691,7 +690,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             Func<IReleaseStatusRepository, IUserPublicationRoleRepository, IUserReleaseRoleRepository, IAuthorizationHandler> authorizationHandler)
             where TRequirement : IAuthorizationRequirement
         {
-            await GetEnumValues<ReleaseStatus>().ForEachAsync(
+            await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                 async status =>
                 {
                     var release = new Release
@@ -701,7 +700,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         {
                             Id = Guid.NewGuid()
                         },
-                        Status = status,
+                        ApprovalStatus = status,
                         Published = DateTime.Now,
                     };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlerTests.cs
@@ -14,7 +14,7 @@ using PublisherReleaseStatus = GovUk.Education.ExploreEducationStatistics.Publis
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.ReleaseAuthorizationHandlersTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusOverallStage;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
@@ -29,13 +29,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             {
                 // Assert that only users with the "UpdateAllReleases" claim can
                 // update an arbitrary Release if it has not started publishing
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
                         {
                             Id = Guid.NewGuid(),
-                            Status = status
+                            ApprovalStatus = status
                         };
 
                         await AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
@@ -52,13 +52,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             {
                 // Assert that no users can update an arbitrary Release
                 // if it has started publishing
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
                         {
                             Id = Guid.NewGuid(),
-                            Status = status,
+                            ApprovalStatus = status,
                         };
 
                         await AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
@@ -74,13 +74,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             {
                 // Assert that no users can update an arbitrary
                 // Release if it has been published
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
                         {
                             Id = Guid.NewGuid(),
-                            Status = status,
+                            ApprovalStatus = status,
                             Published = DateTime.UtcNow
                         };
 
@@ -99,7 +99,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublishingNotStarted()
             {
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
@@ -110,7 +110,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                                 Id = Guid.NewGuid()
                             },
                             Published = null,
-                            Status = status
+                            ApprovalStatus = status
                         };
 
                         // Assert that a User who has the Publication Owner role on a
@@ -139,7 +139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublishing()
             {
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
@@ -150,7 +150,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                                 Id = Guid.NewGuid()
                             },
                             Published = null,
-                            Status = status
+                            ApprovalStatus = status
                         };
 
                         // Assert that no User Publication roles will allow updating a Release once it has started publishing
@@ -165,7 +165,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublished()
             {
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
@@ -175,7 +175,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             {
                                 Id = Guid.NewGuid()
                             },
-                            Status = status,
+                            ApprovalStatus = status,
                             Published = DateTime.UtcNow
                         };
 
@@ -194,7 +194,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublishingNotStarted()
             {
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
@@ -205,7 +205,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                                 Id = Guid.NewGuid()
                             },
                             Published = null,
-                            Status = status
+                            ApprovalStatus = status
                         };
 
                         // Assert that a User who has the "Contributor", "Lead" or "Approver" role on a
@@ -237,7 +237,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublishing()
             {
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
@@ -248,7 +248,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                                 Id = Guid.NewGuid()
                             },
                             Published = null,
-                            Status = status
+                            ApprovalStatus = status
                         };
 
                         // Assert that no User Release roles will allow updating a Release once it has started publishing
@@ -263,7 +263,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublished()
             {
-                await GetEnumValues<ReleaseStatus>().ForEachAsync(
+                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
                     async status =>
                     {
                         var release = new Release
@@ -273,7 +273,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                             {
                                 Id = Guid.NewGuid()
                             },
-                            Status = status,
+                            ApprovalStatus = status,
                             Published = DateTime.UtcNow
                         };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServicePermissionTests.cs
@@ -20,7 +20,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         private readonly Release _release = new Release
         {
             Id = new Guid("af032e3c-67c2-4562-9717-9a305a468263"),
-            Status = ReleaseStatus.Approved,
+            ApprovalStatus = ReleaseApprovalStatus.Approved,
             Version = 0,
             PreviousVersionId = new Guid("af032e3c-67c2-4562-9717-9a305a468263")
         };

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublishingServiceTests.cs
@@ -13,7 +13,6 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.RetryStage;
-using ReleaseStatus = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -27,7 +26,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var release = new Release
             {
                 Id = new Guid("af032e3c-67c2-4562-9717-9a305a468263"),
-                Status = ReleaseStatus.Approved,
+                ApprovalStatus = ReleaseApprovalStatus.Approved,
                 Version = 0,
                 PreviousVersionId = new Guid("af032e3c-67c2-4562-9717-9a305a468263")
             };

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
@@ -52,7 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Id = createdById
             };
             var internalReleaseNote = "Release note";
-            var releaseStatus = ReleaseStatus.Approved;
+            var releaseApprovalStatus = ReleaseApprovalStatus.Approved;
             var publishScheduled = DateTime.Now.AddDays(1);
             var nextReleaseDate = new PartialDate {Day = "1", Month = "1", Year = "2040"};
             var releaseName = "2035";
@@ -95,7 +95,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 TimePeriodCoverage = timePeriodCoverage,
                 PublicationId = publicationId,
                 Published = publishedDate,
-                Status = releaseStatus,
+                ApprovalStatus = releaseApprovalStatus,
                 Version = version,
                 PreviousVersionId = previousVersionReleaseId,
                 Created = createdDate,
@@ -426,7 +426,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Null(amendment.PublishScheduled);
                 Assert.Null(amendment.Published);
                 Assert.Equal(release.Version + 1, amendment.Version);
-                Assert.Equal(ReleaseStatus.Draft, amendment.Status);
+                Assert.Equal(ReleaseApprovalStatus.Draft, amendment.ApprovalStatus);
                 Assert.Equal(release.Id, amendment.PreviousVersion?.Id);
                 Assert.Equal(release.Id, amendment.PreviousVersionId);
                 Assert.Equal(_userId, amendment.CreatedBy.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -108,7 +108,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             _release.Id,
                             new ReleaseUpdateViewModel
                             {
-                                Status = ReleaseStatus.Draft
+                                ApprovalStatus = ReleaseApprovalStatus.Draft
                             }
                         );
                     }
@@ -129,7 +129,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             _release.Id,
                             new ReleaseUpdateViewModel
                             {
-                                Status = ReleaseStatus.HigherLevelReview
+                                ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview
                             }
                         );
                     }
@@ -150,7 +150,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             _release.Id,
                             new ReleaseUpdateViewModel
                             {
-                                Status = ReleaseStatus.Approved
+                                ApprovalStatus = ReleaseApprovalStatus.Approved
                             }
                         );
                     }
@@ -213,7 +213,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             };
 
             repository
-                .Setup(s => s.GetAllReleasesForReleaseStatusesAsync(ReleaseStatus.Approved))
+                .Setup(s => s.GetAllReleasesForReleaseStatusesAsync(ReleaseApprovalStatus.Approved))
                 .ReturnsAsync(list);
 
             await PolicyCheckBuilder<SecurityPolicies>()
@@ -226,7 +226,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             userService: userService.Object,
                             releaseRepository: repository.Object
                         );
-                        var result = await service.GetMyReleasesForReleaseStatusesAsync(ReleaseStatus.Approved);
+                        var result = await service.GetMyReleasesForReleaseStatusesAsync(ReleaseApprovalStatus.Approved);
 
                         Assert.Equal(list, result.Right);
 
@@ -234,7 +234,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }
                 );
 
-            repository.Verify(s => s.GetAllReleasesForReleaseStatusesAsync(ReleaseStatus.Approved));
+            repository.Verify(s => s.GetAllReleasesForReleaseStatusesAsync(ReleaseApprovalStatus.Approved));
             repository.VerifyNoOtherCalls();
         }
 
@@ -252,7 +252,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             };
 
             repository
-                .Setup(s => s.GetReleasesForReleaseStatusRelatedToUserAsync(_userId, ReleaseStatus.Approved))
+                .Setup(s => s.GetReleasesForReleaseStatusRelatedToUserAsync(_userId, ReleaseApprovalStatus.Approved))
                 .ReturnsAsync(list);
 
             await PolicyCheckBuilder<SecurityPolicies>()
@@ -269,7 +269,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             userService: userService.Object,
                             releaseRepository: repository.Object
                         );
-                        var result = await service.GetMyReleasesForReleaseStatusesAsync(ReleaseStatus.Approved);
+                        var result = await service.GetMyReleasesForReleaseStatusesAsync(ReleaseApprovalStatus.Approved);
 
                         Assert.Equal(list, result.Right);
 
@@ -277,7 +277,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }
                 );
 
-            repository.Verify(s => s.GetReleasesForReleaseStatusRelatedToUserAsync(_userId, ReleaseStatus.Approved));
+            repository.Verify(s => s.GetReleasesForReleaseStatusRelatedToUserAsync(_userId, ReleaseApprovalStatus.Approved));
             repository.VerifyNoOtherCalls();
         }
 
@@ -290,7 +290,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     async userService =>
                     {
                         var service = BuildReleaseService(userService: userService.Object);
-                        return await service.GetMyReleasesForReleaseStatusesAsync(ReleaseStatus.Approved);
+                        return await service.GetMyReleasesForReleaseStatusesAsync(ReleaseApprovalStatus.Approved);
                     }
                 );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -306,7 +306,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var release = new Release
             {
-                Status = ReleaseStatus.Draft
+                ApprovalStatus = ReleaseApprovalStatus.Draft
             };
 
             var subject = new Subject
@@ -389,7 +389,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var release = new Release
             {
-                Status = ReleaseStatus.Draft
+                ApprovalStatus = ReleaseApprovalStatus.Draft
             };
 
             var subject = new Subject
@@ -449,7 +449,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var release = new Release
             {
-                Status = ReleaseStatus.Draft
+                ApprovalStatus = ReleaseApprovalStatus.Draft
             };
 
             var subject = new Subject
@@ -558,7 +558,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var release = new Release
             {
-                Status = ReleaseStatus.Draft
+                ApprovalStatus = ReleaseApprovalStatus.Draft
             };
 
             var subject = new Subject
@@ -699,7 +699,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             ReleaseName = "2035",
                             TimePeriodCoverage = TimeIdentifier.March,
                             PreReleaseAccessList = "New access list",
-                            Status = ReleaseStatus.Draft
+                            ApprovalStatus = ReleaseApprovalStatus.Draft
                         }
                     );
 
@@ -798,7 +798,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             TypeId = releaseType.Id,
                             ReleaseName = "2035",
                             TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                            Status = ReleaseStatus.Draft
+                            ApprovalStatus = ReleaseApprovalStatus.Draft
                         }
                     );
 
@@ -877,7 +877,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             TypeId = releaseType.Id,
                             ReleaseName = "2035",
                             TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                            Status = ReleaseStatus.Draft
+                            ApprovalStatus = ReleaseApprovalStatus.Draft
                         }
                     );
 
@@ -947,7 +947,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             TypeId = release.Type.Id,
                             ReleaseName = "2030",
                             TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                            Status = ReleaseStatus.Approved
+                            ApprovalStatus = ReleaseApprovalStatus.Approved
                         }
                     );
 
@@ -1005,7 +1005,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             TypeId = release.Type.Id,
                             ReleaseName = "2030",
                             TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                            Status = ReleaseStatus.Draft
+                            ApprovalStatus = ReleaseApprovalStatus.Draft
                         }
                     );
 
@@ -1061,7 +1061,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             TypeId = release.Type.Id,
                             ReleaseName = "2030",
                             TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                            Status = ReleaseStatus.Approved,
+                            ApprovalStatus = ReleaseApprovalStatus.Approved,
                             PublishMethod = PublishMethod.Scheduled
                         }
                     );
@@ -1177,7 +1177,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             ReleaseName = "2035",
                             TimePeriodCoverage = TimeIdentifier.March,
                             PreReleaseAccessList = "New access list",
-                            Status = ReleaseStatus.Draft
+                            ApprovalStatus = ReleaseApprovalStatus.Draft
 
                         }
                     );
@@ -1314,7 +1314,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             ReleaseName = "2035",
                             TimePeriodCoverage = TimeIdentifier.March,
                             PreReleaseAccessList = "New access list",
-                            Status = ReleaseStatus.Draft
+                            ApprovalStatus = ReleaseApprovalStatus.Draft
 
                         }
                     );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -178,7 +178,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         public async Task<ActionResult<List<MyReleaseViewModel>>> GetDraftReleasesAsync()
         {
             return await _releaseService
-                .GetMyReleasesForReleaseStatusesAsync(ReleaseStatus.Draft, ReleaseStatus.HigherLevelReview)
+                .GetMyReleasesForReleaseStatusesAsync(ReleaseApprovalStatus.Draft, ReleaseApprovalStatus.HigherLevelReview)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210610111801_EES2400RenameReleasesTableStatusToApprovalStatus.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210610111801_EES2400RenameReleasesTableStatusToApprovalStatus.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210610111801_EES2400RenameReleasesTableStatusToApprovalStatus")]
+    partial class EES2400RenameReleasesTableStatusToApprovalStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210610111801_EES2400RenameReleasesTableStatusToApprovalStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210610111801_EES2400RenameReleasesTableStatusToApprovalStatus.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES2400RenameReleasesTableStatusToApprovalStatus : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Status",
+                newName: "ApprovalStatus",
+                table: "Releases");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "ApprovalStatus",
+                newName: "Status",
+                table: "Releases");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/AssignPrereleaseContactsToSpecificReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/AssignPrereleaseContactsToSpecificReleaseAuthorizationHandlers.cs
@@ -5,7 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Authorization;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
@@ -32,7 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             AssignPrereleaseContactsToSpecificReleaseRequirement requirement,
             Release release)
         {
-            if (release.Status != Approved)
+            if (release.ApprovalStatus != Approved)
             {
                 return;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/DeleteSpecificReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/DeleteSpecificReleaseAuthorizationHandlers.cs
@@ -5,7 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Authorization;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             DeleteSpecificReleaseRequirement requirement,
             Release release)
         {
-            if (!release.Amendment || release.Status == Approved)
+            if (!release.Amendment || release.ApprovalStatus == Approved)
             {
                 return;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/PublishSpecificReleaseAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/PublishSpecificReleaseAuthorizationHandler.cs
@@ -27,7 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             PublishSpecificReleaseRequirement requirement,
             Release release)
         {
-            if (release.Status != ReleaseStatus.Approved)
+            if (release.ApprovalStatus != ReleaseApprovalStatus.Approved)
             {
                 return;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ReleaseStatusAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ReleaseStatusAuthorizationHandlers.cs
@@ -7,7 +7,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using Microsoft.AspNetCore.Authorization;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
-using ReleaseStatus = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
@@ -27,7 +26,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
             _userReleaseRoleRepository = userReleaseRoleRepository;
         }
 
-        protected abstract ReleaseStatus TargetStatus { get; }
+        protected abstract ReleaseApprovalStatus TargetApprovalStatus { get; }
 
         protected override async Task HandleRequirementAsync(
             AuthorizationHandlerContext context,
@@ -45,15 +44,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 return;
             }
 
-            switch (TargetStatus)
+            switch (TargetApprovalStatus)
             {
-                case ReleaseStatus.Approved:
+                case ReleaseApprovalStatus.Approved:
                     await HandleApproved(context, requirement, release);
                     break;
-                case ReleaseStatus.HigherLevelReview:
+                case ReleaseApprovalStatus.HigherLevelReview:
                     await HandleHigherLevelReview(context, requirement, release);
                     break;
-                case ReleaseStatus.Draft:
+                case ReleaseApprovalStatus.Draft:
                     await HandleDraft(context, requirement, release);
                     break;
                 default:
@@ -95,7 +94,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 await _userPublicationRoleRepository.GetAllRolesByUser(context.User.GetUserId(), release.PublicationId);
             var releaseRoles = await _userReleaseRoleRepository.GetAllRolesByUser(context.User.GetUserId(), release.Id);
 
-            if (release.Status == ReleaseStatus.Approved
+            if (release.ApprovalStatus == ReleaseApprovalStatus.Approved
                 ? ContainsApproverRole(releaseRoles)
                 : ContainPublicationOwnerRole(publicationRoles) || ContainsEditorRole(releaseRoles))
             {
@@ -118,7 +117,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 await _userPublicationRoleRepository.GetAllRolesByUser(context.User.GetUserId(), release.PublicationId);
             var releaseRoles = await _userReleaseRoleRepository.GetAllRolesByUser(context.User.GetUserId(), release.Id);
 
-            if (release.Status == ReleaseStatus.Approved
+            if (release.ApprovalStatus == ReleaseApprovalStatus.Approved
                 ? ContainsApproverRole(releaseRoles)
                 : ContainPublicationOwnerRole(publicationRoles) || ContainsEditorRole(releaseRoles))
             {
@@ -142,7 +141,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
         {
         }
 
-        protected override ReleaseStatus TargetStatus => ReleaseStatus.Draft;
+        protected override ReleaseApprovalStatus TargetApprovalStatus => ReleaseApprovalStatus.Draft;
     }
 
     public class MarkReleaseAsHigherLevelReviewRequirement : IAuthorizationRequirement
@@ -160,7 +159,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
         {
         }
 
-        protected override ReleaseStatus TargetStatus => ReleaseStatus.HigherLevelReview;
+        protected override ReleaseApprovalStatus TargetApprovalStatus => ReleaseApprovalStatus.HigherLevelReview;
     }
 
     public class MarkReleaseAsApprovedRequirement : IAuthorizationRequirement
@@ -179,6 +178,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
         {
         }
 
-        protected override ReleaseStatus TargetStatus => ReleaseStatus.Approved;
+        protected override ReleaseApprovalStatus TargetApprovalStatus => ReleaseApprovalStatus.Approved;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandler.cs
@@ -6,7 +6,6 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using Microsoft.AspNetCore.Authorization;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
-using ReleaseStatus = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
@@ -56,7 +55,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 await _publicationRoleRepository.GetAllRolesByUser(context.User.GetUserId(), release.PublicationId);
             var releaseRoles = await _releaseRoleRepository.GetAllRolesByUser(context.User.GetUserId(), release.Id);
 
-            if (release.Status == ReleaseStatus.Approved
+            if (release.ApprovalStatus == ReleaseApprovalStatus.Approved
                 ? ContainsApproverRole(releaseRoles)
                 : ContainPublicationOwnerRole(publicationRoles) || ContainsEditorRole(releaseRoles))
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseRepository.cs
@@ -9,10 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     public interface IReleaseRepository
     {
         Task<List<MyReleaseViewModel>> GetAllReleasesForReleaseStatusesAsync(
-            params ReleaseStatus[] releaseStatuses);
+            params ReleaseApprovalStatus[] releaseStatuses);
 
         Task<List<MyReleaseViewModel>> GetReleasesForReleaseStatusRelatedToUserAsync(Guid userId,
-            params ReleaseStatus[] releaseStatuses);
+            params ReleaseApprovalStatus[] releaseApprovalStatuses);
 
         Task<Guid> CreateStatisticsDbReleaseAndSubjectHierarchy(Guid releaseId);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -25,7 +25,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
         Task<Either<ActionResult, TitleAndIdViewModel>> GetLatestReleaseAsync(Guid publicationId);
 
         Task<Either<ActionResult, List<MyReleaseViewModel>>> GetMyReleasesForReleaseStatusesAsync(
-            params ReleaseStatus[] releaseStatuses);
+            params ReleaseApprovalStatus[] releaseApprovalStatues);
 
         Task<Either<ActionResult, List<MyReleaseViewModel>>> GetMyScheduledReleasesAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
@@ -141,19 +141,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanUpdateReleaseStatus(
-            this IUserService userService, Release release, ReleaseStatus status)
+            this IUserService userService, Release release, ReleaseApprovalStatus approvalStatus)
         {
-            switch (status)
+            switch (approvalStatus)
             {
-                case ReleaseStatus.Draft:
+                case ReleaseApprovalStatus.Draft:
                 {
                     return userService.CheckCanMarkReleaseAsDraft(release);
                 }
-                case ReleaseStatus.HigherLevelReview:
+                case ReleaseApprovalStatus.HigherLevelReview:
                 {
                     return userService.CheckCanSubmitReleaseToHigherApproval(release);
                 }
-                case ReleaseStatus.Approved:
+                case ReleaseApprovalStatus.Approved:
                 {
                     return userService.CheckCanApproveRelease(release);
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseService.cs
@@ -69,7 +69,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             DateTime endTime,
             DateTime referenceTime)
         {
-            if (!release.PublishScheduled.HasValue || release.Status != ReleaseStatus.Approved)
+            if (!release.PublishScheduled.HasValue || release.ApprovalStatus != ReleaseApprovalStatus.Approved)
             {
                 return PreReleaseAccess.NoneSet;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublishingService.cs
@@ -14,7 +14,6 @@ using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
-using ReleaseStatus = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 {
@@ -52,7 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(release => _userService.CheckCanPublishRelease(release))
                 .OnSuccess(async release =>
                 {
-                    if (release.Status != ReleaseStatus.Approved)
+                    if (release.ApprovalStatus != ReleaseApprovalStatus.Approved)
                     {
                         return ValidationActionResult(ReleaseNotApproved);
                     }
@@ -66,7 +65,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         /// <summary>
-        /// <para>Notify the Publisher that there has been a change to the Release status.</para>
+        /// <para>Notify the Publisher that there has been a change to the Release approval status.</para>
         /// <para>This could result in:</para>
         /// <list type="bullet">
         /// <item><term>Scheduling publication of a Release after approval</term></item>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseRepository.cs
@@ -31,18 +31,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         public async Task<List<MyReleaseViewModel>> GetAllReleasesForReleaseStatusesAsync(
-            params ReleaseStatus[] releaseStatuses)
+            params ReleaseApprovalStatus[] releaseApprovalStatuses)
         {
             var releases = await 
                 HydrateReleaseForReleaseViewModel(_contentDbContext.Releases)
-                .Where(r => releaseStatuses.Contains(r.Status))
+                .Where(r => releaseApprovalStatuses.Contains(r.ApprovalStatus))
                 .ToListAsync();
             
             return _mapper.Map<List<MyReleaseViewModel>>(releases);
         }
 
         public async Task<List<MyReleaseViewModel>> GetReleasesForReleaseStatusRelatedToUserAsync(Guid userId,
-            params ReleaseStatus[] releaseStatuses)
+            params ReleaseApprovalStatus[] releaseApprovalStatuses)
         {
             var userReleaseIds = await _contentDbContext
                 .UserReleaseRoles
@@ -52,7 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             
             var releases = await 
                 HydrateReleaseForReleaseViewModel(_contentDbContext.Releases)
-                .Where(r => userReleaseIds.Contains(r.Id) && releaseStatuses.Contains(r.Status))
+                .Where(r => userReleaseIds.Contains(r.Id) && releaseApprovalStatuses.Contains(r.ApprovalStatus))
                 .ToListAsync();
             
             return _mapper.Map<List<MyReleaseViewModel>>(releases);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ManageContent/ManageContentPageViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ManageContent/ManageContentPageViewModel.cs
@@ -35,7 +35,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageCont
             public Guid PublicationId { get; set; }
 
             [JsonConverter(typeof(StringEnumConverter))]
-            public ReleaseStatus Status { get; set; }
+            public ReleaseApprovalStatus ApprovalStatus { get; set; }
 
             public PublicationViewModel Publication { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleasePublicationStatusViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleasePublicationStatusViewModel.cs
@@ -7,7 +7,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
     public class ReleasePublicationStatusViewModel
     {
         [JsonConverter(typeof(StringEnumConverter))]
-        public ReleaseStatus Status;
+        public ReleaseApprovalStatus ApprovalStatus;
 
         public bool Amendment;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -55,7 +55,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public Contact Contact { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
-        public ReleaseStatus Status { get; set; }
+        public ReleaseApprovalStatus ApprovalStatus { get; set; }
 
         public string InternalReleaseNote { get; set; }
 
@@ -121,7 +121,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public string PreReleaseAccessList { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
-        public ReleaseStatus Status { get; set; }
+        public ReleaseApprovalStatus ApprovalStatus { get; set; }
 
         public string InternalReleaseNote { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ReleaseTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ReleaseTests.cs
@@ -117,7 +117,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
 
             Assert.Null(amendment.Published);
             Assert.Null(amendment.PublishScheduled);
-            Assert.Equal(ReleaseStatus.Draft, amendment.Status);
+            Assert.Equal(ReleaseApprovalStatus.Draft, amendment.ApprovalStatus);
 
             Assert.Equal(createdDate, amendment.Created);
             Assert.Equal(createdById, amendment.CreatedById);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -211,8 +211,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                     v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : (DateTime?) null);
 
             modelBuilder.Entity<Release>()
-                .Property(release => release.Status)
-                .HasConversion(new EnumToStringConverter<ReleaseStatus>());
+                .Property(release => release.ApprovalStatus)
+                .HasConversion(new EnumToStringConverter<ReleaseApprovalStatus>());
 
             modelBuilder.Entity<DataBlock>()
                 .Property(block => block.Heading)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -190,7 +190,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         [JsonConverter(typeof(TimeIdentifierJsonConverter))]
         public TimeIdentifier TimePeriodCoverage { get; set; }
 
-        public ReleaseStatus Status { get; set; }
+        public ReleaseApprovalStatus ApprovalStatus { get; set; }
 
         public string InternalReleaseNote { get; set; }
 
@@ -225,7 +225,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
             amendment.Id = Guid.NewGuid();
             amendment.Published = null;
             amendment.PublishScheduled = null;
-            amendment.Status = ReleaseStatus.Draft;
+            amendment.ApprovalStatus = ReleaseApprovalStatus.Draft;
             amendment.Created = createdDate;
             amendment.CreatedById = createdByUserId;
             amendment.Version = Version + 1;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseApprovalStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseApprovalStatus.cs
@@ -1,6 +1,6 @@
 namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 {
-    public enum ReleaseStatus
+    public enum ReleaseApprovalStatus
     {
         Draft,
         HigherLevelReview,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
@@ -11,7 +11,7 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.MapperUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Database.ContentDbUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 {
@@ -78,7 +78,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 ReleaseName = "2018",
                 TimePeriodCoverage = AcademicYearQ1,
                 Published = new DateTime(2019, 1, 01),
-                Status = Approved
+                ApprovalStatus = Approved
             };
 
             var publicationBRelease1 = new Release
@@ -87,7 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 ReleaseName = "2018",
                 TimePeriodCoverage = AcademicYearQ1,
                 Published = null,
-                Status = Draft
+                ApprovalStatus = Draft
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -287,7 +287,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 },
                 ReleaseName = "2018",
                 TimePeriodCoverage = AcademicYearQ1,
-                Status = Approved
+                ApprovalStatus = Approved
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();
@@ -321,7 +321,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 },
                 ReleaseName = "2018",
                 TimePeriodCoverage = AcademicYearQ1,
-                Status = Approved
+                ApprovalStatus = Approved
             };
 
             var contentDbContextId = Guid.NewGuid().ToString();

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublicationServiceTests.cs
@@ -12,7 +12,7 @@ using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.MapperUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 {
@@ -152,7 +152,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             TimePeriodCoverage = AcademicYearQ1,
             Published = new DateTime(2019, 1, 01),
             Slug = "publication-a-release-2018-q1",
-            Status = Approved,
+            ApprovalStatus = Approved,
             Version = 0,
             PreviousVersionId = null
         };
@@ -165,7 +165,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             TimePeriodCoverage = AcademicYearQ1,
             Published = new DateTime(2019, 1, 01),
             Slug = "publication-a-release-2018-q1",
-            Status = Approved,
+            ApprovalStatus = Approved,
             Version = 1,
             PreviousVersionId = new Guid("240ca03c-6c22-4b9d-9f15-40fc9017890e"),
             SoftDeleted = true
@@ -179,7 +179,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             TimePeriodCoverage = AcademicYearQ1,
             Published = new DateTime(2019, 1, 01),
             Slug = "publication-a-release-2018-q1",
-            Status = Approved,
+            ApprovalStatus = Approved,
             Version = 1,
             PreviousVersionId = new Guid("240ca03c-6c22-4b9d-9f15-40fc9017890e")
         };
@@ -192,7 +192,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             TimePeriodCoverage = AcademicYearQ2,
             Published = new DateTime(2019, 1, 01),
             Slug = "publication-a-release-2018-q2",
-            Status = Approved,
+            ApprovalStatus = Approved,
             Version = 0,
             PreviousVersionId = null
         };
@@ -205,7 +205,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             TimePeriodCoverage = AcademicYearQ4,
             Published = new DateTime(2019, 1, 01),
             Slug = "publication-a-release-2017-q4",
-            Status = Approved,
+            ApprovalStatus = Approved,
             Version = 0,
             PreviousVersionId = null
         };
@@ -218,7 +218,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             TimePeriodCoverage = AcademicYearQ1,
             Published = null,
             Slug = "publication-b-release-2018-q1",
-            Status = Draft,
+            ApprovalStatus = Draft,
             Version = 0,
             PreviousVersionId = null
         };
@@ -238,7 +238,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 TimePeriodCoverage = AcademicYearQ3,
                 Published = null,
                 Slug = "publication-a-release-2018-q3",
-                Status = Draft,
+                ApprovalStatus = Draft,
                 Version = 0,
                 PreviousVersionId = null
             },

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -22,7 +22,7 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentif
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStorageUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.MapperUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Database.ContentDbUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 {
@@ -90,7 +90,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             },
             Slug = "2018-19-q1",
             Published = new DateTime(2019, 1, 1),
-            Status = Approved,
+            ApprovalStatus = Approved,
             Version = 0,
             PreviousVersionId = null,
             SoftDeleted = false
@@ -114,7 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             },
             Slug = "2018-19-q1",
             Published = new DateTime(2019, 2, 1),
-            Status = Approved,
+            ApprovalStatus = Approved,
             Version = 1,
             PreviousVersionId = new Guid("36725e6b-8682-480b-a04a-0564253b7160"),
             SoftDeleted = false
@@ -138,7 +138,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             },
             Slug = "2018-19-q1",
             Published = null,
-            Status = Approved,
+            ApprovalStatus = Approved,
             Version = 2,
             PreviousVersionId = new Guid("de6dc6ad-dc75-435c-9cf5-1ed4fe49c0cc"),
             SoftDeleted = true
@@ -154,7 +154,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             RelatedInformation = new List<Link>(),
             Slug = "2018-19-q1",
             Published = null,
-            Status = Approved,
+            ApprovalStatus = Approved,
             Version = 3,
             PreviousVersionId = new Guid("de6dc6ad-dc75-435c-9cf5-1ed4fe49c0cc"),
             SoftDeleted = false
@@ -178,7 +178,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             },
             Slug = "2018-19-q2",
             Published = new DateTime(2019, 3, 1),
-            Status = Approved,
+            ApprovalStatus = Approved,
             Version = 0,
             PreviousVersionId = null
         };
@@ -193,7 +193,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             RelatedInformation = new List<Link>(),
             Slug = "2018-19-q3",
             Published = null,
-            Status = Approved,
+            ApprovalStatus = Approved,
             Version = 0,
             PreviousVersionId = null
         };
@@ -214,7 +214,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 TimePeriodCoverage = AcademicYearQ4,
                 Slug = "2017-18-q4",
                 Published = new DateTime(2019, 4, 1),
-                Status = Approved,
+                ApprovalStatus = Approved,
                 Version = 0,
                 PreviousVersionId = null
             },
@@ -226,7 +226,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 TimePeriodCoverage = AcademicYearQ4,
                 Slug = "2018-19-q4",
                 Published = null,
-                Status = Draft,
+                ApprovalStatus = Draft,
                 Version = 0,
                 PreviousVersionId = null
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ValidationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ValidationService.cs
@@ -10,7 +10,6 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.ReleaseStatusOverallStage;
-using ReleaseStatus = GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 {
@@ -82,9 +81,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         private static Either<IEnumerable<ReleaseStatusLogMessage>, Unit> ValidateApproval(Release release)
         {
-            return release.Status == ReleaseStatus.Approved
+            return release.ApprovalStatus == ReleaseApprovalStatus.Approved
                 ? Unit.Instance
-                : Failure(ValidationStage.ReleaseMustBeApproved, $"Release status is {release.Status}");
+                : Failure(ValidationStage.ReleaseMustBeApproved, $"Release approval status is {release.ApprovalStatus}");
         }
 
         private static Either<IEnumerable<ReleaseStatusLogMessage>, Unit> ValidateScheduledPublishDate(

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
@@ -1,6 +1,6 @@
 import ReleaseServiceStatus from '@admin/components/ReleaseServiceStatus';
 import {
-  getReleaseStatusLabel,
+  getReleaseApprovalStatusLabel,
   getReleaseSummaryLabel,
 } from '@admin/pages/release/utils/releaseSummaryUtil';
 import { Release } from '@admin/services/releaseService';
@@ -40,10 +40,10 @@ const ReleaseSummary = ({
       summary={getReleaseSummaryLabel(release)}
       summaryAfter={
         <TagGroup className="govuk-!-margin-left-2">
-          {release.status !== 'Approved' && (
-            <Tag>{getReleaseStatusLabel(release.status)}</Tag>
+          {release.approvalStatus !== 'Approved' && (
+            <Tag>{getReleaseApprovalStatusLabel(release.approvalStatus)}</Tag>
           )}
-          {release.status === 'Approved' && (
+          {release.approvalStatus === 'Approved' && (
             <LazyLoad
               once
               placeholder={
@@ -73,7 +73,7 @@ const ReleaseSummary = ({
             <time>{formatPartialDate(release.nextReleaseDate)}</time>
           </SummaryListItem>
         )}
-        {release.status === 'Approved' && (
+        {release.approvalStatus === 'Approved' && (
           <SummaryListItem term="Release process status">
             <ReleaseServiceStatus releaseId={release.id} />
           </SummaryListItem>

--- a/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleasePageContainer.tsx
@@ -4,7 +4,7 @@ import Page from '@admin/components/Page';
 import PageTitle from '@admin/components/PageTitle';
 import PreviousNextLinks from '@admin/components/PreviousNextLinks';
 import { ReleaseContextProvider } from '@admin/pages/release/contexts/ReleaseContext';
-import { getReleaseStatusLabel } from '@admin/pages/release/utils/releaseSummaryUtil';
+import { getReleaseApprovalStatusLabel } from '@admin/pages/release/utils/releaseSummaryUtil';
 import {
   releaseContentRoute,
   releaseDataBlockCreateRoute,
@@ -144,7 +144,7 @@ const ReleasePageContainer = ({
             </div>
           </div>
 
-          <Tag>{getReleaseStatusLabel(release.status)}</Tag>
+          <Tag>{getReleaseApprovalStatusLabel(release.approvalStatus)}</Tag>
 
           {release.amendment && (
             <Tag className="govuk-!-margin-left-2">Amendment</Tag>

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusPage.tsx
@@ -102,11 +102,11 @@ const ReleaseStatusPage = () => {
       <SummaryList>
         <SummaryListItem term="Current status">
           <StatusBlock
-            text={statusMap[release.status]}
-            id={`CurrentReleaseStatus-${statusMap[release.status]}`}
+            text={statusMap[release.approvalStatus]}
+            id={`CurrentReleaseStatus-${statusMap[release.approvalStatus]}`}
           />
         </SummaryListItem>
-        {release.status === 'Approved' && (
+        {release.approvalStatus === 'Approved' && (
           <SummaryListItem term="Release process status">
             <ReleaseServiceStatus releaseId={releaseId} />
           </SummaryListItem>

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testRelease.ts
@@ -4,7 +4,7 @@ import { Release } from '@admin/services/releaseService';
 export const testRelease: Release = {
   id: 'release-1',
   slug: 'release-1-slug',
-  status: 'Draft',
+  approvalStatus: 'Draft',
   latestRelease: false,
   live: false,
   amendment: false,

--- a/src/explore-education-statistics-admin/src/pages/release/__tests__/ReleaseStatusPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/__tests__/ReleaseStatusPage.test.tsx
@@ -64,7 +64,7 @@ describe('ReleaseStatusPage', () => {
 
     renderPage({
       ...testRelease,
-      status: 'Approved',
+      approvalStatus: 'Approved',
       publishScheduled: '2021-01-15',
       nextReleaseDate: {
         month: 10,

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -26,7 +26,7 @@ export interface ReleaseStatusFormValues {
   publishMethod?: 'Scheduled' | 'Immediate';
   publishScheduled?: Date;
   nextReleaseDate?: PartialDate;
-  status: ReleaseApprovalStatus;
+  approvalStatus: ReleaseApprovalStatus;
   internalReleaseNote: string;
 }
 
@@ -34,7 +34,7 @@ export const formId = 'releaseStatusForm';
 
 const errorMappings = [
   mapFieldErrors<ReleaseStatusFormValues>({
-    target: 'status',
+    target: 'approvalStatus',
     messages: {
       APPROVED_RELEASE_MUST_HAVE_PUBLISH_SCHEDULED_DATE:
         'Enter a publish scheduled date before approving',
@@ -76,12 +76,12 @@ const ReleaseStatusForm = ({
   onSubmit,
 }: Props) => {
   const handleSubmit = useFormSubmit<ReleaseStatusFormValues>(
-    async ({ status, publishMethod, publishScheduled, ...values }) => {
-      const isApproved = status === 'Approved';
+    async ({ approvalStatus, publishMethod, publishScheduled, ...values }) => {
+      const isApproved = approvalStatus === 'Approved';
 
       await onSubmit({
         ...values,
-        status,
+        approvalStatus,
         publishMethod: isApproved ? publishMethod : undefined,
         publishScheduled:
           isApproved && publishScheduled && publishMethod === 'Scheduled'
@@ -96,7 +96,7 @@ const ReleaseStatusForm = ({
     <Formik<ReleaseStatusFormValues>
       enableReinitialize
       initialValues={{
-        status: release.status,
+        approvalStatus: release.approvalStatus,
         internalReleaseNote: release.internalReleaseNote ?? '',
         publishMethod: release.publishScheduled ? 'Scheduled' : undefined,
         publishScheduled: release.publishScheduled
@@ -106,14 +106,14 @@ const ReleaseStatusForm = ({
       }}
       onSubmit={handleSubmit}
       validationSchema={Yup.object<ReleaseStatusFormValues>({
-        status: Yup.string().required('Choose a status') as StringSchema<
-          ReleaseStatusFormValues['status']
-        >,
-        internalReleaseNote: Yup.string().when('status', {
+        approvalStatus: Yup.string().required(
+          'Choose a status',
+        ) as StringSchema<ReleaseStatusFormValues['approvalStatus']>,
+        internalReleaseNote: Yup.string().when('approvalStatus', {
           is: value => ['Approved', 'HigherLevelReview'].includes(value),
           then: Yup.string().required('Enter an internal note'),
         }),
-        publishMethod: Yup.string().when('status', {
+        publishMethod: Yup.string().when('approvalStatus', {
           is: 'Approved',
           then: Yup.string().required('Choose when to publish'),
         }) as StringSchema<ReleaseStatusFormValues['publishMethod']>,
@@ -159,7 +159,7 @@ const ReleaseStatusForm = ({
         <Form id={formId}>
           <FormFieldRadioGroup<ReleaseStatusFormValues>
             legend="Status"
-            name="status"
+            name="approvalStatus"
             order={[]}
             options={[
               {
@@ -188,7 +188,7 @@ const ReleaseStatusForm = ({
             rows={3}
           />
 
-          {form.values.status === 'Approved' && (
+          {form.values.approvalStatus === 'Approved' && (
             <FormFieldRadioGroup<ReleaseStatusFormValues>
               name="publishMethod"
               legend="When to publish"

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
@@ -8,7 +8,7 @@ describe('ReleaseStatusChecklist', () => {
   const testRelease: Release = {
     id: 'release-1',
     slug: 'release-1-slug',
-    status: 'Draft',
+    approvalStatus: 'Draft',
     latestRelease: false,
     live: false,
     amendment: false,

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -14,7 +14,7 @@ describe('ReleaseStatusForm', () => {
   const testRelease: Release = {
     id: 'release-1',
     slug: 'release-1-slug',
-    status: 'Draft',
+    approvalStatus: 'Draft',
     latestRelease: false,
     live: false,
     amendment: false,
@@ -173,7 +173,7 @@ describe('ReleaseStatusForm', () => {
       <ReleaseStatusForm
         release={{
           ...testRelease,
-          status: 'HigherLevelReview',
+          approvalStatus: 'HigherLevelReview',
           nextReleaseDate: {
             month: 10,
             year: 2021,
@@ -229,7 +229,7 @@ describe('ReleaseStatusForm', () => {
 
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: '',
-        status: 'Draft',
+        approvalStatus: 'Draft',
       };
 
       await waitFor(() => {
@@ -268,7 +268,7 @@ describe('ReleaseStatusForm', () => {
 
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: 'Test release note',
-        status: 'HigherLevelReview',
+        approvalStatus: 'HigherLevelReview',
         nextReleaseDate: {
           month: 5,
           year: 2021,
@@ -287,7 +287,7 @@ describe('ReleaseStatusForm', () => {
         <ReleaseStatusForm
           release={{
             ...testRelease,
-            status: 'HigherLevelReview',
+            approvalStatus: 'HigherLevelReview',
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -312,7 +312,7 @@ describe('ReleaseStatusForm', () => {
         <ReleaseStatusForm
           release={{
             ...testRelease,
-            status: 'HigherLevelReview',
+            approvalStatus: 'HigherLevelReview',
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -339,7 +339,7 @@ describe('ReleaseStatusForm', () => {
         <ReleaseStatusForm
           release={{
             ...testRelease,
-            status: 'HigherLevelReview',
+            approvalStatus: 'HigherLevelReview',
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -366,7 +366,7 @@ describe('ReleaseStatusForm', () => {
 
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: 'Test release note',
-        status: 'Draft',
+        approvalStatus: 'Draft',
         nextReleaseDate: {
           month: 5,
           year: 2021,
@@ -385,7 +385,7 @@ describe('ReleaseStatusForm', () => {
         <ReleaseStatusForm
           release={{
             ...testRelease,
-            status: 'Approved',
+            approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -418,7 +418,7 @@ describe('ReleaseStatusForm', () => {
         <ReleaseStatusForm
           release={{
             ...testRelease,
-            status: 'Approved',
+            approvalStatus: 'Approved',
             publishScheduled: '2020-12-15',
           }}
           statusPermissions={testStatusPermissions}
@@ -457,7 +457,7 @@ describe('ReleaseStatusForm', () => {
         <ReleaseStatusForm
           release={{
             ...testRelease,
-            status: 'Approved',
+            approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -480,7 +480,7 @@ describe('ReleaseStatusForm', () => {
         <ReleaseStatusForm
           release={{
             ...testRelease,
-            status: 'Approved',
+            approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -505,7 +505,7 @@ describe('ReleaseStatusForm', () => {
         <ReleaseStatusForm
           release={{
             ...testRelease,
-            status: 'Approved',
+            approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -533,7 +533,7 @@ describe('ReleaseStatusForm', () => {
         <ReleaseStatusForm
           release={{
             ...testRelease,
-            status: 'Approved',
+            approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -593,7 +593,7 @@ describe('ReleaseStatusForm', () => {
           release={{
             ...testRelease,
             publishScheduled: format(new Date(), 'yyyy-MM-dd'),
-            status: 'Approved',
+            approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -620,7 +620,7 @@ describe('ReleaseStatusForm', () => {
 
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: 'Test release note',
-        status: 'Draft',
+        approvalStatus: 'Draft',
         nextReleaseDate: {
           month: 5,
           year: 2021,
@@ -639,7 +639,7 @@ describe('ReleaseStatusForm', () => {
         <ReleaseStatusForm
           release={{
             ...testRelease,
-            status: 'Approved',
+            approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -675,7 +675,7 @@ describe('ReleaseStatusForm', () => {
 
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: 'Test release note',
-        status: 'Approved',
+        approvalStatus: 'Approved',
         publishScheduled: new Date('2022-10-10'),
         publishMethod: 'Scheduled',
         nextReleaseDate: {
@@ -696,7 +696,7 @@ describe('ReleaseStatusForm', () => {
         <ReleaseStatusForm
           release={{
             ...testRelease,
-            status: 'Approved',
+            approvalStatus: 'Approved',
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -724,7 +724,7 @@ describe('ReleaseStatusForm', () => {
 
       const expectedValues: ReleaseStatusFormValues = {
         internalReleaseNote: 'Test release note',
-        status: 'Approved',
+        approvalStatus: 'Approved',
         publishMethod: 'Immediate',
         nextReleaseDate: {
           month: 5,

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/BasicReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/BasicReleaseSummary.tsx
@@ -1,4 +1,4 @@
-import { getReleaseStatusLabel } from '@admin/pages/release/utils/releaseSummaryUtil';
+import { getReleaseApprovalStatusLabel } from '@admin/pages/release/utils/releaseSummaryUtil';
 import metaService from '@admin/services/metaService';
 import { EditableRelease } from '@admin/services/releaseContentService';
 import FormattedDate from '@common/components/FormattedDate';
@@ -57,7 +57,7 @@ const BasicReleaseSummary = ({ release }: Props) => {
         <>
           <div className="dfe-flex dfe-align-items--center dfe-justify-content--space-between">
             <div className="dfe-flex govuk-!-margin-bottom-3">
-              <Tag>{getReleaseStatusLabel(release.status)}</Tag>
+              <Tag>{getReleaseApprovalStatusLabel(release.approvalStatus)}</Tag>
             </div>
             {releaseTypeIdsToIcons[release.type.id] && (
               <div className="dfe-flex">

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/__tests__/ReleaseContentContext.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/__tests__/ReleaseContentContext.test.tsx
@@ -31,7 +31,7 @@ const basicRelease: EditableRelease = {
   releaseName: '2020',
   slug: '2020-21',
   publicationId: '8586c490-7027-4a8b-9df5-cf105c3e88ec',
-  status: 'Draft',
+  approvalStatus: 'Draft',
   dataLastPublished: '',
   published: '',
   publication: {

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
@@ -85,7 +85,7 @@ const ReleasePreReleaseAccessPage = () => {
               </>
             )}
 
-            {release.status === 'Approved' ? (
+            {release.approvalStatus === 'Approved' ? (
               <PreReleaseUserAccessForm
                 releaseId={release.id}
                 isReleaseLive={release.live}

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/ReleasePreReleaseAccessPage.test.tsx
@@ -13,7 +13,7 @@ const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
 const releaseData: Release = {
   id: 'release-1',
   slug: 'release-1-slug',
-  status: 'Draft',
+  approvalStatus: 'Draft',
   latestRelease: false,
   live: false,
   amendment: false,

--- a/src/explore-education-statistics-admin/src/pages/release/utils/releaseSummaryUtil.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/utils/releaseSummaryUtil.ts
@@ -1,7 +1,7 @@
 import { Release } from '@admin/services/releaseService';
 import { ReleaseApprovalStatus } from '@common/services/publicationService';
 
-export const getReleaseStatusLabel = (
+export const getReleaseApprovalStatusLabel = (
   approvalStatus: ReleaseApprovalStatus,
 ) => {
   switch (approvalStatus) {

--- a/src/explore-education-statistics-admin/src/services/releaseContentService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseContentService.ts
@@ -19,7 +19,7 @@ type ContentSectionViewModel = ContentSection<EditableBlock>;
 
 export interface EditableRelease
   extends Release<EditableContentBlock, EditableDataBlock> {
-  status: ReleaseApprovalStatus;
+  approvalStatus: ReleaseApprovalStatus;
   publishScheduled?: string;
   publicationId: string;
 }

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -7,7 +7,7 @@ import { PartialDate } from '@common/utils/date/partialDate';
 export interface Release {
   id: string;
   slug: string;
-  status: ReleaseApprovalStatus;
+  approvalStatus: ReleaseApprovalStatus;
   latestRelease: boolean;
   live: boolean;
   amendment: boolean;
@@ -48,7 +48,7 @@ export interface ReleaseSummary {
   publishScheduled: string;
   nextReleaseDate?: PartialDate;
   internalReleaseNote: string;
-  status: ReleaseApprovalStatus;
+  approvalStatus: ReleaseApprovalStatus;
   yearTitle: string;
 }
 
@@ -66,7 +66,7 @@ export interface CreateReleaseRequest extends BaseReleaseRequest {
 }
 
 export interface UpdateReleaseRequest extends BaseReleaseRequest {
-  status: ReleaseApprovalStatus;
+  approvalStatus: ReleaseApprovalStatus;
   internalReleaseNote?: string;
   publishScheduled?: string;
   publishMethod?: 'Scheduled' | 'Immediate';
@@ -149,7 +149,7 @@ export interface ReleaseChecklist {
 export interface ReleasePublicationStatus {
   publishScheduled: string;
   nextReleaseDate?: PartialDate;
-  status: ReleaseApprovalStatus;
+  approvalStatus: ReleaseApprovalStatus;
   amendment: boolean;
   live: boolean;
 }


### PR DESCRIPTION
This change is to make way for the new ReleaseStatus table that will be made in the Content DB. The status field in the Releases table is also being renamed to avoid confusion.

It also has the added benefit of distinguishing between a release's approval status and its publishing status. Approval status is currently held in the Content DB in the Releases table. The publishing status (hereafter named ReleaseStatus) is currently contained in the ReleaseStatus Azure storage table.