### PR TITLE
EES-2448 Only create ReleaseStatus row if ApprovalStatus changes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -173,6 +173,69 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task UpdateReleaseStatus_Draft()
+        {
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheck(_release, CanUpdateSpecificRelease)
+                .SetupResourceCheckToFail(_release, CanMarkSpecificReleaseAsDraft)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = BuildReleaseService(userService: userService.Object);
+                        return service.UpdateReleaseStatus(
+                            _release.Id,
+                            new ReleaseStatusUpdateViewModel
+                            {
+                                ApprovalStatus = ReleaseApprovalStatus.Draft
+                            }
+                        );
+                    }
+                );
+        }
+
+        [Fact]
+        public async Task UpdateReleaseStatus_HigherLevelReview()
+        {
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheck(_release, CanUpdateSpecificRelease)
+                .SetupResourceCheckToFail(_release, CanSubmitSpecificReleaseToHigherReview)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = BuildReleaseService(userService: userService.Object);
+                        return service.UpdateReleaseStatus(
+                            _release.Id,
+                            new ReleaseStatusUpdateViewModel
+                            {
+                                ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview
+                            }
+                        );
+                    }
+                );
+        }
+
+        [Fact]
+        public async Task UpdateReleaseStatus_Approve()
+        {
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheck(_release, CanUpdateSpecificRelease)
+                .SetupResourceCheckToFail(_release, CanApproveSpecificRelease)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = BuildReleaseService(userService: userService.Object);
+                        return service.UpdateReleaseStatus(
+                            _release.Id,
+                            new ReleaseStatusUpdateViewModel
+                            {
+                                ApprovalStatus = ReleaseApprovalStatus.Approved
+                            }
+                        );
+                    }
+                );
+        }
+
+        [Fact]
         public async Task GetLatestReleaseAsync()
         {
             await PolicyCheckBuilder<SecurityPolicies>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -733,14 +733,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(TimeIdentifier.March, saved.TimePeriodCoverage);
                 Assert.Equal("New access list", saved.PreReleaseAccessList);
 
-                Assert.Single(saved.ReleaseStatuses);
-                var savedStatus = saved.ReleaseStatuses[0];
-                Assert.Equal(ReleaseApprovalStatus.Draft, savedStatus.ApprovalStatus);
-                Assert.Equal("Test internal note", savedStatus.InternalReleaseNote);
-                Assert.NotNull(savedStatus.Created);
-                Assert.InRange(DateTime.UtcNow
-                    .Subtract(savedStatus.Created.Value).Milliseconds, 0, 1500);
-                Assert.Equal(_userId, savedStatus.CreatedById);
+                // No ReleaseStatus created if the ApprovalStatus hasn't changed
+                Assert.Empty(saved.ReleaseStatuses);
             }
 
             MockUtils.VerifyAllMocks(contentService, releaseFileService);
@@ -1191,7 +1185,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             ReleaseName = "2035",
                             TimePeriodCoverage = TimeIdentifier.March,
                             PreReleaseAccessList = "New access list",
-                            ApprovalStatus = ReleaseApprovalStatus.Draft,
+                            ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview,
                             LatestInternalReleaseNote = "Internal note"
 
                         }
@@ -1226,7 +1220,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Single(saved.ReleaseStatuses);
                 var savedStatus = saved.ReleaseStatuses[0];
-                Assert.Equal(ReleaseApprovalStatus.Draft, savedStatus.ApprovalStatus);
+                Assert.Equal(ReleaseApprovalStatus.HigherLevelReview, savedStatus.ApprovalStatus);
                 Assert.Equal("Internal note", savedStatus.InternalReleaseNote);
                 Assert.NotNull(savedStatus.Created);
                 Assert.InRange(DateTime.UtcNow
@@ -1340,7 +1334,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             ReleaseName = "2035",
                             TimePeriodCoverage = TimeIdentifier.March,
                             PreReleaseAccessList = "New access list",
-                            ApprovalStatus = ReleaseApprovalStatus.Draft,
+                            ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview,
                             LatestInternalReleaseNote = "Test internal note"
                         }
                     );
@@ -1381,7 +1375,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Single(saved.ReleaseStatuses);
                 var savedStatus = saved.ReleaseStatuses[0];
-                Assert.Equal(ReleaseApprovalStatus.Draft, savedStatus.ApprovalStatus);
+                Assert.Equal(ReleaseApprovalStatus.HigherLevelReview, savedStatus.ApprovalStatus);
                 Assert.Equal("Test internal note", savedStatus.InternalReleaseNote);
                 Assert.NotNull(savedStatus.Created);
                 Assert.InRange(DateTime.UtcNow

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -1083,6 +1083,276 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task UpdateReleaseStatus()
+        {
+            var releaseId = Guid.NewGuid();
+            var adHocReleaseType = new ReleaseType {Title = "Ad Hoc"};
+            var release = new Release
+            {
+                Id = releaseId,
+                Type = adHocReleaseType,
+                Publication = new Publication {Title = "Old publication"},
+                ReleaseName = "2030",
+                TimePeriodCoverage = TimeIdentifier.March,
+                Slug = "2030-march",
+                PublishScheduled = DateTime.UtcNow,
+                NextReleaseDate = new PartialDate {Day = "15", Month = "6", Year = "2039"},
+                PreReleaseAccessList = "Access list",
+                Version = 0,
+                PreviousVersionId = releaseId
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                await context.AddRangeAsync(adHocReleaseType, release);
+                await context.SaveChangesAsync();
+            }
+
+            var contentService = new Mock<IContentService>(MockBehavior.Strict);
+            var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
+
+            contentService.Setup(mock =>
+                    mock.GetContentBlocks<HtmlBlock>(release.Id))
+                .ReturnsAsync(new List<HtmlBlock>());
+
+            var nextReleaseDateEdited = new PartialDate {Day = "1", Month = "1", Year = "2040"};
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var releaseService = BuildReleaseService(contentDbContext: context,
+                    contentService: contentService.Object,
+                    releaseFileService: releaseFileService.Object);
+
+                var result = await releaseService
+                    .UpdateReleaseStatus(
+                        releaseId,
+                        new ReleaseStatusUpdateViewModel
+                        {
+                            PublishMethod = PublishMethod.Scheduled,
+                            PublishScheduled = "2051-06-30",
+                            NextReleaseDate = nextReleaseDateEdited,
+                            ApprovalStatus = ReleaseApprovalStatus.Draft,
+                            LatestInternalReleaseNote = "Test internal note"
+                        }
+                    );
+
+                Assert.True(result.IsRight);
+
+                Assert.Equal(release.Publication.Id, result.Right.PublicationId);
+                Assert.Equal(new DateTime(2051, 6, 30, 0, 0, 0, DateTimeKind.Unspecified),
+                    result.Right.PublishScheduled);
+                Assert.Equal(nextReleaseDateEdited, result.Right.NextReleaseDate);
+                Assert.Equal(adHocReleaseType, result.Right.Type);
+                Assert.Equal("2030", result.Right.ReleaseName);
+                Assert.Equal(TimeIdentifier.March, result.Right.TimePeriodCoverage);
+                Assert.Equal("Access list", result.Right.PreReleaseAccessList);
+            }
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var saved = await context.Releases
+                    .Include(r => r.ReleaseStatuses)
+                    .FirstAsync(r => r.Id == releaseId);
+
+                Assert.Equal(release.Publication.Id, saved.PublicationId);
+                Assert.Equal(new DateTime(2051, 6, 29, 23, 0, 0, DateTimeKind.Utc),
+                    saved.PublishScheduled);
+                Assert.Equal(nextReleaseDateEdited, saved.NextReleaseDate);
+                Assert.Equal(adHocReleaseType.Id, saved.TypeId);
+                Assert.Equal("2030-march", saved.Slug);
+                Assert.Equal("2030", saved.ReleaseName);
+                Assert.Equal(TimeIdentifier.March, saved.TimePeriodCoverage);
+                Assert.Equal("Access list", saved.PreReleaseAccessList);
+
+                Assert.Single(saved.ReleaseStatuses);
+                var status = saved.ReleaseStatuses[0];
+                Assert.InRange(DateTime.UtcNow
+                    .Subtract(status.Created.Value).Milliseconds, 0, 1500);
+                Assert.Equal(release.Id, status.ReleaseId);
+                Assert.Equal(ReleaseApprovalStatus.Draft, status.ApprovalStatus);
+                Assert.Equal(_userId, status.CreatedById);
+                Assert.Equal("Test internal note", status.InternalReleaseNote);
+            }
+
+            MockUtils.VerifyAllMocks(contentService, releaseFileService);
+        }
+
+        [Fact]
+        public async Task UpdateReleaseStatus_Approved_FailsOnChecklistErrors()
+        {
+            var release = new Release
+            {
+                Type = new ReleaseType {Title = "Ad Hoc"},
+                Publication = new Publication {Title = "Old publication"},
+                ReleaseName = "2030",
+                Slug = "2030",
+                PublishScheduled = DateTime.UtcNow,
+                Version = 0,
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                await context.AddAsync(release);
+                await context.SaveChangesAsync();
+            }
+
+            var releaseChecklistService = new Mock<IReleaseChecklistService>(MockBehavior.Strict);
+            var contentService = new Mock<IContentService>(MockBehavior.Strict);
+            var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                releaseChecklistService
+                    .Setup(s =>
+                            s.GetErrors(It.Is<Release>(r => r.Id == release.Id)))
+                    .ReturnsAsync(
+                        new List<ReleaseChecklistIssue>
+                        {
+                            new ReleaseChecklistIssue(DataFileImportsMustBeCompleted),
+                            new ReleaseChecklistIssue(DataFileReplacementsMustBeCompleted),
+                        }
+                    );
+
+                var releaseService = BuildReleaseService(contentDbContext: context,
+                    releaseChecklistService: releaseChecklistService.Object,
+                    contentService: contentService.Object,
+                    releaseFileService: releaseFileService.Object);
+
+                var result = await releaseService
+                    .UpdateReleaseStatus(
+                        release.Id,
+                        new ReleaseStatusUpdateViewModel
+                        {
+                            ApprovalStatus = ReleaseApprovalStatus.Approved,
+                            LatestInternalReleaseNote = "Test note",
+                            PublishMethod = PublishMethod.Scheduled,
+                            PublishScheduled = "2051-06-30",
+                            NextReleaseDate = new PartialDate {Month="12", Year="2000"}
+                        }
+                    );
+
+                Assert.True(result.IsLeft);
+                AssertValidationProblem(result.Left, DataFileImportsMustBeCompleted);
+                AssertValidationProblem(result.Left, DataFileReplacementsMustBeCompleted);
+            }
+
+            MockUtils.VerifyAllMocks(releaseChecklistService, contentService, releaseFileService);
+        }
+
+        [Fact]
+        public async Task UpdateReleaseStatus_Approved_FailsNoPublishScheduledDate()
+        {
+            var release = new Release
+            {
+                Type = new ReleaseType
+                {
+                    Title = "Ad Hoc"
+                },
+                Publication = new Publication
+                {
+                    Title = "Old publication",
+                },
+                ReleaseName = "2030",
+                Slug = "2030",
+                Published = DateTime.Now,
+                PublishScheduled = DateTime.UtcNow,
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                await context.AddAsync(release);
+                await context.SaveChangesAsync();
+            }
+
+            var contentService = new Mock<IContentService>(MockBehavior.Strict);
+            var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var releaseService = BuildReleaseService(contentDbContext: context,
+                    contentService: contentService.Object,
+                    releaseFileService: releaseFileService.Object);
+
+                var result = await releaseService
+                    .UpdateReleaseStatus(
+                        release.Id,
+                        new ReleaseStatusUpdateViewModel
+                        {
+                            ApprovalStatus = ReleaseApprovalStatus.Approved,
+                            LatestInternalReleaseNote = "Test note",
+                            PublishMethod = PublishMethod.Scheduled,
+                            NextReleaseDate = new PartialDate {Month="12", Year="2000"}
+                        }
+                    );
+
+                Assert.True(result.IsLeft);
+
+                AssertValidationProblem(result.Left, ApprovedReleaseMustHavePublishScheduledDate);
+            }
+
+            MockUtils.VerifyAllMocks(contentService, releaseFileService);
+        }
+
+        [Fact]
+        public async Task UpdateReleaseStatus_Approved_FailsChangingToDraft()
+        {
+            var release = new Release
+            {
+                Type = new ReleaseType
+                {
+                    Title = "Ad Hoc"
+                },
+                Publication = new Publication
+                {
+                    Title = "Old publication",
+                },
+                ReleaseName = "2030",
+                Slug = "2030",
+                Published = DateTime.Now,
+                PublishScheduled = DateTime.UtcNow,
+                Version = 0,
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                await context.AddAsync(release);
+                await context.SaveChangesAsync();
+            }
+
+            var contentService = new Mock<IContentService>(MockBehavior.Strict);
+            var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var releaseService = BuildReleaseService(contentDbContext: context,
+                    contentService: contentService.Object,
+                    releaseFileService: releaseFileService.Object);
+
+                var result = await releaseService
+                    .UpdateReleaseStatus(
+                        release.Id,
+                        new ReleaseStatusUpdateViewModel
+                        {
+                            ApprovalStatus = ReleaseApprovalStatus.Draft,
+                        }
+                    );
+
+                Assert.True(result.IsLeft);
+                AssertValidationProblem(result.Left, PublishedReleaseCannotBeUnapproved);
+            }
+
+            MockUtils.VerifyAllMocks(contentService, releaseFileService);
+        }
+
+        [Fact]
         public async Task UpdateAsync_ReleaseHasImages()
         {
             var releaseId = Guid.NewGuid();
@@ -1187,7 +1457,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                             PreReleaseAccessList = "New access list",
                             ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview,
                             LatestInternalReleaseNote = "Internal note"
-
                         }
                     );
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -173,6 +173,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
+        [HttpPut("releases/{releaseId}/status")]
+        public async Task<ActionResult<ReleaseViewModel>> UpdateReleaseStatus(ReleaseStatusUpdateViewModel request,
+            Guid releaseId)
+        {
+            return await _releaseService
+                .UpdateReleaseStatus(releaseId, request)
+                .HandleFailuresOrOk();
+        }
+
         [HttpGet("publications/{publicationId}/releases/template")]
         public async Task<ActionResult<TitleAndIdViewModel?>> GetTemplateReleaseAsync(
             [Required] Guid publicationId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -24,6 +24,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, ReleaseViewModel>> UpdateRelease(Guid releaseId, ReleaseUpdateViewModel request);
 
+        Task<Either<ActionResult, ReleaseViewModel>> UpdateReleaseStatus(Guid releaseId, ReleaseStatusUpdateViewModel request);
+
         Task<Either<ActionResult, TitleAndIdViewModel>> GetLatestReleaseAsync(Guid publicationId);
 
         Task<Either<ActionResult, List<MyReleaseViewModel>>> GetMyReleasesForReleaseStatusesAsync(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -325,7 +325,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     var releaseStatus = new ReleaseStatus
                     {
-                        Id = Guid.NewGuid(),
                         Release = release,
                         InternalReleaseNote = request.LatestInternalReleaseNote,
                         ApprovalStatus = request.ApprovalStatus,
@@ -344,6 +343,72 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                                 await _context.AddAsync(releaseStatus);
                             }
 
+                            await _context.SaveChangesAsync();
+
+                            // Only need to inform Publisher if changing release approval status to or from Approved
+                            if (oldStatus == ReleaseApprovalStatus.Approved || request.ApprovalStatus == ReleaseApprovalStatus.Approved)
+                            {
+                                await _publishingService.ReleaseChanged(
+                                    releaseId,
+                                    releaseStatus.Id,
+                                    request.PublishMethod == PublishMethod.Immediate
+                                );
+                            }
+
+                            _context.Update(release);
+                            await _context.SaveChangesAsync();
+
+                            return await GetRelease(releaseId);
+                        });
+                });
+        }
+
+        public async Task<Either<ActionResult, ReleaseViewModel>> UpdateReleaseStatus(
+            Guid releaseId, ReleaseStatusUpdateViewModel request)
+        {
+            return await _persistenceHelper
+                .CheckEntityExists<Release>(releaseId, ReleaseChecklistService.HydrateReleaseForChecklist)
+                .OnSuccess(_userService.CheckCanUpdateRelease)
+                .OnSuccessDo(release => _userService.CheckCanUpdateReleaseStatus(release, request.ApprovalStatus))
+                .OnSuccess(async release =>
+                {
+                    if (request.ApprovalStatus != ReleaseApprovalStatus.Approved && release.Published.HasValue)
+                    {
+                        return ValidationActionResult(PublishedReleaseCannotBeUnapproved);
+                    }
+
+                    if (request.ApprovalStatus == ReleaseApprovalStatus.Approved
+                        && request.PublishMethod == PublishMethod.Scheduled
+                        && !request.PublishScheduledDate.HasValue)
+                    {
+                        return ValidationActionResult(ApprovedReleaseMustHavePublishScheduledDate);
+                    }
+
+                    var oldStatus = release.ApprovalStatus;
+
+                    release.ApprovalStatus = request.ApprovalStatus;
+                    release.InternalReleaseNote = request.LatestInternalReleaseNote;
+                    release.NextReleaseDate = request.NextReleaseDate;
+                    release.PublishScheduled = request.PublishMethod == PublishMethod.Immediate &&
+                                               request.ApprovalStatus == ReleaseApprovalStatus.Approved
+                        ? DateTime.UtcNow
+                        : request.PublishScheduledDate;
+
+                    var releaseStatus = new ReleaseStatus
+                    {
+                        Release = release,
+                        InternalReleaseNote = request.LatestInternalReleaseNote,
+                        ApprovalStatus = request.ApprovalStatus,
+                        Created = DateTime.UtcNow,
+                        CreatedById = _userService.GetUserId()
+                    };
+
+                    return await ValidateReleaseWithChecklist(release)
+                        .OnSuccessDo(() => RemoveUnusedImages(release.Id))
+                        .OnSuccess(async () =>
+                        {
+                            _context.Releases.Update(release);
+                            await _context.AddAsync(releaseStatus);
                             await _context.SaveChangesAsync();
 
                             // Only need to inform Publisher if changing release approval status to or from Approved

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -325,6 +325,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     var releaseStatus = new ReleaseStatus
                     {
+                        Id = Guid.NewGuid(),
                         Release = release,
                         InternalReleaseNote = request.LatestInternalReleaseNote,
                         ApprovalStatus = request.ApprovalStatus,
@@ -337,7 +338,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .OnSuccess(async () =>
                         {
                             _context.Releases.Update(release);
-                            await _context.AddAsync(releaseStatus);
+
+                            if (oldStatus != request.ApprovalStatus)
+                            {
+                                await _context.AddAsync(releaseStatus);
+                            }
+
                             await _context.SaveChangesAsync();
 
                             // Only need to inform Publisher if changing release approval status to or from Approved

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -162,4 +162,40 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         private int Year => int.Parse(ReleaseName);
     }
+
+    public class ReleaseStatusUpdateViewModel
+    {
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ReleaseApprovalStatus ApprovalStatus { get; set; }
+
+        public string LatestInternalReleaseNote { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public PublishMethod? PublishMethod { get; set; }
+
+        [DateTimeFormatValidator("yyyy-MM-dd")]
+        public string PublishScheduled { get; set; }
+
+        public DateTime? PublishScheduledDate
+        {
+            get
+            {
+                if (PublishScheduled.IsNullOrEmpty())
+                {
+                    return null;
+                }
+
+                DateTime.TryParseExact(
+                    PublishScheduled,
+                    "yyyy-MM-dd",
+                    InvariantCulture,
+                    DateTimeStyles.None,
+                    out var dateTime
+                );
+                return dateTime.AsStartOfDayUtcForTimeZone();
+            }
+        }
+
+        [PartialDateValidator] public PartialDate NextReleaseDate { get; set; }
+    }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusEditPage.tsx
@@ -38,17 +38,17 @@ const ReleaseStatusEditPage = ({
         statusPermissions={statusPermissions}
         onCancel={onCancel}
         onSubmit={async values => {
-          const nextRelease = await releaseService.updateRelease(release.id, {
-            ...release,
-            typeId: release.type.id,
-            ...values,
-            publishScheduled: values.publishScheduled
-              ? formatISO(values.publishScheduled, {
-                  representation: 'date',
-                })
-              : undefined,
-          });
-
+          const nextRelease = await releaseService.updateReleaseStatus(
+            release.id,
+            {
+              ...values,
+              publishScheduled: values.publishScheduled
+                ? formatISO(values.publishScheduled, {
+                    representation: 'date',
+                  })
+                : undefined,
+            },
+          );
           onUpdate(nextRelease);
         }}
       />

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -74,6 +74,14 @@ export interface UpdateReleaseRequest extends BaseReleaseRequest {
   preReleaseAccessList?: string;
 }
 
+export interface UpdateReleaseStatusRequest {
+  approvalStatus: ReleaseApprovalStatus;
+  latestInternalReleaseNote?: string;
+  publishMethod?: 'Scheduled' | 'Immediate';
+  publishScheduled?: string;
+  nextReleaseDate?: PartialDate;
+}
+
 type PublishingStage =
   | 'Validating'
   | 'Cancelled'
@@ -183,6 +191,13 @@ const releaseService = {
     updateRequest: UpdateReleaseRequest,
   ): Promise<Release> {
     return client.put(`/releases/${releaseId}`, updateRequest);
+  },
+
+  updateReleaseStatus(
+    releaseId: string,
+    updateRequest: UpdateReleaseStatusRequest,
+  ): Promise<Release> {
+    return client.put(`/releases/${releaseId}/status`, updateRequest);
   },
 
   deleteRelease(releaseId: string): Promise<void> {


### PR DESCRIPTION
The same release update endpoint is being used on three different pages: to change a release's ApprovalStatus, to add/edit PreRelease access list content, and to alter a release's summary info. 

By only adding a new ReleaseStatus row when the ApprovalStatus changes, we ensure that we only add a new ReleaseStatus entry when the user is on the Sign off page. This prevents the endpoint erroring if it is used to add/edit an access list or edit a release's summary info.