### PR TITLE
EES-1757 try to prevent cancel upload button spamming

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -420,13 +420,12 @@ const ReleaseDataUploadsSection = ({
           onCancel={() => setCancelDataFile(undefined)}
           onConfirm={async () => {
             try {
+              setCancelDataFile(undefined);
+              setFileCancelling(cancelDataFile, true);
               await releaseDataFileService.cancelImport(
                 releaseId,
                 cancelDataFile.id,
               );
-
-              setCancelDataFile(undefined);
-              setFileCancelling(cancelDataFile, true);
             } catch (err) {
               logger.error(err);
               setFileCancelling(cancelDataFile, false);


### PR DESCRIPTION
I haven't been able to reproduce this locally. The ticket was raised on the day the PR to add the button (https://github.com/dfe-analytical-services/explore-education-statistics/pull/2238) was merged so may well still be valid.

I've moved the code to set the state of the cancel button before it waits for the cancel import to start to try to make sure it always get set as soon as the modal confirmation is clicked.