### PR TITLE
EES-2414 override dnd style to fix accordion opening direction

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.module.scss
@@ -8,3 +8,8 @@
   display: flex;
   justify-content: space-between;
 }
+
+// Override the default dnd style as it causes accordion sections within the dnd area to sometime open in the wrong direction.
+[data-rbd-droppable-id='releaseMainContent'][data-rbd-droppable-context-id] {
+  overflow-anchor: auto;
+}


### PR DESCRIPTION
Accordions in drag and drop areas sometimes open upwards instead of down. This seems to be because the dnd default styles set overflow-anchor to none on the drop area. I've overridden this specifically for the release content accordion.

According to the dnd docs the style is needed because 'The automatic overflow-anchor behavior leads to incorrect scroll positioning post drop.', see  https://github.com/atlassian/react-beautiful-dnd/blob/master/docs/guides/preset-styles.md, however I haven't found any problems when trying it after overriding the style, though it's definitely worth bearing in mind for testing..