### PR TITLE
EES-2364 Update frontend with ancillary file Summary field

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -289,24 +289,19 @@ const ReleaseContent = () => {
       {(release.downloadFiles || release.hasPreReleaseAccessList) && (
         <ReleaseDataAndFilesAccordion
           release={release}
-          renderDownloadLink={file => {
-            return (
-              <>
-                <ButtonText
-                  onClick={() =>
-                    releaseDataFileService.downloadFile(
-                      release.id,
-                      file.id,
-                      file.fileName,
-                    )
-                  }
-                >
-                  {file.name}
-                </ButtonText>
-                {` (${file.extension}, ${file.size})`}
-              </>
-            );
-          }}
+          renderDownloadLink={file => (
+            <ButtonText
+              onClick={() =>
+                releaseDataFileService.downloadFile(
+                  release.id,
+                  file.id,
+                  file.fileName,
+                )
+              }
+            >
+              {file.name}
+            </ButtonText>
+          )}
           renderMetaGuidanceLink={
             <Link
               to={{

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseAncillaryFilePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseAncillaryFilePage.tsx
@@ -5,18 +5,24 @@ import {
 } from '@admin/routes/releaseRoutes';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import useFormSubmit from '@common/hooks/useFormSubmit';
 import React from 'react';
 import Link from '@admin/components/Link';
 import { generatePath, RouteComponentProps } from 'react-router';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
-import { Form, FormFieldTextInput } from '@common/components/form';
+import {
+  Form,
+  FormFieldTextArea,
+  FormFieldTextInput,
+} from '@common/components/form';
 import Button from '@common/components/Button';
 import releaseAncillaryFileService from '@admin/services/releaseAncillaryFileService';
 
 interface FormValues {
   title: string;
+  summary: string;
 }
 
 const ReleaseAncillaryFilePage = ({
@@ -32,6 +38,20 @@ const ReleaseAncillaryFilePage = ({
     () => releaseAncillaryFileService.getAncillaryFile(releaseId, fileId),
     [releaseId, fileId],
   );
+
+  const handleSubmit = useFormSubmit<FormValues>(async ({ title, summary }) => {
+    await releaseAncillaryFileService.updateFile(releaseId, fileId, {
+      title,
+      summary,
+    });
+
+    history.push(
+      generatePath<ReleaseRouteParams>(releaseDataAncillaryRoute.path, {
+        publicationId,
+        releaseId,
+      }),
+    );
+  });
 
   return (
     <>
@@ -52,33 +72,27 @@ const ReleaseAncillaryFilePage = ({
 
           {ancillaryFile ? (
             <Formik<FormValues>
-              initialValues={{ title: ancillaryFile.title }}
+              initialValues={{
+                title: ancillaryFile.title,
+                summary: ancillaryFile.summary,
+              }}
               validationSchema={Yup.object<FormValues>({
                 title: Yup.string().required('Enter a title'),
+                summary: Yup.string().required('Enter a summary'),
               })}
-              onSubmit={async values => {
-                await releaseAncillaryFileService.updateFile(
-                  releaseId,
-                  fileId,
-                  { title: values.title },
-                );
-
-                history.push(
-                  generatePath<ReleaseRouteParams>(
-                    releaseDataAncillaryRoute.path,
-                    {
-                      publicationId,
-                      releaseId,
-                    },
-                  ),
-                );
-              }}
+              onSubmit={handleSubmit}
             >
               <Form id="ancillaryFileForm">
                 <FormFieldTextInput<FormValues>
                   className="govuk-!-width-one-half"
                   label="Title"
                   name="title"
+                />
+
+                <FormFieldTextArea<FormValues>
+                  className="govuk-!-width-one-half"
+                  label="Summary"
+                  name="summary"
                 />
 
                 <Button type="submit">Save changes</Button>

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseAncillaryFilePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseAncillaryFilePage.tsx
@@ -3,6 +3,7 @@ import {
   ReleaseRouteParams,
   releaseDataAncillaryRoute,
 } from '@admin/routes/releaseRoutes';
+import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React from 'react';
 import Link from '@admin/components/Link';
@@ -14,7 +15,7 @@ import { Form, FormFieldTextInput } from '@common/components/form';
 import Button from '@common/components/Button';
 import releaseAncillaryFileService from '@admin/services/releaseAncillaryFileService';
 
-interface EditFormValues {
+interface FormValues {
   title: string;
 }
 
@@ -44,14 +45,16 @@ const ReleaseAncillaryFilePage = ({
       >
         Back
       </Link>
+
       <LoadingSpinner loading={ancillaryFileLoading}>
-        {ancillaryFile && (
-          <section>
-            <h2>Edit ancillary file details</h2>
-            <Formik<EditFormValues>
+        <section>
+          <h2>Edit ancillary file details</h2>
+
+          {ancillaryFile ? (
+            <Formik<FormValues>
               initialValues={{ title: ancillaryFile.title }}
-              validationSchema={Yup.object<EditFormValues>({
-                title: Yup.string().required('Enter a ancillary title'),
+              validationSchema={Yup.object<FormValues>({
+                title: Yup.string().required('Enter a title'),
               })}
               onSubmit={async values => {
                 await releaseAncillaryFileService.updateFile(
@@ -71,15 +74,22 @@ const ReleaseAncillaryFilePage = ({
                 );
               }}
             >
-              {form => (
-                <Form {...form} id="edit-data-file-form">
-                  <FormFieldTextInput id="title" label="Title" name="title" />
-                  <Button type="submit">Save changes</Button>
-                </Form>
-              )}
+              <Form id="ancillaryFileForm">
+                <FormFieldTextInput<FormValues>
+                  className="govuk-!-width-one-half"
+                  label="Title"
+                  name="title"
+                />
+
+                <Button type="submit">Save changes</Button>
+              </Form>
             </Formik>
-          </section>
-        )}
+          ) : (
+            <WarningMessage>
+              Could not load ancillary file details
+            </WarningMessage>
+          )}
+        </section>
       </LoadingSpinner>
     </>
   );

--- a/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/ReleaseDataFilePage.tsx
@@ -3,7 +3,9 @@ import {
   ReleaseRouteParams,
   releaseDataRoute,
 } from '@admin/routes/releaseRoutes';
+import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import useFormSubmit from '@common/hooks/useFormSubmit';
 import React from 'react';
 import releaseDataFileService from '@admin/services/releaseDataFileService';
 import Link from '@admin/components/Link';
@@ -14,7 +16,7 @@ import { Formik } from 'formik';
 import { Form, FormFieldTextInput } from '@common/components/form';
 import Button from '@common/components/Button';
 
-interface EditSubjectFormValues {
+interface FormValues {
   title: string;
 }
 
@@ -32,6 +34,19 @@ const ReleaseDataFilePage = ({
     [releaseId, fileId],
   );
 
+  const handleSubmit = useFormSubmit<FormValues>(async values => {
+    await releaseDataFileService.updateFile(releaseId, fileId, {
+      title: values.title,
+    });
+
+    history.push(
+      generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
+        publicationId,
+        releaseId,
+      }),
+    );
+  });
+
   return (
     <>
       <Link
@@ -44,37 +59,33 @@ const ReleaseDataFilePage = ({
       >
         Back
       </Link>
-      <LoadingSpinner loading={dataFileLoading}>
-        {dataFile && (
-          <section>
-            <h2>Edit data file details</h2>
-            <Formik<EditSubjectFormValues>
-              initialValues={{ title: dataFile.title }}
-              validationSchema={Yup.object<EditSubjectFormValues>({
-                title: Yup.string().required('Enter a subject title'),
-              })}
-              onSubmit={async values => {
-                await releaseDataFileService.updateFile(releaseId, fileId, {
-                  title: values.title,
-                });
 
-                history.push(
-                  generatePath<ReleaseRouteParams>(releaseDataRoute.path, {
-                    publicationId,
-                    releaseId,
-                  }),
-                );
-              }}
+      <LoadingSpinner loading={dataFileLoading}>
+        <section>
+          <h2>Edit data file details</h2>
+
+          {dataFile ? (
+            <Formik<FormValues>
+              initialValues={{ title: dataFile.title }}
+              validationSchema={Yup.object<FormValues>({
+                title: Yup.string().required('Enter a title'),
+              })}
+              onSubmit={handleSubmit}
             >
-              {form => (
-                <Form {...form} id="edit-data-file-form">
-                  <FormFieldTextInput id="title" label="Title" name="title" />
-                  <Button type="submit">Save changes</Button>
-                </Form>
-              )}
+              <Form id="dataFileForm">
+                <FormFieldTextInput<FormValues>
+                  className="govuk-!-width-two-thirds"
+                  label="Title"
+                  name="title"
+                />
+
+                <Button type="submit">Save changes</Button>
+              </Form>
             </Formik>
-          </section>
-        )}
+          ) : (
+            <WarningMessage>Could not load data file details</WarningMessage>
+          )}
+        </section>
       </LoadingSpinner>
     </>
   );

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseAncilllaryFilePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseAncilllaryFilePage.test.tsx
@@ -21,7 +21,8 @@ const releaseAncillaryFileService = _releaseAncillaryFileService as jest.Mocked<
 describe('ReleaseAncillaryFilePage', () => {
   const testFile: AncillaryFile = {
     id: 'file-1',
-    title: 'Test file',
+    title: 'Test title',
+    summary: 'Test summary',
     filename: 'test-file.txt',
     fileSize: {
       size: 20,
@@ -36,7 +37,7 @@ describe('ReleaseAncillaryFilePage', () => {
 
     await renderPage();
 
-    expect(screen.getByLabelText('Title')).toHaveValue('Test file');
+    expect(screen.getByLabelText('Title')).toHaveValue('Test title');
   });
 
   test('does not render form if unable to get ancillary file details', async () => {
@@ -67,10 +68,26 @@ describe('ReleaseAncillaryFilePage', () => {
     });
   });
 
+  test('shows validation message if `summary` field is empty', async () => {
+    releaseAncillaryFileService.getAncillaryFile.mockResolvedValue(testFile);
+
+    await renderPage();
+
+    userEvent.clear(screen.getByLabelText('Summary'));
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Enter a summary' }),
+      ).toHaveAttribute('href', '#ancillaryFileForm-summary');
+    });
+  });
+
   test('shows validation messages if submitted form is invalid', async () => {
     releaseAncillaryFileService.getAncillaryFile.mockResolvedValue({
       ...testFile,
       title: '',
+      summary: '',
     });
 
     await renderPage();
@@ -82,6 +99,10 @@ describe('ReleaseAncillaryFilePage', () => {
         screen.getByRole('link', { name: 'Enter a title' }),
       ).toHaveAttribute('href', '#ancillaryFileForm-title');
     });
+
+    expect(
+      screen.getByRole('link', { name: 'Enter a summary' }),
+    ).toHaveAttribute('href', '#ancillaryFileForm-summary');
   });
 
   test('successfully submitting form sends update request to service', async () => {
@@ -89,10 +110,15 @@ describe('ReleaseAncillaryFilePage', () => {
 
     await renderPage();
 
-    const input = screen.getByLabelText('Title');
+    const title = screen.getByLabelText('Title');
 
-    userEvent.clear(input);
-    await userEvent.type(input, 'Updated test file');
+    userEvent.clear(title);
+    await userEvent.type(title, 'Updated test title');
+
+    const summary = screen.getByLabelText('Summary');
+
+    userEvent.clear(summary);
+    await userEvent.type(summary, 'Updated test summary');
 
     userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
 
@@ -100,7 +126,8 @@ describe('ReleaseAncillaryFilePage', () => {
       expect(releaseAncillaryFileService.updateFile).toHaveBeenCalledWith<
         Parameters<typeof releaseAncillaryFileService.updateFile>
       >('release-1', 'file-1', {
-        title: 'Updated test file',
+        title: 'Updated test title',
+        summary: 'Updated test summary',
       });
     });
   });

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseAncilllaryFilePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseAncilllaryFilePage.test.tsx
@@ -1,0 +1,152 @@
+import ReleaseAncillaryFilePage from '@admin/pages/release/data/ReleaseAncillaryFilePage';
+import {
+  releaseAncillaryFileRoute,
+  ReleaseAncillaryFileRouteParams,
+} from '@admin/routes/releaseRoutes';
+import _releaseAncillaryFileService, {
+  AncillaryFile,
+} from '@admin/services/releaseAncillaryFileService';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createMemoryHistory, MemoryHistory } from 'history';
+import React from 'react';
+import { generatePath, Route, Router } from 'react-router-dom';
+
+jest.mock('@admin/services/releaseAncillaryFileService');
+
+const releaseAncillaryFileService = _releaseAncillaryFileService as jest.Mocked<
+  typeof _releaseAncillaryFileService
+>;
+
+describe('ReleaseAncillaryFilePage', () => {
+  const testFile: AncillaryFile = {
+    id: 'file-1',
+    title: 'Test file',
+    filename: 'test-file.txt',
+    fileSize: {
+      size: 20,
+      unit: 'kB',
+    },
+    userName: '',
+    created: '',
+  };
+
+  test('renders form with initial values', async () => {
+    releaseAncillaryFileService.getAncillaryFile.mockResolvedValue(testFile);
+
+    await renderPage();
+
+    expect(screen.getByLabelText('Title')).toHaveValue('Test file');
+  });
+
+  test('does not render form if unable to get ancillary file details', async () => {
+    releaseAncillaryFileService.getAncillaryFile.mockRejectedValue(
+      new Error('Could not find ancillary file'),
+    );
+
+    await renderPage();
+
+    expect(
+      screen.getByText('Could not load ancillary file details'),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText('Title')).not.toBeInTheDocument();
+  });
+
+  test('shows validation message if `title` field is empty', async () => {
+    releaseAncillaryFileService.getAncillaryFile.mockResolvedValue(testFile);
+
+    await renderPage();
+
+    userEvent.clear(screen.getByLabelText('Title'));
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Enter a title' }),
+      ).toHaveAttribute('href', '#ancillaryFileForm-title');
+    });
+  });
+
+  test('shows validation messages if submitted form is invalid', async () => {
+    releaseAncillaryFileService.getAncillaryFile.mockResolvedValue({
+      ...testFile,
+      title: '',
+    });
+
+    await renderPage();
+
+    userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Enter a title' }),
+      ).toHaveAttribute('href', '#ancillaryFileForm-title');
+    });
+  });
+
+  test('successfully submitting form sends update request to service', async () => {
+    releaseAncillaryFileService.getAncillaryFile.mockResolvedValue(testFile);
+
+    await renderPage();
+
+    const input = screen.getByLabelText('Title');
+
+    userEvent.clear(input);
+    await userEvent.type(input, 'Updated test file');
+
+    userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(releaseAncillaryFileService.updateFile).toHaveBeenCalledWith<
+        Parameters<typeof releaseAncillaryFileService.updateFile>
+      >('release-1', 'file-1', {
+        title: 'Updated test file',
+      });
+    });
+  });
+
+  test('successfully submitting form redirects to ancillary files page', async () => {
+    releaseAncillaryFileService.getAncillaryFile.mockResolvedValue(testFile);
+
+    const history = createMemoryHistory();
+
+    await renderPage(history);
+
+    userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(history.location.pathname).toBe(
+        '/publication/publication-1/release/release-1/data',
+      );
+      expect(history.location.hash).toBe('#file-uploads');
+    });
+  });
+
+  async function renderPage(history: MemoryHistory = createMemoryHistory()) {
+    history.push(
+      generatePath<ReleaseAncillaryFileRouteParams>(
+        releaseAncillaryFileRoute.path,
+        {
+          publicationId: 'publication-1',
+          releaseId: 'release-1',
+          fileId: 'file-1',
+        },
+      ),
+    );
+
+    render(
+      <Router history={history}>
+        <Route
+          path={releaseAncillaryFileRoute.path}
+          component={ReleaseAncillaryFilePage}
+        />
+      </Router>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Edit ancillary file details'),
+      ).toBeInTheDocument();
+    });
+  }
+});

--- a/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFilePage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/__tests__/ReleaseDataFilePage.test.tsx
@@ -1,0 +1,154 @@
+import ReleaseDataFilePage from '@admin/pages/release/data/ReleaseDataFilePage';
+import {
+  releaseDataFileRoute,
+  ReleaseDataFileRouteParams,
+} from '@admin/routes/releaseRoutes';
+import _releaseDataFileService, {
+  DataFile,
+} from '@admin/services/releaseDataFileService';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createMemoryHistory, MemoryHistory } from 'history';
+import React from 'react';
+import { generatePath, Route, Router } from 'react-router-dom';
+
+jest.mock('@admin/services/releaseDataFileService');
+
+const releaseDataFileService = _releaseDataFileService as jest.Mocked<
+  typeof _releaseDataFileService
+>;
+
+describe('ReleaseDataFilePage', () => {
+  const testFile: DataFile = {
+    id: 'file-1',
+    title: 'Test data file',
+    userName: 'user1@test.com',
+    fileName: 'data-1.csv',
+    metaFileId: 'data-1-meta',
+    metaFileName: 'data-1.meta.csv',
+    rows: 100,
+    fileSize: {
+      size: 20,
+      unit: 'KB',
+    },
+    created: '2020-06-12T12:00:00',
+    status: 'COMPLETE',
+    permissions: {
+      canCancelImport: false,
+    },
+  };
+
+  test('renders form with initial values', async () => {
+    releaseDataFileService.getDataFile.mockResolvedValue(testFile);
+
+    await renderPage();
+
+    expect(screen.getByLabelText('Title')).toHaveValue('Test data file');
+  });
+
+  test('does not render form if unable to get data file details', async () => {
+    releaseDataFileService.getDataFile.mockRejectedValue(
+      new Error('Could not find data file'),
+    );
+
+    await renderPage();
+
+    expect(
+      screen.getByText('Could not load data file details'),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText('Title')).not.toBeInTheDocument();
+  });
+
+  test('shows validation message if `title` field is empty', async () => {
+    releaseDataFileService.getDataFile.mockResolvedValue(testFile);
+
+    await renderPage();
+
+    userEvent.clear(screen.getByLabelText('Title'));
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Enter a title' }),
+      ).toHaveAttribute('href', '#dataFileForm-title');
+    });
+  });
+
+  test('shows validation messages if submitted form is invalid', async () => {
+    releaseDataFileService.getDataFile.mockResolvedValue({
+      ...testFile,
+      title: '',
+    });
+
+    await renderPage();
+
+    userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Enter a title' }),
+      ).toHaveAttribute('href', '#dataFileForm-title');
+    });
+  });
+
+  test('successfully submitting form sends update request to service', async () => {
+    releaseDataFileService.getDataFile.mockResolvedValue(testFile);
+
+    await renderPage();
+
+    const input = screen.getByLabelText('Title');
+
+    userEvent.clear(input);
+    await userEvent.type(input, 'Updated test data file');
+
+    userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(releaseDataFileService.updateFile).toHaveBeenCalledWith<
+        Parameters<typeof releaseDataFileService.updateFile>
+      >('release-1', 'file-1', {
+        title: 'Updated test data file',
+      });
+    });
+  });
+
+  test('successfully submitting form redirects to data files page', async () => {
+    releaseDataFileService.getDataFile.mockResolvedValue(testFile);
+
+    const history = createMemoryHistory();
+
+    await renderPage(history);
+
+    userEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(history.location.pathname).toBe(
+        '/publication/publication-1/release/release-1/data',
+      );
+      expect(history.location.hash).toBe('');
+    });
+  });
+
+  async function renderPage(history: MemoryHistory = createMemoryHistory()) {
+    history.push(
+      generatePath<ReleaseDataFileRouteParams>(releaseDataFileRoute.path, {
+        publicationId: 'publication-1',
+        releaseId: 'release-1',
+        fileId: 'file-1',
+      }),
+    );
+
+    render(
+      <Router history={history}>
+        <Route
+          path={releaseDataFileRoute.path}
+          component={ReleaseDataFilePage}
+        />
+      </Router>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit data file details')).toBeInTheDocument();
+    });
+  }
+});

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -174,9 +174,9 @@ const ReleaseFileUploadsSection = ({
                   )}
 
                   <FormFieldTextInput<FormValues>
+                    className="govuk-!-width-one-half"
                     name="name"
                     label="Name"
-                    width={20}
                   />
 
                   <FormFieldFileInput<FormValues>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -6,7 +6,7 @@ import AccordionSection from '@common/components/AccordionSection';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
-import { Form } from '@common/components/form';
+import { Form, FormFieldTextArea } from '@common/components/form';
 import FormFieldFileInput from '@common/components/form/FormFieldFileInput';
 import FormFieldTextInput from '@common/components/form/FormFieldTextInput';
 import InsetText from '@common/components/InsetText';
@@ -31,13 +31,14 @@ import {
 import FormattedDate from '@common/components/FormattedDate';
 
 interface FormValues {
-  name: string;
+  title: string;
+  summary: string;
   file: File | null;
 }
 
 const errorMappings = [
   mapFieldErrors<FormValues>({
-    target: 'name',
+    target: 'title',
     messages: {
       FILE_UPLOAD_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS:
         'File upload name cannot contain special characters',
@@ -100,8 +101,9 @@ const ReleaseFileUploadsSection = ({
       const newFile = await releaseAncillaryFileService.uploadAncillaryFile(
         releaseId,
         {
-          title: values.name.trim(),
+          title: values.title.trim(),
           file: values.file as File,
+          summary: values.summary.trim(),
         },
       );
 
@@ -119,7 +121,8 @@ const ReleaseFileUploadsSection = ({
       <Formik<FormValues>
         enableReinitialize
         initialValues={{
-          name: '',
+          title: '',
+          summary: '',
           file: null,
         }}
         onReset={() => {
@@ -132,12 +135,12 @@ const ReleaseFileUploadsSection = ({
         }}
         onSubmit={handleSubmit}
         validationSchema={Yup.object<FormValues>({
-          name: Yup.string()
+          title: Yup.string()
             .trim()
-            .required('Enter a name')
+            .required('Enter a title')
             .test({
               name: 'unique',
-              message: 'Enter a unique name',
+              message: 'Enter a unique title',
               test(value: string) {
                 if (!value) {
                   return true;
@@ -149,6 +152,7 @@ const ReleaseFileUploadsSection = ({
                 );
               },
             }),
+          summary: Yup.string().required('Enter a summary'),
           file: Yup.file()
             .required('Choose a file')
             .minSize(0, 'Choose a file that is not empty'),
@@ -175,8 +179,14 @@ const ReleaseFileUploadsSection = ({
 
                   <FormFieldTextInput<FormValues>
                     className="govuk-!-width-one-half"
-                    name="name"
-                    label="Name"
+                    name="title"
+                    label="Title"
+                  />
+
+                  <FormFieldTextArea<FormValues>
+                    className="govuk-!-width-one-half"
+                    name="summary"
+                    label="Summary"
                   />
 
                   <FormFieldFileInput<FormValues>
@@ -228,7 +238,8 @@ const ReleaseFileUploadsSection = ({
                   )}
 
                   <SummaryList>
-                    <SummaryListItem term="Name">{file.title}</SummaryListItem>
+                    <SummaryListItem term="Title">{file.title}</SummaryListItem>
+
                     <SummaryListItem term="File">
                       <ButtonText
                         onClick={() =>
@@ -242,17 +253,27 @@ const ReleaseFileUploadsSection = ({
                         {file.filename}
                       </ButtonText>
                     </SummaryListItem>
+
                     <SummaryListItem term="File size">
                       {file.fileSize.size.toLocaleString()} {file.fileSize.unit}
                     </SummaryListItem>
+
                     <SummaryListItem term="Uploaded by">
                       <a href={`mailto:${file.userName}`}>{file.userName}</a>
                     </SummaryListItem>
+
                     <SummaryListItem term="Date uploaded">
                       <FormattedDate format="d MMMM yyyy HH:mm">
                         {file.created}
                       </FormattedDate>
                     </SummaryListItem>
+
+                    <SummaryListItem term="Summary">
+                      <div className="dfe-white-space--pre-wrap">
+                        {file.summary}
+                      </div>
+                    </SummaryListItem>
+
                     {canUpdateRelease && (
                       <SummaryListItem
                         term="Actions"
@@ -269,7 +290,7 @@ const ReleaseFileUploadsSection = ({
                                 },
                               )}
                             >
-                              Edit title
+                              Edit file
                             </Link>
                             <ButtonText onClick={() => setDeleteFile(file)}>
                               Delete file

--- a/src/explore-education-statistics-admin/src/services/releaseAncillaryFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseAncillaryFileService.ts
@@ -3,6 +3,7 @@ import { FileInfo } from '@common/services/types/file';
 import downloadFile from './utils/file/downloadFile';
 
 interface AncillaryFileInfo extends FileInfo {
+  summary: string;
   userName: string;
   created: string;
 }
@@ -10,6 +11,7 @@ interface AncillaryFileInfo extends FileInfo {
 export interface AncillaryFile {
   id: string;
   title: string;
+  summary: string;
   filename: string;
   fileSize: {
     size: number;
@@ -22,19 +24,21 @@ export interface AncillaryFile {
 
 export interface UploadAncillaryFileRequest {
   title: string;
+  summary: string;
   file: File;
 }
 
 export interface AncillaryFileUpdateRequest {
   title: string;
+  summary: string;
 }
 
-function mapFile(file: AncillaryFileInfo): AncillaryFile {
+function mapFile({ name, ...file }: AncillaryFileInfo): AncillaryFile {
   const [size, unit] = file.size.split(' ');
 
   return {
     ...file,
-    title: file.name,
+    title: name,
     filename: file.fileName,
     fileSize: {
       size: parseInt(size, 10),
@@ -61,6 +65,7 @@ const releaseAncillaryFileService = {
     const data = new FormData();
     data.append('file', request.file);
     data.append('title', request.title);
+    data.append('summary', request.summary);
 
     const file = await client.post<AncillaryFileInfo>(
       `/release/${releaseId}/ancillary`,

--- a/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseDataFileService.ts
@@ -91,12 +91,12 @@ export interface DataFileImportStatus {
   numberOfRows: number;
 }
 
-function mapFile(file: DataFileInfo): DataFile {
+function mapFile({ name, ...file }: DataFileInfo): DataFile {
   const [size, unit] = file.size.split(' ');
 
   return {
     ...file,
-    title: file.name,
+    title: name,
     rows: file.rows || 0,
     fileSize: {
       size: parseInt(size, 10),

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAndFilesAccordion.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAndFilesAccordion.tsx
@@ -3,6 +3,7 @@ import AccordionSection from '@common/components/AccordionSection';
 import Details from '@common/components/Details';
 import { Release } from '@common/services/publicationService';
 import { FileInfo } from '@common/services/types/file';
+import orderBy from 'lodash/orderBy';
 import React, { ReactNode } from 'react';
 import styles from './ReleaseDataAndFilesAccordion.module.scss';
 
@@ -14,6 +15,7 @@ interface Props {
   renderPreReleaseAccessLink?: ReactNode;
   onSectionOpen?: (accordionSection: { id: string; title: string }) => void;
 }
+
 const ReleaseDataAndFilesAccordion = ({
   release,
   renderCreateTablesButton,
@@ -22,12 +24,22 @@ const ReleaseDataAndFilesAccordion = ({
   renderPreReleaseAccessLink,
   onSectionOpen,
 }: Props) => {
-  const otherFiles = release.downloadFiles.filter(
-    file => file.name === 'All files' || file.type !== 'Ancillary',
+  const allFilesZip = release.downloadFiles.find(
+    file => file.name === 'All files' && file.type === 'Ancillary',
   );
 
-  const ancillaryFiles = release.downloadFiles.filter(
-    file => file.type === 'Ancillary' && file.name !== 'All files',
+  const files = orderBy(
+    release.downloadFiles.filter(
+      file => file.type !== 'Ancillary' && file.name !== 'All files',
+    ),
+    ['name'],
+  );
+
+  const otherFiles = orderBy(
+    release.downloadFiles.filter(
+      file => file.type === 'Ancillary' && file.name !== 'All files',
+    ),
+    ['name'],
   );
 
   return (
@@ -42,24 +54,25 @@ const ReleaseDataAndFilesAccordion = ({
         }}
       >
         <AccordionSection heading="Explore data and files">
-          {otherFiles.length > 0 && (
-            <>
-              <p>
-                All data used to create this release is published as open data
-                and is available for download.
-              </p>
-              <p>
-                You can create your own tables from this data using our table
-                tool, or view featured tables that we have built for you.
-              </p>
+          <p>
+            All data used to create this release is published as open data and
+            is available for download.
+          </p>
+          <p>
+            You can create your own tables from this data using our table tool,
+            or view featured tables that we have built for you.
+          </p>
 
-              <ul className="govuk-list">
-                {otherFiles.map(file => {
-                  return <li key={file.id}>{renderDownloadLink(file)}</li>;
-                })}
-              </ul>
-            </>
+          {(allFilesZip || files.length > 0) && (
+            <ul className="govuk-list" data-testid="download-files">
+              {allFilesZip && <li>{renderDownloadLink(allFilesZip)}</li>}
+
+              {files.map(file => (
+                <li key={file.id}>{renderDownloadLink(file)}</li>
+              ))}
+            </ul>
           )}
+
           {renderCreateTablesButton && (
             <div className={styles.createTablesButtonContainer}>
               <div>
@@ -87,15 +100,30 @@ const ReleaseDataAndFilesAccordion = ({
               </p>
             </>
           )}
-          {ancillaryFiles.length > 0 && (
+
+          {otherFiles.length > 0 && (
             <>
               <h3>Other files</h3>
               <p>All other files available for download are listed below:</p>
+
               <Details summary="List of other files">
-                <ul className="govuk-list">
-                  {ancillaryFiles.map(file => {
-                    return <li key={file.id}>{renderDownloadLink(file)}</li>;
-                  })}
+                <ul className="govuk-list" data-testid="other-download-files">
+                  {otherFiles.map(file => (
+                    <li key={file.id}>
+                      {renderDownloadLink(file)}
+
+                      {file.summary && (
+                        <Details
+                          summary="More details"
+                          className="govuk-!-margin-top-2"
+                        >
+                          <div className="dfe-white-space--pre-wrap">
+                            {file.summary}
+                          </div>
+                        </Details>
+                      )}
+                    </li>
+                  ))}
                 </ul>
               </Details>
             </>

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAndFilesAccordion.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAndFilesAccordion.tsx
@@ -65,10 +65,18 @@ const ReleaseDataAndFilesAccordion = ({
 
           {(allFilesZip || files.length > 0) && (
             <ul className="govuk-list" data-testid="download-files">
-              {allFilesZip && <li>{renderDownloadLink(allFilesZip)}</li>}
+              {allFilesZip && (
+                <li>
+                  {renderDownloadLink(allFilesZip)}
+                  {` (${allFilesZip.extension}, ${allFilesZip.size})`}
+                </li>
+              )}
 
               {files.map(file => (
-                <li key={file.id}>{renderDownloadLink(file)}</li>
+                <li key={file.id}>
+                  {renderDownloadLink(file)}
+                  {` (${file.extension}, ${file.size})`}
+                </li>
               ))}
             </ul>
           )}
@@ -111,6 +119,7 @@ const ReleaseDataAndFilesAccordion = ({
                   {otherFiles.map(file => (
                     <li key={file.id}>
                       {renderDownloadLink(file)}
+                      {` (${file.extension}, ${file.size})`}
 
                       {file.summary && (
                         <Details

--- a/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseDataAndFilesAccordion.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseDataAndFilesAccordion.test.tsx
@@ -12,29 +12,39 @@ describe('ReleaseDataAndFilesAccordion', () => {
       {
         id: 'file-1',
         name: 'Test data file 2',
+        size: '10 KB',
         type: 'Data',
+        extension: 'csv',
       },
       {
         id: 'file-2',
         name: 'A Test data file 1',
+        size: '15 KB',
         type: 'Data',
+        extension: 'csv',
       },
       {
         id: 'file-3',
         name: 'All files',
         type: 'Ancillary',
+        size: '100 KB',
+        extension: 'zip',
       },
       {
         id: 'file-4',
         name: 'Test ancillary file 2',
         summary: 'Test ancillary file 2 summary',
         type: 'Ancillary',
+        size: '20 KB',
+        extension: 'pdf',
       },
       {
         id: 'file-5',
         name: 'Test ancillary file 1',
         summary: 'A Test ancillary file 1 summary',
         type: 'Ancillary',
+        size: '25 KB',
+        extension: 'txt',
       },
     ],
     hasMetaGuidance: true,
@@ -62,20 +72,34 @@ describe('ReleaseDataAndFilesAccordion', () => {
       screen.getByTestId('download-files'),
     ).getAllByRole('listitem');
 
+    // File 1
     expect(
       within(downloadFiles[0]).getByRole('link', {
         name: 'All files',
       }),
     ).toBeInTheDocument();
     expect(
+      within(downloadFiles[0]).getByText('(zip, 100 KB)'),
+    ).toBeInTheDocument();
+
+    // File 2
+    expect(
       within(downloadFiles[1]).getByRole('link', {
         name: 'A Test data file 1',
       }),
     ).toBeInTheDocument();
     expect(
+      within(downloadFiles[1]).getByText('(csv, 15 KB)'),
+    ).toBeInTheDocument();
+
+    // File 3
+    expect(
       within(downloadFiles[2]).getByRole('link', {
         name: 'Test data file 2',
       }),
+    ).toBeInTheDocument();
+    expect(
+      within(downloadFiles[2]).getByText('(csv, 10 KB)'),
     ).toBeInTheDocument();
 
     expect(screen.getByText('Open data')).toBeInTheDocument();
@@ -93,20 +117,24 @@ describe('ReleaseDataAndFilesAccordion', () => {
       screen.getByTestId('other-download-files'),
     ).getAllByRole('listitem');
 
+    // File 1
     expect(
       within(otherFiles[0]).getByRole('link', {
         name: 'Test ancillary file 1',
       }),
     ).toBeInTheDocument();
+    expect(within(otherFiles[0]).getByText('(txt, 25 KB)')).toBeInTheDocument();
     expect(
       within(otherFiles[0]).getByText('A Test ancillary file 1 summary'),
     ).toBeInTheDocument();
 
+    // File 2
     expect(
       within(otherFiles[1]).getByRole('link', {
         name: 'Test ancillary file 2',
       }),
     ).toBeInTheDocument();
+    expect(within(otherFiles[1]).getByText('(pdf, 20 KB)')).toBeInTheDocument();
     expect(
       within(otherFiles[1]).getByText('Test ancillary file 2 summary'),
     ).toBeInTheDocument();

--- a/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseDataAndFilesAccordion.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/__tests__/ReleaseDataAndFilesAccordion.test.tsx
@@ -1,51 +1,81 @@
 import ReleaseDataAndFilesAccordion from '@common/modules/release/components/ReleaseDataAndFilesAccordion';
 import { Release } from '@common/services/publicationService';
+import { within } from '@testing-library/dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { FileInfo } from '@common/services/types/file';
 
 describe('ReleaseDataAndFilesAccordion', () => {
   const testRelease = {
     id: 'r1',
     downloadFiles: [
       {
-        id: 'f1',
+        id: 'file-1',
+        name: 'Test data file 2',
+        type: 'Data',
+      },
+      {
+        id: 'file-2',
+        name: 'A Test data file 1',
+        type: 'Data',
+      },
+      {
+        id: 'file-3',
         name: 'All files',
         type: 'Ancillary',
       },
       {
-        id: 'f2',
-        name: 'Test data file',
-        type: 'Data',
-      },
-      {
-        id: 'f3',
-        name: 'Test ancillary file',
+        id: 'file-4',
+        name: 'Test ancillary file 2',
+        summary: 'Test ancillary file 2 summary',
         type: 'Ancillary',
       },
-    ] as FileInfo[],
+      {
+        id: 'file-5',
+        name: 'Test ancillary file 1',
+        summary: 'A Test ancillary file 1 summary',
+        type: 'Ancillary',
+      },
+    ],
     hasMetaGuidance: true,
     hasPreReleaseAccessList: true,
     publication: {
-      slug: 'p-slug',
+      slug: 'publication-1',
     },
-    slug: 'r-slug',
-  };
+    slug: 'release-1',
+  } as Release;
 
-  test('renders the data and files accordion', () => {
+  test('renders the accordion with files', () => {
     render(
       <ReleaseDataAndFilesAccordion
-        release={testRelease as Release}
+        release={testRelease}
         renderDownloadLink={file => <a href="/">{file.name}</a>}
         renderMetaGuidanceLink={<a href="#">mock meta guidance link</a>}
       />,
     );
 
     expect(screen.getByText('Explore data and files')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'All files' })).toBeInTheDocument();
+
+    // Files should be ordered alphabetically, with the
+    // 'All files' zip always being at the top
+    const downloadFiles = within(
+      screen.getByTestId('download-files'),
+    ).getAllByRole('listitem');
+
     expect(
-      screen.getByRole('link', { name: 'Test data file' }),
+      within(downloadFiles[0]).getByRole('link', {
+        name: 'All files',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(downloadFiles[1]).getByRole('link', {
+        name: 'A Test data file 1',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(downloadFiles[2]).getByRole('link', {
+        name: 'Test data file 2',
+      }),
     ).toBeInTheDocument();
 
     expect(screen.getByText('Open data')).toBeInTheDocument();
@@ -55,10 +85,49 @@ describe('ReleaseDataAndFilesAccordion', () => {
 
     expect(screen.getByText('Other files')).toBeInTheDocument();
     expect(screen.getByText('List of other files')).toBeInTheDocument();
+
     userEvent.click(screen.getByText('List of other files'));
+
+    // Files should be ordered alphabetically
+    const otherFiles = within(
+      screen.getByTestId('other-download-files'),
+    ).getAllByRole('listitem');
+
     expect(
-      screen.getByRole('link', { name: 'Test ancillary file' }),
+      within(otherFiles[0]).getByRole('link', {
+        name: 'Test ancillary file 1',
+      }),
     ).toBeInTheDocument();
+    expect(
+      within(otherFiles[0]).getByText('A Test ancillary file 1 summary'),
+    ).toBeInTheDocument();
+
+    expect(
+      within(otherFiles[1]).getByRole('link', {
+        name: 'Test ancillary file 2',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(otherFiles[1]).getByText('Test ancillary file 2 summary'),
+    ).toBeInTheDocument();
+  });
+
+  test('renders the accordion without files', () => {
+    render(
+      <ReleaseDataAndFilesAccordion
+        release={{
+          ...testRelease,
+          downloadFiles: [],
+        }}
+        renderDownloadLink={file => <a href="/">{file.name}</a>}
+        renderMetaGuidanceLink={<a href="#">mock meta guidance link</a>}
+      />,
+    );
+
+    expect(screen.queryByTestId('download-files')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('other-download-files'),
+    ).not.toBeInTheDocument();
   });
 
   test('renders the create tables button', () => {

--- a/src/explore-education-statistics-common/src/services/types/file.ts
+++ b/src/explore-education-statistics-common/src/services/types/file.ts
@@ -3,6 +3,7 @@ export interface FileInfo {
   extension: string;
   fileName: string;
   name: string;
+  summary?: string;
   size: string;
   type: 'Data' | 'DataZip' | 'Metadata' | 'Ancillary' | 'Chart' | 'Image';
   userName?: string;

--- a/src/explore-education-statistics-common/src/styles/_all.scss
+++ b/src/explore-education-statistics-common/src/styles/_all.scss
@@ -15,3 +15,4 @@
 @import './utils/flex';
 @import './utils/modifiers';
 @import './utils/position';
+@import './utils/text';

--- a/src/explore-education-statistics-common/src/styles/utils/_text.scss
+++ b/src/explore-education-statistics-common/src/styles/utils/_text.scss
@@ -1,0 +1,3 @@
+.dfe-white-space--pre-wrap {
+  white-space: pre-wrap;
+}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -340,26 +340,24 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
             const url = `${process.env.CONTENT_API_BASE_URL}/releases/${
               release.id
             }/files/${isAllFiles ? 'all' : file.id}`;
+
             return (
-              <>
-                <Link
-                  to={url}
-                  onClick={() => {
-                    logEvent({
-                      category: 'Downloads',
-                      action: `Release page ${
-                        isAllFiles ? 'all files' : 'file'
-                      } downloaded`,
-                      label: `Publication: ${release.title}, File: ${file.fileName}`,
-                    });
-                  }}
-                >
-                  {isAllFiles
-                    ? 'Download all data and files for this release'
-                    : `${file.name}`}
-                </Link>
-                {` (${file.extension}, ${file.size})`}
-              </>
+              <Link
+                to={url}
+                onClick={() => {
+                  logEvent({
+                    category: 'Downloads',
+                    action: `Release page ${
+                      isAllFiles ? 'all files' : 'file'
+                    } downloaded`,
+                    label: `Publication: ${release.title}, File: ${file.fileName}`,
+                  });
+                }}
+              >
+                {isAllFiles
+                  ? 'Download all data and files for this release'
+                  : `${file.name}`}
+              </Link>
             );
           }}
           renderMetaGuidanceLink={

--- a/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
@@ -35,7 +35,7 @@ Update Methodology for Publication
     ${accordion}=  user opens publication on the admin dashboard   ${PUBLICATION_NAME}
     user views methodology for open publication accordion  ${accordion}  ${PUBLICATION_NAME}
     user clicks link  Edit summary
-    user enters text into textfield  Enter methodology title  ${PUBLICATION_NAME} - New methodology title
+    user enters text into element  label:Enter methodology title  ${PUBLICATION_NAME} - New methodology title
     user clicks button  Update methodology
     user waits until h2 is visible  Methodology summary
     user clicks link  Sign off

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -29,10 +29,10 @@ Navigate to 'Data and files' page
 Upload a ZIP file subject
     [Documentation]    EES-1397
     [Tags]    HappyPath
-    user enters text into element    id:dataFileUploadForm-subjectTitle    Absence in PRUs
+    user enters text into element    label:Subject title    Absence in PRUs
     user clicks radio    ZIP file
-    user waits until page contains element    id:dataFileUploadForm-zipFile
-    user chooses file    id:dataFileUploadForm-zipFile    ${FILES_DIR}upload-zip-test.zip
+    user waits until page contains element    label:Upload ZIP file
+    user chooses file    label:Upload ZIP file    ${FILES_DIR}upload-zip-test.zip
     user clicks button    Upload data files
 
     user waits until h2 is visible    Uploaded data files
@@ -51,7 +51,27 @@ Upload a ZIP file subject
     user checks headed table body row contains    Number of rows    613    ${section}
     user checks headed table body row contains    Status    Complete    ${section}    %{WAIT_LONG}
 
-Check Absence in PRUs subject appears in 'Data blocks' page
+Change subject title
+    [Tags]  HappyPath
+    user waits until page contains accordion section     Absence in PRUs
+    user clicks link    Edit title
+
+    user waits until h2 is visible    Edit data file details
+    user clears element text    label:Title
+    user enters text into element    label:Title    Updated Absence in PRUs
+
+    user clicks button    Save changes
+
+Validate subject title has been updated
+    [Tags]  HappyPath
+    user waits until h2 is visible    Uploaded data files
+    user waits until page contains accordion section    Updated Absence in PRUs
+    user opens accordion section    Absence in PRUs
+
+    ${section}=    user gets accordion section content element    Absence in PRUs
+    user checks headed table body row contains    Subject title    Updated Absence in PRUs    ${section}
+
+Check subject appears in 'Data blocks' page
     [Tags]    HappyPath
     user clicks link    Data blocks
     user waits until h2 is visible    Data blocks
@@ -60,7 +80,7 @@ Check Absence in PRUs subject appears in 'Data blocks' page
     user waits until h2 is visible    Create data block
     user waits until table tool wizard step is available    Choose a subject
 
-    user waits until page contains    Absence in PRUs
+    user waits until page contains    Updated Absence in PRUs
 
 Navigate to 'Data and files' page - 'Ancillary file uploads' tab
     [Tags]    HappyPath
@@ -70,48 +90,106 @@ Navigate to 'Data and files' page - 'Ancillary file uploads' tab
     user waits until h2 is visible    Add file to release
     user waits until page contains    No files have been uploaded
 
-Validate cannot upload empty file
+Validate cannot upload empty ancillary file
     [Tags]    HappyPath
-    user enters text into element    id:fileUploadForm-name    Empty test
-    user chooses file    id:fileUploadForm-file    ${FILES_DIR}empty-file.txt
+    user enters text into element    label:Title    Empty test
+    user chooses file    label:Upload file    ${FILES_DIR}empty-file.txt
     user clicks button    Upload file
     user waits until page contains    Choose a file that is not empty
 
-Upload multiple files
+Upload multiple ancillary files
     [Tags]    HappyPath
-    user enters text into element    id:fileUploadForm-name    Test 1
-    user chooses file    id:fileUploadForm-file    ${FILES_DIR}test-file-1.txt
+    user enters text into element    label:Title    Test 1
+    user enters text into element    label:Summary    Test 1 summary
+    user chooses file    label:Upload file    ${FILES_DIR}test-file-1.txt
     user clicks button    Upload file
 
     user waits until page contains accordion section    Test 1
     user opens accordion section    Test 1    id:file-uploads
 
     ${section_1}=    user gets accordion section content element    Test 1    id:file-uploads
-    user checks summary list contains    Name    Test 1    ${section_1}
+    user checks summary list contains    Title    Test 1    ${section_1}
+    user checks summary list contains    Summary    Test 1 summary    ${section_1}
     user checks summary list contains    File    test-file-1.txt    ${section_1}
     user checks summary list contains    File size    12 B    ${section_1}
 
-    user enters text into element    id:fileUploadForm-name    Test 2
-    user chooses file    id:fileUploadForm-file    ${FILES_DIR}test-file-2.txt
+    user enters text into element    label:Title    Test 2
+    user enters text into element    label:Summary    Test 2 summary
+    user chooses file    label:Upload file    ${FILES_DIR}test-file-2.txt
     user clicks button    Upload file
 
     user waits until page contains accordion section    Test 2
     user opens accordion section    Test 2    id:file-uploads
 
     ${section_2}=    user gets accordion section content element    Test 2    id:file-uploads
-    user checks summary list contains    Name    Test 2    ${section_2}
+    user checks summary list contains    Title    Test 2    ${section_2}
+    user checks summary list contains    Summary    Test 2 summary    ${section_2}
     user checks summary list contains    File    test-file-2.txt    ${section_2}
     user checks summary list contains    File size    24 B    ${section_2}
 
     user checks there are x accordion sections    2    id:file-uploads
 
-Delete file
+Validate ancillary files on release page
     [Tags]    HappyPath
-    ${file_2_section}=    user gets accordion section content element    Test 2    id:file-uploads
+    user clicks link  Content
+    user waits until h2 is visible  ${PUBLICATION_NAME}
+
+    user opens accordion section    Explore data and files
+    ${downloads}=    user gets accordion section content element    Explore data and files
+
+    user waits until h3 is visible  Other files
+
+    user opens details dropdown  List of other files
+    ${other_files}=   user gets details content element  List of other files
+    ${other_files_1}=  get child element  ${other_files}  css:li:nth-child(1)
+
+    user checks element contains button  ${other_files_1}  Test 1
+
+    user opens details dropdown  More details  ${other_files_1}
+    ${other_files_1_details}  user gets details content element   More details  ${other_files_1}
+    user checks element should contain  ${other_files_1_details}  Test 1 summary
+
+Navigate back to 'Ancillary file uploads' tab
+    [Tags]    HappyPath
+    user clicks link  Data and files
+    user waits until h2 is visible    Add data file to release
+
+    user clicks link    Ancillary file uploads
+    user waits until h2 is visible    Add file to release
+
+Change ancillary file details
+    [Tags]  HappyPath
+    user waits until page contains accordion section    Test 2
+    user opens accordion section    Test 2   id:file-uploads
+
+    ${section}=    user gets accordion section content element    Test 2  id:file-uploads
+    user clicks link  Edit file  ${section}
+
+    user waits until h2 is visible  Edit ancillary file details
+    user enters text into element  label:Title  Test 2 updated
+    user enters text into element  label:Summary  Test 2 summary updated
+
+    user clicks button  Save changes
+
+Validate ancillary file details were changed
+    [Tags]  HappyPath
+    user waits until h2 is visible    Add file to release
+    user waits until h2 is visible    Uploaded files
+
+    user waits until page contains accordion section    Test 2 updated
+    user opens accordion section    Test 2 updated   id:file-uploads
+
+    ${section}=    user gets accordion section content element    Test 2 updated  id:file-uploads
+    user checks summary list contains    Title    Test 2 updated    ${section}
+    user checks summary list contains    Summary    Test 2 summary updated    ${section}
+
+Delete ancillary file
+    [Tags]    HappyPath
+    ${file_2_section}=    user gets accordion section content element    Test 2 updated   id:file-uploads
     user clicks button    Delete file    ${file_2_section}
     user waits until h1 is visible    Confirm deletion of file
     user clicks button    Confirm
 
-    user waits until page does not contain accordion section    Test 2
+    user waits until page does not contain accordion section    Test 2 updated
     user waits until page contains accordion section    Test 1
     user checks there are x accordion sections    1    id:file-uploads

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -59,15 +59,17 @@ Add ancillary file
     user clicks link    Ancillary file uploads
     user waits until h2 is visible    Add file to release
 
-    user enters text into element    id:fileUploadForm-name    Test ancillary file 1
-    user chooses file    id:fileUploadForm-file    ${FILES_DIR}test-file-1.txt
+    user enters text into element    label:Title    Test ancillary file 1
+    user enters text into element    label:Summary    Test ancillary file 1 summary
+    user chooses file    label:Upload file    ${FILES_DIR}test-file-1.txt
     user clicks button    Upload file
 
     user waits until page contains accordion section    Test ancillary file 1
     user opens accordion section    Test ancillary file 1    id:file-uploads
 
     ${section_1}=    user gets accordion section content element    Test ancillary file 1    id:file-uploads
-    user checks summary list contains    Name    Test ancillary file 1    ${section_1}
+    user checks summary list contains    Title    Test ancillary file 1    ${section_1}
+    user checks summary list contains    Summary    Test ancillary file 1 summary    ${section_1}
     user checks summary list contains    File    test-file-1.txt    ${section_1}
     user checks summary list contains    File size    12 B    ${section_1}
 
@@ -248,8 +250,15 @@ Verify release associated files
     user checks element should contain    ${downloads}
     ...    Learn more about the data files used in this release using our data files guide.
 
-    user clicks element    xpath://*[@data-testid="Expand Details Section List of other files"]
-    user waits until page contains link    Test ancillary file 1    60
+    user opens details dropdown  List of other files
+    ${other_files}=   user gets details content element  List of other files
+    ${other_files_1}=  get child element  ${other_files}  css:li:nth-child(1)
+
+    user waits until element contains link  ${other_files_1}  Test ancillary file 1
+    user opens details dropdown  More details  ${other_files_1}
+    ${other_files_1_details}  user gets details content element   More details  ${other_files_1}
+    user checks element should contain  ${other_files_1_details}  Test ancillary file 1 summary
+
     download file    link:Test ancillary file 1    test_ancillary_file_1.txt
     downloaded file should have first line    test_ancillary_file_1.txt    Test file 1
 
@@ -437,15 +446,17 @@ Add ancillary file to amendment
     user clicks link    Ancillary file uploads
     user waits until h2 is visible    Add file to release
 
-    user enters text into element    id:fileUploadForm-name    Test ancillary file 2
-    user chooses file    id:fileUploadForm-file    ${FILES_DIR}test-file-2.txt
+    user enters text into element    label:Title    Test ancillary file 2
+    user enters text into element    label:Summary    Test ancillary file 2 summary
+    user chooses file    label:Upload file    ${FILES_DIR}test-file-2.txt
     user clicks button    Upload file
 
     user waits until page contains accordion section    Test ancillary file 2
     user opens accordion section    Test ancillary file 2    id:file-uploads
 
     ${section_2}=    user gets accordion section content element    Test ancillary file 2    id:file-uploads
-    user checks summary list contains    Name    Test ancillary file 2    ${section_2}
+    user checks summary list contains    Title    Test ancillary file 2    ${section_2}
+    user checks summary list contains    Summary    Test ancillary file 2 summary    ${section_2}
     user checks summary list contains    File    test-file-2.txt    ${section_2}
     user checks summary list contains    File size    24 B    ${section_2}
 
@@ -593,12 +604,24 @@ Verify amendment files
     user checks element should contain    ${downloads}    Download all data and files for this release (zip, 4 Kb)
     ...    30
 
-    user clicks element    xpath://*[@data-testid="Expand Details Section List of other files"]
-    user waits until page contains link    Test ancillary file 1    60
+    user opens details dropdown  List of other files
+    ${other_files}=   user gets details content element  List of other files
+    ${other_files_1}=  get child element  ${other_files}  css:li:nth-child(1)
+    ${other_files_2}=  get child element  ${other_files}  css:li:nth-child(2)
+
+    user waits until element contains link  ${other_files_1}  Test ancillary file 1
+    user opens details dropdown  More details  ${other_files_1}
+    ${other_files_1_details}  user gets details content element   More details  ${other_files_1}
+    user checks element should contain  ${other_files_1_details}  Test ancillary file 1 summary
+
     download file    link:Test ancillary file 1    test_ancillary_file_1.txt
     downloaded file should have first line    test_ancillary_file_1.txt    Test file 1
 
-    user waits until page contains link    Test ancillary file 2    60
+    user waits until element contains link  ${other_files_2}  Test ancillary file 2
+    user opens details dropdown  More details  ${other_files_2}
+    ${other_files_2_details}  user gets details content element   More details  ${other_files_2}
+    user checks element should contain  ${other_files_2_details}  Test ancillary file 2 summary
+
     download file    link:Test ancillary file 2    test_ancillary_file_2.txt
     downloaded file should have first line    test_ancillary_file_2.txt    Test file 2
 

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -187,8 +187,8 @@ user links publication to external methodology
     ${accordion}=    user opens publication on the admin dashboard    ${publication}
     user clicks button    Link to an externally hosted methodology    ${accordion}
     user waits until legend is visible    Link to an externally hosted methodology
-    user enters text into textfield    Link title    ${title}
-    user enters text into textfield    URL    ${link}
+    user enters text into element    label:Link title    ${title}
+    user enters text into element    label:URL    ${link}
     user clicks button    Save
 
 user edits an external methodology
@@ -202,10 +202,10 @@ user edits an external methodology
     ${accordion}=    user opens publication on the admin dashboard    ${publication}
     user clicks button    Edit externally hosted methodology    ${accordion}
     user waits until legend is visible    Link to an externally hosted methodology
-    user checks textfield contains    Link title    ${original_title}
-    user checks textfield contains    URL    ${original_link}
-    user enters text into textfield    Link title    ${new_title}
-    user enters text into textfield    URL    ${new_link}
+    user checks input field contains    label:Link title    ${original_title}
+    user checks input field contains    label:URL    ${original_link}
+    user enters text into element    label:Link title    ${new_title}
+    user enters text into element    label:URL    ${new_link}
     user clicks button    Save
 
 user removes an external methodology from publication

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -1,6 +1,6 @@
 *** Settings ***
-Library     OperatingSystem
 Library     SeleniumLibrary    timeout=${timeout}    implicit_wait=${implicit_wait}    run_on_failure=do this on failure
+Library     OperatingSystem
 #Library    XvfbRobot    # sudo apt install xvfb + pip install robotframework-xvfb
 Library     file_operations.py
 Library     utilities.py
@@ -28,13 +28,21 @@ do this on failure
     END
 
 custom testid locator strategy
-    [Arguments]    ${browser}    ${test_id}    ${tag}    ${constraints}
-    ${element}=    Execute Javascript
-    ...    let xPathResult = document.evaluate('//*[@data-testid="${test_id}"]', document); if(xPathResult) return xPathResult.iterateNext(); return [];
-    [Return]    ${element}
+    [Arguments]  ${browser}  ${test_id}   ${tag}  ${constraints}
+    ${element}=  user gets testid element  ${test_id}
+    [Return]  ${element}
+
+custom label locator strategy
+    [Arguments]  ${browser}  ${label}  ${tag}  ${constraints}
+    user waits until element is visible  xpath://label[text()="${label}"]
+    ${label_el}=  get web element  xpath://label[text()="${label}"]
+    ${input_id}=  get element attribute  ${label_el}  for
+    ${element}=   get web element  id:${input_id}
+    [Return]  ${element}
 
 set custom locator strategies
-    add location strategy    testid    custom testid locator strategy
+    add location strategy   testid    custom testid locator strategy
+    add location strategy   label     custom label locator strategy
 
 user opens the browser
     set custom locator strategies
@@ -521,15 +529,6 @@ user enters text into element
     user waits until element is visible    ${selector}    60
     user clears element text    ${selector}
     user presses keys    ${text}    ${selector}
-
-user enters text into textfield
-    [Arguments]    ${label}    ${text}
-    user enters text into element    xpath://label[text()="${label}"]/following-sibling::input[@type="text"]    ${text}
-
-user checks textfield contains
-    [Arguments]    ${label}    ${text}
-    user checks input field contains    xpath://label[text()="${label}"]/following-sibling::input[@type="text"]
-    ...    ${text}
 
 user checks element count is x
     [Arguments]    ${locator}    ${amount}

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -15,11 +15,11 @@ sl = BuiltIn().get_library_instance('SeleniumLibrary')
 element_finder = ElementFinder(sl)
 waiting = WaitingKeywords(sl)
 
+
 def raise_assertion_error(err_msg):
     sl.failure_occurred()
     raise AssertionError(err_msg)
-    
-    
+
 def user_waits_until_parent_contains_element(parent_locator: object, child_locator: str,
                                              timeout: int = None, error: str = None,
                                              limit: int = None):
@@ -92,12 +92,12 @@ def user_waits_until_parent_does_not_contain_element(parent_locator: object, chi
 def get_child_element(parent_locator: object, child_locator: str):
     try:
         children = get_child_elements(parent_locator, child_locator)
-        
+
         if len(children) > 1:
             warning(f"Found {len(children)} child elements matching child locator {child_locator} under parent "
                     f"locator {parent_locator} in utilities.py#get_child_element() - was expecting only one. Consider "
                     f"making the parent selector more specific. Returning the first element found.")
-        
+
         return children[0]
     except Exception as err:
         warning(f"Error whilst executing utilities.py get_child_element() with parent {parent_locator} and child "
@@ -204,6 +204,7 @@ def capture_html():
     html_file.close()
     warning(f"Captured HTML of {sl.get_location()}      HTML saved to file://{os.path.realpath(html_file.name)}")
 
+
 def user_gets_row_number_with_heading(heading: str, table_locator: str = 'css:table'):
     elem = get_child_element(table_locator, f'xpath:.//tbody/tr/th[text()="{heading}"]/..')
     rows = get_child_elements(table_locator, 'css:tbody tr')
@@ -285,9 +286,9 @@ def __normalise_child_locator(parent_locator: object, child_locator: str) -> str
     if isinstance(parent_locator, str):
         return child_locator
     elif isinstance(parent_locator, WebElement):
-        # the below substitution is necessary if the parent is a Selenium WebElement in order to correctly find the 
+        # the below substitution is necessary if the parent is a Selenium WebElement in order to correctly find the
         # parent's descendants.  Without the preceding dot, the double forward slash breaks out of the parent container
-        # and returns the xpath query to the root of the DOM, leading to false positives or incorrectly found DOM 
+        # and returns the xpath query to the root of the DOM, leading to false positives or incorrectly found DOM
         # elements.  The below substitution covers both selectors beginning with "xpath://" and "//", as the double
         # forward slashes without the "xpath:" prefix are inferred as being xpath expressions.
         return re.sub(r'^(xpath:)?//', "xpath:.//", child_locator)


### PR DESCRIPTION
This PR adds the new 'Summary' field for ancillary files. This has been added to both the upload and update forms.

## Relevant changes

- Added missing tests for updating ancillary and data file titles.

## Other changes

- Added a new `label` element selector that replaces the previous 'textfield' specific keywords (e.g. `user enters text into textfield`). This reduces duplication and is more versatile as it locates an element by id matching the label's `for` attribute. Comparatively, the previous textfield keywords would only look for an input directly adjacent to the label.

## Screenshots

Upload form:

![image](https://user-images.githubusercontent.com/9917868/125538725-779b85cf-e9db-4cd6-8ca8-af763471a00e.png)

Edit form:

![image](https://user-images.githubusercontent.com/9917868/125538757-e82ab153-0407-46e0-8845-7da1e3f11cf8.png)

In the release's downloads accordion:

![image](https://user-images.githubusercontent.com/9917868/125538829-4d5df885-698e-4ee8-b844-0b3e57e7390c.png)