### PR TITLE
EES-2509 Add new Caching service to cache results in Azure blob storage

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServicePermissionTests.cs
@@ -5,6 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -102,6 +103,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         private MethodologyService SetupMethodologyService(
             ContentDbContext contentDbContext = null,
             IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
+            ICacheService cacheService = null,
             IMethodologyContentService methodologyContentService = null,
             IMethodologyFileRepository methodologyFileRepository = null,
             IMethodologyRepository methodologyRepository = null,
@@ -113,6 +115,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 contentPersistenceHelper ?? DefaultPersistenceHelperMock().Object,
                 contentDbContext ?? new Mock<ContentDbContext>().Object,
                 AdminMapper(),
+                cacheService ?? new Mock<ICacheService>().Object,
                 methodologyContentService ?? new Mock<IMethodologyContentService>().Object,
                 methodologyFileRepository ?? new MethodologyFileRepository(contentDbContext),
                 methodologyRepository ?? new Mock<IMethodologyRepository>().Object,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -6,7 +6,9 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
@@ -20,6 +22,7 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbU
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.ValidationTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
@@ -197,6 +200,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 await context.SaveChangesAsync();
             }
 
+            var cacheService = new Mock<ICacheService>(Strict);
             var contentService = new Mock<IMethodologyContentService>(Strict);
             var imageService = new Mock<IMethodologyImageService>(Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
@@ -213,6 +217,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var service = SetupMethodologyService(contentDbContext: context,
+                    cacheService: cacheService.Object,
                     methodologyContentService: contentService.Object,
                     methodologyImageService: imageService.Object,
                     methodologyRepository: methodologyRepository.Object,
@@ -245,7 +250,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
             }
 
-            VerifyAllMocks(contentService, imageService, methodologyRepository, publishingService);
+            VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
         }
 
         [Fact]
@@ -307,6 +312,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 await context.SaveChangesAsync();
             }
 
+            var cacheService = new Mock<ICacheService>(Strict);
             var contentService = new Mock<IMethodologyContentService>(Strict);
             var imageService = new Mock<IMethodologyImageService>(Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
@@ -331,6 +337,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var service = SetupMethodologyService(contentDbContext: context,
+                    cacheService: cacheService.Object,
                     methodologyContentService: contentService.Object,
                     methodologyImageService: imageService.Object,
                     methodologyRepository: methodologyRepository.Object,
@@ -360,7 +367,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
             }
 
-            VerifyAllMocks(contentService, imageService, methodologyRepository, publishingService);
+            VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
         }
 
         [Fact]
@@ -422,6 +429,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 await context.SaveChangesAsync();
             }
 
+            var cacheService = new Mock<ICacheService>(Strict);
             var contentService = new Mock<IMethodologyContentService>(Strict);
             var imageService = new Mock<IMethodologyImageService>(Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
@@ -446,6 +454,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var service = SetupMethodologyService(contentDbContext: context,
+                    cacheService: cacheService.Object,
                     methodologyContentService: contentService.Object,
                     methodologyImageService: imageService.Object,
                     methodologyRepository: methodologyRepository.Object,
@@ -482,7 +491,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
             }
 
-            VerifyAllMocks(contentService, imageService, methodologyRepository, publishingService);
+            VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
         }
 
         [Fact]
@@ -523,10 +532,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 await context.SaveChangesAsync();
             }
 
+            var cacheService = new Mock<ICacheService>(Strict);
             var contentService = new Mock<IMethodologyContentService>(Strict);
             var imageService = new Mock<IMethodologyImageService>(Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
             var publishingService = new Mock<IPublishingService>(Strict);
+
+            cacheService.Setup(mock =>
+                mock.DeleteItem(PublicContent, AllMethodologiesCacheKey.Instance))
+                .Returns(Task.CompletedTask);
 
             contentService.Setup(mock =>
                     mock.GetContentBlocks<HtmlBlock>(methodology.Id))
@@ -545,6 +559,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var service = SetupMethodologyService(contentDbContext: context,
+                    cacheService: cacheService.Object,
                     methodologyContentService: contentService.Object,
                     methodologyImageService: imageService.Object,
                     methodologyRepository: methodologyRepository.Object,
@@ -579,7 +594,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
             }
 
-            VerifyAllMocks(contentService, imageService, methodologyRepository, publishingService);
+            VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
         }
 
         [Fact]
@@ -621,6 +636,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 await context.SaveChangesAsync();
             }
 
+            var cacheService = new Mock<ICacheService>(Strict);
             var contentService = new Mock<IMethodologyContentService>(Strict);
             var imageService = new Mock<IMethodologyImageService>(Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
@@ -641,6 +657,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var service = SetupMethodologyService(contentDbContext: context,
+                    cacheService: cacheService.Object,
                     methodologyContentService: contentService.Object,
                     methodologyImageService: imageService.Object,
                     methodologyRepository: methodologyRepository.Object,
@@ -673,7 +690,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
             }
 
-            VerifyAllMocks(contentService, imageService, methodologyRepository, publishingService);
+            VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
         }
 
         [Fact]
@@ -719,10 +736,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 await context.SaveChangesAsync();
             }
 
+            var cacheService = new Mock<ICacheService>(Strict);
             var contentService = new Mock<IMethodologyContentService>(Strict);
             var imageService = new Mock<IMethodologyImageService>(Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
             var publishingService = new Mock<IPublishingService>(Strict);
+
+            cacheService.Setup(mock =>
+                    mock.DeleteItem(PublicContent, AllMethodologiesCacheKey.Instance))
+                .Returns(Task.CompletedTask);
 
             contentService.Setup(mock =>
                     mock.GetContentBlocks<HtmlBlock>(methodology.Id))
@@ -738,6 +760,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var service = SetupMethodologyService(contentDbContext: context,
+                    cacheService: cacheService.Object,
                     methodologyContentService: contentService.Object,
                     methodologyImageService: imageService.Object,
                     methodologyRepository: methodologyRepository.Object,
@@ -769,7 +792,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
             }
 
-            VerifyAllMocks(contentService, imageService, methodologyRepository, publishingService);
+            VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
         }
 
         [Fact]
@@ -818,6 +841,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 await context.SaveChangesAsync();
             }
 
+            var cacheService = new Mock<ICacheService>(Strict);
             var contentService = new Mock<IMethodologyContentService>(Strict);
             var imageService = new Mock<IMethodologyImageService>(Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
@@ -834,6 +858,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var service = SetupMethodologyService(contentDbContext: context,
+                    cacheService: cacheService.Object,
                     methodologyContentService: contentService.Object,
                     methodologyImageService: imageService.Object,
                     methodologyRepository: methodologyRepository.Object,
@@ -845,7 +870,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 AssertValidationProblem(result.Left, SlugNotUnique);
             }
 
-            VerifyAllMocks(contentService, imageService, methodologyRepository, publishingService);
+            VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
         }
 
         [Fact]
@@ -1145,6 +1170,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         private static MethodologyService SetupMethodologyService(
             ContentDbContext contentDbContext,
             IPersistenceHelper<ContentDbContext> persistenceHelper = null,
+            ICacheService cacheService = null,
             IMethodologyContentService methodologyContentService = null,
             IMethodologyFileRepository methodologyFileRepository = null,
             IMethodologyRepository methodologyRepository = null,
@@ -1156,6 +1182,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 persistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
                 contentDbContext,
                 AdminMapper(),
+                cacheService ?? new Mock<ICacheService>().Object,
                 methodologyContentService ?? new Mock<IMethodologyContentService>().Object,
                 methodologyFileRepository ?? new MethodologyFileRepository(contentDbContext),
                 methodologyRepository ?? new Mock<IMethodologyRepository>().Object,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -7,7 +7,9 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Metho
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -18,6 +20,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.NamingUtils;
 
@@ -28,6 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
         private readonly ContentDbContext _context;
         private readonly IMapper _mapper;
+        private readonly ICacheService _cacheService;
         private readonly IMethodologyContentService _methodologyContentService;
         private readonly IMethodologyFileRepository _methodologyFileRepository;
         private readonly IMethodologyRepository _methodologyRepository;
@@ -39,6 +43,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             IPersistenceHelper<ContentDbContext> persistenceHelper,
             ContentDbContext context,
             IMapper mapper,
+            ICacheService cacheService,
             IMethodologyContentService methodologyContentService,
             IMethodologyFileRepository methodologyFileRepository,
             IMethodologyRepository methodologyRepository,
@@ -49,6 +54,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             _persistenceHelper = persistenceHelper;
             _context = context;
             _mapper = mapper;
+            _cacheService = cacheService;
             _methodologyContentService = methodologyContentService;
             _methodologyFileRepository = methodologyFileRepository;
             _methodologyRepository = methodologyRepository;
@@ -134,6 +140,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                         // methodology.Published = DateTime.UtcNow;
 
                         methodology.Published ??= DateTime.UtcNow;
+
+                        // Invalidate the 'All Methodologies' cache item
+                        await _cacheService.DeleteItem(PublicContent, AllMethodologiesCacheKey.Instance);
                     }
 
                     await _context.SaveChangesAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -292,6 +292,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IEmailService, EmailService>();
 
             services.AddTransient<IBoundaryLevelService, BoundaryLevelService>();
+            services.AddTransient<ICacheService, BlobStorageCacheService>();
             services.AddTransient<IEmailTemplateService, EmailTemplateService>();
             services.AddTransient<ITableBuilderService, TableBuilderService>();
             services.AddTransient<IFilterService, FilterService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockCacheServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockCacheServiceExtensions.cs
@@ -1,8 +1,8 @@
 ﻿#nullable enable
 using System;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
@@ -13,26 +13,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
     {
         /// <summary>
         /// Set up a call on a mocked cache service that always returns the result of invoking the entity provider
+        /// to emulate a cache miss.
         /// </summary>
         /// <param name="cacheService"></param>
         /// <param name="expectedBlobContainer"></param>
         /// <param name="expectedCacheKey"></param>
         /// <typeparam name="TEntity"></typeparam>
         /// <returns></returns>
-        public static Mock<ICacheService> SetupEntityProviderResult<TEntity>(
+        public static Mock<ICacheService> SetupGetItemForCacheMiss<TEntity>(
             this Mock<ICacheService> cacheService,
             IBlobContainer expectedBlobContainer,
-            ICacheKey<TEntity>? expectedCacheKey = null)
+            ICacheKey? expectedCacheKey = null)
             where TEntity : class
         {
             cacheService.Setup(mock => mock.GetItem(
                     expectedBlobContainer,
-                    It.Is<ICacheKey<TEntity>>(ck =>
+                    It.Is<ICacheKey>(ck =>
                         expectedCacheKey == null ||
                         ck.Key == expectedCacheKey.Key),
                     It.IsAny<Func<Task<TEntity>>>()))
                 .Returns(async (IBlobContainer blobContainer,
-                    ICacheKey<TEntity> cacheKey,
+                    ICacheKey cacheKey,
                     Func<Task<TEntity>> entityProvider) => await entityProvider());
 
             return cacheService;
@@ -40,6 +41,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
 
         /// <summary>
         /// Set up a call on a mocked cache service that always returns the result of invoking the entity provider
+        /// to emulate a cache miss.
         /// </summary>
         /// <param name="cacheService"></param>
         /// <param name="expectedBlobContainer"></param>
@@ -47,22 +49,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
         /// <typeparam name="TEntity"></typeparam>
         /// <typeparam name="TProvider"></typeparam>
         /// <returns></returns>
-        public static Mock<ICacheService> SetupEntityProviderResult<TEntity, TProvider>(
+        public static Mock<ICacheService> SetupGetItemForCacheMiss<TEntity, TProvider>(
             this Mock<ICacheService> cacheService,
             IBlobContainer expectedBlobContainer,
-            ICacheKey<TEntity>? expectedCacheKey = null)
+            ICacheKey? expectedCacheKey = null)
             where TEntity : class
             where TProvider : Task<Either<ActionResult, TEntity>>
         {
             cacheService.Setup(mock => mock.GetItem(
                     expectedBlobContainer,
-                    It.Is<ICacheKey<TEntity>>(ck =>
+                    It.Is<ICacheKey>(ck =>
                         expectedCacheKey == null ||
                         ck.Key == expectedCacheKey.Key),
-                    It.IsAny<Func<TProvider>>()))
+                    It.IsAny<Func<Task<Either<ActionResult, TEntity>>>>()))
                 .Returns(async (IBlobContainer blobContainer,
-                        ICacheKey<TEntity> cacheKey,
-                        Func<TProvider> entityProvider) =>
+                        ICacheKey cacheKey,
+                        Func<Task<Either<ActionResult, TEntity>>> entityProvider) =>
                     await entityProvider());
 
             return cacheService;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockCacheServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockCacheServiceExtensions.cs
@@ -1,0 +1,71 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
+{
+    public static class MockCacheServiceExtensions
+    {
+        /// <summary>
+        /// Set up a call on a mocked cache service that always returns the result of invoking the entity provider
+        /// </summary>
+        /// <param name="cacheService"></param>
+        /// <param name="expectedBlobContainer"></param>
+        /// <param name="expectedCacheKey"></param>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <returns></returns>
+        public static Mock<ICacheService> SetupEntityProviderResult<TEntity>(
+            this Mock<ICacheService> cacheService,
+            IBlobContainer expectedBlobContainer,
+            ICacheKey<TEntity>? expectedCacheKey = null)
+            where TEntity : class
+        {
+            cacheService.Setup(mock => mock.GetCachedEntity(
+                    expectedBlobContainer,
+                    It.Is<ICacheKey<TEntity>>(ck =>
+                        expectedCacheKey == null ||
+                        ck.Key == expectedCacheKey.Key),
+                    It.IsAny<Func<Task<TEntity>>>()))
+                .Returns(async (IBlobContainer blobContainer,
+                    ICacheKey<TEntity> cacheKey,
+                    Func<Task<TEntity>> entityProvider) => await entityProvider());
+
+            return cacheService;
+        }
+
+        /// <summary>
+        /// Set up a call on a mocked cache service that always returns the result of invoking the entity provider
+        /// </summary>
+        /// <param name="cacheService"></param>
+        /// <param name="expectedBlobContainer"></param>
+        /// <param name="expectedCacheKey"></param>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TProvider"></typeparam>
+        /// <returns></returns>
+        public static Mock<ICacheService> SetupEntityProviderResult<TEntity, TProvider>(
+            this Mock<ICacheService> cacheService,
+            IBlobContainer expectedBlobContainer,
+            ICacheKey<TEntity>? expectedCacheKey = null)
+            where TEntity : class
+            where TProvider : Task<Either<ActionResult, TEntity>>
+        {
+            cacheService.Setup(mock => mock.GetCachedEntity(
+                    expectedBlobContainer,
+                    It.Is<ICacheKey<TEntity>>(ck =>
+                        expectedCacheKey == null ||
+                        ck.Key == expectedCacheKey.Key),
+                    It.IsAny<Func<TProvider>>()))
+                .Returns(async (IBlobContainer blobContainer,
+                        ICacheKey<TEntity> cacheKey,
+                        Func<TProvider> entityProvider) =>
+                    await entityProvider());
+
+            return cacheService;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockCacheServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockCacheServiceExtensions.cs
@@ -25,7 +25,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             ICacheKey<TEntity>? expectedCacheKey = null)
             where TEntity : class
         {
-            cacheService.Setup(mock => mock.GetCachedEntity(
+            cacheService.Setup(mock => mock.GetItem(
                     expectedBlobContainer,
                     It.Is<ICacheKey<TEntity>>(ck =>
                         expectedCacheKey == null ||
@@ -54,7 +54,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             where TEntity : class
             where TProvider : Task<Either<ActionResult, TEntity>>
         {
-            cacheService.Setup(mock => mock.GetCachedEntity(
+            cacheService.Setup(mock => mock.GetItem(
                     expectedBlobContainer,
                     It.Is<ICacheKey<TEntity>>(ck =>
                         expectedCacheKey == null ||

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
@@ -1,9 +1,7 @@
+#nullable enable
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Microsoft.AspNetCore.Mvc;
@@ -96,23 +94,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
 
                 return new NotFoundResult();
             };
-        }
-
-        /// <summary>
-        /// Mock cache service that regardless of cache key, always returns the result of invoking the entity provider
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public static Mock<ICacheService> NeverCachedCacheService<T>() where T : class
-        {
-            var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
-
-            cacheService.Setup(mock => mock.GetCachedEntity(
-                    It.IsAny<ICacheKey<T>>(), 
-                    It.IsAny<Func<Task<T>>>()))
-                .Returns(async (ICacheKey<T> _, Func<Task<T>> entityProvider) => await entityProvider());
-
-            return cacheService;
         }
 
         public static Mock<IUserService> AlwaysTrueUserService(Guid? userId = null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Microsoft.AspNetCore.Mvc;
@@ -93,6 +96,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
 
                 return new NotFoundResult();
             };
+        }
+
+        /// <summary>
+        /// Mock cache service that regardless of cache key, always returns the result of invoking the entity provider
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Mock<ICacheService> NeverCachedCacheService<T>() where T : class
+        {
+            var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
+
+            cacheService.Setup(mock => mock.GetCachedEntity(
+                    It.IsAny<ICacheKey<T>>(), 
+                    It.IsAny<Func<Task<T>>>()))
+                .Returns(async (ICacheKey<T> _, Func<Task<T>> entityProvider) => await entityProvider());
+
+            return cacheService;
         }
 
         public static Mock<IUserService> AlwaysTrueUserService(Guid? userId = null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/AllMethodologiesCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/AllMethodologiesCacheKey.cs
@@ -1,0 +1,26 @@
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
+{
+    public sealed class AllMethodologiesCacheKey : ICacheKey
+    {
+        public string Key => "627b1bfc-3436-474c-9d10-7b0b98b6dee5";
+
+        private AllMethodologiesCacheKey()
+        {
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return ReferenceEquals(this, obj) || obj is AllMethodologiesCacheKey other && Key == other.Key;
+        }
+
+        public override int GetHashCode()
+        {
+            return Key.GetHashCode();
+        }
+
+        public static AllMethodologiesCacheKey Instance { get; } = new AllMethodologiesCacheKey();
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/Interfaces/ICacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/Interfaces/ICacheKey.cs
@@ -1,0 +1,8 @@
+﻿#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces
+{
+    public interface ICacheKey
+    {
+        public string Key { get; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Interfaces/ICacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Interfaces/ICacheKey.cs
@@ -1,8 +1,0 @@
-﻿#nullable enable
-namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces
-{
-    public interface ICacheKey<TEntity>
-    {
-        public string Key { get; }
-    }
-}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Interfaces/ICacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Interfaces/ICacheKey.cs
@@ -1,0 +1,8 @@
+﻿#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces
+{
+    public interface ICacheKey<TEntity>
+    {
+        public string Key { get; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageCacheService.cs
@@ -1,0 +1,95 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services
+{
+    public class BlobStorageCacheService : ICacheService
+    {
+        private readonly IBlobStorageService _blobStorageService;
+        private readonly ILogger<BlobStorageCacheService> _logger;
+
+        public BlobStorageCacheService(IBlobStorageService blobStorageService,
+            ILogger<BlobStorageCacheService> logger)
+        {
+            _blobStorageService = blobStorageService;
+            _logger = logger;
+        }
+
+        public async Task<TEntity> GetCachedEntity<TEntity>(ICacheKey<TEntity> cacheKey,
+            Func<TEntity> entityProvider) where TEntity : class
+        {
+            // Attempt to read blob from the cache container
+            var cachedEntity = await ReadFromCache(cacheKey);
+
+            if (cachedEntity != null)
+            {
+                return cachedEntity;
+            }
+
+            // Cache miss - invoke provider instead
+            var entity = entityProvider();
+
+            // Write result to cache as a json blob before returning
+            await WriteToCache(cacheKey, entity);
+            return entity;
+        }
+
+        public async Task<TEntity> GetCachedEntity<TEntity>(ICacheKey<TEntity> cacheKey,
+            Func<Task<TEntity>> entityProvider) where TEntity : class
+        {
+            // Attempt to read blob from the cache container
+            var cachedEntity = await ReadFromCache(cacheKey);
+            if (cachedEntity != null)
+            {
+                return cachedEntity;
+            }
+
+            // Cache miss - invoke provider instead
+            var entity = await entityProvider();
+
+            // Write result to cache as a json blob before returning
+            await WriteToCache(cacheKey, entity);
+            return entity;
+        }
+
+        private async Task<TEntity?> ReadFromCache<TEntity>(ICacheKey<TEntity> cacheKey) where TEntity : class
+        {
+            var key = cacheKey.Key;
+
+            // Attempt to read blob from the storage container
+            try
+            {
+                return await _blobStorageService.GetDeserializedJson<TEntity>(PublicContent, key);
+            }
+            catch (JsonException)
+            {
+                // If there's an error deserializing the blob, we should
+                // assume it's not salvageable and delete it so that it's re-built.
+                await _blobStorageService.DeleteBlob(PublicContent, key);
+            }
+            catch (FileNotFoundException)
+            {
+                // Do nothing as the blob just doesn't exist
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"Caught error fetching cache entry from: {PublicContent}/{key}");
+            }
+
+            return null;
+        }
+
+        private async Task WriteToCache<TEntity>(ICacheKey<TEntity> cacheKey, TEntity entity)
+        {
+            // Write result to cache as a json blob before returning
+            await _blobStorageService.UploadAsJson(PublicContent, cacheKey.Key, entity);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageCacheService.cs
@@ -23,7 +23,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             _logger = logger;
         }
 
-        public async Task<TEntity> GetCachedEntity<TEntity>(
+        public async Task DeleteItem<TEntity>(IBlobContainer blobContainer, ICacheKey<TEntity> cacheKey)
+        {
+            await _blobStorageService.DeleteBlob(blobContainer, cacheKey.Key);
+        }
+
+        public async Task<TEntity> GetItem<TEntity>(
             IBlobContainer blobContainer,
             ICacheKey<TEntity> cacheKey,
             Func<TEntity> entityProvider) where TEntity : class
@@ -44,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return entity;
         }
 
-        public async Task<TEntity> GetCachedEntity<TEntity>(
+        public async Task<TEntity> GetItem<TEntity>(
             IBlobContainer blobContainer,
             ICacheKey<TEntity> cacheKey,
             Func<Task<TEntity>> entityProvider)
@@ -65,7 +70,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return entity;
         }
 
-        public async Task<Either<ActionResult, TEntity>> GetCachedEntity<TEntity>(
+        public async Task<Either<ActionResult, TEntity>> GetItem<TEntity>(
             IBlobContainer blobContainer,
             ICacheKey<TEntity> cacheKey,
             Func<Task<Either<ActionResult, TEntity>>> entityProvider)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageCacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/BlobStorageCacheService.cs
@@ -2,8 +2,8 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -23,18 +23,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             _logger = logger;
         }
 
-        public async Task DeleteItem<TEntity>(IBlobContainer blobContainer, ICacheKey<TEntity> cacheKey)
+        public async Task DeleteItem(IBlobContainer blobContainer, ICacheKey cacheKey)
         {
             await _blobStorageService.DeleteBlob(blobContainer, cacheKey.Key);
         }
 
         public async Task<TEntity> GetItem<TEntity>(
             IBlobContainer blobContainer,
-            ICacheKey<TEntity> cacheKey,
+            ICacheKey cacheKey,
             Func<TEntity> entityProvider) where TEntity : class
         {
             // Attempt to read blob from the cache container
-            var cachedEntity = await ReadFromCache(blobContainer, cacheKey);
+            var cachedEntity = await ReadFromCache<TEntity>(blobContainer, cacheKey);
 
             if (cachedEntity != null)
             {
@@ -51,12 +51,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         public async Task<TEntity> GetItem<TEntity>(
             IBlobContainer blobContainer,
-            ICacheKey<TEntity> cacheKey,
+            ICacheKey cacheKey,
             Func<Task<TEntity>> entityProvider)
             where TEntity : class
         {
             // Attempt to read blob from the cache container
-            var cachedEntity = await ReadFromCache(blobContainer, cacheKey);
+            var cachedEntity = await ReadFromCache<TEntity>(blobContainer, cacheKey);
             if (cachedEntity != null)
             {
                 return cachedEntity;
@@ -72,12 +72,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         public async Task<Either<ActionResult, TEntity>> GetItem<TEntity>(
             IBlobContainer blobContainer,
-            ICacheKey<TEntity> cacheKey,
+            ICacheKey cacheKey,
             Func<Task<Either<ActionResult, TEntity>>> entityProvider)
             where TEntity : class
         {
             // Attempt to read blob from the cache container
-            var cachedEntity = await ReadFromCache(blobContainer, cacheKey);
+            var cachedEntity = await ReadFromCache<TEntity>(blobContainer, cacheKey);
             if (cachedEntity != null)
             {
                 return cachedEntity;
@@ -93,7 +93,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         private async Task<TEntity?> ReadFromCache<TEntity>(
             IBlobContainer blobContainer,
-            ICacheKey<TEntity> cacheKey)
+            ICacheKey cacheKey)
             where TEntity : class
         {
             var key = cacheKey.Key;
@@ -123,7 +123,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         private async Task WriteToCache<TEntity>(
             IBlobContainer blobContainer,
-            ICacheKey<TEntity> cacheKey,
+            ICacheKey cacheKey,
             TEntity entity)
         {
             // Write result to cache as a json blob before returning

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ICacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ICacheService.cs
@@ -1,8 +1,8 @@
 ﻿#nullable enable
 using System;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
@@ -11,24 +11,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
     {
         public Task<TEntity> GetItem<TEntity>(
             IBlobContainer blobContainer,
-            ICacheKey<TEntity> cacheKey,
+            ICacheKey cacheKey,
             Func<TEntity> entityProvider)
             where TEntity : class;
 
         public Task<TEntity> GetItem<TEntity>(
             IBlobContainer blobContainer,
-            ICacheKey<TEntity> cacheKey,
+            ICacheKey cacheKey,
             Func<Task<TEntity>> entityProvider)
             where TEntity : class;
 
         public Task<Either<ActionResult, TEntity>> GetItem<TEntity>(
             IBlobContainer blobContainer,
-            ICacheKey<TEntity> cacheKey,
+            ICacheKey cacheKey,
             Func<Task<Either<ActionResult, TEntity>>> entityProvider)
             where TEntity : class;
 
-        public Task DeleteItem<TEntity>(
+        public Task DeleteItem(
             IBlobContainer blobContainer,
-            ICacheKey<TEntity> cacheKey);
+            ICacheKey cacheKey);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ICacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ICacheService.cs
@@ -1,0 +1,18 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
+{
+    public interface ICacheService
+    {
+        public Task<TEntity> GetCachedEntity<TEntity>(ICacheKey<TEntity> cacheKey,
+            Func<TEntity> entityProvider)
+            where TEntity : class;
+
+        public Task<TEntity> GetCachedEntity<TEntity>(ICacheKey<TEntity> cacheKey,
+            Func<Task<TEntity>> entityProvider)
+            where TEntity : class;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ICacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ICacheService.cs
@@ -9,22 +9,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 {
     public interface ICacheService
     {
-        public Task<TEntity> GetCachedEntity<TEntity>(
+        public Task<TEntity> GetItem<TEntity>(
             IBlobContainer blobContainer,
             ICacheKey<TEntity> cacheKey,
             Func<TEntity> entityProvider)
             where TEntity : class;
 
-        public Task<TEntity> GetCachedEntity<TEntity>(
+        public Task<TEntity> GetItem<TEntity>(
             IBlobContainer blobContainer,
             ICacheKey<TEntity> cacheKey,
             Func<Task<TEntity>> entityProvider)
             where TEntity : class;
 
-        public Task<Either<ActionResult, TEntity>> GetCachedEntity<TEntity>(
+        public Task<Either<ActionResult, TEntity>> GetItem<TEntity>(
             IBlobContainer blobContainer,
             ICacheKey<TEntity> cacheKey,
             Func<Task<Either<ActionResult, TEntity>>> entityProvider)
             where TEntity : class;
+
+        public Task DeleteItem<TEntity>(
+            IBlobContainer blobContainer,
+            ICacheKey<TEntity> cacheKey);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ICacheService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/ICacheService.cs
@@ -1,18 +1,30 @@
 ﻿#nullable enable
 using System;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 {
     public interface ICacheService
     {
-        public Task<TEntity> GetCachedEntity<TEntity>(ICacheKey<TEntity> cacheKey,
+        public Task<TEntity> GetCachedEntity<TEntity>(
+            IBlobContainer blobContainer,
+            ICacheKey<TEntity> cacheKey,
             Func<TEntity> entityProvider)
             where TEntity : class;
 
-        public Task<TEntity> GetCachedEntity<TEntity>(ICacheKey<TEntity> cacheKey,
+        public Task<TEntity> GetCachedEntity<TEntity>(
+            IBlobContainer blobContainer,
+            ICacheKey<TEntity> cacheKey,
             Func<Task<TEntity>> entityProvider)
+            where TEntity : class;
+
+        public Task<Either<ActionResult, TEntity>> GetCachedEntity<TEntity>(
+            IBlobContainer blobContainer,
+            ICacheKey<TEntity> cacheKey,
+            Func<Task<Either<ActionResult, TEntity>>> entityProvider)
             where TEntity : class;
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/BlobStorageCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/BlobStorageCacheServiceTests.cs
@@ -1,0 +1,175 @@
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
+{
+    public class BlobStorageCacheServiceTests
+    {
+        private class SampleClass
+        {
+            public Guid Id { get; }
+
+            public SampleClass()
+            {
+                Id = Guid.NewGuid();
+            }
+        }
+
+        private class SampleCacheKey : ICacheKey<SampleClass>
+        {
+            public string Key { get; }
+
+            public SampleCacheKey(Guid id)
+            {
+                Key = id.ToString();
+            }
+        }
+
+        [Fact]
+        public async Task GetCachedEntity_CachedEntityExists()
+        {
+            var entity = new SampleClass();
+
+            var cacheKey = new SampleCacheKey(entity.Id);
+
+            var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+
+            blobStorageService.Setup(mock =>
+                    mock.GetDeserializedJson<SampleClass>(
+                        PublicContent,
+                        cacheKey.Key))
+                .ReturnsAsync(entity);
+
+            var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
+
+            var result = await service.GetCachedEntity(cacheKey, (Func<SampleClass>) (() =>
+                throw new ArgumentException("Unexpected call to provider when cached entity exists")));
+
+            Assert.Equal(entity, result);
+
+            MockUtils.VerifyAllMocks(blobStorageService);
+        }
+
+        [Fact]
+        public async Task GetCachedEntity_CachedEntityNotFoundUploadsBlob()
+        {
+            var entity = new SampleClass();
+
+            var cacheKey = new SampleCacheKey(entity.Id);
+
+            var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+
+            blobStorageService.Setup(mock =>
+                    mock.GetDeserializedJson<SampleClass>(
+                        PublicContent,
+                        cacheKey.Key))
+                .ThrowsAsync(new FileNotFoundException());
+
+            blobStorageService.Setup(mock =>
+                    mock.UploadAsJson(
+                        PublicContent,
+                        cacheKey.Key,
+                        entity,
+                        null))
+                .Returns(Task.CompletedTask);
+
+            var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
+
+            var result = await service.GetCachedEntity(cacheKey, () => entity);
+
+            Assert.Equal(entity, result);
+
+            MockUtils.VerifyAllMocks(blobStorageService);
+        }
+
+        [Fact]
+        public async Task GetCachedEntity_ExceptionFetchingCachedEntityUploadsBlob()
+        {
+            var entity = new SampleClass();
+
+            var cacheKey = new SampleCacheKey(entity.Id);
+
+            var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+
+            blobStorageService.Setup(mock =>
+                    mock.GetDeserializedJson<SampleClass>(
+                        PublicContent,
+                        cacheKey.Key))
+                .ThrowsAsync(new Exception("An error occurred"));
+
+            blobStorageService.Setup(mock =>
+                    mock.UploadAsJson(
+                        PublicContent,
+                        cacheKey.Key,
+                        entity,
+                        null))
+                .Returns(Task.CompletedTask);
+
+            var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
+
+            var result = await service.GetCachedEntity(cacheKey, () => entity);
+
+            Assert.Equal(entity, result);
+
+            MockUtils.VerifyAllMocks(blobStorageService);
+        }
+
+        [Fact]
+        public async Task GetCachedEntity_ErrorDeserializingCachedEntityDeletesAndUploadsBlob()
+        {
+            var entity = new SampleClass();
+
+            var cacheKey = new SampleCacheKey(entity.Id);
+
+            var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+
+            blobStorageService.Setup(mock =>
+                    mock.GetDeserializedJson<SampleClass>(
+                        PublicContent,
+                        cacheKey.Key))
+                .ThrowsAsync(new JsonException("Could not deserialize the JSON"));
+
+            blobStorageService.Setup(mock =>
+                    mock.DeleteBlob(PublicContent,
+                        cacheKey.Key))
+                .Returns(Task.CompletedTask);
+
+            blobStorageService.Setup(mock =>
+                    mock.UploadAsJson(
+                        PublicContent,
+                        cacheKey.Key,
+                        entity,
+                        null))
+                .Returns(Task.CompletedTask);
+
+            var service = SetupBlobStorageCacheService(blobStorageService: blobStorageService.Object);
+
+            var result = await service.GetCachedEntity(cacheKey, () => entity);
+
+            Assert.Equal(entity, result);
+
+            MockUtils.VerifyAllMocks(blobStorageService);
+        }
+
+        private static BlobStorageCacheService SetupBlobStorageCacheService(
+            IBlobStorageService? blobStorageService = null,
+            ILogger<BlobStorageCacheService>? logger = null)
+        {
+            return new BlobStorageCacheService(
+                blobStorageService ?? new Mock<IBlobStorageService>().Object,
+                logger ?? new Mock<ILogger<BlobStorageCacheService>>().Object
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/BlobStorageCacheServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/BlobStorageCacheServiceTests.cs
@@ -2,8 +2,8 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
@@ -29,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
             }
         }
 
-        private class SampleCacheKey : ICacheKey<SampleClass>
+        private class SampleCacheKey : ICacheKey
         {
             public string Key { get; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MethodologyServiceTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
@@ -382,9 +383,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
             var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(MockBehavior.Strict);
 
-            cacheService.SetupEntityProviderResult(
+            cacheService.SetupGetItemForCacheMiss<List<AllMethodologiesThemeViewModel>>(
                 PublicContent,
-                new AllMethodologiesCacheKey());
+                AllMethodologiesCacheKey.Instance);
 
             methodologyRepository.Setup(mock => mock.GetLatestPublishedByPublication(publication.Id))
                 .ReturnsAsync(latestMethodologies);
@@ -451,9 +452,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
             var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(MockBehavior.Strict);
 
-            cacheService.SetupEntityProviderResult(
+            cacheService.SetupGetItemForCacheMiss<List<AllMethodologiesThemeViewModel>>(
                 PublicContent,
-                new AllMethodologiesCacheKey());
+                AllMethodologiesCacheKey.Instance);
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
@@ -498,9 +499,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
             var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(MockBehavior.Strict);
 
-            cacheService.SetupEntityProviderResult(
+            cacheService.SetupGetItemForCacheMiss<List<AllMethodologiesThemeViewModel>>(
                 PublicContent,
-                new AllMethodologiesCacheKey());
+                AllMethodologiesCacheKey.Instance);
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
@@ -562,9 +563,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
             var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(MockBehavior.Strict);
 
-            cacheService.SetupEntityProviderResult(
-            PublicContent,
-                new AllMethodologiesCacheKey());
+            cacheService.SetupGetItemForCacheMiss<List<AllMethodologiesThemeViewModel>>(
+                PublicContent,
+                AllMethodologiesCacheKey.Instance);
 
             methodologyRepository.Setup(mock => mock.GetLatestPublishedByPublication(publication.Id))
                 .ReturnsAsync(latestMethodologies);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MethodologyServiceTests.cs
@@ -300,7 +300,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
 
             var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
 
-            cacheService.Setup(mock => mock.GetCachedEntity(
+            cacheService.Setup(mock => mock.GetItem(
                     PublicContent,
                     It.IsAny<AllMethodologiesCacheKey>(),
                     It.IsAny<Func<Task<List<AllMethodologiesThemeViewModel>>>>()))

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MethodologyServiceTests.cs
@@ -15,6 +15,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interf
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.Database.ContentDbUtils;
@@ -264,7 +265,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
         }
 
         [Fact]
-        public async Task GetTree_CachedTree()
+        public async Task GetTree_CachedResultExists()
         {
             var expectedResult = new List<AllMethodologiesThemeViewModel>
             {
@@ -300,6 +301,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
             var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
 
             cacheService.Setup(mock => mock.GetCachedEntity(
+                    PublicContent,
                     It.IsAny<AllMethodologiesCacheKey>(),
                     It.IsAny<Func<Task<List<AllMethodologiesThemeViewModel>>>>()))
                 .ReturnsAsync(expectedResult);
@@ -377,8 +379,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
                 await contentDbContext.SaveChangesAsync();
             }
 
-            var cacheService = NeverCachedCacheService<List<AllMethodologiesThemeViewModel>>();
+            var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(MockBehavior.Strict);
+
+            cacheService.SetupEntityProviderResult(
+                PublicContent,
+                new AllMethodologiesCacheKey());
 
             methodologyRepository.Setup(mock => mock.GetLatestPublishedByPublication(publication.Id))
                 .ReturnsAsync(latestMethodologies);
@@ -442,8 +448,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
                 await contentDbContext.SaveChangesAsync();
             }
 
-            var cacheService = NeverCachedCacheService<List<AllMethodologiesThemeViewModel>>();
+            var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(MockBehavior.Strict);
+
+            cacheService.SetupEntityProviderResult(
+                PublicContent,
+                new AllMethodologiesCacheKey());
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
@@ -485,8 +495,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
                 await contentDbContext.SaveChangesAsync();
             }
 
-            var cacheService = NeverCachedCacheService<List<AllMethodologiesThemeViewModel>>();
+            var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(MockBehavior.Strict);
+
+            cacheService.SetupEntityProviderResult(
+                PublicContent,
+                new AllMethodologiesCacheKey());
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
@@ -545,8 +559,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
                 await contentDbContext.SaveChangesAsync();
             }
 
-            var cacheService = NeverCachedCacheService<List<AllMethodologiesThemeViewModel>>();
+            var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
             var methodologyRepository = new Mock<IMethodologyRepository>(MockBehavior.Strict);
+
+            cacheService.SetupEntityProviderResult(
+            PublicContent,
+                new AllMethodologiesCacheKey());
 
             methodologyRepository.Setup(mock => mock.GetLatestPublishedByPublication(publication.Id))
                 .ReturnsAsync(latestMethodologies);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Services/MethodologyServiceTests.cs
@@ -196,19 +196,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
                 var service = SetupMethodologyService(contentDbContext: contentDbContext,
                     methodologyRepository: methodologyRepository.Object);
 
-                var result = await service.GetSummariesByPublication(publication.Id);
+                var result = (await service.GetSummariesByPublication(publication.Id)).AssertRight();
 
-                result.AssertRight();
+                Assert.Equal(2, result.Count);
 
-                Assert.Equal(2, result.Right.Count);
+                Assert.Equal(methodologies[0].Id, result[0].Id);
+                Assert.Equal(methodologyParent.Slug, result[0].Slug);
+                Assert.Equal(methodologyParent.OwningPublicationTitle, result[0].Title);
 
-                Assert.Equal(methodologies[0].Id, result.Right[0].Id);
-                Assert.Equal(methodologyParent.Slug, result.Right[0].Slug);
-                Assert.Equal(methodologyParent.OwningPublicationTitle, result.Right[0].Title);
-
-                Assert.Equal(methodologies[1].Id, result.Right[1].Id);
-                Assert.Equal(methodologyParent.Slug, result.Right[1].Slug);
-                Assert.Equal(methodologies[1].AlternativeTitle, result.Right[1].Title);
+                Assert.Equal(methodologies[1].Id, result[1].Id);
+                Assert.Equal(methodologyParent.Slug, result[1].Slug);
+                Assert.Equal(methodologies[1].AlternativeTitle, result[1].Title);
             }
 
             VerifyAllMocks(methodologyRepository);
@@ -237,11 +235,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
                 var service = SetupMethodologyService(contentDbContext: contentDbContext,
                     methodologyRepository: methodologyRepository.Object);
 
-                var result = await service.GetSummariesByPublication(publication.Id);
+                var result = (await service.GetSummariesByPublication(publication.Id)).AssertRight();
 
-                result.AssertRight();
-
-                Assert.Empty(result.Right);
+                Assert.Empty(result);
             }
 
             VerifyAllMocks(methodologyRepository);
@@ -582,7 +578,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Services
 
                 Assert.Empty(result.Right);
             }
-        
+
             VerifyAllMocks(cacheService, methodologyRepository);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -70,43 +71,43 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
         public async Task<Either<ActionResult, List<AllMethodologiesThemeViewModel>>> GetTree()
         {
             return await _cacheService.GetItem(
-                PublicContent,
-                new AllMethodologiesCacheKey(),
-                async () =>
-            {
-                var themes = await _contentDbContext.Themes
-                    .Include(theme => theme.Topics)
-                    .ThenInclude(topic => topic.Publications)
-                    .AsNoTracking()
-                    .Select(theme => new AllMethodologiesThemeViewModel
-                    {
-                        Id = theme.Id,
-                        Title = theme.Title,
-                        Topics = theme.Topics.Select(topic => new AllMethodologiesTopicViewModel
+                blobContainer: PublicContent,
+                cacheKey: AllMethodologiesCacheKey.Instance,
+                entityProvider: async () =>
+                {
+                    var themes = await _contentDbContext.Themes
+                        .Include(theme => theme.Topics)
+                        .ThenInclude(topic => topic.Publications)
+                        .AsNoTracking()
+                        .Select(theme => new AllMethodologiesThemeViewModel
                         {
-                            Id = topic.Id,
-                            Title = topic.Title,
-                            Publications = topic.Publications.Select(publication =>
-                                new AllMethodologiesPublicationViewModel
-                                {
-                                    Id = publication.Id,
-                                    Title = publication.Title
-                                }).ToList()
-                        }).ToList()
-                    })
-                    .ToListAsync();
+                            Id = theme.Id,
+                            Title = theme.Title,
+                            Topics = theme.Topics.Select(topic => new AllMethodologiesTopicViewModel
+                            {
+                                Id = topic.Id,
+                                Title = topic.Title,
+                                Publications = topic.Publications.Select(publication =>
+                                    new AllMethodologiesPublicationViewModel
+                                    {
+                                        Id = publication.Id,
+                                        Title = publication.Title
+                                    }).ToList()
+                            }).ToList()
+                        })
+                        .ToListAsync();
 
-                await themes.SelectMany(model => model.Topics)
-                    .SelectMany(model => model.Publications)
-                    .ForEachAsync(async publication =>
-                        publication.Methodologies = await BuildMethodologiesForPublication(publication.Id));
+                    await themes.SelectMany(model => model.Topics)
+                        .SelectMany(model => model.Publications)
+                        .ForEachAsync(async publication =>
+                            publication.Methodologies = await BuildMethodologiesForPublication(publication.Id));
 
-                themes.ForEach(theme => theme.RemoveTopicNodesWithoutMethodologiesAndSort());
+                    themes.ForEach(theme => theme.RemoveTopicNodesWithoutMethodologiesAndSort());
 
-                return themes.Where(theme => theme.Topics.Any())
-                    .OrderBy(theme => theme.Title)
-                    .ToList();
-            });
+                    return themes.Where(theme => theme.Topics.Any())
+                        .OrderBy(theme => theme.Title)
+                        .ToList();
+                });
         }
 
         private async Task<List<MethodologySummaryViewModel>> BuildMethodologiesForPublication(Guid publicationId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
@@ -15,6 +15,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interf
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
 {
@@ -68,7 +69,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
 
         public async Task<Either<ActionResult, List<AllMethodologiesThemeViewModel>>> GetTree()
         {
-            return await _cacheService.GetCachedEntity(new AllMethodologiesCacheKey(), async () =>
+            return await _cacheService.GetCachedEntity(
+                PublicContent,
+                new AllMethodologiesCacheKey(),
+                async () =>
             {
                 var themes = await _contentDbContext.Themes
                     .Include(theme => theme.Topics)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Services/MethodologyService.cs
@@ -69,7 +69,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Services
 
         public async Task<Either<ActionResult, List<AllMethodologiesThemeViewModel>>> GetTree()
         {
-            return await _cacheService.GetCachedEntity(
+            return await _cacheService.GetItem(
                 PublicContent,
                 new AllMethodologiesCacheKey(),
                 async () =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -92,6 +92,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
                     );
                 }
             );
+            services.AddTransient<ICacheService, BlobStorageCacheService>();
             services.AddTransient<IFileStorageService, FileStorageService>();
             services.AddTransient<IFilterService, FilterService>();
             services.AddTransient<IIndicatorService, IndicatorService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/ViewModels/AllMethodologiesViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/ViewModels/AllMethodologiesViewModels.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels
@@ -79,10 +78,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels
             if (ReferenceEquals(null, other)) return 1;
             return string.Compare(Title, other.Title, StringComparison.Ordinal);
         }
-    }
-
-    public class AllMethodologiesCacheKey : ICacheKey<List<AllMethodologiesThemeViewModel>>
-    {
-        public string Key => "627b1bfc-3436-474c-9d10-7b0b98b6dee5";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/ViewModels/AllMethodologiesViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/ViewModels/AllMethodologiesViewModels.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels
@@ -78,5 +79,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.ViewModels
             if (ReferenceEquals(null, other)) return 1;
             return string.Compare(Title, other.Title, StringComparison.Ordinal);
         }
+    }
+
+    public class AllMethodologiesCacheKey : ICacheKey<List<AllMethodologiesThemeViewModel>>
+    {
+        public string Key => "627b1bfc-3436-474c-9d10-7b0b98b6dee5";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServiceTests.cs
@@ -237,7 +237,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var tableBuilderService = new Mock<ITableBuilderService>(MockBehavior.Strict);
 
             cacheService
-                .Setup(s => s.GetCachedEntity(
+                .Setup(s => s.GetItem(
                     PublicContent,
                     It.Is<TableBuilderResultCacheKey>(key => key.Key == cacheKey),
                     It.IsAny<Func<Task<Either<ActionResult, TableBuilderResultViewModel>>>>()))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServiceTests.cs
@@ -1,23 +1,22 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
-using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using Moq;
-using Newtonsoft.Json;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 {
@@ -63,8 +62,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             await contentDbContext.AddAsync(releaseContentBlock);
             await contentDbContext.SaveChangesAsync();
 
-            var path = $"publications/publication-slug/releases/release-slug/data-blocks/{_dataBlockId}.json";
-
             var tableResult = new TableBuilderResultViewModel
             {
                 Results = new List<ObservationViewModel>
@@ -73,16 +70,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 }
             };
 
-            var blobStorageService = new Mock<IBlobStorageService>();
+            var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
+            var tableBuilderService = new Mock<ITableBuilderService>(MockBehavior.Strict);
 
-            blobStorageService
-                .Setup(s => s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContent, path))
-                .ThrowsAsync(new FileNotFoundException());
-
-            blobStorageService
-                .Setup(s => s.UploadAsJson(PublicContent, path, tableResult, null));
-
-            var tableBuilderService = new Mock<ITableBuilderService>();
+            cacheService
+                .SetupEntityProviderResult<TableBuilderResultViewModel,
+                    Task<Either<ActionResult, TableBuilderResultViewModel>>>(
+                    PublicContent,
+                    new TableBuilderResultCacheKey(releaseContentBlock));
 
             tableBuilderService
                 .Setup(
@@ -96,18 +91,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var service = BuildDataBlockService(
                 contentDbContext,
-                tableBuilderService: tableBuilderService.Object,
-                blobStorageService: blobStorageService.Object
+                cacheService: cacheService.Object,
+                tableBuilderService: tableBuilderService.Object
             );
 
-            var result = await service.GetDataBlockTableResult(releaseContentBlock);
+            var result = (await service.GetDataBlockTableResult(releaseContentBlock)).AssertRight();
 
-            Assert.True(result.IsRight);
+            Assert.Single(result.Results);
 
-            Assert.IsType<TableBuilderResultViewModel>(result.Right);
-            Assert.Single(result.Right.Results);
-
-            MockUtils.VerifyAllMocks(blobStorageService, tableBuilderService);
+            VerifyAllMocks(cacheService, tableBuilderService);
         }
 
         [Fact]
@@ -151,8 +143,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             await contentDbContext.AddAsync(releaseContentBlock);
             await contentDbContext.SaveChangesAsync();
 
-            var path = $"publications/publication-slug/releases/release-slug/data-blocks/{_dataBlockId}.json";
-
             var tableResult = new TableBuilderResultViewModel
             {
                 Results = new List<ObservationViewModel>
@@ -161,16 +151,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 }
             };
 
-            var blobStorageService = new Mock<IBlobStorageService>();
+            var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
+            var tableBuilderService = new Mock<ITableBuilderService>(MockBehavior.Strict);
 
-            blobStorageService
-                .Setup(s => s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContent, path))
-                .ThrowsAsync(new FileNotFoundException());
-
-            blobStorageService
-                .Setup(s => s.UploadAsJson(PublicContent, path, tableResult, null));
-
-            var tableBuilderService = new Mock<ITableBuilderService>();
+            cacheService
+                .SetupEntityProviderResult<TableBuilderResultViewModel,
+                    Task<Either<ActionResult, TableBuilderResultViewModel>>>(
+                    PublicContent,
+                    new TableBuilderResultCacheKey(releaseContentBlock));
 
             tableBuilderService
                 .Setup(
@@ -187,18 +175,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var service = BuildDataBlockService(
                 contentDbContext,
-                tableBuilderService: tableBuilderService.Object,
-                blobStorageService: blobStorageService.Object
+                cacheService: cacheService.Object,
+                tableBuilderService: tableBuilderService.Object
             );
 
-            var result = await service.GetDataBlockTableResult(releaseContentBlock);
+            var result = (await service.GetDataBlockTableResult(releaseContentBlock)).AssertRight();
 
-            Assert.True(result.IsRight);
+            Assert.Single(result.Results);
 
-            Assert.IsType<TableBuilderResultViewModel>(result.Right);
-            Assert.Single(result.Right.Results);
-
-            MockUtils.VerifyAllMocks(blobStorageService, tableBuilderService);
+            VerifyAllMocks(cacheService, tableBuilderService);
         }
 
         [Fact]
@@ -238,7 +223,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             await contentDbContext.AddAsync(releaseContentBlock);
             await contentDbContext.SaveChangesAsync();
 
-            var path = $"publications/publication-slug/releases/release-slug/data-blocks/{_dataBlockId}.json";
+            var cacheKey = $"publications/publication-slug/releases/release-slug/data-blocks/{_dataBlockId}.json";
 
             var tableResult = new TableBuilderResultViewModel
             {
@@ -248,117 +233,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 }
             };
 
-            var blobStorageService = new Mock<IBlobStorageService>();
+            var cacheService = new Mock<ICacheService>(MockBehavior.Strict);
+            var tableBuilderService = new Mock<ITableBuilderService>(MockBehavior.Strict);
 
-            blobStorageService
-                .Setup(s => s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContent, path))
+            cacheService
+                .Setup(s => s.GetCachedEntity(
+                    PublicContent,
+                    It.Is<TableBuilderResultCacheKey>(key => key.Key == cacheKey),
+                    It.IsAny<Func<Task<Either<ActionResult, TableBuilderResultViewModel>>>>()))
                 .ReturnsAsync(tableResult);
-
-            var tableBuilderService = new Mock<ITableBuilderService>();
 
             var service = BuildDataBlockService(
                 contentDbContext,
-                tableBuilderService: tableBuilderService.Object,
-                blobStorageService: blobStorageService.Object
+                cacheService: cacheService.Object,
+                tableBuilderService: tableBuilderService.Object
             );
 
-            var result = await service.GetDataBlockTableResult(releaseContentBlock);
+            var result = (await service.GetDataBlockTableResult(releaseContentBlock)).AssertRight();
 
-            Assert.True(result.IsRight);
+            Assert.Single(result.Results);
 
-            Assert.IsType<TableBuilderResultViewModel>(result.Right);
-            Assert.Single(result.Right.Results);
-
-            MockUtils.VerifyAllMocks(blobStorageService, tableBuilderService);
-        }
-
-        [Fact]
-        public async Task GetDataBlockTableResult_DeletesInvalidCachedResult()
-        {
-            var subjectId = Guid.NewGuid();
-
-            var releaseContentBlock = new ReleaseContentBlock
-            {
-                ReleaseId = _releaseId,
-                Release = new Release
-                {
-                    Id = _releaseId,
-                    Slug = "release-slug",
-                    Publication = new Publication
-                    {
-                        Slug = "publication-slug"
-                    }
-                },
-                ContentBlockId = _dataBlockId,
-                ContentBlock = new DataBlock
-                {
-                    Id = _dataBlockId,
-                    Query = new ObservationQueryContext
-                    {
-                        SubjectId = subjectId,
-                    },
-                    Charts = new List<IChart>
-                    {
-                        new LineChart()
-                    }
-                }
-            };
-
-            await using var contentDbContext = ContentDbUtils.InMemoryContentDbContext();
-
-            await contentDbContext.AddAsync(releaseContentBlock);
-            await contentDbContext.SaveChangesAsync();
-
-            var path = $"publications/publication-slug/releases/release-slug/data-blocks/{_dataBlockId}.json";
-
-            var tableResult = new TableBuilderResultViewModel
-            {
-                Results = new List<ObservationViewModel>
-                {
-                    new ObservationViewModel()
-                }
-            };
-
-            var blobStorageService = new Mock<IBlobStorageService>();
-
-            blobStorageService
-                .Setup(s =>
-                    s.GetDeserializedJson<TableBuilderResultViewModel>(PublicContent, path))
-                .ThrowsAsync(new JsonException("Could not deserialize the JSON"));
-
-            blobStorageService
-                .Setup(s => s.DeleteBlob(PublicContent, path));
-
-            blobStorageService
-                .Setup(s => s.UploadAsJson(PublicContent, path, tableResult, null));
-
-            var tableBuilderService = new Mock<ITableBuilderService>();
-
-            tableBuilderService
-                .Setup(
-                    s =>
-                        s.Query(
-                            _releaseId,
-                            It.Is<ObservationQueryContext>(q => q.SubjectId == subjectId)
-                        )
-                )
-                .ReturnsAsync(tableResult);
-
-
-            var service = BuildDataBlockService(
-                contentDbContext,
-                tableBuilderService: tableBuilderService.Object,
-                blobStorageService: blobStorageService.Object
-            );
-
-            var result = await service.GetDataBlockTableResult(releaseContentBlock);
-
-            Assert.True(result.IsRight);
-
-            Assert.IsType<TableBuilderResultViewModel>(result.Right);
-            Assert.Single(result.Right.Results);
-
-            MockUtils.VerifyAllMocks(blobStorageService, tableBuilderService);
+            VerifyAllMocks(cacheService, tableBuilderService);
         }
 
         [Fact]
@@ -389,23 +284,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var result = await service.GetDataBlockTableResult(releaseContentBlock);
 
-            Assert.True(result.IsLeft);
-            Assert.IsType<NotFoundResult>(result.Left);
+            result.AssertNotFound();
         }
 
-
-        private DataBlockService BuildDataBlockService(
+        private static DataBlockService BuildDataBlockService(
             ContentDbContext contentDbContext,
-            IBlobStorageService blobStorageService = null,
+            ICacheService cacheService = null,
             ITableBuilderService tableBuilderService = null,
             IUserService userService = null)
         {
             return new DataBlockService(
                 contentDbContext,
-                blobStorageService ?? new Mock<IBlobStorageService>().Object,
+                cacheService ?? new Mock<ICacheService>().Object,
                 tableBuilderService ?? new Mock<ITableBuilderService>().Object,
-                userService ?? MockUtils.AlwaysTrueUserService().Object,
-                new Mock<ILogger<DataBlockService>>().Object
+                userService ?? AlwaysTrueUserService().Object
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/DataBlockServiceTests.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Services;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Cache;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -74,10 +75,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var tableBuilderService = new Mock<ITableBuilderService>(MockBehavior.Strict);
 
             cacheService
-                .SetupEntityProviderResult<TableBuilderResultViewModel,
+                .SetupGetItemForCacheMiss<TableBuilderResultViewModel,
                     Task<Either<ActionResult, TableBuilderResultViewModel>>>(
                     PublicContent,
-                    new TableBuilderResultCacheKey(releaseContentBlock));
+                    new DataBlockTableResultCacheKey(releaseContentBlock));
 
             tableBuilderService
                 .Setup(
@@ -155,10 +156,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var tableBuilderService = new Mock<ITableBuilderService>(MockBehavior.Strict);
 
             cacheService
-                .SetupEntityProviderResult<TableBuilderResultViewModel,
+                .SetupGetItemForCacheMiss<TableBuilderResultViewModel,
                     Task<Either<ActionResult, TableBuilderResultViewModel>>>(
                     PublicContent,
-                    new TableBuilderResultCacheKey(releaseContentBlock));
+                    new DataBlockTableResultCacheKey(releaseContentBlock));
 
             tableBuilderService
                 .Setup(
@@ -239,7 +240,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             cacheService
                 .Setup(s => s.GetItem(
                     PublicContent,
-                    It.Is<TableBuilderResultCacheKey>(key => key.Key == cacheKey),
+                    It.Is<DataBlockTableResultCacheKey>(key => key.Key == cacheKey),
                     It.IsAny<Func<Task<Either<ActionResult, TableBuilderResultViewModel>>>>()))
                 .ReturnsAsync(tableResult);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Cache;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
@@ -56,15 +57,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
                         if (block.ContentBlock is DataBlock dataBlock)
                         {
                             return await _cacheService.GetItem(
-                                PublicContent,
-                                new TableBuilderResultCacheKey(block),
-                                async () =>
-                            {
-                                var query = dataBlock.Query.Clone();
-                                query.IncludeGeoJson = dataBlock.Charts.Any(chart => chart.Type == ChartType.Map);
+                                blobContainer: PublicContent,
+                                cacheKey: new DataBlockTableResultCacheKey(block),
+                                entityProvider: async () =>
+                                {
+                                    var query = dataBlock.Query.Clone();
+                                    query.IncludeGeoJson = dataBlock.Charts.Any(chart => chart.Type == ChartType.Map);
 
-                                return await _tableBuilderService.Query(block.ReleaseId, query);
-                            });
+                                    return await _tableBuilderService.Query(block.ReleaseId, query);
+                                });
                         }
 
                         return new NotFoundResult();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
@@ -1,10 +1,8 @@
-using System;
-using System.IO;
+#nullable enable
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
@@ -14,8 +12,6 @@ using GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
@@ -23,23 +19,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
     public class DataBlockService : IDataBlockService
     {
         private readonly ContentDbContext _contentDbContext;
-        private readonly IBlobStorageService _blobStorageService;
+        private readonly ICacheService _cacheService;
         private readonly ITableBuilderService _tableBuilderService;
         private readonly IUserService _userService;
-        private readonly ILogger<DataBlockService> _logger;
 
         public DataBlockService(
             ContentDbContext contentDbContext,
-            IBlobStorageService blobStorageService,
+            ICacheService cacheService,
             ITableBuilderService tableBuilderService,
-            IUserService userService,
-            ILogger<DataBlockService> logger)
+            IUserService userService)
         {
             _contentDbContext = contentDbContext;
-            _blobStorageService = blobStorageService;
+            _cacheService = cacheService;
             _tableBuilderService = tableBuilderService;
             _userService = userService;
-            _logger = logger;
         }
 
         public async Task<Either<ActionResult, TableBuilderResultViewModel>> GetDataBlockTableResult(
@@ -62,44 +55,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
                     {
                         if (block.ContentBlock is DataBlock dataBlock)
                         {
-                            var path = FileStoragePathUtils.PublicContentDataBlockPath(
-                                block.Release.Publication.Slug,
-                                block.Release.Slug,
-                                block.ContentBlockId
-                            );
+                            return await _cacheService.GetCachedEntity(
+                                PublicContent,
+                                new TableBuilderResultCacheKey(block),
+                                async () =>
+                            {
+                                var query = dataBlock.Query.Clone();
+                                query.IncludeGeoJson = dataBlock.Charts.Any(chart => chart.Type == ChartType.Map);
 
-                            try
-                            {
-                                return await _blobStorageService.GetDeserializedJson<TableBuilderResultViewModel>(
-                                    PublicContent,
-                                    path
-                                );
-                            }
-                            catch (JsonException)
-                            {
-                                // If there's an error deserializing the blob, we should
-                                // assume it's not salvageable and just re-build it.
-                                await _blobStorageService.DeleteBlob(PublicContent, path);
-                            }
-                            catch (FileNotFoundException)
-                            {
-                                // Do nothing as the blob just doesn't exist
-                            }
-                            catch (Exception exception)
-                            {
-                                _logger.LogWarning(
-                                    exception,
-                                    $"Unable to fetch data block response from blob storage with path: {path}"
-                                );
-                            }
-
-                            var query = dataBlock.Query.Clone();
-                            query.IncludeGeoJson = dataBlock.Charts.Any(chart => chart.Type == ChartType.Map);
-
-                            return await _tableBuilderService.Query(block.ReleaseId, query)
-                                .OnSuccessDo(
-                                    result => _blobStorageService.UploadAsJson(PublicContent, path, result)
-                                );
+                                return await _tableBuilderService.Query(block.ReleaseId, query);
+                            });
                         }
 
                         return new NotFoundResult();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/DataBlockService.cs
@@ -55,7 +55,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
                     {
                         if (block.ContentBlock is DataBlock dataBlock)
                         {
-                            return await _cacheService.GetCachedEntity(
+                            return await _cacheService.GetItem(
                                 PublicContent,
                                 new TableBuilderResultCacheKey(block),
                                 async () =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -94,6 +94,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
                 c.SwaggerDoc("v1", new OpenApiInfo {Title = "Explore education statistics - Data API", Version = "v1"});
             });
 
+            services.AddTransient<ICacheService, BlobStorageCacheService>();
             services.AddTransient<IResultBuilder<Observation, ObservationViewModel>, ResultBuilder>();
             services.AddTransient<IBoundaryLevelService, BoundaryLevelService>();
             services.AddTransient<ITableBuilderService, TableBuilderService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Cache/DataBlockTableResultCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Cache/DataBlockTableResultCacheKey.cs
@@ -1,0 +1,35 @@
+﻿#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Cache
+{
+    public class DataBlockTableResultCacheKey : ICacheKey
+    {
+        private string PublicationSlug { get; }
+        private string ReleaseSlug { get; }
+        private Guid DataBlockId { get; }
+
+        public DataBlockTableResultCacheKey(ReleaseContentBlock releaseContentBlock)
+        {
+            if (!(releaseContentBlock.ContentBlock is DataBlock))
+            {
+                throw new ArgumentException(
+                    "Attempting to build key with incorrect type of content block");
+            }
+
+            var release = releaseContentBlock.Release;
+            PublicationSlug = release.Publication.Slug;
+            ReleaseSlug = release.Slug;
+            DataBlockId = releaseContentBlock.ContentBlockId;
+        }
+
+        public string Key => PublicContentDataBlockPath(
+            PublicationSlug,
+            ReleaseSlug,
+            DataBlockId
+        );
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/TableBuilderResultViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/TableBuilderResultViewModel.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Generic;
-using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
-using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
@@ -17,31 +13,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
         {
             Results = new List<ObservationViewModel>();
         }
-    }
-
-    public class TableBuilderResultCacheKey : ICacheKey<TableBuilderResultViewModel>
-    {
-        private string PublicationSlug { get; }
-        private string ReleaseSlug { get; }
-        private Guid DataBlockId { get; }
-
-        public TableBuilderResultCacheKey(ReleaseContentBlock releaseContentBlock)
-        {
-            if (!(releaseContentBlock.ContentBlock is DataBlock))
-            {
-                throw new ArgumentException("Attempting to build data block cache key with incorrect type of content block");
-            }
-
-            var release = releaseContentBlock.Release;
-            PublicationSlug = release.Publication.Slug;
-            ReleaseSlug = release.Slug;
-            DataBlockId = releaseContentBlock.ContentBlockId;
-        }
-
-        public string Key => FileStoragePathUtils.PublicContentDataBlockPath(
-            PublicationSlug,
-            ReleaseSlug,
-            DataBlockId
-        );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/TableBuilderResultViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/TableBuilderResultViewModel.cs
@@ -1,4 +1,8 @@
+using System;
 using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
@@ -13,5 +17,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
         {
             Results = new List<ObservationViewModel>();
         }
+    }
+
+    public class TableBuilderResultCacheKey : ICacheKey<TableBuilderResultViewModel>
+    {
+        private string PublicationSlug { get; }
+        private string ReleaseSlug { get; }
+        private Guid DataBlockId { get; }
+
+        public TableBuilderResultCacheKey(ReleaseContentBlock releaseContentBlock)
+        {
+            if (!(releaseContentBlock.ContentBlock is DataBlock))
+            {
+                throw new ArgumentException("Attempting to build data block cache key with incorrect type of content block");
+            }
+
+            var release = releaseContentBlock.Release;
+            PublicationSlug = release.Publication.Slug;
+            ReleaseSlug = release.Slug;
+            DataBlockId = releaseContentBlock.ContentBlockId;
+        }
+
+        public string Key => FileStoragePathUtils.PublicContentDataBlockPath(
+            PublicationSlug,
+            ReleaseSlug,
+            DataBlockId
+        );
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Utils;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
@@ -13,16 +16,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
     // ReSharper disable once UnusedType.Global
     public class PublishReleaseContentFunction
     {
+        private readonly ICacheService _cacheService;
         private readonly IContentService _contentService;
         private readonly INotificationsService _notificationsService;
         private readonly IReleaseService _releaseService;
         private readonly IReleaseStatusService _releaseStatusService;
 
-        public PublishReleaseContentFunction(IContentService contentService,
+        public PublishReleaseContentFunction(
+            ICacheService cacheService,
+            IContentService contentService,
             INotificationsService notificationsService,
             IReleaseService releaseService,
             IReleaseStatusService releaseStatusService)
         {
+            _cacheService = _cacheService;
             _contentService = contentService;
             _notificationsService = notificationsService;
             _releaseService = releaseService;
@@ -65,6 +72,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 {
                     await _releaseService.DeletePreviousVersionsStatisticalData(message.ReleaseId);
                 }
+
+                // Invalidate the 'All Methodologies' cache item in case any methodologies
+                // are now accessible for the first time after publishing this release
+                await _cacheService.DeleteItem(PublicContent, AllMethodologiesCacheKey.Instance);
 
                 await _contentService.DeletePreviousVersionsDownloadFiles(message.ReleaseId);
                 await _contentService.DeletePreviousVersionsContent(message.ReleaseId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -29,7 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
             IReleaseService releaseService,
             IReleaseStatusService releaseStatusService)
         {
-            _cacheService = _cacheService;
+            _cacheService = cacheService;
             _contentService = contentService;
             _notificationsService = notificationsService;
             _releaseService = releaseService;

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
@@ -15,6 +16,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 {
     public class ContentService : IContentService
     {
+        private readonly ICacheService _cacheService;
         private readonly IBlobStorageService _publicBlobStorageService;
         private readonly IFastTrackService _fastTrackService;
         private readonly IReleaseService _releaseService;
@@ -25,12 +27,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             GetJsonSerializerSettings(new CamelCaseNamingStrategy());
 
         public ContentService(IBlobStorageService publicBlobStorageService,
+            ICacheService cacheService,
             IFastTrackService fastTrackService,
             IDownloadService downloadService,
             IReleaseService releaseService,
             IPublicationService publicationService)
         {
             _publicBlobStorageService = publicBlobStorageService;
+            _cacheService = cacheService;
             _fastTrackService = fastTrackService;
             _releaseService = releaseService;
             _publicationService = publicationService;
@@ -131,6 +135,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         public async Task UpdateTaxonomy(PublishContext context)
         {
+            // Invalidate the 'All Methodologies' cache item in case any methodologies are affected by the changes
+            await _cacheService.DeleteItem(PublicContent, AllMethodologiesCacheKey.Instance);
+
             await CacheTrees(context);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -59,6 +59,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                 .AddScoped<IContentService, ContentService>(provider =>
                     new ContentService(
                         publicBlobStorageService: GetBlobStorageService(provider, "PublicStorage"),
+                        cacheService: provider.GetService<ICacheService>(),
                         fastTrackService: provider.GetService<IFastTrackService>(),
                         downloadService: provider.GetRequiredService<IDownloadService>(),
                         releaseService: provider.GetRequiredService<IReleaseService>(),

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -45,6 +45,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                     options.UseSqlServer(ConnectionUtils.GetAzureSqlConnectionString("PublicStatisticsDb")))
                 .AddSingleton<IFileStorageService, FileStorageService>(provider =>
                     new FileStorageService(GetConfigurationValue(provider, "PublisherStorage")))
+                .AddScoped<ICacheService, BlobStorageCacheService>(provider =>
+                    new BlobStorageCacheService(
+                        blobStorageService: GetBlobStorageService(provider, "PublicStorage"),
+                        logger: provider.GetRequiredService<ILogger<BlobStorageCacheService>>()))
                 .AddScoped<IPublishingService, PublishingService>(provider =>
                     new PublishingService(
                         publicStorageConnectionString: GetConfigurationValue(provider, "PublicStorage"),


### PR DESCRIPTION
This PR introduces a new caching interface with implementation `BlobStorageCacheService` which can read and write cached entity results in blob storage serialised as JSON, identified by a unique key.

It is a the same 'Cache Aside' strategy that we were already using to cache data block results where we first try to read from the cache, and if no result is found then read the result from the database, serialising the result as JSON in the storage container before returning it.

The same logic is moved to this new service so that it can also be used by the Public Content API's endpoint to retrieve the themes 'tree' of all Methodologies via the cache, significantly improving the load time of this page from around 1.5s to <100ms.

The interface of the cache service expects a callback function to provide the entity result.

In future it's expected that other use cases will need to implement a method of expiring cache items.

For now, we know the code points where methodologies can become publicly accessible or their taxonomy can change, so we can invalidate the cache item by deleting the blob at these points.

We also leave expiring data blocks to any mechanism for removing them that might already exist, for example regenerating all content via the Publisher.