### PR TITLE
EES-2560 Reduce priority of Financial Year Part time identifiers

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifier.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifier.cs
@@ -40,6 +40,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         [TimeIdentifierMeta("Calendar Year Q4", "CYQ4", Category.CalendarYear, Default, ShortLabel, "Q4")]
         CalendarYearQ4,
 
+        [TimeIdentifierMeta("Part 1 (April to September)", "P1", FinancialYearPart, Fiscal, ShortLabel, "Part 1 (Apr to Sep)")]
+        FinancialYearPart1,
+
+        [TimeIdentifierMeta("Part 2 (October to March)", "P2", FinancialYearPart, Fiscal, ShortLabel, "Part 2 (Oct to Mar)")]
+        FinancialYearPart2,
+
         [TimeIdentifierMeta("Financial Year", "FY", Category.FinancialYear, Fiscal, NoLabel)]
         FinancialYear,
 
@@ -275,12 +281,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         Week51,
 
         [TimeIdentifierMeta("Week 52", "W52", Week)]
-        Week52,
-
-        [TimeIdentifierMeta("Part 1 (April to September)", "P1", FinancialYearPart, Fiscal, ShortLabel, "Part 1 (Apr to Sep)")]
-        FinancialYearPart1,
-
-        [TimeIdentifierMeta("Part 2 (October to March)", "P2", FinancialYearPart, Fiscal, ShortLabel, "Part 2 (Oct to Mar)")]
-        FinancialYearPart2
+        Week52
     }
 }


### PR DESCRIPTION
This PR should fix the incorrect ordering of releases leading to the wrong latest release being selected: https://explore-education-statistics.service.gov.uk/find-statistics/serious-incident-notifications