### PR TITLE
EES-XXXX - setting Created and CreatedById when creating new Methodol…

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -28,7 +28,6 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockU
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
 using static Moq.MockBehavior;
-using Range = Moq.Range;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies
 {
@@ -67,13 +66,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 };
 
                 repository
-                    .Setup(s => s.CreateMethodologyForPublication(
-                        publication.Id, 
-                        It.IsInRange(
-                            DateTime.UtcNow.AddMilliseconds(-1500), 
-                            DateTime.UtcNow.AddMilliseconds(1500), 
-                            Range.Inclusive),
-                        UserId))
+                    .Setup(s => s.CreateMethodologyForPublication(publication.Id, UserId))
                     .ReturnsAsync(createdMethodology);
 
                 var result = await service.CreateMethodology(publication.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -28,11 +28,14 @@ using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockU
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
 using static Moq.MockBehavior;
+using Range = Moq.Range;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies
 {
     public class MethodologyServiceTests
     {
+        private static readonly Guid UserId = Guid.NewGuid();
+        
         [Fact]
         public async Task CreateMethodology()
         {
@@ -64,7 +67,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 };
 
                 repository
-                    .Setup(s => s.CreateMethodologyForPublication(publication.Id))
+                    .Setup(s => s.CreateMethodologyForPublication(
+                        publication.Id, 
+                        It.IsInRange(
+                            DateTime.UtcNow.AddMilliseconds(-1500), 
+                            DateTime.UtcNow.AddMilliseconds(1500), 
+                            Range.Inclusive),
+                        UserId))
                     .ReturnsAsync(createdMethodology);
 
                 var result = await service.CreateMethodology(publication.Id);
@@ -1188,7 +1197,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 methodologyRepository ?? new Mock<IMethodologyRepository>().Object,
                 methodologyImageService ?? new Mock<IMethodologyImageService>().Object,
                 publishingService ?? new Mock<IPublishingService>().Object,
-                userService ?? AlwaysTrueUserService().Object);
+                userService ?? AlwaysTrueUserService(UserId).Object);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -68,10 +68,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             return _persistenceHelper
                 .CheckEntityExists<Publication>(publicationId)
                 .OnSuccess(_userService.CheckCanCreateMethodologyForPublication)
-                .OnSuccess(() => _methodologyRepository.CreateMethodologyForPublication(
-                    publicationId, 
-                    DateTime.UtcNow, 
-                    _userService.GetUserId())
+                .OnSuccess(() => _methodologyRepository
+                    .CreateMethodologyForPublication(publicationId, _userService.GetUserId())
                 )
                 .OnSuccess(_mapper.Map<MethodologySummaryViewModel>);
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -68,7 +68,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             return _persistenceHelper
                 .CheckEntityExists<Publication>(publicationId)
                 .OnSuccess(_userService.CheckCanCreateMethodologyForPublication)
-                .OnSuccess(() => _methodologyRepository.CreateMethodologyForPublication(publicationId))
+                .OnSuccess(() => _methodologyRepository.CreateMethodologyForPublication(
+                    publicationId, 
+                    DateTime.UtcNow, 
+                    _userService.GetUserId())
+                )
                 .OnSuccess(_mapper.Map<MethodologySummaryViewModel>);
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyRepositoryTests.cs
@@ -17,8 +17,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
 {
     public class MethodologyRepositoryTests
     {
-        private static readonly Guid UserId = Guid.NewGuid();
-        
         [Fact]
         public async Task CreateMethodologyForPublication()
         {
@@ -27,6 +25,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 Title = "The Publication Title",
                 Slug = "the-publication-slug"
             };
+
+            var userId = Guid.NewGuid();
+            var createdDate = DateTime.UtcNow.AddDays(-2);
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
@@ -41,7 +42,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = BuildMethodologyRepository(contentDbContext);
-                var methodology = await service.CreateMethodologyForPublication(publication.Id);
+                var methodology = await service.CreateMethodologyForPublication(publication.Id, createdDate, userId);
                 await contentDbContext.SaveChangesAsync();
                 methodologyId = methodology.Id;
             }
@@ -63,9 +64,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 Assert.Equal(savedPublication, methodology.MethodologyParent.Publications[0].Publication);
                 Assert.Equal(savedPublication.Title, methodology.Title);
                 Assert.Equal(savedPublication.Slug, methodology.Slug);
-                Assert.NotNull(methodology.Created);
-                Assert.InRange(DateTime.UtcNow.Subtract((DateTime) methodology.Created).Milliseconds, 0, 1500);
-                Assert.Equal(UserId, methodology.CreatedById);
+                Assert.Equal(createdDate, methodology.Created);
+                Assert.Equal(userId, methodology.CreatedById);
             }
         }
 
@@ -1501,8 +1501,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         {
             return new MethodologyRepository(
                 contentDbContext,
-                methodologyParentRepository ?? new Mock<IMethodologyParentRepository>().Object,
-                MockUtils.AlwaysTrueUserService(UserId).Object);
+                methodologyParentRepository ?? new Mock<IMethodologyParentRepository>().Object);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyRepositoryTests.cs
@@ -27,7 +27,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             };
 
             var userId = Guid.NewGuid();
-            var createdDate = DateTime.UtcNow.AddDays(-2);
 
             var contentDbContextId = Guid.NewGuid().ToString();
 
@@ -42,7 +41,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 var service = BuildMethodologyRepository(contentDbContext);
-                var methodology = await service.CreateMethodologyForPublication(publication.Id, createdDate, userId);
+                var methodology = await service.CreateMethodologyForPublication(publication.Id, userId);
                 await contentDbContext.SaveChangesAsync();
                 methodologyId = methodology.Id;
             }
@@ -64,7 +63,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 Assert.Equal(savedPublication, methodology.MethodologyParent.Publications[0].Publication);
                 Assert.Equal(savedPublication.Title, methodology.Title);
                 Assert.Equal(savedPublication.Slug, methodology.Slug);
-                Assert.Equal(createdDate, methodology.Created);
+                Assert.NotNull(methodology.Created);
+                Assert.InRange(DateTime.UtcNow.Subtract((DateTime) methodology.Created).Milliseconds, 0, 1500);
                 Assert.Equal(userId, methodology.CreatedById);
             }
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyRepositoryTests.cs
@@ -17,6 +17,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
 {
     public class MethodologyRepositoryTests
     {
+        private static readonly Guid UserId = Guid.NewGuid();
+        
         [Fact]
         public async Task CreateMethodologyForPublication()
         {
@@ -61,6 +63,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                 Assert.Equal(savedPublication, methodology.MethodologyParent.Publications[0].Publication);
                 Assert.Equal(savedPublication.Title, methodology.Title);
                 Assert.Equal(savedPublication.Slug, methodology.Slug);
+                Assert.NotNull(methodology.Created);
+                Assert.InRange(DateTime.UtcNow.Subtract((DateTime) methodology.Created).Milliseconds, 0, 1500);
+                Assert.Equal(UserId, methodology.CreatedById);
             }
         }
 
@@ -1496,7 +1501,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
         {
             return new MethodologyRepository(
                 contentDbContext,
-                methodologyParentRepository ?? new Mock<IMethodologyParentRepository>().Object);
+                methodologyParentRepository ?? new Mock<IMethodologyParentRepository>().Object,
+                MockUtils.AlwaysTrueUserService(UserId).Object);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyRepository.cs
@@ -6,7 +6,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 {
     public interface IMethodologyRepository
     {
-        Task<Methodology> CreateMethodologyForPublication(Guid publicationId);
+        Task<Methodology> CreateMethodologyForPublication(
+            Guid publicationId, 
+            DateTime createdDate, 
+            Guid createdByUserId);
 
         Task<List<Methodology>> GetLatestByPublication(Guid publicationId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyRepository.cs
@@ -6,10 +6,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
 {
     public interface IMethodologyRepository
     {
-        Task<Methodology> CreateMethodologyForPublication(
-            Guid publicationId, 
-            DateTime createdDate, 
-            Guid createdByUserId);
+        Task<Methodology> CreateMethodologyForPublication(Guid publicationId, Guid createdByUserId);
 
         Task<List<Methodology>> GetLatestByPublication(Guid publicationId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -15,12 +16,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
     {
         private readonly ContentDbContext _contentDbContext;
         private readonly IMethodologyParentRepository _methodologyParentRepository;
+        private readonly IUserService _userService;
 
         public MethodologyRepository(ContentDbContext contentDbContext,
-            IMethodologyParentRepository methodologyParentRepository)
+            IMethodologyParentRepository methodologyParentRepository, 
+            IUserService userService)
         {
             _contentDbContext = contentDbContext;
             _methodologyParentRepository = methodologyParentRepository;
+            _userService = userService;
         }
 
         public async Task<Methodology> CreateMethodologyForPublication(Guid publicationId)
@@ -44,7 +48,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                             PublicationId = publicationId
                         }
                     }
-                }
+                },
+                Created = DateTime.UtcNow,
+                CreatedById = _userService.GetUserId()
             })).Entity;
 
             await _contentDbContext.SaveChangesAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
@@ -16,18 +16,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
     {
         private readonly ContentDbContext _contentDbContext;
         private readonly IMethodologyParentRepository _methodologyParentRepository;
-        private readonly IUserService _userService;
 
         public MethodologyRepository(ContentDbContext contentDbContext,
-            IMethodologyParentRepository methodologyParentRepository, 
-            IUserService userService)
+            IMethodologyParentRepository methodologyParentRepository)
         {
             _contentDbContext = contentDbContext;
             _methodologyParentRepository = methodologyParentRepository;
-            _userService = userService;
         }
 
-        public async Task<Methodology> CreateMethodologyForPublication(Guid publicationId)
+        public async Task<Methodology> CreateMethodologyForPublication(
+            Guid publicationId, 
+            DateTime createdDate, 
+            Guid createdByUserId)
         {
             var publication = await _contentDbContext
                 .Publications
@@ -49,8 +49,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                         }
                     }
                 },
-                Created = DateTime.UtcNow,
-                CreatedById = _userService.GetUserId()
+                Created = createdDate,
+                CreatedById = createdByUserId
             })).Entity;
 
             await _contentDbContext.SaveChangesAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
@@ -24,10 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
             _methodologyParentRepository = methodologyParentRepository;
         }
 
-        public async Task<Methodology> CreateMethodologyForPublication(
-            Guid publicationId, 
-            DateTime createdDate, 
-            Guid createdByUserId)
+        public async Task<Methodology> CreateMethodologyForPublication(Guid publicationId, Guid createdByUserId)
         {
             var publication = await _contentDbContext
                 .Publications
@@ -49,7 +46,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                         }
                     }
                 },
-                Created = createdDate,
+                Created = DateTime.UtcNow,
                 CreatedById = createdByUserId
             })).Entity;
 


### PR DESCRIPTION
This PR:
- adds the created date and user id to newly-created Methodology versions.

As a follow-up to this, we should perform some cleanup to make the Created and CreatedById columns mandatory.