### PR TITLE
Ees 2222 UI tests for sow4 create methodology flow 2

### DIFF
--- a/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
@@ -28,4 +28,20 @@ Create Methodology for Publication
     user views methodology for open publication accordion  ${accordion}  ${PUBLICATION_NAME}
     user checks summary list contains   Title   ${PUBLICATION_NAME}
     user checks summary list contains   Status  Draft
-    user checks summary list contains   Published on  Not yet published   
+    user checks summary list contains   Published on  Not yet published
+
+Update Methodology for Publication
+  [Tags]  HappyPath
+  ${accordion}=  user opens publication on the admin dashboard   ${PUBLICATION_NAME}
+  user views methodology for open publication accordion  ${accordion}  ${PUBLICATION_NAME}
+  user clicks link  Edit summary
+  user enters text into textfield  Enter methodology title  New methodology title
+  user clicks button  Update methodology
+  user waits until h2 is visible  Methodology summary
+  user clicks link  Sign off
+  user changes methodology status to Approved
+  user waits until h2 is visible  Methodology status
+  user clicks link  Summary
+  user checks summary list contains   Title   New methodology title
+  user checks summary list contains   Status  Approved
+  user checks summary list contains   Published on  Not yet published

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -55,7 +55,6 @@ Approve methodology
 Check methodology is approved
     [Tags]  HappyPath
     user waits until page contains element  xpath://strong[text()="Approved"]
-    user checks page contains element       xpath://strong[text()="Approved"]
 
 Create new release
     [Tags]  HappyPath
@@ -70,7 +69,7 @@ Upload another subject (for deletion later)
     user waits until page contains element  id:dataFileUploadForm-subjectTitle
     user uploads subject   ${SECOND_SUBJECT}  upload-file-test.csv  upload-file-test.meta.csv
 
-Add meta guidance to ${SUBJECT_NAME} subject
+Add meta guidance to subject
     [Tags]  HappyPath
     user clicks link  Metadata guidance
     user waits until h2 is visible  Public metadata guidance document  90
@@ -93,7 +92,7 @@ Navigate to 'Footnotes' page
     user clicks link  Footnotes
     user waits until h2 is visible  Footnotes
 
-Add footnote to ${SECOND_SUBJECT}
+Add footnote to second Subject
     [Tags]  HappyPath
     user waits until page contains link   Create footnote
     user clicks link  Create footnote
@@ -104,7 +103,7 @@ Add footnote to ${SECOND_SUBJECT}
     user clicks button  Save footnote
     user waits until h2 is visible  Footnotes
 
-Add second footnote to ${SECOND_SUBJECT}
+Add second footnote to second Subject
     user waits until page contains link   Create footnote
     user clicks link  Create footnote
     user waits until h2 is visible  Create footnote
@@ -116,7 +115,7 @@ Add second footnote to ${SECOND_SUBJECT}
     user clicks button  Save footnote
     user waits until h2 is visible  Footnotes
 
-Add footnote to ${SUBJECT_NAME} subject
+Add footnote to subject
     [Tags]  HappyPath
     user waits until page contains link   Create footnote
     user clicks link  Create footnote
@@ -127,7 +126,7 @@ Add footnote to ${SUBJECT_NAME} subject
     user clicks button  Save footnote
     user waits until h2 is visible  Footnotes
 
-Add second footnote to ${SUBJECT_NAME} subject
+Add second footnote to subject
     [Tags]  HappyPath
     user waits until page contains link   Create footnote
     user clicks link  Create footnote
@@ -166,7 +165,7 @@ Select "Test Topic" publication
     user waits until table tool wizard step is available    Choose a subject
     user checks previous table tool step contains  1   Publication   ${PUBLICATION_NAME}
 
-Select "${SUBJECT_NAME}" subject
+Select subject
     [Tags]  HappyPath
     user clicks radio   ${SUBJECT_NAME}
     user clicks element   id:publicationSubjectForm-submit

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -133,8 +133,6 @@ user views methodology for publication
     [Arguments]  ${publication}     ${methodology_title}=${publication}
     ${accordion}=  user opens publication on the admin dashboard   ${publication}
     user views methodology for open publication accordion  ${accordion}  ${methodology_title}
-    user clicks link   Edit this methodology
-    user waits until h2 is visible  Methodology summary 
 
 user views methodology for open publication accordion
     [Arguments]  ${accordion}     ${methodology_title}


### PR DESCRIPTION
This PR:
- fixes a bug in the "view methodology of publication" journey.
- adds test for editing and approving a newly created methodology.
- removes some dynamic test case names, as these don't play well with the report merging that happens when re-running failed test suites. 

![image](https://user-images.githubusercontent.com/12444316/123663302-2b363480-d82e-11eb-86ca-5d667f108bbc.png)
