### PR TITLE
EES-2519 - order of deletion of Releases and Methodologies

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -65,6 +65,9 @@
     "enableSwagger": {
        "value": true
     },
+    "enableThemeDeletion": {
+      "value": true
+    },
     "branch": {
        "value": "dev"
     },

--- a/infrastructure/parameters/pre-prod.parameters.json
+++ b/infrastructure/parameters/pre-prod.parameters.json
@@ -43,6 +43,9 @@
     },
     "publicAppHotjarId": {
       "value": "1341531"
+    },
+    "enableThemeDeletion": {
+      "value": true
     }
   }
 }

--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -49,6 +49,9 @@
     },
     "branch": {
       "value": "dev"
+    },
+    "enableThemeDeletion": {
+      "value": true
     }
   }
 }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -489,6 +489,10 @@
       "type": "bool",
       "defaultValue": false
     },
+    "enableThemeDeletion": {
+      "type": "bool",
+      "defaultValue": false
+    },
     "timeZone": {
       "type": "string",
       "defaultValue": "GMT Standard Time"
@@ -1650,7 +1654,8 @@
         "PublisherStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-publisher'), '2018-02-14').secretUriWithVersion, ')')]",
         "PreReleaseAccess:AccessWindow:MinutesBeforeReleaseTimeStart": "[parameters('preReleaseMinutesBeforeStart')]",
         "PreReleaseAccess:AccessWindow:MinutesBeforeReleaseTimeEnd": "[parameters('preReleaseMinutesBeforeEnd')]",
-        "enableSwagger": "[parameters('enableSwagger')]"
+        "enableSwagger": "[parameters('enableSwagger')]",
+        "enableThemeDeletion": "[parameters('enableThemeDeletion')]"
       }
     },
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
@@ -121,7 +121,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var methodologyAmendmentService = new Mock<IMethodologyAmendmentService>(Strict);
 
             methodologyService
-                .Setup(s => s.DeleteMethodology(_id))
+                .Setup(s => s.DeleteMethodology(_id, false))
                 .ReturnsAsync(new Either<ActionResult, Unit>(Unit.Instance));
             
             var controller = new MethodologyController(methodologyService.Object, methodologyAmendmentService.Object);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/EmailTemplateServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/EmailTemplateServiceTests.cs
@@ -141,41 +141,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
         private static Mock<IConfiguration> ConfigurationMock()
         {
-            var notifyInviteTemplateSection = new Mock<IConfigurationSection>();
-            var publicationRoleTemplateSection = new Mock<IConfigurationSection>();
-            var releaseRoleTemplateSection = new Mock<IConfigurationSection>();
-            var adminUriSection = new Mock<IConfigurationSection>();
-            var configuration = new Mock<IConfiguration>();
-
-            notifyInviteTemplateSection.Setup(m => m.Value)
-                .Returns("invite-template-id");
-
-            publicationRoleTemplateSection.Setup(m => m.Value)
-                .Returns("publication-role-template-id");
-
-            releaseRoleTemplateSection.Setup(m => m.Value)
-                .Returns("release-role-template-id");
-
-            adminUriSection.Setup(m => m.Value)
-                .Returns("admin-uri");
-
-            configuration
-                .Setup(m => m.GetSection("NotifyInviteTemplateId"))
-                .Returns(notifyInviteTemplateSection.Object);
-
-            configuration
-                .Setup(m => m.GetSection("NotifyPublicationRoleTemplateId"))
-                .Returns(publicationRoleTemplateSection.Object);
-
-            configuration
-                .Setup(m => m.GetSection("NotifyReleaseRoleTemplateId"))
-                .Returns(releaseRoleTemplateSection.Object);
-
-            configuration
-                .Setup(m => m.GetSection("AdminUri"))
-                .Returns(adminUriSection.Object);
-
-            return configuration;
+            return CreateMockConfiguration(
+                new Tuple<string, string>("NotifyInviteTemplateId", "invite-template-id"),
+                new Tuple<string, string>("NotifyPublicationRoleTemplateId", "publication-role-template-id"),
+                new Tuple<string, string>("NotifyReleaseRoleTemplateId", "release-role-template-id"),
+                new Tuple<string, string>("AdminUri", "admin-uri"));
         }
 
         private static EmailTemplateService SetupEmailTemplateService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyImageServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyImageServicePermissionTests.cs
@@ -35,7 +35,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     userService =>
                     {
                         var service = SetupMethodologyImageService(userService: userService.Object);
-                        return service.UnlinkAndDeleteIfOrphaned(methodologyId: _methodology.Id,
+                        return service.Delete(methodologyId: _methodology.Id,
                             fileIds: new List<Guid>());
                     }
                 );

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyImageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyImageServiceTests.cs
@@ -38,7 +38,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         };
 
         [Fact]
-        public async Task UnlinkAndDeleteIfOrphaned()
+        public async Task Delete()
         {
             var methodology = new Methodology();
 
@@ -99,7 +99,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var service = SetupMethodologyImageService(contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = await service.UnlinkAndDeleteIfOrphaned(methodology.Id, 
+                var result = await service.Delete(methodology.Id, 
                     AsList(imageFile1.File.Id, imageFile2.File.Id));
 
                 result.AssertRight();
@@ -127,7 +127,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         }
 
         [Fact]
-        public async Task UnlinkAndDeleteIfOrphaned_FilesLinkedToOtherMethodologyVersions()
+        public async Task Delete_FilesLinkedToOtherMethodologyVersions()
         {
             var methodology = new Methodology();
             var anotherMethodology = new Methodology();
@@ -181,7 +181,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var service = SetupMethodologyImageService(contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = await service.UnlinkAndDeleteIfOrphaned(methodology.Id, 
+                var result = await service.Delete(methodology.Id, 
                     AsList(imageFile1.File.Id, imageFile2.File.Id));
 
                 result.AssertRight();
@@ -218,7 +218,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         }
 
         [Fact]
-        public async Task UnlinkAndDeleteIfOrphaned_InvalidFileType()
+        public async Task Delete_InvalidFileType()
         {
             var methodology = new Methodology();
 
@@ -260,7 +260,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var service = SetupMethodologyImageService(contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = await service.UnlinkAndDeleteIfOrphaned(methodology.Id, 
+                var result = await service.Delete(methodology.Id, 
                     AsList(ancillaryFile.File.Id, imageFile.File.Id));
 
                 var actionResult = result.AssertLeft();
@@ -281,7 +281,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         }
 
         [Fact]
-        public async Task UnlinkAndDeleteIfOrphaned_MethodologyNotFound()
+        public async Task Delete_MethodologyNotFound()
         {
             var methodology = new Methodology();
 
@@ -312,7 +312,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var service = SetupMethodologyImageService(contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = await service.UnlinkAndDeleteIfOrphaned(Guid.NewGuid(), 
+                var result = await service.Delete(Guid.NewGuid(), 
                     AsList(imageFile.File.Id));
 
                 result.AssertNotFound();
@@ -329,7 +329,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         }
 
         [Fact]
-        public async Task UnlinkAndDeleteIfOrphaned_FileNotFound()
+        public async Task Delete_FileNotFound()
         {
             var methodology = new Methodology();
 
@@ -360,7 +360,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var service = SetupMethodologyImageService(contentDbContext: contentDbContext,
                     blobStorageService: blobStorageService.Object);
 
-                var result = await service.UnlinkAndDeleteIfOrphaned(methodology.Id, 
+                var result = await service.Delete(methodology.Id, 
                     AsList(imageFile.File.Id, Guid.NewGuid()));
 
                 result.AssertNotFound();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -440,7 +440,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 .ReturnsAsync(new List<HtmlBlock>());
 
             imageService.Setup(mock =>
-                    mock.UnlinkAndDeleteIfOrphaned(methodology.Id, new List<Guid>
+                    mock.Delete(methodology.Id, new List<Guid>
                     {
                         imageFile1.File.Id,
                         imageFile2.File.Id
@@ -463,7 +463,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var viewModel = (await service.UpdateMethodology(methodology.Id, request)).Right;
 
                 imageService.Verify(mock =>
-                    mock.UnlinkAndDeleteIfOrphaned(methodology.Id, new List<Guid>
+                    mock.Delete(methodology.Id, new List<Guid>
                     {
                         imageFile1.File.Id,
                         imageFile2.File.Id
@@ -1058,7 +1058,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     AsArray(methodologyVersion2File1Link.File.Id, methodologyVersion2File2Link.File.Id);
 
                 methodologyImageService
-                    .Setup(s => s.UnlinkAndDeleteIfOrphaned(methodologyParent.Versions[1].Id,
+                    .Setup(s => s.Delete(methodologyParent.Versions[1].Id,
                         methodologyVersion2FileIds))
                     .ReturnsAsync(Unit.Instance);
                 
@@ -1143,7 +1143,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var relatedMethodologyFileLinks = AsArray(relatedFileMethodologyLink.File.Id);
 
                 methodologyImageService
-                    .Setup(s => s.UnlinkAndDeleteIfOrphaned(methodologyParent.Versions[0].Id, relatedMethodologyFileLinks))
+                    .Setup(s => s.Delete(methodologyParent.Versions[0].Id, relatedMethodologyFileLinks))
                     .ReturnsAsync(Unit.Instance);
                 
                 var service = SetupMethodologyService(context, methodologyImageService: methodologyImageService.Object);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServicePermissionTests.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.Extensions.Configuration;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
@@ -233,6 +234,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IPublishingService publishingService = null)
         {
             return new ThemeService(
+                Mock.Of<IConfiguration>(),
                 context ?? new Mock<ContentDbContext>().Object,
                 mapper ?? AdminMapper(),
                 persistenceHelper ?? MockUtils.MockPersistenceHelper<ContentDbContext, Theme>(_theme.Id, _theme).Object,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServicePermissionTests.cs
@@ -3,6 +3,7 @@ using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
@@ -11,6 +12,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
+using Microsoft.Extensions.Configuration;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
@@ -105,18 +107,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IReleaseSubjectRepository releaseSubjectRepository = null,
             IReleaseDataFileService releaseDataFileService = null,
             IReleaseFileService releaseFileService = null,
-            IPublishingService publishingService = null)
+            IPublishingService publishingService = null,
+            IMethodologyService methodologyService = null)
         {
             return new TopicService(
-                contentContext ?? new Mock<ContentDbContext>().Object,
-                statisticsContext ?? new Mock<StatisticsDbContext>().Object,
+                Mock.Of<IConfiguration>(),
+                contentContext ?? Mock.Of<ContentDbContext>(),
+                statisticsContext ?? Mock.Of<StatisticsDbContext>(),
                 persistenceHelper ?? MockUtils.MockPersistenceHelper<ContentDbContext, Topic>(_topic.Id, _topic).Object,
                 mapper ?? AdminMapper(),
                 userService ?? MockUtils.AlwaysTrueUserService().Object,
-                releaseSubjectRepository ?? new Mock<IReleaseSubjectRepository>().Object,
-                releaseDataFileService ?? new Mock<IReleaseDataFileService>().Object,
-                releaseFileService ?? new Mock<IReleaseFileService>().Object,
-                publishingService ?? new Mock<IPublishingService>().Object
+                releaseSubjectRepository ?? Mock.Of<IReleaseSubjectRepository>(),
+                releaseDataFileService ?? Mock.Of<IReleaseDataFileService>(),
+                releaseFileService ?? Mock.Of<IReleaseFileService>(),
+                publishingService ?? Mock.Of<IPublishingService>(),
+                methodologyService ?? Mock.Of<IMethodologyService>()
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
@@ -4,20 +4,28 @@ using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
+using Microsoft.Extensions.Configuration;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Data.Model.Database.StatisticsDbUtils;
+using static Moq.MockBehavior;
 using Release = GovUk.Education.ExploreEducationStatistics.Data.Model.Release;
+using ContentRelease = GovUk.Education.ExploreEducationStatistics.Content.Model.Release;
 using Theme = GovUk.Education.ExploreEducationStatistics.Content.Model.Theme;
 using Topic = GovUk.Education.ExploreEducationStatistics.Content.Model.Topic;
 
@@ -314,20 +322,367 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task DeleteTopic()
         {
             var topicId = Guid.NewGuid();
-
-            var publication = new Publication
+            var releaseId = Guid.NewGuid();
+            var publicationId = Guid.NewGuid();
+            var methodologyId = Guid.NewGuid();
+            
+            var publicationMethodology = new PublicationMethodology
             {
-                Id = Guid.NewGuid(),
-                Topic = new Topic
+                PublicationId = publicationId,
+                MethodologyParent = new MethodologyParent
                 {
-                    Id = topicId,
-                    Title = "UI test topic"
+                    Versions = AsList(new Methodology
+                    {
+                        Id = methodologyId
+                    })
                 }
             };
 
-            var release = new Release
+            var topic = new Topic
             {
-                PublicationId = publication.Id
+                Id = topicId,
+                Title = "UI test topic"
+            };
+
+            var publication = new Publication
+            {
+                Id = publicationId,
+                Topic = topic,
+                Releases = AsList(new ContentRelease
+                {
+                    Id = releaseId
+                })
+            };
+
+            var statsRelease = new Release
+            {
+                Id = releaseId,
+                PublicationId = publicationId
+            };
+            
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
+            await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
+            {
+                await contentContext.Publications.AddAsync(publication);
+                await contentContext.Topics.AddAsync(topic);
+                await contentContext.PublicationMethodologies.AddAsync(publicationMethodology);
+                await statisticsContext.Release.AddAsync(statsRelease);
+
+                await contentContext.SaveChangesAsync();
+                await statisticsContext.SaveChangesAsync();
+
+                Assert.Equal(1, contentContext.Publications.Count());
+                Assert.Equal(1, contentContext.Topics.Count());
+                Assert.Equal(1, contentContext.Methodologies.Count());
+                Assert.Equal(1, contentContext.PublicationMethodologies.Count());
+                Assert.Equal(1, contentContext.Releases.Count());
+                Assert.Equal(1, statisticsContext.Release.Count());
+            }
+
+            var releaseDataFileService = new Mock<IReleaseDataFileService>(Strict);
+            var releaseFileService = new Mock<IReleaseFileService>(Strict);
+            var releaseSubjectRepository = new Mock<IReleaseSubjectRepository>(Strict);
+            var methodologyService = new Mock<IMethodologyService>(Strict);
+
+            await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
+            await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
+            {
+                var service = SetupTopicService(
+                    contentContext, 
+                    statisticsContext,
+                    releaseDataFileService: releaseDataFileService.Object,
+                    releaseFileService: releaseFileService.Object,
+                    releaseSubjectRepository: releaseSubjectRepository.Object,
+                    methodologyService: methodologyService.Object);
+
+                releaseDataFileService
+                    .Setup(s => s.DeleteAll(releaseId, true))
+                    .ReturnsAsync(Unit.Instance);
+                
+                releaseFileService
+                    .Setup(s => s.DeleteAll(releaseId, true))
+                    .ReturnsAsync(Unit.Instance);
+
+                releaseSubjectRepository
+                    .Setup(s => s.DeleteAllReleaseSubjects(releaseId, false))
+                    .Returns(Task.CompletedTask);
+
+                methodologyService
+                    .Setup(s => s.DeleteMethodology(methodologyId, true))
+                    .ReturnsAsync(Unit.Instance);
+                
+                var result = await service.DeleteTopic(topicId);
+                VerifyAllMocks(releaseDataFileService, releaseFileService, releaseSubjectRepository, methodologyService);
+                result.AssertRight();
+
+                Assert.Equal(0, contentContext.Publications.Count());
+                Assert.Equal(0, contentContext.Topics.Count());
+                Assert.Equal(0, contentContext.Releases.Count());
+                Assert.Equal(0, statisticsContext.Release.Count());
+            }
+        }
+
+        [Fact]
+        public async Task DeleteTopic_ReleaseAndMethodologyVersionsDeletedInCorrectOrder()
+        {
+            var topicId = Guid.NewGuid();
+            var publicationId = Guid.NewGuid();
+
+            var releaseVersion1Id = Guid.NewGuid();
+            var releaseVersion2Id = Guid.NewGuid();
+            var releaseVersion3Id = Guid.NewGuid();
+            var releaseVersion4Id = Guid.NewGuid();
+
+            var methodologyVersion1Id = Guid.NewGuid();
+            var methodologyVersion2Id = Guid.NewGuid();
+            var methodologyVersion3Id = Guid.NewGuid();
+            var methodologyVersion4Id = Guid.NewGuid();
+
+            var publicationMethodology = new PublicationMethodology
+            {
+                PublicationId = publicationId,
+                MethodologyParent = new MethodologyParent
+                {
+                    Versions = AsList(new Methodology
+                    {
+                        Id = methodologyVersion2Id,
+                        PreviousVersionId = methodologyVersion1Id
+                    },
+                    new Methodology
+                    {
+                        Id = methodologyVersion1Id
+                    },
+                    new Methodology
+                    {
+                        Id = methodologyVersion4Id,
+                        PreviousVersionId = methodologyVersion3Id
+                    },
+                    new Methodology
+                    {
+                        Id = methodologyVersion3Id,
+                        PreviousVersionId = methodologyVersion2Id,
+                    })
+                }
+            };
+
+            var topic = new Topic
+            {
+                Id = topicId,
+                Title = "UI test topic"
+            };
+
+            var publication = new Publication
+            {
+                Id = publicationId,
+                Topic = topic,
+                Releases = AsList(new ContentRelease
+                {
+                    Id = releaseVersion2Id,
+                    PreviousVersionId = releaseVersion1Id
+                },
+                new ContentRelease
+                {
+                    Id = releaseVersion1Id
+                }, new ContentRelease
+                {
+                    Id = releaseVersion4Id,
+                    PreviousVersionId = releaseVersion3Id
+                }, new ContentRelease
+                {
+                    Id = releaseVersion3Id,
+                    PreviousVersionId = releaseVersion2Id
+                })
+            };
+
+            var statsReleases = AsList(new Release
+            {
+                Id = releaseVersion1Id,
+                PublicationId = publicationId
+            },
+            new Release
+            {
+                Id = releaseVersion2Id,
+                PreviousVersionId = releaseVersion1Id,
+                PublicationId = publicationId
+            },
+            new Release
+            {
+                Id = releaseVersion3Id,
+                PreviousVersionId = releaseVersion2Id,
+                PublicationId = publicationId
+            },
+            new Release
+            {
+                Id = releaseVersion4Id,
+                PreviousVersionId = releaseVersion3Id,
+                PublicationId = publicationId
+            });
+            
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
+            await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
+            {
+                await contentContext.Publications.AddAsync(publication);
+                await contentContext.Topics.AddAsync(topic);
+                await contentContext.PublicationMethodologies.AddAsync(publicationMethodology);
+                await statisticsContext.Release.AddRangeAsync(statsReleases);
+
+                await contentContext.SaveChangesAsync();
+                await statisticsContext.SaveChangesAsync();
+
+                Assert.Equal(1, contentContext.Publications.Count());
+                Assert.Equal(1, contentContext.Topics.Count());
+                Assert.Equal(4, contentContext.Methodologies.Count());
+                Assert.Equal(1, contentContext.PublicationMethodologies.Count());
+                Assert.Equal(4, contentContext.Releases.Count());
+                Assert.Equal(4, statisticsContext.Release.Count());
+            }
+
+            var releaseDataFileService = new Mock<IReleaseDataFileService>(Strict);
+            var releaseFileService = new Mock<IReleaseFileService>(Strict);
+            var releaseSubjectRepository = new Mock<IReleaseSubjectRepository>(Strict);
+            var methodologyService = new Mock<IMethodologyService>(Strict);
+
+            await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
+            await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
+            {
+                var service = SetupTopicService(
+                    contentContext, 
+                    statisticsContext,
+                    releaseDataFileService: releaseDataFileService.Object,
+                    releaseFileService: releaseFileService.Object,
+                    releaseSubjectRepository: releaseSubjectRepository.Object,
+                    methodologyService: methodologyService.Object);
+
+                var releaseDataFileDeleteSequence = new MockSequence();
+                
+                releaseDataFileService
+                    .InSequence(releaseDataFileDeleteSequence)
+                    .Setup(s => s.DeleteAll(releaseVersion4Id, true))
+                    .ReturnsAsync(Unit.Instance);
+
+                releaseDataFileService
+                    .InSequence(releaseDataFileDeleteSequence)
+                    .Setup(s => s.DeleteAll(releaseVersion3Id, true))
+                    .ReturnsAsync(Unit.Instance);
+
+                releaseDataFileService
+                    .InSequence(releaseDataFileDeleteSequence)
+                    .Setup(s => s.DeleteAll(releaseVersion2Id, true))
+                    .ReturnsAsync(Unit.Instance);
+
+                releaseDataFileService
+                    .InSequence(releaseDataFileDeleteSequence)
+                    .Setup(s => s.DeleteAll(releaseVersion1Id, true))
+                    .ReturnsAsync(Unit.Instance);
+                
+                var releaseFileDeleteSequence = new MockSequence();
+
+                releaseFileService
+                    .InSequence(releaseFileDeleteSequence)
+                    .Setup(s => s.DeleteAll(releaseVersion4Id, true))
+                    .ReturnsAsync(Unit.Instance);
+                
+                releaseFileService
+                    .InSequence(releaseFileDeleteSequence)
+                    .Setup(s => s.DeleteAll(releaseVersion3Id, true))
+                    .ReturnsAsync(Unit.Instance);
+                
+                releaseFileService
+                    .InSequence(releaseFileDeleteSequence)
+                    .Setup(s => s.DeleteAll(releaseVersion2Id, true))
+                    .ReturnsAsync(Unit.Instance);
+                
+                releaseFileService
+                    .InSequence(releaseFileDeleteSequence)
+                    .Setup(s => s.DeleteAll(releaseVersion1Id, true))
+                    .ReturnsAsync(Unit.Instance);
+
+                var releaseSubjectDeleteSequence = new MockSequence();
+
+                releaseSubjectRepository
+                    .InSequence(releaseSubjectDeleteSequence)
+                    .Setup(s => s.DeleteAllReleaseSubjects(releaseVersion4Id, false))
+                    .Returns(Task.CompletedTask);
+                
+                releaseSubjectRepository
+                    .InSequence(releaseSubjectDeleteSequence)
+                    .Setup(s => s.DeleteAllReleaseSubjects(releaseVersion3Id, false))
+                    .Returns(Task.CompletedTask);
+                
+                releaseSubjectRepository
+                    .InSequence(releaseSubjectDeleteSequence)
+                    .Setup(s => s.DeleteAllReleaseSubjects(releaseVersion2Id, false))
+                    .Returns(Task.CompletedTask);
+                
+                releaseSubjectRepository
+                    .InSequence(releaseSubjectDeleteSequence)
+                    .Setup(s => s.DeleteAllReleaseSubjects(releaseVersion1Id, false))
+                    .Returns(Task.CompletedTask);
+
+                var methodologyDeleteSequence = new MockSequence();
+
+                methodologyService
+                    .InSequence(methodologyDeleteSequence)
+                    .Setup(s => s.DeleteMethodology(methodologyVersion4Id, true))
+                    .ReturnsAsync(Unit.Instance);
+                
+                methodologyService
+                    .InSequence(methodologyDeleteSequence)
+                    .Setup(s => s.DeleteMethodology(methodologyVersion3Id, true))
+                    .ReturnsAsync(Unit.Instance);
+                
+                methodologyService
+                    .InSequence(methodologyDeleteSequence)
+                    .Setup(s => s.DeleteMethodology(methodologyVersion2Id, true))
+                    .ReturnsAsync(Unit.Instance);
+                
+                methodologyService
+                    .InSequence(methodologyDeleteSequence)
+                    .Setup(s => s.DeleteMethodology(methodologyVersion1Id, true))
+                    .ReturnsAsync(Unit.Instance);
+                
+                var result = await service.DeleteTopic(topicId);
+                VerifyAllMocks(releaseDataFileService, releaseFileService, releaseSubjectRepository, methodologyService);
+                result.AssertRight();
+
+                Assert.Equal(0, contentContext.Publications.Count());
+                Assert.Equal(0, contentContext.Topics.Count());
+                Assert.Equal(0, contentContext.Releases.Count());
+                Assert.Equal(0, statisticsContext.Release.Count());
+            }
+        }
+        
+        [Fact]
+        public async Task DeleteTopic_DisallowedByNamingConvention()
+        {
+            var topicId = Guid.NewGuid();
+            var releaseId = Guid.NewGuid();
+            var publicationId = Guid.NewGuid();
+
+            var topic = new Topic
+            {
+                Id = topicId,
+                Title = "Non-confirming title"
+            };
+
+            var publication = new Publication
+            {
+                Id = publicationId,
+                Topic = topic,
+                Releases = AsList(new ContentRelease
+                {
+                    Id = releaseId
+                })
+            };
+
+            var statsRelease = new Release
+            {
+                Id = releaseId,
+                PublicationId = publicationId
             };
 
             var contextId = Guid.NewGuid().ToString();
@@ -335,25 +690,290 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
             await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
             {
-                contentContext.Add(publication);
-                statisticsContext.Add(release);
+                await contentContext.Publications.AddAsync(publication);
+                await contentContext.Topics.AddAsync(topic);
+                await statisticsContext.Release.AddAsync(statsRelease);
 
                 await contentContext.SaveChangesAsync();
                 await statisticsContext.SaveChangesAsync();
+
+                Assert.Equal(1, contentContext.Topics.Count());
+                Assert.Equal(1, contentContext.Publications.Count());
+                Assert.Equal(1, contentContext.Releases.Count());
+                Assert.Equal(1, statisticsContext.Release.Count());
             }
 
             await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
             await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
             {
-                var service = SetupTopicService(contentContext, statisticsContext: statisticsContext);
+                var service = SetupTopicService(contentContext, statisticsContext);
 
                 var result = await service.DeleteTopic(topicId);
+                result.AssertForbidden();
 
-                Assert.True(result.IsRight);
-
-                Assert.Equal(0, contentContext.Topics.Count());
-                Assert.Equal(0, statisticsContext.Release.Count());
+                Assert.Equal(1, contentContext.Topics.Count());
+                Assert.Equal(1, contentContext.Publications.Count());
+                Assert.Equal(1, contentContext.Releases.Count());
+                Assert.Equal(1, statisticsContext.Release.Count());
             }
+        }
+        
+        [Fact]
+        public async Task DeleteTopic_DisallowedByConfiguration()
+        {
+            var topicId = Guid.NewGuid();
+            var releaseId = Guid.NewGuid();
+            var publicationId = Guid.NewGuid();
+
+            var topic = new Topic
+            {
+                Id = topicId,
+                Title = "UI test topic"
+            };
+
+            var publication = new Publication
+            {
+                Id = publicationId,
+                Topic = topic,
+                Releases = AsList(new ContentRelease
+                {
+                    Id = releaseId
+                })
+            };
+
+            var statsRelease = new Release
+            {
+                Id = releaseId,
+                PublicationId = publicationId
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
+            await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
+            {
+                await contentContext.Publications.AddAsync(publication);
+                await contentContext.Topics.AddAsync(topic);
+                await statisticsContext.Release.AddAsync(statsRelease);
+
+                await contentContext.SaveChangesAsync();
+                await statisticsContext.SaveChangesAsync();
+
+                Assert.Equal(1, contentContext.Topics.Count());
+                Assert.Equal(1, contentContext.Publications.Count());
+                Assert.Equal(1, contentContext.Releases.Count());
+                Assert.Equal(1, statisticsContext.Release.Count());
+            }
+
+            await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
+            await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
+            {
+                var service = SetupTopicService(
+                    contentContext, 
+                    statisticsContext, 
+                    enableThemeDeletion: false);
+
+                var result = await service.DeleteTopic(topicId);
+                result.AssertForbidden();
+
+                Assert.Equal(1, contentContext.Topics.Count());
+                Assert.Equal(1, contentContext.Publications.Count());
+                Assert.Equal(1, contentContext.Releases.Count());
+                Assert.Equal(1, statisticsContext.Release.Count());
+            }
+        }
+        
+        [Fact]
+        public async Task DeleteTopic_OtherTopicsUnaffected()
+        {
+            var topicId = Guid.NewGuid();
+            var releaseId = Guid.NewGuid();
+            var publicationId = Guid.NewGuid();
+            var methodologyId = Guid.NewGuid();
+            
+            var otherTopicId = Guid.NewGuid();
+            var otherReleaseId = Guid.NewGuid();
+            var otherPublicationId = Guid.NewGuid();
+            var otherMethodologyId = Guid.NewGuid();
+
+            var publicationMethodology = new PublicationMethodology
+            {
+                PublicationId = publicationId,
+                MethodologyParent = new MethodologyParent
+                {
+                    Versions = AsList(new Methodology
+                    {
+                        Id = methodologyId
+                    })
+                }
+            };
+
+            var topic = new Topic
+            {
+                Id = topicId,
+                Title = "UI test topic"
+            };
+
+            var publication = new Publication
+            {
+                Id = publicationId,
+                Topic = topic,
+                Releases = AsList(new ContentRelease
+                {
+                    Id = releaseId
+                })
+            };
+
+            var statsRelease = new Release
+            {
+                Id = releaseId,
+                PublicationId = publicationId
+            };
+            
+            var otherPublicationMethodology = new PublicationMethodology
+            {
+                PublicationId = otherPublicationId,
+                MethodologyParent = new MethodologyParent
+                {
+                    Versions = AsList(new Methodology
+                    {
+                        Id = otherMethodologyId
+                    })
+                }
+            };
+
+            var otherTopic = new Topic
+            {
+                Id = otherTopicId,
+                Title = "UI test topic"
+            };
+
+            var otherPublication = new Publication
+            {
+                Id = otherPublicationId,
+                Topic = otherTopic,
+                Releases = AsList(new ContentRelease
+                {
+                    Id = otherReleaseId
+                })
+            };
+
+            var otherStatsRelease = new Release
+            {
+                Id = otherReleaseId,
+                PublicationId = otherPublicationId
+            };
+            
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
+            await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
+            {
+                await contentContext.Publications.AddRangeAsync(publication, otherPublication);
+                await contentContext.Topics.AddRangeAsync(topic, otherTopic);
+                await contentContext.PublicationMethodologies.AddRangeAsync(publicationMethodology, otherPublicationMethodology);
+                await statisticsContext.Release.AddRangeAsync(statsRelease, otherStatsRelease);
+
+                await contentContext.SaveChangesAsync();
+                await statisticsContext.SaveChangesAsync();
+
+                Assert.Equal(2, contentContext.Publications.Count());
+                Assert.Equal(2, contentContext.Topics.Count());
+                Assert.Equal(2, contentContext.Methodologies.Count());
+                Assert.Equal(2, contentContext.PublicationMethodologies.Count());
+                Assert.Equal(2, contentContext.Releases.Count());
+                Assert.Equal(2, statisticsContext.Release.Count());
+            }
+
+            var releaseDataFileService = new Mock<IReleaseDataFileService>(Strict);
+            var releaseFileService = new Mock<IReleaseFileService>(Strict);
+            var releaseSubjectRepository = new Mock<IReleaseSubjectRepository>(Strict);
+            var methodologyService = new Mock<IMethodologyService>(Strict);
+
+            await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
+            await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
+            {
+                var service = SetupTopicService(
+                    contentContext, 
+                    statisticsContext,
+                    releaseDataFileService: releaseDataFileService.Object,
+                    releaseFileService: releaseFileService.Object,
+                    releaseSubjectRepository: releaseSubjectRepository.Object,
+                    methodologyService: methodologyService.Object);
+
+                releaseDataFileService
+                    .Setup(s => s.DeleteAll(releaseId, true))
+                    .ReturnsAsync(Unit.Instance);
+                
+                releaseFileService
+                    .Setup(s => s.DeleteAll(releaseId, true))
+                    .ReturnsAsync(Unit.Instance);
+
+                releaseSubjectRepository
+                    .Setup(s => s.DeleteAllReleaseSubjects(releaseId, false))
+                    .Returns(Task.CompletedTask);
+
+                methodologyService
+                    .Setup(s => s.DeleteMethodology(methodologyId, true))
+                    .ReturnsAsync(Unit.Instance);
+                
+                var result = await service.DeleteTopic(topicId);
+                VerifyAllMocks(releaseDataFileService, releaseFileService, releaseSubjectRepository, methodologyService);
+                result.AssertRight();
+
+                Assert.Equal(otherPublicationId, contentContext.Publications.Select(p => p.Id).Single());
+                Assert.Equal(otherTopicId, contentContext.Topics.Select(t => t.Id).Single());
+                Assert.Equal(otherReleaseId, contentContext.Releases.Select(r => r.Id).Single());
+                Assert.Equal(otherReleaseId, statisticsContext.Release.Select(r => r.Id).Single());
+            }
+        }
+        
+        [Fact]
+        public void VersionedEntityDeletionOrderComparer()
+        {
+            var version1Id = Guid.NewGuid();
+            var version2Id = Guid.NewGuid();
+            var version3Id = Guid.NewGuid();
+            
+            var version1 = new TopicService.IdAndPreviousVersionIdPair(version1Id, null);
+            var version2 = new TopicService.IdAndPreviousVersionIdPair(version2Id, version1Id);
+            var version3 = new TopicService.IdAndPreviousVersionIdPair(version3Id, version2Id);
+            
+            var comparer = new TopicService.VersionedEntityDeletionOrderComparer();
+            
+            Assert.Equal(-1, comparer.Compare(version2, version1));
+            Assert.Equal(-1, comparer.Compare(version3, version2));
+            
+            Assert.Equal(1, comparer.Compare(version1, version2));
+            Assert.Equal(1, comparer.Compare(version2, version3));
+
+            Assert.Equal(1, comparer.Compare(version1, version3));
+            Assert.Equal(-1, comparer.Compare(version3, version1));
+        }
+
+        [Fact]
+        public void VersionedEntityDeletionOrderComparer_WithSequence()
+        {
+            var version1Id = Guid.NewGuid();
+            var version4Id = Guid.NewGuid();
+            var version3Id = Guid.NewGuid();
+            var version2Id = Guid.NewGuid();
+            var version5Id = Guid.NewGuid();
+
+            var versions = AsList(
+                new TopicService.IdAndPreviousVersionIdPair(version2Id, version1Id),
+                new TopicService.IdAndPreviousVersionIdPair(version1Id, null),
+                new TopicService.IdAndPreviousVersionIdPair(version5Id, version4Id),
+                new TopicService.IdAndPreviousVersionIdPair(version4Id, version3Id),
+                new TopicService.IdAndPreviousVersionIdPair(version3Id, version2Id));
+
+            var orderedByLatestVersionsFirst = versions
+                .OrderBy(version => version, new TopicService.VersionedEntityDeletionOrderComparer())
+                .Select(version => version.Id)
+                .ToList();
+
+            var expectedVersionOrder = AsList(version5Id, version4Id, version3Id, version2Id, version1Id);
+            Assert.Equal(expectedVersionOrder, orderedByLatestVersionsFirst);
         }
 
         private TopicService SetupTopicService(
@@ -363,20 +983,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             IMapper mapper = null,
             IUserService userService = null,
             IReleaseSubjectRepository releaseSubjectRepository = null,
-            IReleaseDataFileService releaseDataFilesService = null,
+            IReleaseDataFileService releaseDataFileService = null,
             IReleaseFileService releaseFileService = null,
-            IPublishingService publishingService = null)
+            IPublishingService publishingService = null,
+            IMethodologyService methodologyService = null,
+            bool enableThemeDeletion = true)
         {
+            var configuration =
+                CreateMockConfiguration(new Tuple<string, string>("enableThemeDeletion", enableThemeDeletion.ToString()));
+            
             return new TopicService(
+                configuration.Object,
                 contentContext,
-                statisticsContext ?? new Mock<StatisticsDbContext>().Object,
+                statisticsContext ?? Mock.Of<StatisticsDbContext>(),
                 persistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentContext),
                 mapper ?? AdminMapper(),
-                userService ?? MockUtils.AlwaysTrueUserService().Object,
-                releaseSubjectRepository ?? new Mock<IReleaseSubjectRepository>().Object,
-                releaseDataFilesService ?? new Mock<IReleaseDataFileService>().Object,
-                releaseFileService ?? new Mock<IReleaseFileService>().Object,
-                publishingService ?? new Mock<IPublishingService>().Object
+                userService ?? AlwaysTrueUserService().Object,
+                releaseSubjectRepository ?? Mock.Of<IReleaseSubjectRepository>(),
+                releaseDataFileService ?? Mock.Of<IReleaseDataFileService>(),
+                releaseFileService ?? Mock.Of<IReleaseFileService>(),
+                publishingService ?? Mock.Of<IPublishingService>(),
+                methodologyService ?? Mock.Of<IMethodologyService>()
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyImageService.cs
@@ -10,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 {
     public interface IMethodologyImageService
     {
-        Task<Either<ActionResult, Unit>> UnlinkAndDeleteIfOrphaned(
+        Task<Either<ActionResult, Unit>> Delete(
             Guid methodologyId,
             IEnumerable<Guid> fileIds);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
@@ -15,6 +15,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
         Task<Either<ActionResult, MethodologySummaryViewModel>> UpdateMethodology(Guid id,
             MethodologyUpdateRequest request);
 
-        Task<Either<ActionResult, Unit>> DeleteMethodology(Guid methodologyId);
+        Task<Either<ActionResult, Unit>> DeleteMethodology(Guid methodologyId, bool forceDelete = false);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
@@ -83,8 +83,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
         }
 
         public static Task<Either<ActionResult, Methodology>> CheckCanDeleteMethodology(
-            this IUserService userService, Methodology methodology)
+            this IUserService userService, Methodology methodology, bool ignoreCheck = false)
         {
+            if (ignoreCheck)
+            {
+                return Task.FromResult(new Either<ActionResult, Methodology>(methodology));
+            }
             return userService.CheckPolicy(methodology, SecurityPolicies.CanDeleteSpecificMethodology);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
@@ -51,7 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             _userService = userService;
         }
 
-        public async Task<Either<ActionResult, Unit>> UnlinkAndDeleteIfOrphaned(Guid methodologyId, IEnumerable<Guid> fileIds)
+        public async Task<Either<ActionResult, Unit>> Delete(Guid methodologyId, IEnumerable<Guid> fileIds)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Methodology>(methodologyId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -151,12 +151,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 });
         }
 
-        public Task<Either<ActionResult, Unit>> DeleteMethodology(Guid methodologyId)
+        public Task<Either<ActionResult, Unit>> DeleteMethodology(Guid methodologyId, bool forceDelete = false)
         {
             return _persistenceHelper
                 .CheckEntityExists<Methodology>(methodologyId, 
                     query => query.Include(m => m.MethodologyParent))
-                .OnSuccess(_userService.CheckCanDeleteMethodology)
+                .OnSuccess(methodology => _userService.CheckCanDeleteMethodology(methodology, forceDelete))
                 .OnSuccessDo(UnlinkMethodologyFilesAndDeleteIfOrphaned)
                 .OnSuccessDo(DeleteMethodologyVersion)
                 .OnSuccessVoid(DeleteMethodologyParentIfOrphaned);
@@ -172,7 +172,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
             if (methodologyFileIds.Count > 0)
             {
-                return await _methodologyImageService.UnlinkAndDeleteIfOrphaned(methodology.Id, methodologyFileIds);
+                return await _methodologyImageService.Delete(methodology.Id, methodologyFileIds);
             }
 
             return Unit.Instance;
@@ -233,7 +233,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
                     if (unusedImages.Any())
                     {
-                        return await _methodologyImageService.UnlinkAndDeleteIfOrphaned(methodologyId, unusedImages);
+                        return await _methodologyImageService.Delete(methodologyId, unusedImages);
                     }
 
                     return Unit.Instance;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
@@ -16,6 +18,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
@@ -25,6 +28,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
      */
     public class TopicService : ITopicService
     {
+        private static readonly VersionedEntityDeletionOrderComparer VersionedEntityComparer = 
+            new VersionedEntityDeletionOrderComparer();
+
         private readonly ContentDbContext _contentContext;
         private readonly StatisticsDbContext _statisticsContext;
         private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
@@ -34,8 +40,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IReleaseDataFileService _releaseDataFileService;
         private readonly IReleaseFileService _releaseFileService;
         private readonly IPublishingService _publishingService;
+        private readonly IMethodologyService _methodologyService;
+        private readonly bool _topicDeletionAllowed;
 
         public TopicService(
+            IConfiguration configuration,
             ContentDbContext contentContext,
             StatisticsDbContext statisticsContext,
             IPersistenceHelper<ContentDbContext> persistenceHelper,
@@ -44,7 +53,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             IReleaseSubjectRepository releaseSubjectRepository,
             IReleaseDataFileService releaseDataFileService,
             IReleaseFileService releaseFileService,
-            IPublishingService publishingService)
+            IPublishingService publishingService, 
+            IMethodologyService methodologyService)
         {
             _contentContext = contentContext;
             _statisticsContext = statisticsContext;
@@ -55,6 +65,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _releaseDataFileService = releaseDataFileService;
             _releaseFileService = releaseFileService;
             _publishingService = publishingService;
+            _methodologyService = methodologyService;
+            _topicDeletionAllowed = configuration.GetValue<bool>("enableThemeDeletion");
         }
 
         public async Task<Either<ActionResult, TopicViewModel>> CreateTopic(TopicSaveViewModel created)
@@ -154,48 +166,141 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     )
                 )
                 .OnSuccessDo(_userService.CheckCanManageAllTaxonomy)
-                .OnSuccessVoid(
-                    async topic =>
+                .OnSuccessDo(CheckCanDeleteTopic)
+                .OnSuccessVoid(async topic =>
+                {
+                    var publicationIdsToDelete = topic.Publications.Select(p => p.Id);
+
+                    var releaseIdsToDelete = _statisticsContext
+                        .Release
+                        .Where(r => publicationIdsToDelete.Contains(r.PublicationId))
+                        .ToList()
+                        .OrderBy(release => new IdAndPreviousVersionIdPair(release.Id, release.PreviousVersionId),
+                            VersionedEntityComparer)
+                        .Select(r => r.Id);
+
+                    foreach (var releaseId in releaseIdsToDelete)
                     {
-                        // For now we only want to delete test topics as we
-                        // don't really have a mechanism to clean things up
-                        // properly across the entire application.
-                        // TODO: EES-1295 ability to completely delete releases
-                        if (!topic.Title.StartsWith("UI test topic"))
-                        {
-                            return;
-                        }
+                        await _releaseDataFileService.DeleteAll(releaseId, forceDelete: true);
+                        await _releaseFileService.DeleteAll(releaseId, forceDelete: true);
+                        await _releaseSubjectRepository.DeleteAllReleaseSubjects(releaseId);
+                        
+                        var statsRelease = await _statisticsContext
+                            .Release
+                            .Where(r => r.Id == releaseId)
+                            .SingleAsync();
+                        
+                        var contentRelease = await _contentContext
+                            .Releases
+                            .Where(r => r.Id == releaseId)
+                            .SingleAsync();
 
-                        foreach (var release in topic.Publications.SelectMany(publication => publication.Releases))
-                        {
-                            await _releaseDataFileService.DeleteAll(release.Id, forceDelete: true);
-                            await _releaseFileService.DeleteAll(release.Id, forceDelete: true);
-                            await _releaseSubjectRepository.DeleteAllReleaseSubjects(release.Id);
-                        }
-
-                        var publicationIds = topic.Publications
-                            .Select(p => p.Id)
-                            .ToList();
-                        _statisticsContext.Release.RemoveRange(
-                            _statisticsContext.Release.Where(r => publicationIds.Contains(r.PublicationId))
-                        );
-
-                        await _statisticsContext.SaveChangesAsync();
-
-                        _contentContext.Topics.RemoveRange(
-                            _contentContext.Topics.Where(t => t.Id == topic.Id)
-                        );
-
-                        await _contentContext.SaveChangesAsync();
-
-                        await _publishingService.TaxonomyChanged();
+                        _statisticsContext.Release.Remove(statsRelease);
+                        _contentContext.Releases.Remove(contentRelease);
                     }
-                );
+
+                    await _contentContext.SaveChangesAsync();
+                    await _statisticsContext.SaveChangesAsync();
+                    
+                    var methodologiesToDelete = _contentContext
+                        .PublicationMethodologies
+                        .Include(pm => pm.MethodologyParent)
+                        .ThenInclude(pm => pm.Versions)
+                        .Where(pm => publicationIdsToDelete.Contains(pm.PublicationId))
+                        .SelectMany(pm => pm.MethodologyParent.Versions)
+                        .ToList()
+                        .OrderBy(m => new IdAndPreviousVersionIdPair(m.Id, m.PreviousVersionId),
+                            VersionedEntityComparer);
+
+                    await methodologiesToDelete.ForEachAsync(methodology => 
+                        _methodologyService.DeleteMethodology(methodology.Id, forceDelete: true));
+                    
+                    _contentContext.Topics.Remove(
+                        await _contentContext
+                            .Topics
+                            .Where(t => t.Id == topic.Id)
+                            .SingleAsync()
+                    );
+
+                    await _contentContext.SaveChangesAsync();
+                    await _statisticsContext.SaveChangesAsync();
+
+                    await _publishingService.TaxonomyChanged();
+                });
+        }
+
+        private async Task<Either<ActionResult, Unit>> CheckCanDeleteTopic(Topic topic)
+        {
+            if (!_topicDeletionAllowed)
+            {
+                return new ForbidResult();
+            }
+                        
+            // For now we only want to delete test topics as we
+            // don't really have a mechanism to clean things up
+            // properly across the entire application.
+            // TODO: EES-1295 ability to completely delete releases
+            if (!topic.Title.StartsWith("UI test topic"))
+            {
+                return new ForbidResult();
+            }
+
+            return Unit.Instance;
         }
 
         private static IQueryable<Topic> HydrateTopicForTopicViewModel(IQueryable<Topic> values)
         {
             return values.Include(p => p.Publications);
+        }
+        
+        /// <summary>
+        /// An IComparer implementation that orders entities based upon having previous versions.  This IComparer will
+        /// order the entities so that entities that have no previous versions will appear at the end of the list,
+        /// entities that have that set of entities as previous versions will appear before them etc. 
+        /// </summary>
+        public class VersionedEntityDeletionOrderComparer : IComparer<IdAndPreviousVersionIdPair>
+        {
+            public int Compare(IdAndPreviousVersionIdPair entity1Ids, IdAndPreviousVersionIdPair entity2Ids)
+            {
+                if (entity1Ids == null)
+                {
+                    return 1;
+                }
+                
+                if (entity2Ids == null)
+                {
+                    return -1;
+                }
+
+                if (entity1Ids.PreviousVersionId == null)
+                {
+                    return 1;
+                }
+                
+                if (entity2Ids.PreviousVersionId == null)
+                {
+                    return -1;
+                }
+                
+                if (entity1Ids.PreviousVersionId == entity2Ids.Id)
+                {
+                    return -1;
+                }
+
+                return entity2Ids.PreviousVersionId == entity1Ids.Id ? 1 : -1;
+            }
+        }
+
+        public class IdAndPreviousVersionIdPair
+        {
+            public readonly Guid Id;
+            public readonly Guid? PreviousVersionId;
+
+            public IdAndPreviousVersionIdPair(Guid id, Guid? previousVersionId)
+            {
+                Id = id;
+                PreviousVersionId = previousVersionId;
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -400,7 +400,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                 });
             }
 
-            if(env.IsDevelopment() || Configuration.GetValue<bool>("enableSwagger"))
+            if(Configuration.GetValue<bool>("enableSwagger"))
             {
                 app.UseSwagger();
                 app.UseSwaggerUI(c =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -7,6 +7,7 @@
   "NotifyPreReleaseTemplateId": "change-me",
   "PublicAppUrl": "http://localhost:3000",
   "enableSwagger": true,
+  "enableThemeDeletion": true,
   "CoreStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;QueueEndpoint=http://data-storage:10001/devstoreaccount1;TableEndpoint=http://data-storage:10002/devstoreaccount1",
   "PublicStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://data-storage:10000/devstoreaccount1;QueueEndpoint=http://data-storage:10001/devstoreaccount1;",
   "PublisherStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;QueueEndpoint=http://data-storage:10001/devstoreaccount1;TableEndpoint=http://data-storage:10002/devstoreaccount1;",

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EitherTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EitherTestExtensions.cs
@@ -9,8 +9,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
     {
         public static void AssertNotFound<T>(this Either<ActionResult, T> result)
         {
-            var actionResult = result.AssertLeft("Expecting result to be Left when asserting NotFound");
-            Assert.IsType<NotFoundResult>(actionResult);
+            result.AssertActionResultOfType<NotFoundResult, T>();
+        }
+        
+        public static void AssertForbidden<T>(this Either<ActionResult, T> result)
+        {
+            result.AssertActionResultOfType<ForbidResult, T>();
         }
         
         public static TRight AssertRight<TLeft, TRight>(this Either<TLeft, TRight> either, string message = null)
@@ -31,6 +35,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             }
             
             return either.Left;
+        }
+        
+        private static void AssertActionResultOfType<TActionResult, TRight>(this Either<ActionResult, TRight> result)
+            where TActionResult : ActionResult
+        {
+            var actionResult = result.AssertLeft($"Expecting result to be Left when asserting result of " +
+                                                 $"type {typeof(TActionResult)}");
+            Assert.IsType<TActionResult>(actionResult);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/MockUtils.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Secu
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Moq;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
@@ -140,6 +141,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
                         verifyNoOtherCallsMethod.Invoke(mock, null);
                     }
                 });
+        }
+
+        public static Mock<IConfiguration> CreateMockConfiguration(params Tuple<string, string>[] keysAndValues)
+        {
+            var configuration = new Mock<IConfiguration>();
+            
+            foreach (var keyValue in keysAndValues)
+            {
+                var (key, value) = keyValue;
+                
+                var section = new Mock<IConfigurationSection>();
+            
+                section
+                    .Setup(s => s.Value)
+                    .Returns(value);
+            
+                configuration
+                    .Setup(c => c.GetSection(key))
+                    .Returns(section.Object);
+            }
+
+            return configuration;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -127,7 +127,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
                 app.UseHsts(hsts => hsts.MaxAge(365).IncludeSubdomains());
             }
 
-            if(env.IsDevelopment() || Configuration.GetValue<bool>("enableSwagger"))
+            if(Configuration.GetValue<bool>("enableSwagger"))
             {
                 app.UseSwagger();
                 app.UseSwaggerUI(c =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -179,7 +179,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
                 app.UseHsts(hsts => hsts.MaxAge(365).IncludeSubdomains());
             }
 
-            if(env.IsDevelopment() || Configuration.GetValue<bool>("enableSwagger"))
+            if(Configuration.GetValue<bool>("enableSwagger"))
             {
                 app.UseSwagger();
                 app.UseSwaggerUI(c =>


### PR DESCRIPTION
This PR:
- Adds an order in which Releases and Methodologies are deleted under a Theme when the Theme and its Topics are deleted.  This is to prevent foreign key issues coming from Previous Version Id columns which reference entities of the same type.  This way, the latest version of Releases and Methodologies are deleted first, then their previous versions, then their previous etc etc, until finally the original versions are deleted.
- Adds the removal of Methodology Files and orphaned MethodologyParents from Blob Storage when deleting a Theme and its Topics, by way of using MethodologyService to delete Methodologies cleanly (with an extra "forceDelete" flag to override the default security checks).
- Adds per-environment configuration to allow or disallow the deleting of whole Themes.  By default, this is possible on all environments save for Production.
- Adds additional testing around the previously existing TopicService.Delete() and ThemeService.Delete() methods.