### PR TITLE
EES-2509 Optimise building All Methodologies view

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using Moq;
 using Xunit;
@@ -124,22 +125,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
         public async Task GetMethodologyThemes()
         {
             var themes = AsList(
-                new ThemeTree<PublicationMethodologiesTreeNode>
+                new AllMethodologiesThemeViewModel
                 {
                     Id = Guid.NewGuid(),
-                    Summary = "Publication summary",
                     Title = "Publication title",
                     Topics = AsList(
-                        new TopicTree<PublicationMethodologiesTreeNode>
+                        new AllMethodologiesTopicViewModel
                         {
                             Id = Guid.NewGuid(),
-                            Summary = "Topic summary",
                             Title = "Topic title",
                             Publications = AsList(
-                                new PublicationMethodologiesTreeNode
+                                new AllMethodologiesPublicationViewModel
                                 {
                                     Id = Guid.NewGuid(),
-                                    Summary = "Publication summary",
                                     Title = "Publication title",
                                     Methodologies = AsList(
                                         new MethodologySummaryViewModel

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MethodologyServiceTests.cs
@@ -330,21 +330,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
         {
             var publication = new Publication
             {
-                Title = "Publication title",
-                Slug = "publication-slug",
-                Summary = "Publication summary"
+                Title = "Publication title"
             };
 
             var theme = new Theme
             {
                 Title = "Theme title",
-                Slug = "theme-slug",
-                Summary = "Theme summary",
                 Topics = AsList(
                     new Topic
                     {
                         Title = "Topic title",
-                        Slug = "topic-slug",
                         Publications = AsList(publication)
                     }
                 )
@@ -402,22 +397,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
                 Assert.Single(themes);
 
                 Assert.Equal(theme.Id, themes[0].Id);
-                Assert.Null(themes[0].Summary);
                 Assert.Equal("Theme title", themes[0].Title);
 
                 var topics = themes[0].Topics;
                 Assert.Single(topics);
 
                 Assert.Equal(theme.Topics[0].Id, topics[0].Id);
-                Assert.Null(topics[0].Summary);
                 Assert.Equal("Topic title", topics[0].Title);
 
                 var publications = topics[0].Publications;
                 Assert.Single(publications);
 
                 Assert.Equal(publication.Id, publications[0].Id);
-                Assert.Equal("publication-slug", publications[0].Slug);
-                Assert.Equal("Publication summary", publications[0].Summary);
                 Assert.Equal("Publication title", publications[0].Title);
 
                 var methodologies = publications[0].Methodologies;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/ViewModels/AllMethodologiesThemeViewModelTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/ViewModels/AllMethodologiesThemeViewModelTests.cs
@@ -1,0 +1,213 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.ViewModels
+{
+    public class AllMethodologiesThemeViewModelTests
+    {
+        [Fact]
+        public void RemoveTopicNodesWithoutMethodologiesAndSort_RemovesTopicsWithoutMethodologies()
+        {
+            var model = new AllMethodologiesThemeViewModel
+            {
+                Title = "ThemeWithTopics",
+                Topics = AsList(
+                    new AllMethodologiesTopicViewModel
+                    {
+                        Title = "TopicWithoutPublications",
+                        Publications = new List<AllMethodologiesPublicationViewModel>()
+                    },
+                    new AllMethodologiesTopicViewModel
+                    {
+                        Title = "TopicWithPublicationsButNoMethodologies",
+                        Publications = AsList(
+                            new AllMethodologiesPublicationViewModel
+                            {
+                                Title = "PublicationWithNoMethodologies",
+                                Methodologies = new List<MethodologySummaryViewModel>()
+                            }
+                        )
+                    },
+                    new AllMethodologiesTopicViewModel
+                    {
+                        Title = "TopicWithPublications",
+                        Publications = AsList(
+                            new AllMethodologiesPublicationViewModel
+                            {
+                                Title = "PublicationWithMethodologies",
+                                Methodologies = AsList(
+                                    new MethodologySummaryViewModel()
+                                )
+                            },
+                            new AllMethodologiesPublicationViewModel
+                            {
+                                Title = "PublicationWithoutMethodologies",
+                                Methodologies = new List<MethodologySummaryViewModel>()
+                            }
+                        )
+                    }
+                )
+            };
+
+            model.RemoveTopicNodesWithoutMethodologiesAndSort();
+
+            Assert.Single(model.Topics);
+            Assert.Equal("TopicWithPublications", model.Topics[0].Title);
+            Assert.Single(model.Topics[0].Publications);
+            Assert.Equal("PublicationWithMethodologies", model.Topics[0].Publications[0].Title);
+        }
+
+        [Fact]
+        public void RemoveTopicNodesWithoutMethodologiesAndSort_SortsTopicsAndPublicationsByTitle()
+        {
+            var model = new AllMethodologiesThemeViewModel
+            {
+                Title = "ThemeWithTopics",
+                Topics = AsList(
+                    new AllMethodologiesTopicViewModel
+                    {
+                        Title = "Topic C",
+                        Publications = AsList(
+                            new AllMethodologiesPublicationViewModel
+                            {
+                                Title = "Topic C Publication C",
+                                Methodologies = AsList(
+                                    new MethodologySummaryViewModel()
+                                )
+                            },
+                            new AllMethodologiesPublicationViewModel
+                            {
+                                Title = "Topic C Publication A",
+                                Methodologies = AsList(
+                                    new MethodologySummaryViewModel()
+                                )
+                            },
+                            new AllMethodologiesPublicationViewModel
+                            {
+                                Title = "Topic C Publication B",
+                                Methodologies = AsList(
+                                    new MethodologySummaryViewModel()
+                                )
+                            }
+                        )
+                    },
+                    new AllMethodologiesTopicViewModel
+                    {
+                        Title = "Topic A",
+                        Publications = AsList(
+                            new AllMethodologiesPublicationViewModel
+                            {
+                                Title = "Topic A Publication C",
+                                Methodologies = AsList(
+                                    new MethodologySummaryViewModel()
+                                )
+                            },
+                            new AllMethodologiesPublicationViewModel
+                            {
+                                Title = "Topic A Publication A",
+                                Methodologies = AsList(
+                                    new MethodologySummaryViewModel()
+                                )
+                            },
+                            new AllMethodologiesPublicationViewModel
+                            {
+                                Title = "Topic A Publication B",
+                                Methodologies = AsList(
+                                    new MethodologySummaryViewModel()
+                                )
+                            }
+                        )
+                    },
+                    new AllMethodologiesTopicViewModel
+                    {
+                        Title = "Topic B",
+                        Publications = AsList(
+                            new AllMethodologiesPublicationViewModel
+                            {
+                                Title = "Topic B Publication C",
+                                Methodologies = AsList(
+                                    new MethodologySummaryViewModel()
+                                )
+                            },
+                            new AllMethodologiesPublicationViewModel
+                            {
+                                Title = "Topic B Publication A",
+                                Methodologies = AsList(
+                                    new MethodologySummaryViewModel()
+                                )
+                            },
+                            new AllMethodologiesPublicationViewModel
+                            {
+                                Title = "Topic B Publication B",
+                                Methodologies = AsList(
+                                    new MethodologySummaryViewModel()
+                                )
+                            }
+                        )
+                    }
+                )
+            };
+
+            model.RemoveTopicNodesWithoutMethodologiesAndSort();
+
+            Assert.Equal(3, model.Topics.Count);
+
+            Assert.Equal("Topic A", model.Topics[0].Title);
+            Assert.Equal("Topic B", model.Topics[1].Title);
+            Assert.Equal("Topic C", model.Topics[2].Title);
+
+            Assert.Equal(3, model.Topics[0].Publications.Count);
+            Assert.Equal("Topic A Publication A", model.Topics[0].Publications[0].Title);
+            Assert.Equal("Topic A Publication B", model.Topics[0].Publications[1].Title);
+            Assert.Equal("Topic A Publication C", model.Topics[0].Publications[2].Title);
+
+            Assert.Equal(3, model.Topics[1].Publications.Count);
+            Assert.Equal("Topic B Publication A", model.Topics[1].Publications[0].Title);
+            Assert.Equal("Topic B Publication B", model.Topics[1].Publications[1].Title);
+            Assert.Equal("Topic B Publication C", model.Topics[1].Publications[2].Title);
+
+            Assert.Equal(3, model.Topics[2].Publications.Count);
+            Assert.Equal("Topic C Publication A", model.Topics[2].Publications[0].Title);
+            Assert.Equal("Topic C Publication B", model.Topics[2].Publications[1].Title);
+            Assert.Equal("Topic C Publication C", model.Topics[2].Publications[2].Title);
+        }
+
+        [Fact]
+        public void RemoveTopicNodesWithoutMethodologiesAndSort_HandlesEmptyTopics()
+        {
+            var model = new AllMethodologiesThemeViewModel
+            {
+                Title = "ThemeWithoutTopics",
+                Topics = new List<AllMethodologiesTopicViewModel>()
+            };
+
+            model.RemoveTopicNodesWithoutMethodologiesAndSort();
+
+            Assert.Empty(model.Topics);
+        }
+
+        [Fact]
+        public void RemoveTopicNodesWithoutMethodologiesAndSort_HandlesEmptyPublications()
+        {
+            var model = new AllMethodologiesThemeViewModel
+            {
+                Title = "ThemeWithTopics",
+                Topics = AsList(
+                    new AllMethodologiesTopicViewModel
+                    {
+                        Title = "TopicWithoutPublications",
+                        Publications = new List<AllMethodologiesPublicationViewModel>()
+                    }
+                )
+            };
+
+            model.RemoveTopicNodesWithoutMethodologiesAndSort();
+
+            Assert.Empty(model.Topics);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/ViewModels/AllMethodologiesTopicViewModelTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/ViewModels/AllMethodologiesTopicViewModelTests.cs
@@ -1,0 +1,93 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.ViewModels
+{
+    public class AllMethodologiesTopicViewModelTests
+    {
+        [Fact]
+        public void RemovePublicationNodesWithoutMethodologiesAndSort_RemovesPublicationsWithoutMethodologies()
+        {
+            var model = new AllMethodologiesTopicViewModel
+            {
+                Title = "TopicWithPublications",
+                Publications = AsList(
+                    new AllMethodologiesPublicationViewModel
+                    {
+                        Title = "PublicationWithoutMethodology",
+                        Methodologies = new List<MethodologySummaryViewModel>()
+                    },
+                    new AllMethodologiesPublicationViewModel
+                    {
+                        Title = "PublicationWithMethodology",
+                        Methodologies = AsList(
+                            new MethodologySummaryViewModel()
+                        )
+                    }
+                )
+            };
+
+            model.RemovePublicationNodesWithoutMethodologiesAndSort();
+
+            Assert.Single(model.Publications);
+            Assert.Equal("PublicationWithMethodology", model.Publications[0].Title);
+        }
+
+        [Fact]
+        public void RemovePublicationNodesWithoutMethodologiesAndSort_SortsPublicationsByTitle()
+        {
+            var model = new AllMethodologiesTopicViewModel
+            {
+                Title = "TopicWithPublications",
+                Publications = AsList(
+                    new AllMethodologiesPublicationViewModel
+                    {
+                        Title = "Publication C",
+                        Methodologies = AsList(
+                            new MethodologySummaryViewModel()
+                        )
+                    },
+                    new AllMethodologiesPublicationViewModel
+                    {
+                        Title = "Publication A",
+                        Methodologies = AsList(
+                            new MethodologySummaryViewModel()
+                        )
+                    },
+                    new AllMethodologiesPublicationViewModel
+                    {
+                        Title = "Publication B",
+                        Methodologies = AsList(
+                            new MethodologySummaryViewModel()
+                        )
+                    }
+                )
+            };
+
+            model.RemovePublicationNodesWithoutMethodologiesAndSort();
+
+            Assert.Equal(3, model.Publications.Count);
+            Assert.Equal("Publication A", model.Publications[0].Title);
+            Assert.Equal("Publication B", model.Publications[1].Title);
+            Assert.Equal("Publication C", model.Publications[2].Title);
+        }
+
+        [Fact]
+        public void RemovePublicationNodesWithoutMethodologiesAndSort_HandlesEmptyPublications()
+        {
+            var model = new AllMethodologiesTopicViewModel
+            {
+                Title = "TopicWithoutPublications",
+                Publications = new List<AllMethodologiesPublicationViewModel>()
+            };
+
+            model.RemovePublicationNodesWithoutMethodologiesAndSort();
+
+            Assert.Empty(model.Publications);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ThemeController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ThemeController.cs
@@ -3,6 +3,7 @@ using System.Net.Mime;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
@@ -42,7 +43,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         }
 
         [HttpGet("methodology-themes")]
-        public async Task<ActionResult<List<ThemeTree<PublicationMethodologiesTreeNode>>>> GetMethodologyThemes()
+        public async Task<ActionResult<List<AllMethodologiesThemeViewModel>>> GetMethodologyThemes()
         {
             return await _methodologyService.GetTree()
                 .HandleFailuresOrOk();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/Interfaces/IMethodologyService.cs
@@ -14,6 +14,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interf
 
         public Task<Either<ActionResult, List<MethodologySummaryViewModel>>> GetSummariesByPublication(Guid publicationId);
 
-        public Task<Either<ActionResult, List<ThemeTree<PublicationMethodologiesTreeNode>>>> GetTree();
+        public Task<Either<ActionResult, List<AllMethodologiesThemeViewModel>>> GetTree();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Api.Services.Interfaces;
@@ -39,11 +40,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
             // TODO SOW4 EES-2375 lookup the MethodologyParent by slug when slug is moved to the parent
             // For now, this does a lookup on the parent via any Methodology with the slug
             return await _persistenceHelper
-                .CheckEntityExists<Methodology>(query => 
+                .CheckEntityExists<Methodology>(query =>
                     query.Where(mv => mv.Slug == slug))
                 .OnSuccess<ActionResult, Methodology, MethodologyViewModel>(async arbitraryVersion =>
                 {
-                    var latestPublishedVersion = await _methodologyRepository.GetLatestPublishedByMethodologyParent(arbitraryVersion.MethodologyParentId);
+                    var latestPublishedVersion =
+                        await _methodologyRepository.GetLatestPublishedByMethodologyParent(arbitraryVersion
+                            .MethodologyParentId);
                     if (latestPublishedVersion == null)
                     {
                         return new NotFoundResult();
@@ -58,117 +61,48 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
         {
             return await _persistenceHelper
                 .CheckEntityExists<Publication>(publicationId)
-                .OnSuccess(BuildMethodologiesForPublication);
+                .OnSuccess(publication => BuildMethodologiesForPublication(publication.Id));
         }
 
-        public async Task<Either<ActionResult, List<ThemeTree<PublicationMethodologiesTreeNode>>>> GetTree()
+        public async Task<Either<ActionResult, List<AllMethodologiesThemeViewModel>>> GetTree()
         {
-            var themesWithMethodologies = await _contentDbContext.Themes
+            var themes = await _contentDbContext.Themes
                 .Include(theme => theme.Topics)
                 .ThenInclude(topic => topic.Publications)
+                .AsNoTracking()
+                .Select(theme => new AllMethodologiesThemeViewModel
+                {
+                    Id = theme.Id,
+                    Title = theme.Title,
+                    Topics = theme.Topics.Select(topic => new AllMethodologiesTopicViewModel
+                    {
+                        Id = topic.Id,
+                        Title = topic.Title,
+                        Publications = topic.Publications.Select(publication => new AllMethodologiesPublicationViewModel
+                        {
+                            Id = publication.Id,
+                            Title = publication.Title
+                        }).ToList()
+                    }).ToList()
+                })
                 .ToListAsync();
 
-            var tree = new List<ThemeTree<PublicationMethodologiesTreeNode>>();
+            await themes.SelectMany(model => model.Topics)
+                .SelectMany(model => model.Publications)
+                .ForEachAsync(async publication =>
+                    publication.Methodologies = await BuildMethodologiesForPublication(publication.Id));
 
-            foreach (var theme in themesWithMethodologies)
-            {
-                if (await IsThemeIncluded(theme))
-                {
-                    tree.Add(await BuildThemeTree(theme));
-                }
-            }
+            themes.ForEach(theme => theme.RemoveTopicNodesWithoutMethodologiesAndSort());
 
-            return tree.OrderBy(theme => theme.Title).ToList();
+            return themes.Where(theme => theme.Topics.Any())
+                .OrderBy(theme => theme.Title)
+                .ToList();
         }
 
-        private async Task<ThemeTree<PublicationMethodologiesTreeNode>> BuildThemeTree(Theme theme)
-        {
-            var topics = new List<TopicTree<PublicationMethodologiesTreeNode>>();
-            foreach (var topic in theme.Topics)
-            {
-                if (await IsTopicIncluded(topic))
-                {
-                    topics.Add(await BuildTopicTree(topic));
-                }
-            }
-
-            return new ThemeTree<PublicationMethodologiesTreeNode>
-            {
-                Id = theme.Id,
-                Summary = null,
-                Title = theme.Title,
-                Topics = topics.OrderBy(topic => topic.Title).ToList()
-            };
-        }
-
-        private async Task<TopicTree<PublicationMethodologiesTreeNode>> BuildTopicTree(Topic topic)
-        {
-            var publications = new List<PublicationMethodologiesTreeNode>();
-            foreach (var publication in topic.Publications)
-            {
-                if (await IsPublicationIncluded(publication))
-                {
-                    publications.Add(await BuildPublicationNode(publication));
-                }
-            }
-
-            return new TopicTree<PublicationMethodologiesTreeNode>
-            {
-                Id = topic.Id,
-                Summary = null,
-                Title = topic.Title,
-                Publications = publications.OrderBy(publication => publication.Title).ToList()
-            };
-        }
-
-        private async Task<PublicationMethodologiesTreeNode> BuildPublicationNode(Publication publication)
-        {
-            return new PublicationMethodologiesTreeNode
-            {
-                Id = publication.Id,
-                Title = publication.Title,
-                Summary = publication.Summary,
-                Slug = publication.Slug,
-                Methodologies = await BuildMethodologiesForPublication(publication)
-            };
-        }
-
-        private async Task<bool> IsThemeIncluded(Theme theme)
-        {
-            foreach (var topic in theme.Topics)
-            {
-                if (await IsTopicIncluded(topic))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private async Task<bool> IsTopicIncluded(Topic topic)
-        {
-            foreach (var publication in topic.Publications)
-            {
-                if (await IsPublicationIncluded(publication))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private async Task<bool> IsPublicationIncluded(Publication publication)
-        {
-            var publishedMethodologies = await _methodologyRepository.GetLatestPublishedByPublication(publication.Id);
-            return publishedMethodologies.Any();
-        }
-
-        private async Task<List<MethodologySummaryViewModel>> BuildMethodologiesForPublication(Publication publication)
+        private async Task<List<MethodologySummaryViewModel>> BuildMethodologiesForPublication(Guid publicationId)
         {
             var latestPublishedMethodologies =
-                await _methodologyRepository.GetLatestPublishedByPublication(publication.Id);
+                await _methodologyRepository.GetLatestPublishedByPublication(publicationId);
             return _mapper.Map<List<MethodologySummaryViewModel>>(latestPublishedMethodologies);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/ViewModels/AllMethodologiesViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/ViewModels/AllMethodologiesViewModels.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels
+{
+    public class AllMethodologiesThemeViewModel : IComparable<AllMethodologiesThemeViewModel>
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; }
+        public List<AllMethodologiesTopicViewModel> Topics { get; set; }
+
+        public void RemoveTopicNodesWithoutMethodologiesAndSort()
+        {
+            // Remove all publications without any methodologies
+            Topics.ForEach(topic => topic.RemovePublicationNodesWithoutMethodologiesAndSort());
+
+            // Remove all topics without any publications
+            Topics = Topics
+                .Where(topic => topic.Publications.Any())
+                .ToList();
+
+            Topics.Sort();
+        }
+
+        public int CompareTo(AllMethodologiesThemeViewModel other)
+        {
+            return other == null ? 1 : string.Compare(Title, other.Title, StringComparison.Ordinal);
+        }
+    }
+
+    public class AllMethodologiesTopicViewModel : IComparable<AllMethodologiesTopicViewModel>
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; }
+        public List<AllMethodologiesPublicationViewModel> Publications { get; set; }
+
+        public void RemovePublicationNodesWithoutMethodologiesAndSort()
+        {
+            Publications = Publications
+                .Where(publication => publication.Methodologies.Any())
+                .ToList();
+
+            Publications.Sort();
+        }
+
+        public int CompareTo(AllMethodologiesTopicViewModel other)
+        {
+            return string.Compare(Title, other.Title, StringComparison.Ordinal);
+        }
+    }
+
+    public class AllMethodologiesPublicationViewModel : IComparable<AllMethodologiesPublicationViewModel>
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; }
+        public List<MethodologySummaryViewModel> Methodologies { get; set; }
+
+        public int CompareTo(AllMethodologiesPublicationViewModel other)
+        {
+            return other == null ? 1 : string.Compare(Title, other.Title, StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/ViewModels/AllMethodologiesViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/ViewModels/AllMethodologiesViewModels.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
@@ -8,8 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels
     public class AllMethodologiesThemeViewModel : IComparable<AllMethodologiesThemeViewModel>
     {
         public Guid Id { get; set; }
-        public string Title { get; set; }
-        public List<AllMethodologiesTopicViewModel> Topics { get; set; }
+
+        public string Title { get; set; } = string.Empty;
+
+        public List<AllMethodologiesTopicViewModel> Topics { get; set; } = new List<AllMethodologiesTopicViewModel>();
 
         public void RemoveTopicNodesWithoutMethodologiesAndSort()
         {
@@ -24,17 +27,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels
             Topics.Sort();
         }
 
-        public int CompareTo(AllMethodologiesThemeViewModel other)
+        public int CompareTo(AllMethodologiesThemeViewModel? other)
         {
-            return other == null ? 1 : string.Compare(Title, other.Title, StringComparison.Ordinal);
+            if (ReferenceEquals(this, other)) return 0;
+            if (ReferenceEquals(null, other)) return 1;
+            return string.Compare(Title, other.Title, StringComparison.Ordinal);
         }
     }
 
     public class AllMethodologiesTopicViewModel : IComparable<AllMethodologiesTopicViewModel>
     {
         public Guid Id { get; set; }
-        public string Title { get; set; }
-        public List<AllMethodologiesPublicationViewModel> Publications { get; set; }
+
+        public string Title { get; set; } = string.Empty;
+
+        public List<AllMethodologiesPublicationViewModel> Publications { get; set; } =
+            new List<AllMethodologiesPublicationViewModel>();
 
         public void RemovePublicationNodesWithoutMethodologiesAndSort()
         {
@@ -45,8 +53,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels
             Publications.Sort();
         }
 
-        public int CompareTo(AllMethodologiesTopicViewModel other)
+
+        public int CompareTo(AllMethodologiesTopicViewModel? other)
         {
+            if (ReferenceEquals(this, other)) return 0;
+            if (ReferenceEquals(null, other)) return 1;
             return string.Compare(Title, other.Title, StringComparison.Ordinal);
         }
     }
@@ -54,12 +65,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels
     public class AllMethodologiesPublicationViewModel : IComparable<AllMethodologiesPublicationViewModel>
     {
         public Guid Id { get; set; }
-        public string Title { get; set; }
-        public List<MethodologySummaryViewModel> Methodologies { get; set; }
 
-        public int CompareTo(AllMethodologiesPublicationViewModel other)
+        public string Title { get; set; } = string.Empty;
+
+        public List<MethodologySummaryViewModel> Methodologies { get; set; } =
+            new List<MethodologySummaryViewModel>();
+
+
+        public int CompareTo(AllMethodologiesPublicationViewModel? other)
         {
-            return other == null ? 1 : string.Compare(Title, other.Title, StringComparison.Ordinal);
+            if (ReferenceEquals(this, other)) return 0;
+            if (ReferenceEquals(null, other)) return 1;
+            return string.Compare(Title, other.Title, StringComparison.Ordinal);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyParentRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyParentRepositoryTests.cs
@@ -56,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         }
 
         [Fact]
-        public async Task GetByPublication_PublicationNotFoundThrowsException()
+        public async Task GetByPublication_PublicationNotFoundIsEmpty()
         {
             var contentDbContextId = Guid.NewGuid().ToString();
 
@@ -76,7 +76,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyParentRepository(contentDbContext);
 
-                await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetByPublication(Guid.NewGuid()));
+                var result = await service.GetByPublication(Guid.NewGuid());
+                Assert.Empty(result);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyRepositoryTests.cs
@@ -757,17 +757,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         }
 
         [Fact]
-        public async Task GetLatestPublishedByPublication_PublicationNotFoundThrowsException()
+        public async Task GetLatestPublishedByPublication_PublicationNotFoundIsEmpty()
         {
             var methodologyParentRepository = new Mock<IMethodologyParentRepository>(MockBehavior.Strict);
+
+            methodologyParentRepository.Setup(mock => mock.GetByPublication(It.IsAny<Guid>()))
+                .ReturnsAsync(new List<MethodologyParent>());
 
             await using (var contentDbContext = InMemoryContentDbContext())
             {
                 var service = BuildMethodologyRepository(contentDbContext: contentDbContext,
                     methodologyParentRepository: methodologyParentRepository.Object);
 
-                await Assert.ThrowsAsync<InvalidOperationException>(() =>
-                    service.GetLatestPublishedByPublication(Guid.NewGuid()));
+                var result = await service.GetLatestPublishedByPublication(Guid.NewGuid());
+                Assert.Empty(result);
             }
 
             MockUtils.VerifyAllMocks(methodologyParentRepository);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyParentRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyParentRepository.cs
@@ -19,11 +19,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
 
         public async Task<List<MethodologyParent>> GetByPublication(Guid publicationId)
         {
-            // First check the publication exists
-            var publication = await _contentDbContext.Publications.SingleAsync(p => p.Id == publicationId);
-
-            return await _contentDbContext.MethodologyParents
-                .Where(m => m.Publications.Any(pm => pm.PublicationId == publication.Id))
+            return await _contentDbContext.PublicationMethodologies
+                .Where(pm => pm.PublicationId == publicationId)
+                .Select(pm => pm.MethodologyParent)
                 .ToListAsync();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
@@ -79,10 +79,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
 
         public async Task<List<Methodology>> GetLatestPublishedByPublication(Guid publicationId)
         {
-            // First check the publication exists
-            var publication = await _contentDbContext.Publications.SingleAsync(p => p.Id == publicationId);
-
-            var methodologyParents = await _methodologyParentRepository.GetByPublication(publication.Id);
+            var methodologyParents = await _methodologyParentRepository.GetByPublication(publicationId);
             return (await methodologyParents.SelectAsync(async methodologyParent =>
                     await GetLatestPublishedByMethodologyParent(methodologyParent)))
                 .Where(version => version != null)


### PR DESCRIPTION
This is an experimental PR attempting to optimise fetching and building the view model for the Public All Methodologies page.

The cause of the performance problem appears to be down to fetching the publication in  methods `MethodologyParentRepository#GetByPublication` and `MethodologyRepository#GetLatestPublishedByPublication` to check for its existence before proceeding.

We called these methods a number of times, one for each Publication each time we were attempting to check if the Publication has child Methodology nodes, and once to build the Methodologies for the Publication node view model.

While it's nice to check that the publication exists, in theory it should be impossible to reach this code with a publication id that hasn't first come from some data containing actual publications.

This PR also reorganises the way we build up the view model for the All Methodologies page.

It first selects from the database only the `Id` and `Title` data that's going to be required for the Themes/Topics/Publications rather than querying all of the fields. This is done by projecting from the source themes queryable into the new view model _before_ calling `ToList` which is the border in code between database and in-memory execution.

After building the view model and adding the methodologies it can then filter out leaf nodes with no methodologies at the end. This was previously done before building the view models for any nodes but resulted in additional overhead.

This PR is experimental because I would like to see how this performs in a real Azure environment with more data.

I think its quite likely that there will still be a delay and that we need to think of an alternative approach for caching the response.