### PR TITLE
EES-1757 error handling for data upload cancel button

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataUploadCancelButton.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataUploadCancelButton.tsx
@@ -15,24 +15,24 @@ const DataUploadCancelButton = ({ releaseId, fileId }: Props) => {
   const [{ error }, cancelImport] = useAsyncCallback(() =>
     releaseDataFileService.cancelImport(releaseId, fileId),
   );
-  const [showCancelModal, setShowCancelModal] = useToggle(false);
-  const [showCancelButton, setShowCancelButton] = useToggle(true);
+  const [showCancelModal, toggleShowCancelModal] = useToggle(false);
+  const [showCancelButton, toggleShowCancelButton] = useToggle(true);
 
   return (
     <>
       {showCancelButton && (
-        <ButtonText onClick={() => setShowCancelModal(true)}>Cancel</ButtonText>
+        <ButtonText onClick={toggleShowCancelModal.on}>Cancel</ButtonText>
       )}
       {error && <ErrorMessage>Cancellation failed</ErrorMessage>}
       <ModalConfirm
         open={showCancelModal}
         title="Confirm cancellation of selected data file"
-        onExit={() => setShowCancelModal(false)}
-        onCancel={() => setShowCancelModal(false)}
+        onExit={toggleShowCancelModal.off}
+        onCancel={toggleShowCancelModal.off}
         onConfirm={async () => {
           await cancelImport();
-          setShowCancelModal(false);
-          setShowCancelButton(false);
+          toggleShowCancelModal.off();
+          toggleShowCancelButton.off();
         }}
       >
         <p>This file upload will be cancelled and may then be removed.</p>

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataUploadCancelButton.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataUploadCancelButton.tsx
@@ -1,0 +1,44 @@
+import releaseDataFileService from '@admin/services/releaseDataFileService';
+import ButtonText from '@common/components/ButtonText';
+import ModalConfirm from '@common/components/ModalConfirm';
+import useAsyncCallback from '@common/hooks/useAsyncCallback';
+import ErrorMessage from '@common/components/ErrorMessage';
+import useToggle from '@common/hooks/useToggle';
+import React from 'react';
+
+interface Props {
+  releaseId: string;
+  fileId: string;
+}
+
+const DataUploadCancelButton = ({ releaseId, fileId }: Props) => {
+  const [{ error }, cancelImport] = useAsyncCallback(() =>
+    releaseDataFileService.cancelImport(releaseId, fileId),
+  );
+  const [showCancelModal, setShowCancelModal] = useToggle(false);
+  const [showCancelButton, setShowCancelButton] = useToggle(true);
+
+  return (
+    <>
+      {showCancelButton && (
+        <ButtonText onClick={() => setShowCancelModal(true)}>Cancel</ButtonText>
+      )}
+      {error && <ErrorMessage>Cancellation failed</ErrorMessage>}
+      <ModalConfirm
+        open={showCancelModal}
+        title="Confirm cancellation of selected data file"
+        onExit={() => setShowCancelModal(false)}
+        onCancel={() => setShowCancelModal(false)}
+        onConfirm={async () => {
+          await cancelImport();
+          setShowCancelModal(false);
+          setShowCancelButton(false);
+        }}
+      >
+        <p>This file upload will be cancelled and may then be removed.</p>
+      </ModalConfirm>
+    </>
+  );
+};
+
+export default DataUploadCancelButton;

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -28,6 +28,7 @@ import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import logger from '@common/services/logger';
 import { mapFieldErrors } from '@common/validation/serverValidations';
 import Yup from '@common/validation/yup';
+import DataUploadCancelButton from '@admin/pages/release/data/components/DataUploadCancelButton';
 import orderBy from 'lodash/orderBy';
 import React, { useCallback, useState } from 'react';
 import { generatePath } from 'react-router';
@@ -68,9 +69,7 @@ const ReleaseDataUploadsSection = ({
   onDataFilesChange,
 }: Props) => {
   const [deleteDataFile, setDeleteDataFile] = useState<DeleteDataFile>();
-  const [cancelDataFile, setCancelDataFile] = useState<DataFile>();
   const [activeFileId, setActiveFileId] = useState<string>();
-
   const {
     value: dataFiles = [],
     setState: setDataFilesState,
@@ -88,19 +87,6 @@ const ReleaseDataUploadsSection = ({
           : {
               ...file,
               isDeleting: deleting,
-            },
-      ),
-    );
-  };
-
-  const setFileCancelling = (dataFile: DataFile, cancelling: boolean) => {
-    setDataFiles(
-      dataFiles.map(file =>
-        file.fileName !== dataFile.fileName
-          ? file
-          : {
-              ...file,
-              isCancelling: cancelling,
             },
       ),
     );
@@ -326,13 +312,12 @@ const ReleaseDataUploadsSection = ({
                           </ButtonText>
                         </>
                       )}
-
-                    {dataFile.permissions.canCancelImport &&
-                      !dataFile.isCancelling && (
-                        <ButtonText onClick={() => setCancelDataFile(dataFile)}>
-                          Cancel
-                        </ButtonText>
-                      )}
+                    {dataFile.permissions.canCancelImport && (
+                      <DataUploadCancelButton
+                        releaseId={releaseId}
+                        fileId={dataFile.id}
+                      />
+                    )}
                   </DataFileDetailsTable>
                 </div>
               </AccordionSection>
@@ -409,31 +394,6 @@ const ReleaseDataUploadsSection = ({
               } will be removed or updated.`}
             </p>
           )}
-        </ModalConfirm>
-      )}
-
-      {cancelDataFile && (
-        <ModalConfirm
-          open
-          title="Confirm cancellation of selected data file"
-          onExit={() => setCancelDataFile(undefined)}
-          onCancel={() => setCancelDataFile(undefined)}
-          onConfirm={async () => {
-            try {
-              await releaseDataFileService.cancelImport(
-                releaseId,
-                cancelDataFile.id,
-              );
-
-              setCancelDataFile(undefined);
-              setFileCancelling(cancelDataFile, true);
-            } catch (err) {
-              logger.error(err);
-              setFileCancelling(cancelDataFile, false);
-            }
-          }}
-        >
-          <p>This file upload will be cancelled and may then be removed.</p>
         </ModalConfirm>
       )}
     </>


### PR DESCRIPTION
I was unable to recreate the problem described in the ticket (spamming the cancel button), it may been fixed since it was raised.

This PR adds error handling for the cancel upload button so if something does go wrong users will be informed.

![cancellation-failed](https://user-images.githubusercontent.com/81572860/127012160-d254c4fd-871d-4495-a6b0-c9da31f178bf.png)
