### PR TITLE
EES-2472 prevent chart ref line labels being cut off

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/CustomReferenceLineLabel.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/CustomReferenceLineLabel.tsx
@@ -1,0 +1,44 @@
+import { ReferenceLine } from '@common/modules/charts/types/chart';
+import { ChartData } from '@common/modules/charts/types/dataSet';
+import React from 'react';
+import { ReferenceLineProps } from 'recharts';
+
+interface Props {
+  chartData: ChartData[];
+  referenceLine: ReferenceLine;
+  referenceLineProps: ReferenceLineProps;
+}
+
+const CustomReferenceLineLabel = ({
+  chartData,
+  referenceLine,
+  referenceLineProps,
+}: Props) => {
+  const getTextAnchor = () => {
+    if (referenceLine.position === chartData[0].name) {
+      return 'start';
+    }
+    if (referenceLine.position === chartData[chartData.length - 1].name) {
+      return 'end';
+    }
+    return 'middle';
+  };
+
+  const getY = () => {
+    const y = referenceLineProps.viewBox?.y ?? 0;
+    const height = referenceLineProps.viewBox?.height ?? 0;
+    return height / 2 + y;
+  };
+
+  return (
+    <text
+      x={referenceLineProps.viewBox?.x}
+      y={getY()}
+      textAnchor={getTextAnchor()}
+    >
+      <tspan>{referenceLine.label}</tspan>
+    </text>
+  );
+};
+
+export default CustomReferenceLineLabel;

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -205,13 +205,13 @@ const LineChartBlock = ({
             <ReferenceLine
               key={`${referenceLine.position}_${referenceLine.label}`}
               x={referenceLine.position}
-              label={props =>
-                CustomReferenceLineLabel({
-                  chartData,
-                  referenceLine,
-                  referenceLineProps: props,
-                })
-              }
+              label={props => (
+                <CustomReferenceLineLabel
+                  chartData={chartData}
+                  referenceLine={referenceLine}
+                  referenceLineProps={props}
+                />
+              )}
             />
           ))}
 

--- a/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/LineChartBlock.tsx
@@ -39,6 +39,7 @@ import {
   YAxis,
 } from 'recharts';
 import getDataSetCategoryConfigs from '@common/modules/charts/util/getDataSetCategoryConfigs';
+import CustomReferenceLineLabel from '@common/modules/charts/components/CustomReferenceLineLabel';
 
 const lineStyles: Dictionary<string> = {
   solid: '',
@@ -204,7 +205,13 @@ const LineChartBlock = ({
             <ReferenceLine
               key={`${referenceLine.position}_${referenceLine.label}`}
               x={referenceLine.position}
-              label={referenceLine.label}
+              label={props =>
+                CustomReferenceLineLabel({
+                  chartData,
+                  referenceLine,
+                  referenceLineProps: props,
+                })
+              }
             />
           ))}
 


### PR DESCRIPTION
Renders a custom label for reference lines that changes the text alignment if the label is at the start or end. This is for line charts only currently as I'm not sure it's necessary for bar charts and would look odd with wide bars

Before:
![before](https://user-images.githubusercontent.com/81572860/126315493-925ee596-18d9-4c4e-a3c6-4c77593cab46.png)


After:
![after](https://user-images.githubusercontent.com/81572860/126315509-e517bce5-024c-4ed1-be6d-df97fb53d5d3.png)
