### PR TITLE
EES-2361 fix reselecting the same highlight in table tool

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -71,6 +71,7 @@ export interface TableToolWizardProps {
   scrollOnMount?: boolean;
   onSubmit?: (table: FullTable) => void;
   loadingFastTrack?: boolean;
+  updateStep?: boolean;
 }
 
 const TableToolWizard = ({
@@ -82,6 +83,7 @@ const TableToolWizard = ({
   finalStep,
   onSubmit,
   loadingFastTrack = false,
+  updateStep = false,
 }: TableToolWizardProps) => {
   const [state, updateState] = useImmer<TableToolState>({
     initialStep: 1,
@@ -281,6 +283,7 @@ const TableToolWizard = ({
             scrollOnMount={scrollOnMount}
             initialStep={state.initialStep}
             id="tableToolWizard"
+            updateStep={updateStep}
             onStepChange={async (nextStep, previousStep) => {
               if (nextStep < previousStep) {
                 const confirmed = await askConfirm();

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/Wizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/Wizard.tsx
@@ -26,6 +26,7 @@ interface Props {
   initialStep?: number;
   id: string;
   scrollOnMount?: boolean;
+  updateStep?: boolean;
   onStepChange?: (
     nextStep: number,
     previousStep: number,
@@ -37,6 +38,7 @@ const Wizard = ({
   initialStep = 1,
   id,
   scrollOnMount = false,
+  updateStep,
   onStepChange,
 }: Props) => {
   const [shouldScroll, setShouldScroll] = useState(scrollOnMount);
@@ -75,7 +77,7 @@ const Wizard = ({
 
   useEffect(() => {
     setCurrentStepState(initialStep);
-  }, [initialStep]);
+  }, [initialStep, updateStep]);
 
   return (
     <ol className={styles.stepNav} id={id}>

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -41,9 +41,11 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
   themeMeta,
 }) => {
   const [loadingFastTrack, setLoadingFastTrack] = useState(false);
+  const [updateStep, setUpdateStep] = useState(false);
   useEffect(() => {
     if (fastTrack && subjectMeta) {
       setLoadingFastTrack(false);
+      setUpdateStep(false);
     }
   }, [fastTrack, subjectMeta]);
 
@@ -118,12 +120,16 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
         scrollOnMount
         themeMeta={themeMeta}
         initialState={initialState}
+        updateStep={updateStep}
         loadingFastTrack={loadingFastTrack}
         renderHighlightLink={highlight => (
           <Link
             to="/data-tables/fast-track/[fastTrackId]"
             as={`/data-tables/fast-track/${highlight.id}`}
             onClick={() => {
+              if (fastTrack && fastTrack?.id === highlight.id) {
+                setUpdateStep(true);
+              }
               setLoadingFastTrack(true);
               logEvent({
                 category: 'Table tool',


### PR DESCRIPTION
Currently in the table tool if you select a table highlight, then go back to step 1, select the same publication then the same highlight you get stuck on step 2 instead of showing the highlight.

This fixes it by forcing the Wizard to update the current step in this circumstance. Which feels a bit hacky... so any other suggestions are welcome.