### PR TITLE
EES-2585 - clean-up remaining UI test timeouts

### DIFF
--- a/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
@@ -56,7 +56,7 @@ Validate Analyst1 can see 'Content' page
 
 Validate Analyst1 can see 'Content' page key stats
     [Tags]    HappyPath
-    user waits until page contains element    id:releaseHeadlines    360
+    user waits until page contains element    id:releaseHeadlines    %{WAIT_LONG}
     user waits until page does not contain loading spinner
     user scrolls to element    id:releaseHeadlines
     user checks key stat contents    1    Overall absence rate    4.7%    Up from 4.6% in 2015/16    90

--- a/tests/robot-tests/tests/general_public/methodologies_page.robot
+++ b/tests/robot-tests/tests/general_public/methodologies_page.robot
@@ -30,6 +30,7 @@ Validate page contents
     ...    Pupil absence in schools in England
     ...    Pupil absence statistics: methodology
     ...    %{PUBLIC_URL}/methodology/pupil-absence-in-schools-in-england
+    user waits until page contains title caption  Methodology
 
 Validate Related information section links exist
     [Tags]    HappyPath

--- a/tests/robot-tests/tests/general_public/methodology_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/methodology_page_absence.robot
@@ -29,6 +29,7 @@ User navigates to absence methodology page
     ...    Pupil absence in schools in England
     ...    Pupil absence statistics: methodology
     user waits until h1 is visible    Pupil absence statistics: methodology
+    user waits until page contains title caption  Methodology
 
 Validate Published date, Last updated date
     [Tags]    HappyPath


### PR DESCRIPTION
This PR cleans up 1 instance of a high timeout that can be replaced with the new variable `%{WAIT_LONG}`. In addition to this, I've added additional assertions for the new page captions on methodology slug pages