### PR TITLE
Ees 2530 put methodologies under subheading

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
@@ -114,11 +114,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
             
             // If the Publication Title changed, also change the OwningPublicationTitles of any Methodologies
             // that are owned by this Publication
-            var ownedMethodologyParents = _contentDbContext
+            var ownedMethodologyParents = await _contentDbContext
                 .PublicationMethodologies
                 .Include(m => m.MethodologyParent)
                 .Where(m => m.PublicationId == publicationId && m.Owner)
-                .Select(m => m.MethodologyParent);
+                .Select(m => m.MethodologyParent)
+                .ToListAsync();
 
             await ownedMethodologyParents.ForEachAsync(async methodologyParent =>
             {

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/RelatedPagesSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/RelatedPagesSection.tsx
@@ -96,12 +96,12 @@ const RelatedPagesSection = ({ release }: Props) => {
     <>
       {(editingMode === 'edit' || links.length > 0) && (
         <>
-          <h2
+          <h3
             className="govuk-heading-s govuk-!-margin-top-6"
             id="related-pages"
           >
             Related pages
-          </h2>
+          </h3>
           <nav role="navigation" aria-labelledby="related-content">
             <ul className="govuk-list">
               {links.map(({ id, description, url }) => (

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -190,15 +190,6 @@ const ReleaseContent = () => {
                   View data and files
                 </a>
               </li>
-              {allMethodologies.map(methodology => (
-                <li key={methodology.key}>
-                  {editingMode === 'edit' ? (
-                    <a>{methodology.title}</a>
-                  ) : (
-                    <Link to={methodology.url}>{methodology.title}</Link>
-                  )}
-                </li>
-              ))}
               {release.hasMetaGuidance && (
                 <li>
                   <Link
@@ -277,6 +268,27 @@ const ReleaseContent = () => {
                 )}
               </dd>
             </dl>
+            {allMethodologies.length > 0 && (
+              <>
+                <h2
+                  className="govuk-heading-s govuk-!-margin-top-6"
+                  id="methodologies"
+                >
+                  Methodologies
+                </h2>
+                <ul className="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
+                  {allMethodologies.map(methodology => (
+                    <li key={methodology.key}>
+                      {editingMode === 'edit' ? (
+                        <a>{methodology.title}</a>
+                      ) : (
+                        <Link to={methodology.url}>{methodology.title}</Link>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
             <RelatedPagesSection release={release} />
           </RelatedAside>
         </div>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -270,12 +270,12 @@ const ReleaseContent = () => {
             </dl>
             {allMethodologies.length > 0 && (
               <>
-                <h2
+                <h3
                   className="govuk-heading-s govuk-!-margin-top-6"
                   id="methodologies"
                 >
                   Methodologies
-                </h2>
+                </h3>
                 <ul className="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
                   {allMethodologies.map(methodology => (
                     <li key={methodology.key}>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -279,12 +279,12 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
             </nav>
             {release.publication.methodologies.length > 0 && (
               <>
-                <h2
+                <h3
                   className="govuk-heading-s govuk-!-margin-top-6"
                   id="methodologies"
                 >
                   Methodologies
-                </h2>
+                </h3>
                 <ul className="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
                   {release.publication.methodologies.map(methodology => (
                     <li key={methodology.id}>
@@ -312,12 +312,12 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
             )}
             {release.relatedInformation.length > 0 && (
               <>
-                <h2
+                <h3
                   className="govuk-heading-s govuk-!-margin-top-6"
                   id="related-pages"
                 >
                   Related pages
-                </h2>
+                </h3>
                 <nav role="navigation" aria-labelledby="related-pages">
                   <ul className="govuk-list">
                     {release.relatedInformation &&

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -193,27 +193,6 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                     View data and files
                   </a>
                 </li>
-                {release.publication.methodologies.map(methodology => (
-                  <li key={methodology.id}>
-                    <Link
-                      to="/methodology/[methodology]"
-                      as={`/methodology/${methodology.slug}`}
-                    >
-                      {methodology.title}
-                    </Link>
-                  </li>
-                ))}
-                {release.publication.externalMethodology && (
-                  <li>
-                    <Link
-                      to={release.publication.externalMethodology.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {release.publication.externalMethodology.title}
-                    </Link>
-                  </li>
-                )}
                 {release.hasMetaGuidance && (
                   <li>
                     <Link
@@ -298,7 +277,40 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                 )}
               </ul>
             </nav>
-            {release.relatedInformation.length !== 0 && (
+            {release.publication.methodologies.length > 0 && (
+              <>
+                <h2
+                  className="govuk-heading-s govuk-!-margin-top-6"
+                  id="methodologies"
+                >
+                  Methodologies
+                </h2>
+                <ul className="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
+                  {release.publication.methodologies.map(methodology => (
+                    <li key={methodology.id}>
+                      <Link
+                        to="/methodology/[methodology]"
+                        as={`/methodology/${methodology.slug}`}
+                      >
+                        {methodology.title}
+                      </Link>
+                    </li>
+                  ))}
+                  {release.publication.externalMethodology && (
+                    <li>
+                      <Link
+                        to={release.publication.externalMethodology.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {release.publication.externalMethodology.title}
+                      </Link>
+                    </li>
+                  )}
+                </ul>
+              </>
+            )}
+            {release.relatedInformation.length > 0 && (
               <>
                 <h2
                   className="govuk-heading-s govuk-!-margin-top-6"

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
@@ -2,7 +2,6 @@ import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
 import FormattedDate from '@common/components/FormattedDate';
 import RelatedAside from '@common/components/RelatedAside';
-import MethodologySectionBlocks from '@frontend/modules/methodologies/components/MethodologySectionBlocks';
 import methodologyService, {
   Methodology,
 } from '@common/services/methodologyService';
@@ -11,6 +10,7 @@ import Page from '@frontend/components/Page';
 import PageSearchFormWithAnalytics from '@frontend/components/PageSearchFormWithAnalytics';
 import PrintThisPage from '@frontend/components/PrintThisPage';
 import MethodologyContentSection from '@frontend/modules/methodologies/components/MethodologyContentSection';
+import MethodologySectionBlocks from '@frontend/modules/methodologies/components/MethodologySectionBlocks';
 import { logEvent } from '@frontend/services/googleAnalyticsService';
 import { GetServerSideProps, NextPage } from 'next';
 import React from 'react';
@@ -26,6 +26,7 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
       title={data.title}
       description="Find out how and why we collect, process and publish these statistics"
       breadcrumbs={[{ name: 'Methodologies', link: '/methodology' }]}
+      caption="Methodology"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">


### PR DESCRIPTION
This PR:
- rearranges the list of Methodology links on the Admin and Public Release content pages to sit under a "Methodologies" subheading
- adds the "Methodology" caption to the Public Methodology page to make it more obvious to the user as to what kind of page it is
- fixes a bug whereby a set of MethodologyParents weren't fully fetched before the contentDbContext was used for further operations