### PR TITLE
EES-2427 Make comparison of location names case sensitive when importing

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/ImporterLocationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/ImporterLocationServiceTests.cs
@@ -12,30 +12,83 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
     public class ImporterLocationServiceTests
     {
         [Fact]
-        public async Task Find_EnglishDevolvedAreaCaseSensitiveLocationName()
+        public async Task Find_PreExistingLocation()
         {
-            var country = new Country("1", "england");
-            var lowerCase = new EnglishDevolvedArea("2", "casesensitive");
-            var upperCase = new EnglishDevolvedArea("1", "CASESENSITIVE");
+            var location = new Location
+            {
+                Country = new Country("1", "England"),
+                LocalAuthority = new LocalAuthority("2", "3", "Bedford")
+            };
+
+            var service = BuildImporterLocationService();
+            
             var statisticsDbContextId = Guid.NewGuid().ToString();
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                var service = BuildImporterLocationService();
+                statisticsDbContext.Add(location);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var result1 = service.Find(statisticsDbContext, location.Country,
+                    localAuthority: location.LocalAuthority);
+                Assert.NotNull(result1);
+                Assert.Equal("Bedford", result1.LocalAuthority_Name);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var statDbLocations = statisticsDbContext.Location.ToList();
+                Assert.Single(statDbLocations);
+                Assert.Equal("Bedford", statDbLocations[0].LocalAuthority_Name);
+            }
+        }
+
+        [Fact]
+        public async Task Find_CaseSensitiveLocationName()
+        {
+            var country = new Country("1", "england");
+            var lowerCase = new EnglishDevolvedArea("2", "casesensitive");
+            var upperCase = new EnglishDevolvedArea("2", "CASESENSITIVE");
+
+            var service = BuildImporterLocationService();
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
                 var result1 = service.Find(statisticsDbContext, country,
                     englishDevolvedArea: lowerCase);
                 Assert.NotNull(result1);
                 Assert.Equal("casesensitive", result1.EnglishDevolvedArea_Name);
+
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
                 var result2 = service.Find(statisticsDbContext, country,
                     englishDevolvedArea: upperCase);
                 Assert.NotNull(result2);
+
+                // NOTE: The below assert doesn't actual catch the error fixed by EES-2427 because the
+                // in-memory DB in the EF version we're currently using is case sensitive - while a
+                // MsSQL DBs are case insensitive by default: https://github.com/dotnet/efcore/issues/6153
                 Assert.Equal("CASESENSITIVE", result2.EnglishDevolvedArea_Name);
+
                 await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
                 var statDbLocations = statisticsDbContext.Location.ToList();
                 Assert.Equal(2, statDbLocations.Count);
                 Assert.Equal("casesensitive", statDbLocations[0].EnglishDevolvedArea_Name);
                 Assert.Equal("CASESENSITIVE", statDbLocations[1].EnglishDevolvedArea_Name);
             }
         }
+
         private static ImporterLocationService BuildImporterLocationService()
         {
             return new ImporterLocationService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/ImporterLocationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/ImporterLocationServiceTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Data.Model.Database.StatisticsDbUtils;
+namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Services
+{
+    public class ImporterLocationServiceTests
+    {
+        [Fact]
+        public async Task Find_EnglishDevolvedAreaCaseSensitiveLocationName()
+        {
+            var country = new Country("1", "england");
+            var lowerCase = new EnglishDevolvedArea("2", "casesensitive");
+            var upperCase = new EnglishDevolvedArea("1", "CASESENSITIVE");
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var service = BuildImporterLocationService();
+                var result1 = service.Find(statisticsDbContext, country,
+                    englishDevolvedArea: lowerCase);
+                Assert.NotNull(result1);
+                Assert.Equal("casesensitive", result1.EnglishDevolvedArea_Name);
+                var result2 = service.Find(statisticsDbContext, country,
+                    englishDevolvedArea: upperCase);
+                Assert.NotNull(result2);
+                Assert.Equal("CASESENSITIVE", result2.EnglishDevolvedArea_Name);
+                await statisticsDbContext.SaveChangesAsync();
+                var statDbLocations = statisticsDbContext.Location.ToList();
+                Assert.Equal(2, statDbLocations.Count);
+                Assert.Equal("casesensitive", statDbLocations[0].EnglishDevolvedArea_Name);
+                Assert.Equal("CASESENSITIVE", statDbLocations[1].EnglishDevolvedArea_Name);
+            }
+        }
+        private static ImporterLocationService BuildImporterLocationService()
+        {
+            return new ImporterLocationService(
+                new Mock<IGuidGenerator>().Object,
+                new ImporterMemoryCache());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterLocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterLocationService.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         public Location Find(
             StatisticsDbContext context,
             Country country,
-            EnglishDevolvedArea englishDevolvedArea,
+            EnglishDevolvedArea englishDevolvedArea = null,
             Institution institution = null,
             LocalAuthority localAuthority = null,
             LocalAuthorityDistrict localAuthorityDistrict = null,
@@ -268,8 +268,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             predicateBuilder = predicateBuilder
                 .And(location => location.PlanningArea_Code == (planningArea != null ? planningArea.Code : null)
                                  && location.PlanningArea_Name == (planningArea != null ? planningArea.Name : null));
-            
-            return context.Location.AsNoTracking().FirstOrDefault(predicateBuilder);
+
+            // Can return multiple locations because SQL comparison is case insensitive
+            var locations = context.Location.AsNoTracking()
+                .Where(predicateBuilder)
+                .ToList();
+
+            foreach(var location in locations)
+            {
+                if (location.Country_Name == country?.Name
+                    && location.EnglishDevolvedArea_Name == englishDevolvedArea?.Name
+                    && location.Institution_Name == institution?.Name
+                    && location.LocalAuthority_Name == localAuthority?.Name
+                    && location.LocalAuthorityDistrict_Name == localAuthorityDistrict?.Name
+                    && location.LocalEnterprisePartnership_Name == localEnterprisePartnership?.Name
+                    && location.MayoralCombinedAuthority_Name == mayoralCombinedAuthority?.Name
+                    && location.MultiAcademyTrust_Name == multiAcademyTrust?.Name
+                    && location.OpportunityArea_Name == opportunityArea?.Name
+                    && location.ParliamentaryConstituency_Name == parliamentaryConstituency?.Name
+                    && location.Region_Name == region?.Name
+                    && location.RscRegion_Code == rscRegion?.Code // RscRegion codes function as the name
+                    && location.Sponsor_Name == sponsor?.Name
+                    && location.Ward_Name == ward?.Name
+                    && location.PlanningArea_Name == planningArea?.Name)
+                {
+                    // If case-sensitive match, return it
+                    return location;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterLocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterLocationService.cs
@@ -274,30 +274,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 .Where(predicateBuilder)
                 .ToList();
 
-            foreach(var location in locations)
-            {
-                if (location.Country_Name == country?.Name
-                    && location.EnglishDevolvedArea_Name == englishDevolvedArea?.Name
-                    && location.Institution_Name == institution?.Name
-                    && location.LocalAuthority_Name == localAuthority?.Name
-                    && location.LocalAuthorityDistrict_Name == localAuthorityDistrict?.Name
-                    && location.LocalEnterprisePartnership_Name == localEnterprisePartnership?.Name
-                    && location.MayoralCombinedAuthority_Name == mayoralCombinedAuthority?.Name
-                    && location.MultiAcademyTrust_Name == multiAcademyTrust?.Name
-                    && location.OpportunityArea_Name == opportunityArea?.Name
-                    && location.ParliamentaryConstituency_Name == parliamentaryConstituency?.Name
-                    && location.Region_Name == region?.Name
-                    && location.RscRegion_Code == rscRegion?.Code // RscRegion codes function as the name
-                    && location.Sponsor_Name == sponsor?.Name
-                    && location.Ward_Name == ward?.Name
-                    && location.PlanningArea_Name == planningArea?.Name)
-                {
-                    // If case-sensitive match, return it
-                    return location;
-                }
-            }
-
-            return null;
+            return locations.FirstOrDefault(location =>
+                location.Country_Name == country?.Name
+                && location.EnglishDevolvedArea_Name == englishDevolvedArea?.Name
+                && location.Institution_Name == institution?.Name
+                && location.LocalAuthority_Name == localAuthority?.Name
+                && location.LocalAuthorityDistrict_Name == localAuthorityDistrict?.Name
+                && location.LocalEnterprisePartnership_Name == localEnterprisePartnership?.Name
+                && location.MayoralCombinedAuthority_Name == mayoralCombinedAuthority?.Name
+                && location.MultiAcademyTrust_Name == multiAcademyTrust?.Name
+                && location.OpportunityArea_Name == opportunityArea?.Name
+                && location.ParliamentaryConstituency_Name == parliamentaryConstituency?.Name
+                && location.Region_Name == region?.Name
+                && location.RscRegion_Code == rscRegion?.Code // RscRegion codes function as the name
+                && location.Sponsor_Name == sponsor?.Name
+                && location.Ward_Name == ward?.Name
+                && location.PlanningArea_Name == planningArea?.Name
+            );
         }
     }
 }

--- a/tests/newman/files/small-files/case_sensitive_locations_1.csv
+++ b/tests/newman/files/small-files/case_sensitive_locations_1.csv
@@ -1,0 +1,11 @@
+time_period,time_identifier,geographic_level,country_code,country_name,old_la_code,new_la_code,la_name,region_code,region_name,lad_code,lad_name,local_enterprise_partnership_code,local_enterprise_partnership_name,rsc_region_lead_name,opportunity_area_code,opportunity_area_name,pcon_code,pcon_name,ward_code,ward_name,planning_area_code,planning_area_name,english_devolved_area_code,english_devolved_area_name,admission_numbers
+2018,Calendar year,Local authority,E92000001,england,330,E08000025,casesensitive,,,,,,,,,,,,,,,,,,3962
+2018,Calendar year,Local authority district,E92000001,england,,,,,,E06000001,casesensitive,,,,,,,,,,,,,,6765
+2018,Calendar year,Local enterprise partnership,E92000001,england,,,,,,,,E37000001,casesensitive,,,,,,,,,,,,5876
+2018,Calendar year,RSC region,E92000001,england,,,,,,,,,,casesensitive,,,,,,,,,,,3908
+2018,Calendar year,Opportunity area,E92000001,england,,,,,,,,,,,E02000984,casesensitive,,,,,,,,,8533
+2018,Calendar year,Parliamentary constituency,E92000001,england,,,,,,,,,,,,,E14000683,casesensitive,,,,,,,5549
+2018,Calendar year,Regional,E92000001,england,,,,E12000003,casesensitive,,,,,,,,,,,,,,,,2287
+2018,Calendar year,Ward,E92000001,england,,,,,,,,,,,,,,,E05000364,casesensitive,,,,,1959
+2018,Calendar year,Planning area,E92000001,england,,,,,,,,,,,,,,,,,E02000984,casesensitive,,,8533
+2018,Calendar year,English devolved area,E92000001,england,,,,,,,,,,,,,,,,,,,1,casesensitive,3962

--- a/tests/newman/files/small-files/case_sensitive_locations_1.meta.csv
+++ b/tests/newman/files/small-files/case_sensitive_locations_1.meta.csv
@@ -1,0 +1,2 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+admission_numbers,Indicator,Admission Numbers,,,,,

--- a/tests/newman/files/small-files/case_sensitive_locations_2.csv
+++ b/tests/newman/files/small-files/case_sensitive_locations_2.csv
@@ -1,0 +1,11 @@
+time_period,time_identifier,geographic_level,country_code,country_name,old_la_code,new_la_code,la_name,region_code,region_name,lad_code,lad_name,local_enterprise_partnership_code,local_enterprise_partnership_name,rsc_region_lead_name,opportunity_area_code,opportunity_area_name,pcon_code,pcon_name,ward_code,ward_name,planning_area_code,planning_area_name,english_devolved_area_code,english_devolved_area_name,admission_numbers
+2018,Calendar year,Local authority,E92000001,ENGLAND,330,E08000025,CASESENSITIVE,,,,,,,,,,,,,,,,,,3962
+2018,Calendar year,Local authority district,E92000001,ENGLAND,,,,,,E06000001,CASESENSITIVE,,,,,,,,,,,,,,6765
+2018,Calendar year,Local enterprise partnership,E92000001,ENGLAND,,,,,,,,E37000001,CASESENSITIVE,,,,,,,,,,,,5876
+2018,Calendar year,RSC region,E92000001,ENGLAND,,,,,,,,,,CASESENSITIVE,,,,,,,,,,,3908
+2018,Calendar year,Opportunity area,E92000001,ENGLAND,,,,,,,,,,,E02000984,CASESENSITIVE,,,,,,,,,8533
+2018,Calendar year,Parliamentary constituency,E92000001,ENGLAND,,,,,,,,,,,,,E14000683,CASESENSITIVE,,,,,,,5549
+2018,Calendar year,Regional,E92000001,ENGLAND,,,,E12000003,CASESENSITIVE,,,,,,,,,,,,,,,,2287
+2018,Calendar year,Ward,E92000001,ENGLAND,,,,,,,,,,,,,,,E05000364,CASESENSITIVE,,,,,1959
+2018,Calendar year,Planning area,E92000001,ENGLAND,,,,,,,,,,,,,,,,,E02000984,CASESENSITIVE,,,8533
+2018,Calendar year,English devolved area,E92000001,ENGLAND,,,,,,,,,,,,,,,,,,,1,CASESENSITIVE,3962

--- a/tests/newman/files/small-files/case_sensitive_locations_2.meta.csv
+++ b/tests/newman/files/small-files/case_sensitive_locations_2.meta.csv
@@ -1,0 +1,2 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+admission_numbers,Indicator,Admission Numbers,,,,,


### PR DESCRIPTION
This ensures all comparisons of Location *_Name's are case-sensitive compared. This also includes RscRegion_Code as the code for RscRegions doubles as the name.

Another thing to note about this PR is that the additional unit test currently passes before this change was made. This is because the in-memory DB in the version of EF we're using doesn't support case-insensitive comparisons: https://github.com/dotnet/efcore/issues/20770