### PR TITLE
EES-2328 Import School/Provider data if its the only GeographicLevel

### DIFF
--- a/infrastructure/templates/datafactory/components/template.json
+++ b/infrastructure/templates/datafactory/components/template.json
@@ -1873,6 +1873,26 @@
                                     },
                                     {
                                         "source": {
+                                            "name": "Provider_Name",
+                                            "type": "String"
+                                        },
+                                        "sink": {
+                                            "name": "Provider_Name",
+                                            "type": "String"
+                                        }
+                                    },
+                                    {
+                                        "source": {
+                                            "name": "Provider_Code",
+                                            "type": "String"
+                                        },
+                                        "sink": {
+                                            "name": "Provider_Code",
+                                            "type": "String"
+                                        }
+                                    },
+                                    {
+                                        "source": {
                                             "name": "Region_Code",
                                             "type": "String"
                                         },
@@ -1898,6 +1918,26 @@
                                         },
                                         "sink": {
                                             "name": "RscRegion_Code",
+                                            "type": "String"
+                                        }
+                                    },
+                                    {
+                                        "source": {
+                                            "name": "School_Name",
+                                            "type": "String"
+                                        },
+                                        "sink": {
+                                            "name": "School_Name",
+                                            "type": "String"
+                                        }
+                                    },
+                                    {
+                                        "source": {
+                                            "name": "School_Code",
+                                            "type": "String"
+                                        },
+                                        "sink": {
+                                            "name": "School_Code",
                                             "type": "String"
                                         }
                                     },

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210707104334_EES2328CreateDataImportGeographicLevelsColumn.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210707104334_EES2328CreateDataImportGeographicLevelsColumn.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210707104334_EES2328CreateDataImportGeographicLevelsColumn")]
+    partial class EES2328CreateDataImportGeographicLevelsColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -296,44 +298,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("Annexes")
-                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Content")
-                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime?>("Created")
-                        .HasColumnType("datetime2");
-
-                    b.Property<Guid?>("CreatedById")
-                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("InternalReleaseNote")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<Guid>("MethodologyParentId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid?>("PreviousVersionId")
-                        .HasColumnType("uniqueidentifier");
-
                     b.Property<DateTime?>("Published")
                         .HasColumnType("datetime2");
 
-                    b.Property<string>("PublishingStrategy")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<Guid?>("ScheduledWithReleaseId")
-                        .HasColumnType("uniqueidentifier");
-
                     b.Property<string>("Slug")
-                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Status")
                         .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Summary")
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Title")
@@ -343,18 +326,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<DateTime?>("Updated")
                         .HasColumnType("datetime2");
 
-                    b.Property<int>("Version")
-                        .HasColumnType("int");
-
                     b.HasKey("Id");
-
-                    b.HasIndex("CreatedById");
-
-                    b.HasIndex("MethodologyParentId");
-
-                    b.HasIndex("PreviousVersionId");
-
-                    b.HasIndex("ScheduledWithReleaseId");
 
                     b.ToTable("Methodologies");
                 });
@@ -380,17 +352,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.ToTable("MethodologyFiles");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyParent", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("MethodologyParents");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", b =>
                 {
                     b.Property<Guid>("Id")
@@ -408,6 +369,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.Property<string>("LegacyPublicationUrl")
                         .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid?>("MethodologyId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime?>("Published")
                         .HasColumnType("datetime2");
@@ -432,27 +396,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.HasIndex("ContactId");
 
+                    b.HasIndex("MethodologyId");
+
                     b.HasIndex("TopicId");
 
                     b.ToTable("Publications");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationMethodology", b =>
-                {
-                    b.Property<Guid>("PublicationId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid>("MethodologyParentId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<bool>("Owner")
-                        .HasColumnType("bit");
-
-                    b.HasKey("PublicationId", "MethodologyParentId");
-
-                    b.HasIndex("MethodologyParentId");
-
-                    b.ToTable("PublicationMethodologies");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Release", b =>
@@ -976,28 +924,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "CreatedBy")
-                        .WithMany()
-                        .HasForeignKey("CreatedById")
-                        .OnDelete(DeleteBehavior.NoAction);
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyParent", "MethodologyParent")
-                        .WithMany("Versions")
-                        .HasForeignKey("MethodologyParentId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", "PreviousVersion")
-                        .WithMany()
-                        .HasForeignKey("PreviousVersionId");
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Release", "ScheduledWithRelease")
-                        .WithMany()
-                        .HasForeignKey("ScheduledWithReleaseId");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyFile", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.File", "File")
@@ -1018,6 +944,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Contact", "Contact")
                         .WithMany()
                         .HasForeignKey("ContactId");
+
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", "Methodology")
+                        .WithMany("Publications")
+                        .HasForeignKey("MethodologyId");
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Topic", "Topic")
                         .WithMany("Publications")
@@ -1045,21 +975,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                             b1.WithOwner()
                                 .HasForeignKey("PublicationId");
                         });
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationMethodology", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyParent", "MethodologyParent")
-                        .WithMany("Publications")
-                        .HasForeignKey("MethodologyParentId")
-                        .OnDelete(DeleteBehavior.NoAction)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", "Publication")
-                        .WithMany("Methodologies")
-                        .HasForeignKey("PublicationId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Release", b =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210707104334_EES2328CreateDataImportGeographicLevelsColumn.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210707104334_EES2328CreateDataImportGeographicLevelsColumn.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES2328CreateDataImportGeographicLevelsColumn : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "GeographicLevels",
+                table: "DataImports",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GeographicLevels",
+                table: "DataImports");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -24,7 +24,6 @@ using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
-using static GovUk.Education.ExploreEducationStatistics.Data.Model.Services.LocationService;
 using IReleaseService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseService;
 using Release = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
 using Unit = GovUk.Education.ExploreEducationStatistics.Common.Model.Unit;
@@ -406,7 +405,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             ReplacementSubjectMeta replacementSubjectMeta)
         {
             return GetEnumValues<GeographicLevel>()
-                .Where(geographicLevel => !IgnoredLevels.Contains(geographicLevel))
                 .ToDictionary(geographicLevel => geographicLevel.ToString(),
                     geographicLevel =>
                         ValidateLocationLevelForReplacement(dataBlock.Query.Locations,

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/LocationQuery.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/LocationQuery.cs
@@ -18,9 +18,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query
         public IEnumerable<string> MayoralCombinedAuthority { get; set; }
         public IEnumerable<string> OpportunityArea { get; set; }
         public IEnumerable<string> ParliamentaryConstituency { get; set; }
+        public IEnumerable<string> Provider { get; set; }
         public IEnumerable<string> PlanningArea { get; set; }
         public IEnumerable<string> Region { get; set; }
         public IEnumerable<string> RscRegion { get; set; }
+        public IEnumerable<string> School { get; set; }
         public IEnumerable<string> Sponsor { get; set; }
         public IEnumerable<string> Ward { get; set; }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataImport.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/DataImport.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using Newtonsoft.Json;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.DataImportStatus;
 
@@ -51,6 +52,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public int RowsPerBatch { get; set; }
 
         public int TotalRows { get; set; }
+
+        public HashSet<GeographicLevel> GeographicLevels { get; set; }
 
         public List<DataImportError> Errors { get; set; } = new List<DataImportError>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -87,6 +87,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .Property(import => import.Status)
                 .HasConversion(new EnumToStringConverter<DataImportStatus>());
 
+            modelBuilder.Entity<DataImport>()
+                .Property(import => import.GeographicLevels)
+                .HasConversion(
+                    v => JsonConvert.SerializeObject(v),
+                    v => JsonConvert.DeserializeObject<HashSet<GeographicLevel>>(v));
+
             modelBuilder.Entity<DataImportError>()
                 .Property(importError => importError.Created)
                 .HasConversion(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
@@ -121,6 +121,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
                 .HasIndex(location => location.ParliamentaryConstituency_Code);
 
             modelBuilder.Entity<Location>()
+                .HasIndex(location => location.Provider_Code);
+
+            modelBuilder.Entity<Location>()
                 .HasIndex(location => location.PlanningArea_Code);
 
             modelBuilder.Entity<Location>()
@@ -128,6 +131,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
 
             modelBuilder.Entity<Location>()
                 .HasIndex(location => location.RscRegion_Code);
+
+            modelBuilder.Entity<Location>()
+                .HasIndex(location => location.School_Code);
 
             modelBuilder.Entity<Location>()
                 .HasIndex(location => location.Sponsor_Code);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Location.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Location.cs
@@ -152,6 +152,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
+        [JsonIgnore] public string Provider_Code { get; set; }
+        [JsonIgnore] public string Provider_Name { get; set; }
+
+        [NotMapped]
+        public Provider Provider
+        {
+            get => new Provider(Provider_Code, Provider_Name);
+            set
+            {
+                Provider_Code = value?.Code;
+                Provider_Name = value?.Name;
+            }
+        }
+
         [JsonIgnore] public string Region_Code { get; set; }
         [JsonIgnore] public string Region_Name { get; set; }
 
@@ -173,6 +187,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         {
             get => new RscRegion(RscRegion_Code);
             set => RscRegion_Code = value?.Code;
+        }
+
+        [JsonIgnore] public string School_Code { get; set; }
+        [JsonIgnore] public string School_Name { get; set; }
+
+        [NotMapped]
+        public School School
+        {
+            get => new School(School_Code, School_Name);
+            set
+            {
+                School_Code = value?.Code;
+                School_Name = value?.Name;
+            }
         }
 
         [JsonIgnore] public string Sponsor_Code { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Location.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Location.cs
@@ -10,8 +10,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
     {
         public Guid Id { get; set; }
 
-        [JsonIgnore] public string Country_Code { get; set; }
-        [JsonIgnore] public string Country_Name { get; set; }
+        public string Country_Code { get; set; }
+        public string Country_Name { get; set; }
 
         [NotMapped]
         public Country Country
@@ -24,8 +24,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string EnglishDevolvedArea_Code { get; set; }
-        [JsonIgnore] public string EnglishDevolvedArea_Name { get; set; }
+        public string EnglishDevolvedArea_Code { get; set; }
+        public string EnglishDevolvedArea_Name { get; set; }
 
         [NotMapped]
         public EnglishDevolvedArea EnglishDevolvedArea
@@ -38,8 +38,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string Institution_Code { get; set; }
-        [JsonIgnore] public string Institution_Name { get; set; }
+        public string Institution_Code { get; set; }
+        public string Institution_Name { get; set; }
 
         [NotMapped]
         public Institution Institution
@@ -52,9 +52,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string LocalAuthority_Code { get; set; }
-        [JsonIgnore] public string LocalAuthority_OldCode { get; set; }
-        [JsonIgnore] public string LocalAuthority_Name { get; set; }
+        public string LocalAuthority_Code { get; set; }
+        public string LocalAuthority_OldCode { get; set; }
+        public string LocalAuthority_Name { get; set; }
 
         [NotMapped]
         public LocalAuthority LocalAuthority
@@ -68,8 +68,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string LocalAuthorityDistrict_Code { get; set; }
-        [JsonIgnore] public string LocalAuthorityDistrict_Name { get; set; }
+        public string LocalAuthorityDistrict_Code { get; set; }
+        public string LocalAuthorityDistrict_Name { get; set; }
 
         [NotMapped]
         public LocalAuthorityDistrict LocalAuthorityDistrict
@@ -82,8 +82,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string LocalEnterprisePartnership_Code { get; set; }
-        [JsonIgnore] public string LocalEnterprisePartnership_Name { get; set; }
+        public string LocalEnterprisePartnership_Code { get; set; }
+        public string LocalEnterprisePartnership_Name { get; set; }
 
         [NotMapped]
         public LocalEnterprisePartnership LocalEnterprisePartnership
@@ -96,8 +96,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string MayoralCombinedAuthority_Code { get; set; }
-        [JsonIgnore] public string MayoralCombinedAuthority_Name { get; set; }
+        public string MayoralCombinedAuthority_Code { get; set; }
+        public string MayoralCombinedAuthority_Name { get; set; }
 
         [NotMapped]
         public MayoralCombinedAuthority MayoralCombinedAuthority
@@ -110,8 +110,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string MultiAcademyTrust_Code { get; set; }
-        [JsonIgnore] public string MultiAcademyTrust_Name { get; set; }
+        public string MultiAcademyTrust_Code { get; set; }
+        public string MultiAcademyTrust_Name { get; set; }
 
         [NotMapped]
         public Mat MultiAcademyTrust
@@ -124,8 +124,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string OpportunityArea_Code { get; set; }
-        [JsonIgnore] public string OpportunityArea_Name { get; set; }
+        public string OpportunityArea_Code { get; set; }
+        public string OpportunityArea_Name { get; set; }
 
         [NotMapped]
         public OpportunityArea OpportunityArea
@@ -138,8 +138,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string ParliamentaryConstituency_Code { get; set; }
-        [JsonIgnore] public string ParliamentaryConstituency_Name { get; set; }
+        public string ParliamentaryConstituency_Code { get; set; }
+        public string ParliamentaryConstituency_Name { get; set; }
 
         [NotMapped]
         public ParliamentaryConstituency ParliamentaryConstituency
@@ -152,8 +152,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string Provider_Code { get; set; }
-        [JsonIgnore] public string Provider_Name { get; set; }
+        public string Provider_Code { get; set; }
+        public string Provider_Name { get; set; }
 
         [NotMapped]
         public Provider Provider
@@ -166,8 +166,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string Region_Code { get; set; }
-        [JsonIgnore] public string Region_Name { get; set; }
+        public string Region_Code { get; set; }
+        public string Region_Name { get; set; }
 
         [NotMapped]
         public Region Region
@@ -180,7 +180,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string RscRegion_Code { get; set; }
+        public string RscRegion_Code { get; set; }
 
         [NotMapped]
         public RscRegion RscRegion
@@ -189,8 +189,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             set => RscRegion_Code = value?.Code;
         }
 
-        [JsonIgnore] public string School_Code { get; set; }
-        [JsonIgnore] public string School_Name { get; set; }
+        public string School_Code { get; set; }
+        public string School_Name { get; set; }
 
         [NotMapped]
         public School School
@@ -203,8 +203,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string Sponsor_Code { get; set; }
-        [JsonIgnore] public string Sponsor_Name { get; set; }
+        public string Sponsor_Code { get; set; }
+        public string Sponsor_Name { get; set; }
 
         [NotMapped]
         public Sponsor Sponsor
@@ -217,8 +217,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string Ward_Code { get; set; }
-        [JsonIgnore] public string Ward_Name { get; set; }
+        public string Ward_Code { get; set; }
+        public string Ward_Name { get; set; }
 
         [NotMapped]
         public Ward Ward
@@ -231,8 +231,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
             }
         }
 
-        [JsonIgnore] public string PlanningArea_Code { get; set; }
-        [JsonIgnore] public string PlanningArea_Name { get; set; }
+        public string PlanningArea_Code { get; set; }
+        public string PlanningArea_Name { get; set; }
 
         [NotMapped]
         public PlanningArea PlanningArea

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20210712091202_EES2328AddSchoolAndProviderLocationColumns.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20210712091202_EES2328AddSchoolAndProviderLocationColumns.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
 {
     [DbContext(typeof(StatisticsDbContext))]
-    partial class StatisticsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210712091202_EES2328AddSchoolAndProviderLocationColumns")]
+    partial class EES2328AddSchoolAndProviderLocationColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20210712091202_EES2328AddSchoolAndProviderLocationColumns.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20210712091202_EES2328AddSchoolAndProviderLocationColumns.cs
@@ -1,0 +1,75 @@
+﻿using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.EntityFrameworkCore.Migrations;
+using static GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations.MigrationConstants;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Migrations
+{
+    public partial class EES2328AddSchoolAndProviderLocationColumns : Migration
+    {
+        private const string MigrationId = "20210712091202";
+        private const string PreviousFilteredObservationsMigrationId = "20210512112804";
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Provider_Code",
+                table: "Location",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Provider_Name",
+                table: "Location",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "School_Code",
+                table: "Location",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "School_Name",
+                table: "Location",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Location_Provider_Code",
+                table: "Location",
+                column: "Provider_Code");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Location_School_Code",
+                table: "Location",
+                column: "School_Code");
+
+            migrationBuilder.SqlFromFile(MigrationsPath, $"{MigrationId}_Routine_FilteredObservations.sql");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Location_Provider_Code",
+                table: "Location");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Location_School_Code",
+                table: "Location");
+
+            migrationBuilder.DropColumn(
+                name: "Provider_Code",
+                table: "Location");
+
+            migrationBuilder.DropColumn(
+                name: "Provider_Name",
+                table: "Location");
+
+            migrationBuilder.DropColumn(
+                name: "School_Code",
+                table: "Location");
+
+            migrationBuilder.DropColumn(
+                name: "School_Name",
+                table: "Location");
+
+            migrationBuilder.SqlFromFile(MigrationsPath, $"{PreviousFilteredObservationsMigrationId}_Routine_FilteredObservations.sql");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20210712091202_Routine_FilteredObservations.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/20210712091202_Routine_FilteredObservations.sql
@@ -1,0 +1,207 @@
+CREATE OR ALTER PROCEDURE FilteredObservations
+    @subjectId uniqueidentifier,
+    @geographicLevel nvarchar(6) = NULL,
+    @timePeriodList TimePeriodListType READONLY,
+    @countriesList IdListVarcharType READONLY,
+    @englishDevolvedAreasList IdListVarcharType READONLY,
+    @institutionsList IdListVarcharType READONLY,
+    @localAuthorityList IdListVarcharType READONLY,
+    @localAuthorityOldCodeList IdListVarcharType READONLY,
+    @localAuthorityDistrictList IdListVarcharType READONLY,
+    @localEnterprisePartnershipsList IdListVarcharType READONLY,
+    @mayoralCombinedAuthoritiesList IdListVarcharType READONLY,
+    @multiAcademyTrustList IdListVarcharType READONLY,
+    @opportunityAreasList IdListVarcharType READONLY,
+    @parliamentaryConstituenciesList IdListVarcharType READONLY,
+    @providersList IdListVarcharType READONLY,
+    @regionsList IdListVarcharType READONLY,
+    @rscRegionsList IdListVarcharType READONLY,
+    @schoolsList IdListVarcharType READONLY,
+    @sponsorList IdListVarcharType READONLY,
+    @wardsList IdListVarcharType READONLY,
+    @planningAreasList IdListVarcharType READONLY,
+    @filterItemList IdListGuidType READONLY
+AS
+DECLARE
+    @timePeriodCount INT = (SELECT count(year) FROM @timePeriodList),
+    @observationalUnitExists BIT = CAST(IIF(
+                EXISTS(SELECT TOP 1 1 FROM @countriesList)
+                OR EXISTS(SELECT TOP 1 1 FROM @englishDevolvedAreasList)
+                OR EXISTS(SELECT TOP 1 1 FROM @institutionsList)
+                OR EXISTS(SELECT TOP 1 1 FROM @localAuthorityList)
+                OR EXISTS(SELECT TOP 1 1 FROM @localAuthorityOldCodeList)
+                OR EXISTS(SELECT TOP 1 1 FROM @localAuthorityDistrictList)
+                OR EXISTS(SELECT TOP 1 1 FROM @localEnterprisePartnershipsList)
+                OR EXISTS(SELECT TOP 1 1 FROM @mayoralCombinedAuthoritiesList)
+                OR EXISTS(SELECT TOP 1 1 FROM @multiAcademyTrustList)
+                OR EXISTS(SELECT TOP 1 1 FROM @opportunityAreasList)
+                OR EXISTS(SELECT TOP 1 1 FROM @parliamentaryConstituenciesList)
+                OR EXISTS(SELECT TOP 1 1 FROM @providersList)
+                OR EXISTS(SELECT TOP 1 1 FROM @regionsList)
+                OR EXISTS(SELECT TOP 1 1 FROM @rscRegionsList)
+                OR EXISTS(SELECT TOP 1 1 FROM @schoolsList)
+                OR EXISTS(SELECT TOP 1 1 FROM @sponsorList)
+                OR EXISTS(SELECT TOP 1 1 FROM @wardsList)
+                OR EXISTS(SELECT TOP 1 1 FROM @planningAreasList), 1, 0) AS BIT),
+    @paramDefinition NVARCHAR(2000),
+    @idsList NVARCHAR(MAX),
+    @sqlString NVARCHAR(MAX) = N'SELECT o.id ' +
+                                'FROM Observation o ' +
+                                'JOIN Location l ON o.LocationId = l.Id ' +
+                                'LEFT JOIN ObservationFilterItem ofi ON o.Id = ofi.ObservationId ' +
+                                'AND ofi.FilterItemId IN (SELECT id FROM @filterItemList) ' +
+                                'WHERE o.SubjectId = @subjectId '
+    IF (@geographicLevel IS NOT NULL)
+        SET @sqlString = @sqlString + N'AND o.GeographicLevel = @geographicLevel '
+    IF (@timePeriodCount > 0)
+        SET @sqlString = @sqlString + N'AND EXISTS(SELECT 1 from @timePeriodList t WHERE t.year = o.Year AND t.timeIdentifier = o.TimeIdentifier) '
+    IF (@observationalUnitExists = 1)
+        BEGIN
+            SET @sqlString = @sqlString + N'AND ('
+            IF (EXISTS(SELECT TOP 1 1 FROM @countriesList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @countriesList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.Country_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''NAT'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @englishDevolvedAreasList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @englishDevolvedAreasList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.EnglishDevolvedArea_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''EDA'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @institutionsList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @institutionsList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.Institution_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''INS'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @localAuthorityList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @localAuthorityList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.LocalAuthority_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''LA'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @localAuthorityOldCodeList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @localAuthorityOldCodeList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.LocalAuthority_OldCode IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''LA'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @localAuthorityDistrictList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @localAuthorityDistrictList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.LocalAuthorityDistrict_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''LAD'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @localEnterprisePartnershipsList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @localEnterprisePartnershipsList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.LocalEnterprisePartnership_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''LEP'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @mayoralCombinedAuthoritiesList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @mayoralCombinedAuthoritiesList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.MayoralCombinedAuthority_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''MCA'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @multiAcademyTrustList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @multiAcademyTrustList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.MultiAcademyTrust_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''MAT'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @opportunityAreasList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @opportunityAreasList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.OpportunityArea_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''OA'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @parliamentaryConstituenciesList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @parliamentaryConstituenciesList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.ParliamentaryConstituency_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''PC'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @providersList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @providersList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.Provider_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''PRO'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @regionsList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @regionsList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.Region_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''REG'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @rscRegionsList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @rscRegionsList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.RscRegion_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''RSCR'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @schoolsList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @schoolsList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.School_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''SCH'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @sponsorList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @sponsorList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.Sponsor_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''SPO'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @wardsList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @wardsList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.Ward_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''WAR'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @planningAreasList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @planningAreasList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.PlanningArea_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''PA'')) OR '
+                END
+            SET @sqlString = left(@sqlString, len(@sqlString) - 3) + N') '
+        END
+    SET @sqlString = @sqlString + N'GROUP BY o.Id ' +
+                     'HAVING COUNT(DISTINCT ofi.FilterItemId) = (' +
+                     '    SELECT COUNT(DISTINCT f.id) AS filterCount' +
+                     '    FROM' +
+                     '    FilterItem fi' +
+                     '    JOIN FilterGroup fg ON fi.FilterGroupId = fg.Id' +
+                     '    JOIN Filter f ON fg.FilterId = f.Id' +
+                     '    WHERE fi.Id IN (SELECT id FROM @filterItemList)' +
+                     ') ' +
+                     'ORDER BY o.Id;'
+    SET @paramDefinition = N'@subjectId uniqueidentifier,
+                           @geographicLevel nvarchar(6) = NULL,
+                           @timePeriodList TimePeriodListType READONLY,
+                           @countriesList IdListVarcharType READONLY,
+                           @englishDevolvedAreasList IdListVarcharType READONLY,
+                           @institutionsList IdListVarcharType READONLY,
+                           @localAuthorityList IdListVarcharType READONLY,
+                           @localAuthorityOldCodeList IdListVarcharType READONLY,
+                           @localAuthorityDistrictList IdListVarcharType READONLY,
+                           @localEnterprisePartnershipsList IdListVarcharType READONLY,
+                           @mayoralCombinedAuthoritiesList IdListVarcharType READONLY,
+                           @multiAcademyTrustList IdListVarcharType READONLY,
+                           @opportunityAreasList IdListVarcharType READONLY,
+                           @parliamentaryConstituenciesList IdListVarcharType READONLY,
+                           @providersList IdListVarcharType READONLY,
+                           @regionsList IdListVarcharType READONLY,
+                           @rscRegionsList IdListVarcharType READONLY,
+                           @schoolsList IdListVarcharType READONLY,
+                           @sponsorList IdListVarcharType READONLY,
+                           @wardsList IdListVarcharType READONLY,
+                           @planningAreasList IdListVarcharType READONLY,
+                           @filterItemList IdListGuidType READONLY'
+    EXEC sp_executesql @sqlString, @paramDefinition,
+         @subjectId = @subjectId,
+         @geographicLevel = @geographicLevel,
+         @timePeriodList = @timePeriodList,
+         @countriesList = @countriesList,
+         @englishDevolvedAreasList = @englishDevolvedAreasList,
+         @institutionsList = @institutionsList,
+         @localAuthorityList = @localAuthorityList,
+         @localAuthorityOldCodeList = @localAuthorityOldCodeList,
+         @localAuthorityDistrictList = @localAuthorityDistrictList,
+         @localEnterprisePartnershipsList = @localEnterprisePartnershipsList,
+         @mayoralCombinedAuthoritiesList = @mayoralCombinedAuthoritiesList,
+         @multiAcademyTrustList = @multiAcademyTrustList,
+         @opportunityAreasList = @opportunityAreasList,
+         @parliamentaryConstituenciesList = @parliamentaryConstituenciesList,
+         @providersList = @providersList,
+         @regionsList = @regionsList,
+         @rscRegionsList = @rscRegionsList,
+         @schoolsList = @schoolsList,
+         @sponsorList = @sponsorList,
+         @wardsList = @wardsList,
+         @planningAreasList = @planningAreasList,
+         @filterItemList = @filterItemList;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/Current_Routine_FilteredObservations.sql
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Migrations/Current_Routine_FilteredObservations.sql
@@ -13,8 +13,10 @@ CREATE OR ALTER PROCEDURE FilteredObservations
     @multiAcademyTrustList IdListVarcharType READONLY,
     @opportunityAreasList IdListVarcharType READONLY,
     @parliamentaryConstituenciesList IdListVarcharType READONLY,
+    @providersList IdListVarcharType READONLY,
     @regionsList IdListVarcharType READONLY,
     @rscRegionsList IdListVarcharType READONLY,
+    @schoolsList IdListVarcharType READONLY,
     @sponsorList IdListVarcharType READONLY,
     @wardsList IdListVarcharType READONLY,
     @planningAreasList IdListVarcharType READONLY,
@@ -34,8 +36,10 @@ DECLARE
                 OR EXISTS(SELECT TOP 1 1 FROM @multiAcademyTrustList)
                 OR EXISTS(SELECT TOP 1 1 FROM @opportunityAreasList)
                 OR EXISTS(SELECT TOP 1 1 FROM @parliamentaryConstituenciesList)
+                OR EXISTS(SELECT TOP 1 1 FROM @providersList)
                 OR EXISTS(SELECT TOP 1 1 FROM @regionsList)
                 OR EXISTS(SELECT TOP 1 1 FROM @rscRegionsList)
+                OR EXISTS(SELECT TOP 1 1 FROM @schoolsList)
                 OR EXISTS(SELECT TOP 1 1 FROM @sponsorList)
                 OR EXISTS(SELECT TOP 1 1 FROM @wardsList)
                 OR EXISTS(SELECT TOP 1 1 FROM @planningAreasList), 1, 0) AS BIT),
@@ -109,6 +113,11 @@ DECLARE
                     SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @parliamentaryConstituenciesList)), ''''))
                     SET @sqlString = @sqlString + N'(l.ParliamentaryConstituency_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''PC'')) OR '
                 END
+            IF (EXISTS(SELECT TOP 1 1 FROM @providersList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @providersList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.Provider_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''PRO'')) OR '
+                END
             IF (EXISTS(SELECT TOP 1 1 FROM @regionsList))
                 BEGIN
                     SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @regionsList)), ''''))
@@ -118,6 +127,11 @@ DECLARE
                 BEGIN
                     SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @rscRegionsList)), ''''))
                     SET @sqlString = @sqlString + N'(l.RscRegion_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''RSCR'')) OR '
+                END
+            IF (EXISTS(SELECT TOP 1 1 FROM @schoolsList))
+                BEGIN
+                    SET @idsList = (SELECT CONCAT(CONCAT('''', (SELECT STRING_AGG(Id, ''',''') FROM @schoolsList)), ''''))
+                    SET @sqlString = @sqlString + N'(l.School_Code IN (' + @idsList + ') AND (@geographicLevel IS NOT NULL OR o.GeographicLevel = ''SCH'')) OR '
                 END
             IF (EXISTS(SELECT TOP 1 1 FROM @sponsorList))
                 BEGIN
@@ -160,8 +174,10 @@ DECLARE
                            @multiAcademyTrustList IdListVarcharType READONLY,
                            @opportunityAreasList IdListVarcharType READONLY,
                            @parliamentaryConstituenciesList IdListVarcharType READONLY,
+                           @providersList IdListVarcharType READONLY,
                            @regionsList IdListVarcharType READONLY,
                            @rscRegionsList IdListVarcharType READONLY,
+                           @schoolsList IdListVarcharType READONLY,
                            @sponsorList IdListVarcharType READONLY,
                            @wardsList IdListVarcharType READONLY,
                            @planningAreasList IdListVarcharType READONLY,
@@ -181,8 +197,10 @@ DECLARE
          @multiAcademyTrustList = @multiAcademyTrustList,
          @opportunityAreasList = @opportunityAreasList,
          @parliamentaryConstituenciesList = @parliamentaryConstituenciesList,
+         @providersList = @providersList,
          @regionsList = @regionsList,
          @rscRegionsList = @rscRegionsList,
+         @schoolsList = @schoolsList,
          @sponsorList = @sponsorList,
          @wardsList = @wardsList,
          @planningAreasList = @planningAreasList,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Provider.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Provider.cs
@@ -1,0 +1,41 @@
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model
+{
+    public class Provider : IObservationalUnit
+    {
+        public string Code { get; set; }
+        public string Name { get; set; }
+
+        private Provider()
+        {
+        }
+
+        public Provider(string ukprn, string name)
+        {
+            Code = ukprn;
+            Name = name;
+        }
+
+        public static Provider Empty()
+        {
+            return new Provider(null, null);
+        }
+
+        protected bool Equals(Provider other)
+        {
+            return string.Equals(Code, other.Code);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Provider) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Code != null ? Code.GetHashCode() : 0);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/School.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/School.cs
@@ -1,0 +1,44 @@
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model
+{
+    public class School : IObservationalUnit
+    {
+        public string Code { get; set; }
+        public string Name { get; set; }
+
+        public School()
+        {
+        }
+
+        public School(string urn, string name)
+        {
+            Code = urn;
+            Name = name;
+        }
+
+        public static School Empty()
+        {
+            return new School(null, null);
+        }
+
+        protected bool Equals(School other)
+        {
+            return string.Equals(Code, other.Code);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((School) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Code != null ? Code.GetHashCode() : 0);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/LocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/LocationService.cs
@@ -11,12 +11,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
 {
     public class LocationService : AbstractRepository<Location, Guid>, ILocationService
     {
-        public static readonly List<GeographicLevel> IgnoredLevels = new List<GeographicLevel>
-        {
-            GeographicLevel.School,
-            GeographicLevel.Provider
-        };
-
         public LocationService(StatisticsDbContext context, ILogger<LocationService> logger) : base(context, logger)
         {
         }
@@ -184,8 +178,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
         private Dictionary<GeographicLevel, IEnumerable<Location>> GetLocationsGroupedByGeographicLevel(Guid subjectId)
         {
             var locationIdsWithGeographicLevel = _context.Observation
-                .Where(observation =>
-                    !IgnoredLevels.Contains(observation.GeographicLevel) && observation.SubjectId == subjectId)
+                .Where(observation => observation.SubjectId == subjectId)
                 .Select(observation => new {observation.GeographicLevel, observation.LocationId})
                 .Distinct()
                 .AsNoTracking()
@@ -199,7 +192,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
             IQueryable<Observation> observations)
         {
             var locationIdsWithGeographicLevel = observations
-                .Where(observation => !IgnoredLevels.Contains(observation.GeographicLevel))
                 .Select(observation => new {observation.GeographicLevel, observation.LocationId})
                 .Distinct()
                 .AsNoTracking()

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/LocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/LocationService.cs
@@ -88,6 +88,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
                         .Where(q => codes.Contains(q.ParliamentaryConstituency_Code))
                         .GroupBy(q => new {q.ParliamentaryConstituency_Code, q.ParliamentaryConstituency_Name})
                         .Select(q => new ParliamentaryConstituency(q.Key.ParliamentaryConstituency_Code, q.Key.ParliamentaryConstituency_Name)),
+                GeographicLevel.Provider =>
+                    _context.Location
+                        .Where(q => codes.Contains(q.Provider_Code))
+                        .GroupBy(q => new {q.Provider_Code, q.Provider_Name})
+                        .Select(q => new Provider(q.Key.Provider_Code, q.Key.Provider_Name)),
                 GeographicLevel.Region =>
                     _context.Location
                         .Where(q => codes.Contains(q.Region_Code))
@@ -98,6 +103,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
                         .Where(q => codes.Contains(q.RscRegion_Code))
                         .GroupBy(q => new {q.RscRegion_Code})
                         .Select(q => new RscRegion(q.Key.RscRegion_Code)),
+                GeographicLevel.School =>
+                    _context.Location
+                        .Where(q => codes.Contains(q.School_Code))
+                        .GroupBy(q => new {q.School_Code, q.School_Name})
+                        .Select(q => new School(q.Key.School_Code, q.Key.School_Name)),
                 GeographicLevel.Sponsor =>
                     _context.Location
                         .Where(q => codes.Contains(q.Sponsor_Code))
@@ -152,10 +162,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
                     return location.OpportunityArea;
                 case GeographicLevel.ParliamentaryConstituency:
                     return location.ParliamentaryConstituency;
+                case GeographicLevel.Provider:
+                    return location.Provider;
                 case GeographicLevel.Region:
                     return location.Region;
                 case GeographicLevel.RscRegion:
                     return location.RscRegion;
+                case GeographicLevel.School:
+                    return location.School;
                 case GeographicLevel.Sponsor:
                     return location.Sponsor;
                 case GeographicLevel.Ward:

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/DataImportServiceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services;
 using Microsoft.Extensions.Logging;
@@ -135,7 +136,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             await service.Update(import.Id,
                 rowsPerBatch: 1000,
                 totalRows: 10000,
-                numBatches: 10);
+                numBatches: 10,
+                geographicLevels: new HashSet<GeographicLevel>
+                {
+                    GeographicLevel.Country,
+                    GeographicLevel.Region
+                });
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
@@ -143,6 +149,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
                 Assert.Equal(1000, updated.RowsPerBatch);
                 Assert.Equal(10000, updated.TotalRows);
                 Assert.Equal(10, updated.NumBatches);
+
+                Assert.Equal(2, updated.GeographicLevels.Count);
+                Assert.Contains(GeographicLevel.Country, updated.GeographicLevels);
+                Assert.Contains(GeographicLevel.Region, updated.GeographicLevels);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/ImporterLocationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/ImporterLocationServiceTests.cs
@@ -31,7 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                var result1 = service.Find(statisticsDbContext, location.Country,
+                var result1 = service.FindOrCreate(statisticsDbContext, location.Country,
                     localAuthority: location.LocalAuthority);
                 Assert.NotNull(result1);
                 Assert.Equal("Bedford", result1.LocalAuthority_Name);
@@ -58,7 +58,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
             var statisticsDbContextId = Guid.NewGuid().ToString();
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                var result1 = service.Find(statisticsDbContext, country,
+                var result1 = service.FindOrCreate(statisticsDbContext, country,
                     englishDevolvedArea: lowerCase);
                 Assert.NotNull(result1);
                 Assert.Equal("casesensitive", result1.EnglishDevolvedArea_Name);
@@ -68,7 +68,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
             {
-                var result2 = service.Find(statisticsDbContext, country,
+                var result2 = service.FindOrCreate(statisticsDbContext, country,
                     englishDevolvedArea: upperCase);
                 Assert.NotNull(result2);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/ProcessorStatistics.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/ProcessorStatistics.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+
 namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
 {
     public class ProcessorStatistics
@@ -5,16 +8,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor
         public int FilteredObservationCount { get; set; }
         public int RowsPerBatch { get; set; }
         public int NumBatches { get; set; }
+        public HashSet<GeographicLevel> GeographicLevels { get; set; }
 
-        public ProcessorStatistics(int filteredObservationCount, int rowsPerBatch, int numBatches)
+        public ProcessorStatistics(int filteredObservationCount,
+            int rowsPerBatch,
+            int numBatches,
+            HashSet<GeographicLevel> geographicLevels)
         {
             FilteredObservationCount = filteredObservationCount;
             RowsPerBatch = rowsPerBatch;
             NumBatches = numBatches;
-        }
-
-        public ProcessorStatistics()
-        {
+            GeographicLevels = geographicLevels;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/DataImportService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
@@ -75,7 +76,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             return import.Status;
         }
 
-        public async Task Update(Guid id, int rowsPerBatch, int totalRows, int numBatches)
+        public async Task Update(Guid id, int rowsPerBatch, int totalRows, int numBatches,
+            HashSet<GeographicLevel> geographicLevels)
         {
             await using var contentDbContext = new ContentDbContext(_contentDbContextOptions);
             var import = await contentDbContext.DataImports.FindAsync(id);
@@ -84,6 +86,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             import.RowsPerBatch = rowsPerBatch;
             import.TotalRows = totalRows;
             import.NumBatches = numBatches;
+            import.GeographicLevels = geographicLevels;
 
             await contentDbContext.SaveChangesAsync();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/FileImportService.cs
@@ -76,6 +76,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     dataFileTable.Rows,
                     subject,
                     _importerService.GetMeta(metaFileTable, subject, context),
+                    import.GeographicLevels,
                     message.BatchNo,
                     import.RowsPerBatch,
                     context

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterLocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterLocationService.cs
@@ -18,7 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             _guidGenerator = guidGenerator;
         }
 
-        public Location Find(
+        public Location FindOrCreate(
             StatisticsDbContext context,
             Country country,
             EnglishDevolvedArea englishDevolvedArea = null,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterLocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterLocationService.cs
@@ -30,8 +30,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             Mat multiAcademyTrust = null,
             OpportunityArea opportunityArea = null,
             ParliamentaryConstituency parliamentaryConstituency = null,
+            Provider provider = null,
             Region region = null,
             RscRegion rscRegion = null,
+            School school = null,
             Sponsor sponsor = null,
             Ward ward = null,
             PlanningArea planningArea = null)
@@ -47,8 +49,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 multiAcademyTrust,
                 opportunityArea,
                 parliamentaryConstituency,
+                provider,
                 region,
                 rscRegion,
+                school,
                 sponsor,
                 ward,
                 planningArea);
@@ -70,8 +74,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 multiAcademyTrust,
                 opportunityArea,
                 parliamentaryConstituency,
+                provider,
                 region,
                 rscRegion,
+                school,
                 sponsor,
                 ward,
                 planningArea);
@@ -91,8 +97,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             Mat multiAcademyTrust,
             OpportunityArea opportunityArea,
             ParliamentaryConstituency parliamentaryConstituency,
+            Provider provider,
             Region region,
             RscRegion rscRegion,
+            School school,
             Sponsor sponsor,
             Ward ward,
             PlanningArea planningArea)
@@ -108,9 +116,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 mayoralCombinedAuthority,
                 multiAcademyTrust,
                 parliamentaryConstituency,
+                provider,
                 opportunityArea,
                 region,
                 rscRegion,
+                school,
                 sponsor,
                 ward,
                 planningArea
@@ -136,8 +146,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             Mat multiAcademyTrust = null,
             OpportunityArea opportunityArea = null,
             ParliamentaryConstituency parliamentaryConstituency = null,
+            Provider provider = null,
             Region region = null,
             RscRegion rscRegion = null,
+            School school = null,
             Sponsor sponsor = null,
             Ward ward = null,
             PlanningArea planningArea = null)
@@ -154,8 +166,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 multiAcademyTrust,
                 opportunityArea,
                 parliamentaryConstituency,
+                provider,
                 region,
                 rscRegion,
+                school,
                 sponsor,
                 ward,
                 planningArea);
@@ -175,8 +189,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     MultiAcademyTrust = multiAcademyTrust ?? Mat.Empty(),
                     OpportunityArea = opportunityArea ?? OpportunityArea.Empty(),
                     ParliamentaryConstituency = parliamentaryConstituency ?? ParliamentaryConstituency.Empty(),
+                    Provider = provider ?? Provider.Empty(),
                     Region = region ?? Region.Empty(),
                     RscRegion = rscRegion ?? RscRegion.Empty(),
+                    School = school ?? School.Empty(),
                     Sponsor = sponsor ?? Sponsor.Empty(),
                     Ward = ward ?? Ward.Empty(),
                     PlanningArea = planningArea ?? PlanningArea.Empty()
@@ -200,8 +216,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             Mat multiAcademyTrust = null,
             OpportunityArea opportunityArea = null,
             ParliamentaryConstituency parliamentaryConstituency = null,
+            Provider provider = null,
             Region region = null,
             RscRegion rscRegion = null,
+            School school = null,
             Sponsor sponsor = null,
             Ward ward = null,
             PlanningArea planningArea = null)
@@ -250,12 +268,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                                  && location.ParliamentaryConstituency_Name == (parliamentaryConstituency != null ? parliamentaryConstituency.Name : null));
 
             predicateBuilder = predicateBuilder
+                .And(location => location.Provider_Code == (provider != null ? provider.Code : null)
+                                 && location.Provider_Name == (provider != null ? provider.Name : null));
+
+            predicateBuilder = predicateBuilder
                 .And(location => location.Region_Code == (region != null ? region.Code : null)
                                  && location.Region_Name == (region != null ? region.Name : null));
 
             // Note that Name is not included in the predicate here as it is the same as the code
             predicateBuilder = predicateBuilder
                 .And(location => location.RscRegion_Code == (rscRegion != null ? rscRegion.Code : null));
+
+            predicateBuilder = predicateBuilder
+                .And(location =>
+                    location.School_Code == (school != null ? school.Code : null)
+                    && location.School_Name == (school != null ? school.Name : null));
 
             predicateBuilder = predicateBuilder
                 .And(location => location.Sponsor_Code == (sponsor != null ? sponsor.Code : null)
@@ -285,8 +312,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 && location.MultiAcademyTrust_Name == multiAcademyTrust?.Name
                 && location.OpportunityArea_Name == opportunityArea?.Name
                 && location.ParliamentaryConstituency_Name == parliamentaryConstituency?.Name
+                && location.Provider_Name == provider?.Name
                 && location.Region_Name == region?.Name
                 && location.RscRegion_Code == rscRegion?.Code // RscRegion codes function as the name
+                && location.School_Name == school?.Name
                 && location.Sponsor_Name == sponsor?.Name
                 && location.Ward_Name == ward?.Name
                 && location.PlanningArea_Name == planningArea?.Name

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterService.cs
@@ -338,7 +338,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
         private Guid GetLocationId(IReadOnlyList<string> line, List<string> headers, StatisticsDbContext context)
         {
-            return _importerLocationService.Find(
+            return _importerLocationService.FindOrCreate(
                 context,
                 GetCountry(line, headers),
                 GetEnglishDevolvedArea(line, headers),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterService.cs
@@ -14,6 +14,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Processor.Exceptions;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Models;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Processor.Utils;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -75,8 +76,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     new[] {"pcon_code", "pcon_name"}
                 },
                 {
+                    GeographicLevel.Provider,
+                    new[] {"provider_ukprn", "provider_name"}
+                },
+                {
                     GeographicLevel.Region,
                     new[] {"region_code", "region_name"}
+                },
+                {
+                    GeographicLevel.School,
+                    new[] {"school_urn", "school_name"}
                 },
                 {
                     GeographicLevel.Sponsor,
@@ -341,8 +350,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 GetMultiAcademyTrust(line, headers),
                 GetOpportunityArea(line, headers),
                 GetParliamentaryConstituency(line, headers),
+                GetProvider(line, headers),
                 GetRegion(line, headers),
                 GetRscRegion(line, headers),
+                GetSchool(line, headers),
                 GetSponsor(line, headers),
                 GetWard(line, headers),
                 GetPlanningArea(line, headers)
@@ -425,6 +436,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 new ParliamentaryConstituency(values[0], values[1]));
         }
 
+        private static Provider GetProvider(IReadOnlyList<string> line,
+            List<string> headers)
+        {
+            return CsvUtil.BuildType(line, headers, ColumnValues[GeographicLevel.Provider], values =>
+                new Provider(values[0], values[1]));
+        }
+
         private static Region GetRegion(IReadOnlyList<string> line, List<string> headers)
         {
             return CsvUtil.BuildType(line, headers, ColumnValues[GeographicLevel.Region], values =>
@@ -434,6 +452,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         private static RscRegion GetRscRegion(IReadOnlyList<string> line, List<string> headers)
         {
             return CsvUtil.BuildType(line, headers, "rsc_region_lead_name", value => new RscRegion(value));
+        }
+
+        private static School GetSchool(IReadOnlyList<string> line, List<string> headers)
+        {
+            return CsvUtil.BuildType(line, headers, ColumnValues[GeographicLevel.School], values =>
+                new School(values[0], values[1]));
         }
 
         private static Sponsor GetSponsor(IReadOnlyList<string> line, List<string> headers)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IDataImportService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Interfaces
@@ -17,6 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Int
 
         Task UpdateStatus(Guid id, DataImportStatus newStatus, double percentageComplete);
 
-        Task Update(Guid id, int rowsPerBatch, int totalRows, int numBatches);
+        Task Update(Guid id, int rowsPerBatch, int totalRows, int numBatches,
+            HashSet<GeographicLevel> geographicLevels);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IImporterService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IImporterService.cs
@@ -31,10 +31,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Int
             SubjectMeta subjectMeta,
             StatisticsDbContext context);
 
-        GeographicLevel GetGeographicLevel(IReadOnlyList<string> line, List<string> headers);
+        GeographicLevel GetGeographicLevel(IReadOnlyList<string> rowValues, List<string> colValues);
 
-        TimeIdentifier GetTimeIdentifier(IReadOnlyList<string> line, List<string> headers);
+        TimeIdentifier GetTimeIdentifier(IReadOnlyList<string> rowValues, List<string> colValues);
 
-        int GetYear(IReadOnlyList<string> line, List<string> headers);
+        int GetYear(IReadOnlyList<string> rowValues, List<string> colValues);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IImporterService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/Interfaces/IImporterService.cs
@@ -20,6 +20,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.Int
             DataRowCollection rows,
             Subject subject,
             SubjectMeta subjectMeta,
+            HashSet<GeographicLevel> subjectGeographicLevels,
             int batchNo,
             int rowsPerBatch,
             StatisticsDbContext context);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ProcessorService.cs
@@ -57,7 +57,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     await _dataImportService.Update(importId, 
                         rowsPerBatch: result.RowsPerBatch,
                         totalRows: result.FilteredObservationCount,
-                        numBatches: result.NumBatches);
+                        numBatches: result.NumBatches,
+                        geographicLevels: result.GeographicLevels);
                 })
                 .OnFailureDo(async errors =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
@@ -109,7 +109,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             DataImport dataImport,
             DataTable dataFileTable)
         {
-            var headerList = CsvUtil.GetColumnValues(dataFileTable.Columns);
+            var colValues = CsvUtil.GetColumnValues(dataFileTable.Columns);
             var batches = dataFileTable.Rows.OfType<DataRow>().Batch(dataImport.RowsPerBatch);
             var batchCount = 1;
             var numRows = dataFileTable.Rows.Count + 1;
@@ -151,7 +151,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
                 var table = new DataTable();
                 CopyColumns(dataFileTable, table);
-                CopyRows(table, batch.ToList(), headerList, dataImport.GeographicLevels);
+                CopyRows(table, batch.ToList(), colValues, dataImport.GeographicLevels);
 
                 var percentageComplete = (double) batchCount / numBatches * 100;
 
@@ -233,13 +233,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
         private static void CopyRows(DataTable target,
             IEnumerable<DataRow> rows,
-            List<string> headerList,
+            List<string> colValues,
             HashSet<GeographicLevel> importGeographicLevels)
         {
             rows.ForEach(row =>
             {
                 var rowValues = CsvUtil.GetRowValues(row);
-                var geographicLevel = GetGeographicLevel(rowValues, headerList);
+                var geographicLevel = GetGeographicLevel(rowValues, colValues);
                 if (AllowRowImport(importGeographicLevels, geographicLevel))
                 {
                     target.Rows.Add(row.ItemArray);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
@@ -21,6 +21,7 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStorageUtils;
+using static GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.ImporterService;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 {
@@ -30,14 +31,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
         private readonly IBlobStorageService _blobStorageService;
         private readonly ILogger<ISplitFileService> _logger;
         private readonly IDataImportService _dataImportService;
-
-        private static readonly List<GeographicLevel> IgnoredGeographicLevels = new List<GeographicLevel>
-        {
-            GeographicLevel.Institution,
-            GeographicLevel.Provider,
-            GeographicLevel.School,
-            GeographicLevel.PlanningArea
-        };
 
         public SplitFileService(
             IBatchService batchService,
@@ -158,7 +151,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
                 var table = new DataTable();
                 CopyColumns(dataFileTable, table);
-                CopyRows(table, batch.ToList(), headerList);
+                CopyRows(table, batch.ToList(), headerList, dataImport.GeographicLevels);
 
                 var percentageComplete = (double) batchCount / numBatches * 100;
 
@@ -191,12 +184,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 batchFilesExist = true;
                 batchCount++;
             }
-        }
-
-        private static bool IsGeographicLevelIgnored(IReadOnlyList<string> line, List<string> headers)
-        {
-            var geographicLevel = GetGeographicLevel(line, headers);
-            return IgnoredGeographicLevels.Contains(geographicLevel);
         }
 
         private static GeographicLevel GetGeographicLevel(IReadOnlyList<string> line, List<string> headers)
@@ -244,12 +231,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             }
         }
 
-        private static void CopyRows(DataTable target, IEnumerable<DataRow> rows, List<string> headerList)
+        private static void CopyRows(DataTable target,
+            IEnumerable<DataRow> rows,
+            List<string> headerList,
+            HashSet<GeographicLevel> importGeographicLevels)
         {
-            foreach (var row in from line in rows let s = CsvUtil.GetRowValues(line) where !IsGeographicLevelIgnored(s, headerList) select line)
+            rows.ForEach(row =>
             {
-                target.Rows.Add(row.ItemArray);
-            }
+                var rowValues = CsvUtil.GetRowValues(row);
+                var geographicLevel = GetGeographicLevel(rowValues, headerList);
+                if (AllowRowImport(importGeographicLevels, geographicLevel))
+                {
+                    target.Rows.Add(row.ItemArray);
+                }
+            });
         }
 
         private static int GetBatchNumberFromBatchFileName(string batchFileName)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/SplitFileService.cs
@@ -21,7 +21,7 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStorageUtils;
-using static GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.ImporterService;
+using static GovUk.Education.ExploreEducationStatistics.Data.Processor.Utils.ImporterUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 {
@@ -236,11 +236,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             List<string> colValues,
             HashSet<GeographicLevel> importGeographicLevels)
         {
+            var hasSoloAllowedGeographicLevel = HasSoloAllowedGeographicLevel(importGeographicLevels);
             rows.ForEach(row =>
             {
                 var rowValues = CsvUtil.GetRowValues(row);
                 var geographicLevel = GetGeographicLevel(rowValues, colValues);
-                if (AllowRowImport(importGeographicLevels, geographicLevel))
+                if (hasSoloAllowedGeographicLevel || AllowRowImport(geographicLevel))
                 {
                     target.Rows.Add(row.ItemArray);
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
@@ -8,6 +8,7 @@ using CsvHelper;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
@@ -243,15 +244,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 ExecutionContext executionContext,
                 Guid importId)
         {
-            var idx = 0;
-            var filteredRows = 0;
             var totalRowCount = 0;
+            var filteredRows = 0;
             var errors = new List<DataImportError>();
             var dataRows = rows.Count;
+            var geographicLevels = new HashSet<GeographicLevel>();
 
             foreach (DataRow row in rows)
             {
-                idx++;
+                totalRowCount++;
                 if (errors.Count == 100)
                 {
                     errors.Add(new DataImportError(FirstOneHundredErrors.GetEnumLabel()));
@@ -263,7 +264,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                     var rowValues = CsvUtil.GetRowValues(row);
                     var colValues = CsvUtil.GetColumnValues(cols);
 
-                    _importerService.GetGeographicLevel(rowValues, colValues);
+                    geographicLevels
+                        .Add(_importerService.GetGeographicLevel(rowValues, colValues));
                     _importerService.GetTimeIdentifier(rowValues, colValues);
                     _importerService.GetYear(rowValues, colValues);
                     
@@ -274,11 +276,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 }
                 catch (Exception e)
                 {
-                    errors.Add(new DataImportError($"error at row {idx}: {e.Message}"));
+                    errors.Add(new DataImportError($"error at row {totalRowCount}: {e.Message}"));
                 }
                 
-                totalRowCount++;
-
                 if (totalRowCount % Stage1RowCheck == 0)
                 {
                     await _dataImportService.UpdateStatus(importId,
@@ -298,12 +298,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
 
             var rowsPerBatch = Convert.ToInt32(LoadAppSettings(executionContext).GetValue<string>("RowsPerBatch"));
 
-            return new ProcessorStatistics
-            {
-                FilteredObservationCount = filteredRows,
-                RowsPerBatch = rowsPerBatch,
-                NumBatches = GetNumBatches(totalRowCount, rowsPerBatch)
-            };
+            return new ProcessorStatistics(
+                filteredObservationCount: filteredRows,
+                rowsPerBatch: rowsPerBatch,
+                numBatches: GetNumBatches(totalRowCount, rowsPerBatch),
+                geographicLevels: geographicLevels
+            );
         }
 
         private bool IsGeographicLevelIgnored(IReadOnlyList<string> line, List<string> headers)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ValidatorService.cs
@@ -20,7 +20,7 @@ using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Common.Validators.FileTypeValidationUtils;
-using static GovUk.Education.ExploreEducationStatistics.Data.Processor.Services.ImporterService;
+using static GovUk.Education.ExploreEducationStatistics.Data.Processor.Utils.ImporterUtils;
 using File = GovUk.Education.ExploreEducationStatistics.Content.Model.File;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Utils/CsvUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Utils/CsvUtil.cs
@@ -8,28 +8,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Utils
 {
     public static class CsvUtil
     {
-        public static T BuildType<T>(IReadOnlyList<string> line, List<string> headers, string column,
+        public static T BuildType<T>(IReadOnlyList<string> rowValues, List<string> colValues, string column,
             Func<string, T> func)
         {
-            var value = Value(line, headers, column);
+            var value = Value(rowValues, colValues, column);
             return value == null ? default(T) : func(value);
         }
 
-        public static T BuildType<T>(IReadOnlyList<string> line, List<string> headers, IEnumerable<string> columns,
+        public static T BuildType<T>(IReadOnlyList<string> rowValues, List<string> colValues, IEnumerable<string> columns,
             Func<string[], T> func)
         {
-            var values = Values(line, headers, columns);
+            var values = Values(rowValues, colValues, columns);
             return values.All(value => value == null) ? default(T) : func(values);
         }
 
-        public static string[] Values(IReadOnlyList<string> line, List<string> headers, IEnumerable<string> columns)
+        public static string[] Values(IReadOnlyList<string> rowValues, List<string> colValues, IEnumerable<string> columns)
         {
-            return columns.Select(c => Value(line, headers, c)).ToArray();
+            return columns.Select(c => Value(rowValues, colValues, c)).ToArray();
         }
 
-        public static string Value(IReadOnlyList<string> line, List<string> headers, string column)
+        public static string Value(IReadOnlyList<string> rowValues, List<string> colValues, string column)
         {
-            return headers.Contains(column) ? line[headers.FindIndex(h => h.Equals(column))].Trim().NullIfWhiteSpace() : null;
+            return colValues.Contains(column) ? rowValues[colValues.FindIndex(h => h.Equals(column))].Trim().NullIfWhiteSpace() : null;
         }
 
         public static List<string> GetColumnValues(DataColumnCollection cols)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Utils/ImporterUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Utils/ImporterUtils.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Utils
+{
+    public static class ImporterUtils
+    {
+        public static readonly List<GeographicLevel> IgnoredGeographicLevels = new List<GeographicLevel>
+        {
+            GeographicLevel.Institution,
+            GeographicLevel.Provider,
+            GeographicLevel.School,
+            GeographicLevel.PlanningArea
+        };
+
+        private static readonly List<GeographicLevel> AllowedSoloGeographicLevels = new List<GeographicLevel>
+        {
+            GeographicLevel.Provider,
+            GeographicLevel.School,
+        };
+
+        /// <summary>
+        /// If a subject contains a single geographic level that is contained in AllowedSoloGeographicLevels, then
+        /// we import every CSV row of that subject's data file.
+        /// </summary>
+        /// <remarks>
+        /// If a subject contains more than one geographic level or isn't included in AllowedSoloGeographicLevels,
+        /// we then defer to AllowRowImport to determine if a particular row should be imported.
+        /// </remarks>
+        public static bool HasSoloAllowedGeographicLevel(HashSet<GeographicLevel> subjectGeographicLevels)
+        {
+            return subjectGeographicLevels.Count == 1
+                   && AllowedSoloGeographicLevels.Contains(subjectGeographicLevels.ElementAt(0));
+        }
+
+        /// <summary>
+        /// Determines if a specific data file CSV row should be imported based on whether it is in
+        /// IgnoredGeographicLevels.
+        /// </summary>
+        /// <remarks>
+        /// This method is used in conjunction with HasSoloAllowedGeographicLevel to determine what data file CSV rows
+        /// should and shouldn't be imported.
+        /// </remarks>
+        public static bool AllowRowImport(GeographicLevel rowGeographicLevel)
+        {
+            return !IgnoredGeographicLevels.Contains(rowGeographicLevel);
+        }
+
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationPredicateBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationPredicateBuilder.cs
@@ -102,6 +102,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 predicate = predicate.Or(ParliamentaryConstituencyPredicate(query));
             }
 
+            if (query.Provider != null)
+            {
+                predicate = predicate.Or(ProviderPredicate(query));
+            }
+
             if (query.Region != null)
             {
                 predicate = predicate.Or(RegionPredicate(query));
@@ -110,6 +115,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             if (query.RscRegion != null)
             {
                 predicate = predicate.Or(RscRegionPredicate(query));
+            }
+
+            if (query.School != null)
+            {
+                predicate = predicate.Or(SchoolPredicate(query));
             }
 
             if (query.Sponsor != null)
@@ -221,6 +231,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     query.ParliamentaryConstituency.Contains(observation.Location.ParliamentaryConstituency_Code));
         }
 
+        private static Expression<Func<Observation, bool>> ProviderPredicate(
+            LocationQuery query)
+        {
+            return ObservationalUnitPredicate(query, GeographicLevel.Provider,
+                observation =>
+                    query.Provider.Contains(observation.Location.Provider_Code));
+        }
+
         private static Expression<Func<Observation, bool>> RegionPredicate(LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.Region,
@@ -231,6 +249,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         {
             return ObservationalUnitPredicate(query, GeographicLevel.RscRegion,
                 observation => query.RscRegion.Contains(observation.Location.RscRegion_Code));
+        }
+
+        private static Expression<Func<Observation, bool>> SchoolPredicate(LocationQuery query)
+        {
+            return ObservationalUnitPredicate(query, GeographicLevel.School,
+                observation => query.School.Contains(observation.Location.School_Code));
         }
 
         private static Expression<Func<Observation, bool>> SponsorPredicate(LocationQuery query)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
@@ -57,10 +57,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 CreateIdListType("opportunityAreaList", locationsQuery?.OpportunityArea);
             var parliamentaryConstituencyListParam =
                 CreateIdListType("parliamentaryConstituencyList", locationsQuery?.ParliamentaryConstituency);
+            var providersListParam =
+                CreateIdListType("providersList", locationsQuery?.Provider);
             var planningAreaListParam =
                 CreateIdListType("planningAreaList", locationsQuery?.PlanningArea);
             var regionsListParam = CreateIdListType("regionsList", locationsQuery?.Region);
             var rscRegionListParam = CreateIdListType("rscRegionsList", locationsQuery?.RscRegion);
+            var schoolsListParam = CreateIdListType("schoolsList", locationsQuery?.School);
             var sponsorListParam = CreateIdListType("sponsorList", locationsQuery?.Sponsor);
             var wardListParam =
                 CreateIdListType("wardList", locationsQuery?.Ward);
@@ -85,8 +88,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                             "@multiAcademyTrustList," +
                             "@opportunityAreaList," +
                             "@parliamentaryConstituencyList," +
+                            "@providersList," +
                             "@regionsList," +
                             "@rscRegionsList," +
+                            "@schoolsList," +
                             "@sponsorList," +
                             "@wardList," +
                             "@planningAreaList," +
@@ -105,8 +110,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     multiAcademyTrustListParam,
                     opportunityAreaListParam,
                     parliamentaryConstituencyListParam,
+                    providersListParam,
                     regionsListParam,
                     rscRegionListParam,
+                    schoolsListParam,
                     sponsorListParam,
                     wardListParam,
                     planningAreaListParam,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/LocationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/LocationViewModel.cs
@@ -12,8 +12,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
         public CodeNameViewModel MultiAcademyTrust { get; set; }
         public CodeNameViewModel OpportunityArea { get; set; }
         public CodeNameViewModel ParliamentaryConstituency { get; set; }
+        public CodeNameViewModel Provider { get; set; }
         public CodeNameViewModel Region { get; set; }
         public CodeNameViewModel RscRegion { get; set; }
+        public CodeNameViewModel School { get; set; }
         public CodeNameViewModel Sponsor { get; set; }
         public CodeNameViewModel Ward { get; set; }
         public CodeNameViewModel PlanningArea { get; set; }

--- a/tests/newman/files/small-files/all_geographies.csv
+++ b/tests/newman/files/small-files/all_geographies.csv
@@ -1,201 +1,204 @@
-time_period,time_identifier,geographic_level,country_code,country_name,old_la_code,new_la_code,la_name,region_code,region_name,lad_code,lad_name,local_enterprise_partnership_code,local_enterprise_partnership_name,rsc_region_lead_name,opportunity_area_code,opportunity_area_name,pcon_code,pcon_name,ward_code,ward_name,planning_area_code,planning_area_name,english_devolved_area_code,english_devolved_area_name,admission_numbers
-2018,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,,,3962
-2018,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,,,8123
-2018,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,,,5669
-2018,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,,,2399
-2017,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,,,8530
-2017,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,,,5032
-2017,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,,,6981
-2017,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,,,4180
-2016,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,,,8856
-2016,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,,,7419
-2016,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,,,8427
-2016,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,,,3548
-2015,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,,,9303
-2015,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,,,1134
-2015,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,,,6114
-2015,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,,,9790
-2014,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,,,3708
-2014,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,,,9854
-2014,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,,,8247
-2014,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,,,1054
-2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,,,6765
-2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,,,8024
-2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,,,2911
-2013,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,,,5456
-2012,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,,,6480
-2014,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,,,2284
-2020,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,,,4195
-2012,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,,,6005
-2016,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,,,2014
-2007,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,,,7769
-2013,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,,,3758
-2015,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,,,2787
-2011,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,,,9043
-2017,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,,,3001
-2017,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,,,9123
-2006,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,,,8052
-2020,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,,,1506
-2012,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,,,1090
-2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,,,8730
-2018,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,,,7423
-2011,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,,,5876
-2017,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,,,5124
-2017,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,,,2076
-2018,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,,,6170
-2014,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,,,3085
-2020,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,,,4503
-2011,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,,,1574
-2016,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,,,3221
-2010,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,,,4368
-2006,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,,,7360
-2017,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,,,6385
-2012,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,,,9216
-2010,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,,,1816
-2020,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,,,6078
-2014,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,,,5018
-2015,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,,,6882
-2016,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,,,6493
-2011,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,,,3902
-2019,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,,,8179
-2019,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,,,2701
-2013,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,,,3908
-2007,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,,,9023
-2018,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,,,7612
-2008,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,,,7916
-2011,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,,,8639
-2016,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,,,5346
-2011,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,,,6888
-2011,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,,,6526
-2010,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,,,6781
-2013,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,,,9961
-2007,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,,,6637
-2017,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,,,4896
-2008,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,,,4890
-2017,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,,,7242
-2015,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,,,2748
-2008,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,,,1010
-2009,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,,,4900
-2006,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,,,3338
-2019,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,,,1258
-2019,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,,,1023
-2019,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000984,Bolton 001,,,,,,,,,8533
-2008,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000985,Bolton 002,,,,,,,,,4587
-2010,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000986,Bolton 003,,,,,,,,,4621
-2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000987,Bolton 004,,,,,,,,,6031
-2009,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,,,,,5815
-2016,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,,,,,5831
-2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,,,,,1028
-2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,,,,,3481
-2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,,,,,6373
-2006,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,,,,,9341
-2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,,,,,6641
-2005,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,,,,,8557
-2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,,,,,3837
-2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,,,,,5680
-2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,,,,,1869
-2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,,,,,8427
-2010,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,,,,,5595
-2019,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,,,,,6945
-2014,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,,,,,8084
-2018,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,,,,,8630
-2018,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,,,5549
-2020,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,,,6676
-2009,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,,,2409
-2010,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,,,2321
-2015,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,,,5653
-2016,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,,,1433
-2006,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,,,1605
-2020,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,,,7569
-2016,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,,,1617
-2019,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,,,9468
-2015,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,,,8650
-2009,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,,,3004
-2011,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,,,5099
-2005,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,,,2179
-2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,,,4066
-2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,,,2003
-2017,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,,,4465
-2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,,,9208
-2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,,,8322
-2019,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,,,3927
-2009,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,,,2287
-2016,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,,,7357
-2006,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,,,7066
-2007,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,,,7004
-2015,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,,,6850
-2005,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,,,7988
-2019,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,,,1695
-2015,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,,,5872
-2018,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,,,4496
-2010,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,,,2266
-2019,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,,,6296
-2008,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,,,5901
-2009,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,,,4157
-2015,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,,,7731
-2012,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,,,6383
-2011,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,,,7904
-2017,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,,,1615
-2016,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,,,9207
-2009,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,,,2848
-2009,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,,,2192
-2017,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,,,1959
-2017,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,,,9857
-2005,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,,,3612
-2011,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,,,4415
-2007,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,,,9914
-2016,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,,,6772
-2016,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,,,4198
-2015,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,,,4613
-2010,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,,,6060
-2014,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,,,3646
-2010,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,,,9304
-2020,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,,,6650
-2012,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,,,1109
-2018,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,,,1926
-2012,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,,,8150
-2016,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,,,4035
-2008,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,,,5505
-2007,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,,,7499
-2011,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,,,9603
-2007,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,,,9884
-2019,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E02000984,Bolton 001,,,8533
-2008,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E02000985,Bolton 002,,,4587
-2010,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E02000986,Bolton 003,,,4621
-2020,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E02000987,Bolton 004,,,6031
-2009,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05000364,Bolton 001,,,5815
-2016,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05006937,Bolton 002,,,5831
-2020,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010291,Bolton 003,,,1028
-2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010450,Bolton 004,,,3481
-2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05000364,Bolton 001,,,6373
-2006,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05006937,Bolton 002,,,9341
-2020,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010291,Bolton 003,,,6641
-2005,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010450,Bolton 004,,,8557
-2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05000364,Bolton 001,,,3837
-2020,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05006937,Bolton 002,,,5680
-2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010291,Bolton 003,,,1869
-2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010450,Bolton 004,,,8427
-2010,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05000364,Bolton 001,,,5595
-2019,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05006937,Bolton 002,,,6945
-2014,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010291,Bolton 003,,,8084
-2018,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010450,Bolton 004,,,8630
-2018,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,1,one,3962
-2018,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,2,two,8123
-2018,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,3,three,5669
-2018,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,4,four,2399
-2017,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,5,five,8530
-2017,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,6,six,5032
-2017,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,7,seven,6981
-2017,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,8,eight,4180
-2016,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,9,nine,8856
-2016,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,10,ten,7419
-2016,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,11,eleven,8427
-2016,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,12,twelve,3548
-2015,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,13,thirteen,9303
-2015,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,14,fourteen,1134
-2015,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,15,fifteen,6114
-2015,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,16,sixteen,9790
-2014,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,17,seventeen,3708
-2014,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,18,eighteen,9854
-2014,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,19,nineteen,8247
-2014,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,20,twenty,1054
+time_period,time_identifier,geographic_level,country_code,country_name,old_la_code,new_la_code,la_name,region_code,region_name,lad_code,lad_name,local_enterprise_partnership_code,local_enterprise_partnership_name,rsc_region_lead_name,opportunity_area_code,opportunity_area_name,pcon_code,pcon_name,ward_code,ward_name,planning_area_code,planning_area_name,english_devolved_area_code,english_devolved_area_name,institution_name,institution_id,provider_name,provider_ukprn,school_name,school_urn,admission_numbers
+2018,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,,,,,,,,,3962
+2018,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,,,,,,,,,8123
+2018,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,,,,,,,,,5669
+2018,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,,,,,,,,,2399
+2017,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,,,,,,,,,8530
+2017,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,,,,,,,,,5032
+2017,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,,,,,,,,,6981
+2017,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,,,,,,,,,4180
+2016,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,,,,,,,,,8856
+2016,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,,,,,,,,,7419
+2016,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,,,,,,,,,8427
+2016,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,,,,,,,,,3548
+2015,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,,,,,,,,,9303
+2015,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,,,,,,,,,1134
+2015,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,,,,,,,,,6114
+2015,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,,,,,,,,,9790
+2014,Calendar year,Local authority,E92000001,England,330,E08000025,Birmingham,,,,,,,,,,,,,,,,,,,,,,,,3708
+2014,Calendar year,Local authority,E92000001,England,370,E08000016,Barnsley,,,,,,,,,,,,,,,,,,,,,,,,9854
+2014,Calendar year,Local authority,E92000001,England,203,E09000011,Greenwich,,,,,,,,,,,,,,,,,,,,,,,,8247
+2014,Calendar year,Local authority,E92000001,England,202,E09000007,Camden,,,,,,,,,,,,,,,,,,,,,,,,1054
+2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,,,,,,,,,6765
+2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,,,,,,,,,8024
+2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,,,,,,,,,2911
+2013,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,,,,,,,,,5456
+2012,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,,,,,,,,,6480
+2014,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,,,,,,,,,2284
+2020,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,,,,,,,,,4195
+2012,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,,,,,,,,,6005
+2016,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,,,,,,,,,2014
+2007,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,,,,,,,,,7769
+2013,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,,,,,,,,,3758
+2015,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,,,,,,,,,2787
+2011,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,,,,,,,,,9043
+2017,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,,,,,,,,,3001
+2017,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,,,,,,,,,9123
+2006,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,,,,,,,,,8052
+2020,Calendar year,Local authority district,E92000001,England,,,,,,E06000001,Hartlepool,,,,,,,,,,,,,,,,,,,,1506
+2012,Calendar year,Local authority district,E92000001,England,,,,,,E06000002,Middlesbrough,,,,,,,,,,,,,,,,,,,,1090
+2008,Calendar year,Local authority district,E92000001,England,,,,,,E06000003,Redcar and Cleveland,,,,,,,,,,,,,,,,,,,,8730
+2018,Calendar year,Local authority district,E92000001,England,,,,,,E06000004,Stockton-on-Tees,,,,,,,,,,,,,,,,,,,,7423
+2011,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,,,,,,,,,5876
+2017,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,,,,,,,,,5124
+2017,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,,,,,,,,,2076
+2018,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,,,,,,,,,6170
+2014,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,,,,,,,,,3085
+2020,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,,,,,,,,,4503
+2011,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,,,,,,,,,1574
+2016,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,,,,,,,,,3221
+2010,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,,,,,,,,,4368
+2006,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,,,,,,,,,7360
+2017,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,,,,,,,,,6385
+2012,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,,,,,,,,,9216
+2010,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,,,,,,,,,1816
+2020,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,,,,,,,,,6078
+2014,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,,,,,,,,,5018
+2015,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,,,,,,,,,6882
+2016,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000001,Black Country,,,,,,,,,,,,,,,,,,6493
+2011,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000003,Chesire and Warrington,,,,,,,,,,,,,,,,,,3902
+2019,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000005,Cornwall and Isles of Scilly,,,,,,,,,,,,,,,,,,8179
+2019,Calendar year,Local enterprise partnership,E92000001,England,,,,,,,,E37000006,Coventry and Warwickshire,,,,,,,,,,,,,,,,,,2701
+2013,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,,,,,,,,,3908
+2007,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,,,,,,,,,9023
+2018,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,,,,,,,,,7612
+2008,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,,,,,,,,,7916
+2011,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,,,,,,,,,8639
+2016,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,,,,,,,,,5346
+2011,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,,,,,,,,,6888
+2011,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,,,,,,,,,6526
+2010,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,,,,,,,,,6781
+2013,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,,,,,,,,,9961
+2007,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,,,,,,,,,6637
+2017,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,,,,,,,,,4896
+2008,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,,,,,,,,,4890
+2017,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,,,,,,,,,7242
+2015,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,,,,,,,,,2748
+2008,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,,,,,,,,,1010
+2009,Calendar year,RSC region,E92000001,England,,,,,,,,,,East of England and North-East London,,,,,,,,,,,,,,,,,4900
+2006,Calendar year,RSC region,E92000001,England,,,,,,,,,,East Midlands and the Humber,,,,,,,,,,,,,,,,,3338
+2019,Calendar year,RSC region,E92000001,England,,,,,,,,,,Lancashire and West Yorkshire,,,,,,,,,,,,,,,,,1258
+2019,Calendar year,RSC region,E92000001,England,,,,,,,,,,North of England,,,,,,,,,,,,,,,,,1023
+2019,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000984,Bolton 001,,,,,,,,,,,,,,,8533
+2008,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000985,Bolton 002,,,,,,,,,,,,,,,4587
+2010,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000986,Bolton 003,,,,,,,,,,,,,,,4621
+2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E02000987,Bolton 004,,,,,,,,,,,,,,,6031
+2009,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,,,,,,,,,,,5815
+2016,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,,,,,,,,,,,5831
+2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,,,,,,,,,,,1028
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,,,,,,,,,,,3481
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,,,,,,,,,,,6373
+2006,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,,,,,,,,,,,9341
+2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,,,,,,,,,,,6641
+2005,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,,,,,,,,,,,8557
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,,,,,,,,,,,3837
+2020,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,,,,,,,,,,,5680
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,,,,,,,,,,,1869
+2017,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,,,,,,,,,,,8427
+2010,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05000364,Bolton 001,,,,,,,,,,,,,,,5595
+2019,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05006937,Bolton 002,,,,,,,,,,,,,,,6945
+2014,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010291,Bolton 003,,,,,,,,,,,,,,,8084
+2018,Calendar year,Opportunity area,E92000001,England,,,,,,,,,,,E05010450,Bolton 004,,,,,,,,,,,,,,,8630
+2018,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,,,,,,,,,5549
+2020,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,,,,,,,,,6676
+2009,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,,,,,,,,,2409
+2010,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,,,,,,,,,2321
+2015,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,,,,,,,,,5653
+2016,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,,,,,,,,,1433
+2006,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,,,,,,,,,1605
+2020,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,,,,,,,,,7569
+2016,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,,,,,,,,,1617
+2019,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,,,,,,,,,9468
+2015,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,,,,,,,,,8650
+2009,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,,,,,,,,,3004
+2011,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,,,,,,,,,5099
+2005,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,,,,,,,,,2179
+2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,,,,,,,,,4066
+2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,,,,,,,,,2003
+2017,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000683,East Yorkshire,,,,,,,,,,,,,4465
+2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14000895,Richmond (Yorks),,,,,,,,,,,,,9208
+2014,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001061,York Central,,,,,,,,,,,,,8322
+2019,Calendar year,Parliamentary constituency,E92000001,England,,,,,,,,,,,,,E14001062,York Outer,,,,,,,,,,,,,3927
+2009,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,,,,,,,,,2287
+2016,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,,,,,,,,,7357
+2006,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,,,,,,,,,7066
+2007,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,,,,,,,,,7004
+2015,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,,,,,,,,,6850
+2005,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,,,,,,,,,7988
+2019,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,,,,,,,,,1695
+2015,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,,,,,,,,,5872
+2018,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,,,,,,,,,4496
+2010,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,,,,,,,,,2266
+2019,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,,,,,,,,,6296
+2008,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,,,,,,,,,5901
+2009,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,,,,,,,,,4157
+2015,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,,,,,,,,,7731
+2012,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,,,,,,,,,6383
+2011,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,,,,,,,,,7904
+2017,Calendar year,Regional,E92000001,England,,,,E12000003,Yorkshire and the Humber,,,,,,,,,,,,,,,,,,,,,,1615
+2016,Calendar year,Regional,E92000001,England,,,,E12000001,North East,,,,,,,,,,,,,,,,,,,,,,9207
+2009,Calendar year,Regional,E92000001,England,,,,E12000002,North West,,,,,,,,,,,,,,,,,,,,,,2848
+2009,Calendar year,Regional,E92000001,England,,,,E12000005,West Midlands,,,,,,,,,,,,,,,,,,,,,,2192
+2017,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,,,,,,,,,1959
+2017,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,,,,,,,,,9857
+2005,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,,,,,,,,,3612
+2011,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,,,,,,,,,4415
+2007,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,,,,,,,,,9914
+2016,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,,,,,,,,,6772
+2016,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,,,,,,,,,4198
+2015,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,,,,,,,,,4613
+2010,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,,,,,,,,,6060
+2014,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,,,,,,,,,3646
+2010,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,,,,,,,,,9304
+2020,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,,,,,,,,,6650
+2012,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,,,,,,,,,1109
+2018,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,,,,,,,,,1926
+2012,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,,,,,,,,,8150
+2016,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,,,,,,,,,4035
+2008,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05000364,Syon,,,,,,,,,,,5505
+2007,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05006937,Yoxall,,,,,,,,,,,7499
+2011,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010291,Nailsea Youngwood,,,,,,,,,,,9603
+2007,Calendar year,Ward,E92000001,England,,,,,,,,,,,,,,,E05010450,Rural West York,,,,,,,,,,,9884
+2019,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E02000984,ShouldNotAppear 1,,,,,,,,,8533
+2008,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E02000985,ShouldNotAppear 2,,,,,,,,,4587
+2010,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E02000986,ShouldNotAppear 3,,,,,,,,,4621
+2020,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E02000987,ShouldNotAppear 4,,,,,,,,,6031
+2009,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05000364,ShouldNotAppear 5,,,,,,,,,5815
+2016,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05006937,ShouldNotAppear 6,,,,,,,,,5831
+2020,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010291,ShouldNotAppear 7,,,,,,,,,1028
+2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010450,ShouldNotAppear 8,,,,,,,,,3481
+2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05000364,ShouldNotAppear 9,,,,,,,,,6373
+2006,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05006937,ShouldNotAppear 10,,,,,,,,,9341
+2020,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010291,ShouldNotAppear 11,,,,,,,,,6641
+2005,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010450,ShouldNotAppear 12,,,,,,,,,8557
+2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05000364,ShouldNotAppear 13,,,,,,,,,3837
+2020,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05006937,ShouldNotAppear 14,,,,,,,,,5680
+2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010291,ShouldNotAppear 15,,,,,,,,,1869
+2017,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010450,ShouldNotAppear 16,,,,,,,,,8427
+2010,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05000364,ShouldNotAppear 17,,,,,,,,,5595
+2019,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05006937,ShouldNotAppear 18,,,,,,,,,6945
+2014,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010291,ShouldNotAppear 19,,,,,,,,,8084
+2018,Calendar year,Planning area,E92000001,England,,,,,,,,,,,,,,,,,E05010450,ShouldNotAppear 20,,,,,,,,,8630
+2018,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,1,one,,,,,,,3962
+2018,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,2,two,,,,,,,8123
+2018,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,3,three,,,,,,,5669
+2018,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,4,four,,,,,,,2399
+2017,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,5,five,,,,,,,8530
+2017,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,6,six,,,,,,,5032
+2017,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,7,seven,,,,,,,6981
+2017,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,8,eight,,,,,,,4180
+2016,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,9,nine,,,,,,,8856
+2016,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,10,ten,,,,,,,7419
+2016,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,11,eleven,,,,,,,8427
+2016,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,12,twelve,,,,,,,3548
+2015,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,13,thirteen,,,,,,,9303
+2015,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,14,fourteen,,,,,,,1134
+2015,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,15,fifteen,,,,,,,6114
+2015,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,16,sixteen,,,,,,,9790
+2014,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,17,seventeen,,,,,,,3708
+2014,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,18,eighteen,,,,,,,9854
+2014,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,19,nineteen,,,,,,,8247
+2014,Calendar year,English devolved area,E92000001,England,,,,,,,,,,,,,,,,,,,20,twenty,,,,,,,1054
+2020,Calendar year,Provider,E92000001,England,,,,,,,,,,,,,,,,,,,,,,,ThisShouldNotAppear,1,,,
+2020,Calendar year,School,E92000001,England,,,,,,,,,,,,,,,,,,,,,,,,,ThisShouldNotAppear,1,
+2020,Calendar year,Institution,E92000001,England,,,,,,,,,,,,,,,,,,,,,ThisShouldNotAppear,1,,,,,

--- a/tests/newman/files/small-files/institution_and_provider.csv
+++ b/tests/newman/files/small-files/institution_and_provider.csv
@@ -1,0 +1,11 @@
+time_period,time_identifier,geographic_level,country_code,country_name,institution_name,institution_id,provider_ukprn,provider_name,admission_numbers
+2011,Calendar year,Institution,E92000001,England,One,1,,,712196
+2011,Calendar year,Institution,E92000001,England,Two,2,,,709548
+2011,Calendar year,Institution,E92000001,England,Three,3,,,709143
+2011,Calendar year,Institution,E92000001,England,Four,4,,,607928
+2222,Calendar year,Institution,E92000001,England,Five,5,,,600903
+2011,Calendar year,Provider,E92000001,England,,,6,Six,712196
+2011,Calendar year,Provider,E92000001,England,,,7,Seven,709548
+2011,Calendar year,Provider,E92000001,England,,,8,Eight,709143
+2011,Calendar year,Provider,E92000001,England,,,9,Nine,607928
+2222,Calendar year,Provider,E92000001,England,,,10,Ten,600903

--- a/tests/newman/files/small-files/institution_and_provider.meta.csv
+++ b/tests/newman/files/small-files/institution_and_provider.meta.csv
@@ -1,0 +1,2 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+admission_numbers,Indicator,Admission Numbers,,,,,

--- a/tests/newman/files/small-files/institution_only.csv
+++ b/tests/newman/files/small-files/institution_only.csv
@@ -1,0 +1,6 @@
+time_period,time_identifier,geographic_level,country_code,country_name,institution_id,institution_name,admission_numbers
+2011,Calendar year,Institution,E92000001,England,1,One,712196
+2011,Calendar year,Institution,E92000001,England,2,Two,709548
+2011,Calendar year,Institution,E92000001,England,3,Three,709143
+2011,Calendar year,Institution,E92000001,England,4,Four,607928
+2222,Calendar year,Institution,E92000001,England,5,Five,600903

--- a/tests/newman/files/small-files/institution_only.meta.csv
+++ b/tests/newman/files/small-files/institution_only.meta.csv
@@ -1,0 +1,2 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+admission_numbers,Indicator,Admission Numbers,,,,,

--- a/tests/newman/files/small-files/provider_only.csv
+++ b/tests/newman/files/small-files/provider_only.csv
@@ -1,0 +1,6 @@
+time_period,time_identifier,geographic_level,country_code,country_name,provider_ukprn,provider_name,admission_numbers
+2011,Calendar year,Provider,E92000001,England,1,One,712196
+2011,Calendar year,Provider,E92000001,England,2,Two,709548
+2011,Calendar year,Provider,E92000001,England,3,Three,709143
+2011,Calendar year,Provider,E92000001,England,4,Four,607928
+2222,Calendar year,Provider,E92000001,England,5,Five,600903

--- a/tests/newman/files/small-files/provider_only.meta.csv
+++ b/tests/newman/files/small-files/provider_only.meta.csv
@@ -1,0 +1,2 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+admission_numbers,Indicator,Admission Numbers,,,,,

--- a/tests/newman/files/small-files/school_and_provider.csv
+++ b/tests/newman/files/small-files/school_and_provider.csv
@@ -1,0 +1,11 @@
+time_period,time_identifier,geographic_level,country_code,country_name,provider_ukprn,provider_name,school_urn,school_name,admission_numbers
+2011,Calendar year,Provider,E92000001,England,1,One,,,712196
+2011,Calendar year,Provider,E92000001,England,2,Two,,,709548
+2011,Calendar year,Provider,E92000001,England,3,Three,,,709143
+2011,Calendar year,Provider,E92000001,England,4,Four,,,607928
+2222,Calendar year,Provider,E92000001,England,5,Five,,,600903
+2011,Calendar year,School,E92000001,England,,,6,Six,712196
+2011,Calendar year,School,E92000001,England,,,7,Seven,709548
+2011,Calendar year,School,E92000001,England,,,8,Eight,709143
+2011,Calendar year,School,E92000001,England,,,9,Nine,607928
+2222,Calendar year,School,E92000001,England,,,10,Ten,600903

--- a/tests/newman/files/small-files/school_and_provider.meta.csv
+++ b/tests/newman/files/small-files/school_and_provider.meta.csv
@@ -1,0 +1,2 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+admission_numbers,Indicator,Admission Numbers,,,,,

--- a/tests/newman/files/small-files/school_only.csv
+++ b/tests/newman/files/small-files/school_only.csv
@@ -1,0 +1,6 @@
+time_period,time_identifier,geographic_level,country_code,country_name,school_urn,school_name,admission_numbers
+2011,Calendar year,School,E92000001,England,6,Six,712196
+2011,Calendar year,School,E92000001,England,7,Seven,709548
+2011,Calendar year,School,E92000001,England,8,Eight,709143
+2011,Calendar year,School,E92000001,England,9,Nine,607928
+2222,Calendar year,School,E92000001,England,10,Ten,600903

--- a/tests/newman/files/small-files/school_only.meta.csv
+++ b/tests/newman/files/small-files/school_only.meta.csv
@@ -1,0 +1,2 @@
+col_name,col_type,label,indicator_grouping,indicator_unit,indicator_dp,filter_hint,filter_grouping_column
+admission_numbers,Indicator,Admission Numbers,,,,,


### PR DESCRIPTION
This PR adds new GeographicLevels School and Provider. These new GeographicLevels are only imported if they are the sole GeographicLevel on a subject. Insitution and PlanningArea GeographicLevels are still never imported. All other GeographicLevels are always imported.

The GeographicLevels of a particular subject are now saved in the DataImport table. This is then used to determine whether that row should be imported in `ImporterService#AllowRowImport`. 

`ImporterService#HasSoloAllowedGeographicLevel` has been created to allow us to keep `FileImportService#CheckComplete` working, specifically that the number of Observations imported into the database matches what `ValidatorService#ValidateAndCountObservations` expected.

For future reference, the first commit of this PR should list all the places that need changing when adding a new GeographicLevel.