### PR TITLE
EES-2549 Fix private stats DB wired into publisher's ReleaseSubjectService

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/ReleaseSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Services/ReleaseSubjectService.cs
@@ -17,11 +17,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Services
         public ReleaseSubjectService(
             StatisticsDbContext statisticsDbContext,
             IFootnoteRepository footnoteRepository,
-            SubjectDeleter subjectDeleter)
+            SubjectDeleter? subjectDeleter = null)
         {
             _statisticsDbContext = statisticsDbContext;
             _footnoteRepository = footnoteRepository;
-            _subjectDeleter = subjectDeleter;
+            _subjectDeleter = subjectDeleter ?? new SubjectDeleter();
         }
 
         public async Task SoftDeleteAllReleaseSubjects(Guid releaseId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -99,7 +99,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                             logger: provider.GetRequiredService<ILogger<QueueService>>()))
                 .AddScoped<IReleaseStatusService, ReleaseStatusService>()
                 .AddScoped<IValidationService, ValidationService>()
-                .AddScoped<IReleaseSubjectService, ReleaseSubjectService>()
+                .AddScoped<IReleaseSubjectService, ReleaseSubjectService>(provider =>
+                    new ReleaseSubjectService(
+                        statisticsDbContext: provider.GetService<PublicStatisticsDbContext>(),
+                        footnoteRepository: provider.GetService<IFootnoteRepository>()))
                 .AddScoped<IFilterService, FilterService>()
                 .AddScoped<IIndicatorService, IndicatorService>()
                 .AddScoped<IReleaseDataFileRepository, ReleaseDataFileRepository>()


### PR DESCRIPTION
This was causing SQL errors on pre-prod due to `ReleaseSubjectService` trying to run delete commands against the private stats DB (the publisher only has read access).

To fix this, we explicitly provide the `PublicStatisticsDbContext` as a dependency of `ReleaseSubjectService`.