### PR TITLE
Ees 2156 sow4 create methodology amendment part 2

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
@@ -19,6 +19,7 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Map
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies
 {
@@ -58,7 +59,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             // Call the method under test
             await using(var context = InMemoryApplicationDbContext(contextId))
             {
-                var methodologyService = new Mock<IMethodologyService>();
+                var methodologyService = new Mock<IMethodologyService>(Strict);
                 var service = BuildService(context, methodologyService: methodologyService.Object);
                 
                 var amendmentIdCapture = new List<Guid>();
@@ -69,6 +70,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     .ReturnsAsync(summaryViewModel);
                 
                 var result = await service.CreateMethodologyAmendment(originalMethodology.Id);
+                VerifyAllMocks(methodologyService);
+                
                 var resultingViewModel = result.AssertRight();
                 Assert.Same(summaryViewModel, resultingViewModel);
                 amendmentId = Assert.Single(amendmentIdCapture);
@@ -144,7 +147,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             // Call the method under test
             await using(var context = InMemoryApplicationDbContext(contextId))
             {
-                var methodologyService = new Mock<IMethodologyService>();
+                var methodologyService = new Mock<IMethodologyService>(Strict);
                 var service = BuildService(context, methodologyService: methodologyService.Object);
                 
                 var amendmentIdCapture = new List<Guid>();
@@ -155,6 +158,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     .ReturnsAsync(summaryViewModel);
                 
                 var result = await service.CreateMethodologyAmendment(originalMethodology.Id);
+                VerifyAllMocks(methodologyService);
+                
                 var resultingViewModel = result.AssertRight();
                 Assert.Same(summaryViewModel, resultingViewModel);
                 amendmentId = Assert.Single(amendmentIdCapture);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyImageServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyImageServicePermissionTests.cs
@@ -35,7 +35,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     userService =>
                     {
                         var service = SetupMethodologyImageService(userService: userService.Object);
-                        return service.Delete(methodologyId: _methodology.Id,
+                        return service.UnlinkAndDeleteIfOrphaned(methodologyId: _methodology.Id,
                             fileIds: new List<Guid>());
                     }
                 );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyFileRepository.cs
@@ -24,5 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
         public Task<MethodologyFile> Get(Guid methodologyId, Guid fileId);
 
         public Task<List<MethodologyFile>> GetByFileType(Guid methodologyId, params FileType[] types);
+        
+        public Task<List<MethodologyFile>> GetMethodologyLinksToFile(Guid fileId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyImageService.cs
@@ -10,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 {
     public interface IMethodologyImageService
     {
-        Task<Either<ActionResult, Unit>> Delete(
+        Task<Either<ActionResult, Unit>> UnlinkAndDeleteIfOrphaned(
             Guid methodologyId,
             IEnumerable<Guid> fileIds);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyFileRepository.cs
@@ -104,5 +104,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                     && types.Contains(methodologyFile.File.Type))
                 .ToListAsync();
         }
+
+        public Task<List<MethodologyFile>> GetMethodologyLinksToFile(Guid fileId)
+        {
+            return _contentDbContext
+                .MethodologyFiles
+                .Where(f => f.FileId == fileId)
+                .ToListAsync();
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
@@ -67,9 +67,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
                         await _methodologyFileRepository.Delete(methodologyId, file.Id);
 
-                        // If this Methodology is the only Methodology that is referencing this Methodology File, it
+                        // If this Methodology is the only Methodology that is referencing this Blob and File, it
                         // can be deleted from Blob Storage and the File table.  Otherwise preserve them for the other
-                        // Methodology versions that are still using them.
+                        // Methodology versions that are still using them. 
                         if (methodologyLinks.Count == 1 && methodologyLinks[0].MethodologyId == methodologyId)
                         {
                             await _blobStorageService.DeleteBlob(PrivateMethodologyFiles, file.Path());

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
@@ -51,7 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             _userService = userService;
         }
 
-        public async Task<Either<ActionResult, Unit>> Delete(Guid methodologyId, IEnumerable<Guid> fileIds)
+        public async Task<Either<ActionResult, Unit>> UnlinkAndDeleteIfOrphaned(Guid methodologyId, IEnumerable<Guid> fileIds)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Methodology>(methodologyId)
@@ -63,10 +63,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 {
                     await files.ForEachAsync(async file =>
                     {
-                        // TODO EES-1263 Methodology amendments - Check if file is linked to other methodolgies before deleting blob
-                        await _blobStorageService.DeleteBlob(PrivateMethodologyFiles, file.Path());
+                        var methodologyLinks = await _methodologyFileRepository.GetMethodologyLinksToFile(file.Id);
+
                         await _methodologyFileRepository.Delete(methodologyId, file.Id);
-                        await _fileRepository.Delete(file.Id);
+
+                        // If this Methodology is the only Methodology that is referencing this Methodology File, it
+                        // can be deleted from Blob Storage and the File table.  Otherwise preserve them for the other
+                        // Methodology versions that are still using them.
+                        if (methodologyLinks.Count == 1 && methodologyLinks[0].MethodologyId == methodologyId)
+                        {
+                            await _blobStorageService.DeleteBlob(PrivateMethodologyFiles, file.Path());
+                            await _fileRepository.Delete(file.Id);
+                        }
                     });
                 });
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -155,14 +155,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             return Unit.Instance;
         }
         
-        private async Task<Either<ActionResult, Unit>> DeleteMethodologyVersion(Methodology methodology)
+        private async Task DeleteMethodologyVersion(Methodology methodology)
         {
             _context.Methodologies.Remove(methodology);
             await _context.SaveChangesAsync();
-            return Unit.Instance;
         }
         
-        private async Task<Either<ActionResult, Unit>> DeleteMethodologyParentIfOrphaned(Methodology methodology)
+        private async Task DeleteMethodologyParentIfOrphaned(Methodology methodology)
         {
             var methodologyParent = await _context
                 .MethodologyParents
@@ -174,8 +173,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 _context.MethodologyParents.Remove(methodologyParent);
                 await _context.SaveChangesAsync();
             }
-
-            return Unit.Instance;
         }
 
         private Task<Either<ActionResult, Methodology>> CheckCanUpdateMethodologyStatus(Methodology methodology,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -128,30 +128,54 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 });
         }
 
-        // TODO SOW4 EES-2156 - delete Methodology Files
         public Task<Either<ActionResult, Unit>> DeleteMethodology(Guid methodologyId)
         {
             return _persistenceHelper
                 .CheckEntityExists<Methodology>(methodologyId, 
                     query => query.Include(m => m.MethodologyParent))
                 .OnSuccess(_userService.CheckCanDeleteMethodology)
-                .OnSuccessVoid(async methodology =>
-                {
-                    _context.Methodologies.Remove(methodology);
-                    await _context.SaveChangesAsync();
+                .OnSuccessDo(UnlinkMethodologyFilesAndDeleteIfOrphaned)
+                .OnSuccessDo(DeleteMethodologyVersion)
+                .OnSuccessVoid(DeleteMethodologyParentIfOrphaned);
+        }
 
-                    var methodologyParent = await _context
-                        .MethodologyParents
-                        .Include(p => p.Versions)
-                        .SingleAsync(p => p.Id == methodology.MethodologyParentId);
+        private async Task<Either<ActionResult, Unit>> UnlinkMethodologyFilesAndDeleteIfOrphaned(Methodology methodology)
+        {
+            var methodologyFileIds = await _context
+                    .MethodologyFiles
+                    .Where(f => f.MethodologyId == methodology.Id)
+                    .Select(f => f.FileId)
+                    .ToListAsync();
+
+            if (methodologyFileIds.Count > 0)
+            {
+                return await _methodologyImageService.UnlinkAndDeleteIfOrphaned(methodology.Id, methodologyFileIds);
+            }
+
+            return Unit.Instance;
+        }
+        
+        private async Task<Either<ActionResult, Unit>> DeleteMethodologyVersion(Methodology methodology)
+        {
+            _context.Methodologies.Remove(methodology);
+            await _context.SaveChangesAsync();
+            return Unit.Instance;
+        }
+        
+        private async Task<Either<ActionResult, Unit>> DeleteMethodologyParentIfOrphaned(Methodology methodology)
+        {
+            var methodologyParent = await _context
+                .MethodologyParents
+                .Include(p => p.Versions)
+                .SingleAsync(p => p.Id == methodology.MethodologyParentId);
                     
-                    if (methodologyParent.Versions.Count == 0)
-                    {
-                        _context.MethodologyParents.Remove(methodologyParent);
-                        await _context.SaveChangesAsync();
-                    }
+            if (methodologyParent.Versions.Count == 0)
+            {
+                _context.MethodologyParents.Remove(methodologyParent);
+                await _context.SaveChangesAsync();
+            }
 
-                });
+            return Unit.Instance;
         }
 
         private Task<Either<ActionResult, Methodology>> CheckCanUpdateMethodologyStatus(Methodology methodology,
@@ -189,7 +213,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
                     if (unusedImages.Any())
                     {
-                        return await _methodologyImageService.Delete(methodologyId, unusedImages);
+                        return await _methodologyImageService.UnlinkAndDeleteIfOrphaned(methodologyId, unusedImages);
                     }
 
                     return Unit.Instance;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EitherTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EitherTestExtensions.cs
@@ -9,18 +9,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
     {
         public static void AssertNotFound<T>(this Either<ActionResult, T> result)
         {
-            Assert.True(result.IsLeft, "Expecting result to be Left when asserting NotFound");
-            Assert.IsType<NotFoundResult>(result.Left);
+            var actionResult = result.AssertLeft("Expecting result to be Left when asserting NotFound");
+            Assert.IsType<NotFoundResult>(actionResult);
         }
         
-        public static TRight AssertRight<TLeft, TRight>(this Either<TLeft, TRight> either)
+        public static TRight AssertRight<TLeft, TRight>(this Either<TLeft, TRight> either, string message = null)
         {
             if (either.IsLeft)
             {
-                AssertFail($"Expected Either to be Right, but was Left with value {either.Left}");
+                AssertFail(message ?? $"Expected Either to be Right, but was Left with value {either.Left}");
             }
             
             return either.Right;
+        }
+        
+        public static TLeft AssertLeft<TLeft, TRight>(this Either<TLeft, TRight> either, string message = null)
+        {
+            if (either.IsRight)
+            {
+                AssertFail(message ?? $"Expected Either to be Left, but was Right with value {either.Right}");
+            }
+            
+            return either.Left;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -126,18 +126,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             }
         }
 
-        public static async Task<List<TResult>> ForEachAsync<T, TResult>(this IEnumerable<T> source, Func<T, Task<TResult>> func)
-        {
-            List<TResult> results = new List<TResult>();
-
-            foreach (var item in source)
-            {
-                results.Add(await func(item));
-            }
-
-            return results;
-        }
-
         public static async Task<Either<TLeft, List<TRight>>> ForEachAsync<T, TLeft, TRight>(this IEnumerable<T> source,
             Func<T, Task<Either<TLeft, TRight>>> func)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -126,6 +126,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             }
         }
 
+        public static async Task<List<TResult>> ForEachAsync<T, TResult>(this IEnumerable<T> source, Func<T, Task<TResult>> func)
+        {
+            List<TResult> results = new List<TResult>();
+
+            foreach (var item in source)
+            {
+                results.Add(await func(item));
+            }
+
+            return results;
+        }
+
         public static async Task<Either<TLeft, List<TRight>>> ForEachAsync<T, TLeft, TRight>(this IEnumerable<T> source,
             Func<T, Task<Either<TLeft, TRight>>> func)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -131,6 +131,15 @@ public class Either<Tl, Tr> {
             return Unit.Instance;
         }
 
+        /**
+         * Convenience method so that the success chain can be converted to a Unit without having to explicitly supply
+         * it.
+         */
+        public static Task<Either<TFailure, Unit>> OnSuccessVoid<TFailure, TSuccess>(this Task<Either<TFailure, TSuccess>> task)
+        {
+            return OnSuccessVoid(task, () => { });
+        }
+
         public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(this Task<Either<TFailure, TSuccess1>> task, Func<Task<TSuccess2>> func)
         {
             var firstResult = await task;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/CollectionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/CollectionUtils.cs
@@ -8,5 +8,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         {
             return new List<T>(objects);
         }
+        
+        public static T[] AsArray<T>(params T[] objects)
+        {
+            return objects;
+        }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -26,14 +26,12 @@ export interface Props {
   publication: MyPublication;
   topicId: string;
   onChangePublication: () => void;
-  allowAmendments?: boolean; // TODO EES-2156 - remove when Amendments are ready to use
 }
 
 const MethodologySummary = ({
   publication,
   topicId,
   onChangePublication,
-  allowAmendments = false,
 }: Props) => {
   const history = useHistory();
   const [
@@ -244,19 +242,16 @@ const MethodologySummary = ({
                           ? 'Edit this methodology'
                           : 'View this methodology'}
                       </ButtonLink>
-                      {allowAmendments &&
-                        methodology.permissions
-                          .canMakeAmendmentOfMethodology && (
-                          <Button
-                            type="button"
-                            onClick={() =>
-                              setAmendMethodologyId(methodology.id)
-                            }
-                            variant="secondary"
-                          >
-                            Amend methodology
-                          </Button>
-                        )}
+                      {methodology.permissions
+                        .canMakeAmendmentOfMethodology && (
+                        <Button
+                          type="button"
+                          onClick={() => setAmendMethodologyId(methodology.id)}
+                          variant="secondary"
+                        >
+                          Amend methodology
+                        </Button>
+                      )}
                     </ButtonGroup>
                   </>
                 )}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -33,7 +33,7 @@ const MethodologySummary = ({
   publication,
   topicId,
   onChangePublication,
-  allowAmendments = false,
+  allowAmendments = true,
 }: Props) => {
   const history = useHistory();
   const [

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -33,7 +33,7 @@ const MethodologySummary = ({
   publication,
   topicId,
   onChangePublication,
-  allowAmendments = true,
+  allowAmendments = false,
 }: Props) => {
   const history = useHistory();
   const [

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -425,7 +425,6 @@ describe('MethodologySummary', () => {
             publication={testPublicationWithMethodologyCanAmend}
             topicId={testTopicId}
             onChangePublication={noop}
-            allowAmendments
           />
         </MemoryRouter>,
       );
@@ -442,7 +441,6 @@ describe('MethodologySummary', () => {
             publication={testPublicationWithMethodology}
             topicId={testTopicId}
             onChangePublication={noop}
-            allowAmendments
           />
         </MemoryRouter>,
       );
@@ -459,7 +457,6 @@ describe('MethodologySummary', () => {
             publication={testPublicationWithMethodologyCanAmend}
             topicId={testTopicId}
             onChangePublication={noop}
-            allowAmendments
           />
         </MemoryRouter>,
       );
@@ -500,7 +497,6 @@ describe('MethodologySummary', () => {
             publication={testPublicationWithMethodologyCanAmend}
             topicId={testTopicId}
             onChangePublication={noop}
-            allowAmendments
           />
         </Router>,
       );


### PR DESCRIPTION
This PR:
* Creates links to an original Methodology version's files when creating a new Methodology amendment.
* Unlinks files from a Methodology version when deleting it, and deletes the files from the Files table and Blob Storage if no other Methodology version is using them.

With this PR in place, Methodology Amendments no longer have to be a hidden feature, and so the "Amend Methodology" button has been reinstated in the UI.