### PR TITLE
EES-2513 - avoid Stale Reference errors

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -533,7 +533,7 @@ Select publication
     user checks previous table tool step contains  1   Publication   ${PUBLICATION_NAME}
     #user checks page does not contain  ${SECOND_SUBJECT}   # EES-1360
 
-Select subject
+Select subject again
     [Tags]  HappyPath
     user clicks radio   ${SUBJECT_NAME}
     user clicks element   id:publicationSubjectForm-submit

--- a/tests/robot-tests/tests/libs/tables-common.robot
+++ b/tests/robot-tests/tests/libs/tables-common.robot
@@ -9,7 +9,7 @@ user waits until table is visible
 user checks table column heading contains
     [Arguments]    ${row}    ${column}    ${expected}    ${parent}=css:table    ${wait}=30
     user waits until parent contains element    ${parent}
-    ...    xpath:.//thead/tr[${row}]/th[${column}][text()="${expected}"]
+    ...    xpath://thead/tr[${row}]/th[${column}][text()="${expected}"]
     ...    timeout=${wait}
 
 user checks row contains heading

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -292,6 +292,7 @@ def __normalise_child_locator(parent_locator: object, child_locator: str) -> str
     else:
         raise_assertion_error(f"Parent locator was neither a str or a WebElement - {parent_locator}")
 
+
 def __get_parent_webelement_from_locator(parent_locator: object, timeout: int = None, error: str = '') -> WebElement:
     if isinstance(parent_locator, str):
         sl.wait_until_page_contains_element(parent_locator, timeout=timeout, error=error)

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -6,7 +6,6 @@ from logging import warning
 from SeleniumLibrary.utils import is_noney
 from robot.libraries.BuiltIn import BuiltIn
 from SeleniumLibrary import ElementFinder
-from SeleniumLibrary.errors import ElementNotFound
 from SeleniumLibrary.keywords.waiting import WaitingKeywords
 from selenium.webdriver.remote.webelement import WebElement
 import os
@@ -28,10 +27,7 @@ def user_waits_until_parent_contains_element(parent_locator: object, child_locat
 
         def parent_contains_matching_element() -> bool:
             parent_el = __get_parent_webelement_from_locator(parent_locator, timeout, error)
-            return element_finder.find(
-                child_locator, 
-                required=False, 
-                parent=parent_el) is not None
+            return element_finder.find(child_locator, required=False, parent=parent_el) is not None
 
         if is_noney(limit):
             return waiting._wait_until(
@@ -96,11 +92,10 @@ def get_child_element(parent_locator: object, child_locator: str):
     try:
         children = get_child_elements(parent_locator, child_locator)
         
-        if (len(children) > 1):
+        if len(children) > 1:
             warning(f"Found {len(children)} child elements matching child locator {child_locator} under parent "
                     f"locator {parent_locator} in utilities.py#get_child_element() - was expecting only one. Consider "
                     f"making the parent selector more specific. Returning the first element found.")
-            return children[0]
         
         return children[0]
     except Exception as err:
@@ -165,8 +160,7 @@ def get_current_datetime(strf: str, offset_days: int = 0) -> str:
 def user_should_be_at_top_of_page():
     (x, y) = sl.get_window_position()
     if y != 0:
-        raise_assertion_error(
-            f"Windows position Y is {y} not 0! User should be at the top of the page!")
+        raise_assertion_error(f"Windows position Y is {y} not 0! User should be at the top of the page!")
 
 
 def prompt_to_continue():

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -9,6 +9,7 @@ from SeleniumLibrary import ElementFinder
 from SeleniumLibrary.keywords.waiting import WaitingKeywords
 from selenium.webdriver.remote.webelement import WebElement
 import os
+import re
 
 sl = BuiltIn().get_library_instance('SeleniumLibrary')
 element_finder = ElementFinder(sl)
@@ -287,8 +288,9 @@ def __normalise_child_locator(parent_locator: object, child_locator: str) -> str
         # the below substitution is necessary if the parent is a Selenium WebElement in order to correctly find the 
         # parent's descendants.  Without the preceding dot, the double forward slash breaks out of the parent container
         # and returns the xpath query to the root of the DOM, leading to false positives or incorrectly found DOM 
-        # elements.
-        return child_locator.replace("xpath://", "xpath:.//")
+        # elements.  The below substitution covers both selectors beginning with "xpath://" and "//", as the double
+        # forward slashes without the "xpath:" prefix are inferred as being xpath expressions.
+        return re.sub(r'^(xpath:)?//', "xpath:.//", child_locator)
     else:
         raise_assertion_error(f"Parent locator was neither a str or a WebElement - {parent_locator}")
 

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -8,6 +8,7 @@ from robot.libraries.BuiltIn import BuiltIn
 from SeleniumLibrary import ElementFinder
 from SeleniumLibrary.errors import ElementNotFound
 from SeleniumLibrary.keywords.waiting import WaitingKeywords
+from selenium.webdriver.remote.webelement import WebElement
 import os
 
 sl = BuiltIn().get_library_instance('SeleniumLibrary')
@@ -17,25 +18,20 @@ waiting = WaitingKeywords(sl)
 def raise_assertion_error(err_msg):
     sl.failure_occurred()
     raise AssertionError(err_msg)
-
+    
+    
 def user_waits_until_parent_contains_element(parent_locator: object, child_locator: str,
                                              timeout: int = None, error: str = None,
                                              limit: int = None):
     try:
-        if isinstance(parent_locator, str):
-            sl.wait_until_page_contains_element(parent_locator, timeout=timeout, error=error)
-            parent_el = sl.find_element(parent_locator)
-            # the below substitution is necessary if the parent is an xpath expression in order
-            # to correctly find the parent's descendants  
-            child_locator = child_locator.replace("xpath:.//", "xpath://")
-        else:
-            parent_el = parent_locator
-            # the below substitution is necessary if the parent is a Selenium WebElement in order
-            # to correctly find the parent's descendants
-            child_locator = child_locator.replace("xpath://", "xpath:.//")
+        child_locator = __normalise_child_locator(parent_locator, child_locator)
 
         def parent_contains_matching_element() -> bool:
-            return element_finder.find(child_locator, required=False, parent=parent_el) is not None
+            parent_el = __get_parent_webelement_from_locator(parent_locator, timeout, error)
+            return element_finder.find(
+                child_locator, 
+                required=False, 
+                parent=parent_el) is not None
 
         if is_noney(limit):
             return waiting._wait_until(
@@ -47,6 +43,7 @@ def user_waits_until_parent_contains_element(parent_locator: object, child_locat
         limit = int(limit)
 
         def parent_contains_matching_elements() -> bool:
+            parent_el = __get_parent_webelement_from_locator(parent_locator, timeout, error)
             return len(sl.find_elements(child_locator, parent=parent_el)) == limit
 
         waiting._wait_until(
@@ -63,25 +60,11 @@ def user_waits_until_parent_contains_element(parent_locator: object, child_locat
 def user_waits_until_parent_does_not_contain_element(parent_locator: object, child_locator: str,
                                                      timeout: int = None, error: str = None,
                                                      limit: int = None):
-
-    if isinstance(parent_locator, str):
-        sl.wait_until_page_contains_element(parent_locator, timeout=timeout, error=error)
-        parent_el = sl.find_element(parent_locator)
-        if (child_locator.startswith("xpath:.//")):
-            child_locator = child_locator.replace("xpath:.//", "xpath://")
-    else:
-        parent_el = parent_locator
-        if (child_locator.startswith("xpath://")):
-            child_locator = child_locator.replace("xpath://", "xpath:.//")
-
     try:
-        if isinstance(parent_locator, str):
-            sl.wait_until_page_contains_element(parent_locator, timeout=timeout, error=error)
-            parent_el = sl.find_element(parent_locator)
-        else:
-            parent_el = parent_locator
+        child_locator = __normalise_child_locator(parent_locator, child_locator)
 
         def parent_does_not_contain_matching_element() -> bool:
+            parent_el = __get_parent_webelement_from_locator(parent_locator, timeout, error)
             return element_finder.find(child_locator, required=False, parent=parent_el) is None
 
         if is_noney(limit):
@@ -95,6 +78,7 @@ def user_waits_until_parent_does_not_contain_element(parent_locator: object, chi
         limit = int(limit)
 
         def parent_does_not_contain_matching_elements() -> bool:
+            parent_el = __get_parent_webelement_from_locator(parent_locator, timeout, error)
             return len(sl.find_elements(child_locator, parent=parent_el)) != limit
 
         waiting._wait_until(
@@ -109,33 +93,27 @@ def user_waits_until_parent_does_not_contain_element(parent_locator: object, chi
 
 
 def get_child_element(parent_locator: object, child_locator: str):
-
     try:
-        if isinstance(parent_locator, str):
-            sl.wait_until_page_contains_element(parent_locator)
-            parent_el = sl.find_element(parent_locator)
-        else:
-            parent_el = parent_locator
-
-        return sl.find_element(child_locator, parent=parent_el)
-    except ElementNotFound as err:
-        warning(f"Error whilst executing utilities.py get_child_element() with parent {parent_locator} and child locator {child_locator} - {err}")
-        raise_assertion_error(
-            f"Could not find child '{child_locator}' within parent '{parent_locator}'")
+        children = get_child_elements(parent_locator, child_locator)
+        
+        if (len(children) > 1):
+            warning(f"Found {len(children)} child elements matching child locator {child_locator} under parent "
+                    f"locator {parent_locator} in utilities.py#get_child_element() - was expecting only one. Consider "
+                    f"making the parent selector more specific. Returning the first element found.")
+            return children[0]
+        
+        return children[0]
     except Exception as err:
-        warning(f"Error whilst executing utilities.py get_child_element() with parent {parent_locator} and child locator {child_locator} - {err}")
+        warning(f"Error whilst executing utilities.py get_child_element() with parent {parent_locator} and child "
+                f"locator {child_locator} - {err}")
         raise_assertion_error(err)
 
 
 def get_child_elements(parent_locator: object, child_locator: str):
     try:
-        if isinstance(parent_locator, str):
-            sl.wait_until_page_contains_element(parent_locator)
-            parent_el = sl.find_element(parent_locator)
-        else:
-            parent_el = parent_locator
-
-        return sl.find_elements(child_locator, parent=parent_el)
+        child_locator = __normalise_child_locator(parent_locator, child_locator)
+        parent_el = __get_parent_webelement_from_locator(parent_locator)
+        return element_finder.find(child_locator, required=True, first_only=False, parent=parent_el)
     except Exception as err:
         warning(f"Error whilst executing utilities.py get_child_elements() - {err}")
         raise_assertion_error(err)
@@ -306,3 +284,25 @@ def remove_substring_from_right_of_string(string, substring):
 def user_clicks_element_if_exists(selector):
     if element_finder.find(selector, required=False) is not None:
         sl.click_element(selector)
+
+
+def __normalise_child_locator(parent_locator: object, child_locator: str) -> str:
+    if isinstance(parent_locator, str):
+        return child_locator
+    elif isinstance(parent_locator, WebElement):
+        # the below substitution is necessary if the parent is a Selenium WebElement in order to correctly find the 
+        # parent's descendants.  Without the preceding dot, the double forward slash breaks out of the parent container
+        # and returns the xpath query to the root of the DOM, leading to false positives or incorrectly found DOM 
+        # elements.
+        return child_locator.replace("xpath://", "xpath:.//")
+    else:
+        raise_assertion_error(f"Parent locator was neither a str or a WebElement - {parent_locator}")
+
+def __get_parent_webelement_from_locator(parent_locator: object, timeout: int = None, error: str = '') -> WebElement:
+    if isinstance(parent_locator, str):
+        sl.wait_until_page_contains_element(parent_locator, timeout=timeout, error=error)
+        return sl.find_element(parent_locator)
+    elif isinstance(parent_locator, WebElement):
+        return parent_locator
+    else:
+        raise_assertion_error(f"Parent locator was neither a str or a WebElement - {parent_locator}")


### PR DESCRIPTION
This PR:
- moves the lookup of parents from a single initial lookup in `user_waits_until_parent_contains_element` and `user_waits_until_parent_does_not_contain_element` to a dynamic lookup within the `waiting._wait_until` loop, thus ensuring that the parent being used to find the child is always fresh
- refactors `get_child_element` and `get_child_elements` to reuse much of the code used within `user_waits_until_parent_contains_element` for easier maintenance.
- adds a warning within `get_child_element` if the lookup resulted in more than one element being found.  Previous behaviour was just to return the first element that the query matched without any warning.  This highlights some areas where we're currently "getting away with it".
- corrects a table xpath expression that was only succeeding previously due to an overzealous rewrite of the selector within `utilities.py`.

## Test results

Note that the screenshot says that there's 1 test failure, but this is actually just due to the fact that I changed a test name so that it was unique within its suite, and so the "failure" indicated here is just the originally named test that failed during the first run.  Its newly named test passed in the following run (otherwise there would have been 2 test failures indicated here, one under the old name, one under the new).

![image](https://user-images.githubusercontent.com/12444316/125599376-49065adc-fe6c-43f2-8e91-4e838ab32be6.png)
