### PR TITLE
EES-2466 Set Methodology Published dates when they first turn publicly accessible

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -43,28 +43,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var repository = new Mock<IMethodologyRepository>(Strict);
-            
+
                 var service = SetupMethodologyService(
-                    context, 
+                    context,
                     methodologyRepository: repository.Object);
 
                 var createdMethodology = new Methodology
                 {
                     Id = Guid.NewGuid()
                 };
-            
+
                 repository
                     .Setup(s => s.CreateMethodologyForPublication(publication.Id))
                     .ReturnsAsync(createdMethodology);
 
                 var result = await service.CreateMethodology(publication.Id);
                 VerifyAllMocks(repository);
-            
+
                 var viewModel = result.AssertRight();
                 Assert.Equal(createdMethodology.Id, viewModel.Id);
             }
         }
-        
+
         [Fact]
         public async Task GetSummary()
         {
@@ -155,6 +155,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var model = await context.Methodologies.FindAsync(methodology.Id);
 
+                Assert.Null(model.Published);
                 Assert.Equal(Draft, model.Status);
                 Assert.Equal(Immediately, model.PublishingStrategy);
                 Assert.Equal("pupil-absence-statistics-updated-methodology", model.Slug);
@@ -251,6 +252,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var model = await context.Methodologies.FindAsync(methodology.Id);
 
+                Assert.Null(model.Published);
                 Assert.Equal(Draft, model.Status);
                 Assert.Equal(Immediately, model.PublishingStrategy);
                 Assert.Equal("pupil-absence-statistics-updated-methodology", model.Slug);
@@ -354,6 +356,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var model = await context.Methodologies.FindAsync(methodology.Id);
 
+                Assert.Null(model.Published);
                 Assert.Equal(Draft, model.Status);
                 Assert.Equal(Immediately, model.PublishingStrategy);
                 Assert.Equal("pupil-absence-statistics-updated-methodology", model.Slug);
@@ -413,7 +416,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 Assert.Equal(methodology.Id, viewModel.Id);
                 Assert.Equal("Test approval", viewModel.InternalReleaseNote);
-                Assert.Null(viewModel.Published);
+                Assert.True(viewModel.Published.HasValue);
+                Assert.InRange(DateTime.UtcNow.Subtract(viewModel.Published.Value).Milliseconds, 0, 1500);
                 Assert.Equal(request.Status, viewModel.Status);
                 Assert.Equal(request.Title, viewModel.Title);
             }
@@ -422,6 +426,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var model = await context.Methodologies.FindAsync(methodology.Id);
 
+                Assert.True(model.Published.HasValue);
+                Assert.InRange(DateTime.UtcNow.Subtract(model.Published.Value).Milliseconds, 0, 1500);
                 Assert.Equal(Approved, model.Status);
                 Assert.Equal(Immediately, model.PublishingStrategy);
                 Assert.Equal("pupil-absence-statistics-updated-methodology", model.Slug);
@@ -487,6 +493,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var model = await context.Methodologies.FindAsync(methodology.Id);
 
+                Assert.Null(model.Published);
                 Assert.Equal(Approved, model.Status);
                 Assert.Equal(WithRelease, model.PublishingStrategy);
                 Assert.Equal("pupil-absence-statistics-updated-methodology", model.Slug);
@@ -561,7 +568,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var model = await context.Methodologies.FindAsync(methodology.Id);
 
-                Assert.Equal(Approved,model.Status);
+                Assert.Equal(methodology.Published, model.Published);
+                Assert.Equal(Approved, model.Status);
                 Assert.Equal(Immediately, model.PublishingStrategy);
                 // Slug remains unchanged
                 Assert.Equal("pupil-absence-statistics-methodology", model.Slug);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -86,7 +86,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 {
                     Id = new Guid("9eb283bd-4f28-4e65-bc91-1da9cc6567f9"),
                     Description = "Related Information",
-                    Url = "http://example.com"
+                    Url = "https://example.com"
                 }
             },
             Slug = "2018-19-q1",
@@ -110,7 +110,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 {
                     Id = new Guid("9eb283bd-4f28-4e65-bc91-1da9cc6567f9"),
                     Description = "Related Information",
-                    Url = "http://example.com"
+                    Url = "https://example.com"
                 }
             },
             Slug = "2018-19-q1",
@@ -134,7 +134,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 {
                     Id = new Guid("9eb283bd-4f28-4e65-bc91-1da9cc6567f9"),
                     Description = "Related Information",
-                    Url = "http://example.com"
+                    Url = "https://example.com"
                 }
             },
             Slug = "2018-19-q1",
@@ -174,7 +174,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 {
                     Id = new Guid("a0855237-b2f1-4dae-b2fc-027bb2802ba3"),
                     Description = "Related Information",
-                    Url = "http://example.com"
+                    Url = "https://example.com"
                 }
             },
             Slug = "2018-19-q2",
@@ -570,7 +570,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         {
             var contentDbContextId = Guid.NewGuid().ToString();
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 await contentDbContext.AddRangeAsync(Publications);
                 await contentDbContext.AddRangeAsync(Releases);
@@ -580,7 +580,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var publicBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 publicBlobStorageService.Setup(s =>
                         s.CheckBlobExists(PublicReleaseFiles,
@@ -672,7 +672,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         {
             var contentDbContextId = Guid.NewGuid().ToString();
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 await contentDbContext.AddRangeAsync(Publications);
                 await contentDbContext.AddRangeAsync(Releases);
@@ -680,7 +680,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 await contentDbContext.SaveChangesAsync();
             }
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = BuildReleaseService(contentDbContext);
 
@@ -699,14 +699,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         {
             var contentDbContextId = Guid.NewGuid().ToString();
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 await contentDbContext.AddRangeAsync(Publications);
                 await contentDbContext.AddRangeAsync(Releases);
                 await contentDbContext.SaveChangesAsync();
             }
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = BuildReleaseService(contentDbContext);
 
@@ -722,7 +722,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         {
             var contentDbContextId = Guid.NewGuid().ToString();
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 await contentDbContext.AddRangeAsync(Publications);
                 await contentDbContext.AddRangeAsync(Releases);
@@ -735,7 +735,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var publicBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 publicBlobStorageService.Setup(s =>
                         s.CheckBlobExists(PublicReleaseFiles,
@@ -884,7 +884,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         {
             var contentDbContextId = Guid.NewGuid().ToString();
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 await contentDbContext.AddRangeAsync(Publications);
                 await contentDbContext.AddRangeAsync(Releases);
@@ -915,7 +915,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                     created: null
                 ));
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = BuildReleaseService(contentDbContext: contentDbContext,
                     publicBlobStorageService: publicBlobStorageService.Object);
@@ -993,7 +993,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         {
             var contentDbContextId = Guid.NewGuid().ToString();
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 await contentDbContext.AddRangeAsync(Publications);
                 await contentDbContext.AddRangeAsync(Releases);
@@ -1024,7 +1024,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                     created: null
                 ));
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = BuildReleaseService(contentDbContext: contentDbContext,
                     publicBlobStorageService: publicBlobStorageService.Object);
@@ -1061,7 +1061,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
         {
             var contentDbContextId = Guid.NewGuid().ToString();
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 await contentDbContext.AddRangeAsync(Publications);
                 await contentDbContext.AddRangeAsync(Releases);
@@ -1092,7 +1092,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                     created: null
                 ));
 
-            using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = BuildReleaseService(contentDbContext: contentDbContext,
                     publicBlobStorageService: publicBlobStorageService.Object);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -13,6 +13,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -1133,12 +1134,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             ContentDbContext contentDbContext,
             StatisticsDbContext statisticsDbContext = null,
             IBlobStorageService publicBlobStorageService = null,
+            IMethodologyService methodologyService = null,
             IReleaseSubjectService releaseSubjectService = null)
         {
             return new ReleaseService(
                 contentDbContext,
                 statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
                 publicBlobStorageService ?? new Mock<IBlobStorageService>().Object,
+                methodologyService ?? new Mock<IMethodologyService>().Object,
                 releaseSubjectService ?? new Mock<IReleaseSubjectService>().Object,
                 new Mock<ILogger<ReleaseService>>().Object,
                 MapperForProfile<MappingProfiles>());

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -59,7 +59,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             try
             {
                 await _contentService.UpdateContent(context, message.ReleaseId);
-                await _releaseService.SetPublishedDatesAsync(message.ReleaseId, context.Published);
+                await _releaseService.SetPublishedDates(message.ReleaseId, context.Published);
 
                 if (!PublisherUtils.IsDevelopment())
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IMethodologyService.cs
@@ -13,5 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
         Task<List<Methodology>> GetLatestByRelease(Guid releaseId);
 
         Task<List<File>> GetFiles(Guid methodologyId, params FileType[] types);
+
+        Task SetPublishedDatesByPublication(Guid publicationId, DateTime published);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IReleaseService.cs
@@ -28,7 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task<CachedReleaseViewModel> GetReleaseViewModel(Guid id, PublishContext context);
 
-        Task SetPublishedDatesAsync(Guid id, DateTime published);
+        Task SetPublishedDates(Guid id, DateTime published);
 
         Task DeletePreviousVersionsStatisticalData(params Guid[] releaseIds);
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/MethodologyService.cs
@@ -43,5 +43,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 .Where(file => types.Contains(file.Type))
                 .ToListAsync();
         }
+
+        public async Task SetPublishedDatesByPublication(Guid publicationId, DateTime published)
+        {
+            var methodologies = await _methodologyRepository.GetLatestPublishedByPublication(publicationId);
+
+            _context.UpdateRange(methodologies);
+
+            methodologies.ForEach(methodology => { methodology.Published ??= published; });
+
+            await _context.SaveChangesAsync();
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -51,7 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 destinationDirectoryPath: string.Empty
             );
 
-            await _releaseService.SetPublishedDatesAsync(releaseId, DateTime.UtcNow);
+            await _releaseService.SetPublishedDates(releaseId, DateTime.UtcNow);
         }
 
         public async Task PublishMethodologyFiles(Guid methodologyId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -59,6 +59,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                         contentDbContext: provider.GetService<ContentDbContext>(),
                         statisticsDbContext: provider.GetService<StatisticsDbContext>(),
                         publicBlobStorageService: GetBlobStorageService(provider, "PublicStorage"),
+                        methodologyService: provider.GetService<IMethodologyService>(),
                         releaseSubjectService: provider.GetService<IReleaseSubjectService>(),
                         logger: provider.GetRequiredService<ILogger<ReleaseService>>(),
                         mapper: provider.GetRequiredService<IMapper>()


### PR DESCRIPTION
This PR sets the published dates of methodologies when they first turn publicly accessible.

A Methodology can 'turn' publicly accessible:

**Now** -  if its been approved for immediate publishing and a Publication using it already has a published Release.

Here the published date is set by the Admin application when the Methodology is approved.

or

**Later** - If it's been approved for immediate publishing - When a publication using it has it's first release published.
**Later** - If its been approved for publishing with a Release - When that Release is published.

In both of these cases the published date is set by the Publisher function application when the Release is published.

These changes rely on a method for calculating if a methodology is publicly accessible which has a known problem with it. Methodologies shouldn't be publicly accessible unless they are related to publications with at least one published Release.
This issue is due to be worked on next in EES-2455.