### PR TITLE
EES-2359 Fix various UI test failures associated with updated 'All files' zip

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileService.cs
@@ -25,6 +25,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 {
     public class ReleaseFileService : IReleaseFileService
     {
+        private static readonly FileType[] DeletableFileTypes = { Ancillary, Chart, Image, DataGuidance };
+
         private readonly ContentDbContext _contentDbContext;
         private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
         private readonly IBlobStorageService _blobStorageService;
@@ -69,7 +71,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(async release => await _userService.CheckCanUpdateRelease(release, ignoreCheck: forceDelete))
                 .OnSuccess(async release =>
                     await ids.Select(id =>
-                        _releaseFileRepository.CheckFileExists(releaseId, id, Ancillary, Chart, Image)).OnSuccessAll())
+                        _releaseFileRepository.CheckFileExists(releaseId, id, DeletableFileTypes)).OnSuccessAll())
                 .OnSuccessVoid(async files =>
                 {
                     foreach (var file in files)
@@ -89,10 +91,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<Either<ActionResult, Unit>> DeleteAll(Guid releaseId, bool forceDelete = false)
         {
-            var releaseFiles = await _releaseFileRepository.GetByFileType(releaseId,
-                Ancillary,
-                Chart,
-                Image);
+            var releaseFiles = await _releaseFileRepository.GetByFileType(releaseId, DeletableFileTypes);
 
             return await Delete(releaseId,
                 releaseFiles.Select(releaseFile => releaseFile.File.Id),

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
@@ -1,10 +1,10 @@
-using System.Linq;
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
 {
-    public class StringExtensionTests
+    public static class StringExtensionTests
     {
         public class ToLinesListTests
         {
@@ -74,50 +74,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
         public class CamelCaseTests
         {
             [Fact]
-            public void NullIfWhitespace_IsNullForNullString()
-            {
-                const string input = null;
-                Assert.Null(input.NullIfWhiteSpace());
-            }
-
-            [Fact]
-            public void NullIfWhitespace_RemainsUntouchedForNonWhiteSpaceString()
-            {
-                const string input = "foo";
-                Assert.Equal(input, input.NullIfWhiteSpace());
-            }
-
-            [Fact]
-            public void NullIfWhitespace_IsNullForWhiteSpaceString()
-            {
-                Assert.Null("".NullIfWhiteSpace());
-                Assert.Null(" ".NullIfWhiteSpace());
-            }
-
-            [Fact]
-            public void NullStringCanAppendTrailingSlash()
-            {
-                string input = null;
-                Assert.Null(input.AppendTrailingSlash());
-            }
-
-            [Fact]
-            public void EmptyStringCanAppendTrailingSlash()
-            {
-                Assert.Equal("/", string.Empty.AppendTrailingSlash());
-            }
-
-            [Fact]
-            public void AppendTrailingSlash()
-            {
-                Assert.Equal("foo/", "foo".AppendTrailingSlash());
-            }
-
-            [Fact]
             public void NullStringCanBeCamelCased()
             {
-                string input = null;
-                Assert.Null(input.CamelCase());
+                string? input = null;
+                Assert.Null(input!.CamelCase());
             }
 
             [Fact]
@@ -165,26 +125,111 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             }
         }
 
+        public class AppendTrailingSlashTests
+        {
+            [Fact]
+            public void AppendTrailingSlash()
+            {
+                Assert.Equal("foo/", "foo".AppendTrailingSlash());
+            }
+
+            [Fact]
+            public void EmptyStringCanAppendTrailingSlash()
+            {
+                Assert.Equal("/", string.Empty.AppendTrailingSlash());
+            }
+        }
+
+        public class NullIfWhitespaceTests
+        {
+            [Fact]
+            public void NullIfWhitespace_IsNullForNullString()
+            {
+                string? input = null;
+                Assert.Null(input!.NullIfWhiteSpace());
+            }
+
+            [Fact]
+            public void NullIfWhitespace_RemainsUntouchedForNonWhiteSpaceString()
+            {
+                const string input = "foo";
+                Assert.Equal(input, input.NullIfWhiteSpace());
+            }
+
+            [Fact]
+            public void NullIfWhitespace_IsNullForWhiteSpaceString()
+            {
+                Assert.Null("".NullIfWhiteSpace());
+                Assert.Null(" ".NullIfWhiteSpace());
+            }
+
+            [Fact]
+            public void NullStringCanAppendTrailingSlash()
+            {
+                string? input = null;
+                Assert.Null(input.AppendTrailingSlash());
+            }
+        }
+
         public class IsNullOrEmptyTests
         {
             [Fact]
-            public void IsNullOrEmptyIsTrueForNullString()
+            public void TrueForNullString()
             {
-                const string input = null;
+                string? input = null;
                 Assert.True(input.IsNullOrEmpty());
             }
 
 
             [Fact]
-            public void IsNullOrEmptyIsTrueForEmptyString()
+            public void TrueForEmptyString()
             {
                 Assert.True("".IsNullOrEmpty());
             }
 
             [Fact]
-            public void IsNullOrEmptyIsFalseForNonEmptyString()
+            public void FalseForWhitespaceString()
+            {
+                Assert.False("   ".IsNullOrEmpty());
+                Assert.False(" \n  ".IsNullOrEmpty());
+                Assert.False(" \r\n  ".IsNullOrEmpty());
+            }
+
+            [Fact]
+            public void FalseForNonEmptyString()
             {
                 Assert.False("foo".IsNullOrEmpty());
+            }
+        }
+
+        public class IsNullOrWhitespaceTests
+        {
+            [Fact]
+            public void TrueForNullString()
+            {
+                string? input = null;
+                Assert.True(input.IsNullOrWhitespace());
+            }
+
+
+            [Fact]
+            public void TrueForEmptyString()
+            {
+                Assert.True("".IsNullOrWhitespace());
+            }
+
+            [Fact]
+            public void TrueForWhitespaceString()
+            {
+                Assert.True("   ".IsNullOrWhitespace());
+                Assert.True(" \n  ".IsNullOrWhitespace());
+                Assert.True(" \r\n  ".IsNullOrWhitespace());
+            }
+
+            [Fact]
+            public void FalseForNonEmptyString()
+            {
+                Assert.False("foo".IsNullOrWhitespace());
             }
         }
 
@@ -193,8 +238,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             [Fact]
             public void NullStringCanBePascalCased()
             {
-                string input = null;
-                Assert.Null(input.PascalCase());
+                string? input = null;
+                Assert.Null(input!.PascalCase());
             }
 
             [Fact]
@@ -248,8 +293,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             [Fact]
             public void NullStringsCanBeScreamingSnakeCased()
             {
-                string input = null;
-                Assert.Null(input.ScreamingSnakeCase());
+                string? input = null;
+                Assert.Null(input!.ScreamingSnakeCase());
             }
 
             [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -40,7 +41,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return value.StripLineBreaks();
         }
 
-        public static string AppendTrailingSlash(this string input)
+        public static string? AppendTrailingSlash(this string? input)
         {
             if (input == null)
             {
@@ -61,12 +62,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return char.ToLowerInvariant(s[0]) + s.Substring(1);
         }
 
-        public static bool IsNullOrEmpty(this string value)
+        public static bool IsNullOrEmpty(this string? value)
         {
             return string.IsNullOrEmpty(value);
         }
 
-        public static string NullIfWhiteSpace(this string value)
+        public static bool IsNullOrWhitespace(this string? value)
+        {
+            return string.IsNullOrWhiteSpace(value);
+        }
+
+        public static string? NullIfWhiteSpace(this string value)
         {
             return string.IsNullOrWhiteSpace(value) ? null : value;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -83,9 +83,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         [JsonIgnore]
         public List<ReleaseContentBlock> ContentBlocks { get; set; }
 
-        public string PreReleaseAccessList { get; set; }
+        public string PreReleaseAccessList { get; set; } = string.Empty;
 
-        public string MetaGuidance { get; set; }
+        public string MetaGuidance { get; set; } = string.Empty;
 
         public Release? PreviousVersion { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/DataGuidanceFileWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/DataGuidanceFileWriter.cs
@@ -35,6 +35,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         public async Task<FileStream> WriteFile(Guid releaseId, string path)
         {
             var release = await _releaseService.Get(releaseId);
+
+            if (release.MetaGuidance.IsNullOrWhitespace())
+            {
+                throw new InvalidOperationException(
+                    $"Cannot create data guidance file for release {release.Id} with no data guidance"
+                );
+            }
+
             var subjects = await _metaGuidanceSubjectService.GetSubjects(release.Id);
 
             if (subjects.IsLeft)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -1,7 +1,9 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -104,9 +106,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 Image
             );
 
-            var dataGuidanceFile = await _dataGuidanceFileService.CreateDataGuidanceFile(release.Id);
+            if (!release.MetaGuidance.IsNullOrWhitespace())
+            {
+                var dataGuidanceFile = await _dataGuidanceFileService.CreateDataGuidanceFile(release.Id);
 
-            files.Add(dataGuidanceFile);
+                files.Add(dataGuidanceFile);
+            }
 
             var destinationDirectoryPath = $"{release.Id}/";
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -226,22 +226,21 @@ Verify publish and update dates
 
 Verify release associated files
     [Tags]  HappyPath
-    
     user opens accordion section  Explore data and files
     ${downloads}=  user gets accordion section content element  Explore data and files
     user waits until page contains element  ${downloads}  60
-    
-    user checks element should contain  ${downloads}  Download all data and files for this release (zip, 3 Kb)  60
+
+    user checks element should contain  ${downloads}  Download all data and files for this release (zip, 4 Kb)  60
     user checks element should contain  ${downloads}  Dates test subject (csv, 17 Kb)  60
     user checks element should contain  ${downloads}  All data used to create this release is published as open data and is available for download.
     user checks element should contain  ${downloads}  You can create your own tables from this data using our table tool, or view featured tables that we have built for you.
 
     user checks element should contain  ${downloads}  The open data files contain all data used in this release in a machine readable format.
     user checks element should contain  ${downloads}  Learn more about the data files used in this release using our data files guide.
-    
+
     user clicks element  xpath://*[@data-testid="Expand Details Section List of other files"]
     user waits until page contains link  Test ancillary file 1  60
-    download file  link:Test ancillary file 1  test_ancillary_file_1.txt 
+    download file  link:Test ancillary file 1  test_ancillary_file_1.txt
     downloaded file should have first line  test_ancillary_file_1.txt   Test file 1
 
 Verify public metadata guidance document
@@ -578,15 +577,15 @@ Verify amendment files
     [Tags]  HappyPath
     user opens accordion section  Explore data and files
     ${downloads}=  user gets accordion section content element  Explore data and files
-    user checks element should contain  ${downloads}  Download all data and files for this release (zip, 3 Kb)  30
-    
+    user checks element should contain  ${downloads}  Download all data and files for this release (zip, 4 Kb)  30
+
     user clicks element  xpath://*[@data-testid="Expand Details Section List of other files"]
     user waits until page contains link  Test ancillary file 1  60
-    download file  link:Test ancillary file 1  test_ancillary_file_1.txt 
+    download file  link:Test ancillary file 1  test_ancillary_file_1.txt
     downloaded file should have first line  test_ancillary_file_1.txt   Test file 1
 
     user waits until page contains link  Test ancillary file 2  60
-    download file  link:Test ancillary file 2  test_ancillary_file_2.txt 
+    download file  link:Test ancillary file 2  test_ancillary_file_2.txt
     downloaded file should have first line  test_ancillary_file_2.txt   Test file 2
 
 Verify amendment public metadata guidance document


### PR DESCRIPTION
This PR:

- Adds handling of published releases with no (meta)data guidance. These releases should not generate a data guidance file in the 'All files' zip. Unfortunately this logic was accidentally omitted, hence we were getting a exception due to the release's `MetaGuidance` field being null/empty.
- Fixes UI test teardown throwing foreign key errors due to `DataGuidance` file types still being attached to the release. This type has now been added to the types of files that can be deleted by `ReleaseFileService.DeleteAll`.
- Fixes some remaining test failures related to the 'All files' zip size increasing due to the new data guidance file.

## Other changes

- Cleaned up and reorganized some of the `StringExtensions` tests.