### PR TITLE
EES-2215 updated methodology summary form

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/components/MethodologySummaryForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/components/MethodologySummaryForm.tsx
@@ -3,6 +3,7 @@ import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
 import Form from '@common/components/form/Form';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
+import FormFieldRadioGroup from '@common/components/form/FormFieldRadioGroup';
 import useFormSubmit from '@common/hooks/useFormSubmit';
 import { mapFieldErrors } from '@common/validation/serverValidations';
 import Yup from '@common/validation/yup';
@@ -11,6 +12,7 @@ import React from 'react';
 
 export interface MethodologySummaryFormValues {
   title: string;
+  titleType?: 'publication' | 'alternative';
 }
 
 const errorMappings = [
@@ -23,6 +25,7 @@ const errorMappings = [
 ];
 
 interface Props {
+  canUpdateTitle?: boolean;
   id: string;
   initialValues?: MethodologySummaryFormValues;
   submitText: string;
@@ -31,6 +34,7 @@ interface Props {
 }
 
 const MethodologySummaryForm = ({
+  canUpdateTitle = false, // EES-2159 - flip to true to test. Replace with actual permission or remove.
   id,
   initialValues,
   submitText,
@@ -44,6 +48,62 @@ const MethodologySummaryForm = ({
     errorMappings,
   );
 
+  // EES-2159 - new version of the form. The form values will probably need to be changed when the BE is done.
+  if (canUpdateTitle) {
+    return (
+      <Formik<MethodologySummaryFormValues>
+        enableReinitialize
+        initialValues={
+          initialValues ??
+          ({
+            title: '',
+            titleType: 'publication',
+          } as MethodologySummaryFormValues)
+        }
+        validationSchema={Yup.object<MethodologySummaryFormValues>({
+          titleType: Yup.mixed<MethodologySummaryFormValues['titleType']>()
+            .oneOf(['publication', 'alternative'])
+            .required('Choose a title type'),
+          title: Yup.string().when('titleType', {
+            is: 'alternative',
+            then: Yup.string().required('Enter a methodology title'),
+            otherwise: Yup.string(),
+          }),
+        })}
+        onSubmit={handleSubmit}
+      >
+        <Form id={id}>
+          <FormFieldRadioGroup<MethodologySummaryFormValues>
+            legend="Methodology title"
+            name="titleType"
+            order={[]}
+            options={[
+              {
+                label: 'Use publication title',
+                value: 'publication',
+              },
+              {
+                label: 'Set an  alternative title',
+                value: 'alternative',
+                conditional: (
+                  <FormFieldTextInput<MethodologySummaryFormValues>
+                    label="Enter methodology title"
+                    name="title"
+                  />
+                ),
+              },
+            ]}
+          />
+          <ButtonGroup>
+            <Button type="submit">{submitText}</Button>
+            <ButtonText onClick={onCancel}>Cancel</ButtonText>
+          </ButtonGroup>
+        </Form>
+      </Formik>
+    );
+  }
+
+  // EES-2159 - remove this version of the form
   return (
     <Formik<MethodologySummaryFormValues>
       enableReinitialize

--- a/src/explore-education-statistics-admin/src/pages/methodology/components/__tests__/MethodologySummaryForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/components/__tests__/MethodologySummaryForm.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import noop from 'lodash/noop';
+import MethodologySummaryForm from '@admin/pages/methodology/components/MethodologySummaryForm';
+
+describe('MethodologySummaryForm', () => {
+  test('renders the form with initial values', () => {
+    render(
+      <MethodologySummaryForm
+        canUpdateTitle
+        id="id"
+        initialValues={{
+          title: 'the publication title',
+          titleType: 'publication',
+        }}
+        submitText="Update methodology"
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(screen.getByText('Methodology title')).toBeInTheDocument();
+
+    expect(screen.getByLabelText('Use publication title')).toBeInTheDocument();
+
+    expect(
+      screen.getByLabelText('Set an alternative title'),
+    ).toBeInTheDocument();
+  });
+
+  test('shows validation error when select alternative title type and no title given', async () => {
+    render(
+      <MethodologySummaryForm
+        canUpdateTitle
+        id="id"
+        initialValues={{
+          title: '',
+          titleType: 'publication',
+        }}
+        submitText="Update methodology"
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    userEvent.click(screen.getByLabelText('Set an alternative title'));
+    userEvent.click(screen.getByLabelText('Enter methodology title'));
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Enter a methodology title', {
+          selector: '#id-title-error',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('submits successfully with an alternative title', async () => {
+    const handleSubmit = jest.fn();
+    render(
+      <MethodologySummaryForm
+        canUpdateTitle
+        id="id"
+        initialValues={{
+          title: '',
+          titleType: 'publication',
+        }}
+        submitText="Update methodology"
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    userEvent.click(screen.getByLabelText('Set an alternative title'));
+    await userEvent.type(
+      screen.getByLabelText('Enter methodology title'),
+      'an alternative title',
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Update methodology' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        title: 'an alternative title',
+        titleType: 'alternative',
+      });
+    });
+  });
+
+  test('submits successfully with the publicatione title', async () => {
+    const handleSubmit = jest.fn();
+    render(
+      <MethodologySummaryForm
+        canUpdateTitle
+        id="id"
+        initialValues={{
+          title: '',
+          titleType: 'publication',
+        }}
+        submitText="Update methodology"
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Update methodology' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith({
+        title: '',
+        titleType: 'publication',
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/summary/MethodologySummaryEditPage.tsx
@@ -29,6 +29,7 @@ const MethodologySummaryEditPage = ({
             id="updateMethodologyForm"
             initialValues={{
               title: methodology.title,
+              titleType: 'publication', // EES-2159 - use real value
             }}
             submitText="Update methodology"
             onSubmit={async values => {


### PR DESCRIPTION
Adds a new version of the methodology summary form with an option to use the publication title or set an alternative one.

This is hidden under a flag so the current form will still work. Switch `canUpdateTitle` to true to see it in action.

It will need updating once the back end is ready but can be merged safely before then. 

![Screenshot (22)](https://user-images.githubusercontent.com/81572860/123824749-38b6f180-d8f6-11eb-9fd6-634ef06cad14.png)
