### PR TITLE
EES-2409 - package up publication owner functionality into custom key…

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/release_and_publication_role_permissions.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/release_and_publication_role_permissions.robot
@@ -65,20 +65,8 @@ Assert that test users are present in table
 
 Give Analyst1 User1 publication owner access
     [Tags]  HappyPath
-    user clicks link  Manage  xpath://td[text()="ees-analyst1@education.gov.uk"]/..
-    user waits until page does not contain loading spinner
+    user gives analyst publication owner access  ees-analyst1@education.gov.uk  ${PUBLICATION_NAME}
 
-    # stale element exception if you don't wait until it's enabled    
-    user waits until button is enabled  Add publication access
-    user scrolls to element  css:[name="selectedPublicationId"]
-    
-    user waits until element is enabled  css:[name="selectedPublicationId"]
-    user selects from list by label  css:[name="selectedPublicationId"]  ${PUBLICATION_NAME}
-
-    user waits until element is enabled  css:[name="selectedPublicationRole"]
-    user selects from list by label  css:[name="selectedPublicationRole"]  Owner
-    user clicks button  Add publication access
-    
 Sign in as Analyst1 User1 (publication owner) & navigate to publication
     [Tags]  HappyPath
     user changes to analyst1
@@ -200,20 +188,11 @@ Navigate to manage users
 
 Remove publication owner access 
     [Tags]  HappyPath
-    user waits until element is enabled  css:[name="selectedPublicationId"]
-    user scrolls to element  css:[name="selectedPublicationId"]
-    user clicks testid element  remove-publication-role-${PUBLICATION_NAME}
-    user waits until page does not contain loading spinner
+    user removes publication owner access from analyst  ${PUBLICATION_NAME}
 
 Give release approver access to Analyst1
     [Tags]  HappyPath
-    user waits until element is enabled  css:[name="selectedReleaseId"]
-    user scrolls to element  css:[name="selectedReleaseId"]
-    user selects from list by label  css:[name="selectedReleaseId"]  ${RELEASE_NAME}
-    user waits until element is enabled  css:[name="selectedReleaseRole"]
-    user selects from list by label  css:[name="selectedReleaseRole"]  Approver
-    user clicks button  Add release access
-    user waits until page does not contain loading spinner
+    user gives analyst release access  ${RELEASE_NAME}  Approver
 
 Check release owner can access release
     [Tags]  HappyPath
@@ -328,12 +307,7 @@ Navigate to manage users page to remove viewer access
 
 Give release contributor access to Analyst1
     [Tags]  HappyPath
-    user scrolls to element  css:[name="selectedReleaseId"]
-    user waits until element is enabled  css:[name="selectedReleaseId"]
-    user selects from list by label  css:[name="selectedReleaseId"]  ${RELEASE_NAME}
-    user waits until element is enabled  css:[name="selectedReleaseRole"]
-    user selects from list by label  css:[name="selectedReleaseRole"]  Contributor
-    user clicks button  Add release access
+    user gives analyst release access   ${RELEASE_NAME}  Contributor
 
 Login as a release contributor 
     [Tags]  HappyPath

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -418,3 +418,36 @@ user changes methodology status to Approved
     user clicks element  id:methodologyStatusForm-status-Approved
     user enters text into element  id:methodologyStatusForm-internalReleaseNote  Approved by UI tests
     user clicks button  Update status
+
+user gives analyst publication owner access
+    [Arguments]  ${ANALYST_EMAIL}  ${PUBLICATION_NAME}
+    user clicks link  Manage  xpath://td[text()="${ANALYST_EMAIL}"]/..
+    user waits until page does not contain loading spinner
+
+    # stale element exception if you don't wait until it's enabled    
+    user waits until button is enabled  Add publication access
+    user scrolls to element  css:[name="selectedPublicationId"]
+    
+    user waits until element is enabled  css:[name="selectedPublicationId"]
+    user selects from list by label  css:[name="selectedPublicationId"]  ${PUBLICATION_NAME}
+
+    user waits until element is enabled  css:[name="selectedPublicationRole"]
+    user selects from list by label  css:[name="selectedPublicationRole"]  Owner
+    user clicks button  Add publication access
+
+user removes publication owner access from analyst 
+    [Arguments]  ${PUBLICATION_NAME}
+    user waits until element is enabled  css:[name="selectedPublicationId"]
+    user scrolls to element  css:[name="selectedPublicationId"]
+    user clicks testid element  remove-publication-role-${PUBLICATION_NAME}
+    user waits until page does not contain loading spinner
+
+user gives analyst release access 
+    [Arguments]    ${RELEASE_NAME}  ${ROLE}
+    user waits until element is enabled  css:[name="selectedReleaseId"]
+    user scrolls to element  css:[name="selectedReleaseId"]
+    user selects from list by label  css:[name="selectedReleaseId"]  ${RELEASE_NAME}
+    user waits until element is enabled  css:[name="selectedReleaseRole"]
+    user selects from list by label  css:[name="selectedReleaseRole"]  ${ROLE}
+    user clicks button  Add release access
+    user waits until page does not contain loading spinner


### PR DESCRIPTION
…words

This PR moves certain publication owner test functionality into `admin-common.robot` 

Functionality moved into `admin-common.robot`: 

- `user gives analyst publication owner access`
- `user removes publication owner access from analyst`
- `user gives analyst release access`


