### PR TITLE
EES-2378 Reinstate support for the public View All Methodologies page and support multiple Methodologies

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -9,7 +9,6 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Secur
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interfaces
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controllers
 {
@@ -16,7 +18,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         [Fact]
         public async Task GetThemes()
         {
-            var fileStorageService = new Mock<IFileStorageService>();
+            var fileStorageService = new Mock<IFileStorageService>(MockBehavior.Strict);
+            var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
 
             fileStorageService
                 .Setup(
@@ -43,11 +46,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
                     }
                 );
 
-            var controller = new ThemeController(fileStorageService.Object);
+            var controller = BuildThemeController(fileStorageService.Object,
+                methodologyService.Object);
 
             var result = await controller.GetThemes();
 
-            Assert.IsAssignableFrom<IEnumerable<ThemeTree<PublicationTreeNode>>>(result.Value);
             Assert.Single(result.Value);
 
             var theme = result.Value.First();
@@ -56,12 +59,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
 
             var topic = theme.Topics.First();
             Assert.Single(topic.Publications);
+
+            MockUtils.VerifyAllMocks(fileStorageService, methodologyService);
         }
 
         [Fact]
         public async Task GetDownloadThemes()
         {
             var fileStorageService = new Mock<IFileStorageService>();
+            var methodologyService = new Mock<IMethodologyService>();
 
             fileStorageService
                 .Setup(
@@ -94,10 +100,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
                     }
                 );
 
-            var controller = new ThemeController(fileStorageService.Object);
+            var controller = BuildThemeController(fileStorageService.Object,
+                methodologyService.Object);
+
             var result = await controller.GetDownloadThemes();
 
-            Assert.IsAssignableFrom<IEnumerable<ThemeTree<PublicationDownloadTreeNode>>>(result.Value);
             Assert.Single(result.Value);
 
             var theme = result.Value.First();
@@ -109,31 +116,71 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
 
             var publication = topic.Publications.First();
             Assert.Single(publication.DownloadFiles);
+
+            MockUtils.VerifyAllMocks(fileStorageService, methodologyService);
         }
 
         [Fact]
         public async Task GetMethodologyThemes()
         {
-            var fileStorageService = new Mock<IFileStorageService>(MockBehavior.Strict);
+            var themes = AsList(
+                new ThemeTree<PublicationMethodologiesTreeNode>
+                {
+                    Id = Guid.NewGuid(),
+                    Summary = "Publication summary",
+                    Title = "Publication title",
+                    Topics = AsList(
+                        new TopicTree<PublicationMethodologiesTreeNode>
+                        {
+                            Id = Guid.NewGuid(),
+                            Summary = "Topic summary",
+                            Title = "Topic title",
+                            Publications = AsList(
+                                new PublicationMethodologiesTreeNode
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Summary = "Publication summary",
+                                    Title = "Publication title",
+                                    Methodologies = AsList(
+                                        new MethodologySummaryViewModel
+                                        {
+                                            Id = Guid.NewGuid(),
+                                            Slug = "methodology-slug",
+                                            Title = "Methodology title"
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    )
+                }
+            );
 
-            var controller = new ThemeController(fileStorageService.Object);
+            var fileStorageService = new Mock<IFileStorageService>(MockBehavior.Strict);
+            var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.GetTree())
+                .ReturnsAsync(themes);
+
+            var controller = BuildThemeController(fileStorageService.Object,
+                methodologyService.Object);
 
             var result = await controller.GetMethodologyThemes();
 
-            // TODO SOW4 EES-2378 Return all public methodologies from content database
-            // Assert.IsAssignableFrom<IEnumerable<ThemeTree<MethodologyTreeNode>>>(result.Value);
-            Assert.Empty(result.Value);
-            // Assert.Single(result.Value);
-            //
-            // var theme = result.Value.First();
-            //
-            // Assert.IsType<ThemeTree<MethodologyTreeNode>>(theme);
-            // Assert.Single(theme.Topics);
-            //
-            // var topic = theme.Topics.First();
-            // Assert.Single(topic.Publications);
+            Assert.Equal(themes, result.Value);
 
-            MockUtils.VerifyAllMocks(fileStorageService);
+            MockUtils.VerifyAllMocks(fileStorageService, methodologyService);
+        }
+
+        private static ThemeController BuildThemeController(
+            IFileStorageService fileStorageService = null,
+            IMethodologyService methodologyService = null
+        )
+        {
+            return new ThemeController(
+                fileStorageService ?? new Mock<IFileStorageService>().Object,
+                methodologyService ?? new Mock<IMethodologyService>().Object
+            );
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ThemeController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ThemeController.cs
@@ -14,10 +14,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
     public class ThemeController : ControllerBase
     {
         private readonly IFileStorageService _fileStorageService;
+        private readonly IMethodologyService _methodologyService;
 
-        public ThemeController(IFileStorageService fileStorageService)
+        public ThemeController(IFileStorageService fileStorageService,
+            IMethodologyService methodologyService)
         {
             _fileStorageService = fileStorageService;
+            _methodologyService = methodologyService;
         }
 
         [HttpGet("themes")]
@@ -39,10 +42,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         }
 
         [HttpGet("methodology-themes")]
-        public async Task<ActionResult<IEnumerable<ThemeTree<MethodologyTreeNode>>>> GetMethodologyThemes()
+        public async Task<ActionResult<List<ThemeTree<PublicationMethodologiesTreeNode>>>> GetMethodologyThemes()
         {
-            // TODO SOW4 EES-2378 Return all public methodologies from content database
-            return await Task.FromResult(new List<ThemeTree<MethodologyTreeNode>>());
+            return await _methodologyService.GetTree()
+                .HandleFailuresOrOk();
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/Interfaces/IMethodologyService.cs
@@ -13,5 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interf
         public Task<Either<ActionResult, MethodologyViewModel>> GetLatestMethodologyBySlug(string slug);
 
         public Task<Either<ActionResult, List<MethodologySummaryViewModel>>> GetSummariesByPublication(Guid publicationId);
+
+        public Task<Either<ActionResult, List<ThemeTree<PublicationMethodologiesTreeNode>>>> GetTree();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interfaces
 using GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -18,14 +19,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
 {
     public class MethodologyService : IMethodologyService
     {
+        private readonly ContentDbContext _contentDbContext;
         private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
         private readonly IMapper _mapper;
         private readonly IMethodologyRepository _methodologyRepository;
 
-        public MethodologyService(IPersistenceHelper<ContentDbContext> persistenceHelper,
+        public MethodologyService(ContentDbContext contentDbContext,
+            IPersistenceHelper<ContentDbContext> persistenceHelper,
             IMapper mapper,
             IMethodologyRepository methodologyRepository)
         {
+            _contentDbContext = contentDbContext;
             _persistenceHelper = persistenceHelper;
             _mapper = mapper;
             _methodologyRepository = methodologyRepository;
@@ -64,6 +68,106 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
                         await _methodologyRepository.GetLatestPublishedByPublication(publication.Id);
                     return _mapper.Map<List<MethodologySummaryViewModel>>(latestPublishedMethodologies);
                 });
+        }
+
+        public async Task<Either<ActionResult, List<ThemeTree<PublicationMethodologiesTreeNode>>>> GetTree()
+        {
+            var themesWithMethodologies = await _contentDbContext.Themes
+                .Include(theme => theme.Topics)
+                .ThenInclude(t => t.Publications)
+                .ThenInclude(p => p.Releases)
+                .Include(t => t.Topics)
+                .ThenInclude(t => t.Publications)
+                .ThenInclude(p => p.Methodologies)
+                .ThenInclude(pm => pm.MethodologyParent)
+                .ThenInclude(m => m.Versions)
+                .ToListAsync();
+
+            return themesWithMethodologies.Where(IsThemePublished)
+                .Select(BuildThemeTree)
+                .OrderBy(theme => theme.Title)
+                .ToList();
+        }
+
+        private static ThemeTree<PublicationMethodologiesTreeNode> BuildThemeTree(Theme theme)
+        {
+            return new ThemeTree<PublicationMethodologiesTreeNode>
+            {
+                Id = theme.Id,
+                Summary = null,
+                Title = theme.Title,
+                Topics = theme.Topics
+                    .Where(IsTopicPublished)
+                    .Select(BuildTopicTree)
+                    .OrderBy(topic => topic.Title)
+                    .ToList()
+            };
+        }
+
+        private static TopicTree<PublicationMethodologiesTreeNode> BuildTopicTree(Topic topic)
+        {
+            return new TopicTree<PublicationMethodologiesTreeNode>
+            {
+                Id = topic.Id,
+                Summary = null,
+                Title = topic.Title,
+                Publications = topic.Publications
+                    .Where(IsPublicationPublished)
+                    .Select(BuildPublicationNode)
+                    .OrderBy(publication => publication.Title)
+                    .ToList()
+            };
+        }
+
+        private static PublicationMethodologiesTreeNode BuildPublicationNode(Publication publication)
+        {
+            return new PublicationMethodologiesTreeNode
+            {
+                Id = publication.Id,
+                Title = publication.Title,
+                Summary = publication.Summary,
+                Slug = publication.Slug,
+                Methodologies = publication.Methodologies.Select(BuildMethodologyForLatestVersion).ToList()
+            };
+        }
+
+        private static bool IsThemePublished(Theme theme)
+        {
+            return theme.Topics.Any(IsTopicPublished);
+        }
+
+        private static bool IsTopicPublished(Topic topic)
+        {
+            return topic.Publications.Any(IsPublicationPublished);
+        }
+
+        private static bool IsPublicationPublished(Publication publication)
+        {
+            // TODO SOW4 Potentially remove this check on Releases in future
+            var hasReleases = publication.Releases.Any(release => release.IsLatestPublishedVersionOfRelease());
+
+            if (hasReleases)
+            {
+                // TODO SOW4 There should be no LatestPublishedVersion of a Methodology returned if the Publication has no published releases
+                // removing the need for the outer check on hasReleases
+                var hasMethodologies = publication.Methodologies.Any(pm =>
+                    pm.MethodologyParent.LatestPublishedVersion() != null);
+                return hasMethodologies;
+            }
+
+            return false;
+        }
+
+        private static MethodologySummaryViewModel BuildMethodologyForLatestVersion(
+            PublicationMethodology publicationMethodology)
+        {
+            var latestVersion = publicationMethodology.MethodologyParent.LatestPublishedVersion();
+            return new MethodologySummaryViewModel
+            {
+                Id = latestVersion.Id,
+                Slug = latestVersion.Slug,
+                Title = latestVersion.Title
+            };
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
@@ -83,7 +83,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
                 .ThenInclude(m => m.Versions)
                 .ToListAsync();
 
-            return themesWithMethodologies.Where(IsThemePublished)
+            return themesWithMethodologies.Where(IsThemeIncluded)
                 .Select(BuildThemeTree)
                 .OrderBy(theme => theme.Title)
                 .ToList();
@@ -97,7 +97,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
                 Summary = null,
                 Title = theme.Title,
                 Topics = theme.Topics
-                    .Where(IsTopicPublished)
+                    .Where(IsTopicIncluded)
                     .Select(BuildTopicTree)
                     .OrderBy(topic => topic.Title)
                     .ToList()
@@ -112,7 +112,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
                 Summary = null,
                 Title = topic.Title,
                 Publications = topic.Publications
-                    .Where(IsPublicationPublished)
+                    .Where(IsPublicationIncluded)
                     .Select(BuildPublicationNode)
                     .OrderBy(publication => publication.Title)
                     .ToList()
@@ -131,17 +131,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
             };
         }
 
-        private static bool IsThemePublished(Theme theme)
+        private static bool IsThemeIncluded(Theme theme)
         {
-            return theme.Topics.Any(IsTopicPublished);
+            return theme.Topics.Any(IsTopicIncluded);
         }
 
-        private static bool IsTopicPublished(Topic topic)
+        private static bool IsTopicIncluded(Topic topic)
         {
-            return topic.Publications.Any(IsPublicationPublished);
+            return topic.Publications.Any(IsPublicationIncluded);
         }
 
-        private static bool IsPublicationPublished(Publication publication)
+        private static bool IsPublicationIncluded(Publication publication)
         {
             // TODO SOW4 Potentially remove this check on Releases in future
             var hasReleases = publication.Releases.Any(release => release.IsLatestPublishedVersionOfRelease());

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/MethodologyTreeNode.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/MethodologyTreeNode.cs
@@ -1,7 +1,0 @@
-namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels
-{
-    public class MethodologyTreeNode : AbstractPublicationTreeNode
-    {
-        public MethodologySummaryViewModel Methodology { get; set; }
-    }
-}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/PublicationMethodologiesTreeNode.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/PublicationMethodologiesTreeNode.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels
+{
+    public class PublicationMethodologiesTreeNode : AbstractPublicationTreeNode
+    {
+        public List<MethodologySummaryViewModel> Methodologies { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/MethodologyServiceTests.cs
@@ -6,123 +6,12 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.MapperUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Database.ContentDbUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 {
     public class MethodologyServiceTests
     {
-        // TODO SOW4 EES-2378 Update for new model after moving to Content API
-        // [Fact]
-        // public async Task GetTree()
-        // {
-        //     var topicA = new Topic
-        //     {
-        //         Title = "Topic A",
-        //         Theme = new Theme
-        //         {
-        //             Title = "Theme A",
-        //             Slug = "theme-a",
-        //             Summary = "The first theme"
-        //         },
-        //         Slug = "topic-a"
-        //     };
-        //
-        //     var methodologyA = new Methodology
-        //     {
-        //         Slug = "methodology-a",
-        //         Title = "Methodology A",
-        //         Summary = "first methodology",
-        //         Published = new DateTime(2019, 1, 01),
-        //         Updated = new DateTime(2019, 1, 15),
-        //         Annexes = new List<ContentSection>(),
-        //         Content = new List<ContentSection>()
-        //     };
-        //
-        //     var methodologyB = new Methodology
-        //     {
-        //         Slug = "methodology-b",
-        //         Title = "Methodology B",
-        //         Summary = "second methodology",
-        //         Published = new DateTime(2019, 3, 01),
-        //         Updated = new DateTime(2019, 3, 15),
-        //         Annexes = new List<ContentSection>(),
-        //         Content = new List<ContentSection>()
-        //     };
-        //
-        //     var publicationA = new Publication
-        //     {
-        //         Title = "Publication A",
-        //         Topic = topicA,
-        //         Slug = "publication-a",
-        //         Summary = "first publication",
-        //         Methodology = methodologyA
-        //     };
-        //
-        //     var publicationB = new Publication
-        //     {
-        //         Title = "Publication B",
-        //         Topic = topicA,
-        //         Slug = "publication-b",
-        //         Summary = "second publication",
-        //         Methodology = methodologyB
-        //     };
-        //
-        //     var publicationARelease1 = new Release
-        //     {
-        //         Publication = publicationA,
-        //         ReleaseName = "2018",
-        //         TimePeriodCoverage = AcademicYearQ1,
-        //         Published = new DateTime(2019, 1, 01),
-        //         Status = Approved
-        //     };
-        //
-        //     var publicationBRelease1 = new Release
-        //     {
-        //         Publication = publicationB,
-        //         ReleaseName = "2018",
-        //         TimePeriodCoverage = AcademicYearQ1,
-        //         Published = null,
-        //         Status = Draft
-        //     };
-        //
-        //     var contentDbContextId = Guid.NewGuid().ToString();
-        //
-        //     await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-        //     {
-        //         await contentDbContext.Topics.AddAsync(topicA);
-        //         await contentDbContext.Methodologies.AddRangeAsync(methodologyA, methodologyB);
-        //         await contentDbContext.Publications.AddRangeAsync(publicationA, publicationB);
-        //         await contentDbContext.Releases.AddRangeAsync(publicationARelease1, publicationBRelease1);
-        //         await contentDbContext.SaveChangesAsync();
-        //     }
-        //
-        //     await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-        //     {
-        //         var service = new MethodologyService(contentDbContext, MapperForProfile<MappingProfiles>());
-        //
-        //         var result = service.GetTree(Enumerable.Empty<Guid>());
-        //
-        //         Assert.Single(result);
-        //         var theme = result.First();
-        //         Assert.Equal("Theme A", theme.Title);
-        //
-        //         Assert.Single(theme.Topics);
-        //         var topic = theme.Topics.First();
-        //         Assert.Equal("Topic A", topic.Title);
-        //
-        //         Assert.Single(topic.Publications);
-        //         var publication = topic.Publications.First();
-        //         Assert.Equal("Publication A", publication.Title);
-        //
-        //         var methodology = publication.Methodology;
-        //         Assert.Equal("methodology-a", methodology.Slug);
-        //         Assert.Equal("first methodology", methodology.Summary);
-        //         Assert.Equal("Methodology A", methodology.Title);
-        //     }
-        // }
-
         [Fact]
         public async Task GetFiles()
         {
@@ -242,11 +131,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             }
         }
 
-        private MethodologyService SetupMethodologyService(ContentDbContext contentDbContext)
+        private static MethodologyService SetupMethodologyService(ContentDbContext contentDbContext)
         {
-            return new MethodologyService(
-                contentDbContext,
-                MapperForProfile<MappingProfiles>());
+            return new MethodologyService(contentDbContext);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces
 {
@@ -14,8 +13,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
         Task<List<Methodology>> GetByRelease(Guid releaseId);
 
         Task<List<File>> GetFiles(Guid methodologyId, params FileType[] types);
-
-        // TODO SOW4 EES-2378 Move to Content API
-        List<ThemeTree<MethodologyTreeNode>> GetTree(IEnumerable<Guid> includedReleaseIds);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
@@ -2,27 +2,21 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
-using static GovUk.Education.ExploreEducationStatistics.Publisher.Extensions.PublisherExtensions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 {
     public class MethodologyService : IMethodologyService
     {
         private readonly ContentDbContext _context;
-        private readonly IMapper _mapper;
 
-        public MethodologyService(ContentDbContext context,
-            IMapper mapper)
+        public MethodologyService(ContentDbContext context)
         {
             _context = context;
-            _mapper = mapper;
         }
 
         public async Task<Methodology> Get(Guid id)
@@ -44,94 +38,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 .Select(mf => mf.File)
                 .Where(file => types.Contains(file.Type))
                 .ToListAsync();
-        }
-
-        // TODO SOW4 EES-2378 Move to Content API
-        public List<ThemeTree<MethodologyTreeNode>> GetTree(IEnumerable<Guid> includedReleaseIds)
-        {
-            return _context.Themes
-                .Include(theme => theme.Topics)
-                .ThenInclude(topic => topic.Publications)
-                .Include(theme => theme.Topics)
-                .ThenInclude(topic => topic.Publications)
-                .ThenInclude(publication => publication.Releases)
-                .ToList()
-                .Where(theme => IsThemePublished(theme, includedReleaseIds))
-                .Select(theme => BuildThemeTree(theme, includedReleaseIds))
-                .OrderBy(theme => theme.Title)
-                .ToList();
-        }
-
-        private static ThemeTree<MethodologyTreeNode> BuildThemeTree(Theme theme, IEnumerable<Guid> includedReleaseIds)
-        {
-            return new ThemeTree<MethodologyTreeNode>
-            {
-                Id = theme.Id,
-                Title = theme.Title,
-                Topics = theme.Topics
-                    .Where(topic => IsTopicPublished(topic, includedReleaseIds))
-                    .Select(topic => BuildTopicTree(topic, includedReleaseIds))
-                    .OrderBy(topic => topic.Title)
-                    .ToList()
-            };
-        }
-
-        private static TopicTree<MethodologyTreeNode> BuildTopicTree(Topic topic, IEnumerable<Guid> includedReleaseIds)
-        {
-            return new TopicTree<MethodologyTreeNode>
-            {
-                Id = topic.Id,
-                Title = topic.Title,
-                Publications = topic.Publications
-                    .Where(publication => IsPublicationPublished(publication, includedReleaseIds))
-                    .Select(BuildPublicationNode)
-                    .OrderBy(publication => publication.Title)
-                    .ToList()
-            };
-        }
-
-        private static MethodologyTreeNode BuildPublicationNode(Publication publication)
-        {
-            return new MethodologyTreeNode
-            {
-                Id = publication.Id,
-                Title = publication.Title,
-                Summary = publication.Summary,
-                Slug = publication.Slug,
-                // TODO SOW4 EES-2378 Update to build Methodology Tree with new model
-                // Might need to be multiple methodology tree nodes for a Publication?
-                Methodology = null
-                //Methodology = BuildMethodology(publication.Methodology)
-            };
-        }
-
-        private static MethodologySummaryViewModel BuildMethodology(Methodology methodology)
-        {
-            return new MethodologySummaryViewModel
-            {
-                Id = methodology.Id,
-                Slug = methodology.Slug,
-                Title = methodology.Title
-            };
-        }
-
-        private static bool IsThemePublished(Theme theme, IEnumerable<Guid> includedReleaseIds)
-        {
-            return theme.Topics.Any(topic => IsTopicPublished(topic, includedReleaseIds));
-        }
-
-        private static bool IsTopicPublished(Topic topic, IEnumerable<Guid> includedReleaseIds)
-        {
-            return topic.Publications.Any(publication => IsPublicationPublished(publication, includedReleaseIds));
-        }
-
-        private static bool IsPublicationPublished(Publication publication, IEnumerable<Guid> includedReleaseIds)
-        {
-            // TODO SOW4 EES-2378 determine if Publication has one or more published methodologies)
-            const bool hasMethodologies = true;
-
-            return hasMethodologies &&
-                   publication.Releases.Any(release => release.IsReleasePublished(includedReleaseIds));
         }
     }
 }

--- a/src/explore-education-statistics-common/src/services/themeService.ts
+++ b/src/explore-education-statistics-common/src/services/themeService.ts
@@ -1,5 +1,6 @@
 import { contentApi } from '@common/services/api';
 import { FileInfo } from '@common/services/types/file';
+import { MethodologySummary } from '@common/services/types/methodology';
 
 interface BasePublicationSummary {
   id: string;
@@ -20,11 +21,7 @@ export interface PublicationDownloadSummary extends BasePublicationSummary {
 }
 
 export interface PublicationMethodologySummary extends BasePublicationSummary {
-  methodology: {
-    id: string;
-    slug: string;
-    title: string;
-  };
+  methodologies: MethodologySummary[];
 }
 
 export interface Topic<Publication = PublicationSummary> {

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/components/MethodologyList.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/components/MethodologyList.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 function MethodologyList({ publications }: Props) {
   const filteredPublications = publications.filter(
-    publication => !!publication.methodology,
+    publication => !!publication.methodologies,
   );
 
   if (!filteredPublications.length) {
@@ -23,12 +23,18 @@ function MethodologyList({ publications }: Props) {
             {publication.title}
           </h3>
 
-          <Link
-            to="/methodology/[methodology]"
-            as={`/methodology/${publication.methodology?.slug}`}
-          >
-            View methodology
-          </Link>
+          <ul>
+            {publication.methodologies.map(methodology => (
+              <li key={methodology.id}>
+                <Link
+                  to="/methodology/[methodology]"
+                  as={`/methodology/${methodology.slug}`}
+                >
+                  {methodology.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
This PR reinstates the back end support for the public View All Methodologies view produced from the Content API.

It also alters the public view to support a Publication having multiple methodologies.