### PR TITLE
EES-417 - replace Now with UtcNow

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/PublicationNotifier.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/PublicationNotifier.cs
@@ -301,7 +301,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier
         {
             logger.LogInformation("{0} triggered at: {1}",
                 context.FunctionName,
-                DateTime.Now);
+                DateTime.UtcNow);
 
             var config = LoadAppSettings(context);
             var pendingSubscriptionsTbl = GetCloudTable(_storageTableService, config, PendingSubscriptionsTblName);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -50,7 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         {
             logger.LogInformation("{0} triggered at: {1}",
                 executionContext.FunctionName,
-                DateTime.Now);
+                DateTime.UtcNow);
 
             await UpdateStage(message.ReleaseId, message.ReleaseStatusId, State.Started);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleasesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleasesFunction.cs
@@ -40,7 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         {
             logger.LogInformation("{0} triggered at: {1}",
                 executionContext.FunctionName,
-                DateTime.Now);
+                DateTime.UtcNow);
 
             await PublishReleases();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishStagedReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishStagedReleaseContentFunction.cs
@@ -52,7 +52,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         {
             logger.LogInformation("{0} triggered at: {1}",
                 executionContext.FunctionName,
-                DateTime.Now);
+                DateTime.UtcNow);
 
             var scheduled = (await QueryScheduledReleases()).ToList();
             if (scheduled.Any())

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/RetryStageFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/RetryStageFunction.cs
@@ -46,7 +46,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         {
             logger.LogInformation("{0} triggered at: {1}",
                 executionContext.FunctionName,
-                DateTime.Now);
+                DateTime.UtcNow);
 
             var releaseStatus = await _releaseStatusService.GetLatestAsync(message.ReleaseId);
 


### PR DESCRIPTION
This PR removes superfluous usages of `Date.Now` (i.e. in logging information) with `Date.UtcNow`. 

Currently there is a problem with how dates are stored in Azure blobs and the differences between local Azure blob environments & production Azure blob environments. Because of this difference the majority of `Date.Now` usages have been left in the codebase.