### PR TITLE
EES-2359 Add handling for empty data guidance values

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/HtmlToTextUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/HtmlToTextUtilsTests.cs
@@ -28,6 +28,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
         }
 
         [Fact]
+        public async Task HtmlToText_EmptyString()
+        {
+            Assert.Empty(await HtmlToTextUtils.HtmlToText(""));
+        }
+
+        [Fact]
+        public async Task HtmlToText_WhitespaceStrings()
+        {
+            Assert.Empty(await HtmlToTextUtils.HtmlToText("  "));
+            Assert.Empty(await HtmlToTextUtils.HtmlToText("  \n  "));
+            Assert.Empty(await HtmlToTextUtils.HtmlToText("  \r\n  "));
+        }
+
+        [Fact]
         public async Task HtmlToText_SingleElement()
         {
             var text = await HtmlToTextUtils.HtmlToText(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/HtmlToTextUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/HtmlToTextUtils.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Threading.Tasks;
 using AngleSharp;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils.Html;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/DataGuidanceFileWriterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/DataGuidanceFileWriterTests.cs
@@ -42,6 +42,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             </ul>
             ";
 
+        private const string TestBasicMetaGuidance = @"
+            <p>
+                This document describes the data included in the ‘Children looked after in England'
+            </p>
+        ";
+
         private readonly List<string> _filePaths = new List<string>();
 
         public void Dispose()
@@ -58,7 +64,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var releaseService = new Mock<IReleaseService>();
 
-            releaseService.Setup(s => s.Get(releaseId))
+            releaseService
+                .Setup(s => s.Get(releaseId))
                 .ThrowsAsync(new ArgumentException("Could not find release"));
 
             var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>(MockBehavior.Strict);
@@ -71,10 +78,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var path = GenerateFilePath();
 
             var exception = await Assert.ThrowsAsync<ArgumentException>(
-                async () =>
-                {
-                    await writer.WriteFile(releaseId, path);
-                }
+                async () => { await writer.WriteFile(releaseId, path); }
             );
 
             Assert.Equal($"Could not find release", exception.Message);
@@ -99,7 +103,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var releaseService = new Mock<IReleaseService>();
 
-            releaseService.Setup(s => s.Get(release.Id))
+            releaseService
+                .Setup(s => s.Get(release.Id))
                 .ReturnsAsync(release);
 
             var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>(MockBehavior.Strict);
@@ -112,13 +117,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var path = GenerateFilePath();
 
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-                async () =>
-                {
-                    await writer.WriteFile(release.Id, path);
-                }
+                async () => { await writer.WriteFile(release.Id, path); }
             );
 
-            Assert.Equal($"Cannot create data guidance file for release {release.Id} with no data guidance", exception.Message);
+            Assert.Equal(
+                $"Cannot create data guidance file for release {release.Id} with no data guidance",
+                exception.Message
+            );
 
             Assert.False(File.Exists(path));
             MockUtils.VerifyAllMocks(releaseService, metaGuidanceSubjectService);
@@ -141,12 +146,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var releaseService = new Mock<IReleaseService>();
 
-            releaseService.Setup(s => s.Get(release.Id))
+            releaseService
+                .Setup(s => s.Get(release.Id))
                 .ReturnsAsync(release);
 
             var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>();
 
-            metaGuidanceSubjectService.Setup(s => s.GetSubjects(release.Id, null))
+            metaGuidanceSubjectService
+                .Setup(s => s.GetSubjects(release.Id, null))
                 .ReturnsAsync(new NotFoundResult());
 
             var writer = BuildDataGuidanceFileWriter(
@@ -157,10 +164,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var path = GenerateFilePath();
 
             var exception = await Assert.ThrowsAsync<ArgumentException>(
-                async () =>
-                {
-                    await writer.WriteFile(release.Id, path);
-                }
+                async () => { await writer.WriteFile(release.Id, path); }
             );
 
             Assert.Equal($"Could not find subjects for release: {release.Id}", exception.Message);
@@ -236,12 +240,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var releaseService = new Mock<IReleaseService>();
 
-            releaseService.Setup(s => s.Get(release.Id))
+            releaseService
+                .Setup(s => s.Get(release.Id))
                 .ReturnsAsync(release);
 
             var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>();
 
-            metaGuidanceSubjectService.Setup(s => s.GetSubjects(release.Id, null))
+            metaGuidanceSubjectService
+                .Setup(s => s.GetSubjects(release.Id, null))
                 .ReturnsAsync(subjects);
 
             var writer = BuildDataGuidanceFileWriter(
@@ -306,12 +312,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var releaseService = new Mock<IReleaseService>();
 
-            releaseService.Setup(s => s.Get(release.Id))
+            releaseService
+                .Setup(s => s.Get(release.Id))
                 .ReturnsAsync(release);
 
             var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>();
 
-            metaGuidanceSubjectService.Setup(s => s.GetSubjects(release.Id, null))
+            metaGuidanceSubjectService
+                .Setup(s => s.GetSubjects(release.Id, null))
                 .ReturnsAsync(subjects);
 
             var writer = BuildDataGuidanceFileWriter(
@@ -348,12 +356,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var releaseService = new Mock<IReleaseService>();
 
-            releaseService.Setup(s => s.Get(release.Id))
+            releaseService
+                .Setup(s => s.Get(release.Id))
                 .ReturnsAsync(release);
 
             var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>();
 
-            metaGuidanceSubjectService.Setup(s => s.GetSubjects(release.Id, null))
+            metaGuidanceSubjectService
+                .Setup(s => s.GetSubjects(release.Id, null))
                 .ReturnsAsync(new List<MetaGuidanceSubjectViewModel>());
 
             var writer = BuildDataGuidanceFileWriter(
@@ -363,6 +373,300 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             var path = GenerateFilePath();
             await using var file = await writer.WriteFile(release.Id, path);
+
+            using var reader = new StreamReader(file);
+            var text = await File.ReadAllTextAsync(path);
+
+            Assert.Equal(text, await reader.ReadToEndAsync());
+
+            Snapshot.Match(text);
+            MockUtils.VerifyAllMocks(releaseService, metaGuidanceSubjectService);
+        }
+
+        [Fact]
+        public async Task WriteFile_FileWithSingleProperties()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2020",
+                TimePeriodCoverage = TimeIdentifier.ReportingYear,
+                Publication = new Publication
+                {
+                    Title = "Test publication"
+                },
+                MetaGuidance = TestBasicMetaGuidance
+            };
+
+            var subjects = new List<MetaGuidanceSubjectViewModel>
+            {
+                new MetaGuidanceSubjectViewModel
+                {
+                    Filename = "test-1.csv",
+                    Name = "Test data 1",
+                    Content = "<p>Test file content</p>",
+                    GeographicLevels = new List<string>
+                    {
+                        "Local Authority",
+                    },
+                    TimePeriods = new TimePeriodLabels("2018", "2018"),
+                    Variables = new List<LabelValue>
+                    {
+                        new LabelValue("Accommodation type", "accommodation_type"),
+                    }
+                }
+            };
+
+            var releaseService = new Mock<IReleaseService>();
+
+            releaseService
+                .Setup(s => s.Get(release.Id))
+                .ReturnsAsync(release);
+
+            var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>();
+
+            metaGuidanceSubjectService
+                .Setup(s => s.GetSubjects(release.Id, null))
+                .ReturnsAsync(subjects);
+
+            var writer = BuildDataGuidanceFileWriter(
+                releaseService: releaseService.Object,
+                metaGuidanceSubjectService: metaGuidanceSubjectService.Object
+            );
+
+            var path = GenerateFilePath();
+            var file = await writer.WriteFile(release.Id, path);
+
+            using var reader = new StreamReader(file);
+            var text = await File.ReadAllTextAsync(path);
+
+            Assert.Equal(text, await reader.ReadToEndAsync());
+
+            Snapshot.Match(text);
+            MockUtils.VerifyAllMocks(releaseService, metaGuidanceSubjectService);
+        }
+
+        [Fact]
+        public async Task WriteFile_FileWithEmptyProperties()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2020",
+                TimePeriodCoverage = TimeIdentifier.ReportingYear,
+                Publication = new Publication
+                {
+                    Title = "Test publication"
+                },
+                MetaGuidance = TestBasicMetaGuidance
+            };
+
+            var subjects = new List<MetaGuidanceSubjectViewModel>
+            {
+                new MetaGuidanceSubjectViewModel
+                {
+                    Filename = "test-1.csv",
+                    Name = "Test data 1",
+                    Content = "",
+                    GeographicLevels = new List<string>(),
+                    TimePeriods = new TimePeriodLabels(),
+                    Variables = new List<LabelValue>()
+                }
+            };
+
+            var releaseService = new Mock<IReleaseService>();
+
+            releaseService
+                .Setup(s => s.Get(release.Id))
+                .ReturnsAsync(release);
+
+            var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>();
+
+            metaGuidanceSubjectService
+                .Setup(s => s.GetSubjects(release.Id, null))
+                .ReturnsAsync(subjects);
+
+            var writer = BuildDataGuidanceFileWriter(
+                releaseService: releaseService.Object,
+                metaGuidanceSubjectService: metaGuidanceSubjectService.Object
+            );
+
+            var path = GenerateFilePath();
+            var file = await writer.WriteFile(release.Id, path);
+
+            using var reader = new StreamReader(file);
+            var text = await File.ReadAllTextAsync(path);
+
+            Assert.Equal(text, await reader.ReadToEndAsync());
+
+            Snapshot.Match(text);
+            MockUtils.VerifyAllMocks(releaseService, metaGuidanceSubjectService);
+        }
+
+        [Fact]
+        public async Task WriteFile_FileWithEmptyTimePeriodStart()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2020",
+                TimePeriodCoverage = TimeIdentifier.ReportingYear,
+                Publication = new Publication
+                {
+                    Title = "Test publication"
+                },
+                MetaGuidance = TestBasicMetaGuidance
+            };
+
+            var subjects = new List<MetaGuidanceSubjectViewModel>
+            {
+                new MetaGuidanceSubjectViewModel
+                {
+                    Filename = "test-1.csv",
+                    Name = "Test data 1",
+                    Content = "",
+                    GeographicLevels = new List<string>(),
+                    TimePeriods = new TimePeriodLabels("", "2019"),
+                    Variables = new List<LabelValue>()
+                }
+            };
+
+            var releaseService = new Mock<IReleaseService>();
+
+            releaseService
+                .Setup(s => s.Get(release.Id))
+                .ReturnsAsync(release);
+
+            var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>();
+
+            metaGuidanceSubjectService
+                .Setup(s => s.GetSubjects(release.Id, null))
+                .ReturnsAsync(subjects);
+
+            var writer = BuildDataGuidanceFileWriter(
+                releaseService: releaseService.Object,
+                metaGuidanceSubjectService: metaGuidanceSubjectService.Object
+            );
+
+            var path = GenerateFilePath();
+            var file = await writer.WriteFile(release.Id, path);
+
+            using var reader = new StreamReader(file);
+            var text = await File.ReadAllTextAsync(path);
+
+            Assert.Equal(text, await reader.ReadToEndAsync());
+
+            Snapshot.Match(text);
+            MockUtils.VerifyAllMocks(releaseService, metaGuidanceSubjectService);
+        }
+
+        [Fact]
+        public async Task WriteFile_FileWithEmptyTimePeriodEnd()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2020",
+                TimePeriodCoverage = TimeIdentifier.ReportingYear,
+                Publication = new Publication
+                {
+                    Title = "Test publication"
+                },
+                MetaGuidance = TestBasicMetaGuidance
+            };
+
+            var subjects = new List<MetaGuidanceSubjectViewModel>
+            {
+                new MetaGuidanceSubjectViewModel
+                {
+                    Filename = "test-1.csv",
+                    Name = "Test data 1",
+                    Content = "",
+                    GeographicLevels = new List<string>(),
+                    TimePeriods = new TimePeriodLabels("2018", ""),
+                    Variables = new List<LabelValue>()
+                }
+            };
+
+            var releaseService = new Mock<IReleaseService>();
+
+            releaseService
+                .Setup(s => s.Get(release.Id))
+                .ReturnsAsync(release);
+
+            var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>();
+
+            metaGuidanceSubjectService
+                .Setup(s => s.GetSubjects(release.Id, null))
+                .ReturnsAsync(subjects);
+
+            var writer = BuildDataGuidanceFileWriter(
+                releaseService: releaseService.Object,
+                metaGuidanceSubjectService: metaGuidanceSubjectService.Object
+            );
+
+            var path = GenerateFilePath();
+            var file = await writer.WriteFile(release.Id, path);
+
+            using var reader = new StreamReader(file);
+            var text = await File.ReadAllTextAsync(path);
+
+            Assert.Equal(text, await reader.ReadToEndAsync());
+
+            Snapshot.Match(text);
+            MockUtils.VerifyAllMocks(releaseService, metaGuidanceSubjectService);
+        }
+
+        [Fact]
+        public async Task WriteFile_FileWithEmptyVariable()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                ReleaseName = "2020",
+                TimePeriodCoverage = TimeIdentifier.ReportingYear,
+                Publication = new Publication
+                {
+                    Title = "Test publication"
+                },
+                MetaGuidance = TestBasicMetaGuidance
+            };
+
+            var subjects = new List<MetaGuidanceSubjectViewModel>
+            {
+                new MetaGuidanceSubjectViewModel
+                {
+                    Filename = "test-1.csv",
+                    Name = "Test data 1",
+                    Content = "",
+                    GeographicLevels = new List<string>(),
+                    TimePeriods = new TimePeriodLabels("2018", ""),
+                    Variables = new List<LabelValue>
+                    {
+                        new LabelValue("", "")
+                    }
+                }
+            };
+
+            var releaseService = new Mock<IReleaseService>();
+
+            releaseService
+                .Setup(s => s.Get(release.Id))
+                .ReturnsAsync(release);
+
+            var metaGuidanceSubjectService = new Mock<IMetaGuidanceSubjectService>();
+
+            metaGuidanceSubjectService
+                .Setup(s => s.GetSubjects(release.Id, null))
+                .ReturnsAsync(subjects);
+
+            var writer = BuildDataGuidanceFileWriter(
+                releaseService: releaseService.Object,
+                metaGuidanceSubjectService: metaGuidanceSubjectService.Object
+            );
+
+            var path = GenerateFilePath();
+            var file = await writer.WriteFile(release.Id, path);
 
             using var reader = new StreamReader(file);
             var text = await File.ReadAllTextAsync(path);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithEmptyProperties.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithEmptyProperties.snap
@@ -1,0 +1,10 @@
+﻿Test publication
+2020 Reporting Year
+
+This document describes the data included in the ‘Children looked after in England'
+
+Data files
+
+Test data 1
+
+Filename: test-1.csv

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithEmptyTimePeriodEnd.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithEmptyTimePeriodEnd.snap
@@ -1,0 +1,11 @@
+﻿Test publication
+2020 Reporting Year
+
+This document describes the data included in the ‘Children looked after in England'
+
+Data files
+
+Test data 1
+
+Filename: test-1.csv
+Time period: 2018

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithEmptyTimePeriodStart.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithEmptyTimePeriodStart.snap
@@ -1,0 +1,11 @@
+﻿Test publication
+2020 Reporting Year
+
+This document describes the data included in the ‘Children looked after in England'
+
+Data files
+
+Test data 1
+
+Filename: test-1.csv
+Time period: 2019

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithEmptyVariable.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithEmptyVariable.snap
@@ -1,0 +1,11 @@
+﻿Test publication
+2020 Reporting Year
+
+This document describes the data included in the ‘Children looked after in England'
+
+Data files
+
+Test data 1
+
+Filename: test-1.csv
+Time period: 2018

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithSingleProperties.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithSingleProperties.snap
@@ -1,0 +1,19 @@
+﻿Test publication
+2020 Reporting Year
+
+This document describes the data included in the ‘Children looked after in England'
+
+Data files
+
+Test data 1
+
+Filename: test-1.csv
+Geographic levels: Local Authority
+Time period: 2018
+Content summary: Test file content
+
+Variable names and descriptions for this file are provided below:
+
+Variable name       |  Variable description
+------------------  |  ------------------
+accommodation_type  |  Accommodation type


### PR DESCRIPTION
This change adds missing handling for potential empty values across the data guidance file. Empty values can consist of things like empty strings for geographic levels, time periods and variable names/descriptions.

We want to avoid displaying parts of the guidance file that may contain these empty values.