### PR TITLE
EES-2484 Add HTML to text util

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/IntExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/IntExtensionsTests.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
+{
+    public class IntExtensionsTests
+    {
+        public class ToEnumerable
+        {
+            [Fact]
+            public void CountEqualToPositiveIntValue()
+            {
+                Assert.Equal(5, 5.ToEnumerable().Count());
+            }
+
+            [Fact]
+            public void CountEqualToNegativeIntValue()
+            {
+                Assert.Equal(-5, -5.ToEnumerable().Count());
+            }
+
+            [Fact]
+            public void ItemsMatchSeriesUpToPositiveIntValue()
+            {
+                var ints = 5.ToEnumerable().ToList();
+
+                Assert.Equal(1, ints[0]);
+                Assert.Equal(2, ints[1]);
+                Assert.Equal(3, ints[2]);
+                Assert.Equal(4, ints[3]);
+                Assert.Equal(5, ints[4]);
+            }
+
+            [Fact]
+            public void ItemsMatchSeriesUpToNegativeIntValue()
+            {
+                var ints = (-5).ToEnumerable().ToList();
+
+                Assert.Equal(-1, ints[0]);
+                Assert.Equal(-2, ints[1]);
+                Assert.Equal(-3, ints[2]);
+                Assert.Equal(-4, ints[3]);
+                Assert.Equal(-5, ints[4]);
+            }
+
+            [Fact]
+            public void ZeroHasNoItems()
+            {
+                Assert.Empty(0.ToEnumerable());
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Xunit;
 
@@ -5,6 +6,71 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
 {
     public class StringExtensionTests
     {
+        public class ToLinesListTests
+        {
+            [Fact]
+            public void ReturnsSingleLine()
+            {
+                var lines = "Test line 1"
+                    .ToLinesList();
+
+                Assert.Single(lines);
+                Assert.Equal("Test line 1", lines[0]);
+            }
+
+            [Fact]
+            public void ReturnsMultipleLines()
+            {
+                var lines = "Test line 1\nTest line 2\nTest line 3"
+                    .ToLinesList();
+
+                Assert.Equal(3, lines.Count);
+                Assert.Equal("Test line 1", lines[0]);
+                Assert.Equal("Test line 2", lines[1]);
+                Assert.Equal("Test line 3", lines[2]);
+            }
+
+            [Fact]
+            public void EmptyStringReturnsNoLines()
+            {
+                var lines = ""
+                    .ToLinesList();
+
+                Assert.Empty(lines);
+            }
+        }
+
+        public class StripLinesTests
+        {
+            [Fact]
+            public void RemovesUnixLines()
+            {
+                var stripped = "test line 1 \ntest line 2".StripLines();
+                Assert.Equal("test line 1 test line 2", stripped);
+            }
+
+            [Fact]
+            public void RemovesUnixLines_ToEmptyString()
+            {
+                var stripped = "\n".StripLines();
+                Assert.Equal("", stripped);
+            }
+
+            [Fact]
+            public void RemovesWindowsLine()
+            {
+                var stripped = "test line 1 \r\ntest line 2".StripLines();
+                Assert.Equal("test line 1 test line 2", stripped);
+            }
+
+            [Fact]
+            public void RemovesWindowsLines_ToEmptyString()
+            {
+                var stripped = "\r\n".StripLines();
+                Assert.Equal("", stripped);
+            }
+        }
+
         public class CamelCaseTests
         {
             [Fact]
@@ -46,7 +112,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             {
                 Assert.Equal("foo/", "foo".AppendTrailingSlash());
             }
-            
+
             [Fact]
             public void NullStringCanBeCamelCased()
             {
@@ -107,21 +173,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
                 const string input = null;
                 Assert.True(input.IsNullOrEmpty());
             }
-            
-            
+
+
             [Fact]
             public void IsNullOrEmptyIsTrueForEmptyString()
             {
                 Assert.True("".IsNullOrEmpty());
             }
-            
+
             [Fact]
             public void IsNullOrEmptyIsFalseForNonEmptyString()
             {
                 Assert.False("foo".IsNullOrEmpty());
             }
         }
-        
+
         public class PascalCaseTests
         {
             [Fact]
@@ -213,7 +279,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
                 Assert.Equal("FOO_BAR", "Foo_Bar".ScreamingSnakeCase());
                 Assert.Equal("FOO_BAR", "FOO_Bar".ScreamingSnakeCase());
             }
-            
+
             [Fact]
             public void PascalCasedStringsAreScreamingSnakeCased()
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
@@ -8,6 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="Moq" Version="4.13.1" />
+        <PackageReference Include="Snapshooter.Xunit" Version="0.6.2" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
         <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Resources/test-html-1.html
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Resources/test-html-1.html
@@ -1,0 +1,73 @@
+<h3>Description</h3>
+<p>
+  This document describes the data included in the Initial teacher training
+  performance profiles Official Statistics release’s underlying data files. This
+  data is released under the terms of the
+  <a
+    href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+    >Open Government License</a
+  >
+  and is intended to meet at least 3 stars for
+  <a
+    href="https://www.gov.uk/government/publications/2010-to-2015-government-policy-government-transparency-and-accountability/2010-to-2015-government-policy-government-transparency-and-accountability#appendix-3-releasing-data-in-open-and-anonymised-formats"
+    >Open Data</a
+  >. The methodology, found at the bottom of the publication site, should be
+  referenced alongside this data. It provides information on the data sources,
+  their coverage and quality as well as explaining methodology used in producing
+  the data.&nbsp;
+</p>
+
+<h3>Coverage</h3>
+
+<p>
+  This release provides provisional &nbsp;numbers of new entrants to ITT courses
+  starting in the academic year 2020/21. The release also provides revised
+  numbers of new entrants to ITT courses starting in the academic year 2019/20.
+  It includes information on:
+</p>
+
+<ul>
+  <li>training route and subject</li>
+  <li>trainee characteristics</li>
+</ul>
+
+<h3>File formats and conventions</h3>
+
+<p><strong>Suppression</strong></p>
+
+<p>
+  Suppression has been applied to the following personal characteristics:&nbsp;
+</p>
+
+<ul>
+  <li>Gender</li>
+  <li>Disability status</li>
+</ul>
+
+<p>
+  The following symbols have been used within the publication and are defined
+  below:
+</p>
+
+<figure class="table">
+  <table>
+    <tbody>
+      <tr>
+        <td>0</td>
+        <td>Zero</td>
+      </tr>
+      <tr>
+        <td>c</td>
+        <td>Small number suppressed to preserve confidentiality</td>
+      </tr>
+      <tr>
+        <td>z &nbsp;</td>
+        <td>Not applicable</td>
+      </tr>
+      <tr>
+        <td>:</td>
+        <td>Not available</td>
+      </tr>
+    </tbody>
+  </table>
+</figure>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/HtmlToTextUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/HtmlToTextUtilsTests.cs
@@ -1,0 +1,930 @@
+#nullable enable
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Snapshooter.Xunit;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
+{
+    public class HtmlToTextUtilsTests
+    {
+        private readonly string _dir;
+
+        public HtmlToTextUtilsTests()
+        {
+            var directoryName = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
+            if (directoryName != null)
+            {
+                _dir = directoryName;
+            }
+            else
+            {
+                throw new Exception("Could not locate tests directory");
+            }
+        }
+
+        [Fact]
+        public async Task HtmlToText_SingleElement()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                "<p>Test paragraph</p>");
+
+            Assert.Equal("Test paragraph", text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_SingleElementInDiv()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                "<div><p>Test paragraph</p></div>");
+
+            Assert.Equal("Test paragraph", text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_InlineElements()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                "<p>Test paragraph with <strong>bold text</strong> and <em>italic text</em></p>");
+
+            Assert.Equal("Test paragraph with bold text and italic text", text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_InlineElementsWithMultilineFormatting()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"<p>
+                    Test paragraph with 
+                    <strong>bold text</strong> 
+                    and <em>italic text</em> and
+                    <small>small text</small>
+                  </p>");
+
+            Assert.Equal("Test paragraph with bold text and italic text and small text", text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_InlineElementsWithPunctuation()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"<p>
+                    Test paragraph with 
+                    <strong>bold text</strong>, 
+                    <em>italic text</em>! And
+                    <small>small text</small>.
+                    <strong>Next sentence?</strong>
+                    Over here.
+                  </p>");
+
+            Assert.Equal("Test paragraph with bold text, italic text! And small text. Next sentence? Over here.", text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_MultipleElements()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <h1>Test heading 1</h1>
+                <h2>Test heading 2</h2>
+                <h3>Test heading 3</h3>
+                <h4>Test heading 4</h4>
+                <h5>Test heading 5</h5>
+                <h6>Test heading 6</h6>
+                <p>Test paragraph 1</p>
+                <span>Test span 1</span>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_MultipleElementsInDiv()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <div>
+                    <h1>Test heading 1</h1>
+                    <h2>Test heading 2</h2>
+                    <h3>Test heading 3</h3>
+                    <h4>Test heading 4</h4>
+                    <h5>Test heading 5</h5>
+                    <h6>Test heading 6</h6>
+                    <p>Test paragraph 1</p>
+                    <span>Test span 1</span>
+                </div>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_HorizontalLineElement()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <p>Test paragraph 1</p>
+                <hr/>
+                <p>Test paragraph 2</p>
+                ");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_LineBreakElements()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <p>Test paragraph 1
+                    <br/>with line break</p>
+                <br/>
+                <p>Test paragraph 2</p>
+                ");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_UnorderedListElements()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <ul>
+                    <li>List item 1</li>
+                    <li>List item 2</li>
+                </ul>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_OrderedListElements()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <ol>
+                    <li>List item 1</li>
+                    <li>List item 2</li>
+                </ol>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_UnorderedListElementsWithNestedText()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <ul>
+                    <li>List item 1</li>
+                    <li>
+                        List item 2
+                        <p>List item 2 paragraph 1</p>
+                        <p>List item 2 paragraph 2</p>
+                    </li>
+                    <li>List item 3</li>
+                </ul>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_UnorderedListElementsWithNestedList()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <ul>
+                    <li>List item 1</li>
+                    <li>
+                        Nested list
+                        <ul>
+                            <li>Nested list item 1</li>
+                            <li>Nested list item 2</li>
+                        </ul>
+                    </li>
+                </ul>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_UnorderedListElementsWithDeeplyNestedList()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <ul>
+                    <li>List item 1</li>
+                    <li>
+                        Nested list
+                        <ul>
+                            <li>Nested 1 list item 1</li>
+                            <li>
+                                Nested 1 list item 2 
+                                <ul>
+                                    <li>Nested 2 list item 1</li>
+                                    <li>Nested 2 list item 2</li>
+                                </ul>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_DescriptionList()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <dl>
+                    <dt>Term 1</dt>
+                    <dd>Description 1</dd>
+                    <dt>Term 2</dt>
+                    <dd>Description 2</dd>
+                    <dt>Term 3</dt>
+                    <dd>Description 3</dd>
+                </dl>
+                <p>Paragraph after</p>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_DescriptionListWithMultilineItem()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <dl>
+                    <dt>Term 1</dt>
+                    <dd>Description 1</dd>
+                    <dt>Term 2</dt>
+                    <dd>
+                        Description 2
+                        <p>Description 2 paragraph 1</p>
+                        <ul>
+                            <li>Description 2 list item 1</li>
+                            <li>Description 2 list item 2</li>
+                        </ul>
+                    </dd>
+                    <dt>Term 3</dt>
+                    <dd>Description 3</dd>
+                </dl>
+                <p>Paragraph after</p>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_Blockquote()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                "<blockquote>Test quote</blockquote>");
+
+            Assert.Equal("Test quote", text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_BlockquoteWithParagraphs()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <blockquote>
+                    <p>Test paragraph quote 1</p>
+                    <p>Test paragraph quote 2</p>
+                </blockquote>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_BlockquoteWithCaption()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <figure>
+                    <blockquote>
+                        <p>Test paragraph quote 1</p>
+                        <p>Test paragraph quote 2</p>
+                    </blockquote>
+                    <figcaption>
+                        <cite>Test citation</cite>
+                    </figcaption>
+                </figure>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElementPadsToLargestCell()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td>Cell 2</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 3 with more text</td>
+                            <td>Cell 4</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_MultilineCell()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td>Cell 2</td>
+                            <td>Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 4</td>
+                            <td>
+                                <p>Cell 5 paragraph 1</p>
+                                <ul>
+                                    <li>Cell 5 list item 1</li>
+                                    <li>Cell 5 list item 2</li>
+                                <ul>
+                            </td>
+                            <td>Cell 6</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 7</td>
+                            <td>Cell 8</td>
+                            <td>Cell 9</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_EmptyCells()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td></td>
+                            <td>Cell 2</td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td>Cell 4</td>
+                            <td>Cell 5</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 6</td>
+                            <td>Cell 7</td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowHeader()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Header 1</th>
+                            <th>Header 2</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td>Cell 2</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 3</td>
+                            <td>Cell 4</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_ColumnHeader()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <th>Header 1</th>
+                            <th>Header 1</th>
+                        </tr>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td>Cell 2</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_ColumnAndRowHeaders()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Header 1</th>
+                            <th>Header 2</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th>Header 3</th>
+                            <td>Cell 1</td>
+                        </tr>
+                        <tr>
+                            <th>Header 4</th>
+                            <td>Cell 2</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_ColSpans()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td colspan=""2"">Cell 2</td>
+                            <td>Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 4</td>
+                            <td colspan=""3"">Cell 5</td>
+                        </tr>
+                        <tr>
+                            <td colspan=""2"">Cell 6</td>
+                            <td>Cell 7</td>
+                            <td>Cell 8</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_ColSpanWithMultiline()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td colspan=""2"">Cell 2</td>
+                            <td>Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 4</td>
+                            <td colspan=""3"">
+                                <p>Cell 5 paragraph 1</p>
+                                <ul>
+                                    <li>Cell 5 list item 1</li>
+                                    <li>Cell 5 list item 2</li>
+                                <ul>                    
+                            </td>
+                        </tr>
+                        <tr>
+                            <td colspan=""2"">Cell 6</td>
+                            <td>Cell 7</td>
+                            <td>Cell 8</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowHeaderWithColSpans()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Header 1</th>
+                            <th colspan=""2"">Header 2</th>
+                        </tr>
+                        <tr>
+                            <th>Header 3</th>
+                            <th>Header 4</th>
+                            <th>Header 5</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td>Cell 2</td>
+                            <td>Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 4</td>
+                            <td>Cell 5</td>
+                            <td>Cell 6</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_ColumnHeaderWithColSpans()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <th colspan=""2"">Header 1</th>
+                            <td>Cell 1</td>
+                        </tr>
+                        <tr>
+                            <th>Header 2</th>
+                            <th>Header 3</th>
+                            <td>Cell 2</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowSpans()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td rowspan=""3"">Cell 1</td>
+                            <td>Cell 2</td>
+                            <td rowspan=""2"">Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td rowspan=""2"">Cell 4</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 5</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowSpansWithMultiline()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td rowspan=""3"">Cell 1</td>
+                            <td>Cell 2</td>
+                            <td rowspan=""2"">Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td rowspan=""2"">
+                                <p>Cell 4 paragraph 1</p>
+                                <ul>
+                                    <li>Cell 4 list item 1</li>
+                                    <li>Cell 4 list item 2</li>
+                                <ul>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Cell 5</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowHeaderWithRowSpans()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <thead>
+                        <tr>
+                            <th rowspan=""2"">Header 1</th>
+                            <th>Header 2</th>
+                            <th>Header 3</th>
+                        </tr>
+                        <tr>
+                            <th>Header 4</th>
+                            <th>Header 5</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td>Cell 2</td>
+                            <td>Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 4</td>
+                            <td>Cell 5</td>
+                            <td>Cell 6</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_ColHeaderWithRowSpans()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <th rowspan=""2"">Header 1</th>
+                            <th>Header 2</th>
+                            <td>Cell 1</td>
+                        </tr>
+                        <tr>
+                            <th>Header 3</th>
+                            <td>Cell 2</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowAndColSpansInTopLeft()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td colspan=""2"" rowspan=""2"">Cell 1</td>
+                            <td>Cell 2</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 4</td>
+                            <td>Cell 5</td>
+                            <td>Cell 6</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowAndColSpansInTopCenter()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td colspan=""2"" rowspan=""2"">Cell 2</td>
+                            <td>Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 3</td>
+                            <td>Cell 4</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 5</td>
+                            <td>Cell 6</td>
+                            <td>Cell 7</td>
+                            <td>Cell 8</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowAndColSpansInTopRight()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td colspan=""2"" rowspan=""2"">Cell 2</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 4</td>
+                            <td>Cell 5</td>
+                            <td>Cell 6</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowAndColSpansInCenterLeft()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td>Cell 2</td>
+                            <td>Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td colspan=""2"" rowspan=""2"">Cell 4</td>
+                            <td>Cell 5</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 6</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 7</td>
+                            <td>Cell 8</td>
+                            <td>Cell 9</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowAndColSpansInCenterRight()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td>Cell 2</td>
+                            <td>Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 4</td>
+                            <td colspan=""2"" rowspan=""2"">Cell 5</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 6</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 6</td>
+                            <td>Cell 7</td>
+                            <td>Cell 8</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowAndColSpansInBottomLeft()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td>Cell 2</td>
+                            <td>Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td colspan=""2"" rowspan=""2"">Cell 4</td>
+                            <td>Cell 5</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 6</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowAndColSpansInBottomCenter()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td>Cell 2</td>
+                            <td>Cell 3</td>
+                            <td>Cell 7</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 4</td>
+                            <td colspan=""2"" rowspan=""2"">Cell 5</td>
+                            <td>Cell 6</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 7</td>
+                            <td>Cell 8</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TableElement_RowAndColSpansInBottomRight()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Cell 1</td>
+                            <td>Cell 2</td>
+                            <td>Cell 3</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 4</td>
+                            <td colspan=""2"" rowspan=""2"">Cell 5</td>
+                        </tr>
+                        <tr>
+                            <td>Cell 6</td>
+                        </tr>
+                    </tbody>
+                </table>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_TestHtml1()
+        {
+            var html = await File.ReadAllTextAsync(Path.Combine(_dir, "Resources/test-html-1.html"));
+            var text = await HtmlToTextUtils.HtmlToText(html);
+
+            Snapshot.Match(text);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_BlockquoteWithCaption.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_BlockquoteWithCaption.snap
@@ -1,0 +1,5 @@
+﻿Test paragraph quote 1
+
+Test paragraph quote 2
+
+— Test citation

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_BlockquoteWithParagraphs.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_BlockquoteWithParagraphs.snap
@@ -1,0 +1,3 @@
+﻿Test paragraph quote 1
+
+Test paragraph quote 2

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_DescriptionList.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_DescriptionList.snap
@@ -1,0 +1,8 @@
+﻿Term 1
+  Description 1
+Term 2
+  Description 2
+Term 3
+  Description 3
+
+Paragraph after

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_DescriptionListWithMultilineItem.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_DescriptionListWithMultilineItem.snap
@@ -1,0 +1,12 @@
+﻿Term 1
+  Description 1
+Term 2
+  Description 2
+  Description 2 paragraph 1
+
+  - Description 2 list item 1
+  - Description 2 list item 2
+Term 3
+  Description 3
+
+Paragraph after

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_HorizontalLineElement.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_HorizontalLineElement.snap
@@ -1,0 +1,5 @@
+﻿Test paragraph 1
+
+---------------
+
+Test paragraph 2

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_LineBreakElements.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_LineBreakElements.snap
@@ -1,0 +1,5 @@
+﻿Test paragraph 1
+with line break
+
+
+Test paragraph 2

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_MultipleElements.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_MultipleElements.snap
@@ -1,0 +1,15 @@
+﻿Test heading 1
+
+Test heading 2
+
+Test heading 3
+
+Test heading 4
+
+Test heading 5
+
+Test heading 6
+
+Test paragraph 1
+
+Test span 1

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_MultipleElementsInDiv.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_MultipleElementsInDiv.snap
@@ -1,0 +1,15 @@
+﻿Test heading 1
+
+Test heading 2
+
+Test heading 3
+
+Test heading 4
+
+Test heading 5
+
+Test heading 6
+
+Test paragraph 1
+
+Test span 1

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_OrderedListElements.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_OrderedListElements.snap
@@ -1,0 +1,2 @@
+﻿1. List item 1
+2. List item 2

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElementPadsToLargestCell.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElementPadsToLargestCell.snap
@@ -1,0 +1,2 @@
+﻿Cell 1                 |  Cell 2
+Cell 3 with more text  |  Cell 4

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_ColHeaderWithRowSpans.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_ColHeaderWithRowSpans.snap
@@ -1,0 +1,2 @@
+﻿Header 1  |  Header 2  |  Cell 1
+          |  Header 3  |  Cell 2

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_ColSpanWithMultiline.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_ColSpanWithMultiline.snap
@@ -1,0 +1,6 @@
+﻿Cell 1  |  Cell 2                           |  Cell 3
+Cell 4  |  Cell 5 paragraph 1
+        |
+        |  - Cell 5 list item 1
+        |  - Cell 5 list item 2
+Cell 6                           |  Cell 7  |  Cell 8

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_ColSpans.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_ColSpans.snap
@@ -1,0 +1,3 @@
+﻿Cell 1  |  Cell 2             |  Cell 3
+Cell 4  |  Cell 5
+Cell 6             |  Cell 7  |  Cell 8

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_ColumnAndRowHeaders.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_ColumnAndRowHeaders.snap
@@ -1,0 +1,4 @@
+﻿Header 1  |  Header 2
+--------  |  --------
+Header 3  |  Cell 1
+Header 4  |  Cell 2

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_ColumnHeader.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_ColumnHeader.snap
@@ -1,0 +1,2 @@
+﻿Header 1  |  Header 1
+Cell 1    |  Cell 2

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_ColumnHeaderWithColSpans.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_ColumnHeaderWithColSpans.snap
@@ -1,0 +1,2 @@
+﻿Header 1               |  Cell 1
+Header 2  |  Header 3  |  Cell 2

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_EmptyCells.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_EmptyCells.snap
@@ -1,0 +1,3 @@
+﻿Cell 1  |          |  Cell 2
+        |  Cell 4  |  Cell 5
+Cell 6  |  Cell 7  |

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_MultilineCell.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_MultilineCell.snap
@@ -1,0 +1,6 @@
+﻿Cell 1  |  Cell 2                |  Cell 3
+Cell 4  |  Cell 5 paragraph 1    |  Cell 6
+        |                        |
+        |  - Cell 5 list item 1  |
+        |  - Cell 5 list item 2  |
+Cell 7  |  Cell 8                |  Cell 9

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInBottomCenter.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInBottomCenter.snap
@@ -1,0 +1,3 @@
+﻿Cell 1  |  Cell 2  |  Cell 3  |  Cell 7
+Cell 4  |  Cell 5             |  Cell 6
+Cell 7  |                     |  Cell 8

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInBottomLeft.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInBottomLeft.snap
@@ -1,0 +1,3 @@
+﻿Cell 1  |  Cell 2  |  Cell 3
+Cell 4             |  Cell 5
+                   |  Cell 6

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInBottomRight.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInBottomRight.snap
@@ -1,0 +1,3 @@
+﻿Cell 1  |  Cell 2  |  Cell 3
+Cell 4  |  Cell 5
+Cell 6  |

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInCenterLeft.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInCenterLeft.snap
@@ -1,0 +1,4 @@
+﻿Cell 1  |  Cell 2  |  Cell 3
+Cell 4             |  Cell 5
+                   |  Cell 6
+Cell 7  |  Cell 8  |  Cell 9

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInCenterRight.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInCenterRight.snap
@@ -1,0 +1,4 @@
+﻿Cell 1  |  Cell 2  |  Cell 3
+Cell 4  |  Cell 5
+Cell 6  |
+Cell 6  |  Cell 7  |  Cell 8

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInTopCenter.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInTopCenter.snap
@@ -1,0 +1,3 @@
+﻿Cell 1  |  Cell 2             |  Cell 3
+Cell 3  |                     |  Cell 4
+Cell 5  |  Cell 6  |  Cell 7  |  Cell 8

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInTopLeft.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInTopLeft.snap
@@ -1,0 +1,3 @@
+﻿Cell 1             |  Cell 2
+                   |  Cell 3
+Cell 4  |  Cell 5  |  Cell 6

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInTopRight.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowAndColSpansInTopRight.snap
@@ -1,0 +1,3 @@
+﻿Cell 1  |  Cell 2
+Cell 3  |
+Cell 4  |  Cell 5  |  Cell 6

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowHeader.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowHeader.snap
@@ -1,0 +1,4 @@
+﻿Header 1  |  Header 2
+--------  |  --------
+Cell 1    |  Cell 2
+Cell 3    |  Cell 4

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowHeaderWithColSpans.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowHeaderWithColSpans.snap
@@ -1,0 +1,5 @@
+﻿Header 1  |  Header 2
+Header 3  |  Header 4  |  Header 5
+--------  |  --------  |  --------
+Cell 1    |  Cell 2    |  Cell 3
+Cell 4    |  Cell 5    |  Cell 6

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowHeaderWithRowSpans.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowHeaderWithRowSpans.snap
@@ -1,0 +1,5 @@
+﻿Header 1  |  Header 2  |  Header 3
+          |  Header 4  |  Header 5
+--------  |  --------  |  --------
+Cell 1    |  Cell 2    |  Cell 3
+Cell 4    |  Cell 5    |  Cell 6

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowSpans.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowSpans.snap
@@ -1,0 +1,3 @@
+﻿Cell 1  |  Cell 2  |  Cell 3
+        |  Cell 4  |
+        |          |  Cell 5

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowSpansWithMultiline.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TableElement_RowSpansWithMultiline.snap
@@ -1,0 +1,6 @@
+﻿Cell 1  |  Cell 2                |  Cell 3
+        |  Cell 4 paragraph 1    |
+        |                        |
+        |  - Cell 4 list item 1  |
+        |  - Cell 4 list item 2  |
+        |                        |  Cell 5

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TestHtml1.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_TestHtml1.snap
@@ -1,0 +1,26 @@
+﻿Description
+
+This document describes the data included in the Initial teacher training performance profiles Official Statistics release’s underlying data files. This data is released under the terms of the Open Government License and is intended to meet at least 3 stars for Open Data. The methodology, found at the bottom of the publication site, should be referenced alongside this data. It provides information on the data sources, their coverage and quality as well as explaining methodology used in producing the data.
+
+Coverage
+
+This release provides provisional  numbers of new entrants to ITT courses starting in the academic year 2020/21. The release also provides revised numbers of new entrants to ITT courses starting in the academic year 2019/20. It includes information on:
+
+- training route and subject
+- trainee characteristics
+
+File formats and conventions
+
+Suppression
+
+Suppression has been applied to the following personal characteristics:
+
+- Gender
+- Disability status
+
+The following symbols have been used within the publication and are defined below:
+
+0  |  Zero
+c  |  Small number suppressed to preserve confidentiality
+z  |  Not applicable
+:  |  Not available

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_UnorderedListElements.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_UnorderedListElements.snap
@@ -1,0 +1,2 @@
+﻿- List item 1
+- List item 2

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_UnorderedListElementsWithDeeplyNestedList.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_UnorderedListElementsWithDeeplyNestedList.snap
@@ -1,0 +1,6 @@
+﻿- List item 1
+- Nested list
+  - Nested 1 list item 1
+  - Nested 1 list item 2
+    - Nested 2 list item 1
+    - Nested 2 list item 2

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_UnorderedListElementsWithNestedList.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_UnorderedListElementsWithNestedList.snap
@@ -1,0 +1,4 @@
+﻿- List item 1
+- Nested list
+  - Nested list item 1
+  - Nested list item 2

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_UnorderedListElementsWithNestedText.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_UnorderedListElementsWithNestedText.snap
@@ -1,0 +1,6 @@
+﻿- List item 1
+- List item 2
+  List item 2 paragraph 1
+
+  List item 2 paragraph 2
+- List item 3

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -99,6 +99,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             }
         }
 
+        public static void ForEach<T>(this IEnumerable<T> source, Action<T> func)
+        {
+            foreach (var item in source)
+            {
+                func(item);
+            }
+        }
+
+        public static void ForEach<T>(this IEnumerable<T> source, Action<T, int> func)
+        {
+            var index = 0;
+
+            foreach (var item in source)
+            {
+                func(item, index);
+                index += 1;
+            }
+        }
+
         public static async Task ForEachAsync<T>(this IEnumerable<T> source, Func<T, Task> func)
         {
             foreach (var item in source)
@@ -107,11 +126,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             }
         }
 
-        public static async Task<Either<TLeft, List<TRight>>> ForEachAsync<T, TLeft, TRight>(this IEnumerable<T> source, 
+        public static async Task<Either<TLeft, List<TRight>>> ForEachAsync<T, TLeft, TRight>(this IEnumerable<T> source,
             Func<T, Task<Either<TLeft, TRight>>> func)
         {
             List<TRight> rightResults = new List<TRight>();
-            
+
             foreach (var item in source)
             {
                 var result = await func(item);
@@ -120,7 +139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
                 {
                     return new Either<TLeft, List<TRight>>(result.Left);
                 }
-                
+
                 rightResults.Add(result.Right);
             }
 
@@ -150,7 +169,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 
             return result;
         }
-        
+
         /// <summary>
         /// Filter a sequence of elements asynchronously.
         /// </summary>
@@ -177,7 +196,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 
         public static IEnumerable<(T item, int index)> WithIndex<T>(this IEnumerable<T> self) =>
             self.Select((item, index) => (item, index));
-        
+
         /// <summary>
         /// Filter a list down to distinct elements based on a property of the type.
         /// </summary>
@@ -188,7 +207,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
         /// that we can use for equality.  A good property type then could be a Guid Id field, as two identical Guid Ids
         /// can then represent that 2 or more entities in the list are duplicates as they will have the same hash code.
         /// </remarks>
-        /// 
+        ///
         /// <param name="source">Sequence of elements to filter on a distinct property</param>
         /// <param name="propertyGetter">A supplier of a property from each entity to check for equality. The property
         /// chosen must produce the same hash code for any two elements in the source list that are considered
@@ -196,7 +215,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
         public static IEnumerable<T> DistinctByProperty<T>(
-            this IEnumerable<T> source, 
+            this IEnumerable<T> source,
             Func<T, object> propertyGetter)
             where T : class
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/IntExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/IntExtensions.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+{
+    public static class IntExtensions
+    {
+        /// <summary>
+        /// Enumerate a series of integers up to the specified value
+        /// </summary>
+        /// <remarks>
+        /// If the input integer is negative, a negative series
+        /// of integers will be produced instead.
+        /// </remarks>
+        public static IEnumerable<int> ToEnumerable(this int value)
+        {
+            if (value == 0)
+            {
+                yield break;
+            }
+
+            if (value > 0)
+            {
+                for (var i = 1; i <= value; i++)
+                {
+                    yield return i;
+                }
+            }
+            else
+            {
+                for (var i = -1; i >= value; i--)
+                {
+                    yield return i;
+                }
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
@@ -1,10 +1,44 @@
+using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 {
     public static class StringExtensions
     {
+        /// <summary>
+        /// Convert a string into an enumerable of its constituent lines.
+        /// </summary>
+        public static IEnumerable<string> ToLines(this string value)
+        {
+            var reader = new StringReader(value);
+
+            var currentLine = reader.ReadLine();
+
+            while (currentLine != null)
+            {
+                yield return currentLine;
+                currentLine = reader.ReadLine();
+            }
+
+            reader.Close();
+        }
+
+        /// <summary>
+        /// Convert a string into a list of its constituent lines.
+        /// </summary>
+        public static IList<string> ToLinesList(this string value)
+        {
+            return value.ToLines().ToList();
+        }
+
+        public static string StripLines(this string value)
+        {
+            return Regex.Replace(value, "(\n|\r)", string.Empty);
+        }
+
         public static string AppendTrailingSlash(this string input)
         {
             if (input == null)
@@ -14,7 +48,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 
             return input.EndsWith("/") ? input : input + "/";
         }
-        
+
         public static string CamelCase(this string input)
         {
             if (input.IsNullOrEmpty())

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using AngleSharp.Text;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 {
@@ -36,7 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
 
         public static string StripLines(this string value)
         {
-            return Regex.Replace(value, "(\n|\r)", string.Empty);
+            return value.StripLineBreaks();
         }
 
         public static string AppendTrailingSlash(this string input)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AngleSharp" Version="1.0.0-alpha-844" />
         <PackageReference Include="AutoMapper" Version="9.0.0" />
         <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.5" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextConverter.cs
@@ -1,0 +1,247 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using AngleSharp.Text;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
+{
+    internal class HtmlToTextConverter
+    {
+        private readonly StringBuilder _builder = new StringBuilder();
+
+        public string Convert(IElement rootElement)
+        {
+            _builder.Clear();
+
+            ParseChildren(rootElement, ParseElement);
+
+            var rawLines = _builder.ToString().ToLines();
+
+            // Run post-filtering on lines to remove any extraneous
+            // whitespace from the end of lines. This is mostly for
+            // better compat with editors/IDEs, where whitespace may
+            // be automatically removed upon file save.
+            var filteredBuilder = new StringBuilder();
+
+            rawLines.ForEach(line => filteredBuilder.AppendLine(line.TrimEnd()));
+
+            return filteredBuilder.ToString().TrimEnd();
+        }
+
+        private void ParseChildren(INode node, Action<IElement> parseChildElement)
+        {
+            ParseNodes(node.ChildNodes, (child, _) => parseChildElement(child));
+        }
+
+        private void ParseNodes(IEnumerable<INode> nodes, Action<IElement, int> parseChildElement)
+        {
+            nodes.ForEach(
+                (node, index) =>
+                {
+                    switch (node)
+                    {
+                        case null:
+                            return;
+
+                        case IElement element:
+                            parseChildElement(element, index);
+                            break;
+
+                        case IText text:
+                            ParseTextNode(text);
+                            break;
+                    }
+                }
+            );
+        }
+
+        private void ParseElement(IElement element)
+        {
+            // If the previous sibling is a non-empty text node, it may
+            // not have an associated line break, so we should add one
+            // to prevent the current element from being appended
+            // on-top of the text node (this looks broken).
+            if (element.PreviousSibling?.NodeType == NodeType.Text &&
+                element.PreviousSibling?.TextContent?.Trim() != string.Empty)
+            {
+                _builder.AppendLine();
+            }
+
+            switch (element.LocalName)
+            {
+                case "h1":
+                case "h2":
+                case "h3":
+                case "h4":
+                case "h5":
+                case "h6":
+                case "p":
+                    ParseChildren(element, ParseTextElement);
+                    _builder.AppendLine();
+                    _builder.AppendLine();
+                    break;
+
+                case "ul":
+                case "ol":
+                    ParseListElement(element);
+                    break;
+
+                case "dl":
+                    ParseDescriptionListElement(element);
+                    break;
+
+                case "cite":
+                case "figcaption":
+                    _builder.Append('—');
+                    ParseTextElement(element);
+                    break;
+
+                case "br":
+                    _builder.AppendLine();
+                    break;
+
+                case "hr":
+                    _builder.AppendLine("---------------");
+                    _builder.AppendLine();
+                    break;
+
+                case "table":
+                    ParseTableElement(element);
+                    break;
+
+                default:
+                    ParseChildren(element, ParseElement);
+                    break;
+            }
+        }
+
+        private void ParseTextNode(INode node)
+        {
+            // Text node may be split over multiple lines for
+            // formatting purposes in HTML, but this would
+            // lead to unnecessary line breaks in rendered text,
+            // so we should remove these line breaks.
+            var content = node.TextContent.CollapseAndStrip();
+
+            if (content == string.Empty)
+            {
+                return;
+            }
+
+            // As there are potentially inline elements such as span/strong/em,
+            // we should try and add an extra space to avoid the text bunching up.
+            // We currently only add this if the text content starts with an
+            // alphanumeric character, as we can safely assume this isn't a
+            // punctuation character. Not sure if there may be edge cases to this?
+            if (node.PreviousSibling != null
+                && !(node.PreviousSibling is IHtmlBreakRowElement)
+                && content[0].IsAlphanumericAscii())
+            {
+                _builder.Append(' ');
+            }
+
+            _builder.Append(content);
+        }
+
+        private void ParseTextElement(IElement element)
+        {
+            switch (element.LocalName)
+            {
+                case "br":
+                    _builder.AppendLine();
+                    break;
+                default:
+                    ParseTextNode(element);
+                    break;
+            }
+        }
+
+        private void ParseListElement(IElement element)
+        {
+            var isOrdered = element.LocalName == "ol";
+            // Add indentation to align list item children
+            // with where the bullet/number ends.
+            var indentation = isOrdered ? "   " : "  ";
+
+            var listItems = element.ChildNodes
+                .Where(node => node is IElement { LocalName: "li" });
+
+            ParseNodes(
+                listItems,
+                (item, index) =>
+                {
+                    _builder.Append(isOrdered ? $"{index + 1}. " : "- ");
+
+                    var converter = new HtmlToTextConverter();
+                    var text = converter.Convert(item);
+
+                    text.ToLines()
+                        .ForEach(
+                            (line, lineIndex) =>
+                            {
+                                if (lineIndex == 0)
+                                {
+                                    _builder.AppendLine(line);
+                                    return;
+                                }
+
+                                _builder.AppendLine(indentation + line);
+                            }
+                        );
+                }
+            );
+
+            _builder.AppendLine();
+        }
+
+        private void ParseDescriptionListElement(IElement element)
+        {
+            const string indentation = "  ";
+
+            var listItems = element.ChildNodes
+                .Where(node => node is IElement { LocalName: "dt" } || node is IElement { LocalName: "dd" });
+
+            ParseNodes(
+                listItems,
+                (item, _) =>
+                {
+                    switch (item.LocalName)
+                    {
+                        case "dt":
+                            _builder.AppendLine(item.TextContent.CollapseAndStrip());
+                            break;
+
+                        case "dd":
+                            var converter = new HtmlToTextConverter();
+                            var text = converter.Convert(item);
+
+                            text.ToLines()
+                                .ForEach(line => _builder.AppendLine(indentation + line));
+
+                            break;
+                    }
+                }
+            );
+
+            _builder.AppendLine();
+        }
+
+        private void ParseTableElement(IElement element)
+        {
+            var headerRows = element.QuerySelectorAll<IElement>("thead tr");
+            var bodyRows = element.QuerySelectorAll<IElement>("tbody tr");
+
+            var table = new HtmlToTextTableRenderer();
+
+            headerRows.ForEach(row => table.AddHeaderRow(row));
+            bodyRows.ForEach(row => table.AddBodyRow(row));
+
+            _builder.Append(table.Render());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextTableRenderer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextTableRenderer.cs
@@ -1,0 +1,246 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
+{
+    internal class HtmlToTextTableRenderer
+    {
+        private const string Separator = "  |  ";
+        private const string EmptySeparator = "     ";
+
+        private readonly List<List<TableCell>> _headerRows = new List<List<TableCell>>();
+        private readonly List<List<TableCell>> _bodyRows = new List<List<TableCell>>();
+        private readonly List<int> _columnWidths = new List<int>();
+
+        private class TableCell
+        {
+            public readonly IList<string> Lines;
+
+            public readonly int RemainingColSpan;
+            public readonly int RemainingRowSpan;
+
+            public TableCell(
+                string text,
+                int remainingColSpan = 0,
+                int remainingRowSpan = 0)
+            {
+                Lines = text.ToLinesList();
+                RemainingColSpan = remainingColSpan;
+                RemainingRowSpan = remainingRowSpan;
+            }
+        }
+
+        public void AddHeaderRow(IElement rowElement)
+        {
+            _headerRows.Add(
+                GenerateTableCells(
+                    rowElement: rowElement,
+                    previousRowCells: _headerRows.LastOrDefault()
+                )
+            );
+        }
+
+        public void AddBodyRow(IElement rowElement)
+        {
+            _bodyRows.Add(
+                GenerateTableCells(
+                    rowElement: rowElement,
+                    previousRowCells: _bodyRows.LastOrDefault()
+                )
+            );
+        }
+
+        private List<TableCell> GenerateTableCells(IElement rowElement, List<TableCell>? previousRowCells)
+        {
+            var cellElements = rowElement.Children
+                .Where(cell => cell is IHtmlTableCellElement)
+                .Cast<IHtmlTableCellElement>()
+                .ToList();
+
+            var cells = new List<TableCell?>();
+
+            if (previousRowCells != null)
+            {
+                previousRowCells.ForEach(
+                    (cell, index) =>
+                    {
+                        // Insert empty cells from the previous row
+                        // that have remaining row span as these need
+                        // to take up space in this current row.
+                        // We insert nulls to represent cells that are to
+                        // be filled by the current list of cell elements.
+                        cells.Insert(
+                            index,
+                            cell.RemainingRowSpan > 0
+                                ? new TableCell(
+                                    text: string.Empty,
+                                    remainingColSpan: cell.RemainingColSpan,
+                                    remainingRowSpan: cell.RemainingRowSpan - 1
+                                )
+                                : null
+                        );
+                    }
+                );
+            }
+            else
+            {
+                cellElements.ForEach(
+                    (cellElement, index) =>
+                    {
+                        // Initialise cells with placeholder
+                        // nulls so that these can be replaced
+                        // by table cells later.
+                        cellElement.ColumnSpan
+                            .ToEnumerable()
+                            .ForEach(
+                                span => { cells.Add(null); }
+                            );
+                    }
+                );
+            }
+
+            cellElements
+                .ForEach(
+                    child =>
+                    {
+                        var converter = new HtmlToTextConverter();
+                        var text = converter.Convert(child);
+
+                        var cellIndex = cells.FindIndex(cell => cell == null);
+
+                        var tableCell = new TableCell(
+                            text: text,
+                            remainingColSpan: child.ColumnSpan - 1,
+                            remainingRowSpan: child.RowSpan - 1
+                        );
+
+                        cells[cellIndex] = tableCell;
+
+                        // Initialise any missing column widths with 0
+                        if (_columnWidths.Count - 1 < cellIndex)
+                        {
+                            var newColumns = (_columnWidths.Count - 1 - cellIndex)
+                                .ToEnumerable()
+                                .Select(_ => 0);
+
+                            _columnWidths.AddRange(newColumns);
+                        }
+
+                        var childWidth = text.ToLines()
+                            .DefaultIfEmpty(string.Empty)
+                            .Max(line => line.Length);
+
+                        if (childWidth > _columnWidths[cellIndex])
+                        {
+                            _columnWidths[cellIndex] = childWidth;
+                        }
+
+                        if (child.ColumnSpan == 1)
+                        {
+                            return;
+                        }
+
+                        // We add empty cells with colspans so that we can
+                        // create a complete matrix of table cells (instead
+                        // of HTML's incomplete representation).
+                        var spans = child.ColumnSpan - 1;
+
+                        spans.ToEnumerable()
+                            .ForEach(
+                                span =>
+                                {
+                                    cells[cellIndex + span] = new TableCell(
+                                        text: string.Empty,
+                                        remainingColSpan: spans - span,
+                                        remainingRowSpan: tableCell.RemainingRowSpan
+                                    );
+                                }
+                            );
+                    }
+                );
+
+            return cells as List<TableCell>;
+        }
+
+        public string Render()
+        {
+            var builder = new StringBuilder();
+
+            // Render table header with an extra row that is
+            // composed of dashes to separate it from the body.
+            if (_headerRows.Count > 0)
+            {
+                RenderRows(builder, _headerRows);
+
+                _columnWidths.ForEach(
+                    (columnWidth, index) =>
+                    {
+                        builder.Append(string.Empty.PadRight(columnWidth, '-'));
+
+                        if (index != _columnWidths.Count - 1)
+                        {
+                            builder.Append(Separator);
+                        }
+                    }
+                );
+
+                builder.AppendLine();
+            }
+
+            RenderRows(builder, _bodyRows);
+
+            return builder.ToString();
+        }
+
+        private void RenderRows(StringBuilder builder, List<List<TableCell>> rows)
+        {
+            rows.ForEach(
+                row =>
+                {
+                    var lineIndex = 0;
+                    var hasLines = true;
+
+                    // As table cells can be multi-line, we need to continue
+                    // rendering each row until each cell's lines have been
+                    // completely rendered out to the builder.
+                    while (hasLines)
+                    {
+                        var currentLineIndex = lineIndex;
+
+                        row.ForEach(
+                            (cell, cellIndex) =>
+                            {
+                                var columnWidth = _columnWidths[cellIndex];
+
+                                if (cell.Lines.ElementAtOrDefault(currentLineIndex) != null)
+                                {
+                                    builder.Append(cell.Lines[currentLineIndex].PadRight(columnWidth));
+                                }
+                                else
+                                {
+                                    builder.Append(string.Empty.PadRight(columnWidth));
+                                }
+
+                                if (cellIndex != row.Count - 1)
+                                {
+                                    builder.Append(cell.RemainingColSpan == 0 ? Separator : EmptySeparator);
+                                }
+                            }
+                        );
+
+
+                        hasLines = row.Any(cell => cell.Lines.ElementAtOrDefault(currentLineIndex + 1) != null);
+                        lineIndex += 1;
+
+                        builder.AppendLine();
+                    }
+                }
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/HtmlToTextUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/HtmlToTextUtils.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using AngleSharp;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils.Html;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
+{
+    public static class HtmlToTextUtils
+    {
+        public static async Task<string> HtmlToText(string html)
+        {
+            var config = Configuration.Default;
+            var context = BrowsingContext.New(config);
+
+            var document = await context.OpenAsync(req => req.Content(html));
+
+            var converter = new HtmlToTextConverter();
+            return converter.Convert(document.Body);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new `HtmlToTextUtils.HtmlToText` util function that allows us to convert HTML to human-readable text. This is particularly important as we need this to convert data guidance created by analysts into a `.txt` files ([EES-2359](https://dfedigital.atlassian.net/browse/EES-2359)).

The logic in this isn't particularly simple, so this PR isn't for the faint of heart. I've tried to cover as many cases as possible with tests, but this is naturally a really hard thing to test comprehensively.

## Other changes

- Adds snapshot tests using [Snapshooter](https://github.com/SwissLife-OSS/snapshooter). Really helpful for testing this kind of thing.
- Adds various extension functions for strings and ints to create collections from these primitives e.g. list of lines, etc.