### PR TITLE
EES-2538 Fix StatisticsDbContext constructor with default timeout parameter not working

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
@@ -15,7 +15,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
         {
         }
 
-        public StatisticsDbContext(DbContextOptions<StatisticsDbContext> options, int? timeout = int.MaxValue) : base(options)
+        public StatisticsDbContext(DbContextOptions<StatisticsDbContext> options) : this(options, int.MaxValue)
+        {
+        }
+
+        public StatisticsDbContext(DbContextOptions<StatisticsDbContext> options, int? timeout) : base(options)
         {
             Configure(timeout);
         }
@@ -27,7 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
         /// level and this doesn't really work with the DI container (unless
         /// we created an abstract base class with a type parameter).
         /// </summary>
-        protected StatisticsDbContext(DbContextOptions options, int? timeout = int.MaxValue) : base(options)
+        protected StatisticsDbContext(DbContextOptions options, int? timeout) : base(options)
         {
             Configure(timeout);
         }


### PR DESCRIPTION
This PR tries to fix admin potentially failing (may not happen depending on your machine) due to some weirdness around the new `StatisticsDbContext` constructor using a default `timeout` parameter.

I can't really understand why this is happening, so I'm just going to chalk it up to some reflection-based madness that's going on under the hood.

Adding in the original constructor implementation back in seems to fix it.