### PR TITLE
EES-2361 reset table tool route when edit publication

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -32,6 +32,7 @@ import tableBuilderService, {
 } from '@common/services/tableBuilderService';
 import React, { ReactElement, ReactNode } from 'react';
 import { useImmer } from 'use-immer';
+import { useRouter } from 'next/router';
 
 export interface InitialTableToolState {
   initialStep: number;
@@ -83,6 +84,7 @@ const TableToolWizard = ({
   onSubmit,
   loadingFastTrack = false,
 }: TableToolWizardProps) => {
+  const router = useRouter();
   const [state, updateState] = useImmer<TableToolState>({
     initialStep: 1,
     subjects: [],
@@ -105,6 +107,10 @@ const TableToolWizard = ({
     },
     ...initialState,
   });
+
+  const handlePublicationStepBack = () => {
+    router.push('/data-tables', undefined, { shallow: true });
+  };
 
   const handlePublicationFormSubmit: PublicationFormSubmitHandler = async ({
     publicationId: selectedPublicationId,
@@ -291,7 +297,7 @@ const TableToolWizard = ({
             }}
           >
             {!hidePublicationSelectionStage && (
-              <WizardStep>
+              <WizardStep onBack={handlePublicationStepBack}>
                 {stepProps => (
                   <PublicationForm
                     {...stepProps}


### PR DESCRIPTION
Currently in the table tool if you select a table highlight, then go back to step 1, select the same publication then the same highlight you get stuck on step 2 instead of showing the highlight.

Trying to force update the step, see https://github.com/dfe-analytical-services/explore-education-statistics/pull/2584 (or do it a nicer way) ended up causing other problems - changing filters after then re-selecting wouldn't reset the filters to the highlight table ones.

So I've changed approach and am now resetting the url when you go back to step 1, this fixes the original problem and the only side effect is that the original publication isn't still selected, which I think is ok. 

If you've gone through the table tool without the fast track and go back to step 1, it still keeps your previous selections as before.