### PR TITLE
EES-2024 Put Methodology links back on the Admin Dashboard

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyMethodologyPermissionsPropertyResolverTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyMethodologyPermissionsPropertyResolverTest.cs
@@ -19,14 +19,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
             var userService = new Mock<IUserService>(Strict);
             var resolver = new MyMethodologyPermissionSetPropertyResolver(userService.Object);
             
-            userService.Setup(s => s.MatchesPolicy(methodology, SecurityPolicies.CanUpdateSpecificMethodology)).ReturnsAsync(true); //TODO
+            userService.Setup(s => s.MatchesPolicy(methodology, SecurityPolicies.CanUpdateSpecificMethodology)).ReturnsAsync(true);
             userService.Setup(s => s.MatchesPolicy(methodology, SecurityPolicies.CanMakeAmendmentOfSpecificMethodology)).ReturnsAsync(false);
             
             var permissionsSet = resolver.Resolve(methodology, null, null, null);
             VerifyAllMocks(userService);
             
             Assert.True(permissionsSet.CanUpdateMethodology);
-            Assert.True(permissionsSet.CanRemoveMethodology);
+            Assert.False(permissionsSet.CanCancelMethodologyAmendment);
             Assert.False(permissionsSet.CanMakeAmendmentOfMethodology);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyMethodologyPermissionsPropertyResolverTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyMethodologyPermissionsPropertyResolverTest.cs
@@ -1,0 +1,33 @@
+using GovUk.Education.ExploreEducationStatistics.Admin.Mappings;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
+{
+    public class MyMethodologyPermissionsPropertyResolverTest
+    {
+        [Fact]
+        public void ResolvePermissions()
+        {
+            var methodology = new Methodology();
+            
+            var userService = new Mock<IUserService>(Strict);
+            var resolver = new MyMethodologyPermissionSetPropertyResolver(userService.Object);
+            
+            userService.Setup(s => s.MatchesPolicy(methodology, SecurityPolicies.CanUpdateSpecificMethodology)).ReturnsAsync(true); //TODO
+            userService.Setup(s => s.MatchesPolicy(methodology, SecurityPolicies.CanMakeAmendmentOfSpecificMethodology)).ReturnsAsync(false);
+            
+            var permissionsSet = resolver.Resolve(methodology, null, null, null);
+            VerifyAllMocks(userService);
+            
+            Assert.True(permissionsSet.CanUpdateMethodology);
+            Assert.True(permissionsSet.CanRemoveMethodology);
+            Assert.False(permissionsSet.CanMakeAmendmentOfMethodology);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyPublicationPermissionsPropertyResolverTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyPublicationPermissionsPropertyResolverTest.cs
@@ -22,6 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
             userService.Setup(s => s.MatchesPolicy(publication, SecurityPolicies.CanUpdateSpecificPublication)).ReturnsAsync(true);
             userService.Setup(s => s.MatchesPolicy(publication, SecurityPolicies.CanCreateReleaseForSpecificPublication)).ReturnsAsync(true);
             userService.Setup(s => s.MatchesPolicy(publication, SecurityPolicies.CanCreateMethodologyForSpecificPublication)).ReturnsAsync(false);
+            userService.Setup(s => s.MatchesPolicy(publication, SecurityPolicies.CanManageExternalMethodologyForSpecificPublication)).ReturnsAsync(false);
 
             var permissionsSet = resolver.Resolve(publication, null, null, null);
             VerifyAllMocks(userService);
@@ -29,6 +30,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
             Assert.True(permissionsSet.CanUpdatePublication);
             Assert.True(permissionsSet.CanCreateReleases);
             Assert.False(permissionsSet.CanCreateMethodologies);
+            Assert.False(permissionsSet.CanManageExternalMethodology);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyPublicationPermissionsPropertyResolverTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyPublicationPermissionsPropertyResolverTest.cs
@@ -1,0 +1,34 @@
+using GovUk.Education.ExploreEducationStatistics.Admin.Mappings;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
+{
+    public class MyPublicationPermissionsPropertyResolverTest
+    {
+        [Fact]
+        public void ResolvePermissions()
+        {
+            var publication = new Publication();
+            
+            var userService = new Mock<IUserService>(Strict);
+            var resolver = new MyPublicationPermissionSetPropertyResolver(userService.Object);
+            
+            userService.Setup(s => s.MatchesPolicy(publication, SecurityPolicies.CanUpdateSpecificPublication)).ReturnsAsync(true);
+            userService.Setup(s => s.MatchesPolicy(publication, SecurityPolicies.CanCreateReleaseForSpecificPublication)).ReturnsAsync(true);
+            userService.Setup(s => s.MatchesPolicy(publication, SecurityPolicies.CanCreateMethodologyForSpecificPublication)).ReturnsAsync(false);
+
+            var permissionsSet = resolver.Resolve(publication, null, null, null);
+            VerifyAllMocks(userService);
+            
+            Assert.True(permissionsSet.CanUpdatePublication);
+            Assert.True(permissionsSet.CanCreateReleases);
+            Assert.False(permissionsSet.CanCreateMethodologies);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyReleasePermissionsPropertyResolverTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyReleasePermissionsPropertyResolverTest.cs
@@ -1,0 +1,36 @@
+using GovUk.Education.ExploreEducationStatistics.Admin.Mappings;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
+{
+    public class MyReleasePermissionsPropertyResolverTest
+    {
+        [Fact]
+        public void ResolvePermissions()
+        {
+            var release = new Release();
+            
+            var userService = new Mock<IUserService>(Strict);
+            var resolver = new MyReleasePermissionSetPropertyResolver(userService.Object);
+            
+            userService.Setup(s => s.MatchesPolicy(release, SecurityPolicies.CanUpdateSpecificRelease)).ReturnsAsync(true);
+            userService.Setup(s => s.MatchesPolicy(release, SecurityPolicies.CanDeleteSpecificRelease)).ReturnsAsync(true);
+            userService.Setup(s => s.MatchesPolicy(release, SecurityPolicies.CanAssignPrereleaseContactsToSpecificRelease)).ReturnsAsync(false);
+            userService.Setup(s => s.MatchesPolicy(release, SecurityPolicies.CanMakeAmendmentOfSpecificRelease)).ReturnsAsync(false);
+
+            var permissionsSet = resolver.Resolve(release, null, null, null);
+            VerifyAllMocks(userService);
+            
+            Assert.True(permissionsSet.CanUpdateRelease);
+            Assert.True(permissionsSet.CanDeleteRelease);
+            Assert.False(permissionsSet.CanAddPrereleaseUsers);
+            Assert.False(permissionsSet.CanMakeAmendmentOfRelease);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ManageExternalMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ManageExternalMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
@@ -16,7 +16,7 @@ using static Moq.MockBehavior;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
     // ReSharper disable once ClassNeverInstantiated.Global
-    public class CreateMethodologyForSpecificPublicationAuthorizationHandlerTests
+    public class ManageExternalMethodologyForSpecificPublicationAuthorizationHandlerTests
     {
         private static readonly Guid UserId = Guid.NewGuid();
             
@@ -25,16 +25,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             Id = Guid.NewGuid()
         };
             
-        private static readonly Publication PublicationWithExternalMethodology = new Publication
+        private static readonly Publication PublicationWithMethodology = new Publication
         {
             Id = Guid.NewGuid(),
-            ExternalMethodology = new ExternalMethodology()
+            Methodologies = AsList(new PublicationMethodology())
         };
 
-        public class CreateMethodologyForSpecificPublicationAuthorizationHandlerClaimTests
+        public class ManageExternalMethodologyForSpecificPublicationAuthorizationHandlerClaimTests
         {
             [Fact]
-            public async Task UserWithCorrectClaimCanCreateMethodologyForAnyPublication()
+            public async Task UserWithCorrectClaimCanManageExternalMethodologyForAnyPublication()
             {
                 await ForEachSecurityClaimAsync(async claim => {
                     
@@ -62,14 +62,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
             
             [Fact]
-            public async Task UserWithCorrectClaimCannotCreateMethodologyForAnyPublication_LinkedToExternalMethodology()
+            public async Task UserWithCorrectClaimCannotManageExternalMethodologyForAnyPublication_LinkedToMethodology()
             {
                 await ForEachSecurityClaimAsync(async claim => {
                     
                     var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();
                     
                     var user = CreateClaimsPrincipal(UserId, claim);
-                    var authContext = CreateAuthContext(user, PublicationWithExternalMethodology);
+                    var authContext = CreateAuthContext(user, PublicationWithMethodology);
 
                     await handler.HandleAsync(authContext);
                     VerifyAllMocks(publicationRoleRepository);
@@ -79,10 +79,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
         }
         
-        public class CreateMethodologyForSpecificPublicationAuthorizationHandlerPublicationRoleTests
+        public class ManageExternalMethodologyForSpecificPublicationAuthorizationHandlerPublicationRoleTests
         {
             [Fact]
-            public async Task UserCanCreateMethodologyForPublicationWithPublicationOwnerRole()
+            public async Task UserCanManageExternalMethodologyForPublicationWithPublicationOwnerRole()
             {
                 var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();
                 
@@ -102,7 +102,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
             
             [Fact]
-            public async Task UserCannotCreateMethodologyForPublicationWithoutPublicationOwnerRole()
+            public async Task UserCannotManageExternalMethodologyForPublicationWithoutPublicationOwnerRole()
             {
                 var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();
                 
@@ -122,12 +122,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             }
             
             [Fact]
-            public async Task UserCannotCreateMethodologyForPublication_LinkedToExternalMethodology()
+            public async Task UserCannotManageExternalMethodologyForPublication_LinkedToMethodology()
             {
                 var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();
                 
                 var user = CreateClaimsPrincipal(UserId);
-                var authContext = CreateAuthContext(user, PublicationWithExternalMethodology);
+                var authContext = CreateAuthContext(user, PublicationWithMethodology);
                 
                 await handler.HandleAsync(authContext);
                 VerifyAllMocks(publicationRoleRepository);
@@ -140,16 +140,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
         private static AuthorizationHandlerContext CreateAuthContext(ClaimsPrincipal user, Publication publication)
         {
-            return CreateAuthorizationHandlerContext<CreateMethodologyForSpecificPublicationRequirement, Publication>
+            return CreateAuthorizationHandlerContext<ManageExternalMethodologyForSpecificPublicationRequirement, Publication>
                 (user, publication);
         }
 
-        private static (CreateMethodologyForSpecificPublicationAuthorizationHandler, Mock<IUserPublicationRoleRepository>)
+        private static (ManageExternalMethodologyForSpecificPublicationAuthorizationHandler, Mock<IUserPublicationRoleRepository>)
             CreateHandlerAndDependencies()
         {
             var publicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
 
-            var handler = new CreateMethodologyForSpecificPublicationAuthorizationHandler(
+            var handler = new ManageExternalMethodologyForSpecificPublicationAuthorizationHandler(
                 publicationRoleRepository.Object);
 
             return (handler, publicationRoleRepository);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MapperUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MapperUtils.cs
@@ -16,7 +16,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 { typeof(IMyPublicationPermissionSetPropertyResolver), 
                     new Mock<IMyPublicationPermissionSetPropertyResolver>().Object },
                 { typeof(IMyReleasePermissionSetPropertyResolver), 
-                    new Mock<IMyReleasePermissionSetPropertyResolver>().Object }
+                    new Mock<IMyReleasePermissionSetPropertyResolver>().Object },
+                { typeof(IMyMethodologyPermissionSetPropertyResolver), 
+                    new Mock<IMyMethodologyPermissionSetPropertyResolver>().Object }
             };
 
             object ServiceLocator(Type serviceType) => serviceLookupByType[serviceType];

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -57,6 +57,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var result = publicationService.GetMyPublicationsAndReleasesByTopic(topicId).Result.Left;
             Assert.IsAssignableFrom<ForbidResult>(result);
 
+            userService.Verify(s => s.GetUserId());
             userService.Verify(s => s.MatchesPolicy(SecurityPolicies.CanAccessSystem));
             userService.VerifyNoOtherCalls();
 
@@ -91,6 +92,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var result = publicationService.GetMyPublicationsAndReleasesByTopic(topicId).Result.Right;
             Assert.Equal(list, result);
 
+            userService.Verify(s => s.GetUserId());
             userService.Verify(s => s.MatchesPolicy(SecurityPolicies.CanAccessSystem));
             userService.Verify(s => s.MatchesPolicy(SecurityPolicies.CanViewAllReleases));
             userService.VerifyNoOtherCalls();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/Interfaces/IMyMethodoloyPermissionSetPropertyResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/Interfaces/IMyMethodoloyPermissionSetPropertyResolver.cs
@@ -1,0 +1,12 @@
+using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces
+{
+    public interface IMyMethodologyPermissionSetPropertyResolver
+        : IValueResolver<Methodology, MyMethodologyViewModel, MyMethodologyViewModel.PermissionsSet> 
+    {
+        
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -99,8 +99,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                         .ThenByDescending(r => r.TimePeriodCoverage)))
                 .ForMember(dest => dest.Methodologies, m => m.MapFrom(p => 
                     p.Methodologies
-                        .Select(methodology => methodology.MethodologyParent.LatestVersion())
-                        .OrderBy(methodologyParent => methodologyParent.Slug)))
+                        .Select(methodologyLink => methodologyLink.MethodologyParent.LatestVersion())
+                        .OrderBy(methodology => methodology.Title)))
                 .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyPublicationPermissionSetPropertyResolver>());
 
             CreateMap<Contact, ContactViewModel>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -84,6 +84,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                 .ForMember(
                     dest => dest.ThemeId,
                     m => m.MapFrom(p => p.Topic.ThemeId));
+            
+            CreateMap<Methodology, MyMethodologyViewModel>()
+                .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyMethodologyPermissionSetPropertyResolver>());
 
             CreateMap<Publication, MyPublicationViewModel>()
                 .ForMember(
@@ -94,6 +97,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                         .FindAll(r => IsLatestVersionOfRelease(p.Releases, r.Id))
                         .OrderByDescending(r => r.Year)
                         .ThenByDescending(r => r.TimePeriodCoverage)))
+                .ForMember(dest => dest.Methodologies, m => m.MapFrom(p => 
+                    p.Methodologies
+                        .Select(methodology => methodology.MethodologyParent.LatestVersion())
+                        .OrderBy(methodologyParent => methodologyParent.Slug)))
                 .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyPublicationPermissionSetPropertyResolver>());
 
             CreateMap<Contact, ContactViewModel>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyMethodologyPermissionSetPropertyResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyMethodologyPermissionSetPropertyResolver.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
+{
+    public class MyMethodologyPermissionSetPropertyResolver : IMyMethodologyPermissionSetPropertyResolver
+    {
+        private readonly IUserService _userService;
+ 
+        public MyMethodologyPermissionSetPropertyResolver(IUserService userService)
+        {
+            _userService = userService;
+        }
+ 
+        public MyMethodologyViewModel.PermissionsSet Resolve(
+            Methodology methodology, 
+            MyMethodologyViewModel destination, 
+            MyMethodologyViewModel.PermissionsSet destMember, 
+            ResolutionContext context)
+        {
+            return new MyMethodologyViewModel.PermissionsSet
+            {
+                CanUpdateMethodology = CheckResult(_userService.CheckCanUpdateMethodology(methodology)),
+                CanRemoveMethodology = CheckResult(_userService.CheckCanUpdateMethodology(methodology)), //TODO
+                CanMakeAmendmentOfMethodology = CheckResult(_userService.CheckCanMakeAmendmentOfMethodology(methodology))
+            };
+        }
+
+        private static bool CheckResult(Task<Either<ActionResult, Methodology>> result)
+        {
+            return result.Result.IsRight;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyMethodologyPermissionSetPropertyResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyMethodologyPermissionSetPropertyResolver.cs
@@ -28,7 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
             return new MyMethodologyViewModel.PermissionsSet
             {
                 CanUpdateMethodology = CheckResult(_userService.CheckCanUpdateMethodology(methodology)),
-                CanRemoveMethodology = CheckResult(_userService.CheckCanUpdateMethodology(methodology)), //TODO
+                CanCancelMethodologyAmendment = CheckResult(_userService.CheckCanCancelMethodologyAmendment(methodology)),
                 CanMakeAmendmentOfMethodology = CheckResult(_userService.CheckCanMakeAmendmentOfMethodology(methodology))
             };
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyPublicationPermissionSetPropertyResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyPublicationPermissionSetPropertyResolver.cs
@@ -35,6 +35,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                 CanCreateMethodologies = _userService
                     .CheckCanCreateMethodologyForPublication(source)
                     .Result
+                    .IsRight,
+                CanManageExternalMethodology = _userService
+                    .CheckCanManageExternalMethodologyForPublication(source)
+                    .Result
                     .IsRight
             };
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/CreateMethodologyForSpecificPublicationAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/CreateMethodologyForSpecificPublicationAuthorizationHandlers.cs
@@ -1,7 +1,9 @@
+using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using IdentityServer4.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
@@ -29,6 +31,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
         {
             // If a Publication is linked to an External Methodology, this should be unlinked first.
             if (publication.ExternalMethodology != null)
+            {
+                return;
+            }
+            
+            // If a Publication owns a Methodology already, they cannot own another.
+            if (!publication.Methodologies.IsNullOrEmpty() && publication.Methodologies.Any(m => m.Owner))
             {
                 return;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ManageExternalMethodologyForSpecificPublicationAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/ManageExternalMethodologyForSpecificPublicationAuthorizationHandlers.cs
@@ -8,27 +8,27 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityC
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
-    public class CreateMethodologyForSpecificPublicationRequirement : IAuthorizationRequirement
+    public class ManageExternalMethodologyForSpecificPublicationRequirement : IAuthorizationRequirement
     {
     }
 
-    public class CreateMethodologyForSpecificPublicationAuthorizationHandler 
-        : AuthorizationHandler<CreateMethodologyForSpecificPublicationRequirement, Publication>
+    public class ManageExternalMethodologyForSpecificPublicationAuthorizationHandler 
+        : AuthorizationHandler<ManageExternalMethodologyForSpecificPublicationRequirement, Publication>
     {
         private readonly IUserPublicationRoleRepository _userPublicationRoleRepository;
 
-        public CreateMethodologyForSpecificPublicationAuthorizationHandler(
+        public ManageExternalMethodologyForSpecificPublicationAuthorizationHandler(
             IUserPublicationRoleRepository userPublicationRoleRepository)
         {
             _userPublicationRoleRepository = userPublicationRoleRepository;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context,
-            CreateMethodologyForSpecificPublicationRequirement requirement,
+            ManageExternalMethodologyForSpecificPublicationRequirement requirement,
             Publication publication)
         {
-            // If a Publication is linked to an External Methodology, this should be unlinked first.
-            if (publication.ExternalMethodology != null)
+            // If a Publication is linked to a Methodology, this should be unlinked first.
+            if (publication.Methodologies?.Count > 0)
             {
                 return;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityPolicies.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityPolicies.cs
@@ -59,6 +59,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
          * Methodology management
          */
         CanCreateMethodologyForSpecificPublication,
+        CanManageExternalMethodologyForSpecificPublication,
         CanViewAllMethodologies,
         CanViewSpecificMethodology,
         CanUpdateSpecificMethodology,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
@@ -56,6 +56,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
                 options.AddPolicy(SecurityPolicies.CanCreateMethodologyForSpecificPublication.ToString(), policy =>
                     policy.Requirements.Add(new CreateMethodologyForSpecificPublicationRequirement()));
 
+                // does this user have permission to manage the external methodology for a specific Publication?
+                options.AddPolicy(SecurityPolicies.CanManageExternalMethodologyForSpecificPublication.ToString(), policy =>
+                    policy.Requirements.Add(new ManageExternalMethodologyForSpecificPublicationRequirement()));
+
                 /**
                  * Release management
                  */
@@ -199,6 +203,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
             services.AddTransient<IAuthorizationHandler, CreatePublicationForSpecificTopicAuthorizationHandler>();
             services.AddTransient<IAuthorizationHandler, CreateReleaseForSpecificPublicationAuthorizationHandler>();
             services.AddTransient<IAuthorizationHandler, CreateMethodologyForSpecificPublicationAuthorizationHandler>();
+            services.AddTransient<IAuthorizationHandler, ManageExternalMethodologyForSpecificPublicationAuthorizationHandler>();
 
             /**
              * Release management

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
@@ -46,6 +46,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
             return userService.CheckPolicy(publication, SecurityPolicies.CanCreateMethodologyForSpecificPublication);
         }
 
+        public static Task<Either<ActionResult, Publication>> CheckCanManageExternalMethodologyForPublication(
+            this IUserService userService, Publication publication)
+        {
+            return userService.CheckPolicy(publication, SecurityPolicies.CanManageExternalMethodologyForSpecificPublication);
+        }
+
         public static Task<Either<ActionResult, Methodology>> CheckCanViewMethodology(
             this IUserService userService, Methodology methodology)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
@@ -82,6 +82,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
             return userService.CheckPolicy(methodology, SecurityPolicies.CanMakeAmendmentOfSpecificMethodology);
         }
 
+        public static Task<Either<ActionResult, Methodology>> CheckCanCancelMethodologyAmendment(
+            this IUserService userService, Methodology methodology)
+        {
+            return userService.CheckPolicy(methodology, SecurityPolicies.CanMakeAmendmentOfSpecificMethodology);
+        }
+
         public static Task<Either<ActionResult, Unit>> CheckCanViewAllReleases(this IUserService userService)
         {
             return userService.CheckPolicy(SecurityPolicies.CanViewAllReleases);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -47,33 +47,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, List<MyPublicationViewModel>>> GetMyPublicationsAndReleasesByTopic(
             Guid topicId)
         {
+            var userId = _userService.GetUserId();
+            
             return await _userService
                 .CheckCanAccessSystem()
-                .OnSuccess(_ =>
-                {
-                    return _userService
-                        .CheckCanViewAllReleases()
-                        .OnSuccess(() =>
-                            _publicationRepository.GetAllPublicationsForTopicAsync(topicId))
-                        .OrElse(() =>
-                            _publicationRepository.GetPublicationsForTopicRelatedToUser(topicId,
-                                _userService.GetUserId()));
-                });
+                .OnSuccess(_ => _userService.CheckCanViewAllReleases()
+                    .OnSuccess(() => _publicationRepository.GetAllPublicationsForTopicAsync(topicId))
+                    .OrElse(() => _publicationRepository.GetPublicationsForTopicRelatedToUser(topicId, userId))
+                );
         }
 
         public async Task<Either<ActionResult, MyPublicationViewModel>> GetMyPublication(Guid publicationId)
         {
+            var userId = _userService.GetUserId();
+            
             return await _userService
                 .CheckCanAccessSystem()
-                .OnSuccess(_ =>
-                {
-                    return _userService
-                        .CheckCanViewAllReleases()
-                        .OnSuccess(() =>
-                            _publicationRepository.GetPublicationWithAllReleases(publicationId))
-                        .OrElse(() =>
-                            _publicationRepository.GetPublicationForUser(publicationId, _userService.GetUserId()));
-                });
+                .OnSuccess(_ => _userService.CheckCanViewAllReleases()
+                    .OnSuccess(() => _publicationRepository.GetPublicationWithAllReleases(publicationId))
+                    .OrElse(() => _publicationRepository.GetPublicationForUser(publicationId, userId)));
         }
 
         public async Task<Either<ActionResult, PublicationViewModel>> CreatePublication(
@@ -255,7 +247,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .Include(p => p.Releases)
                 .ThenInclude(r => r.ReleaseStatuses)
                 .Include(p => p.LegacyReleases)
-                .Include(p => p.Topic);
+                .Include(p => p.Topic)
+                .Include(p => p.Methodologies)
+                .ThenInclude(p => p.MethodologyParent)
+                .ThenInclude(p => p.Versions);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -197,6 +197,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
             services.AddTransient<IMyReleasePermissionSetPropertyResolver, MyReleasePermissionSetPropertyResolver>();
             services.AddTransient<IMyPublicationPermissionSetPropertyResolver, MyPublicationPermissionSetPropertyResolver>();
+            services.AddTransient<IMyMethodologyPermissionSetPropertyResolver, MyMethodologyPermissionSetPropertyResolver>();
 
             services.AddMvc(options =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyMethodologyViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyMethodologyViewModel.cs
@@ -1,0 +1,16 @@
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
+{
+    public class MyMethodologyViewModel : MethodologyTitleViewModel
+    {
+        public PermissionsSet Permissions { get; set; }
+
+        public class PermissionsSet
+        {
+            public bool CanUpdateMethodology { get; set; }
+            public bool CanRemoveMethodology { get; set; }
+            public bool CanMakeAmendmentOfMethodology { get; set; }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyMethodologyViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyMethodologyViewModel.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public class PermissionsSet
         {
             public bool CanUpdateMethodology { get; set; }
-            public bool CanRemoveMethodology { get; set; }
+            public bool CanCancelMethodologyAmendment { get; set; }
             public bool CanMakeAmendmentOfMethodology { get; set; }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationViewModel.cs
@@ -32,6 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
             public bool CanUpdatePublication { get; set; }
             public bool CanCreateReleases { get; set; }
             public bool CanCreateMethodologies { get; set; }
+            public bool CanManageExternalMethodology { get; set; }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationViewModel.cs
@@ -15,7 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         public List<MyReleaseViewModel> Releases { get; set; }
         
-        public MethodologyTitleViewModel Methodology { get; set; }
+        public List<MyMethodologyViewModel> Methodologies { get; set; }
 
         public ExternalMethodology ExternalMethodology { get; set; }
         

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -35,12 +35,8 @@ const MethodologySummary = ({
 }: Props) => {
   const history = useHistory();
   const [
-    showAddExternalMethodologyForm,
-    setShowAddExternalMethodologyForm,
-  ] = useState<boolean>();
-  const [
-    showEditExternalMethodologyForm,
-    setShowEditExternalMethodologyForm,
+    showAddEditExternalMethodologyForm,
+    setShowAddEditExternalMethodologyForm,
   ] = useState<boolean>();
   const [amendMethodologyId, setAmendMethodologyId] = useState<string>();
   const [
@@ -55,8 +51,6 @@ const MethodologySummary = ({
     id: publicationId,
     title,
   } = publication;
-
-  const methodology = methodologies.length ? methodologies[0] : undefined;
 
   const handleExternalMethodologySubmit = async (
     values: ExternalMethodology,
@@ -104,8 +98,81 @@ const MethodologySummary = ({
 
   return (
     <>
-      {methodology ? (
+      {publication.permissions.canCreateMethodologies && (
+        <ButtonGroup className="govuk-!-margin-bottom-2">
+          <Button
+            onClick={async () => {
+              const {
+                id: methodologyId,
+              } = await methodologyService.createMethodology(publicationId);
+              history.push(
+                generatePath<MethodologyRouteParams>(
+                  methodologySummaryRoute.path,
+                  {
+                    methodologyId,
+                  },
+                ),
+              );
+            }}
+            data-testid={`Create methodology for ${title}`}
+            disabled={showAddEditExternalMethodologyForm}
+          >
+            Create methodology
+          </Button>
+
+          {publication.permissions.canManageExternalMethodology && (
+            <Button
+              type="button"
+              data-testid={`Link methodology for ${title}`}
+              variant="secondary"
+              onClick={() => setShowAddEditExternalMethodologyForm(true)}
+              disabled={showAddEditExternalMethodologyForm}
+            >
+              Link to an externally hosted methodology
+            </Button>
+          )}
+        </ButtonGroup>
+      )}
+
+      {externalMethodology?.url && (
+        <>
+          <Link to={externalMethodology.url} unvisited>
+            {externalMethodology.title} (external methodology)
+          </Link>
+          {publication.permissions.canManageExternalMethodology && (
+            <ButtonGroup className="govuk-!-margin-bottom-2 govuk-!-margin-top-2">
+              <Button
+                type="button"
+                onClick={() => setShowAddEditExternalMethodologyForm(true)}
+              >
+                Edit
+              </Button>
+              <Button
+                type="button"
+                variant="warning"
+                onClick={handleRemoveExternalMethodology}
+              >
+                Remove
+              </Button>
+            </ButtonGroup>
+          )}
+        </>
+      )}
+
+      {showAddEditExternalMethodologyForm && (
+        <MethodologyExternalLinkForm
+          initialValues={externalMethodology}
+          onCancel={() => setShowAddEditExternalMethodologyForm(false)}
+          onSubmit={values => {
+            handleExternalMethodologySubmit(values);
+            setShowAddEditExternalMethodologyForm(false);
+          }}
+        />
+      )}
+
+      {methodologies.map(methodology => (
         <Details
+          key={methodology.id}
           open={false}
           className="govuk-!-margin-bottom-0"
           summary={methodology.title}
@@ -194,92 +261,7 @@ const MethodologySummary = ({
             </div>
           </div>
         </Details>
-      ) : (
-        <>
-          {externalMethodology?.url ? (
-            <>
-              {!showEditExternalMethodologyForm ? (
-                <>
-                  <Link to={externalMethodology.url} unvisited>
-                    {externalMethodology.title} (external methodology)
-                  </Link>
-                  {publication.permissions.canCreateMethodologies && (
-                    <ButtonGroup className="govuk-!-margin-bottom-2 govuk-!-margin-top-2">
-                      <Button
-                        type="button"
-                        onClick={() => setShowEditExternalMethodologyForm(true)}
-                      >
-                        Edit
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="warning"
-                        onClick={handleRemoveExternalMethodology}
-                      >
-                        Remove
-                      </Button>
-                    </ButtonGroup>
-                  )}
-                </>
-              ) : (
-                <MethodologyExternalLinkForm
-                  initialValues={externalMethodology}
-                  onCancel={() => setShowEditExternalMethodologyForm(false)}
-                  onSubmit={values => {
-                    handleExternalMethodologySubmit(values);
-                    setShowEditExternalMethodologyForm(false);
-                  }}
-                />
-              )}
-            </>
-          ) : (
-            <>
-              {!showAddExternalMethodologyForm &&
-                publication.permissions.canCreateMethodologies && (
-                  <ButtonGroup className="govuk-!-margin-bottom-2">
-                    <Button
-                      onClick={async () => {
-                        const {
-                          id: methodologyId,
-                        } = await methodologyService.createMethodology(
-                          publicationId,
-                        );
-                        history.push(
-                          generatePath<MethodologyRouteParams>(
-                            methodologySummaryRoute.path,
-                            {
-                              methodologyId,
-                            },
-                          ),
-                        );
-                      }}
-                      data-testid={`Create methodology for ${title}`}
-                    >
-                      Create methodology
-                    </Button>
-                    <Button
-                      type="button"
-                      data-testid={`Link methodology for ${title}`}
-                      variant="secondary"
-                      onClick={() => setShowAddExternalMethodologyForm(true)}
-                    >
-                      Link to an externally hosted methodology
-                    </Button>
-                  </ButtonGroup>
-                )}
-              {showAddExternalMethodologyForm && (
-                <MethodologyExternalLinkForm
-                  onCancel={() => setShowAddExternalMethodologyForm(false)}
-                  onSubmit={values => {
-                    handleExternalMethodologySubmit(values);
-                    setShowAddExternalMethodologyForm(false);
-                  }}
-                />
-              )}
-            </>
-          )}
-        </>
-      )}
+      ))}
 
       {amendMethodologyId && (
         <ModalConfirm

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -51,10 +51,12 @@ const MethodologySummary = ({
   const {
     contact,
     externalMethodology,
-    methodology,
+    methodologies,
     id: publicationId,
     title,
   } = publication;
+
+  const methodology = methodologies.length ? methodologies[0] : undefined;
 
   const handleExternalMethodologySubmit = async (
     values: ExternalMethodology,
@@ -178,7 +180,7 @@ const MethodologySummary = ({
               )}
             </div>
             <div className="govuk-grid-column-one-third dfe-align--right">
-              {methodology.permissions.canDeleteMethodology &&
+              {methodology.permissions.canRemoveMethodology &&
                 methodology.amendment && (
                   <Button
                     onClick={() =>

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -247,7 +247,7 @@ const MethodologySummary = ({
               )}
             </div>
             <div className="govuk-grid-column-one-third dfe-align--right">
-              {methodology.permissions.canRemoveMethodology &&
+              {methodology.permissions.canCancelMethodologyAmendment &&
                 methodology.amendment && (
                   <Button
                     onClick={() =>

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
@@ -89,7 +89,7 @@ const PublicationSummary = ({
             </td>
           </tr>
           <tr>
-            <th>Methodology</th>
+            <th>Methodologies</th>
             <td data-testid={`Methodology for ${publication.title}`}>
               <MethodologySummary
                 publication={publication}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ManagePublicationsAndReleasesTab.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ManagePublicationsAndReleasesTab.test.tsx
@@ -85,10 +85,12 @@ describe('ManagePublicationsAndReleasesTab', () => {
       title: 'Publication 1',
       contact: testContact,
       releases: [],
+      methodologies: [],
       permissions: {
         canCreateReleases: true,
         canUpdatePublication: true,
         canCreateMethodologies: true,
+        canManageExternalMethodology: true,
       },
     },
     {
@@ -96,10 +98,12 @@ describe('ManagePublicationsAndReleasesTab', () => {
       title: 'Publication 2',
       contact: testContact,
       releases: [],
+      methodologies: [],
       permissions: {
         canCreateReleases: true,
         canUpdatePublication: true,
         canCreateMethodologies: true,
+        canManageExternalMethodology: true,
       },
     },
   ];

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -79,26 +79,28 @@ const testPublicationNoMethodology: MyPublication = {
   title: 'Publication 1',
   contact: testContact,
   releases: [],
+  methodologies: [],
   permissions: {
     canCreateReleases: true,
     canUpdatePublication: true,
     canCreateMethodologies: true,
+    canManageExternalMethodology: true,
   },
 };
 
 const testPublicationWithMethodology = {
   ...testPublicationNoMethodology,
-  methodology: testMethodology,
+  methodologies: [testMethodology],
 };
 
 const testPublicationWithDraftMethodology = {
   ...testPublicationWithMethodology,
-  methodology: testDraftMethodology,
+  methodologies: [testDraftMethodology],
 };
 
 const testPublicationWithAmendmentMethodology = {
   ...testPublicationWithMethodology,
-  methodology: testAmendmentMethodology,
+  methodologies: [testAmendmentMethodology],
 };
 
 const testPublicationWithExternalMethodology = {
@@ -108,12 +110,12 @@ const testPublicationWithExternalMethodology = {
 
 const testPublicationWithMethodologyCanAmend = {
   ...testPublicationWithMethodology,
-  methodology: testMethodologyCanAmend,
+  methodologies: [testMethodologyCanAmend],
 };
 
 const testPublicationWithMethodologyCanCancelAmend = {
   ...testPublicationWithMethodology,
-  methodology: testMethodologyCanCancelAmend,
+  methodologies: [testMethodologyCanCancelAmend],
 };
 
 const testTopicId = 'topic-id';
@@ -352,7 +354,7 @@ describe('MethodologySummary', () => {
                 ...testPublicationWithExternalMethodology,
                 permissions: {
                   ...testPublicationWithExternalMethodology.permissions,
-                  canCreateMethodologies: false,
+                  canManageExternalMethodology: false,
                 },
               }}
               topicId={testTopicId}
@@ -475,7 +477,7 @@ describe('MethodologySummary', () => {
         expect(
           methodologyService.createMethodologyAmendment,
         ).toHaveBeenCalledWith(
-          testPublicationWithMethodologyCanAmend.methodology.id,
+          testPublicationWithMethodologyCanAmend.methodologies[0].id,
         );
         expect(history.push).toBeCalledWith(
           `/methodology/${mockMethodology.id}/summary`,
@@ -551,7 +553,7 @@ describe('MethodologySummary', () => {
 
       await waitFor(() => {
         expect(methodologyService.deleteMethodology).toHaveBeenCalledWith(
-          testPublicationWithMethodologyCanAmend.methodology.id,
+          testPublicationWithMethodologyCanAmend.methodologies[0].id,
         );
       });
     });

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -41,7 +41,7 @@ const testMethodology: MyMethodology = {
   title: 'I am a methodology',
   permissions: {
     canUpdateMethodology: false,
-    canDeleteMethodology: false,
+    canRemoveMethodology: false,
     canMakeAmendmentOfMethodology: false,
   },
 };
@@ -65,7 +65,7 @@ const testMethodologyCanCancelAmend: MyMethodology = {
   amendment: true,
   permissions: {
     ...testMethodology.permissions,
-    canDeleteMethodology: true,
+    canRemoveMethodology: true,
   },
 };
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -41,7 +41,7 @@ const testMethodology: MyMethodology = {
   title: 'I am a methodology',
   permissions: {
     canUpdateMethodology: false,
-    canRemoveMethodology: false,
+    canCancelMethodologyAmendment: false,
     canMakeAmendmentOfMethodology: false,
   },
 };
@@ -65,7 +65,7 @@ const testMethodologyCanCancelAmend: MyMethodology = {
   amendment: true,
   permissions: {
     ...testMethodology.permissions,
-    canRemoveMethodology: true,
+    canCancelMethodologyAmendment: true,
   },
 };
 

--- a/src/explore-education-statistics-admin/src/services/methodologyService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyService.ts
@@ -31,7 +31,7 @@ export interface BasicMethodology {
 export interface MyMethodology extends BasicMethodology {
   permissions: {
     canUpdateMethodology: boolean;
-    canRemoveMethodology: boolean;
+    canCancelMethodologyAmendment: boolean;
     canMakeAmendmentOfMethodology: boolean;
   };
 }

--- a/src/explore-education-statistics-admin/src/services/methodologyService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyService.ts
@@ -31,7 +31,7 @@ export interface BasicMethodology {
 export interface MyMethodology extends BasicMethodology {
   permissions: {
     canUpdateMethodology: boolean;
-    canDeleteMethodology: boolean;
+    canRemoveMethodology: boolean;
     canMakeAmendmentOfMethodology: boolean;
   };
 }

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -42,6 +42,7 @@ export interface MyPublication {
     canCreateReleases: boolean;
     canUpdatePublication: boolean;
     canCreateMethodologies: boolean;
+    canManageExternalMethodology: boolean;
   };
 }
 

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -34,7 +34,7 @@ export interface ExternalMethodology {
 export interface MyPublication {
   id: string;
   title: string;
-  methodology?: MyMethodology;
+  methodologies: MyMethodology[];
   externalMethodology?: ExternalMethodology;
   releases: MyRelease[];
   contact?: PublicationContactDetails;

--- a/src/explore-education-statistics-admin/test/createMemoryHistoryWithMockedPush.ts
+++ b/src/explore-education-statistics-admin/test/createMemoryHistoryWithMockedPush.ts
@@ -1,4 +1,4 @@
-import createMemoryHistory from 'history/createMemoryHistory';
+import { createMemoryHistory } from 'history';
 
 export default function createMemoryHistoryWithMockedPush() {
   const history = createMemoryHistory();


### PR DESCRIPTION
This PR:
- returns Methodologies with Publications for the Admin Dashboard
- adds proper permissions around the Methodology actions

Still to do: need to only allow each Publication to own a single Methodology.