### PR TITLE
EES-2523 Disable methodology amendments button

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -25,12 +25,14 @@ import { generatePath, useHistory } from 'react-router';
 export interface Props {
   publication: MyPublication;
   topicId: string;
+  allowAmendments?: boolean;
   onChangePublication: () => void;
 }
 
 const MethodologySummary = ({
   publication,
   topicId,
+  allowAmendments = false,
   onChangePublication,
 }: Props) => {
   const history = useHistory();
@@ -241,16 +243,19 @@ const MethodologySummary = ({
                           ? 'Edit this methodology'
                           : 'View this methodology'}
                       </ButtonLink>
-                      {methodology.permissions
-                        .canMakeAmendmentOfMethodology && (
-                        <Button
-                          type="button"
-                          variant="secondary"
-                          onClick={() => setAmendMethodologyId(methodology.id)}
-                        >
-                          Amend methodology
-                        </Button>
-                      )}
+                      {allowAmendments &&
+                        methodology.permissions
+                          .canMakeAmendmentOfMethodology && (
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            onClick={() =>
+                              setAmendMethodologyId(methodology.id)
+                            }
+                          >
+                            Amend methodology
+                          </Button>
+                        )}
                     </ButtonGroup>
                   </>
                 )}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -431,6 +431,7 @@ describe('MethodologySummary', () => {
           <MethodologySummary
             publication={testPublicationWithMethodologyCanAmend}
             topicId={testTopicId}
+            allowAmendments
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -447,6 +448,7 @@ describe('MethodologySummary', () => {
           <MethodologySummary
             publication={testPublicationWithMethodology}
             topicId={testTopicId}
+            allowAmendments
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -463,6 +465,7 @@ describe('MethodologySummary', () => {
           <MethodologySummary
             publication={testPublicationWithMethodologyCanAmend}
             topicId={testTopicId}
+            allowAmendments
             onChangePublication={noop}
           />
         </MemoryRouter>,
@@ -506,6 +509,7 @@ describe('MethodologySummary', () => {
           <MethodologySummary
             publication={testPublicationWithMethodologyCanAmend}
             topicId={testTopicId}
+            allowAmendments
             onChangePublication={noop}
           />
         </Router>,


### PR DESCRIPTION
This PR hides the methodology amendments button which won't be made public until further development and testing of amendments is completed.