### PR TITLE
EES-2395 Show links to Methodologies from Admin Manage Content page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -141,8 +141,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                         Summary = r.Publication.Summary,
                         DataSource = r.Publication.DataSource,
                         Contact = r.Publication.Contact,
-                        // TODO SOW4 EES-2395 Populate latest methodologies for Admin Manage Content page 
-                        Methodologies = new List<MethodologyTitleViewModel>(),
                         Topic = new ManageContentPageViewModel.TopicViewModel
                         {
                             Theme = new ManageContentPageViewModel.ThemeViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.ManageContent;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.ManageContent;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -19,23 +22,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
 {
     public class ManageContentPageService : IManageContentPageService
     {
-        private readonly IMapper _mapper;
-        private readonly IReleaseFileService _releaseFileService;
-        private readonly IContentService _contentService;
         private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
+        private readonly IMapper _mapper;
+        private readonly IContentService _contentService;
+        private readonly IMethodologyRepository _methodologyRepository;
+        private readonly IReleaseFileService _releaseFileService;
         private readonly IUserService _userService;
 
-        public ManageContentPageService(
+        public ManageContentPageService(IPersistenceHelper<ContentDbContext> persistenceHelper,
             IMapper mapper,
-            IReleaseFileService releaseFileService,
             IContentService contentService,
-            IPersistenceHelper<ContentDbContext> persistenceHelper,
+            IMethodologyRepository methodologyRepository,
+            IReleaseFileService releaseFileService,
             IUserService userService)
         {
-            _mapper = mapper;
-            _releaseFileService = releaseFileService;
-            _contentService = contentService;
             _persistenceHelper = persistenceHelper;
+            _mapper = mapper;
+            _contentService = contentService;
+            _methodologyRepository = methodologyRepository;
+            _releaseFileService = releaseFileService;
             _userService = userService;
         }
 
@@ -45,23 +50,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
             return await _persistenceHelper
                 .CheckEntityExists<Release>(releaseId, HydrateReleaseForReleaseViewModel)
                 .OnSuccess(_userService.CheckCanViewRelease)
-                .OnSuccess(release => _contentService.GetUnattachedContentBlocksAsync<DataBlock>(releaseId)
-                    .OnSuccess(blocks => _releaseFileService.ListAll(
-                            releaseId,
-                            Ancillary,
-                            FileType.Data)
-                        .OnSuccess(files =>
-                        {
-                            var releaseViewModel =
-                                _mapper.Map<ManageContentPageViewModel.ReleaseViewModel>(release);
-                            releaseViewModel.DownloadFiles = files.ToList();
+                .OnSuccessCombineWith(release => _contentService.GetUnattachedContentBlocksAsync<DataBlock>(releaseId))
+                .OnSuccessCombineWith(releaseAndBlocks => _releaseFileService.ListAll(
+                    releaseId,
+                    Ancillary,
+                    FileType.Data))
+                .OnSuccess(async releaseBlocksAndFiles =>
+                {
+                    var (release, blocks, files) = releaseBlocksAndFiles;
 
-                            return new ManageContentPageViewModel
-                            {
-                                Release = releaseViewModel,
-                                AvailableDataBlocks = blocks
-                            };
-                        })));
+                    var methodologies = await _methodologyRepository.GetLatestByPublication(release.PublicationId);
+
+                    var releaseViewModel = _mapper.Map<ManageContentPageViewModel.ReleaseViewModel>(release);
+                    releaseViewModel.DownloadFiles = files.ToList();
+                    releaseViewModel.Publication.Methodologies =
+                        _mapper.Map<List<MethodologyTitleViewModel>>(methodologies);
+
+                    return new ManageContentPageViewModel
+                    {
+                        Release = releaseViewModel,
+                        AvailableDataBlocks = blocks
+                    };
+                });
         }
 
         private static IQueryable<Release> HydrateReleaseForReleaseViewModel(IQueryable<Release> values)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -175,7 +175,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                 .OnSuccessCombineWith(globalAndPublicationRoles => _userRoleService.GetReleaseRoles(id))
                                 .OnSuccess(tuple =>
                                 {
-                                    var ((globalRoles, publicationRoles), releaseRoles) = tuple;
+                                    var (globalRoles, publicationRoles, releaseRoles) = tuple;
 
                                     // Currently we only allow a user to have a maximum of one global role
                                     var globalRole = globalRoles.First();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -193,6 +193,25 @@ public class Either<Tl, Tr> {
             });
         }
 
+        /**
+         * Allows 3 OnSuccess(...) calls to be chained and the next OnSuccess() to receive a Tuple containing all 3 of
+         * the results.  If any OnSuccess(...) fails, the entire result fails and additionally, if the first result
+         * fails, the subsequent OnSuccess(...) will not be called.
+         *
+         * When C# allows better destructuring, we will be able to destructure the resulting Tuple much better. 
+         */
+        public static async Task<Either<TFailure, Tuple<TSuccess1, TSuccess2, TSuccess3>>>
+            OnSuccessCombineWith<TFailure, TSuccess1, TSuccess2, TSuccess3>(
+                this Task<Either<TFailure, Tuple<TSuccess1, TSuccess2>>> task,
+                Func<Tuple<TSuccess1, TSuccess2>, Task<Either<TFailure, TSuccess3>>> func)
+        {
+            return await task.OnSuccess(success =>
+            {
+                return func(success).OnSuccess(combinator =>
+                    new Tuple<TSuccess1, TSuccess2, TSuccess3>(success.Item1, success.Item2, combinator));
+            });
+        }
+
         public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(this Task<Either<TFailure, TSuccess1>> task, Func<TSuccess1, Task<TSuccess2>> func)
         {
             var firstResult = await task;

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -171,7 +171,7 @@ const ReleaseContent = () => {
                   {isEditing ? (
                     <a>{methodology.title}</a>
                   ) : (
-                    <Link to={`/methodologies/${methodology.id}`}>
+                    <Link to={`/methodology/${methodology.id}/summary`}>
                       {methodology.title}
                     </Link>
                   )}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHelpAndSupportSection.tsx
@@ -38,7 +38,7 @@ const ReleaseHelpAndSupportSection = ({
                   {isEditing ? (
                     <a>{`${methodology.title}`}</a>
                   ) : (
-                    <Link to={`/methodologies/${methodology.id}`}>
+                    <Link to={`/methodology/${methodology.id}/summary`}>
                       {methodology.title}
                     </Link>
                   )}


### PR DESCRIPTION
This PR adds the functionality to show links to the latest methodology (or methodologies) of the Publication on the Manage Content page of a Release.

This was removed at the beginning of SOW4 work and is now reintroduced with support for multiple methodologies. Each methodology may have multiple versions. In the Admin a link to the latest version is shown for each Methodology.