### PR TITLE
EES-1768 Add footnotes to data guidance endpoint and file

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/HtmlToTextUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/HtmlToTextUtilsTests.cs
@@ -216,6 +216,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
         }
 
         [Fact]
+        public async Task HtmlToText_OrderedList_OverTenItemsWithMultiline()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <ol>
+                    <li>List item 1</li>
+                    <li>List item 2</li>
+                    <li>List item 3</li>
+                    <li>List item 4</li>
+                    <li>List item 5</li>
+                    <li>List item 6</li>
+                    <li>List item 7</li>
+                    <li>List item 8</li>
+                    <li>
+                        <p>List item 9</p>
+                        <p>Over multiple lines</p>
+                    </li>
+                    <li>List item 10</li>
+                    <li>
+                        <p>List item 10</p>
+                        <p>Over multiple lines</p>
+                    </li>
+                </ol>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
         public async Task HtmlToText_UnorderedList_WithNestedText()
         {
             var text = await HtmlToTextUtils.HtmlToText(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_OrderedList_OverTenItemsWithMultiline.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_OrderedList_OverTenItemsWithMultiline.snap
@@ -1,0 +1,15 @@
+﻿1. List item 1
+2. List item 2
+3. List item 3
+4. List item 4
+5. List item 5
+6. List item 6
+7. List item 7
+8. List item 8
+9. List item 9
+
+   Over multiple lines
+10. List item 10
+11. List item 10
+
+    Over multiple lines

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextConverter.cs
@@ -181,16 +181,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
             var isOrdered = element.LocalName == "ol";
             // Add indentation to align list item children
             // with where the bullet/number ends.
-            var indentation = isOrdered ? "   " : "  ";
+            var baseIndent = isOrdered ? 2 : 1;
 
             var listItems = element.ChildNodes
-                .Where(node => node is IElement { LocalName: "li" });
+                .Where(node => node is IElement { LocalName: "li" })
+                .ToList();
 
             ParseNodes(
                 listItems,
                 (item, index) =>
                 {
                     _builder.Append(isOrdered ? $"{index + 1}. " : "- ");
+
+                    var indexWidth = (index + 1).ToString().Length;
+                    var indent = string.Empty.PadRight(indexWidth + baseIndent);
 
                     var converter = new HtmlToTextConverter();
                     var text = converter.Convert(item);
@@ -205,7 +209,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
                                     return;
                                 }
 
-                                _builder.AppendLine(indentation + line);
+                                _builder.AppendLine(indent + line);
                             }
                         );
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -97,6 +97,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             services.AddTransient<IIndicatorService, IndicatorService>();
             services.AddTransient<IMetaGuidanceService, MetaGuidanceService>();
             services.AddTransient<IMetaGuidanceSubjectService, MetaGuidanceSubjectService>();
+            services.AddTransient<IFootnoteRepository, FootnoteRepository>();
             services.AddTransient<IReleaseFileService, ReleaseFileService>();
             services.AddTransient<IReleaseDataFileRepository, ReleaseDataFileRepository>();
             services.AddTransient<IMethodologyImageService, MethodologyImageService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/IndicatorGroup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/IndicatorGroup.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public string Label { get; set; }
         public Subject Subject { get; set; }
         public Guid SubjectId { get; set; }
-        public ICollection<Indicator> Indicators { get; set; }
+        public IList<Indicator> Indicators { get; set; }
 
         public IndicatorGroup()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/MetaGuidanceSubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/MetaGuidanceSubjectServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -967,10 +968,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
         private static MetaGuidanceSubjectService SetupMetaGuidanceSubjectService(
             StatisticsDbContext statisticsDbContext,
-            IFilterService filterService = null,
-            IIndicatorService indicatorService = null,
-            IPersistenceHelper<StatisticsDbContext> persistenceHelper = null,
-            ContentDbContext contentDbContext = null)
+            IFilterService? filterService = null,
+            IIndicatorService? indicatorService = null,
+            IPersistenceHelper<StatisticsDbContext>? persistenceHelper = null,
+            ContentDbContext? contentDbContext = null)
         {
             return new MetaGuidanceSubjectService(
                 filterService ?? new FilterService(statisticsDbContext, new Mock<ILogger<FilterService>>().Object),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IMetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IMetaGuidanceSubjectService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -9,8 +10,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
 {
     public interface IMetaGuidanceSubjectService
     {
-        Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(Guid releaseId,
-            List<Guid> subjectIds = null);
+        Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(
+            Guid releaseId,
+            List<Guid>? subjectIds = null);
 
         Task<TimePeriodLabels> GetTimePeriods(Guid subjectId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,7 +7,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -39,8 +39,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             _releaseDataFileRepository = releaseDataFileRepository;
         }
 
-        public async Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(Guid releaseId,
-            List<Guid> subjectIds = null)
+        public async Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(
+            Guid releaseId,
+            List<Guid>? subjectIds = null)
         {
             return await _statisticsPersistenceHelper.CheckEntityExists<Release>(releaseId)
                 .OnSuccess(async release =>
@@ -142,7 +143,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 await _releaseDataFileRepository.GetBySubject(
                     releaseSubject.ReleaseId,
                     releaseSubject.SubjectId);
-            
+
             var geographicLevels = await GetGeographicLevels(subject.Id);
             var timePeriods = await GetTimePeriods(subject.Id);
             var variables = GetVariables(subject.Id);
@@ -152,7 +153,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 Id = subject.Id,
                 Content = releaseSubject.MetaGuidance ?? "",
                 Filename = releaseFile.File.Filename,
-                Name = releaseFile.Name,
+                Name = releaseFile.Name ?? "",
                 GeographicLevels = geographicLevels,
                 TimePeriods = timePeriods,
                 Variables = variables

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
@@ -25,18 +25,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         private readonly StatisticsDbContext _context;
         private readonly IPersistenceHelper<StatisticsDbContext> _statisticsPersistenceHelper;
         private readonly IReleaseDataFileRepository _releaseDataFileRepository;
+        private readonly IFootnoteRepository _footnoteRepository;
 
         public MetaGuidanceSubjectService(IFilterService filterService,
             IIndicatorService indicatorService,
             StatisticsDbContext context,
             IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper,
-            IReleaseDataFileRepository releaseDataFileRepository)
+            IReleaseDataFileRepository releaseDataFileRepository,
+            IFootnoteRepository footnoteRepository)
         {
             _filterService = filterService;
             _indicatorService = indicatorService;
             _context = context;
             _statisticsPersistenceHelper = statisticsPersistenceHelper;
             _releaseDataFileRepository = releaseDataFileRepository;
+            _footnoteRepository = footnoteRepository;
         }
 
         public async Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(
@@ -135,6 +138,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 .ToList();
         }
 
+        private List<FootnoteViewModel> GetFootnotes(Guid releaseId, Guid subjectId)
+        {
+            return _footnoteRepository.GetFootnotes(releaseId, subjectId)
+                .Select(footnote => new FootnoteViewModel(footnote.Id, footnote.Content))
+                .ToList();
+        }
+
         private async Task<MetaGuidanceSubjectViewModel> BuildSubjectViewModel(ReleaseSubject releaseSubject)
         {
             var subject = releaseSubject.Subject;
@@ -147,6 +157,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             var geographicLevels = await GetGeographicLevels(subject.Id);
             var timePeriods = await GetTimePeriods(subject.Id);
             var variables = GetVariables(subject.Id);
+            var footnotes = GetFootnotes(releaseSubject.ReleaseId, subject.Id);
 
             return new MetaGuidanceSubjectViewModel
             {
@@ -156,7 +167,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 Name = releaseFile.Name ?? "",
                 GeographicLevels = geographicLevels,
                 TimePeriods = timePeriods,
-                Variables = variables
+                Variables = variables,
+                Footnotes = footnotes
             };
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
@@ -8,11 +8,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
     public class MetaGuidanceSubjectViewModel
     {
         public Guid Id { get; set; }
+
         public string Filename { get; set; } = string.Empty;
+
         public string Name { get; set; } = string.Empty;
+
         public string Content { get; set; } = string.Empty;
+
         public TimePeriodLabels TimePeriods { get; set; } = new TimePeriodLabels();
+
         public List<string> GeographicLevels { get; set; } = new List<string>();
+
         public List<LabelValue> Variables { get; set; } = new List<LabelValue>();
+
+        public List<FootnoteViewModel> Footnotes { get; set; } = new List<FootnoteViewModel>();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
@@ -8,11 +8,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
     public class MetaGuidanceSubjectViewModel
     {
         public Guid Id { get; set; }
-        public string Filename { get; set; }
-        public string Name { get; set; }
-        public string Content { get; set; }
-        public TimePeriodLabels TimePeriods { get; set; }
-        public List<string> GeographicLevels { get; set; }
-        public List<LabelValue> Variables { get; set; }
+        public string Filename { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+        public TimePeriodLabels TimePeriods { get; set; } = new TimePeriodLabels();
+        public List<string> GeographicLevels { get; set; } = new List<string>();
+        public List<LabelValue> Variables { get; set; } = new List<LabelValue>();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithEmptyFootnote.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithEmptyFootnote.snap
@@ -8,16 +8,10 @@ Data files
 Test data 1
 
 Filename: test-1.csv
-Geographic levels: Local Authority
 Time period: 2018
-Content summary: Test file content
 
 Variable names and descriptions for this file are provided below:
 
 Variable name       |  Variable description
 ------------------  |  ------------------
 accommodation_type  |  Accommodation type
-
-Footnotes:
-
-1. Footnote 1

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithOverTenFootnotesAndMultiline.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithOverTenFootnotesAndMultiline.snap
@@ -8,9 +8,7 @@ Data files
 Test data 1
 
 Filename: test-1.csv
-Geographic levels: Local Authority
 Time period: 2018
-Content summary: Test file content
 
 Variable names and descriptions for this file are provided below:
 
@@ -21,3 +19,17 @@ accommodation_type  |  Accommodation type
 Footnotes:
 
 1. Footnote 1
+2. Footnote 2
+3. Footnote 3
+4. Footnote 4
+5. Footnote 5
+6. Footnote 6
+7. Footnote 7
+8. Footnote 8
+9. Footnote 9
+   over some
+   lines.
+10. Footnote 10
+11. Footnote 11
+    over some
+    other lines.

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_MultipleDataFiles.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_MultipleDataFiles.snap
@@ -32,6 +32,11 @@ age_end                |  Age at end
 number_of_leavers      |  Number of leavers
 percentage_of_leavers  |  Percentage of leavers by accommodation type
 
+Footnotes:
+
+1. Subject 1 Footnote 1
+2. Subject 1 Footnote 2
+
 
 Test data 2
 
@@ -48,3 +53,10 @@ age                   |  Academic age
 category              |  Activity
 gender                |  Gender
 labour_market_status  |  Labour market status
+
+Footnotes:
+
+1. Subject 2 Footnote 1
+2. Subject 2 Footnote 2
+3. Subject 2 Footnote 3
+4. Subject 2 Footnote 4

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_SingleDataFile.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_SingleDataFile.snap
@@ -31,3 +31,8 @@ accommodation_type     |  Accommodation type
 age_end                |  Age at end
 number_of_leavers      |  Number of leavers
 percentage_of_leavers  |  Percentage of leavers by accommodation type
+
+Footnotes:
+
+1. Footnote 1
+2. Footnote 2


### PR DESCRIPTION
This PR adds footnotes to the data endpoint and the associated data guidance file (in the All files zip).

## Other changes

- Fixed indentation issue with `ol` elements in HTML to text conversion. This would previously lead to misalignment of the list item content if there were over 10 items in a list.