### PR TITLE
EES-2265 methodology dependent release FE

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -109,7 +109,7 @@ const MethodologyStatusPage = ({
                 isPublished={isPublished}
                 methodologySummary={model.summary}
                 onCancel={toggleForm.off}
-                onSubmit={(values, actions) => handleSubmit(values, actions)}
+                onSubmit={handleSubmit}
               />
             )}
           </>

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -8,7 +8,6 @@ import Button from '@common/components/Button';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
-import useFormSubmit from '@common/hooks/useFormSubmit';
 import useToggle from '@common/hooks/useToggle';
 import { Dictionary } from '@common/types';
 import MethodologyStatusForm from '@admin/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm';
@@ -52,7 +51,7 @@ const MethodologyStatusPage = ({
     };
   }, [methodologyId]);
 
-  const handleSubmit = useFormSubmit<FormValues>(async values => {
+  const handleSubmit = async (values: FormValues) => {
     if (!model) {
       return;
     }
@@ -76,7 +75,7 @@ const MethodologyStatusPage = ({
     });
 
     toggleForm.off();
-  });
+  };
 
   const isEditable = model?.canApprove || model?.canMarkAsDraft;
   const isPublished = model?.summary.published;

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -5,32 +5,27 @@ import methodologyService, {
 } from '@admin/services/methodologyService';
 import permissionService from '@admin/services/permissionService';
 import Button from '@common/components/Button';
-import ButtonGroup from '@common/components/ButtonGroup';
-import ButtonText from '@common/components/ButtonText';
-import { Form, FormFieldRadioGroup } from '@common/components/form';
-import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import useFormSubmit from '@common/hooks/useFormSubmit';
 import useToggle from '@common/hooks/useToggle';
 import { Dictionary } from '@common/types';
-import Yup from '@common/validation/yup';
-import { Formik } from 'formik';
+import MethodologyStatusForm from '@admin/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
 interface FormValues {
   status: MethodologyStatus;
   latestInternalReleaseNote: string;
+  publishingStrategy?: 'WithRelease' | 'Immediately';
+  withReleaseId?: string;
 }
 
 const statusMap: Dictionary<string> = {
   Draft: 'In Draft',
   Approved: 'Approved',
 };
-
-const formId = 'methodologyStatusForm';
 
 const MethodologyStatusPage = ({
   match,
@@ -110,69 +105,12 @@ const MethodologyStatusPage = ({
                 )}
               </>
             ) : (
-              <Formik<FormValues>
-                initialValues={{
-                  status: model.summary.status,
-                  latestInternalReleaseNote: '',
-                }}
-                onSubmit={handleSubmit}
-                validationSchema={Yup.object<FormValues>({
-                  status: Yup.mixed().required('Choose a status'),
-                  latestInternalReleaseNote: Yup.string().when('status', {
-                    is: 'Approved',
-                    then: Yup.string().required('Enter an internal note'),
-                  }),
-                })}
-              >
-                {form => {
-                  return (
-                    <Form id={formId}>
-                      <h2>Edit methodology status</h2>
-
-                      <FormFieldRadioGroup<FormValues, MethodologyStatus>
-                        legend="Status"
-                        hint={
-                          isPublished &&
-                          'Once approved, changes will be available to the public immediately.'
-                        }
-                        name="status"
-                        options={[
-                          {
-                            label: 'In draft',
-                            value: 'Draft',
-                          },
-                          {
-                            label: 'Approved for publication',
-                            value: 'Approved',
-                            conditional: (
-                              <FormFieldTextArea<FormValues>
-                                name="latestInternalReleaseNote"
-                                className="govuk-!-width-one-half"
-                                label="Internal note"
-                                hint="Please include any relevant information"
-                                rows={2}
-                              />
-                            ),
-                          },
-                        ]}
-                        orderDirection={[]}
-                      />
-
-                      <ButtonGroup>
-                        <Button type="submit">Update status</Button>
-                        <ButtonText
-                          onClick={() => {
-                            form.resetForm();
-                            toggleForm.off();
-                          }}
-                        >
-                          Cancel
-                        </ButtonText>
-                      </ButtonGroup>
-                    </Form>
-                  );
-                }}
-              </Formik>
+              <MethodologyStatusForm
+                isPublished={isPublished}
+                methodologySummary={model.summary}
+                onCancel={toggleForm.off}
+                onSubmit={(values, actions) => handleSubmit(values, actions)}
+              />
             )}
           </>
         ) : (

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm.tsx
@@ -74,7 +74,7 @@ const MethodologyStatusForm = ({
         }) as StringSchema<FormValues['publishingStrategy']>,
         withReleaseId: Yup.string().when('publishingStrategy', {
           is: 'WithRelease',
-          then: Yup.string().required('Select a release'),
+          then: Yup.string().required('Choose a release'),
         }),
       })}
     >

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm.tsx
@@ -11,7 +11,8 @@ import { Form, FormFieldRadioGroup } from '@common/components/form';
 import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
 import FormFieldSelect from '@common/components/form/FormFieldSelect';
 import Yup from '@common/validation/yup';
-import { Formik, FormikHelpers } from 'formik';
+import useFormSubmit from '@common/hooks/useFormSubmit';
+import { Formik } from 'formik';
 import React from 'react';
 import { StringSchema } from 'yup';
 
@@ -40,7 +41,7 @@ interface Props {
   showWithRelease?: boolean; // EES-2163 - flag for showing publishing strategy sections for testing, remove when BE done.
   unPublishedReleases?: Release[];
   onCancel: () => void;
-  onSubmit: (values: FormValues, actions: FormikHelpers<FormValues>) => void;
+  onSubmit: (values: FormValues) => void;
 }
 
 const MethodologyStatusForm = ({
@@ -61,7 +62,7 @@ const MethodologyStatusForm = ({
           methodologySummary.publishingStrategy ?? 'Immediately',
         withReleaseId: methodologySummary.withReleaseId,
       }}
-      onSubmit={onSubmit}
+      onSubmit={useFormSubmit<FormValues>(onSubmit)}
       validationSchema={Yup.object<FormValues>({
         status: Yup.mixed().required('Choose a status'),
         latestInternalReleaseNote: Yup.string().when('status', {

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm.tsx
@@ -1,0 +1,165 @@
+import {
+  BasicMethodology,
+  MethodologyPublishingStrategy,
+  MethodologyStatus,
+} from '@admin/services/methodologyService';
+import { Release } from '@admin/services/releaseService';
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import ButtonText from '@common/components/ButtonText';
+import { Form, FormFieldRadioGroup } from '@common/components/form';
+import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
+import FormFieldSelect from '@common/components/form/FormFieldSelect';
+import Yup from '@common/validation/yup';
+import { Formik, FormikHelpers } from 'formik';
+import React from 'react';
+import { StringSchema } from 'yup';
+
+export interface FormValues {
+  status: MethodologyStatus;
+  latestInternalReleaseNote: string;
+  publishingStrategy?: MethodologyPublishingStrategy;
+  withReleaseId?: string;
+}
+
+// EES-2163 Replace with real list when EES-2264 done.
+const fakeUnpublishedReleases: Release[] = [
+  {
+    id: 'rel-1',
+    title: 'Release 1',
+  } as Release,
+  {
+    id: 'rel-2',
+    title: 'Release 2',
+  } as Release,
+];
+
+interface Props {
+  isPublished?: string;
+  methodologySummary: BasicMethodology;
+  showWithRelease?: boolean; // EES-2163 - flag for showing publishing strategy sections for testing, remove when BE done.
+  unPublishedReleases?: Release[];
+  onCancel: () => void;
+  onSubmit: (values: FormValues, actions: FormikHelpers<FormValues>) => void;
+}
+
+const MethodologyStatusForm = ({
+  isPublished,
+  methodologySummary,
+  showWithRelease = false,
+  unPublishedReleases = fakeUnpublishedReleases, // EES-2163 use fake for now.
+  onCancel,
+  onSubmit,
+}: Props) => {
+  return (
+    <Formik<FormValues>
+      initialValues={{
+        status: methodologySummary.status,
+        latestInternalReleaseNote:
+          methodologySummary.latestInternalReleaseNote ?? '',
+        publishingStrategy:
+          methodologySummary.publishingStrategy ?? 'Immediately',
+        withReleaseId: methodologySummary.withReleaseId,
+      }}
+      onSubmit={onSubmit}
+      validationSchema={Yup.object<FormValues>({
+        status: Yup.mixed().required('Choose a status'),
+        latestInternalReleaseNote: Yup.string().when('status', {
+          is: 'Approved',
+          then: Yup.string().required('Enter an internal note'),
+        }),
+        publishingStrategy: Yup.string().when('status', {
+          is: 'Approved',
+          then: Yup.string().required('Choose when to publish'),
+        }) as StringSchema<FormValues['publishingStrategy']>,
+        withReleaseId: Yup.string().when('publishingStrategy', {
+          is: 'WithRelease',
+          then: Yup.string().required('Select a release'),
+        }),
+      })}
+    >
+      {form => {
+        return (
+          <Form id="methodologyStatusForm">
+            <h2>Edit methodology status</h2>
+
+            <FormFieldRadioGroup<FormValues, MethodologyStatus>
+              legend="Status"
+              hint={
+                isPublished &&
+                'Once approved, changes will be available to the public immediately.'
+              }
+              name="status"
+              options={[
+                {
+                  label: 'In draft',
+                  value: 'Draft',
+                },
+                {
+                  label: 'Approved for publication',
+                  value: 'Approved',
+                  conditional: (
+                    <FormFieldTextArea<FormValues>
+                      name="latestInternalReleaseNote"
+                      className="govuk-!-width-one-half"
+                      label="Internal note"
+                      hint="Please include any relevant information"
+                      rows={2}
+                    />
+                  ),
+                },
+              ]}
+              order={[]}
+            />
+            {form.values.status === 'Approved' && showWithRelease && (
+              <FormFieldRadioGroup<FormValues>
+                name="publishingStrategy"
+                legend="When to publish"
+                legendSize="m"
+                hint="Do you want to publish this methodology with a specific release or immediately?"
+                order={[]}
+                options={[
+                  {
+                    label: 'With a specific release',
+                    value: 'WithRelease',
+                    conditional: (
+                      <FormFieldSelect<FormValues>
+                        label="Select release"
+                        name="withReleaseId"
+                        options={unPublishedReleases.map(release => {
+                          return {
+                            label: release.title,
+                            value: release.id,
+                          };
+                        })}
+                        placeholder="Choose a release"
+                      />
+                    ),
+                  },
+                  {
+                    label: 'Immediately',
+                    value: 'Immediately',
+                  },
+                ]}
+              />
+            )}
+
+            <ButtonGroup>
+              <Button type="submit">Update status</Button>
+              <ButtonText
+                onClick={() => {
+                  form.resetForm();
+                  onCancel();
+                }}
+              >
+                Cancel
+              </ButtonText>
+            </ButtonGroup>
+          </Form>
+        );
+      }}
+    </Formik>
+  );
+};
+
+export default MethodologyStatusForm;

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
@@ -1,0 +1,256 @@
+import MethodologyStatusForm, {
+  FormValues,
+} from '@admin/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm';
+import { Release } from '@admin/services/releaseService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import noop from 'lodash/noop';
+import { BasicMethodology } from 'src/services/methodologyService';
+
+describe('MethodologyStatusForm', () => {
+  const testUnpublishedReleases: Release[] = [
+    {
+      id: 'test-release-1',
+      title: 'Test Release 1',
+    } as Release,
+    {
+      id: 'test-release-2',
+      title: 'Test Release 2',
+    } as Release,
+  ];
+
+  test('renders the form with draft initial values', () => {
+    render(
+      <MethodologyStatusForm
+        methodologySummary={
+          {
+            status: 'Draft',
+          } as BasicMethodology
+        }
+        showWithRelease // EES-2163 flag
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(screen.getByText('Edit methodology status')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+
+    const statuses = within(
+      screen.getByRole('group', { name: 'Status' }),
+    ).getAllByRole('radio');
+
+    expect(statuses).toHaveLength(2);
+    expect(statuses[0]).toHaveAttribute('value', 'Draft');
+    expect(statuses[0]).toBeEnabled();
+    expect(statuses[0]).toBeChecked();
+    expect(screen.getByLabelText('In draft')).toBeInTheDocument();
+
+    expect(statuses[1]).toHaveAttribute('value', 'Approved');
+    expect(statuses[1]).toBeEnabled();
+    expect(
+      screen.getByLabelText('Approved for publication'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('group', { name: 'When to publish' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders the form with approved status initial values', () => {
+    render(
+      <MethodologyStatusForm
+        methodologySummary={
+          {
+            status: 'Approved',
+            latestInternalReleaseNote: 'The latest note',
+          } as BasicMethodology
+        }
+        showWithRelease // EES-2163 flag
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    const approvedRadio = screen.getByLabelText('Approved for publication');
+    expect(approvedRadio).toBeChecked();
+
+    const noteField = screen.getByLabelText('Internal note');
+    expect(noteField).toHaveValue('The latest note');
+
+    expect(
+      screen.queryByRole('group', { name: 'When to publish' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders the form with publishing strategy initial values', () => {
+    render(
+      <MethodologyStatusForm
+        methodologySummary={
+          {
+            status: 'Approved',
+            latestInternalReleaseNote: 'The latest note',
+            publishingStrategy: 'WithRelease',
+            withReleaseId: 'test-release-2',
+          } as BasicMethodology
+        }
+        showWithRelease // EES-2163 flag
+        unPublishedReleases={testUnpublishedReleases}
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(screen.getByText('When to publish')).toBeInTheDocument();
+
+    const publishStatuses = within(
+      screen.getByRole('group', { name: 'When to publish' }),
+    ).getAllByRole('radio');
+
+    expect(publishStatuses[0]).toBeChecked();
+    expect(publishStatuses[0]).toBeEnabled();
+    expect(
+      screen.getByLabelText('With a specific release'),
+    ).toBeInTheDocument();
+
+    expect(publishStatuses[1]).not.toBeChecked();
+    expect(publishStatuses[1]).toBeEnabled();
+    expect(screen.getByLabelText('Immediately')).toBeInTheDocument();
+
+    const releaseSelect = screen.getByLabelText('Select release');
+    expect(releaseSelect.children.length).toBe(3);
+    expect(releaseSelect).toHaveValue('test-release-2');
+  });
+
+  test('Shows validation error if internal note is empty and status is approved', async () => {
+    render(
+      <MethodologyStatusForm
+        methodologySummary={
+          {
+            status: 'Draft',
+          } as BasicMethodology
+        }
+        showWithRelease // EES-2163 flag
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    userEvent.click(screen.getByLabelText('Approved for publication'));
+    userEvent.click(screen.getByLabelText('Internal note'));
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Enter an internal note' }),
+      ).toHaveAttribute(
+        'href',
+        '#methodologyStatusForm-latestInternalReleaseNote',
+      );
+    });
+  });
+
+  test('Shows validation error if a release is not selected when publish strategy is with release', async () => {
+    render(
+      <MethodologyStatusForm
+        methodologySummary={
+          {
+            status: 'Approved',
+          } as BasicMethodology
+        }
+        showWithRelease // EES-2163 flag
+        unPublishedReleases={testUnpublishedReleases}
+        onCancel={noop}
+        onSubmit={noop}
+      />,
+    );
+
+    userEvent.click(screen.getByLabelText('With a specific release'));
+    userEvent.click(screen.getByLabelText('Select release'));
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Select a release' }),
+      ).toHaveAttribute('href', '#methodologyStatusForm-withReleaseId');
+    });
+  });
+
+  test('Fails to submit with invalid values', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <MethodologyStatusForm
+        methodologySummary={
+          {
+            status: 'Approved',
+            publishingStrategy: 'WithRelease',
+          } as BasicMethodology
+        }
+        showWithRelease // EES-2163 flag
+        unPublishedReleases={testUnpublishedReleases}
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('There is a problem')).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Enter an internal note' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Select a release' }),
+      ).toBeInTheDocument();
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  test('Successfully submits with valid values', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <MethodologyStatusForm
+        methodologySummary={
+          {
+            status: 'Approved',
+            publishingStrategy: 'WithRelease',
+          } as BasicMethodology
+        }
+        showWithRelease // EES-2163 flag
+        unPublishedReleases={testUnpublishedReleases}
+        onCancel={noop}
+        onSubmit={handleSubmit}
+      />,
+    );
+
+    await userEvent.type(
+      screen.getByLabelText('Internal note'),
+      'Test release note',
+    );
+
+    await userEvent.selectOptions(screen.getByLabelText('Select release'), [
+      'test-release-1',
+    ]);
+
+    userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+    const expectedValues: FormValues = {
+      latestInternalReleaseNote: 'Test release note',
+      status: 'Approved',
+      publishingStrategy: 'WithRelease',
+      withReleaseId: 'test-release-1',
+    };
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith(
+        expectedValues,
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
@@ -11,12 +11,12 @@ import { BasicMethodology } from 'src/services/methodologyService';
 describe('MethodologyStatusForm', () => {
   const testUnpublishedReleases: Release[] = [
     {
-      id: 'test-release-1',
-      title: 'Test Release 1',
-    } as Release,
-    {
       id: 'test-release-2',
       title: 'Test Release 2',
+    } as Release,
+    {
+      id: 'test-release-1',
+      title: 'Test Release 1',
     } as Release,
   ];
 
@@ -37,21 +37,20 @@ describe('MethodologyStatusForm', () => {
     expect(screen.getByText('Edit methodology status')).toBeInTheDocument();
     expect(screen.getByText('Status')).toBeInTheDocument();
 
-    const statuses = within(
-      screen.getByRole('group', { name: 'Status' }),
-    ).getAllByRole('radio');
+    const statusGroup = within(screen.getByRole('group', { name: 'Status' }));
+    const statuses = statusGroup.getAllByRole('radio');
 
     expect(statuses).toHaveLength(2);
     expect(statuses[0]).toHaveAttribute('value', 'Draft');
     expect(statuses[0]).toBeEnabled();
     expect(statuses[0]).toBeChecked();
-    expect(screen.getByLabelText('In draft')).toBeInTheDocument();
+    expect(statuses[0]).toEqual(statusGroup.getByLabelText('In draft'));
 
     expect(statuses[1]).toHaveAttribute('value', 'Approved');
     expect(statuses[1]).toBeEnabled();
-    expect(
-      screen.getByLabelText('Approved for publication'),
-    ).toBeInTheDocument();
+    expect(statuses[1]).toEqual(
+      statusGroup.getByLabelText('Approved for publication'),
+    );
 
     expect(
       screen.queryByRole('group', { name: 'When to publish' }),
@@ -104,26 +103,37 @@ describe('MethodologyStatusForm', () => {
 
     expect(screen.getByText('When to publish')).toBeInTheDocument();
 
-    const publishStatuses = within(
+    const publishStatusGroup = within(
       screen.getByRole('group', { name: 'When to publish' }),
-    ).getAllByRole('radio');
+    );
+    const publishStatuses = publishStatusGroup.getAllByRole('radio');
 
     expect(publishStatuses[0]).toBeChecked();
     expect(publishStatuses[0]).toBeEnabled();
-    expect(
-      screen.getByLabelText('With a specific release'),
-    ).toBeInTheDocument();
+    expect(publishStatuses[0]).toEqual(
+      publishStatusGroup.getByLabelText('With a specific release'),
+    );
 
     expect(publishStatuses[1]).not.toBeChecked();
     expect(publishStatuses[1]).toBeEnabled();
-    expect(screen.getByLabelText('Immediately')).toBeInTheDocument();
+    expect(publishStatuses[1]).toEqual(
+      publishStatusGroup.getByLabelText('Immediately'),
+    );
 
     const releaseSelect = screen.getByLabelText('Select release');
     expect(releaseSelect.children.length).toBe(3);
+    expect(releaseSelect.children[0]).toHaveTextContent('Choose a release');
+    expect(releaseSelect.children[0]).toHaveValue('');
+    expect(releaseSelect.children[1]).toHaveTextContent('Test Release 1');
+    expect(releaseSelect.children[1]).toHaveValue('test-release-1');
+    expect(releaseSelect.children[2]).toHaveTextContent('Test Release 2');
+    expect(releaseSelect.children[2]).toHaveValue('test-release-2');
+
+    expect(releaseSelect).toHaveDisplayValue('Test Release 2');
     expect(releaseSelect).toHaveValue('test-release-2');
   });
 
-  test('Shows validation error if internal note is empty and status is approved', async () => {
+  test('shows validation error if internal note is empty and status is approved', async () => {
     render(
       <MethodologyStatusForm
         methodologySummary={
@@ -151,7 +161,7 @@ describe('MethodologyStatusForm', () => {
     });
   });
 
-  test('Shows validation error if a release is not selected when publish strategy is with release', async () => {
+  test('shows validation error if a release is not selected when publish strategy is with release', async () => {
     render(
       <MethodologyStatusForm
         methodologySummary={
@@ -172,12 +182,12 @@ describe('MethodologyStatusForm', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('link', { name: 'Select a release' }),
+        screen.getByRole('link', { name: 'Choose a release' }),
       ).toHaveAttribute('href', '#methodologyStatusForm-withReleaseId');
     });
   });
 
-  test('Fails to submit with invalid values', async () => {
+  test('fails to submit with invalid values', async () => {
     const handleSubmit = jest.fn();
 
     render(
@@ -203,14 +213,14 @@ describe('MethodologyStatusForm', () => {
         screen.getByRole('link', { name: 'Enter an internal note' }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('link', { name: 'Select a release' }),
+        screen.getByRole('link', { name: 'Choose a release' }),
       ).toBeInTheDocument();
 
       expect(handleSubmit).not.toHaveBeenCalled();
     });
   });
 
-  test('Successfully submits with valid values', async () => {
+  test('successfully submits with valid values', async () => {
     const handleSubmit = jest.fn();
 
     render(

--- a/src/explore-education-statistics-admin/src/services/methodologyService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyService.ts
@@ -5,6 +5,7 @@ export type UpdateMethodology = {
 };
 
 export type MethodologyStatus = 'Draft' | 'Approved';
+export type MethodologyPublishingStrategy = 'WithRelease' | 'Immediately';
 
 interface MethodologyPublication {
   id: string;
@@ -15,13 +16,16 @@ export interface BasicMethodology {
   amendment: boolean;
   id: string;
   internalReleaseNote?: string;
+  latestInternalReleaseNote?: string;
   previousVersionId?: string;
+  publishingStrategy?: MethodologyPublishingStrategy;
   title: string;
   slug: string;
   status: MethodologyStatus;
   published?: string;
   publication: MethodologyPublication;
   otherPublications?: MethodologyPublication[];
+  withReleaseId?: string;
 }
 
 export interface MyMethodology extends BasicMethodology {


### PR DESCRIPTION
Adds a 'When to publish' section to the methodology sign off form allow users to select a release to publish the methodology with.

I've copied and adapted the UI for setting a publish date on releases.

I've had to make some guesses & assumptions so will likely need a bit of tweaking when the BE is hooked up. 

This is hidden under the showWithRelease flag in the component, you'll need to flip it to true to see it. When the backend is ready this flag can be removed. With the flag set to false it should work as now so is safe to merge to dev.

![Screenshot (41)](https://user-images.githubusercontent.com/81572860/127162923-c8577454-1b88-4cb2-85bc-d690e21ee32c.png)
