### PR TITLE
EES-2199 amend methodology and related buttons

### DIFF
--- a/src/explore-education-statistics-admin/package.json
+++ b/src/explore-education-statistics-admin/package.json
@@ -171,6 +171,7 @@
     "moduleNameMapper": {
       "^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy",
       "^@admin/(.*)$": "<rootDir>/src/$1",
+      "^@admin-test/(.*)$": "<rootDir>/../explore-education-statistics-admin/test/$1",
       "^@common/(.*)$": "<rootDir>/../explore-education-statistics-common/src/$1",
       "^@common-test/(.*)$": "<rootDir>/../explore-education-statistics-common/test/$1",
       "^react$": "<rootDir>/node_modules/react",

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -1,3 +1,11 @@
+
+import publicationService, {
+  ExternalMethodology,
+  MyPublication,
+} from '@admin/services/publicationService';
+import methodologyService from '@admin/services/methodologyService';
+import ButtonGroup from '@common/components/ButtonGroup';
+import Button from '@common/components/Button';
 import ButtonLink from '@admin/components/ButtonLink';
 import Link from '@admin/components/Link';
 import {
@@ -5,36 +13,29 @@ import {
   methodologySummaryEditRoute,
   methodologySummaryRoute,
 } from '@admin/routes/methodologyRoutes';
-import methodologyService from '@admin/services/methodologyService';
-import publicationService, {
-  ExternalMethodology,
-  MyPublication,
-} from '@admin/services/publicationService';
-import Button from '@common/components/Button';
-import ButtonGroup from '@common/components/ButtonGroup';
 import Details from '@common/components/Details';
 import FormattedDate from '@common/components/FormattedDate';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import Tag from '@common/components/Tag';
 import TagGroup from '@common/components/TagGroup';
+import ModalConfirm from '@common/components/ModalConfirm';
 import React, { useState } from 'react';
 import { generatePath, useHistory } from 'react-router';
-import MethodologyExternalLinkForm from './MethodologyExternalLinkForm';
+import MethodologyExternalLinkForm from '@admin/pages/admin-dashboard/components/MethodologyExternalLinkForm';
 
 export interface Props {
-  canAmendMethodology?: boolean;
   publication: MyPublication;
   topicId: string;
   onChangePublication: () => void;
 }
 
 const MethodologySummary = ({
-  canAmendMethodology = false, // TO DO replace with real permission check
   publication,
   topicId,
   onChangePublication,
 }: Props) => {
+  const history = useHistory();
   const [
     showAddExternalMethodologyForm,
     setShowAddExternalMethodologyForm,
@@ -43,6 +44,11 @@ const MethodologySummary = ({
     showEditExternalMethodologyForm,
     setShowEditExternalMethodologyForm,
   ] = useState<boolean>();
+  const [amendMethodologyId, setAmendMethodologyId] = useState<string>();
+  const [
+    cancelAmendmentMethodologyId,
+    setCancelAmendmentMethodologyId,
+  ] = useState<string>();
 
   const {
     contact,
@@ -51,8 +57,6 @@ const MethodologySummary = ({
     id: publicationId,
     title,
   } = publication;
-
-  const history = useHistory();
 
   const handleExternalMethodologySubmit = async (
     values: ExternalMethodology,
@@ -122,27 +126,73 @@ const MethodologySummary = ({
               </SummaryListItem>
             )}
           </SummaryList>
-          <ButtonGroup>
-            <ButtonLink
-              to={generatePath(methodologySummaryRoute.path, {
-                publicationId,
-                methodologyId: methodology.id,
-              })}
-            >
-              View methodology
-            </ButtonLink>
-            {canAmendMethodology && (
-              <ButtonLink
-                to={generatePath(methodologySummaryEditRoute.path, {
-                  publicationId,
-                  methodologyId: methodology.id,
-                })}
-                variant="secondary"
-              >
-                Amend methodology
-              </ButtonLink>
-            )}
-          </ButtonGroup>
+
+          <div className="govuk-grid-row">
+            <div className="govuk-grid-column-two-thirds">
+              {methodology.amendment ? (
+                <>
+                  <ButtonGroup>
+                    <ButtonLink
+                      to={generatePath(methodologySummaryRoute.path, {
+                        publicationId,
+                        methodologyId: methodology.id,
+                      })}
+                    >
+                      {methodology.permissions.canUpdateMethodology
+                        ? 'Edit this amendment'
+                        : 'View this amendment'}
+                    </ButtonLink>
+                    <ButtonLink
+                      to={generatePath(methodologySummaryRoute.path, {
+                        publicationId,
+                        methodologyId: methodology.previousVersionId,
+                      })}
+                      className="govuk-button--secondary govuk-!-margin-left-4"
+                    >
+                      View original methodology
+                    </ButtonLink>
+                  </ButtonGroup>
+                </>
+              ) : (
+                <>
+                  <ButtonGroup>
+                    <ButtonLink
+                      to={generatePath(methodologySummaryRoute.path, {
+                        publicationId,
+                        methodologyId: methodology.id,
+                      })}
+                    >
+                      {methodology.permissions.canUpdateMethodology
+                        ? 'Edit this methodology'
+                        : 'View this methodology'}
+                    </ButtonLink>
+                    {methodology.permissions.canMakeAmendmentOfMethodology && (
+                      <Button
+                        type="button"
+                        onClick={() => setAmendMethodologyId(methodology.id)}
+                        variant="secondary"
+                      >
+                        Amend methodology
+                      </Button>
+                    )}
+                  </ButtonGroup>
+                </>
+              )}
+            </div>
+            <div className="govuk-grid-column-one-third dfe-align--right">
+              {methodology.permissions.canDeleteMethodology &&
+                methodology.amendment && (
+                  <Button
+                    onClick={() =>
+                      setCancelAmendmentMethodologyId(methodology.id)
+                    }
+                    className="govuk-button--warning"
+                  >
+                    Cancel amendment
+                  </Button>
+                )}
+            </div>
+          </div>
         </Details>
       ) : (
         <>
@@ -228,6 +278,54 @@ const MethodologySummary = ({
             </>
           )}
         </>
+      )}
+
+      {amendMethodologyId && (
+        <ModalConfirm
+          title="Confirm you want to amend this live methodology"
+          onConfirm={async () => {
+            const amendment = await methodologyService.createMethodologyAmendment(
+              amendMethodologyId,
+            );
+            history.push(
+              generatePath<MethodologyRouteParams>(
+                methodologySummaryRoute.path,
+                {
+                  publicationId,
+                  methodologyId: amendment.id,
+                },
+              ),
+            );
+          }}
+          onExit={() => setAmendMethodologyId(undefined)}
+          onCancel={() => setAmendMethodologyId(undefined)}
+          open
+        >
+          <p>
+            Please note, any changes made to this live methodology must be
+            approved before updates can be published.
+          </p>
+        </ModalConfirm>
+      )}
+      {cancelAmendmentMethodologyId && (
+        <ModalConfirm
+          title="Confirm you want to cancel this amended methodology"
+          onConfirm={async () => {
+            await methodologyService.deleteMethodology(
+              cancelAmendmentMethodologyId,
+            );
+            setCancelAmendmentMethodologyId(undefined);
+            onChangePublication();
+          }}
+          onCancel={() => setCancelAmendmentMethodologyId(undefined)}
+          onExit={() => setCancelAmendmentMethodologyId(undefined)}
+          open
+        >
+          <p>
+            By cancelling the amendments you will lose any changes made, and the
+            original methodology will remain unchanged.
+          </p>
+        </ModalConfirm>
       )}
     </>
   );

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -1,4 +1,3 @@
-
 import publicationService, {
   ExternalMethodology,
   MyPublication,

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -1,6 +1,7 @@
 import MethodologySummary from '@admin/pages/admin-dashboard/components/MethodologySummary';
 import _methodologyService, {
   BasicMethodology,
+  MyMethodology
 } from '@admin/services/methodologyService';
 import {
   ExternalMethodology,
@@ -8,11 +9,17 @@ import {
   PublicationContactDetails,
 } from '@admin/services/publicationService';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import noop from 'lodash/noop';
 import React from 'react';
 import { MemoryRouter, Router } from 'react-router';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@admin/services/methodologyService');
+
+const methodologyService = _methodologyService as jest.Mocked<
+  typeof _methodologyService
+>;
 
 const createMemoryHistoryWithMockedPush = () => {
   const history = createMemoryHistory();
@@ -22,12 +29,6 @@ const createMemoryHistoryWithMockedPush = () => {
   };
 };
 
-jest.mock('@admin/services/methodologyService');
-
-const methodologyService = _methodologyService as jest.Mocked<
-  typeof _methodologyService
->;
-
 const testContact: PublicationContactDetails = {
   id: 'contact-1',
   contactName: 'John Smith',
@@ -36,22 +37,44 @@ const testContact: PublicationContactDetails = {
   teamName: 'Team Smith',
 };
 
-const testMethodology: BasicMethodology = {
+const testMethodology: MyMethodology = {
   amendment: false,
+  live: true,
   id: '1234',
   internalReleaseNote: 'this is the release note',
+  previousVersionId: 'lfkjdlfj',
   published: '2021-06-08T09:04:17.9805585',
   slug: 'meth-1',
   status: 'Approved',
   title: 'I am a methodology',
+  permissions: {
+    canUpdateMethodology: false,
+    canDeleteMethodology: false,
+    canMakeAmendmentOfMethodology: false,
+  },
 };
-const testDraftMethodology: BasicMethodology = {
+const testDraftMethodology: MyMethodology = {
   ...testMethodology,
   status: 'Draft',
 };
-const testAmendmentMethodology: BasicMethodology = {
+const testAmendmentMethodology: MyMethodology = {
   ...testMethodology,
   amendment: true,
+};
+const testMethodologyCanAmend: MyMethodology = {
+  ...testMethodology,
+  permissions: {
+    ...testMethodology.permissions,
+    canMakeAmendmentOfMethodology: true,
+  },
+};
+const testMethodologyCanCancelAmend: MyMethodology = {
+  ...testMethodology,
+  amendment: true,
+  permissions: {
+    ...testMethodology.permissions,
+    canDeleteMethodology: true,
+  },
 };
 
 const externalMethodology: ExternalMethodology = {
@@ -88,6 +111,16 @@ const testPublicationWithAmendmentMethodology = {
 const testPublicationWithExternalMethodology = {
   ...testPublicationNoMethodology,
   externalMethodology,
+};
+
+const testPublicationWithMethodologyCanAmend = {
+  ...testPublicationWithMethodology,
+  methodology: testMethodologyCanAmend,
+};
+
+const testPublicationWithMethodologyCanCancelAmend = {
+  ...testPublicationWithMethodology,
+  methodology: testMethodologyCanCancelAmend,
 };
 
 const testTopicId = 'topic-id';
@@ -203,42 +236,8 @@ describe('MethodologySummary', () => {
       ).toBeInTheDocument();
 
       expect(
-        screen.queryByText('View methodology', { selector: 'a' }),
+        screen.queryByText('View this methodology', { selector: 'a' }),
       ).toBeInTheDocument();
-    });
-
-    test('the amend methodology link is shown if user has permission', () => {
-      render(
-        <MemoryRouter>
-          <MethodologySummary
-            canAmendMethodology
-            publication={testPublicationWithMethodology}
-            topicId={testTopicId}
-            onChangePublication={noop}
-          />
-        </MemoryRouter>,
-      );
-
-      expect(
-        screen.queryByText('Amend methodology', { selector: 'a' }),
-      ).toBeInTheDocument();
-    });
-
-    test('the amend methodology link is not shown if user does not have permission', () => {
-      render(
-        <MemoryRouter>
-          <MethodologySummary
-            canAmendMethodology={false}
-            publication={testPublicationWithMethodology}
-            topicId={testTopicId}
-            onChangePublication={noop}
-          />
-        </MemoryRouter>,
-      );
-
-      expect(
-        screen.queryByText('Amend methodology', { selector: 'a' }),
-      ).not.toBeInTheDocument();
     });
 
     test('the approved tag is shown', () => {
@@ -313,6 +312,186 @@ describe('MethodologySummary', () => {
       expect(
         screen.getByRole('button', { name: 'Remove' }),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('Amending a methodology', () => {
+    test('the amend methodology button is shown if user has permission', () => {
+      render(
+        <MemoryRouter>
+          <MethodologySummary
+            publication={testPublicationWithMethodologyCanAmend}
+            topicId={testTopicId}
+            onChangePublication={noop}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(
+        screen.getByText('Amend methodology', { selector: 'button' }),
+      ).toBeInTheDocument();
+    });
+
+    test('the amend methodology button is not shown if user does not have permission', () => {
+      render(
+        <MemoryRouter>
+          <MethodologySummary
+            publication={testPublicationWithMethodology}
+            topicId={testTopicId}
+            onChangePublication={noop}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(
+        screen.queryByText('Amend methodology', { selector: 'button' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('shows the confirm modal when click the amend button', async () => {
+      render(
+        <MemoryRouter>
+          <MethodologySummary
+            publication={testPublicationWithMethodologyCanAmend}
+            topicId={testTopicId}
+            onChangePublication={noop}
+          />
+        </MemoryRouter>,
+      );
+
+      userEvent.click(
+        screen.getByText('Amend methodology', { selector: 'button' }),
+      );
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Confirm you want to amend this live methodology'),
+        ).toBeInTheDocument();
+
+        expect(
+          screen.getByText('Confirm', { selector: 'button' }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('calls the service to amend the methodology when the confirm button is clicked', async () => {
+      const history = createMemoryHistoryWithMockedPush();
+      const mockMethodology: BasicMethodology = {
+        amendment: true,
+        live: false,
+        id: '12345',
+        internalReleaseNote: 'this is the release note',
+        previousVersionId: 'lfkjdlfj',
+        published: '2021-06-08T09:04:17.9805585',
+        slug: 'meth-1',
+        status: 'Approved',
+        title: 'I am a methodology amendment',
+      };
+      methodologyService.createMethodologyAmendment.mockImplementation(() =>
+        Promise.resolve(mockMethodology),
+      );
+      render(
+        <Router history={history}>
+          <MethodologySummary
+            publication={testPublicationWithMethodologyCanAmend}
+            topicId={testTopicId}
+            onChangePublication={noop}
+          />
+        </Router>,
+      );
+      userEvent.click(
+        screen.getByText('Amend methodology', { selector: 'button' }),
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByText('Confirm', { selector: 'button' }),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.click(screen.getByText('Confirm', { selector: 'button' }));
+
+      await waitFor(() => {
+        expect(
+          methodologyService.createMethodologyAmendment,
+        ).toHaveBeenCalledWith(
+          testPublicationWithMethodologyCanAmend.methodology.id,
+        );
+        expect(history.push).toBeCalledWith(
+          `/publication/${testPublicationWithMethodologyCanAmend.id}/methodology/${mockMethodology.id}/summary`,
+        );
+      });
+    });
+  });
+
+  describe('Cancelling an amendment', () => {
+    test('the cancel amendment button is shown if user has permission', () => {
+      render(
+        <MemoryRouter>
+          <MethodologySummary
+            publication={testPublicationWithMethodologyCanCancelAmend}
+            topicId={testTopicId}
+            onChangePublication={noop}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(
+        screen.getByText('Cancel amendment', { selector: 'button' }),
+      ).toBeInTheDocument();
+    });
+
+    test('shows the confirm modal when click the cancel amendment  button', async () => {
+      render(
+        <MemoryRouter>
+          <MethodologySummary
+            publication={testPublicationWithMethodologyCanCancelAmend}
+            topicId={testTopicId}
+            onChangePublication={noop}
+          />
+        </MemoryRouter>,
+      );
+
+      userEvent.click(
+        screen.getByText('Cancel amendment', { selector: 'button' }),
+      );
+      await waitFor(() => {
+        expect(
+          screen.queryByText(
+            'Confirm you want to cancel this amended methodology',
+          ),
+        ).toBeInTheDocument();
+
+        expect(
+          screen.getByText('Confirm', { selector: 'button' }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('calls the service to cancel the amendment when the confirm button is clicked', async () => {
+      render(
+        <MemoryRouter>
+          <MethodologySummary
+            publication={testPublicationWithMethodologyCanCancelAmend}
+            topicId={testTopicId}
+            onChangePublication={noop}
+          />
+        </MemoryRouter>,
+      );
+      userEvent.click(
+        screen.getByText('Cancel amendment', { selector: 'button' }),
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByText('Confirm', { selector: 'button' }),
+        ).toBeInTheDocument();
+
+        userEvent.click(screen.getByText('Confirm', { selector: 'button' }));
+      });
+
+      await waitFor(() => {
+        expect(methodologyService.deleteMethodology).toHaveBeenCalledWith(
+          testPublicationWithMethodologyCanAmend.methodology.id,
+        );
+      });
     });
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -1,7 +1,7 @@
 import MethodologySummary from '@admin/pages/admin-dashboard/components/MethodologySummary';
 import _methodologyService, {
   BasicMethodology,
-  MyMethodology
+  MyMethodology,
 } from '@admin/services/methodologyService';
 import {
   ExternalMethodology,
@@ -9,25 +9,17 @@ import {
   PublicationContactDetails,
 } from '@admin/services/publicationService';
 import { render, screen, waitFor } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
 import noop from 'lodash/noop';
 import React from 'react';
 import { MemoryRouter, Router } from 'react-router';
 import userEvent from '@testing-library/user-event';
+import createMemoryHistoryWithMockedPush from '@admin-test/createMemoryHistoryWithMockedPush';
 
 jest.mock('@admin/services/methodologyService');
 
 const methodologyService = _methodologyService as jest.Mocked<
   typeof _methodologyService
 >;
-
-const createMemoryHistoryWithMockedPush = () => {
-  const history = createMemoryHistory();
-  return {
-    ...history,
-    push: jest.fn(),
-  };
-};
 
 const testContact: PublicationContactDetails = {
   id: 'contact-1',
@@ -302,9 +294,7 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.queryByText('Ext methodolology title (external methodology)', {
-          selector: 'a',
-        }),
+        screen.queryByText('Ext methodolology title (external methodology)'),
       ).toBeInTheDocument();
 
       expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
@@ -398,16 +388,17 @@ describe('MethodologySummary', () => {
           />
         </Router>,
       );
+
       userEvent.click(
         screen.getByText('Amend methodology', { selector: 'button' }),
       );
       await waitFor(() => {
         expect(
-          screen.getByText('Confirm', { selector: 'button' }),
+          screen.getByRole('button', { name: 'Confirm' }),
         ).toBeInTheDocument();
       });
 
-      userEvent.click(screen.getByText('Confirm', { selector: 'button' }));
+      userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
       await waitFor(() => {
         expect(

--- a/src/explore-education-statistics-admin/src/services/methodologyService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyService.ts
@@ -20,10 +20,20 @@ export interface BasicMethodology {
   amendment: boolean;
   id: string;
   internalReleaseNote?: string;
+  live: boolean;
+  previousVersionId?: string;
   title: string;
   slug: string;
   status: MethodologyStatus;
   published?: string;
+}
+
+export interface MyMethodology extends BasicMethodology {
+  permissions: {
+    canUpdateMethodology: boolean;
+    canDeleteMethodology: boolean;
+    canMakeAmendmentOfMethodology: boolean;
+  };
 }
 
 const methodologyService = {
@@ -52,6 +62,14 @@ const methodologyService = {
     return client.get<BasicMethodology>(
       `/methodology/${methodologyId}/summary`,
     );
+  },
+
+  createMethodologyAmendment(methodologyId: string): Promise<BasicMethodology> {
+    return client.post(`/methodology/${methodologyId}/amendment`);
+  },
+
+  deleteMethodology(methodologyId: string): Promise<void> {
+    return client.delete(`/methodology/${methodologyId}`);
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -2,7 +2,10 @@ import {
   LegacyRelease,
   UpdateLegacyRelease,
 } from '@admin/services/legacyReleaseService';
-import { BasicMethodology } from '@admin/services/methodologyService';
+import {
+  BasicMethodology,
+  MyMethodology,
+} from '@admin/services/methodologyService';
 import { MyRelease } from '@admin/services/releaseService';
 import { IdTitlePair } from '@admin/services/types/common';
 import client from '@admin/services/utils/service';
@@ -31,7 +34,7 @@ export interface ExternalMethodology {
 export interface MyPublication {
   id: string;
   title: string;
-  methodology?: BasicMethodology;
+  methodology?: MyMethodology;
   externalMethodology?: ExternalMethodology;
   releases: MyRelease[];
   contact?: PublicationContactDetails;

--- a/src/explore-education-statistics-admin/test/createMemoryHistoryWithMockedPush.ts
+++ b/src/explore-education-statistics-admin/test/createMemoryHistoryWithMockedPush.ts
@@ -1,0 +1,9 @@
+import createMemoryHistory from 'history/createMemoryHistory';
+
+export default function createMemoryHistoryWithMockedPush() {
+  const history = createMemoryHistory();
+  return {
+    ...history,
+    push: jest.fn(),
+  };
+}

--- a/src/explore-education-statistics-admin/tsconfig.json
+++ b/src/explore-education-statistics-admin/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "@admin/*": ["../explore-education-statistics-admin/src/*"],
+      "@admin-test/*": ["../explore-education-statistics-admin/test/*"],
       "@common/*": ["../explore-education-statistics-common/src/*"],
       "@common-test/*": ["../explore-education-statistics-common/test/*"]
     },


### PR DESCRIPTION
Adds logic for showing the amend, edit, view and cancel methodology buttons. The logic here is copied from release amendments so may need to be adapted if it's different for methodologies.

Hooks up the amend and cancel buttons to what I expect the service to be, again copied from release amendments so may need altering. There are confirmation modals for both buttons.

I've assumed the permissions will be similar to releases so this may need changing.

None of this is visible currently as methodologies can't be created. I override the methodology with a test one to check it.

I shamelessly copied createMemoryHistoryWithMockedPush.ts from @duncan-at-hiveit's PR https://github.com/dfe-analytical-services/explore-education-statistics/pull/2579