### PR TITLE
EES-2450 Change UpdateRelease into UpdateReleaseInfo

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -167,15 +167,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var mocks = Mocks();
 
             mocks.ReleaseService
-                .Setup(s => s.UpdateReleaseInfo(
+                .Setup(s => s.UpdateRelease(
                     It.Is<Guid>(id => id.Equals(_releaseId)),
-                    It.IsAny<ReleaseInfoUpdateViewModel>())
+                    It.IsAny<ReleaseUpdateViewModel>())
                 )
                 .ReturnsAsync(new ReleaseViewModel {Id = _releaseId});
             var controller = ReleasesControllerWithMocks(mocks);
 
             // Method under test
-            var result = await controller.UpdateReleaseInfo(new ReleaseInfoUpdateViewModel(), _releaseId);
+            var result = await controller.UpdateRelease(new ReleaseUpdateViewModel(), _releaseId);
             var unboxed = AssertOkResult(result);
             Assert.Equal(_releaseId, unboxed.Id);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/ReleasesControllerTests.cs
@@ -167,15 +167,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var mocks = Mocks();
 
             mocks.ReleaseService
-                .Setup(s => s.UpdateRelease(
+                .Setup(s => s.UpdateReleaseInfo(
                     It.Is<Guid>(id => id.Equals(_releaseId)),
-                    It.IsAny<ReleaseUpdateViewModel>())
+                    It.IsAny<ReleaseInfoUpdateViewModel>())
                 )
                 .ReturnsAsync(new ReleaseViewModel {Id = _releaseId});
             var controller = ReleasesControllerWithMocks(mocks);
 
             // Method under test
-            var result = await controller.UpdateRelease(new ReleaseUpdateViewModel(), _releaseId);
+            var result = await controller.UpdateReleaseInfo(new ReleaseInfoUpdateViewModel(), _releaseId);
             var unboxed = AssertOkResult(result);
             Assert.Equal(_releaseId, unboxed.Id);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -93,7 +93,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateReleaseInfo()
+        public async Task UpdateRelease()
         {
             await PolicyCheckBuilder<SecurityPolicies>()
                 .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
@@ -101,9 +101,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService =>
                     {
                         var service = BuildReleaseService(userService: userService.Object);
-                        return service.UpdateReleaseInfo(
+                        return service.UpdateRelease(
                             _release.Id,
-                            new ReleaseInfoUpdateViewModel()
+                            new ReleaseUpdateViewModel()
                         );
                     }
                 );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -119,9 +119,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService =>
                     {
                         var service = BuildReleaseService(userService: userService.Object);
-                        return service.UpdateReleaseStatus(
+                        return service.CreateReleaseStatus(
                             _release.Id,
-                            new ReleaseStatusUpdateViewModel
+                            new ReleaseStatusCreateViewModel
                             {
                                 ApprovalStatus = ReleaseApprovalStatus.Draft
                             }
@@ -140,9 +140,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService =>
                     {
                         var service = BuildReleaseService(userService: userService.Object);
-                        return service.UpdateReleaseStatus(
+                        return service.CreateReleaseStatus(
                             _release.Id,
-                            new ReleaseStatusUpdateViewModel
+                            new ReleaseStatusCreateViewModel
                             {
                                 ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview
                             }
@@ -161,9 +161,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService =>
                     {
                         var service = BuildReleaseService(userService: userService.Object);
-                        return service.UpdateReleaseStatus(
+                        return service.CreateReleaseStatus(
                             _release.Id,
-                            new ReleaseStatusUpdateViewModel
+                            new ReleaseStatusCreateViewModel
                             {
                                 ApprovalStatus = ReleaseApprovalStatus.Approved
                             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -93,7 +93,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateRelease()
+        public async Task UpdateReleaseInfo()
         {
             await PolicyCheckBuilder<SecurityPolicies>()
                 .SetupResourceCheckToFail(_release, CanUpdateSpecificRelease)
@@ -101,72 +101,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     userService =>
                     {
                         var service = BuildReleaseService(userService: userService.Object);
-                        return service.UpdateRelease(
+                        return service.UpdateReleaseInfo(
                             _release.Id,
-                            new ReleaseUpdateViewModel()
-                        );
-                    }
-                );
-        }
-
-        [Fact]
-        public async Task UpdateRelease_Draft()
-        {
-            await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheck(_release, CanUpdateSpecificRelease)
-                .SetupResourceCheckToFail(_release, CanMarkSpecificReleaseAsDraft)
-                .AssertForbidden(
-                    userService =>
-                    {
-                        var service = BuildReleaseService(userService: userService.Object);
-                        return service.UpdateRelease(
-                            _release.Id,
-                            new ReleaseUpdateViewModel
-                            {
-                                ApprovalStatus = ReleaseApprovalStatus.Draft
-                            }
-                        );
-                    }
-                );
-        }
-
-        [Fact]
-        public async Task UpdateRelease_SubmitForHigherLevelReview()
-        {
-            await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheck(_release, CanUpdateSpecificRelease)
-                .SetupResourceCheckToFail(_release, CanSubmitSpecificReleaseToHigherReview)
-                .AssertForbidden(
-                    userService =>
-                    {
-                        var service = BuildReleaseService(userService: userService.Object);
-                        return service.UpdateRelease(
-                            _release.Id,
-                            new ReleaseUpdateViewModel
-                            {
-                                ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview
-                            }
-                        );
-                    }
-                );
-        }
-
-        [Fact]
-        public async Task UpdateRelease_Approve()
-        {
-            await PolicyCheckBuilder<SecurityPolicies>()
-                .SetupResourceCheck(_release, CanUpdateSpecificRelease)
-                .SetupResourceCheckToFail(_release, CanApproveSpecificRelease)
-                .AssertForbidden(
-                    userService =>
-                    {
-                        var service = BuildReleaseService(userService: userService.Object);
-                        return service.UpdateRelease(
-                            _release.Id,
-                            new ReleaseUpdateViewModel
-                            {
-                                ApprovalStatus = ReleaseApprovalStatus.Approved
-                            }
+                            new ReleaseInfoUpdateViewModel()
                         );
                     }
                 );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -626,7 +626,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateReleaseInfo()
+        public async Task UpdateRelease()
         {
             var releaseId = Guid.NewGuid();
 
@@ -665,9 +665,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateReleaseInfo(
+                    .UpdateRelease(
                         releaseId,
-                        new ReleaseInfoUpdateViewModel
+                        new ReleaseUpdateViewModel
                         {
                             TypeId = officialStatisticsReleaseType.Id,
                             ReleaseName = "2035",
@@ -706,7 +706,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateReleaseInfo_FailsNonUniqueSlug()
+        public async Task UpdateRelease_FailsNonUniqueSlug()
         {
             var releaseType = new ReleaseType {Title = "Ad Hoc"};
 
@@ -755,9 +755,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateReleaseInfo(
+                    .UpdateRelease(
                         releaseId,
-                        new ReleaseInfoUpdateViewModel
+                        new ReleaseUpdateViewModel
                         {
                             TypeId = releaseType.Id,
                             ReleaseName = "2035",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -564,7 +564,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var subject = new Subject
             {
-                Id = Guid.NewGuid()
+                Id = Guid.NewGuid(),
             };
 
             var replacementSubject = new Subject
@@ -590,11 +590,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             file.ReplacedBy = replacementFile;
 
             var contentDbContextId = Guid.NewGuid().ToString();
-
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                await contentDbContext.AddAsync(release);
-                await contentDbContext.AddRangeAsync(file, replacementFile);
+                await contentDbContext.AddRangeAsync(release, file, replacementFile);
                 await contentDbContext.SaveChangesAsync();
             }
 
@@ -628,34 +626,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateRelease()
+        public async Task UpdateReleaseInfo()
         {
             var releaseId = Guid.NewGuid();
 
-            var adHocReleaseType = new ReleaseType
-            {
-                Title = "Ad Hoc"
-            };
-
-            var officialStatisticsReleaseType = new ReleaseType
-            {
-                Title = "Official Statistics"
-            };
+            var adHocReleaseType = new ReleaseType {Title = "Ad Hoc"};
+            var officialStatisticsReleaseType = new ReleaseType {Title = "Official Statistics"};
 
             var release = new Release
             {
                 Id = releaseId,
                 Type = adHocReleaseType,
-                Publication = new Publication
-                {
-                    Title = "Old publication"
-                },
+                Publication = new Publication(),
                 ReleaseName = "2030",
                 PublishScheduled = DateTime.UtcNow,
-                NextReleaseDate = new PartialDate
-                {
-                    Day = "15", Month = "6", Year = "2039"
-                },
+                NextReleaseDate = new PartialDate {Day = "15", Month = "6", Year = "2039"},
                 PreReleaseAccessList = "Old access list",
                 Version = 0,
                 PreviousVersionId = releaseId
@@ -665,23 +650,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddRangeAsync(adHocReleaseType, officialStatisticsReleaseType);
-
-                await context.AddAsync(release);
+                await context.AddRangeAsync(release,
+                    adHocReleaseType, officialStatisticsReleaseType);
                 await context.SaveChangesAsync();
             }
 
             var contentService = new Mock<IContentService>(MockBehavior.Strict);
             var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
-
-            contentService.Setup(mock =>
-                    mock.GetContentBlocks<HtmlBlock>(release.Id))
-                .ReturnsAsync(new List<HtmlBlock>());
-
-            var nextReleaseDateEdited = new PartialDate
-            {
-                Day = "1", Month = "1", Year = "2040"
-            };
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
@@ -690,31 +665,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateRelease(
+                    .UpdateReleaseInfo(
                         releaseId,
-                        new ReleaseUpdateViewModel
+                        new ReleaseInfoUpdateViewModel
                         {
-                            PublishScheduled = "2051-06-30",
-                            NextReleaseDate = nextReleaseDateEdited,
                             TypeId = officialStatisticsReleaseType.Id,
                             ReleaseName = "2035",
                             TimePeriodCoverage = TimeIdentifier.March,
                             PreReleaseAccessList = "New access list",
-                            ApprovalStatus = ReleaseApprovalStatus.Draft,
-                            LatestInternalReleaseNote = "Test internal note"
                         }
                     );
 
                 Assert.True(result.IsRight);
+                var viewModel = result.Right;
 
-                Assert.Equal(release.Publication.Id, result.Right.PublicationId);
-                Assert.Equal(new DateTime(2051, 6, 30, 0, 0, 0, DateTimeKind.Unspecified),
-                    result.Right.PublishScheduled);
-                Assert.Equal(nextReleaseDateEdited, result.Right.NextReleaseDate);
-                Assert.Equal(officialStatisticsReleaseType, result.Right.Type);
-                Assert.Equal("2035", result.Right.ReleaseName);
-                Assert.Equal(TimeIdentifier.March, result.Right.TimePeriodCoverage);
-                Assert.Equal("New access list", result.Right.PreReleaseAccessList);
+                Assert.Equal(release.Publication.Id, viewModel.PublicationId);
+                Assert.Equal(release.NextReleaseDate, viewModel.NextReleaseDate);
+                Assert.Equal(officialStatisticsReleaseType, viewModel.Type);
+                Assert.Equal("2035", viewModel.ReleaseName);
+                Assert.Equal(TimeIdentifier.March, viewModel.TimePeriodCoverage);
+                Assert.Equal("New access list", viewModel.PreReleaseAccessList);
             }
 
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -724,34 +694,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .FirstAsync(r => r.Id == releaseId);
 
                 Assert.Equal(release.Publication.Id, saved.PublicationId);
-                Assert.Equal(new DateTime(2051, 6, 29, 23, 0, 0, DateTimeKind.Utc),
-                    saved.PublishScheduled);
-                Assert.Equal(nextReleaseDateEdited, saved.NextReleaseDate);
+                Assert.Equal(release.NextReleaseDate, saved.NextReleaseDate);
                 Assert.Equal(officialStatisticsReleaseType.Id, saved.TypeId);
                 Assert.Equal("2035-march", saved.Slug);
                 Assert.Equal("2035", saved.ReleaseName);
                 Assert.Equal(TimeIdentifier.March, saved.TimePeriodCoverage);
                 Assert.Equal("New access list", saved.PreReleaseAccessList);
 
-                // No ReleaseStatus created if the ApprovalStatus hasn't changed
                 Assert.Empty(saved.ReleaseStatuses);
             }
-
-            MockUtils.VerifyAllMocks(contentService, releaseFileService);
         }
 
         [Fact]
-        public async Task UpdateRelease_FailsNonUniqueSlug()
+        public async Task UpdateReleaseInfo_FailsNonUniqueSlug()
         {
-            var releaseType = new ReleaseType
-            {
-                Title = "Ad Hoc"
-            };
+            var releaseType = new ReleaseType {Title = "Ad Hoc"};
 
-            var publication = new Publication
-            {
-                Title = "Old publication"
-            };
+            var publication = new Publication();
 
             var releaseId = Guid.NewGuid();
             var release = new Release
@@ -780,11 +739,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             };
 
             var contextId = Guid.NewGuid().ToString();
-
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddAsync(releaseType);
-                await context.AddRangeAsync(release, otherRelease);
+                await context.AddRangeAsync(releaseType, release, otherRelease);
                 await context.SaveChangesAsync();
             }
 
@@ -798,15 +755,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateRelease(
+                    .UpdateReleaseInfo(
                         releaseId,
-                        new ReleaseUpdateViewModel
+                        new ReleaseInfoUpdateViewModel
                         {
-                            PublishScheduled = "2051-06-30",
                             TypeId = releaseType.Id,
                             ReleaseName = "2035",
                             TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                            ApprovalStatus = ReleaseApprovalStatus.Draft
+                            PreReleaseAccessList = "Test"
                         }
                     );
 
@@ -818,23 +774,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateRelease_Amendment_NoUniqueSlugFailure()
+        public async Task UpdateReleaseStatus_Amendment_NoUniqueSlugFailure()
         {
-            var releaseType = new ReleaseType
-            {
-                Title = "Ad Hoc"
-            };
+            var releaseType = new ReleaseType {Title = "Ad Hoc"};
 
-            var publication = new Publication
-            {
-                Title = "Old publication"
-            };
+            var publication = new Publication();
 
             var initialReleaseId = Guid.NewGuid();
             var initialRelease = new Release
             {
                 Id = initialReleaseId,
                 Type = releaseType,
+                TimePeriodCoverage = TimeIdentifier.TaxYear,
                 Publication = publication,
                 ReleaseName = "2035",
                 Slug = "2035",
@@ -846,6 +797,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var amendedRelease = new Release
             {
                 Type = releaseType,
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
                 Publication = publication,
                 ReleaseName = "2030",
                 Slug = "2030",
@@ -877,206 +829,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateRelease(
+                    .UpdateReleaseStatus(
                         amendedRelease.Id,
-                        new ReleaseUpdateViewModel
+                        new ReleaseStatusUpdateViewModel
                         {
                             PublishScheduled = "2051-06-30",
-                            TypeId = releaseType.Id,
-                            ReleaseName = "2035",
-                            TimePeriodCoverage = TimeIdentifier.CalendarYear,
                             ApprovalStatus = ReleaseApprovalStatus.Draft
                         }
                     );
 
                 Assert.True(result.IsRight);
-                Assert.Equal("2035", result.Right.ReleaseName);
-                Assert.Equal(TimeIdentifier.CalendarYear, result.Right.TimePeriodCoverage);
-            }
+                var viewModel = result.Right;
 
-            MockUtils.VerifyAllMocks(contentService, releaseFileService);
-        }
-
-        [Fact]
-        public async Task UpdateRelease_Approved_FailsOnChecklistErrors()
-        {
-            var release = new Release
-            {
-                Type = new ReleaseType
-                {
-                    Title = "Ad Hoc"
-                },
-                Publication = new Publication
-                {
-                    Title = "Old publication"
-                },
-                ReleaseName = "2030",
-                Slug = "2030",
-                PublishScheduled = DateTime.UtcNow,
-                Version = 0,
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.AddAsync(release);
-                await context.SaveChangesAsync();
-            }
-
-            var releaseChecklistService = new Mock<IReleaseChecklistService>(MockBehavior.Strict);
-            var contentService = new Mock<IContentService>(MockBehavior.Strict);
-            var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                releaseChecklistService
-                    .Setup(s =>
-                            s.GetErrors(It.Is<Release>(r => r.Id == release.Id)))
-                    .ReturnsAsync(
-                        new List<ReleaseChecklistIssue>
-                        {
-                            new ReleaseChecklistIssue(DataFileImportsMustBeCompleted),
-                            new ReleaseChecklistIssue(DataFileReplacementsMustBeCompleted),
-                        }
-                    );
-
-                var releaseService = BuildReleaseService(contentDbContext: context,
-                    releaseChecklistService: releaseChecklistService.Object,
-                    contentService: contentService.Object,
-                    releaseFileService: releaseFileService.Object);
-
-                var result = await releaseService
-                    .UpdateRelease(
-                        release.Id,
-                        new ReleaseUpdateViewModel
-                        {
-                            PublishScheduled = "2051-06-30",
-                            TypeId = release.Type.Id,
-                            ReleaseName = "2030",
-                            TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                            ApprovalStatus = ReleaseApprovalStatus.Approved
-                        }
-                    );
-
-                Assert.True(result.IsLeft);
-                AssertValidationProblem(result.Left, DataFileImportsMustBeCompleted);
-                AssertValidationProblem(result.Left, DataFileReplacementsMustBeCompleted);
-            }
-
-            MockUtils.VerifyAllMocks(releaseChecklistService, contentService, releaseFileService);
-        }
-
-        [Fact]
-        public async Task UpdateRelease_Approved_FailsChangingToDraft()
-        {
-            var release = new Release
-            {
-                Type = new ReleaseType
-                {
-                    Title = "Ad Hoc"
-                },
-                Publication = new Publication
-                {
-                    Title = "Old publication",
-                },
-                ReleaseName = "2030",
-                Slug = "2030",
-                Published = DateTime.Now,
-                PublishScheduled = DateTime.UtcNow,
-                Version = 0,
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.AddAsync(release);
-                await context.SaveChangesAsync();
-            }
-
-            var contentService = new Mock<IContentService>(MockBehavior.Strict);
-            var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var releaseService = BuildReleaseService(contentDbContext: context,
-                    contentService: contentService.Object,
-                    releaseFileService: releaseFileService.Object);
-
-                var result = await releaseService
-                    .UpdateRelease(
-                        release.Id,
-                        new ReleaseUpdateViewModel
-                        {
-                            PublishScheduled = "2051-06-30",
-                            TypeId = release.Type.Id,
-                            ReleaseName = "2030",
-                            TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                            ApprovalStatus = ReleaseApprovalStatus.Draft
-                        }
-                    );
-
-                Assert.True(result.IsLeft);
-                AssertValidationProblem(result.Left, PublishedReleaseCannotBeUnapproved);
-            }
-
-            MockUtils.VerifyAllMocks(contentService, releaseFileService);
-        }
-
-        [Fact]
-        public async Task UpdateRelease_Approved_FailsNoPublishScheduledDate()
-        {
-            var release = new Release
-            {
-                Type = new ReleaseType
-                {
-                    Title = "Ad Hoc"
-                },
-                Publication = new Publication
-                {
-                    Title = "Old publication",
-                },
-                ReleaseName = "2030",
-                Slug = "2030",
-                Published = DateTime.Now,
-                PublishScheduled = DateTime.UtcNow,
-                Version = 0,
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.AddAsync(release);
-                await context.SaveChangesAsync();
-            }
-
-            var contentService = new Mock<IContentService>(MockBehavior.Strict);
-            var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                var releaseService = BuildReleaseService(contentDbContext: context,
-                    contentService: contentService.Object,
-                    releaseFileService: releaseFileService.Object);
-
-                var result = await releaseService
-                    .UpdateRelease(
-                        release.Id,
-                        new ReleaseUpdateViewModel
-                        {
-                            TypeId = release.Type.Id,
-                            ReleaseName = "2030",
-                            TimePeriodCoverage = TimeIdentifier.CalendarYear,
-                            ApprovalStatus = ReleaseApprovalStatus.Approved,
-                            PublishMethod = PublishMethod.Scheduled
-                        }
-                    );
-
-                Assert.True(result.IsLeft);
-
-                AssertValidationProblem(result.Left, ApprovedReleaseMustHavePublishScheduledDate);
+                Assert.Equal("2030", viewModel.ReleaseName);
+                Assert.Equal(TimeIdentifier.CalendarYear, viewModel.TimePeriodCoverage);
             }
 
             MockUtils.VerifyAllMocks(contentService, releaseFileService);
@@ -1353,35 +1119,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateAsync_ReleaseHasImages()
+        public async Task UpdateReleaseStatus_ReleaseHasImages()
         {
             var releaseId = Guid.NewGuid();
 
-            var adHocReleaseType = new ReleaseType
-            {
-                Title = "Ad Hoc"
-            };
-
-            var officialStatisticsReleaseType = new ReleaseType
-            {
-                Title = "Official Statistics"
-            };
+            var adHocReleaseType = new ReleaseType {Title = "Ad Hoc"};
 
             var release = new Release
             {
                 Id = releaseId,
                 Type = adHocReleaseType,
-                Publication = new Publication
-                {
-                    Title = "Old publication"
-                },
+                Publication = new Publication {Title = "Old publication"},
                 ReleaseName = "2030",
+                TimePeriodCoverage = TimeIdentifier.March,
+                Slug = "2030-march",
                 PublishScheduled = DateTime.UtcNow,
-                NextReleaseDate = new PartialDate
-                {
-                    Day = "15", Month = "6", Year = "2039"
-                },
-                PreReleaseAccessList = "Old access list",
+                NextReleaseDate = new PartialDate {Day = "15", Month = "6", Year = "2039"},
+                PreReleaseAccessList = "Access list",
                 Version = 0,
                 PreviousVersionId = releaseId
             };
@@ -1412,9 +1166,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddRangeAsync(adHocReleaseType, officialStatisticsReleaseType);
-                await context.Releases.AddAsync(release);
-                await context.ReleaseFiles.AddRangeAsync(imageFile1, imageFile2);
+                await context.AddRangeAsync(adHocReleaseType, release, imageFile1, imageFile2);
                 await context.SaveChangesAsync();
             }
 
@@ -1433,10 +1185,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }
                 });
 
-            var nextReleaseDateEdited = new PartialDate
-            {
-                Day = "1", Month = "1", Year = "2040"
-            };
+            var nextReleaseDateEdited = new PartialDate {Day = "1", Month = "1", Year = "2040"};
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
@@ -1445,31 +1194,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateRelease(
+                    .UpdateReleaseStatus(
                         releaseId,
-                        new ReleaseUpdateViewModel
+                        new ReleaseStatusUpdateViewModel
                         {
                             PublishScheduled = "2051-06-30",
                             NextReleaseDate = nextReleaseDateEdited,
-                            TypeId = officialStatisticsReleaseType.Id,
-                            ReleaseName = "2035",
-                            TimePeriodCoverage = TimeIdentifier.March,
-                            PreReleaseAccessList = "New access list",
                             ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview,
                             LatestInternalReleaseNote = "Internal note"
                         }
                     );
 
                 Assert.True(result.IsRight);
+                var viewModel = result.Right;
 
-                Assert.Equal(release.Publication.Id, result.Right.PublicationId);
                 Assert.Equal(new DateTime(2051, 6, 30, 0, 0, 0, DateTimeKind.Unspecified),
-                    result.Right.PublishScheduled);
-                Assert.Equal(nextReleaseDateEdited, result.Right.NextReleaseDate);
-                Assert.Equal(officialStatisticsReleaseType, result.Right.Type);
-                Assert.Equal("2035", result.Right.ReleaseName);
-                Assert.Equal(TimeIdentifier.March, result.Right.TimePeriodCoverage);
-                Assert.Equal("New access list", result.Right.PreReleaseAccessList);
+                    viewModel.PublishScheduled);
+                Assert.Equal(nextReleaseDateEdited, viewModel.NextReleaseDate);
+                Assert.Equal(ReleaseApprovalStatus.HigherLevelReview, viewModel.ApprovalStatus);
+
+                Assert.Equal(release.Publication.Id, viewModel.PublicationId);
+                Assert.Equal(release.Type, viewModel.Type);
+                Assert.Equal(release.ReleaseName, viewModel.ReleaseName);
+                Assert.Equal(release.TimePeriodCoverage, viewModel.TimePeriodCoverage);
+                Assert.Equal(release.PreReleaseAccessList, viewModel.PreReleaseAccessList);
             }
             
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -1481,11 +1229,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(release.Publication.Id, saved.PublicationId);
                 Assert.Equal(new DateTime(2051, 6, 29, 23, 0, 0, DateTimeKind.Utc), saved.PublishScheduled);
                 Assert.Equal(nextReleaseDateEdited, saved.NextReleaseDate);
-                Assert.Equal(officialStatisticsReleaseType.Id, saved.TypeId);
-                Assert.Equal("2035-march", saved.Slug);
-                Assert.Equal("2035", saved.ReleaseName);
+                Assert.Equal(adHocReleaseType.Id, saved.TypeId);
+                Assert.Equal("2030-march", saved.Slug);
+                Assert.Equal("2030", saved.ReleaseName);
                 Assert.Equal(TimeIdentifier.March, saved.TimePeriodCoverage);
-                Assert.Equal("New access list", saved.PreReleaseAccessList);
+                Assert.Equal("Access list", saved.PreReleaseAccessList);
 
                 Assert.Single(saved.ReleaseStatuses);
                 var savedStatus = saved.ReleaseStatuses[0];
@@ -1501,35 +1249,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateAsync_ReleaseHasUnusedImages()
+        public async Task UpdateReleaseStatus_ReleaseHasUnusedImages()
         {
             var releaseId = Guid.NewGuid();
 
-            var adHocReleaseType = new ReleaseType
-            {
-                Title = "Ad Hoc"
-            };
-
-            var officialStatisticsReleaseType = new ReleaseType
-            {
-                Title = "Official Statistics"
-            };
+            var adHocReleaseType = new ReleaseType {Title = "Ad Hoc"};
 
             var release = new Release
             {
                 Id = releaseId,
                 Type = adHocReleaseType,
-                Publication = new Publication
-                {
-                    Title = "Old publication"
-                },
+                Publication = new Publication {Title = "Old publication"},
                 ReleaseName = "2030",
+                TimePeriodCoverage = TimeIdentifier.March,
                 PublishScheduled = DateTime.UtcNow,
-                NextReleaseDate = new PartialDate
-                {
-                    Day = "15", Month = "6", Year = "2039"
-                },
-                PreReleaseAccessList = "Old access list",
+                NextReleaseDate = new PartialDate {Day = "15", Month = "6", Year = "2039"},
+                PreReleaseAccessList = "Access list",
                 Version = 0,
                 PreviousVersionId = releaseId
             };
@@ -1560,9 +1295,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                await context.AddRangeAsync(adHocReleaseType, officialStatisticsReleaseType);
-                await context.Releases.AddAsync(release);
-                await context.ReleaseFiles.AddRangeAsync(imageFile1, imageFile2);
+                await context.AddRangeAsync(release, adHocReleaseType, imageFile1, imageFile2);
                 await context.SaveChangesAsync();
             }
 
@@ -1581,10 +1314,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     }, false))
                 .ReturnsAsync(Unit.Instance);
 
-            var nextReleaseDateEdited = new PartialDate
-            {
-                Day = "1", Month = "1", Year = "2040"
-            };
+            var nextReleaseDateEdited = new PartialDate {Day = "1", Month = "1", Year = "2040"};
 
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
@@ -1593,22 +1323,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateRelease(
+                    .UpdateReleaseStatus(
                         releaseId,
-                        new ReleaseUpdateViewModel
+                        new ReleaseStatusUpdateViewModel
                         {
                             PublishScheduled = "2051-06-30",
                             NextReleaseDate = nextReleaseDateEdited,
-                            TypeId = officialStatisticsReleaseType.Id,
-                            ReleaseName = "2035",
-                            TimePeriodCoverage = TimeIdentifier.March,
-                            PreReleaseAccessList = "New access list",
                             ApprovalStatus = ReleaseApprovalStatus.HigherLevelReview,
                             LatestInternalReleaseNote = "Test internal note"
                         }
                     );
 
                 Assert.True(result.IsRight);
+                var viewModel = result.Right;
 
                 releaseFileService.Verify(mock =>
                     mock.Delete(release.Id, new List<Guid>
@@ -1617,14 +1344,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         imageFile2.File.Id
                     }, false), Times.Once);
 
-                Assert.Equal(release.Publication.Id, result.Right.PublicationId);
+                Assert.Equal(release.Publication.Id, viewModel.PublicationId);
                 Assert.Equal(new DateTime(2051, 6, 30, 0, 0, 0, DateTimeKind.Unspecified),
-                    result.Right.PublishScheduled);
-                Assert.Equal(nextReleaseDateEdited, result.Right.NextReleaseDate);
-                Assert.Equal(officialStatisticsReleaseType, result.Right.Type);
-                Assert.Equal("2035", result.Right.ReleaseName);
-                Assert.Equal(TimeIdentifier.March, result.Right.TimePeriodCoverage);
-                Assert.Equal("New access list", result.Right.PreReleaseAccessList);
+                    viewModel.PublishScheduled);
+                Assert.Equal(nextReleaseDateEdited, viewModel.NextReleaseDate);
+                Assert.Equal("2030", viewModel.ReleaseName);
+                Assert.Equal(TimeIdentifier.March, viewModel.TimePeriodCoverage);
+                Assert.Equal("Access list", viewModel.PreReleaseAccessList);
             }
             
             await using (var context = InMemoryApplicationDbContext(contextId))
@@ -1636,11 +1362,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(release.Publication.Id, saved.PublicationId);
                 Assert.Equal(new DateTime(2051, 6, 29, 23, 0, 0, DateTimeKind.Utc), saved.PublishScheduled);
                 Assert.Equal(nextReleaseDateEdited, saved.NextReleaseDate);
-                Assert.Equal(officialStatisticsReleaseType.Id, saved.TypeId);
-                Assert.Equal("2035-march", saved.Slug);
-                Assert.Equal("2035", saved.ReleaseName);
+                Assert.Equal(adHocReleaseType.Id, saved.TypeId);
+                Assert.Equal("2030", saved.ReleaseName);
                 Assert.Equal(TimeIdentifier.March, saved.TimePeriodCoverage);
-                Assert.Equal("New access list", saved.PreReleaseAccessList);
+                Assert.Equal("Access list", saved.PreReleaseAccessList);
 
                 Assert.Single(saved.ReleaseStatuses);
                 var savedStatus = saved.ReleaseStatuses[0];
@@ -1740,6 +1465,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var result = await releaseService.GetRelease(releaseId);
 
+                Assert.True(result.IsRight);
                 var viewModel = result.Right;
 
                 Assert.Equal("2035", viewModel.ReleaseName);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -774,7 +774,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateReleaseStatus_Amendment_NoUniqueSlugFailure()
+        public async Task CreateReleaseStatus_Amendment_NoUniqueSlugFailure()
         {
             var releaseType = new ReleaseType {Title = "Ad Hoc"};
 
@@ -829,9 +829,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateReleaseStatus(
+                    .CreateReleaseStatus(
                         amendedRelease.Id,
-                        new ReleaseStatusUpdateViewModel
+                        new ReleaseStatusCreateViewModel
                         {
                             PublishScheduled = "2051-06-30",
                             ApprovalStatus = ReleaseApprovalStatus.Draft
@@ -849,7 +849,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateReleaseStatus()
+        public async Task CreateReleaseStatus()
         {
             var releaseId = Guid.NewGuid();
             var adHocReleaseType = new ReleaseType {Title = "Ad Hoc"};
@@ -892,9 +892,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateReleaseStatus(
+                    .CreateReleaseStatus(
                         releaseId,
-                        new ReleaseStatusUpdateViewModel
+                        new ReleaseStatusCreateViewModel
                         {
                             PublishMethod = PublishMethod.Scheduled,
                             PublishScheduled = "2051-06-30",
@@ -946,7 +946,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateReleaseStatus_Approved_FailsOnChecklistErrors()
+        public async Task CreateReleaseStatus_Approved_FailsOnChecklistErrors()
         {
             var release = new Release
             {
@@ -989,9 +989,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateReleaseStatus(
+                    .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusUpdateViewModel
+                        new ReleaseStatusCreateViewModel
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -1010,7 +1010,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateReleaseStatus_Approved_FailsNoPublishScheduledDate()
+        public async Task CreateReleaseStatus_Approved_FailsNoPublishScheduledDate()
         {
             var release = new Release
             {
@@ -1046,9 +1046,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateReleaseStatus(
+                    .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusUpdateViewModel
+                        new ReleaseStatusCreateViewModel
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Approved,
                             LatestInternalReleaseNote = "Test note",
@@ -1066,7 +1066,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateReleaseStatus_Approved_FailsChangingToDraft()
+        public async Task CreateReleaseStatus_Approved_FailsChangingToDraft()
         {
             var release = new Release
             {
@@ -1103,9 +1103,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateReleaseStatus(
+                    .CreateReleaseStatus(
                         release.Id,
-                        new ReleaseStatusUpdateViewModel
+                        new ReleaseStatusCreateViewModel
                         {
                             ApprovalStatus = ReleaseApprovalStatus.Draft,
                         }
@@ -1119,7 +1119,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateReleaseStatus_ReleaseHasImages()
+        public async Task CreateReleaseStatus_ReleaseHasImages()
         {
             var releaseId = Guid.NewGuid();
 
@@ -1194,9 +1194,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateReleaseStatus(
+                    .CreateReleaseStatus(
                         releaseId,
-                        new ReleaseStatusUpdateViewModel
+                        new ReleaseStatusCreateViewModel
                         {
                             PublishScheduled = "2051-06-30",
                             NextReleaseDate = nextReleaseDateEdited,
@@ -1249,7 +1249,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task UpdateReleaseStatus_ReleaseHasUnusedImages()
+        public async Task CreateReleaseStatus_ReleaseHasUnusedImages()
         {
             var releaseId = Guid.NewGuid();
 
@@ -1323,9 +1323,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseFileService: releaseFileService.Object);
 
                 var result = await releaseService
-                    .UpdateReleaseStatus(
+                    .CreateReleaseStatus(
                         releaseId,
-                        new ReleaseStatusUpdateViewModel
+                        new ReleaseStatusCreateViewModel
                         {
                             PublishScheduled = "2051-06-30",
                             NextReleaseDate = nextReleaseDateEdited,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -173,12 +173,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
-        [HttpPut("releases/{releaseId}/status")]
-        public async Task<ActionResult<ReleaseViewModel>> UpdateReleaseStatus(ReleaseStatusUpdateViewModel request,
+        [HttpPost("releases/{releaseId}/status")]
+        public async Task<ActionResult<ReleaseViewModel>> CreateReleaseStatus(ReleaseStatusCreateViewModel request,
             Guid releaseId)
         {
             return await _releaseService
-                .UpdateReleaseStatus(releaseId, request)
+                .CreateReleaseStatus(releaseId, request)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -164,12 +164,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
-        [HttpPut("releases/{releaseId}/info")]
-        public async Task<ActionResult<ReleaseViewModel>> UpdateReleaseInfo(ReleaseInfoUpdateViewModel request,
+        [HttpPut("releases/{releaseId}")]
+        public async Task<ActionResult<ReleaseViewModel>> UpdateRelease(ReleaseUpdateViewModel request,
             Guid releaseId)
         {
             return await _releaseService
-                .UpdateReleaseInfo(releaseId, request)
+                .UpdateRelease(releaseId, request)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -164,12 +164,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
-        [HttpPut("releases/{releaseId}")]
-        public async Task<ActionResult<ReleaseViewModel>> UpdateRelease(ReleaseUpdateViewModel request,
+        [HttpPut("releases/{releaseId}/info")]
+        public async Task<ActionResult<ReleaseViewModel>> UpdateReleaseInfo(ReleaseInfoUpdateViewModel request,
             Guid releaseId)
         {
             return await _releaseService
-                .UpdateRelease(releaseId, request)
+                .UpdateReleaseInfo(releaseId, request)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -22,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, ReleasePublicationStatusViewModel>> GetReleasePublicationStatusAsync(Guid releaseId);
 
-        Task<Either<ActionResult, ReleaseViewModel>> UpdateRelease(Guid releaseId, ReleaseUpdateViewModel request);
+        Task<Either<ActionResult, ReleaseViewModel>> UpdateReleaseInfo(Guid releaseId, ReleaseInfoUpdateViewModel request);
 
         Task<Either<ActionResult, ReleaseViewModel>> UpdateReleaseStatus(Guid releaseId, ReleaseStatusUpdateViewModel request);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -22,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, ReleasePublicationStatusViewModel>> GetReleasePublicationStatusAsync(Guid releaseId);
 
-        Task<Either<ActionResult, ReleaseViewModel>> UpdateReleaseInfo(Guid releaseId, ReleaseInfoUpdateViewModel request);
+        Task<Either<ActionResult, ReleaseViewModel>> UpdateRelease(Guid releaseId, ReleaseUpdateViewModel request);
 
         Task<Either<ActionResult, ReleaseViewModel>> UpdateReleaseStatus(Guid releaseId, ReleaseStatusUpdateViewModel request);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -24,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 
         Task<Either<ActionResult, ReleaseViewModel>> UpdateRelease(Guid releaseId, ReleaseUpdateViewModel request);
 
-        Task<Either<ActionResult, ReleaseViewModel>> UpdateReleaseStatus(Guid releaseId, ReleaseStatusUpdateViewModel request);
+        Task<Either<ActionResult, ReleaseViewModel>> CreateReleaseStatus(Guid releaseId, ReleaseStatusCreateViewModel request);
 
         Task<Either<ActionResult, TitleAndIdViewModel>> GetLatestReleaseAsync(Guid publicationId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -329,7 +329,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     var oldStatus = release.ApprovalStatus;
 
                     release.ApprovalStatus = request.ApprovalStatus;
-                    release.InternalReleaseNote = request.LatestInternalReleaseNote;
                     release.NextReleaseDate = request.NextReleaseDate;
                     release.PublishScheduled = request.PublishMethod == PublishMethod.Immediate &&
                                                request.ApprovalStatus == ReleaseApprovalStatus.Approved

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -290,75 +290,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return await _persistenceHelper
                 .CheckEntityExists<Release>(releaseId, ReleaseChecklistService.HydrateReleaseForChecklist)
                 .OnSuccess(_userService.CheckCanUpdateRelease)
-                .OnSuccessDo(release => _userService.CheckCanUpdateReleaseStatus(release, request.ApprovalStatus))
                 .OnSuccessDo(async release => await ValidateReleaseSlugUniqueToPublication(request.Slug, release.PublicationId, releaseId))
                 .OnSuccess(async release =>
                 {
-                    if (request.ApprovalStatus != ReleaseApprovalStatus.Approved && release.Published.HasValue)
-                    {
-                        return ValidationActionResult(PublishedReleaseCannotBeUnapproved);
-                    }
-
-                    if (request.ApprovalStatus == ReleaseApprovalStatus.Approved
-                        && request.PublishMethod == PublishMethod.Scheduled
-                        && !request.PublishScheduledDate.HasValue)
-                    {
-                        return ValidationActionResult(ApprovedReleaseMustHavePublishScheduledDate);
-                    }
-
                     release.Slug = request.Slug;
                     release.TypeId = request.TypeId;
                     release.ReleaseName = request.ReleaseName;
                     release.TimePeriodCoverage = request.TimePeriodCoverage;
                     release.PreReleaseAccessList = request.PreReleaseAccessList;
-
-                    var oldStatus = release.ApprovalStatus;
-
-                    release.ApprovalStatus = request.ApprovalStatus;
-                    release.NextReleaseDate = request.NextReleaseDate;
-
-                    release.PublishScheduled = request.PublishMethod == PublishMethod.Immediate &&
-                                               request.ApprovalStatus == ReleaseApprovalStatus.Approved
-                        ? DateTime.UtcNow
-                        : request.PublishScheduledDate;
-
-                    var releaseStatus = new ReleaseStatus
-                    {
-                        Release = release,
-                        InternalReleaseNote = request.LatestInternalReleaseNote,
-                        ApprovalStatus = request.ApprovalStatus,
-                        Created = DateTime.UtcNow,
-                        CreatedById = _userService.GetUserId()
-                    };
-
-                    return await ValidateReleaseWithChecklist(release)
-                        .OnSuccessDo(() => RemoveUnusedImages(release.Id))
-                        .OnSuccess(async () =>
-                        {
-                            _context.Releases.Update(release);
-
-                            if (oldStatus != request.ApprovalStatus)
-                            {
-                                await _context.AddAsync(releaseStatus);
-                            }
-
-                            await _context.SaveChangesAsync();
-
-                            // Only need to inform Publisher if changing release approval status to or from Approved
-                            if (oldStatus == ReleaseApprovalStatus.Approved || request.ApprovalStatus == ReleaseApprovalStatus.Approved)
-                            {
-                                await _publishingService.ReleaseChanged(
-                                    releaseId,
-                                    releaseStatus.Id,
-                                    request.PublishMethod == PublishMethod.Immediate
-                                );
-                            }
-
-                            _context.Update(release);
-                            await _context.SaveChangesAsync();
-
-                            return await GetRelease(releaseId);
-                        });
+                    
+                    _context.Releases.Update(release);
+                    await _context.SaveChangesAsync();
+                    return await GetRelease(releaseId);
                 });
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -305,8 +305,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
-        public async Task<Either<ActionResult, ReleaseViewModel>> UpdateReleaseStatus(
-            Guid releaseId, ReleaseStatusUpdateViewModel request)
+        public async Task<Either<ActionResult, ReleaseViewModel>> CreateReleaseStatus(
+            Guid releaseId, ReleaseStatusCreateViewModel request)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Release>(releaseId, ReleaseChecklistService.HydrateReleaseForChecklist)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -130,7 +130,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         private int Year => int.Parse(ReleaseName);
     }
 
-    public class ReleaseStatusUpdateViewModel
+    public class ReleaseStatusCreateViewModel
     {
         [JsonConverter(typeof(StringEnumConverter))]
         public ReleaseApprovalStatus ApprovalStatus { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -111,7 +111,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public Guid? TemplateReleaseId { get; set; }
     }
 
-    public class ReleaseUpdateViewModel
+    public class ReleaseInfoUpdateViewModel
     {
         [Required] public Guid TypeId { get; set; }
 
@@ -120,39 +120,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public TimeIdentifier TimePeriodCoverage { get; set; }
 
         public string PreReleaseAccessList { get; set; }
-
-        [JsonConverter(typeof(StringEnumConverter))]
-        public ReleaseApprovalStatus ApprovalStatus { get; set; }
-
-        public string LatestInternalReleaseNote { get; set; }
-
-        [JsonConverter(typeof(StringEnumConverter))]
-        public PublishMethod? PublishMethod { get; set; }
-
-        [DateTimeFormatValidator("yyyy-MM-dd")]
-        public string PublishScheduled { get; set; }
-
-        public DateTime? PublishScheduledDate
-        {
-            get
-            {
-                if (PublishScheduled.IsNullOrEmpty())
-                {
-                    return null;
-                }
-
-                DateTime.TryParseExact(
-                    PublishScheduled,
-                    "yyyy-MM-dd",
-                    InvariantCulture,
-                    DateTimeStyles.None,
-                    out var dateTime
-                );
-                return dateTime.AsStartOfDayUtcForTimeZone();
-            }
-        }
-
-        [PartialDateValidator] public PartialDate NextReleaseDate { get; set; }
 
         [RegularExpression(@"^([0-9]{4})?$")] public string ReleaseName { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -111,7 +111,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public Guid? TemplateReleaseId { get; set; }
     }
 
-    public class ReleaseInfoUpdateViewModel
+    public class ReleaseUpdateViewModel
     {
         [Required] public Guid TypeId { get; set; }
 

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseStatusEditPage.tsx
@@ -38,7 +38,7 @@ const ReleaseStatusEditPage = ({
         statusPermissions={statusPermissions}
         onCancel={onCancel}
         onSubmit={async values => {
-          const nextRelease = await releaseService.updateReleaseStatus(
+          const nextRelease = await releaseService.createReleaseStatus(
             release.id,
             {
               ...values,

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
@@ -48,13 +48,13 @@ const ReleaseSummaryEditPage = ({ history }: RouteComponentProps) => {
       throw new Error('Could not update missing release');
     }
 
-    const nextRelease = await releaseService.updateRelease(releaseId, {
-      ...release,
+    const nextRelease = await releaseService.updateReleaseInfo(releaseId, {
+      releaseName: values.timePeriodCoverageStartYear,
       timePeriodCoverage: {
         value: values.timePeriodCoverageCode,
       },
-      releaseName: values.timePeriodCoverageStartYear,
       typeId: values.releaseTypeId,
+      preReleaseAccessList: release.preReleaseAccessList,
     });
 
     onReleaseChange(nextRelease);

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
@@ -48,7 +48,7 @@ const ReleaseSummaryEditPage = ({ history }: RouteComponentProps) => {
       throw new Error('Could not update missing release');
     }
 
-    const nextRelease = await releaseService.updateReleaseInfo(releaseId, {
+    const nextRelease = await releaseService.updateRelease(releaseId, {
       releaseName: values.timePeriodCoverageStartYear,
       timePeriodCoverage: {
         value: values.timePeriodCoverageCode,

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
@@ -120,10 +120,11 @@ const ReleasePreReleaseAccessPage = () => {
               isReleaseLive={release.live}
               preReleaseAccessList={release.preReleaseAccessList}
               onSubmit={async ({ preReleaseAccessList }) => {
-                const updatedRelease = await releaseService.updateRelease(
+                const updatedRelease = await releaseService.updateReleaseInfo(
                   release.id,
                   {
-                    ...release,
+                    releaseName: release.releaseName,
+                    timePeriodCoverage: release.timePeriodCoverage,
                     typeId: release.type.id,
                     preReleaseAccessList,
                   },

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/ReleasePreReleaseAccessPage.tsx
@@ -120,7 +120,7 @@ const ReleasePreReleaseAccessPage = () => {
               isReleaseLive={release.live}
               preReleaseAccessList={release.preReleaseAccessList}
               onSubmit={async ({ preReleaseAccessList }) => {
-                const updatedRelease = await releaseService.updateReleaseInfo(
+                const updatedRelease = await releaseService.updateRelease(
                   release.id,
                   {
                     releaseName: release.releaseName,

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -65,12 +65,12 @@ export interface CreateReleaseRequest extends BaseReleaseRequest {
   templateReleaseId?: string;
 }
 
-export interface UpdateReleaseRequest extends BaseReleaseRequest {
-  approvalStatus: ReleaseApprovalStatus;
-  latestInternalReleaseNote?: string;
-  publishScheduled?: string;
-  publishMethod?: 'Scheduled' | 'Immediate';
-  nextReleaseDate?: PartialDate;
+export interface UpdateReleaseInfoRequest {
+  releaseName: string;
+  timePeriodCoverage: {
+    value: string;
+  };
+  typeId: string;
   preReleaseAccessList?: string;
 }
 
@@ -186,11 +186,11 @@ const releaseService = {
     return client.get(`/releases/${releaseId}/status`);
   },
 
-  updateRelease(
+  updateReleaseInfo(
     releaseId: string,
-    updateRequest: UpdateReleaseRequest,
+    updateRequest: UpdateReleaseInfoRequest,
   ): Promise<Release> {
-    return client.put(`/releases/${releaseId}`, updateRequest);
+    return client.put(`/releases/${releaseId}/info`, updateRequest);
   },
 
   updateReleaseStatus(

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -65,7 +65,7 @@ export interface CreateReleaseRequest extends BaseReleaseRequest {
   templateReleaseId?: string;
 }
 
-export interface UpdateReleaseInfoRequest {
+export interface UpdateReleaseRequest {
   releaseName: string;
   timePeriodCoverage: {
     value: string;
@@ -186,11 +186,11 @@ const releaseService = {
     return client.get(`/releases/${releaseId}/status`);
   },
 
-  updateReleaseInfo(
+  updateRelease(
     releaseId: string,
-    updateRequest: UpdateReleaseInfoRequest,
+    updateRequest: UpdateReleaseRequest,
   ): Promise<Release> {
-    return client.put(`/releases/${releaseId}/info`, updateRequest);
+    return client.put(`/releases/${releaseId}`, updateRequest);
   },
 
   updateReleaseStatus(

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -74,7 +74,7 @@ export interface UpdateReleaseRequest {
   preReleaseAccessList?: string;
 }
 
-export interface UpdateReleaseStatusRequest {
+export interface CreateReleaseStatusRequest {
   approvalStatus: ReleaseApprovalStatus;
   latestInternalReleaseNote?: string;
   publishMethod?: 'Scheduled' | 'Immediate';
@@ -193,11 +193,11 @@ const releaseService = {
     return client.put(`/releases/${releaseId}`, updateRequest);
   },
 
-  updateReleaseStatus(
+  createReleaseStatus(
     releaseId: string,
-    updateRequest: UpdateReleaseStatusRequest,
+    createRequest: CreateReleaseStatusRequest,
   ): Promise<Release> {
-    return client.put(`/releases/${releaseId}/status`, updateRequest);
+    return client.post(`/releases/${releaseId}/status`, createRequest);
   },
 
   deleteRelease(releaseId: string): Promise<void> {


### PR DESCRIPTION
After EES-2448, the ReleaseUpdate method still allowed the changing of the ApprovalStatus of a release even though the frontend didn't use this functionality, and if it were to be used to publish a release it would lead to bugs because the backend now only expects releases to be published with the ReleaseStatusUpdate method.

This PR fixes this issue by changing ReleaseUpdate to ReleaseUpdateInfo. This method is now only used on two pages - when editing a release's details (i.e. timeperiodcoverage, year, release type) and when adding or editing a prerelease access list.