### PR TITLE
EES-2538 Update Publisher to use private statistics DB

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -530,8 +530,8 @@
       "defaultValue": "deploy"
     },
     "maxDbSizeBytes": {
-      "type": "int", 
-      "defaultValue": 268435456000 
+      "type": "int",
+      "defaultValue": 268435456000
     },
     "enableAlerts": {
       "type": "bool",
@@ -2964,6 +2964,11 @@
             },
             {
               "name": "StatisticsDb",
+              "type": "SQLAzure",
+              "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('sqlServerName'))).fullyQualifiedDomainName, ',1433;Initial Catalog=', 'statistics', ';User Id=', parameters('sqlPublisherUser'), '@', reference(concat('Microsoft.Sql/servers/', variables('sqlServerName'))).fullyQualifiedDomainName, ';Password=', parameters('sqlPublisherUserPassword'), ';')]"
+            },
+            {
+              "name": "PublicStatisticsDb",
               "type": "SQLAzure",
               "connectionString": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('publicSqlserverName'))).fullyQualifiedDomainName, ',1433;Initial Catalog=', 'public-statistics', ';User Id=', parameters('sqlPublisherUser'), '@', reference(concat('Microsoft.Sql/servers/', variables('publicSqlServerName'))).fullyQualifiedDomainName, ';Password=', parameters('sqlPublisherUserPassword'), ';')]"
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/PublicStatisticsDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/PublicStatisticsDbContext.cs
@@ -1,0 +1,17 @@
+#nullable enable
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
+{
+    public class PublicStatisticsDbContext : StatisticsDbContext
+    {
+        public PublicStatisticsDbContext()
+        {
+        }
+
+        public PublicStatisticsDbContext(DbContextOptions<PublicStatisticsDbContext> options, int? timeout = null) :
+            base(options, timeout)
+        {
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
@@ -12,14 +13,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
     {
         public StatisticsDbContext()
         {
-
         }
 
-        public StatisticsDbContext(DbContextOptions<StatisticsDbContext> options) : this(options, int.MaxValue)
+        public StatisticsDbContext(DbContextOptions<StatisticsDbContext> options, int? timeout = int.MaxValue) : base(options)
         {
+            Configure(timeout);
         }
 
-        public StatisticsDbContext(DbContextOptions<StatisticsDbContext> options, int? timeout) : base(options)
+        /// <summary>
+        /// This constructor is required to allow sub-classes to pass in
+        /// DbContextOptions without a type parameter.
+        /// We would otherwise need to set a type parameter at the class
+        /// level and this doesn't really work with the DI container (unless
+        /// we created an abstract base class with a type parameter).
+        /// </summary>
+        protected StatisticsDbContext(DbContextOptions options, int? timeout = int.MaxValue) : base(options)
+        {
+            Configure(timeout);
+        }
+
+        private void Configure(int? timeout)
         {
             if (timeout.HasValue)
             {
@@ -27,27 +40,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
             }
         }
 
-        public DbSet<BoundaryLevel> BoundaryLevel { get; set; }
-        public DbSet<Filter> Filter { get; set; }
-        public DbSet<FilterFootnote> FilterFootnote { get; set; }
-        public DbSet<FilterGroup> FilterGroup { get; set; }
-        public DbSet<FilterGroupFootnote> FilterGroupFootnote { get; set; }
-        public DbSet<FilterItem> FilterItem { get; set; }
-        public DbSet<FilterItemFootnote> FilterItemFootnote { get; set; }
-        public DbSet<Footnote> Footnote { get; set; }
-        public DbSet<GeoJson> GeoJson { get; set; }
-        public DbSet<Indicator> Indicator { get; set; }
-        public DbSet<IndicatorFootnote> IndicatorFootnote { get; set; }
-        public DbSet<IndicatorGroup> IndicatorGroup { get; set; }
-        public DbSet<Location> Location { get; set; }
-        public DbSet<Observation> Observation { get; set; }
-        public DbSet<ObservationFilterItem> ObservationFilterItem { get; set; }
-        public DbSet<Release> Release { get; set; }
-        public DbSet<Subject> Subject { get; set; }
-        public DbSet<SubjectFootnote> SubjectFootnote { get; set; }
+        public DbSet<BoundaryLevel> BoundaryLevel { get; set; } = null!;
+        public DbSet<Filter> Filter { get; set; } = null!;
+        public DbSet<FilterFootnote> FilterFootnote { get; set; } = null!;
+        public DbSet<FilterGroup> FilterGroup { get; set; } = null!;
+        public DbSet<FilterGroupFootnote> FilterGroupFootnote { get; set; } = null!;
+        public DbSet<FilterItem> FilterItem { get; set; } = null!;
+        public DbSet<FilterItemFootnote> FilterItemFootnote { get; set; } = null!;
+        public DbSet<Footnote> Footnote { get; set; } = null!;
+        public DbSet<GeoJson> GeoJson { get; set; } = null!;
+        public DbSet<Indicator> Indicator { get; set; } = null!;
+        public DbSet<IndicatorFootnote> IndicatorFootnote { get; set; } = null!;
+        public DbSet<IndicatorGroup> IndicatorGroup { get; set; } = null!;
+        public DbSet<Location> Location { get; set; } = null!;
+        public DbSet<Observation> Observation { get; set; } = null!;
+        public DbSet<ObservationFilterItem> ObservationFilterItem { get; set; } = null!;
+        public DbSet<Release> Release { get; set; } = null!;
+        public DbSet<Subject> Subject { get; set; } = null!;
+        public DbSet<SubjectFootnote> SubjectFootnote { get; set; } = null!;
 
-        public DbSet<ReleaseSubject> ReleaseSubject { get; set; }
-        public DbSet<ReleaseFootnote> ReleaseFootnote { get; set; }
+        public DbSet<ReleaseSubject> ReleaseSubject { get; set; } = null!;
+        public DbSet<ReleaseFootnote> ReleaseFootnote { get; set; } = null!;
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             ConfigureBoundaryLevel(modelBuilder);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbUtils.cs
@@ -16,5 +16,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
         {
             return InMemoryStatisticsDbContext(Guid.NewGuid().ToString());
         }
+
+        public static PublicStatisticsDbContext InMemoryPublicStatisticsDbContext(string dbName)
+        {
+            var builder = new DbContextOptionsBuilder<PublicStatisticsDbContext>();
+            builder.UseInMemoryDatabase(databaseName: dbName);
+            return new PublicStatisticsDbContext(builder.Options, null);
+        }
+
+        public static PublicStatisticsDbContext InMemoryPublicStatisticsDbContext()
+        {
+            return InMemoryPublicStatisticsDbContext(Guid.NewGuid().ToString());
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/ReleaseServiceTests.cs
@@ -1148,7 +1148,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var statisticsDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var statisticsDbContext = InMemoryPublicStatisticsDbContext(statisticsDbContextId))
             {
                 await contentDbContext.Releases.AddAsync(contentRelease);
                 await contentDbContext.SaveChangesAsync();
@@ -1164,7 +1164,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 .Returns(Task.CompletedTask);
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var statisticsDbContext = InMemoryPublicStatisticsDbContext(statisticsDbContextId))
             {
                 var service = BuildReleaseService(contentDbContext: contentDbContext,
                     statisticsDbContext: statisticsDbContext,
@@ -1174,7 +1174,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             }
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var statisticsDbContext = InMemoryPublicStatisticsDbContext(statisticsDbContextId))
             {
                 var actualContentRelease = await contentDbContext.Releases
                     .Include(r => r.Publication)
@@ -1223,7 +1223,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 .Returns(Task.CompletedTask);
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext())
+            await using (var statisticsDbContext = InMemoryPublicStatisticsDbContext())
             {
                 var service = BuildReleaseService(contentDbContext: contentDbContext,
                     statisticsDbContext: statisticsDbContext,
@@ -1282,7 +1282,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             var statisticsDbContextId = Guid.NewGuid().ToString();
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var statisticsDbContext = InMemoryPublicStatisticsDbContext(statisticsDbContextId))
             {
                 await contentDbContext.Publications.AddAsync(publication);
                 await contentDbContext.Releases.AddRangeAsync(previousContentRelease, contentRelease);
@@ -1299,7 +1299,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
                 .Returns(Task.CompletedTask);
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var statisticsDbContext = InMemoryPublicStatisticsDbContext(statisticsDbContextId))
             {
                 var service = BuildReleaseService(contentDbContext: contentDbContext,
                     statisticsDbContext: statisticsDbContext,
@@ -1309,7 +1309,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
             }
 
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
-            await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+            await using (var statisticsDbContext = InMemoryPublicStatisticsDbContext(statisticsDbContextId))
             {
                 var actualContentRelease = await contentDbContext.Releases
                     .Include(r => r.Publication)
@@ -1330,7 +1330,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
             MockUtils.VerifyAllMocks(methodologyService);
         }
-        
+
         private static PublishContext PublishContext()
         {
             var published = DateTime.Today.Add(new TimeSpan(9, 30, 0));
@@ -1339,14 +1339,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
 
         private static ReleaseService BuildReleaseService(
             ContentDbContext contentDbContext,
-            StatisticsDbContext statisticsDbContext = null,
+            PublicStatisticsDbContext statisticsDbContext = null,
             IBlobStorageService publicBlobStorageService = null,
             IMethodologyService methodologyService = null,
             IReleaseSubjectService releaseSubjectService = null)
         {
             return new ReleaseService(
                 contentDbContext,
-                statisticsDbContext ?? new Mock<StatisticsDbContext>().Object,
+                statisticsDbContext ?? new Mock<PublicStatisticsDbContext>().Object,
                 publicBlobStorageService ?? new Mock<IBlobStorageService>().Object,
                 methodologyService ?? new Mock<IMethodologyService>().Object,
                 releaseSubjectService ?? new Mock<IReleaseSubjectService>().Object,

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ReleaseService.cs
@@ -26,7 +26,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
     public class ReleaseService : IReleaseService
     {
         private readonly ContentDbContext _contentDbContext;
-        private readonly StatisticsDbContext _statisticsDbContext;
+        private readonly PublicStatisticsDbContext _publicStatisticsDbContext;
         private readonly IBlobStorageService _publicBlobStorageService;
         private readonly IMethodologyService _methodologyService;
         private readonly IReleaseSubjectService _releaseSubjectService;
@@ -34,7 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
         private readonly IMapper _mapper;
 
         public ReleaseService(ContentDbContext contentDbContext,
-            StatisticsDbContext statisticsDbContext,
+            PublicStatisticsDbContext publicStatisticsDbContext,
             IBlobStorageService publicBlobStorageService,
             IMethodologyService methodologyService,
             IReleaseSubjectService releaseSubjectService,
@@ -42,7 +42,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             IMapper mapper)
         {
             _contentDbContext = contentDbContext;
-            _statisticsDbContext = statisticsDbContext;
+            _publicStatisticsDbContext = publicStatisticsDbContext;
             _publicBlobStorageService = publicBlobStorageService;
             _methodologyService = methodologyService;
             _releaseSubjectService = releaseSubjectService;
@@ -158,7 +158,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                 .Include(release => release.Publication)
                 .SingleOrDefaultAsync(r => r.Id == id);
 
-            var statisticsRelease = await _statisticsDbContext.Release
+            var statisticsRelease = await _publicStatisticsDbContext.Release
                 .SingleOrDefaultAsync(r => r.Id == id);
 
             if (contentRelease == null)
@@ -196,9 +196,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             // The Release in the statistics database can be absent if no Subjects were created
             if (statisticsRelease != null)
             {
-                _statisticsDbContext.Release.Update(statisticsRelease);
+                _publicStatisticsDbContext.Release.Update(statisticsRelease);
                 statisticsRelease.Published ??= published;
-                await _statisticsDbContext.SaveChangesAsync();
+                await _publicStatisticsDbContext.SaveChangesAsync();
             }
         }
 
@@ -244,7 +244,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
             // Remove Statistical Releases for each of the Content Releases
             await RemoveStatisticalReleases(previousVersions);
 
-            await _statisticsDbContext.SaveChangesAsync();
+            await _publicStatisticsDbContext.SaveChangesAsync();
         }
 
         private async Task<FileInfo> GetAllFilesZip(Release release)
@@ -313,11 +313,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         private async Task RemoveStatisticalReleases(IEnumerable<Guid> releaseIds)
         {
-            var releases = await _statisticsDbContext.Release
+            var releases = await _publicStatisticsDbContext.Release
                 .Where(r => releaseIds.Contains(r.Id))
                 .ToListAsync();
 
-            _statisticsDbContext.Release.RemoveRange(releases);
+            _publicStatisticsDbContext.Release.RemoveRange(releases);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -41,6 +41,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                     options.UseSqlServer(ConnectionUtils.GetAzureSqlConnectionString("ContentDb")))
                 .AddDbContext<StatisticsDbContext>(options =>
                     options.UseSqlServer(ConnectionUtils.GetAzureSqlConnectionString("StatisticsDb")))
+                .AddDbContext<PublicStatisticsDbContext>(options =>
+                    options.UseSqlServer(ConnectionUtils.GetAzureSqlConnectionString("PublicStatisticsDb")))
                 .AddSingleton<IFileStorageService, FileStorageService>(provider =>
                     new FileStorageService(GetConfigurationValue(provider, "PublisherStorage")))
                 .AddScoped<IPublishingService, PublishingService>(provider =>
@@ -65,7 +67,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                 .AddScoped<IReleaseService, ReleaseService>(provider =>
                     new ReleaseService(
                         contentDbContext: provider.GetService<ContentDbContext>(),
-                        statisticsDbContext: provider.GetService<StatisticsDbContext>(),
+                        publicStatisticsDbContext: provider.GetService<PublicStatisticsDbContext>(),
                         publicBlobStorageService: GetBlobStorageService(provider, "PublicStorage"),
                         methodologyService: provider.GetService<IMethodologyService>(),
                         releaseSubjectService: provider.GetService<IReleaseSubjectService>(),
@@ -93,8 +95,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                     new QueueService(
                         storageQueueService: new StorageQueueService(
                             storageConnectionString: GetConfigurationValue(provider, "PublisherStorage")),
-                        releaseStatusService: provider.GetService<IReleaseStatusService>(),
-                        logger: provider.GetRequiredService<ILogger<QueueService>>()))
+                            releaseStatusService: provider.GetService<IReleaseStatusService>(),
+                            logger: provider.GetRequiredService<ILogger<QueueService>>()))
                 .AddScoped<IReleaseStatusService, ReleaseStatusService>()
                 .AddScoped<IValidationService, ValidationService>()
                 .AddScoped<IReleaseSubjectService, ReleaseSubjectService>()
@@ -116,6 +118,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                     ));
 
             AddPersistenceHelper<StatisticsDbContext>(builder.Services);
+            AddPersistenceHelper<PublicStatisticsDbContext>(builder.Services);
         }
 
         private static IBlobStorageService GetBlobStorageService(IServiceProvider provider, string connectionStringKey)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/local.settings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/local.settings.json
@@ -13,7 +13,8 @@
   },
   "ConnectionStrings": {
     "ContentDb": "Server=db;Database=content;User=SA;Password=Your_Password123;",
-    "StatisticsDb": "Server=db;Database=statistics;User=SA;Password=Your_Password123;"
+    "StatisticsDb": "Server=db;Database=statistics;User=SA;Password=Your_Password123;",
+    "PublicStatisticsDb": "Server=db;Database=statistics;User=SA;Password=Your_Password123;"
   },
   "Host": {
     "CORS": "*"


### PR DESCRIPTION
This PR adds a new connection to the private statistics DB from the Publisher. This has been implemented by extending `StatisticsDbContext` with a `PublicStatisticsDbContext`.