### PR TITLE
EES-2338 fix editing, deleting and num of unresolved comments

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/Comments.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/Comments.tsx
@@ -67,20 +67,19 @@ const Comments = ({
     }
   };
 
-  const removeComment = (index: number) => {
-    const commentId = comments[index].id;
-
+  const removeComment = (commentId: string) => {
+    const index = comments.findIndex(comment => comment.id === commentId);
     releaseContentCommentService
       .deleteContentSectionComment(commentId)
       .then(() => {
         const newComments = [...comments];
         newComments.splice(index, 1);
-
         onChange(blockId, newComments);
       });
   };
 
-  const updateComment = (index: number, content: string) => {
+  const updateComment = (commentId: string, content: string) => {
+    const index = comments.findIndex(comment => comment.id === commentId);
     const editedComment: UpdateComment = {
       ...comments[index],
       content,
@@ -133,7 +132,7 @@ const Comments = ({
         )}
 
         <ul className={styles.commentsContainer}>
-          {orderBy(comments, ['created'], ['desc']).map((comment, index) => {
+          {orderBy(comments, ['created'], ['desc']).map(comment => {
             const { createdBy } = comment;
 
             return (
@@ -159,7 +158,7 @@ const Comments = ({
                       content: Yup.string().required('Enter a comment'),
                     })}
                     onSubmit={values => {
-                      updateComment(index, values.content);
+                      updateComment(comment.id, values.content);
                     }}
                   >
                     <Form
@@ -201,7 +200,7 @@ const Comments = ({
 
                         <ButtonText
                           onClick={() => {
-                            removeComment(index);
+                            removeComment(comment.id);
                           }}
                         >
                           Delete

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/Comments.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/Comments.test.tsx
@@ -549,5 +549,79 @@ describe('Comments', () => {
         ] as Comment[]);
       });
     });
+
+    test('deleting comment calls the `onChange` handler with it removed from comments when selecting one of multiple comments', async () => {
+      const handleChange = jest.fn();
+
+      const testCommentsMultiple = [
+        ...testComments,
+        {
+          id: 'comment-3',
+          content: 'Test comment 3',
+          createdBy: {
+            id: 'user-2',
+            email: 'test2@test.com',
+            firstName: 'Jane',
+            lastName: 'Roberts',
+          },
+          created: '2020-06-08T11:00:00',
+        },
+      ];
+
+      render(
+        <AuthContext.Provider
+          value={{
+            user: testUser,
+          }}
+        >
+          <ReleaseContextProvider release={testRelease}>
+            <Comments
+              blockId="test-block"
+              sectionId="section-1"
+              comments={testCommentsMultiple}
+              onChange={handleChange}
+            />
+          </ReleaseContextProvider>
+        </AuthContext.Provider>,
+      );
+
+      releaseContentCommentService.deleteContentSectionComment.mockImplementation(
+        () => Promise.resolve(),
+      );
+
+      fireEvent.click(
+        screen.getAllByRole('button', {
+          name: 'Delete',
+          hidden: true,
+        })[0],
+      );
+
+      await waitFor(() => {
+        expect(handleChange).toHaveBeenCalledWith('test-block', [
+          {
+            id: 'comment-1',
+            content: 'Test comment 1',
+            createdBy: {
+              id: 'user-1',
+              email: 'test@test.com',
+              firstName: 'John',
+              lastName: 'Smith',
+            },
+            created: '2020-06-06T12:00:00',
+          },
+          {
+            id: 'comment-2',
+            content: 'Test comment 2',
+            createdBy: {
+              id: 'user-2',
+              email: 'test2@test.com',
+              firstName: 'Jane',
+              lastName: 'Roberts',
+            },
+            created: '2020-06-06T11:00:00',
+          },
+        ] as Comment[]);
+      });
+    });
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/ReleaseContentPage.tsx
@@ -9,15 +9,12 @@ import {
 } from '@admin/pages/release/content/contexts/ReleaseContentContext';
 import { ReleaseRouteParams } from '@admin/routes/releaseRoutes';
 import permissionService from '@admin/services/permissionService';
-import releaseContentService, {
-  EditableRelease,
-} from '@admin/services/releaseContentService';
-import { Comment, EditableBlock } from '@admin/services/types/content';
+import releaseContentService from '@admin/services/releaseContentService';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
-import { ContentSection } from '@common/services/publicationService';
 import { getNumberOfUnSavedBlocks } from '@admin/pages/release/content/components/utils/unSavedEdits';
+import getUnresolvedComments from '@admin/pages/release/content/utils/getUnresolvedComments';
 import classNames from 'classnames';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
@@ -58,13 +55,12 @@ const ReleaseContentPageLoaded = () => {
                       : `${numOfEdits} content blocks have unsaved changes. Clicking away from this tab will result in the changes being lost.`}
                   </WarningMessage>
                 )}
-                {unresolvedComments.length > 0 &&
-                unresolvedComments.length > 1 ? (
+                {unresolvedComments.length > 0 && (
                   <WarningMessage>
-                    There are {unresolvedComments.length} unresolved comments
+                    {unresolvedComments.length === 1
+                      ? 'There is 1 unresolved comment'
+                      : `There are ${unresolvedComments.length} unresolved comments`}
                   </WarningMessage>
-                ) : (
-                  <WarningMessage>There is 1 unresolved comment</WarningMessage>
                 )}
 
                 <EditablePageModeToggle />
@@ -94,39 +90,6 @@ const ReleaseContentPageLoaded = () => {
     </EditingContextProvider>
   );
 };
-
-const contentSectionComments = (
-  contentSection: ContentSection<EditableBlock>,
-): Comment[] => {
-  if (contentSection.content?.length) {
-    return contentSection.content.reduce<Comment[]>(
-      (allCommentsForSection, content) => {
-        content.comments.forEach(comment =>
-          allCommentsForSection.push(comment),
-        );
-        return allCommentsForSection;
-      },
-      [],
-    );
-  }
-
-  return [];
-};
-
-const getUnresolvedComments = (release: EditableRelease) =>
-  [
-    ...contentSectionComments(release.summarySection),
-    ...contentSectionComments(release.keyStatisticsSection),
-    ...release.content
-      .filter(_ => _.content !== undefined)
-      .reduce<Comment[]>(
-        (allComments, contentSection) => [
-          ...allComments,
-          ...contentSectionComments(contentSection),
-        ],
-        [],
-      ),
-  ].filter(comment => comment !== undefined);
 
 const ReleaseContentPage = ({
   match,

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/ReleaseContentContext.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/ReleaseContentContext.tsx
@@ -4,6 +4,7 @@ import { Comment, EditableBlock } from '@admin/services/types/content';
 import { useLoggedImmerReducer } from '@common/hooks/useLoggedReducer';
 import { ContentSection } from '@common/services/publicationService';
 import { BaseBlock, DataBlock } from '@common/services/types/blocks';
+import getUnresolvedComments from '@admin/pages/release/content/utils/getUnresolvedComments';
 import remove from 'lodash/remove';
 import React, { createContext, ReactNode, useContext } from 'react';
 import { Reducer } from 'use-immer';
@@ -234,6 +235,8 @@ export const releaseReducer: Reducer<
       } else {
         matchingBlock.comments = comments;
       }
+
+      draft.unresolvedComments = getUnresolvedComments(draft.release);
       return draft;
     }
     default: {

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/__tests__/ReleaseContentContext.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/__tests__/ReleaseContentContext.test.tsx
@@ -748,7 +748,7 @@ describe('ReleaseContentContext', () => {
     expect(release?.content[0].heading).toEqual('updated heading');
   });
 
-  test("UPDATE_BLOCK_COMMENTS updates a block's comments", () => {
+  test("UPDATE_BLOCK_COMMENTS updates a block's comments and the unresolved comments list", () => {
     const sectionKey = 'content';
 
     const newComment: Comment = {
@@ -768,7 +768,7 @@ describe('ReleaseContentContext', () => {
       newComment,
     ];
 
-    const { release } = releaseReducer(
+    const { release, unresolvedComments } = releaseReducer(
       {
         release: basicRelease,
         canUpdateRelease: true,
@@ -789,6 +789,42 @@ describe('ReleaseContentContext', () => {
     );
 
     expect(release?.content[0].content[0].comments).toEqual<Comment[]>([
+      {
+        id: 'comment-1',
+        content: 'A comment',
+        createdBy: {
+          id: 'user-1',
+          firstName: 'Bau1',
+          lastName: '',
+          email: 'bau1@test.com',
+        },
+        created: '2020-03-09T09:39:53.736',
+      },
+      {
+        id: 'comment-2',
+        content: 'another comment',
+        createdBy: {
+          id: 'user-1',
+          firstName: 'Bau1',
+          lastName: '',
+          email: 'bau1@test.com',
+        },
+        created: '2020-03-09T09:40:16.534',
+      },
+      {
+        id: 'comment-3',
+        content: 'a third comment',
+        createdBy: {
+          id: 'user-1',
+          firstName: 'Bau1',
+          lastName: '',
+          email: 'bau1@test.com',
+        },
+        created: '2020-03-10T12:00:00.000',
+      },
+    ]);
+
+    expect(unresolvedComments).toEqual([
       {
         id: 'comment-1',
         content: 'A comment',

--- a/src/explore-education-statistics-admin/src/pages/release/content/utils/getUnresolvedComments.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/content/utils/getUnresolvedComments.ts
@@ -1,0 +1,38 @@
+import { EditableRelease } from '@admin/services/releaseContentService';
+import { Comment, EditableBlock } from '@admin/services/types/content';
+import { ContentSection } from '@common/services/publicationService';
+
+const getContentSectionComments = (
+  contentSection: ContentSection<EditableBlock>,
+): Comment[] => {
+  if (contentSection.content?.length) {
+    return contentSection.content.reduce<Comment[]>(
+      (allCommentsForSection, content) => {
+        content.comments.forEach(comment =>
+          allCommentsForSection.push(comment),
+        );
+        return allCommentsForSection;
+      },
+      [],
+    );
+  }
+
+  return [];
+};
+
+const getUnresolvedComments = (release: EditableRelease) =>
+  [
+    ...getContentSectionComments(release.summarySection),
+    ...getContentSectionComments(release.keyStatisticsSection),
+    ...release.content
+      .filter(_ => _.content !== undefined)
+      .reduce<Comment[]>(
+        (allComments, contentSection) => [
+          ...allComments,
+          ...getContentSectionComments(contentSection),
+        ],
+        [],
+      ),
+  ].filter(comment => comment !== undefined);
+
+export default getUnresolvedComments;


### PR DESCRIPTION
Comments fixes:
- Only shows the unresolved comments warning if there are some
- Updates the  unresolved comments warning when comments are added and deleted
- Fixes problem where the wrong comment id could be sent when editing or deleting comments causing either the wrong comment to be edited / deleted or a permissions error 