### PR TITLE
EES-2504 Fix bug to allow deleting all container blobs

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Mime;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -110,7 +111,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         public async Task DeleteBlobs(IBlobContainer containerName, string directoryPath, string excludePattern = null)
         {
-            var prefix = directoryPath.AppendTrailingSlash();
+            if (!directoryPath.IsNullOrEmpty())
+            {
+                // Forcefully add a trailing slash to prevent deleting blobs whose names begin with that string
+                directoryPath = directoryPath.AppendTrailingSlash();
+            }
 
             var blobContainer = await GetBlobContainer(containerName);
 
@@ -120,7 +125,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
             do
             {
-                var blobPages = blobContainer.GetBlobsAsync(prefix: prefix)
+                var blobPages = blobContainer.GetBlobsAsync(prefix: directoryPath)
                     .AsPages(continuationToken);
 
                 var deleteTasks = new List<Task>();


### PR DESCRIPTION
This PR fixes a bug in `BlobStorageService` which is preventing deleting all blobs in a container.

As well as deleting a subfolder of blobs, this method can be used to delete all container blobs without specifying a `directoryPath`, e.g. as used by the Publisher DeleteAllContentFunction which is used to perform a full content refresh.

In this case we don't want to append a trailing slash to an empty `directoryPath` otherwise

Prefix: `/`

matches no blobs which have names of the format

```
Blob name: FolderA/blob1
Blob name: FolderA/blob2
Blob name: FolderA/blob3
Blob name: FolderA/FolderB/blob1
Blob name: FolderB/blob1
Blob name: FolderB/blob2
```

since no blob names begin `/`.