### PR TITLE
EES-2562 apply editable accordion direction fix to all

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.module.scss
@@ -10,6 +10,6 @@
 }
 
 // Override the default dnd style as it causes accordion sections within the dnd area to sometime open in the wrong direction.
-[data-rbd-droppable-id='releaseMainContent'][data-rbd-droppable-context-id] {
+.container [data-rbd-droppable-context-id] {
   overflow-anchor: auto;
 }

--- a/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableAccordion.tsx
@@ -84,7 +84,7 @@ const EditableAccordion = (props: EditableAccordionProps) => {
   }
 
   return (
-    <>
+    <div className={styles.container}>
       <h2 className={classNames('govuk-heading-l', styles.heading)}>
         {sectionName}
 
@@ -138,7 +138,7 @@ const EditableAccordion = (props: EditableAccordionProps) => {
           Add new section
         </Button>
       </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
Makes the fix for Editable Accordions sometimes opening in the wrong direction apply to all of them, not just the release content one. They're used on:
- release content
- methodology content