### PR TITLE
EES-2371 Add footnotes to data guidance endpoint and file

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/HtmlToTextUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/HtmlToTextUtilsTests.cs
@@ -216,6 +216,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
         }
 
         [Fact]
+        public async Task HtmlToText_OrderedList_OverTenItemsWithMultiline()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <ol>
+                    <li>List item 1</li>
+                    <li>List item 2</li>
+                    <li>List item 3</li>
+                    <li>List item 4</li>
+                    <li>List item 5</li>
+                    <li>List item 6</li>
+                    <li>List item 7</li>
+                    <li>List item 8</li>
+                    <li>
+                        <p>List item 9</p>
+                        <p>Over multiple lines</p>
+                    </li>
+                    <li>List item 10</li>
+                    <li>
+                        <p>List item 11</p>
+                        <p>Over multiple lines</p>
+                    </li>
+                </ol>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
         public async Task HtmlToText_UnorderedList_WithNestedText()
         {
             var text = await HtmlToTextUtils.HtmlToText(
@@ -271,6 +299,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
                                 </ul>
                             </li>
                         </ul>
+                    </li>
+                </ul>");
+
+            Snapshot.Match(text);
+        }
+
+        [Fact]
+        public async Task HtmlToText_UnorderedList_OverTenItemsWithMultiline()
+        {
+            var text = await HtmlToTextUtils.HtmlToText(
+                @"
+                <ul>
+                    <li>List item 1</li>
+                    <li>List item 2</li>
+                    <li>List item 3</li>
+                    <li>List item 4</li>
+                    <li>List item 5</li>
+                    <li>List item 6</li>
+                    <li>List item 7</li>
+                    <li>List item 8</li>
+                    <li>
+                        <p>List item 9</p>
+                        <p>Over multiple lines</p>
+                    </li>
+                    <li>List item 10</li>
+                    <li>
+                        <p>List item 11</p>
+                        <p>Over multiple lines</p>
                     </li>
                 </ul>");
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_OrderedList_OverTenItemsWithMultiline.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_OrderedList_OverTenItemsWithMultiline.snap
@@ -1,0 +1,15 @@
+﻿1. List item 1
+2. List item 2
+3. List item 3
+4. List item 4
+5. List item 5
+6. List item 6
+7. List item 7
+8. List item 8
+9. List item 9
+
+   Over multiple lines
+10. List item 10
+11. List item 11
+
+    Over multiple lines

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_UnorderedList_OverTenItemsWithMultiline.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/__snapshots__/HtmlToTextUtilsTests.HtmlToText_UnorderedList_OverTenItemsWithMultiline.snap
@@ -1,0 +1,15 @@
+﻿- List item 1
+- List item 2
+- List item 3
+- List item 4
+- List item 5
+- List item 6
+- List item 7
+- List item 8
+- List item 9
+
+  Over multiple lines
+- List item 10
+- List item 11
+
+  Over multiple lines

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/Html/HtmlToTextConverter.cs
@@ -179,18 +179,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
         private void ParseListElement(IElement element)
         {
             var isOrdered = element.LocalName == "ol";
-            // Add indentation to align list item children
-            // with where the bullet/number ends.
-            var indentation = isOrdered ? "   " : "  ";
-
             var listItems = element.ChildNodes
-                .Where(node => node is IElement { LocalName: "li" });
+                .Where(node => node is IElement { LocalName: "li" })
+                .ToList();
 
             ParseNodes(
                 listItems,
                 (item, index) =>
                 {
-                    _builder.Append(isOrdered ? $"{index + 1}. " : "- ");
+                    var lineItemStart = isOrdered ? $"{index + 1}. " : "- ";
+
+                    _builder.Append(lineItemStart);
+
+                    var indent = string.Empty.PadRight(lineItemStart.Length);
 
                     var converter = new HtmlToTextConverter();
                     var text = converter.Convert(item);
@@ -205,7 +206,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Utils.Html
                                     return;
                                 }
 
-                                _builder.AppendLine(indentation + line);
+                                _builder.AppendLine(indent + line);
                             }
                         );
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -98,6 +98,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             services.AddTransient<IIndicatorRepository, IndicatorRepository>();
             services.AddTransient<IMetaGuidanceService, MetaGuidanceService>();
             services.AddTransient<IMetaGuidanceSubjectService, MetaGuidanceSubjectService>();
+            services.AddTransient<IFootnoteRepository, FootnoteRepository>();
             services.AddTransient<IReleaseFileService, ReleaseFileService>();
             services.AddTransient<IReleaseDataFileRepository, ReleaseDataFileRepository>();
             services.AddTransient<IMethodologyImageService, MethodologyImageService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/IndicatorGroup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/IndicatorGroup.cs
@@ -9,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public string Label { get; set; }
         public Subject Subject { get; set; }
         public Guid SubjectId { get; set; }
-        public ICollection<Indicator> Indicators { get; set; }
+        public IList<Indicator> Indicators { get; set; }
 
         public IndicatorGroup()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/MetaGuidanceSubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/MetaGuidanceSubjectServiceTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -966,10 +967,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
         private static MetaGuidanceSubjectService SetupMetaGuidanceSubjectService(
             StatisticsDbContext statisticsDbContext,
-            IFilterRepository filterRepository = null,
-            IIndicatorRepository indicatorRepository = null,
-            IPersistenceHelper<StatisticsDbContext> persistenceHelper = null,
-            ContentDbContext contentDbContext = null)
+            IFilterRepository? filterRepository = null,
+            IIndicatorRepository? indicatorRepository = null,
+            IPersistenceHelper<StatisticsDbContext>? persistenceHelper = null,
+            ContentDbContext? contentDbContext = null)
         {
             return new MetaGuidanceSubjectService(
                 filterRepository ?? new FilterRepository(statisticsDbContext),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/MetaGuidanceSubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/MetaGuidanceSubjectServiceTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
@@ -136,6 +137,83 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 TimeIdentifier = TimeIdentifier.SpringTerm
             };
 
+            var subject1Footnote1 = new SubjectFootnote
+            {
+                Subject = subject1,
+                Footnote = new Footnote
+                {
+                    Content = "Subject 1 Footnote 1"
+                }
+            };
+            var subject1Footnote2 = new FilterFootnote
+            {
+                Filter = subject1Filter,
+                Footnote = new Footnote
+                {
+                    Content = "Subject 1 Footnote 2"
+                }
+            };
+            var subject1Footnote3 = new FilterGroupFootnote
+            {
+                FilterGroup = new FilterGroup
+                {
+                    Filter = subject1Filter
+                },
+                Footnote = new Footnote
+                {
+                    Content = "Subject 1 Footnote 3"
+                }
+            };
+
+            var subject2Footnote1 = new FilterItemFootnote
+            {
+                FilterItem = new FilterItem
+                {
+                    FilterGroup = new FilterGroup
+                    {
+                        Filter = subject2Filter
+                    }
+                },
+                Footnote = new Footnote
+                {
+                    Content = "Subject 2 Footnote 1"
+                }
+            };
+            var subject2Footnote2 = new IndicatorFootnote
+            {
+                Indicator = subject2IndicatorGroup.Indicators[0],
+                Footnote = new Footnote
+                {
+                    Content = "Subject 2 Footnote 2"
+                }
+            };
+
+            var releaseFootnote1 = new ReleaseFootnote
+            {
+                Footnote = subject1Footnote1.Footnote,
+                Release = release
+            };
+            var releaseFootnote2 = new ReleaseFootnote
+            {
+                Footnote = subject1Footnote2.Footnote,
+                Release = release
+            };
+            var releaseFootnote3 = new ReleaseFootnote
+            {
+                Footnote = subject1Footnote3.Footnote,
+                Release = release
+            };
+            var releaseFootnote4 = new ReleaseFootnote
+            {
+                Footnote = subject2Footnote1.Footnote,
+                Release = release
+            };
+            var releaseFootnote5 = new ReleaseFootnote
+            {
+                Footnote = subject2Footnote2.Footnote,
+                Release = release
+            };
+
             var statisticsDbContextId = Guid.NewGuid().ToString();
 
             await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
@@ -145,8 +223,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 await statisticsDbContext.AddRangeAsync(releaseSubject1, releaseSubject2);
                 await statisticsDbContext.AddRangeAsync(subject1Filter, subject2Filter);
                 await statisticsDbContext.AddRangeAsync(subject1IndicatorGroup, subject2IndicatorGroup);
-                await statisticsDbContext.AddRangeAsync(subject1Observation1, subject1Observation2,
-                    subject1Observation3, subject2Observation1, subject2Observation2, subject2Observation3);
+                await statisticsDbContext.AddRangeAsync(
+                    subject1Observation1,
+                    subject1Observation2,
+                    subject1Observation3,
+                    subject2Observation1,
+                    subject2Observation2,
+                    subject2Observation3
+                );
+                await statisticsDbContext.AddRangeAsync(subject1Footnote1, subject1Footnote2, subject1Footnote3);
+                await statisticsDbContext.AddRangeAsync(subject2Footnote1, subject2Footnote2);
+                await statisticsDbContext.AddRangeAsync(
+                    releaseFootnote1,
+                    releaseFootnote2,
+                    releaseFootnote3,
+                    releaseFootnote4,
+                    releaseFootnote5
+                );
                 await statisticsDbContext.SaveChangesAsync();
             }
 
@@ -188,44 +281,64 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     statisticsDbContext: statisticsDbContext,
                     contentDbContext: contentDbContext);
 
-                var result = await service.GetSubjects(release.Id);
+                var result = (await service.GetSubjects(release.Id)).AssertRight();
 
                 // Assert there are two Subjects with the correct content
-                Assert.True(result.IsRight);
 
-                Assert.Equal(2, result.Right.Count);
+                Assert.Equal(2, result.Count);
 
-                Assert.Equal(subject1.Id, result.Right[0].Id);
-                Assert.Equal("Subject 1 Meta Guidance", result.Right[0].Content);
-                Assert.Equal("file1.csv", result.Right[0].Filename);
-                Assert.Equal("Subject 1", result.Right[0].Name);
-                Assert.Equal("2020/21 Q3", result.Right[0].TimePeriods.From);
-                Assert.Equal("2021/22 Q1", result.Right[0].TimePeriods.To);
+                Assert.Equal(subject1.Id, result[0].Id);
+                Assert.Equal("Subject 1 Meta Guidance", result[0].Content);
+                Assert.Equal("file1.csv", result[0].Filename);
+                Assert.Equal("Subject 1", result[0].Name);
+
+                Assert.Equal("2020/21 Q3", result[0].TimePeriods.From);
+                Assert.Equal("2021/22 Q1", result[0].TimePeriods.To);
                 Assert.Equal(new List<string>
                 {
-                    "National", "Local Authority", "Local Authority District"
-                }, result.Right[0].GeographicLevels);
-                Assert.Equal(2, result.Right[0].Variables.Count);
-                Assert.Equal("Subject 1 Filter - Hint", result.Right[0].Variables[0].Label);
-                Assert.Equal("subject1_filter", result.Right[0].Variables[0].Value);
-                Assert.Equal("Subject 1 Indicator", result.Right[0].Variables[1].Label);
-                Assert.Equal("subject1_indicator", result.Right[0].Variables[1].Value);
+                    "National",
+                    "Local Authority",
+                    "Local Authority District"
+                }, result[0].GeographicLevels);
 
-                Assert.Equal(subject2.Id, result.Right[1].Id);
-                Assert.Equal("Subject 2 Meta Guidance", result.Right[1].Content);
-                Assert.Equal("file2.csv", result.Right[1].Filename);
-                Assert.Equal("Subject 2", result.Right[1].Name);
-                Assert.Equal("2020/21 Summer Term", result.Right[1].TimePeriods.From);
-                Assert.Equal("2021/22 Spring Term", result.Right[1].TimePeriods.To);
+                Assert.Equal(2, result[0].Variables.Count);
+                Assert.Equal("Subject 1 Filter - Hint", result[0].Variables[0].Label);
+                Assert.Equal("subject1_filter", result[0].Variables[0].Value);
+                Assert.Equal("Subject 1 Indicator", result[0].Variables[1].Label);
+                Assert.Equal("subject1_indicator", result[0].Variables[1].Value);
+
+                Assert.Equal(3, result[0].Footnotes.Count);
+                Assert.Equal("Subject 1 Footnote 1", result[0].Footnotes[0].Label);
+                Assert.Equal(subject1Footnote1.FootnoteId, result[0].Footnotes[0].Id);
+                Assert.Equal("Subject 1 Footnote 2", result[0].Footnotes[1].Label);
+                Assert.Equal(subject1Footnote2.FootnoteId, result[0].Footnotes[1].Id);
+                Assert.Equal("Subject 1 Footnote 3", result[0].Footnotes[2].Label);
+                Assert.Equal(subject1Footnote3.FootnoteId, result[0].Footnotes[2].Id);
+
+                Assert.Equal(subject2.Id, result[1].Id);
+                Assert.Equal("Subject 2 Meta Guidance", result[1].Content);
+                Assert.Equal("file2.csv", result[1].Filename);
+                Assert.Equal("Subject 2", result[1].Name);
+
+                Assert.Equal("2020/21 Summer Term", result[1].TimePeriods.From);
+                Assert.Equal("2021/22 Spring Term", result[1].TimePeriods.To);
                 Assert.Equal(new List<string>
                 {
-                    "National", "Regional"
-                }, result.Right[1].GeographicLevels);
-                Assert.Equal(2, result.Right[1].Variables.Count);
-                Assert.Equal("Subject 2 Filter", result.Right[1].Variables[0].Label);
-                Assert.Equal("subject2_filter", result.Right[1].Variables[0].Value);
-                Assert.Equal("Subject 2 Indicator", result.Right[1].Variables[1].Label);
-                Assert.Equal("subject2_indicator", result.Right[1].Variables[1].Value);
+                    "National",
+                    "Regional"
+                }, result[1].GeographicLevels);
+
+                Assert.Equal(2, result[1].Variables.Count);
+                Assert.Equal("Subject 2 Filter", result[1].Variables[0].Label);
+                Assert.Equal("subject2_filter", result[1].Variables[0].Value);
+                Assert.Equal("Subject 2 Indicator", result[1].Variables[1].Label);
+                Assert.Equal("subject2_indicator", result[1].Variables[1].Value);
+
+                Assert.Equal(2, result[1].Footnotes.Count);
+                Assert.Equal("Subject 2 Footnote 1", result[1].Footnotes[0].Label);
+                Assert.Equal(subject2Footnote1.FootnoteId, result[1].Footnotes[0].Id);
+                Assert.Equal("Subject 2 Footnote 2", result[1].Footnotes[1].Label);
+                Assert.Equal(subject2Footnote2.FootnoteId, result[1].Footnotes[1].Id);
             }
         }
 
@@ -970,7 +1083,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             IFilterRepository? filterRepository = null,
             IIndicatorRepository? indicatorRepository = null,
             IPersistenceHelper<StatisticsDbContext>? persistenceHelper = null,
-            ContentDbContext? contentDbContext = null)
+            ContentDbContext? contentDbContext = null,
+            IFootnoteRepository? footnoteRepository = null)
         {
             return new MetaGuidanceSubjectService(
                 filterRepository ?? new FilterRepository(statisticsDbContext),
@@ -979,7 +1093,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 persistenceHelper ?? new PersistenceHelper<StatisticsDbContext>(statisticsDbContext),
                 contentDbContext != null
                     ? new ReleaseDataFileRepository(contentDbContext)
-                    : Mock.Of<IReleaseDataFileRepository>()
+                    : Mock.Of<IReleaseDataFileRepository>(),
+                footnoteRepository ?? new FootnoteRepository(statisticsDbContext)
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IMetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/IMetaGuidanceSubjectService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -9,8 +10,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
 {
     public interface IMetaGuidanceSubjectService
     {
-        Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(Guid releaseId,
-            List<Guid> subjectIds = null);
+        Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(
+            Guid releaseId,
+            List<Guid>? subjectIds = null);
 
         Task<TimePeriodLabels> GetTimePeriods(Guid subjectId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
@@ -25,18 +25,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         private readonly StatisticsDbContext _context;
         private readonly IPersistenceHelper<StatisticsDbContext> _statisticsPersistenceHelper;
         private readonly IReleaseDataFileRepository _releaseDataFileRepository;
+        private readonly IFootnoteRepository _footnoteRepository;
 
         public MetaGuidanceSubjectService(IFilterRepository filterRepository,
             IIndicatorRepository indicatorRepository,
             StatisticsDbContext context,
             IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper,
-            IReleaseDataFileRepository releaseDataFileRepository)
+            IReleaseDataFileRepository releaseDataFileRepository,
+            IFootnoteRepository footnoteRepository)
         {
             _filterRepository = filterRepository;
             _indicatorRepository = indicatorRepository;
             _context = context;
             _statisticsPersistenceHelper = statisticsPersistenceHelper;
             _releaseDataFileRepository = releaseDataFileRepository;
+            _footnoteRepository = footnoteRepository;
         }
 
         public async Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(
@@ -135,6 +138,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 .ToList();
         }
 
+        private List<FootnoteViewModel> GetFootnotes(Guid releaseId, Guid subjectId)
+        {
+            return _footnoteRepository.GetFootnotes(releaseId, subjectId)
+                .Select(footnote => new FootnoteViewModel(footnote.Id, footnote.Content))
+                .ToList();
+        }
+
         private async Task<MetaGuidanceSubjectViewModel> BuildSubjectViewModel(ReleaseSubject releaseSubject)
         {
             var subject = releaseSubject.Subject;
@@ -147,6 +157,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             var geographicLevels = await GetGeographicLevels(subject.Id);
             var timePeriods = await GetTimePeriods(subject.Id);
             var variables = GetVariables(subject.Id);
+            var footnotes = GetFootnotes(releaseSubject.ReleaseId, subject.Id);
 
             return new MetaGuidanceSubjectViewModel
             {
@@ -156,7 +167,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 Name = releaseFile.Name ?? "",
                 GeographicLevels = geographicLevels,
                 TimePeriods = timePeriods,
-                Variables = variables
+                Variables = variables,
+                Footnotes = footnotes
             };
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,7 +7,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
@@ -39,8 +39,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             _releaseDataFileRepository = releaseDataFileRepository;
         }
 
-        public async Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(Guid releaseId,
-            List<Guid> subjectIds = null)
+        public async Task<Either<ActionResult, List<MetaGuidanceSubjectViewModel>>> GetSubjects(
+            Guid releaseId,
+            List<Guid>? subjectIds = null)
         {
             return await _statisticsPersistenceHelper.CheckEntityExists<Release>(releaseId)
                 .OnSuccess(async release =>
@@ -142,7 +143,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 await _releaseDataFileRepository.GetBySubject(
                     releaseSubject.ReleaseId,
                     releaseSubject.SubjectId);
-            
+
             var geographicLevels = await GetGeographicLevels(subject.Id);
             var timePeriods = await GetTimePeriods(subject.Id);
             var variables = GetVariables(subject.Id);
@@ -152,7 +153,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 Id = subject.Id,
                 Content = releaseSubject.MetaGuidance ?? "",
                 Filename = releaseFile.File.Filename,
-                Name = releaseFile.Name,
+                Name = releaseFile.Name ?? "",
                 GeographicLevels = geographicLevels,
                 TimePeriods = timePeriods,
                 Variables = variables

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
@@ -8,11 +8,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
     public class MetaGuidanceSubjectViewModel
     {
         public Guid Id { get; set; }
+
         public string Filename { get; set; } = string.Empty;
+
         public string Name { get; set; } = string.Empty;
+
         public string Content { get; set; } = string.Empty;
+
         public TimePeriodLabels TimePeriods { get; set; } = new TimePeriodLabels();
+
         public List<string> GeographicLevels { get; set; } = new List<string>();
+
         public List<LabelValue> Variables { get; set; } = new List<LabelValue>();
+
+        public List<FootnoteViewModel> Footnotes { get; set; } = new List<FootnoteViewModel>();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
@@ -8,11 +8,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
     public class MetaGuidanceSubjectViewModel
     {
         public Guid Id { get; set; }
-        public string Filename { get; set; }
-        public string Name { get; set; }
-        public string Content { get; set; }
-        public TimePeriodLabels TimePeriods { get; set; }
-        public List<string> GeographicLevels { get; set; }
-        public List<LabelValue> Variables { get; set; }
+        public string Filename { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+        public TimePeriodLabels TimePeriods { get; set; } = new TimePeriodLabels();
+        public List<string> GeographicLevels { get; set; } = new List<string>();
+        public List<LabelValue> Variables { get; set; } = new List<LabelValue>();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithEmptyFootnote.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithEmptyFootnote.snap
@@ -8,16 +8,10 @@ Data files
 Test data 1
 
 Filename: test-1.csv
-Geographic levels: Local Authority
 Time period: 2018
-Content summary: Test file content
 
 Variable names and descriptions for this file are provided below:
 
 Variable name       |  Variable description
 ------------------  |  ------------------
 accommodation_type  |  Accommodation type
-
-Footnotes:
-
-1. Footnote 1

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithOverTenFootnotesAndMultiline.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_FileWithOverTenFootnotesAndMultiline.snap
@@ -8,9 +8,7 @@ Data files
 Test data 1
 
 Filename: test-1.csv
-Geographic levels: Local Authority
 Time period: 2018
-Content summary: Test file content
 
 Variable names and descriptions for this file are provided below:
 
@@ -21,3 +19,17 @@ accommodation_type  |  Accommodation type
 Footnotes:
 
 1. Footnote 1
+2. Footnote 2
+3. Footnote 3
+4. Footnote 4
+5. Footnote 5
+6. Footnote 6
+7. Footnote 7
+8. Footnote 8
+9. Footnote 9
+   over some
+   lines.
+10. Footnote 10
+11. Footnote 11
+    over some
+    other lines.

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_MultipleDataFiles.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_MultipleDataFiles.snap
@@ -32,6 +32,11 @@ age_end                |  Age at end
 number_of_leavers      |  Number of leavers
 percentage_of_leavers  |  Percentage of leavers by accommodation type
 
+Footnotes:
+
+1. Subject 1 Footnote 1
+2. Subject 1 Footnote 2
+
 
 Test data 2
 
@@ -48,3 +53,10 @@ age                   |  Academic age
 category              |  Activity
 gender                |  Gender
 labour_market_status  |  Labour market status
+
+Footnotes:
+
+1. Subject 2 Footnote 1
+2. Subject 2 Footnote 2
+3. Subject 2 Footnote 3
+4. Subject 2 Footnote 4

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_SingleDataFile.snap
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/__snapshots__/DataGuidanceFileWriterTests.WriteFile_SingleDataFile.snap
@@ -31,3 +31,8 @@ accommodation_type     |  Accommodation type
 age_end                |  Age at end
 number_of_leavers      |  Number of leavers
 percentage_of_leavers  |  Percentage of leavers by accommodation type
+
+Footnotes:
+
+1. Footnote 1
+2. Footnote 2

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/DataGuidanceFileWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/DataGuidanceFileWriter.cs
@@ -121,12 +121,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                         await file.WriteLineAsync($"Content summary: {content}");
                     }
 
-                    // TODO EES-1768 - Add footnotes
-
                     var variables = subject.Variables
-                        .Where(variable =>
-                            !variable.Label.IsNullOrWhitespace()
-                            || !variable.Value.IsNullOrWhitespace())
+                        .Where(
+                            variable =>
+                                !variable.Label.IsNullOrWhitespace()
+                                || !variable.Value.IsNullOrWhitespace()
+                        )
                         .ToList();
 
                     if (variables.Any())
@@ -173,6 +173,44 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
                                 );
                             }
                         );
+                    }
+
+                    var footnotes = subject.Footnotes
+                        .Where(footnote => !footnote.Label.IsNullOrWhitespace())
+                        .ToList();
+
+                    if (footnotes.Any())
+                    {
+                        await file.WriteLineAsync();
+                        await file.WriteLineAsync("Footnotes:");
+                        await file.WriteLineAsync();
+
+                        await footnotes
+                            .ForEachAsync(
+                                async (footnote, footnoteIndex) =>
+                                {
+                                    var listItemStart = $"{footnoteIndex + 1}. ";
+
+                                    await file.WriteAsync(listItemStart);
+
+                                    var indent = string.Empty.PadRight(listItemStart.Length);
+
+                                    await footnote.Label
+                                        .ToLines()
+                                        .ForEachAsync(
+                                            async (line, lineIndex) =>
+                                            {
+                                                if (lineIndex == 0)
+                                                {
+                                                    await file.WriteLineAsync(line);
+                                                    return;
+                                                }
+
+                                                await file.WriteLineAsync(indent + line);
+                                            }
+                                        );
+                                }
+                            );
                     }
 
                     // Add some extra lines between data files

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Startup.cs
@@ -107,8 +107,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                 .AddScoped<IReleaseSubjectRepository, ReleaseSubjectRepository>(provider =>
                     new ReleaseSubjectRepository(
                         statisticsDbContext: provider.GetService<PublicStatisticsDbContext>(),
-                        footnoteRepository: provider.GetService<IFootnoteRepository>()))
+                        footnoteRepository: new FootnoteRepository(provider.GetService<PublicStatisticsDbContext>())
+                    ))
                 .AddScoped<IFilterRepository, FilterRepository>()
+                .AddScoped<IFootnoteRepository, FootnoteRepository>()
                 .AddScoped<IIndicatorRepository, IndicatorRepository>()
                 .AddScoped<IReleaseDataFileRepository, ReleaseDataFileRepository>()
                 .AddScoped<IMetaGuidanceSubjectService, MetaGuidanceSubjectService>()
@@ -119,9 +121,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher
                         dataGuidanceFileWriter: provider.GetService<IDataGuidanceFileWriter>(),
                         blobStorageService: GetBlobStorageService(provider, "CoreStorage")
                     ))
-                .AddScoped<IFootnoteRepository, FootnoteRepository>(provider =>
-                    new FootnoteRepository(
-                        context: provider.GetService<PublicStatisticsDbContext>()))
                 .AddScoped<IZipFileService, ZipFileService>(provider =>
                     new ZipFileService(
                         publicBlobStorageService: GetBlobStorageService(provider, "PublicStorage")


### PR DESCRIPTION
This PR adds footnotes to the data endpoint and the associated data guidance file (in the All files zip).

## Other changes

- Fixed indentation issue with `ol` elements in HTML to text conversion. This would previously lead to misalignment of the list item content if there were over 10 items in a list.