### PR TITLE
EES-2430 contact us caption and link on release page

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -226,6 +226,9 @@ const ReleaseContent = () => {
                   </Link>
                 </li>
               )}
+              <li>
+                <a href="#contact-us">Contact us</a>
+              </li>
             </ul>
 
             <dl className="dfe-meta-content">

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseHelpAndSupportSection.tsx
@@ -61,7 +61,12 @@ const ReleaseHelpAndSupportSection = ({
             <NationalStatisticsSection />
           </AccordionSection>
         )}
-        <AccordionSection heading="Contact us" headingTag="h3">
+        <AccordionSection
+          heading="Contact us"
+          headingTag="h3"
+          id="contact-us"
+          caption="Ask questions and provide feedback"
+        >
           <ContactUsSection
             publicationContact={publication.contact}
             publicationTitle={publication.title}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseHelpAndSupportSection.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleaseHelpAndSupportSection.tsx
@@ -64,7 +64,12 @@ const PublicationReleaseHelpAndSupportSection = ({
             <NationalStatisticsSection />
           </AccordionSection>
         )}
-        <AccordionSection heading="Contact us" headingTag="h3">
+        <AccordionSection
+          heading="Contact us"
+          headingTag="h3"
+          caption="Ask questions and provide feedback"
+          id="contact-us"
+        >
           <ContactUsSection
             publicationContact={publicationContact}
             publicationTitle={publicationTitle}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -248,6 +248,9 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                     </Link>
                   </li>
                 )}
+                <li>
+                  <a href="#contact-us">Contact us</a>
+                </li>
                 {!!releaseCount && (
                   <>
                     <p className="govuk-!-margin-bottom-0">


### PR DESCRIPTION
On release pages:
- adds a link to contact us from the useful information section
- adds a caption to the contact us accordion 