### PR TITLE
Ees 2220 add create methodology permissions to front end

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyRepositoryTests.cs
@@ -57,6 +57,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.NotNull(methodology.MethodologyParent);
                 Assert.Single(methodology.MethodologyParent.Publications);
                 Assert.Equal(savedPublication, methodology.MethodologyParent.Publications[0].Publication);
+                Assert.Equal(savedPublication.Title, methodology.Title);
+                Assert.Equal(savedPublication.Slug, methodology.Slug);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyPublicationPermissionSetPropertyResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyPublicationPermissionSetPropertyResolver.cs
@@ -27,15 +27,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                 CanUpdatePublication = _userService
                     .CheckCanUpdatePublication(source)
                     .Result
-                    .OnSuccess(_ => true)
-                    .OrElse(() => false)
-                    .Right,
+                    .IsRight,
                 CanCreateReleases = _userService
                     .CheckCanCreateReleaseForPublication(source)
                     .Result
-                    .OnSuccess(_ => true)
-                    .OrElse(() => false)
-                    .Right
+                    .IsRight,
+                CanCreateMethodologies = _userService
+                    .CheckCanCreateMethodologyForPublication(source)
+                    .Result
+                    .IsRight
             };
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyRepository.cs
@@ -23,10 +23,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
         public async Task<Methodology> CreateMethodologyForPublication(Guid publicationId)
         {
+            var publication = await _contentDbContext
+                .Publications
+                .SingleAsync(p => p.Id == publicationId);
+            
             var methodology = (await _contentDbContext.Methodologies.AddAsync(new Methodology
             {
-                Slug = publicationId.ToString(),
-                Title = publicationId.ToString(),
+                Slug = publication.Slug,
+                Title = publication.Title,
                 MethodologyParent = new MethodologyParent
                 {
                     Publications = new List<PublicationMethodology>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationViewModel.cs
@@ -31,6 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         {
             public bool CanUpdatePublication { get; set; }
             public bool CanCreateReleases { get; set; }
+            public bool CanCreateMethodologies { get; set; }
         }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -197,39 +197,39 @@ const MethodologySummary = ({
         <>
           {externalMethodology?.url ? (
             <>
-              {!showEditExternalMethodologyForm && (
+              {!showEditExternalMethodologyForm ? (
                 <>
                   <Link to={externalMethodology.url} unvisited>
                     {externalMethodology.title} (external methodology)
                   </Link>
-                  <ButtonGroup className="govuk-!-margin-bottom-2 govuk-!-margin-top-2">
-                    <Button
-                      type="button"
-                      onClick={() => setShowEditExternalMethodologyForm(true)}
-                    >
-                      Edit
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="warning"
-                      onClick={handleRemoveExternalMethodology}
-                    >
-                      Remove
-                    </Button>
-                  </ButtonGroup>
+                  {publication.permissions.canCreateMethodologies && (
+                    <ButtonGroup className="govuk-!-margin-bottom-2 govuk-!-margin-top-2">
+                      <Button
+                        type="button"
+                        onClick={() => setShowEditExternalMethodologyForm(true)}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="warning"
+                        onClick={handleRemoveExternalMethodology}
+                      >
+                        Remove
+                      </Button>
+                    </ButtonGroup>
+                  )}
                 </>
+              ) : (
+                <MethodologyExternalLinkForm
+                  initialValues={externalMethodology}
+                  onCancel={() => setShowEditExternalMethodologyForm(false)}
+                  onSubmit={values => {
+                    handleExternalMethodologySubmit(values);
+                    setShowEditExternalMethodologyForm(false);
+                  }}
+                />
               )}
-              {showEditExternalMethodologyForm &&
-                publication.permissions.canCreateMethodologies && (
-                  <MethodologyExternalLinkForm
-                    initialValues={externalMethodology}
-                    onCancel={() => setShowEditExternalMethodologyForm(false)}
-                    onSubmit={values => {
-                      handleExternalMethodologySubmit(values);
-                      setShowEditExternalMethodologyForm(false);
-                    }}
-                  />
-                )}
             </>
           ) : (
             <>
@@ -247,7 +247,6 @@ const MethodologySummary = ({
                           generatePath<MethodologyRouteParams>(
                             methodologySummaryRoute.path,
                             {
-                              publicationId,
                               methodologyId,
                             },
                           ),

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -219,52 +219,54 @@ const MethodologySummary = ({
                   </ButtonGroup>
                 </>
               )}
-              {showEditExternalMethodologyForm && (
-                <MethodologyExternalLinkForm
-                  initialValues={externalMethodology}
-                  onCancel={() => setShowEditExternalMethodologyForm(false)}
-                  onSubmit={values => {
-                    handleExternalMethodologySubmit(values);
-                    setShowEditExternalMethodologyForm(false);
-                  }}
-                />
-              )}
+              {showEditExternalMethodologyForm &&
+                publication.permissions.canCreateMethodologies && (
+                  <MethodologyExternalLinkForm
+                    initialValues={externalMethodology}
+                    onCancel={() => setShowEditExternalMethodologyForm(false)}
+                    onSubmit={values => {
+                      handleExternalMethodologySubmit(values);
+                      setShowEditExternalMethodologyForm(false);
+                    }}
+                  />
+                )}
             </>
           ) : (
             <>
-              {!showAddExternalMethodologyForm && (
-                <ButtonGroup className="govuk-!-margin-bottom-2">
-                  <Button
-                    onClick={async () => {
-                      const {
-                        id: methodologyId,
-                      } = await methodologyService.createMethodology(
-                        publicationId,
-                      );
-                      history.push(
-                        generatePath<MethodologyRouteParams>(
-                          methodologySummaryRoute.path,
-                          {
-                            publicationId,
-                            methodologyId,
-                          },
-                        ),
-                      );
-                    }}
-                    data-testid={`Create methodology for ${title}`}
-                  >
-                    Create methodology
-                  </Button>
-                  <Button
-                    type="button"
-                    data-testid={`Link methodology for ${title}`}
-                    variant="secondary"
-                    onClick={() => setShowAddExternalMethodologyForm(true)}
-                  >
-                    Link to an externally hosted methodology
-                  </Button>
-                </ButtonGroup>
-              )}
+              {!showAddExternalMethodologyForm &&
+                publication.permissions.canCreateMethodologies && (
+                  <ButtonGroup className="govuk-!-margin-bottom-2">
+                    <Button
+                      onClick={async () => {
+                        const {
+                          id: methodologyId,
+                        } = await methodologyService.createMethodology(
+                          publicationId,
+                        );
+                        history.push(
+                          generatePath<MethodologyRouteParams>(
+                            methodologySummaryRoute.path,
+                            {
+                              publicationId,
+                              methodologyId,
+                            },
+                          ),
+                        );
+                      }}
+                      data-testid={`Create methodology for ${title}`}
+                    >
+                      Create methodology
+                    </Button>
+                    <Button
+                      type="button"
+                      data-testid={`Link methodology for ${title}`}
+                      variant="secondary"
+                      onClick={() => setShowAddExternalMethodologyForm(true)}
+                    >
+                      Link to an externally hosted methodology
+                    </Button>
+                  </ButtonGroup>
+                )}
               {showAddExternalMethodologyForm && (
                 <MethodologyExternalLinkForm
                   onCancel={() => setShowAddExternalMethodologyForm(false)}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -291,7 +291,6 @@ const MethodologySummary = ({
               generatePath<MethodologyRouteParams>(
                 methodologySummaryRoute.path,
                 {
-                  publicationId,
                   methodologyId: amendment.id,
                 },
               ),

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ManagePublicationsAndReleasesTab.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ManagePublicationsAndReleasesTab.test.tsx
@@ -88,6 +88,7 @@ describe('ManagePublicationsAndReleasesTab', () => {
       permissions: {
         canCreateReleases: true,
         canUpdatePublication: true,
+        canCreateMethodologies: true,
       },
     },
     {
@@ -98,6 +99,7 @@ describe('ManagePublicationsAndReleasesTab', () => {
       permissions: {
         canCreateReleases: true,
         canUpdatePublication: true,
+        canCreateMethodologies: true,
       },
     },
   ];

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -82,6 +82,7 @@ const testPublicationNoMethodology: MyPublication = {
   permissions: {
     canCreateReleases: true,
     canUpdatePublication: true,
+    canCreateMethodologies: true,
   },
 };
 
@@ -146,6 +147,34 @@ describe('MethodologySummary', () => {
           `/publication/${testPublicationNoMethodology.id}/methodology/${testMethodology.id}/summary`,
         );
       });
+    });
+
+    test('does not render the Create Methodology button if the user does not have permission to create one', async () => {
+      render(
+        <MemoryRouter>
+          <MethodologySummary
+            publication={{
+              ...testPublicationNoMethodology,
+              permissions: {
+                ...testPublicationNoMethodology.permissions,
+                canCreateMethodologies: false,
+              },
+            }}
+            topicId={testTopicId}
+            onChangePublication={noop}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(
+        screen.queryByRole('button', { name: 'Create methodology' }),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', {
+          name: 'Link to an externally hosted methodology',
+        }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -144,7 +144,7 @@ describe('MethodologySummary', () => {
           testPublicationNoMethodology.id,
         );
         expect(history.push).toBeCalledWith(
-          `/publication/${testPublicationNoMethodology.id}/methodology/${testMethodology.id}/summary`,
+          `/methodology/${testMethodology.id}/summary`,
         );
       });
     });
@@ -311,7 +311,7 @@ describe('MethodologySummary', () => {
   });
 
   describe('Has an external methodology', () => {
-    test('the external methodology link and buttons are shown', () => {
+    test('renders the external methodology link and buttons if the user can edit or remove it', () => {
       render(
         <MemoryRouter>
           <MethodologySummary
@@ -323,7 +323,9 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.queryByText('Ext methodolology title (external methodology)'),
+        screen.queryByText('Ext methodolology title (external methodology)', {
+          selector: 'a',
+        }),
       ).toBeInTheDocument();
 
       expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
@@ -331,6 +333,36 @@ describe('MethodologySummary', () => {
       expect(
         screen.getByRole('button', { name: 'Remove' }),
       ).toBeInTheDocument();
+    });
+
+    test('does not render the external methodology link and buttons if the user cannot edit or remove it', () => {
+      render(
+        <MemoryRouter>
+          <MethodologySummary
+            publication={{
+              ...testPublicationWithExternalMethodology,
+              permissions: {
+                ...testPublicationWithExternalMethodology.permissions,
+                canCreateMethodologies: false,
+              },
+            }}
+            topicId={testTopicId}
+            onChangePublication={noop}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(
+        screen.queryByText('Ext methodolology title (external methodology)'),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', { name: 'Edit' }),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.queryByRole('button', { name: 'Remove' }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -311,59 +311,69 @@ describe('MethodologySummary', () => {
   });
 
   describe('Has an external methodology', () => {
-    test('renders the external methodology link and buttons if the user can edit or remove it', () => {
-      render(
-        <MemoryRouter>
-          <MethodologySummary
-            publication={testPublicationWithExternalMethodology}
-            topicId={testTopicId}
-            onChangePublication={noop}
-          />
-        </MemoryRouter>,
-      );
+    test(
+      'renders the external methodology link, and renders the Edit and Remove buttons if the user has ' +
+        'permission',
+      () => {
+        render(
+          <MemoryRouter>
+            <MethodologySummary
+              publication={testPublicationWithExternalMethodology}
+              topicId={testTopicId}
+              onChangePublication={noop}
+            />
+          </MemoryRouter>,
+        );
 
-      expect(
-        screen.queryByText('Ext methodolology title (external methodology)', {
-          selector: 'a',
-        }),
-      ).toBeInTheDocument();
+        expect(
+          screen.queryByText('Ext methodolology title (external methodology)', {
+            selector: 'a',
+          }),
+        ).toBeInTheDocument();
 
-      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+        expect(
+          screen.getByRole('button', { name: 'Edit' }),
+        ).toBeInTheDocument();
 
-      expect(
-        screen.getByRole('button', { name: 'Remove' }),
-      ).toBeInTheDocument();
-    });
+        expect(
+          screen.getByRole('button', { name: 'Remove' }),
+        ).toBeInTheDocument();
+      },
+    );
 
-    test('does not render the external methodology link and buttons if the user cannot edit or remove it', () => {
-      render(
-        <MemoryRouter>
-          <MethodologySummary
-            publication={{
-              ...testPublicationWithExternalMethodology,
-              permissions: {
-                ...testPublicationWithExternalMethodology.permissions,
-                canCreateMethodologies: false,
-              },
-            }}
-            topicId={testTopicId}
-            onChangePublication={noop}
-          />
-        </MemoryRouter>,
-      );
+    test(
+      'renders the external methodology link, but not the Edit or Remove buttons if the user does not have ' +
+        'permission',
+      () => {
+        render(
+          <MemoryRouter>
+            <MethodologySummary
+              publication={{
+                ...testPublicationWithExternalMethodology,
+                permissions: {
+                  ...testPublicationWithExternalMethodology.permissions,
+                  canCreateMethodologies: false,
+                },
+              }}
+              topicId={testTopicId}
+              onChangePublication={noop}
+            />
+          </MemoryRouter>,
+        );
 
-      expect(
-        screen.queryByText('Ext methodolology title (external methodology)'),
-      ).toBeInTheDocument();
+        expect(
+          screen.queryByText('Ext methodolology title (external methodology)'),
+        ).toBeInTheDocument();
 
-      expect(
-        screen.queryByRole('button', { name: 'Edit' }),
-      ).not.toBeInTheDocument();
+        expect(
+          screen.queryByRole('button', { name: 'Edit' }),
+        ).not.toBeInTheDocument();
 
-      expect(
-        screen.queryByRole('button', { name: 'Remove' }),
-      ).not.toBeInTheDocument();
-    });
+        expect(
+          screen.queryByRole('button', { name: 'Remove' }),
+        ).not.toBeInTheDocument();
+      },
+    );
   });
 
   describe('Amending a methodology', () => {

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -478,7 +478,7 @@ describe('MethodologySummary', () => {
           testPublicationWithMethodologyCanAmend.methodology.id,
         );
         expect(history.push).toBeCalledWith(
-          `/publication/${testPublicationWithMethodologyCanAmend.id}/methodology/${mockMethodology.id}/summary`,
+          `/methodology/${mockMethodology.id}/summary`,
         );
       });
     });

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/MethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/MethodologyPage.tsx
@@ -36,7 +36,7 @@ const MethodologyPage = ({
   match,
   location,
 }: RouteComponentProps<MethodologyRouteParams>) => {
-  const { methodologyId, publicationId } = match.params;
+  const { methodologyId } = match.params;
 
   const { value, isLoading } = useAsyncHandledRetry(
     () => methodologyService.getMethodology(methodologyId),
@@ -47,7 +47,6 @@ const MethodologyPage = ({
     methodologyRoutes.findIndex(
       route =>
         generatePath<MethodologyRouteParams>(route.path, {
-          publicationId,
           methodologyId,
         }) === location.pathname,
     ) || 0;
@@ -66,7 +65,6 @@ const MethodologyPage = ({
     ? {
         label: previousRoute.title,
         linkTo: generatePath<MethodologyRouteParams>(previousRoute.path, {
-          publicationId,
           methodologyId,
         }),
       }
@@ -76,7 +74,6 @@ const MethodologyPage = ({
     ? {
         label: nextRoute.title,
         linkTo: generatePath<MethodologyRouteParams>(nextRoute.path, {
-          publicationId,
           methodologyId,
         }),
       }
@@ -109,7 +106,6 @@ const MethodologyPage = ({
               routes={navRoutes.map(route => ({
                 title: route.title,
                 to: generatePath<MethodologyRouteParams>(route.path, {
-                  publicationId,
                   methodologyId,
                 }),
               }))}

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryEditPage.tsx
@@ -1,10 +1,13 @@
 import MethodologySummaryForm from '@admin/pages/methodology/components/MethodologySummaryForm';
-import { MethodologyRouteParams } from '@admin/routes/methodologyRoutes';
+import {
+  MethodologyRouteParams,
+  methodologySummaryRoute,
+} from '@admin/routes/methodologyRoutes';
 import methodologyService from '@admin/services/methodologyService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React from 'react';
-import { RouteComponentProps } from 'react-router';
+import { generatePath, RouteComponentProps } from 'react-router';
 
 const MethodologySummaryEditPage = ({
   history,
@@ -34,7 +37,14 @@ const MethodologySummaryEditPage = ({
                 title: values.title,
               });
 
-              history.push(`/methodologies/${methodologyId}/summary`);
+              history.push(
+                generatePath<MethodologyRouteParams>(
+                  methodologySummaryRoute.path,
+                  {
+                    methodologyId,
+                  },
+                ),
+              );
             }}
             onCancel={history.goBack}
           />

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryPage.tsx
@@ -1,5 +1,8 @@
 import ButtonLink from '@admin/components/ButtonLink';
-import { MethodologyRouteParams } from '@admin/routes/methodologyRoutes';
+import {
+  MethodologyRouteParams,
+  methodologySummaryEditRoute,
+} from '@admin/routes/methodologyRoutes';
 import methodologyService from '@admin/services/methodologyService';
 import FormattedDate from '@common/components/FormattedDate';
 import LoadingSpinner from '@common/components/LoadingSpinner';
@@ -9,7 +12,7 @@ import Tag from '@common/components/Tag';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React from 'react';
-import { RouteComponentProps } from 'react-router';
+import { generatePath, RouteComponentProps } from 'react-router';
 
 const MethodologySummaryPage = ({
   match,
@@ -44,7 +47,14 @@ const MethodologySummaryPage = ({
             </SummaryList>
 
             {currentMethodology.status !== 'Approved' && (
-              <ButtonLink to={`/methodologies/${methodologyId}/summary/edit`}>
+              <ButtonLink
+                to={generatePath<MethodologyRouteParams>(
+                  methodologySummaryEditRoute.path,
+                  {
+                    methodologyId,
+                  },
+                )}
+              >
                 Edit summary
               </ButtonLink>
             )}

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusChecklist.tsx
@@ -73,7 +73,6 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
               methodologyStatusRoute.path,
               {
                 methodologyId: error.methodologyId,
-                publicationId: release.publicationId,
               },
             ),
           };
@@ -117,7 +116,7 @@ const ReleaseStatusChecklist = ({ checklist, release }: Props) => {
           };
       }
     });
-  }, [checklist.errors, releaseRouteParams, release.publicationId]);
+  }, [checklist.errors, releaseRouteParams]);
 
   const warnings = useMemo<ChecklistMessage[]>(() => {
     return checklist.warnings.map(warning => {

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusChecklist.test.tsx
@@ -88,10 +88,7 @@ describe('ReleaseStatusChecklist', () => {
       screen.getByRole('link', {
         name: 'Methodology must be approved',
       }),
-    ).toHaveAttribute(
-      'href',
-      '/publication/publication-1/methodology/methodology-1/status',
-    );
+    ).toHaveAttribute('href', '/methodology/methodology-1/status');
 
     expect(
       screen.getByRole('link', {

--- a/src/explore-education-statistics-admin/src/routes/methodologyRoutes.ts
+++ b/src/explore-education-statistics-admin/src/routes/methodologyRoutes.ts
@@ -11,29 +11,28 @@ export interface MethodologyRouteProps extends RouteProps {
 
 export type MethodologyRouteParams = {
   methodologyId: string;
-  publicationId: string;
 };
 
 export const methodologySummaryRoute: MethodologyRouteProps = {
-  path: '/publication/:publicationId/methodology/:methodologyId/summary',
+  path: '/methodology/:methodologyId/summary',
   title: 'Summary',
   component: MethodologySummaryPage,
 };
 
 export const methodologySummaryEditRoute: MethodologyRouteProps = {
-  path: '/publication/:publicationId/methodology/:methodologyId/summary/edit',
+  path: '/methodology/:methodologyId/summary/edit',
   title: 'Edit summary',
   component: MethodologySummaryEditPage,
 };
 
 export const methodologyContentRoute: MethodologyRouteProps = {
-  path: '/publication/:publicationId/methodology/:methodologyId/content',
+  path: '/methodology/:methodologyId/content',
   title: 'Manage content',
   component: MethodologyContentPage,
 };
 
 export const methodologyStatusRoute: MethodologyRouteProps = {
-  path: '/publication/:publicationId/methodology/:methodologyId/status',
+  path: '/methodology/:methodologyId/status',
   title: 'Sign off',
   component: MethodologyStatusPage,
 };

--- a/src/explore-education-statistics-admin/src/routes/routes.ts
+++ b/src/explore-education-statistics-admin/src/routes/routes.ts
@@ -114,7 +114,7 @@ export const methodologiesIndexRoute: ProtectedRouteProps = {
 };
 
 export const methodologyRoute: ProtectedRouteProps = {
-  path: '/publication/:publicationId/methodology/:methodologyId',
+  path: '/methodology/:methodologyId',
   component: MethodologyPage,
   protectionAction: user => user.permissions.canAccessAnalystPages,
 };

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -41,6 +41,7 @@ export interface MyPublication {
   permissions: {
     canCreateReleases: boolean;
     canUpdatePublication: boolean;
+    canCreateMethodologies: boolean;
   };
 }
 


### PR DESCRIPTION
This PR:
- controls the visibility of the Create Methodology and Link to External Methodology buttons based on permissions checks
- controls the visibility of the Edit and Remove External Methodology buttons based on permissions checks
- refactors the Methodology routes to not have them always under the context of a particular Publication