### PR TITLE
Add volume to Azurite container to persist data

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - "10000:10000"
       - "10001:10001"
       - "10002:10002"
+    volumes:
+      - data-storage-data:/data
   db:
     container_name: ees-mssql
     image: "mcr.microsoft.com/mssql/server"
@@ -39,3 +41,6 @@ services:
       dockerfile: Dockerfile-Keycloak
     ports:
       - 5030:8080
+
+volumes:
+  data-storage-data:


### PR DESCRIPTION
This PR mounts a volume to the Azurite container, allowing it to persist data in between running `docker-compose up` and `down`.