### PR TITLE
EES-2575 Upgrade to C# 9 without .NET 5

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
@@ -2,10 +2,12 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>9.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="Snapshooter.Xunit" Version="0.6.2" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
@@ -2,10 +2,12 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>9.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>9.0</LangVersion>
         <AssemblyName>GovUk.Education.ExploreEducationStatistics.Content.Api</AssemblyName>
         <RootNamespace>GovUk.Education.ExploreEducationStatistics.Content.Api</RootNamespace>
     </PropertyGroup>
@@ -9,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="10.1.1" />
         <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
         <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.7" />
         <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.7" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj
@@ -2,11 +2,13 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>9.0</LangVersion>
         <IsPackable>false</IsPackable>
         <RootNamespace>GovUk.Education.ExploreEducationStatistics.Content.Model.Tests</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/GovUk.Education.ExploreEducationStatistics.Content.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/GovUk.Education.ExploreEducationStatistics.Content.Model.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="JsonKnownTypes" Version="0.4.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.csproj
@@ -2,9 +2,11 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/GovUk.Education.ExploreEducationStatistics.Content.Security.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/GovUk.Education.ExploreEducationStatistics.Content.Security.csproj
@@ -2,10 +2,11 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.5" />
     </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>GovUk.Education.ExploreEducationStatistics.Data.Api</AssemblyName>
     <RootNamespace>GovUk.Education.ExploreEducationStatistics.Data.Api</RootNamespace>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.7" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.csproj
@@ -2,9 +2,11 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
@@ -2,10 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Model/GovUk.Education.ExploreEducationStatistics.Data.Processor.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Model/GovUk.Education.ExploreEducationStatistics.Data.Processor.Model.csproj
@@ -2,6 +2,10 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
+    <ItemGroup>
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
+    </ItemGroup>
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.csproj
@@ -2,11 +2,12 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>9.0</LangVersion>
         <RootNamespace>GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/GovUk.Education.ExploreEducationStatistics.Data.Processor.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/GovUk.Education.ExploreEducationStatistics.Data.Processor.csproj
@@ -2,9 +2,11 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="15.0.1" />
+    <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.csproj
@@ -2,11 +2,12 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>9.0</LangVersion>
         <RootNamespace>GovUk.Education.ExploreEducationStatistics.Data.Services.Tests</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/GovUk.Education.ExploreEducationStatistics.Data.Services.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/GovUk.Education.ExploreEducationStatistics.Data.Services.csproj
@@ -2,11 +2,12 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="9.0.0" />
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.5" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/GovUk.Education.ExploreEducationStatistics.Notifier.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/GovUk.Education.ExploreEducationStatistics.Notifier.Model.csproj
@@ -2,7 +2,10 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
+    <ItemGroup>
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
+    </ItemGroup>
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/GovUk.Education.ExploreEducationStatistics.Publisher.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/GovUk.Education.ExploreEducationStatistics.Publisher.Model.csproj
@@ -2,10 +2,12 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.7" />
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.7" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/GovUk.Education.ExploreEducationStatistics.Publisher.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/GovUk.Education.ExploreEducationStatistics.Publisher.Tests.csproj
@@ -2,11 +2,12 @@
 
     <PropertyGroup>
         <TargetFramework>netcoreapp3.1</TargetFramework>
-
+        <LangVersion>9.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="Snapshooter.Xunit" Version="0.6.2" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>9.0</LangVersion>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.0-alpha-844" />
     <PackageReference Include="AutoMapper" Version="9.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.DataFactory" Version="4.7.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.0.0-preview" />


### PR DESCRIPTION
This was really easy to do as it just involves adding the [IsExternalInit](https://github.com/manuelroemer/IsExternalInit) package to get it working.

With this, we can get C# 9 features whilst avoiding general migration pain for upgrading to .NET 5. I found the main barrier to upgrading to .NET 5  was that Azure Functions didn't really work correctly. It appears that there will be proper support for .NET 6 in November, so it's worth waiting until then for us to do that upgrade.

All UI tests have been ran and there are no failures to speak of.

## Highlights

C# 9 gives us few really nice new features:

- Records - https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#record-types
- Init only setters - https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#init-only-setters
- Can omit explicit types for `new` declarations - https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#fit-and-finish-features
- Better pattern matching for switch expressions - https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#pattern-matching-enhancements
- Immutable copying with new `with` keyword - https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-9#nondestructive-mutation

## Recommendations

Based on the above features I would make the following suggestions to our code moving forward:

- Records should be pretty much used by default for all DTO-like types (view models, etc).
- Init setters should be used instead of standard setters, unless you need to be able to mutate a field later (hardly if ever). You can instead use the `with` keyword in most cases.
- Use the omitted type `new` declaration where possible - I don't think this should necessarily be a hard and fast rule though.

## Caveats

Note that **not all** features of C# 9 will work without the latest and great runtime that is included in .NET 5/6 e.g. covariant return types.