### PR TITLE
EES-2526 Publish the images of the latest Methodologies related to this Release

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/PublishingServiceTests.cs
@@ -1,0 +1,437 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
+{
+    public class PublishingServiceTests
+    {
+        private const string? PublicStorageConnectionString = "public-storage-conn";
+        
+        [Fact]
+        public async Task PublishMethodologyFiles()
+        {
+            var methodology = new Methodology
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var logger = new Mock<ILogger<PublishingService>>();
+            var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
+            var publicBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var privateBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.Get(methodology.Id))
+                .ReturnsAsync(methodology);
+
+            methodologyService.Setup(mock => mock.GetFiles(methodology.Id, Image))
+                .ReturnsAsync(new List<File>());
+            
+            publicBlobStorageService.Setup(mock => mock.DeleteBlobs(
+                    PublicMethodologyFiles,
+                    $"{methodology.Id}/",
+                    null))
+                .Returns(Task.CompletedTask);
+
+            privateBlobStorageService.Setup(mock => mock.CopyDirectory(
+                PrivateMethodologyFiles,
+                $"{methodology.Id}/",
+                PublicMethodologyFiles,
+                $"{methodology.Id}/",
+                It.Is<IBlobStorageService.CopyDirectoryOptions>(options =>
+                    options.DestinationConnectionString == PublicStorageConnectionString)))
+                .ReturnsAsync(new List<BlobInfo>());
+
+            var service = BuildPublishingService(publicStorageConnectionString: PublicStorageConnectionString,
+                methodologyService: methodologyService.Object,
+                publicBlobStorageService: publicBlobStorageService.Object,
+                privateBlobStorageService: privateBlobStorageService.Object,
+                logger: logger.Object);
+
+            await service.PublishMethodologyFiles(methodology.Id);
+
+            MockUtils.VerifyAllMocks(methodologyService, publicBlobStorageService, privateBlobStorageService);
+        }
+
+        [Fact]
+        public async Task PublishMethodologyFilesIfApplicableForRelease_ReleaseHasNoRelatedMethodologies()
+        {
+            var releaseId = Guid.NewGuid();
+
+            var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
+            var publicBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var privateBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var publicationService = new Mock<IPublicationService>(MockBehavior.Strict);
+            var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.GetLatestByRelease(releaseId))
+                .ReturnsAsync(new List<Methodology>());
+
+            // No other invocations on the services expected because the release has no related methodologies
+
+            var service = BuildPublishingService(methodologyService: methodologyService.Object,
+                publicBlobStorageService: publicBlobStorageService.Object,
+                privateBlobStorageService: privateBlobStorageService.Object,
+                publicationService: publicationService.Object,
+                releaseService: releaseService.Object);
+
+            await service.PublishMethodologyFilesIfApplicableForRelease(releaseId);
+
+            MockUtils.VerifyAllMocks(methodologyService,
+                publicBlobStorageService,
+                privateBlobStorageService,
+                publicationService,
+                releaseService);
+        }
+
+        [Fact]
+        public async Task PublishMethodologyFilesIfApplicableForRelease_ReleaseHasDraftMethodology()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                PublicationId = Guid.NewGuid()
+            };
+
+            var methodology = new Methodology
+            {
+                Id = Guid.NewGuid(),
+                PublishingStrategy = Immediately,
+                Status = Draft
+            };
+
+            var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
+            var publicBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var privateBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var publicationService = new Mock<IPublicationService>(MockBehavior.Strict);
+            var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
+                .ReturnsAsync(AsList(methodology));
+
+            publicationService.Setup(mock => mock.IsPublicationPublished(release.PublicationId))
+                .ReturnsAsync(true);
+
+            releaseService.Setup(mock => mock.Get(release.Id))
+                .ReturnsAsync(release);
+
+            // No invocations on the storage services expected because the methodology is draft
+
+            var service = BuildPublishingService(methodologyService: methodologyService.Object,
+                publicBlobStorageService: publicBlobStorageService.Object,
+                privateBlobStorageService: privateBlobStorageService.Object,
+                publicationService: publicationService.Object,
+                releaseService: releaseService.Object);
+
+            await service.PublishMethodologyFilesIfApplicableForRelease(release.Id);
+
+            MockUtils.VerifyAllMocks(methodologyService,
+                publicBlobStorageService,
+                privateBlobStorageService,
+                publicationService,
+                releaseService);
+        }
+
+        [Fact]
+        public async Task PublishMethodologyFilesIfApplicableForRelease_ReleaseHasMethodologyScheduledWithThisRelease()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                PublicationId = Guid.NewGuid()
+            };
+
+            var methodology = new Methodology
+            {
+                Id = Guid.NewGuid(),
+                PublishingStrategy = WithRelease,
+                ScheduledWithReleaseId = release.Id,
+                Status = Approved
+            };
+
+            var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
+            var publicBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var privateBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var publicationService = new Mock<IPublicationService>(MockBehavior.Strict);
+            var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
+                .ReturnsAsync(AsList(methodology));
+
+            methodologyService.Setup(mock => mock.GetFiles(methodology.Id, Image))
+                .ReturnsAsync(new List<File>());
+
+            publicationService.Setup(mock => mock.IsPublicationPublished(release.PublicationId))
+                .ReturnsAsync(true);
+
+            // Invocations on the storage services expected because the methodology is scheduled with this release
+
+            publicBlobStorageService.Setup(mock => mock.DeleteBlobs(
+                    PublicMethodologyFiles,
+                    $"{methodology.Id}/",
+                    null))
+                .Returns(Task.CompletedTask);
+
+            privateBlobStorageService.Setup(mock => mock.CopyDirectory(
+                    PrivateMethodologyFiles,
+                    $"{methodology.Id}/",
+                    PublicMethodologyFiles,
+                    $"{methodology.Id}/",
+                    It.Is<IBlobStorageService.CopyDirectoryOptions>(options =>
+                        options.DestinationConnectionString == PublicStorageConnectionString)))
+                .ReturnsAsync(new List<BlobInfo>());
+
+            releaseService.Setup(mock => mock.Get(release.Id))
+                .ReturnsAsync(release);
+
+            var service = BuildPublishingService(publicStorageConnectionString: PublicStorageConnectionString,
+                methodologyService: methodologyService.Object,
+                publicBlobStorageService: publicBlobStorageService.Object,
+                privateBlobStorageService: privateBlobStorageService.Object,
+                publicationService: publicationService.Object,
+                releaseService: releaseService.Object);
+
+            await service.PublishMethodologyFilesIfApplicableForRelease(release.Id);
+
+            MockUtils.VerifyAllMocks(methodologyService,
+                publicBlobStorageService,
+                privateBlobStorageService,
+                publicationService,
+                releaseService);
+        }
+
+        [Fact]
+        public async Task PublishMethodologyFilesIfApplicableForRelease_ReleaseHasMethodologyScheduledWithOtherRelease()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                PublicationId = Guid.NewGuid()
+            };
+
+            var methodology = new Methodology
+            {
+                Id = Guid.NewGuid(),
+                PublishingStrategy = WithRelease,
+                ScheduledWithReleaseId = Guid.NewGuid(),
+                Status = Approved
+            };
+
+            var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
+            var publicBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var privateBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var publicationService = new Mock<IPublicationService>(MockBehavior.Strict);
+            var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
+                .ReturnsAsync(AsList(methodology));
+
+            publicationService.Setup(mock => mock.IsPublicationPublished(release.PublicationId))
+                .ReturnsAsync(true);
+
+            releaseService.Setup(mock => mock.Get(release.Id))
+                .ReturnsAsync(release);
+
+            // No invocations on the storage services expected because the methodology is scheduled with another release
+
+            var service = BuildPublishingService(methodologyService: methodologyService.Object,
+                publicBlobStorageService: publicBlobStorageService.Object,
+                privateBlobStorageService: privateBlobStorageService.Object,
+                publicationService: publicationService.Object,
+                releaseService: releaseService.Object);
+
+            await service.PublishMethodologyFilesIfApplicableForRelease(release.Id);
+
+            MockUtils.VerifyAllMocks(methodologyService,
+                publicBlobStorageService,
+                privateBlobStorageService,
+                publicationService,
+                releaseService);
+        }
+
+                [Fact]
+        public async Task PublishMethodologyFilesIfApplicableForRelease_FirstPublicReleaseHasMethodologyScheduledImmediately()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                PublicationId = Guid.NewGuid()
+            };
+
+            var methodology = new Methodology
+            {
+                Id = Guid.NewGuid(),
+                PublishingStrategy = Immediately,
+                Status = Approved
+            };
+
+            var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
+            var publicBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var privateBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var publicationService = new Mock<IPublicationService>(MockBehavior.Strict);
+            var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
+                .ReturnsAsync(AsList(methodology));
+
+            methodologyService.Setup(mock => mock.GetFiles(methodology.Id, Image))
+                .ReturnsAsync(new List<File>());
+
+            publicationService.Setup(mock => mock.IsPublicationPublished(release.PublicationId))
+                .ReturnsAsync(false);
+
+            // Invocations on the storage services expected because this will be the first published release.
+            // The methodology and its files will be published for the first time with this release
+
+            publicBlobStorageService.Setup(mock => mock.DeleteBlobs(
+                    PublicMethodologyFiles,
+                    $"{methodology.Id}/",
+                    null))
+                .Returns(Task.CompletedTask);
+
+            privateBlobStorageService.Setup(mock => mock.CopyDirectory(
+                    PrivateMethodologyFiles,
+                    $"{methodology.Id}/",
+                    PublicMethodologyFiles,
+                    $"{methodology.Id}/",
+                    It.Is<IBlobStorageService.CopyDirectoryOptions>(options =>
+                        options.DestinationConnectionString == PublicStorageConnectionString)))
+                .ReturnsAsync(new List<BlobInfo>());
+
+            releaseService.Setup(mock => mock.Get(release.Id))
+                .ReturnsAsync(release);
+
+            var service = BuildPublishingService(publicStorageConnectionString: PublicStorageConnectionString,
+                methodologyService: methodologyService.Object,
+                publicBlobStorageService: publicBlobStorageService.Object,
+                privateBlobStorageService: privateBlobStorageService.Object,
+                publicationService: publicationService.Object,
+                releaseService: releaseService.Object);
+
+            await service.PublishMethodologyFilesIfApplicableForRelease(release.Id);
+
+            MockUtils.VerifyAllMocks(methodologyService,
+                publicBlobStorageService,
+                privateBlobStorageService,
+                publicationService,
+                releaseService);
+        }
+
+        [Fact]
+        public async Task PublishMethodologyFilesIfApplicableForRelease_NotFirstPublicReleaseHasMethodologyScheduledImmediately()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                PublicationId = Guid.NewGuid()
+            };
+
+            var methodology = new Methodology
+            {
+                Id = Guid.NewGuid(),
+                PublishingStrategy = Immediately,
+                Status = Approved
+            };
+
+            var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
+            var publicBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var privateBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var publicationService = new Mock<IPublicationService>(MockBehavior.Strict);
+            var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
+
+            methodologyService.Setup(mock => mock.GetLatestByRelease(release.Id))
+                .ReturnsAsync(AsList(methodology));
+
+            publicationService.Setup(mock => mock.IsPublicationPublished(release.PublicationId))
+                .ReturnsAsync(true);
+
+            releaseService.Setup(mock => mock.Get(release.Id))
+                .ReturnsAsync(release);
+
+            // No invocations on the storage services expected because the publication already has published releases.
+            // Files for this methodology will be published independently of this release
+
+            var service = BuildPublishingService(publicStorageConnectionString: PublicStorageConnectionString,
+                methodologyService: methodologyService.Object,
+                publicBlobStorageService: publicBlobStorageService.Object,
+                privateBlobStorageService: privateBlobStorageService.Object,
+                publicationService: publicationService.Object,
+                releaseService: releaseService.Object);
+
+            await service.PublishMethodologyFilesIfApplicableForRelease(release.Id);
+
+            MockUtils.VerifyAllMocks(methodologyService,
+                publicBlobStorageService,
+                privateBlobStorageService,
+                publicationService,
+                releaseService);
+        }
+
+        [Fact]
+        public async Task PublishStagedReleaseContent()
+        {
+            var releaseId = Guid.NewGuid();
+
+            var publicBlobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+            var releaseService = new Mock<IReleaseService>(MockBehavior.Strict);
+
+            publicBlobStorageService.Setup(mock => mock.MoveDirectory(PublicContent,
+                    PublicContentStagingPath(),
+                    PublicContent,
+                    string.Empty,
+                    null))
+                .Returns(Task.CompletedTask);
+
+            releaseService.Setup(mock =>
+                    mock.SetPublishedDates(releaseId, It.IsAny<DateTime>()))
+                .Returns(Task.CompletedTask);
+
+            var service = BuildPublishingService(publicBlobStorageService: publicBlobStorageService.Object,
+                releaseService: releaseService.Object);
+
+            await service.PublishStagedReleaseContent(releaseId);
+
+            MockUtils.VerifyAllMocks(publicBlobStorageService, releaseService);
+        }
+
+        private static PublishingService BuildPublishingService(
+            string? publicStorageConnectionString = null,
+            IBlobStorageService? privateBlobStorageService = null,
+            IBlobStorageService? publicBlobStorageService = null,
+            IMethodologyService? methodologyService = null,
+            IPublicationService? publicationService = null,
+            IReleaseService? releaseService = null,
+            IZipFileService? zipFileService = null,
+            IDataGuidanceFileService? dataGuidanceFileService = null,
+            ILogger<PublishingService>? logger = null)
+        {
+            return new PublishingService(
+                publicStorageConnectionString ?? "",
+                privateBlobStorageService ?? new Mock<IBlobStorageService>().Object,
+                publicBlobStorageService ?? new Mock<IBlobStorageService>().Object,
+                methodologyService ?? new Mock<IMethodologyService>().Object,
+                publicationService ?? new Mock<IPublicationService>().Object,
+                releaseService ?? new Mock<IReleaseService>().Object,
+                zipFileService ?? new Mock<IZipFileService>().Object,
+                dataGuidanceFileService ?? new Mock<IDataGuidanceFileService>().Object,
+                logger ?? new Mock<ILogger<PublishingService>>().Object
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseFilesFunction.cs
@@ -14,17 +14,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
     // ReSharper disable once UnusedType.Global
     public class PublishReleaseFilesFunction
     {
-        private readonly IMethodologyService _methodologyService;
         private readonly IPublishingService _publishingService;
         private readonly IQueueService _queueService;
         private readonly IReleaseStatusService _releaseStatusService;
 
-        public PublishReleaseFilesFunction(IMethodologyService methodologyService,
-            IPublishingService publishingService, 
+        public PublishReleaseFilesFunction(
+            IPublishingService publishingService,
             IQueueService queueService,
             IReleaseStatusService releaseStatusService)
         {
-            _methodologyService = methodologyService;
             _publishingService = publishingService;
             _queueService = queueService;
             _releaseStatusService = releaseStatusService;
@@ -60,20 +58,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 await UpdateStage(releaseId, releaseStatusId, Started);
                 try
                 {
-                    var methodologies = await _methodologyService.GetLatestByRelease(releaseId);
-                    // Publish the files of the latest methodologies of this release that
-                    // aren't already accessible but depended on this release being published,
-                    // since those methodologies will be published for the first time with this release
-                    foreach (var methodology in methodologies)
-                    {
-                        // TODO SOW EES-2385 Also need to do this if ScheduledForPublishingImmediately
-                        // but not accessible yet because this is the first Release
-                        if (methodology.ScheduledForPublishingWithPublishedRelease
-                            && methodology.ScheduledWithReleaseId == releaseId)
-                        {
-                            await _publishingService.PublishMethodologyFiles(methodology.Id);
-                        }
-                    }
+                    await _publishingService.PublishMethodologyFilesIfApplicableForRelease(releaseId);
                     await _publishingService.PublishReleaseFiles(releaseId);
                     published.Add((releaseId, releaseStatusId));
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublicationService.cs
@@ -9,9 +9,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
     public interface IPublicationService
     {
         Task<Publication> Get(Guid id);
+
         List<Publication> GetPublicationsWithPublishedReleases();
+
         Task<CachedPublicationViewModel> GetViewModel(Guid id, IEnumerable<Guid> includedReleaseIds);
+
         List<ThemeTree<PublicationTreeNode>> GetTree(IEnumerable<Guid> includedReleaseIds);
+
+        Task<bool> IsPublicationPublished(Guid publicationId);
+
         Task SetPublishedDate(Guid id, DateTime published);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IPublishingService.cs
@@ -9,6 +9,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task PublishMethodologyFiles(Guid methodologyId);
 
+        Task PublishMethodologyFilesIfApplicableForRelease(Guid releaseId);
+
         Task PublishReleaseFiles(Guid releaseId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublicationService.cs
@@ -76,6 +76,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 .ToList();
         }
 
+        public async Task<bool> IsPublicationPublished(Guid publicationId)
+        {
+            var publication = await _contentDbContext.Publications
+                .Include(p => p.Releases)
+                .SingleAsync(p => p.Id == publicationId);
+
+            return publication.Releases.Any(release => release.IsLatestPublishedVersionOfRelease());
+        }
+
         public async Task SetPublishedDate(Guid id, DateTime published)
         {
             var publication = await Get(id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -49,6 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                         privateBlobStorageService: GetBlobStorageService(provider, "CoreStorage"),
                         publicBlobStorageService: GetBlobStorageService(provider, "PublicStorage"),
                         methodologyService: provider.GetRequiredService<IMethodologyService>(),
+                        publicationService: provider.GetRequiredService<IPublicationService>(),
                         releaseService: provider.GetRequiredService<IReleaseService>(),
                         zipFileService: provider.GetRequiredService<IZipFileService>(),
                         dataGuidanceFileService: provider.GetRequiredService<IDataGuidanceFileService>(),


### PR DESCRIPTION
This PR completes a TODO in the code that had been accidently missed that relates to publishing Methodology image files while publishing a Release.

```
// TODO SOW EES-2385 Also need to do this if ScheduledForPublishingImmediately
but not accessible yet because this is the first Release
```

If publishing a Release is about to make a Methodology public then we also need to publish the files for that Methodology.

We were already do this for a Methodology scheduled for publishing with the Release (note: even though  this functionality isn't available to analysts yet).

When a Methodology is approved for publishing immediately the image files are not copied if no publications using that Methodology are public.

Upon publishing the first Release for one of those publications we need to publish the Methodology image files. This is now added by this PR.