### PR TITLE
EES-2423 Remove reference to InternalReleaseNote on SOW4 branch

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -1401,7 +1401,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 ReleaseName = "2035",
                 Slug = "2035-1",
                 Version = 0,
-                InternalReleaseNote = "Test release note",
                 PreReleaseAccessList = "Test access list",
                 ReleaseStatuses = new List<ReleaseStatus>
                 {


### PR DESCRIPTION
This PR removes a reference to InternalReleaseNote on Release on the SOW4 branch.

This attribute was removed on the dev branch by 2b5e7a3c2daaafff53d017218399fcaf4bb5086a but despite there being no changes to pull in, it still exists for some reason so this PR removes it.