### PR TITLE
Ees 2572 - refactor CLI to use common services

### DIFF
--- a/useful-scripts/misc-test-utils/src/index.ts
+++ b/useful-scripts/misc-test-utils/src/index.ts
@@ -1,9 +1,9 @@
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import 'dotenv-safe/config';
-import createReleaseAndPublish from './modules/publication/publishPublication';
-import createPublicationAndRelease from './modules/release/createRelease';
 import uploadSingleSubject from './modules/subject/uploadSubject';
+import createPublicationAndRelease from './modules/release/createRelease';
+import createReleaseAndPublish from './modules/publication/publishPublication';
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 

--- a/useful-scripts/misc-test-utils/src/index.ts
+++ b/useful-scripts/misc-test-utils/src/index.ts
@@ -4,6 +4,7 @@ import 'dotenv-safe/config';
 import uploadSingleSubject from './modules/subject/uploadSubject';
 import createPublicationAndRelease from './modules/release/createRelease';
 import createReleaseAndPublish from './modules/publication/publishPublication';
+import errorHandler from './utils/errorHandler';
 
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
@@ -21,31 +22,34 @@ const start = async () => {
     choices,
     prefix: '>',
   });
+  try {
+    switch (answers.test) {
+      case 'create new release':
+        await createPublicationAndRelease();
+        break;
 
-  switch (answers.test) {
-    case 'create new release':
-      await createPublicationAndRelease();
-      break;
+      case 'publish a new release':
+        await createReleaseAndPublish();
+        break;
 
-    case 'publish a new release':
-      await createReleaseAndPublish();
-      break;
+      case 'upload subject':
+        // eslint-disable-next-line no-case-declarations
+        const release = await inquirer.prompt({
+          name: 'id',
+          type: 'input',
+          message: 'Release ID from existing publication',
+          prefix: '>',
+        });
 
-    case 'upload subject':
-      // eslint-disable-next-line no-case-declarations
-      const release = await inquirer.prompt({
-        name: 'id',
-        type: 'input',
-        message: 'Release ID from existing publication',
-        prefix: '>',
-      });
+        await uploadSingleSubject(release.id);
+        break;
 
-      await uploadSingleSubject(release.id);
-      break;
-
-    default:
-      // eslint-disable-next-line no-console
-      console.error(chalk.red('Invalid action:', answers.test));
+      default:
+        // eslint-disable-next-line no-console
+        console.error(chalk.red('Invalid action:', answers.test));
+    }
+  } catch (e) {
+    errorHandler(e);
   }
 };
 start();

--- a/useful-scripts/misc-test-utils/src/modules/publication/publishPublication.ts
+++ b/useful-scripts/misc-test-utils/src/modules/publication/publishPublication.ts
@@ -1,390 +1,30 @@
 /* eslint-disable no-console */
-import axios from 'axios';
 import chalk from 'chalk';
-import FormData from 'form-data';
-import fs from 'fs';
-import globby from 'globby';
-import StreamZip from 'node-stream-zip';
-import path from 'path';
-import rimraf from 'rimraf';
 import { v4 } from 'uuid';
+import publicationService from '../../services/publicationService';
 import { projectRoot } from '../../config';
-import { ReleaseData } from '../../types/ReleaseData';
-import { SubjectData } from '../../types/SubjectData';
-import errorHandler from '../../utils/errorHandler';
-import sleep from '../../utils/sleep';
+import releaseService from '../../services/releaseService';
+import commonService from '../../services/commonService';
 import ZipDirectory from '../../utils/zipDirectory';
+import sleep from '../../utils/sleep';
+import subjectService from '../../services/subjectService';
 
-// disable insecure warnings
-const { ADMIN_URL, TOPIC_ID, JWT_TOKEN } = process.env;
 const cwd = projectRoot;
 
-const createPublication = async () => {
-  console.time('createPublication');
-
-  try {
-    const res = await axios({
-      method: 'POST',
-      url: `${ADMIN_URL}/api/publications`,
-      data: {
-        title: `importer-testing-${v4()}`,
-        topicId: TOPIC_ID,
-        contact: {
-          teamName: 'testing',
-          teamEmail: 'johndoe@gmail.com',
-          contactName: 'John Doe',
-          contactTelNo: '123456789',
-        },
-      },
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${JWT_TOKEN}`,
-      },
-    });
-
-    console.timeEnd('createPublication');
-    console.log(chalk.green(`Created publication. Status code ${res.status}`));
-
-    return res.data.id;
-  } catch (e) {
-    errorHandler(e);
-  }
-  return null;
-};
-
-const createRelease = async (publicationId: string): Promise<string | null> => {
-  console.time('createRelease');
-  try {
-    const res = await axios({
-      method: 'POST',
-      url: `${ADMIN_URL}/api/publications/${publicationId}/releases`,
-      data: {
-        timePeriodCoverage: { value: 'AY' },
-        releaseName: 2222,
-        typeId: '1821abb8-68b0-431b-9770-0bea65d02ff0',
-        publicationId: 'c76c1bc4-0a01-4116-74cd-08d8eebbf0c1',
-        templateReleaseId: '',
-      },
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${JWT_TOKEN}`,
-      },
-    });
-
-    console.timeEnd('createRelease');
-
-    const releaseId = res.data.id;
-
-    console.log(
-      chalk.green(
-        `Release URL: ${ADMIN_URL}/publication/${publicationId}/release/${releaseId}/data`,
-      ),
-    );
-    return releaseId;
-  } catch (e) {
-    errorHandler(e);
-  }
-  return null;
-};
-
-const extractZip = async () => {
-  const zippedFile = await globby(`${cwd}/*.zip`);
-  const cleanZipFile = zippedFile[0];
-  const archive = fs.existsSync(zippedFile[0]);
-  if (archive) {
-    // eslint-disable-next-line new-cap
-    const zip = new StreamZip.async({ file: cleanZipFile });
-    const count = await zip.extract(null, `${cwd}/test-files`);
-    console.log(chalk.green(`Extracted ${count} entries to test-files`));
-    await zip.close();
-  }
-};
-
-const renameFiles = async () => {
-  // define a random id to assign to the renamed data & meta file...
-  const randomId = Math.floor(Math.random() * 1000000);
-
-  // rename csv file..
-  const csvGlob1 = await globby(`${cwd}/test-files/*.csv`);
-
-  const csvGlob2 = csvGlob1[0];
-
-  fs.rename(`${csvGlob2}`, `${cwd}/test-files/testfile-${randomId}.csv`, e =>
-    e ? console.error(chalk.red(e)) : '',
-  );
-
-  // rename the meta file...
-  const metaGlob = await globby(`${cwd}/test-files/*.meta.csv`);
-  const metaGlob2 = metaGlob[0];
-
-  fs.rename(
-    `${metaGlob2}`,
-    `${cwd}/test-files/testfile-${randomId}.meta.csv`,
-    e => (e ? console.error(chalk.red(e)) : ''),
-  );
-};
-
-const addSubject = async (releaseId: string): Promise<string | null> => {
-  const finalZipFileGlob = await globby(
-    `${cwd}/zip-files/clean-test-zip-*.zip`,
-  );
-
-  const oldPath = finalZipFileGlob[0];
-
-  const newPath = path.resolve(oldPath, '..', path.basename(oldPath));
-  fs.renameSync(oldPath, newPath);
-
-  const form = new FormData();
-  form.append('zipFile', fs.createReadStream(newPath));
-
-  try {
-    const res = await axios({
-      maxContentLength: Infinity,
-      maxBodyLength: Infinity,
-      method: 'POST',
-      url: `${ADMIN_URL}/api/release/${releaseId}/zip-data?name=importer-subject-${v4()}`,
-      data: form,
-      headers: {
-        ...form.getHeaders(),
-        Authorization: `Bearer ${JWT_TOKEN}`,
-      },
-    });
-
-    return res.data.id;
-  } catch (e) {
-    errorHandler(e);
-  }
-
-  return null;
-};
-
-const getSubjectProgress = async (
-  releaseId: string,
-  subjectId: string,
-  // eslint-disable-next-line consistent-return
-) => {
-  try {
-    const res = await axios({
-      method: 'GET',
-      url: `${ADMIN_URL}/api/release/${releaseId}/data/${subjectId}/import/status`,
-      headers: {
-        Authorization: `Bearer ${JWT_TOKEN}`,
-        'Content-Type': 'application/json',
-      },
-    });
-    if (!res.data.status) {
-      console.info(
-        chalk.cyan(
-          'No import status available. Waiting 3 seconds before polling the API',
-        ),
-      );
-      await sleep(3000);
-    }
-    return res.data.status;
-  } catch (e) {
-    errorHandler(e);
-  }
-};
-
-const getSubjectIdArr = async (
-  releaseId: string,
-): Promise<{ id: string; content: string }[] | null> => {
-  try {
-    const res = await axios({
-      method: 'GET',
-      url: `${ADMIN_URL}/api/release/${releaseId}/meta-guidance`,
-      headers: {
-        Authorization: `Bearer ${JWT_TOKEN}`,
-        'Content-Type': 'application/json',
-      },
-    });
-    const subjects: SubjectData[] = res.data?.subjects;
-    const subjArr: { id: string; content: string }[] = [];
-    subjects.forEach(sub => {
-      subjArr.push({ id: sub.id, content: `Hello ${v4()}` });
-    });
-    return subjArr;
-  } catch (e) {
-    errorHandler(e);
-  }
-  return null;
-};
-
-const addMetaGuidance = async (
-  subjArr: { id: string; content: string }[],
-  releaseId: string,
-): Promise<boolean> => {
-  try {
-    await axios({
-      method: 'PATCH',
-      url: `${ADMIN_URL}/api/release/${releaseId}/meta-guidance`,
-      headers: {
-        Authorization: `Bearer ${JWT_TOKEN}`,
-        'Content-Type': 'application/json',
-      },
-      data: {
-        content: '<p>testing</p>',
-        subjects: subjArr,
-      },
-    });
-    return true;
-  } catch (e) {
-    errorHandler(e);
-  }
-  return false;
-};
-
-const getFinalReleaseDetails = async (releaseId: string) => {
-  try {
-    const res = await axios({
-      method: 'GET',
-      url: `${ADMIN_URL}/api/releases/${releaseId}`,
-      headers: {
-        Authorization: `Bearer ${JWT_TOKEN}`,
-        'Content-Type': 'application/json',
-      },
-    });
-    const releaseData: ReleaseData = res.data;
-
-    await sleep(1000);
-
-    return {
-      id: releaseData.id,
-      title: releaseData.title,
-      slug: releaseData.slug,
-      publicationId: releaseData.publicationId,
-      publicationTitle: releaseData.publicationTitle,
-      publicationSlug: releaseData.publicationSlug,
-      releaseName: releaseData.releaseName,
-      yearTitle: releaseData.yearTitle,
-      typeId: releaseData.typeId,
-      live: 'false',
-      timePeriodCoverage: {
-        value: releaseData.timePeriodCoverage.value,
-        label: releaseData.timePeriodCoverage.label,
-      },
-      preReleaseAccessList: '',
-      latestRelease: 'false',
-      type: {
-        id: releaseData.type.id,
-        title: releaseData.type.title,
-      },
-      contact: {
-        id: releaseData.contact.id,
-        teamName: releaseData.contact.teamName,
-        teamEmail: releaseData.contact.teamEmail,
-        contactName: releaseData.contact.contactName,
-        contactTelNo: releaseData.contact.contactTelNo,
-      },
-      approvalstatus: 'Approved',
-      amendment: 'false',
-      latestInternalReleaseNote: 'Approved by publisher testing',
-      publishMethod: 'Immediate',
-    };
-  } catch (e) {
-    errorHandler(e);
-    return undefined;
-  }
-};
-
-const publishRelease = async (obj: ReleaseData, releaseId: string) => {
-  try {
-    await axios({
-      method: 'POST',
-      url: `${ADMIN_URL}/api/releases/${releaseId}/status`,
-      headers: {
-        Authorization: `Bearer ${JWT_TOKEN}`,
-        'Content-Type': 'application/json',
-      },
-      data: obj,
-    });
-  } catch (e) {
-    errorHandler(e);
-  }
-};
-
-const getPublicationProgress = async (releaseId: string) => {
-  try {
-    const res = await axios({
-      maxContentLength: Infinity,
-      maxBodyLength: Infinity,
-      method: 'GET',
-      url: `${ADMIN_URL}/api/releases/${releaseId}/stage-status`,
-      headers: {
-        Authorization: `Bearer ${JWT_TOKEN}`,
-        'content-Type': 'application/json',
-      },
-    });
-    // eslint-disable-next-line no-constant-condition
-    while (res.data.overallStage !== 'Complete') {
-      console.log(
-        chalk.blue('overall stage'),
-        chalk.green(res.data.overallStage),
-      );
-      console.log(chalk.blue('data stage'), chalk.green(res.data.dataStage));
-      console.log(
-        chalk.blue('content stage'),
-        chalk.green(res.data.contentStage),
-      );
-      console.log(chalk.blue('files stage'), chalk.green(res.data.filesStage));
-      console.log(
-        chalk.blue('publishing stage'),
-        chalk.green(res.data.publishingStage),
-      );
-      // eslint-disable-next-line no-await-in-loop
-      await sleep(3000);
-      // eslint-disable-next-line no-await-in-loop
-      await getPublicationProgress(releaseId);
-    }
-    return res.data;
-  } catch (e) {
-    return errorHandler(e);
-  }
-};
+const { ADMIN_URL } = process.env;
 
 const createReleaseAndPublish = async () => {
-  const zipGlob = await globby(`${cwd}/*.zip`);
-  if (fs.existsSync(zipGlob[0]) && zipGlob[0].includes('archive.zip')) {
-    console.log(chalk.green('found zip file, continuing'));
-  } else {
-    throw new Error(
-      'No zip file named archive.zip in root dir! Exiting test with failures',
-    );
-  }
-
-  if (fs.existsSync(`${cwd}/test-files`)) {
-    rimraf(`${cwd}/test-files/*`, () => {
-      console.log(chalk.green('cleaned test-files folder'));
-    });
-  }
-
-  if (fs.existsSync(`${cwd}/zip-files`)) {
-    rimraf(`${cwd}/zip-files/*`, () => {
-      console.log(chalk.green('cleaned zip-files folder'));
-    });
-  }
-
-  if (!fs.existsSync(`${cwd}/test-files`)) {
-    fs.mkdirSync(`${cwd}/test-files`);
-  }
-
-  if (!fs.existsSync(`${cwd}/zip-files`)) {
-    fs.mkdirSync(`${cwd}/zip-files`);
-  }
-
-  if (zipGlob[1]) {
-    rimraf(zipGlob[1], () => {
-      console.log(chalk.green('cleaned stale zip files'));
-    });
-  }
+  await commonService.validateArchives();
+  await commonService.prepareDirectories();
 
   type importStages = 'STARTED' | 'QUEUED' | 'COMPLETE' | '';
   let importStatus: importStages = '';
 
-  const publicationId = await createPublication();
-  const releaseId = await createRelease(publicationId);
-  await extractZip();
-  await renameFiles();
+  const publicationId = await publicationService.createPublication();
+  const releaseId = await releaseService.createRelease(publicationId);
+
+  await commonService.extractZip();
+  await commonService.renameFiles();
   await ZipDirectory(
     `${cwd}/test-files`,
     `${cwd}/zip-files/clean-test-zip-${v4()}.zip`,
@@ -396,7 +36,7 @@ const createReleaseAndPublish = async () => {
       ),
     );
   }
-  const subjectId = await addSubject(releaseId);
+  const subjectId = await subjectService.addSubject(releaseId);
   console.time('import subject upload');
   if (!importStatus) {
     console.log(
@@ -411,26 +51,29 @@ const createReleaseAndPublish = async () => {
     await sleep(1000);
 
     // eslint-disable-next-line no-await-in-loop
-    importStatus = await getSubjectProgress(releaseId, subjectId as string);
+    importStatus = await subjectService.getSubjectProgress(
+      releaseId,
+      subjectId as string,
+    );
   }
   console.timeEnd('import subject upload');
 
-  const subjectArray = await getSubjectIdArr(releaseId);
+  const subjectArray = await subjectService.getSubjectIdArr(releaseId);
 
-  await addMetaGuidance(
+  await releaseService.addMetaGuidance(
     subjectArray as { id: string; content: string }[],
     releaseId,
   );
-  const finalReleaseObject = await getFinalReleaseDetails(releaseId);
 
-  await publishRelease(finalReleaseObject as never, releaseId);
+  const finalReleaseObject = await releaseService.getRelease(releaseId);
+
+  await releaseService.publishRelease(finalReleaseObject as never, releaseId);
   console.time('publication elapsed time');
   console.log(
     chalk.green(
       `Started publication of release: ${ADMIN_URL}/publication/${publicationId}/release/${releaseId}/status`,
     ),
   );
-
-  await getPublicationProgress(releaseId);
+  await releaseService.getReleaseProgress(releaseId);
 };
 export default createReleaseAndPublish;

--- a/useful-scripts/misc-test-utils/src/modules/release/createRelease.ts
+++ b/useful-scripts/misc-test-utils/src/modules/release/createRelease.ts
@@ -1,75 +1,8 @@
-/* eslint-disable no-console */
-import axios from 'axios';
-import { v4 } from 'uuid';
-import errorHandler from '../../utils/errorHandler';
+import releaseService from '../../services/releaseService';
+import publicationService from '../../services/publicationService';
 
-const { JWT_TOKEN, ADMIN_URL, TOPIC_ID } = process.env;
-
-const createPublication = async () => {
-  console.time('CreatePublication');
-  try {
-    const res = await axios({
-      method: 'post',
-      url: `${ADMIN_URL}/api/publications`,
-      data: {
-        title: `importer-testing-${v4()}`,
-        topicId: TOPIC_ID,
-        contact: {
-          teamName: 'testing',
-          teamEmail: 'johndoe@gmail.com',
-          contactName: 'John Doe',
-          contactTelNo: '123456789',
-        },
-      },
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${JWT_TOKEN}`,
-      },
-    });
-    console.timeEnd('CreatePublication');
-    console.log(`Created publication. Status code ${res.status}`);
-
-    return res.data.id;
-  } catch (e) {
-    errorHandler(e);
-  }
-  return null;
-};
-
-const createRelease = async (publicationId: string) => {
-  console.time('createRelease');
-  try {
-    const res = await axios({
-      method: 'POST',
-      url: `${ADMIN_URL}/api/publications/${publicationId}/releases`,
-      data: {
-        timePeriodCoverage: { value: 'AY' },
-        releaseName: 2222,
-        typeId: '1821abb8-68b0-431b-9770-0bea65d02ff0',
-        templateReleaseId: '',
-      },
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${JWT_TOKEN}`,
-      },
-    });
-
-    console.timeEnd('createRelease');
-
-    const releaseId = res.data.id;
-
-    console.log(
-      `Release URL: ${ADMIN_URL}/publication/${publicationId}/release/${releaseId}/data`,
-    );
-
-    return releaseId;
-  } catch (e) {
-    errorHandler(e);
-  }
-  return null;
-};
 const createPublicationAndRelease = async () => {
-  const publicationId: string = await createPublication();
-  await createRelease(publicationId);
+  const publicationId: string = await publicationService.createPublication();
+  await releaseService.createRelease(publicationId);
 };
 export default createPublicationAndRelease;

--- a/useful-scripts/misc-test-utils/src/modules/subject/uploadSubject.ts
+++ b/useful-scripts/misc-test-utils/src/modules/subject/uploadSubject.ts
@@ -9,6 +9,7 @@ import subjectService from '../../services/subjectService';
 import releaseService from '../../services/releaseService';
 
 const cwd = projectRoot;
+export type importStages = 'STARTED' | 'QUEUED' | 'COMPLETE' | '';
 
 const uploadSingleSubject = async (releaseId: string) => {
   if (releaseId === '') {
@@ -17,7 +18,6 @@ const uploadSingleSubject = async (releaseId: string) => {
   await commonService.validateArchives();
   await commonService.prepareDirectories();
 
-  type importStages = 'STARTED' | 'QUEUED' | 'COMPLETE' | '';
   let importStatus: importStages = '';
 
   await commonService.extractZip();

--- a/useful-scripts/misc-test-utils/src/modules/subject/uploadSubject.ts
+++ b/useful-scripts/misc-test-utils/src/modules/subject/uploadSubject.ts
@@ -1,244 +1,63 @@
 /* eslint-disable no-console */
-import axios from 'axios';
 import chalk from 'chalk';
-import FormData from 'form-data';
-import fs from 'fs';
-import globby from 'globby';
-import StreamZip from 'node-stream-zip';
-import path from 'path';
-import rimraf from 'rimraf';
 import { v4 } from 'uuid';
 import { projectRoot } from '../../config';
-import { SubjectData } from '../../types/SubjectData';
-import errorHandler from '../../utils/errorHandler';
-import sleep from '../../utils/sleep';
+import commonService from '../../services/commonService';
 import ZipDirectory from '../../utils/zipDirectory';
+import sleep from '../../utils/sleep';
+import subjectService from '../../services/subjectService';
+import releaseService from '../../services/releaseService';
 
-const { ADMIN_URL, JWT_TOKEN } = process.env;
 const cwd = projectRoot;
-
-const extractZip = async () => {
-  const zippedFile = await globby(`${cwd}/*.zip`);
-  const cleanZipFile = zippedFile[0];
-  const archive = fs.existsSync(zippedFile[0]);
-  if (archive) {
-    // eslint-disable-next-line new-cap
-    const zip = new StreamZip.async({ file: cleanZipFile });
-    const count = await zip.extract(null, `${cwd}/test-files`);
-    console.log(chalk.green(`Extracted ${count} entries to test-files`));
-    await zip.close();
-  }
-};
-
-const renameFiles = async () => {
-  // define a random id to assign to the renamed data & meta file...
-  const randomId = Math.floor(Math.random() * 1000000);
-
-  // rename csv file..
-  const csvGlob1 = await globby(`${cwd}/test-files/*.csv`);
-
-  const csvGlob2 = csvGlob1[0];
-
-  fs.rename(`${csvGlob2}`, `${cwd}/test-files/testfile-${randomId}.csv`, e =>
-    e ? console.error(chalk.red(e)) : '',
-  );
-
-  // rename the meta file...
-  const metaGlob = await globby(`${cwd}/test-files/*.meta.csv`);
-  const metaGlob2 = metaGlob[0];
-
-  fs.rename(
-    `${metaGlob2}`,
-    `${cwd}/test-files/testfile-${randomId}.meta.csv`,
-    e => (e ? console.error(chalk.red(e)) : ''),
-  );
-};
-
-const addSubject = async (releaseId: string): Promise<string | null> => {
-  const finalZipFileGlob = await globby(
-    `${cwd}/zip-files/clean-test-zip-*.zip`,
-  );
-
-  const oldPath = finalZipFileGlob[0];
-
-  const newPath = path.resolve(oldPath, '..', path.basename(oldPath));
-  fs.renameSync(oldPath, newPath);
-
-  const form = new FormData();
-  form.append('zipFile', fs.createReadStream(newPath));
-
-  try {
-    const res = await axios({
-      maxContentLength: Infinity,
-      maxBodyLength: Infinity,
-      method: 'POST',
-      url: `${ADMIN_URL}/api/release/${releaseId}/zip-data?name=importer-subject-${v4()}`,
-      data: form,
-      headers: {
-        ...form.getHeaders(),
-        Authorization: `Bearer ${JWT_TOKEN}`,
-      },
-    });
-
-    return res.data.id;
-  } catch (e) {
-    errorHandler(e);
-  }
-  return null;
-};
-
-const getSubjectProgress = async (releaseId: string, subjectId: string) => {
-  try {
-    const res = await axios({
-      method: 'GET',
-      url: `${ADMIN_URL}/api/release/${releaseId}/data/${subjectId}/import/status`,
-      headers: {
-        Authorization: `Bearer ${JWT_TOKEN}`,
-        'Content-Type': 'application/json',
-      },
-    });
-    if (!res.data.status) {
-      console.info(
-        chalk.cyan(
-          'No import status available. Waiting 3 seconds before polling the API',
-        ),
-      );
-      await sleep(3000);
-    }
-    return res.data.status;
-  } catch (e) {
-    return errorHandler(e);
-  }
-};
-
-const getSubjectIdArr = async (
-  releaseId: string,
-): Promise<{ id: string; content: string }[] | null> => {
-  try {
-    const res = await axios({
-      method: 'GET',
-      url: `${ADMIN_URL}/api/release/${releaseId}/meta-guidance`,
-      headers: {
-        Authorization: `Bearer ${JWT_TOKEN}`,
-        'Content-Type': 'application/json',
-      },
-    });
-    const subjects: SubjectData[] = res.data?.subjects;
-    const subjArr: { id: string; content: string }[] = [];
-    subjects.forEach(sub => {
-      subjArr.push({ id: sub.id, content: `Hello ${v4()}` });
-    });
-    return subjArr;
-  } catch (e) {
-    errorHandler(e);
-  }
-  return null;
-};
-
-const addMetaGuidance = async (
-  subjArr: { id: string; content: string }[],
-  releaseId: string,
-): Promise<boolean> => {
-  try {
-    await axios({
-      method: 'PATCH',
-      url: `${ADMIN_URL}/api/release/${releaseId}/meta-guidance`,
-      headers: {
-        Authorization: `Bearer ${JWT_TOKEN}`,
-        'Content-Type': 'application/json',
-      },
-      data: {
-        content: '<p>testing</p>',
-        subjects: subjArr,
-      },
-    });
-    return true;
-  } catch (e) {
-    errorHandler(e);
-  }
-  return false;
-};
 
 const uploadSingleSubject = async (releaseId: string) => {
   if (releaseId === '') {
     throw new Error(chalk.red('Release ID is required!'));
   }
-  const zipGlob = await globby(`${cwd}/*.zip`);
-  if (fs.existsSync(zipGlob[0]) && zipGlob[0].includes('archive.zip')) {
-    console.log(chalk.green('found zip file, continuing'));
-  } else {
-    throw new Error(
-      chalk.red(
-        'No zip file named archive.zip in root dir! Exiting test with failures',
-      ),
-    );
-  }
-
-  if (fs.existsSync(`${cwd}/test-files`)) {
-    rimraf(`${cwd}/test-files/*`, () => {
-      console.log(chalk.green('cleaned test-files folder'));
-    });
-  }
-
-  if (fs.existsSync(`${cwd}/zip-files`)) {
-    rimraf(`${cwd}/zip-files/*`, () => {
-      console.log(chalk.green('cleaned zip-files folder'));
-    });
-  }
-
-  if (!fs.existsSync(`${cwd}/test-files`)) {
-    fs.mkdirSync(`${cwd}/test-files`);
-  }
-
-  if (!fs.existsSync(`${cwd}/zip-files`)) {
-    fs.mkdirSync(`${cwd}/zip-files`);
-  }
-
-  if (zipGlob[1]) {
-    rimraf(zipGlob[1], () => {
-      console.log(chalk.green('cleaned stale zip files'));
-    });
-  }
+  await commonService.validateArchives();
+  await commonService.prepareDirectories();
 
   type importStages = 'STARTED' | 'QUEUED' | 'COMPLETE' | '';
   let importStatus: importStages = '';
 
-  await extractZip();
-  await renameFiles();
+  await commonService.extractZip();
+  await commonService.renameFiles();
   await ZipDirectory(
     `${cwd}/test-files`,
     `${cwd}/zip-files/clean-test-zip-${v4()}.zip`,
   );
 
-  const subjectId = await addSubject(releaseId);
+  const subjectId = await subjectService.addSubject(releaseId);
+  await sleep(3000);
+
+  console.time('import subject upload');
+  await sleep(900);
+
+  const subjectArray = await subjectService.getSubjectIdArr(releaseId);
+
+  await releaseService.addMetaGuidance(
+    subjectArray as { id: string; content: string }[],
+    releaseId,
+  );
+
+  if (!importStatus) {
+    console.log(
+      'No importStatus just yet, waiting 4 seconds before polling again',
+    );
+    await sleep(4000);
+  }
 
   while (importStatus !== 'COMPLETE') {
-    console.time('import subject upload');
-    console.log(chalk.blue('importStatus', importStatus));
+    console.log(chalk.blue('importStatus', chalk.green(importStatus)));
     // eslint-disable-next-line no-await-in-loop
     await sleep(1000);
+
     // eslint-disable-next-line no-await-in-loop
-    importStatus = await getSubjectProgress(releaseId, subjectId as string);
+    importStatus = await subjectService.getSubjectProgress(
+      releaseId,
+      subjectId as string,
+    );
   }
-
-  console.timeEnd(chalk.green('import subject upload'));
-
-  try {
-    const subjArr = await getSubjectIdArr(releaseId);
-
-    if (!subjArr) {
-      throw new Error(
-        chalk.red(
-          'No subject array returned from `getSubjectIdArr` function!, existing test with failures',
-        ),
-      );
-    }
-
-    await addMetaGuidance(subjArr, releaseId);
-    console.timeEnd(chalk.green('publication elapsed time'));
-  } catch (e) {
-    errorHandler(e);
-  }
+  console.timeEnd('import subject upload');
 };
-
 export default uploadSingleSubject;

--- a/useful-scripts/misc-test-utils/src/services/commonService.ts
+++ b/useful-scripts/misc-test-utils/src/services/commonService.ts
@@ -1,0 +1,85 @@
+/* eslint-disable no-console */
+import chalk from 'chalk';
+import StreamZip from 'node-stream-zip';
+import globby from 'globby';
+import fs from 'fs';
+import rimraf from 'rimraf';
+import { projectRoot } from '../config';
+
+const cwd = projectRoot;
+
+const commonService = {
+  validateArchives: async () => {
+    const zipGlob = await globby(`${cwd}/*.zip`);
+    if (fs.existsSync(zipGlob[0]) && zipGlob[0].includes('archive.zip')) {
+      console.log(chalk.green('found zip file, continuing'));
+    } else {
+      throw new Error(
+        'No zip file named archive.zip in root dir! Exiting test with failures',
+      );
+    }
+    if (zipGlob[1]) {
+      rimraf(zipGlob[1], () => {
+        console.log(chalk.green('cleaned stale zip files'));
+      });
+    }
+  },
+
+  prepareDirectories: async () => {
+    if (fs.existsSync(`${cwd}/test-files`)) {
+      rimraf(`${cwd}/test-files/*`, () => {
+        console.log(chalk.green('cleaned test-files folder'));
+      });
+    }
+
+    if (fs.existsSync(`${cwd}/zip-files`)) {
+      rimraf(`${cwd}/zip-files/*`, () => {
+        console.log(chalk.green('cleaned zip-files folder'));
+      });
+    }
+
+    if (!fs.existsSync(`${cwd}/test-files`)) {
+      fs.mkdirSync(`${cwd}/test-files`);
+    }
+
+    if (!fs.existsSync(`${cwd}/zip-files`)) {
+      fs.mkdirSync(`${cwd}/zip-files`);
+    }
+  },
+  extractZip: async () => {
+    const zippedFile = await globby(`${cwd}/*.zip`);
+    const cleanZipFile = zippedFile[0];
+    const archive = fs.existsSync(zippedFile[0]);
+    if (archive) {
+      // eslint-disable-next-line new-cap
+      const zip = new StreamZip.async({ file: cleanZipFile });
+      const count = await zip.extract(null, `${cwd}/test-files`);
+      console.log(chalk.green(`Extracted ${count} entries to test-files`));
+      await zip.close();
+    }
+  },
+  renameFiles: async () => {
+    // define a random id to assign to the renamed data & meta file...
+    const randomId = Math.floor(Math.random() * 1000000);
+
+    // rename csv file..
+    const csvGlob1 = await globby(`${cwd}/test-files/*.csv`);
+
+    const csvGlob2 = csvGlob1[0];
+
+    fs.rename(`${csvGlob2}`, `${cwd}/test-files/testfile-${randomId}.csv`, e =>
+      e ? console.error(chalk.red(e)) : '',
+    );
+
+    // rename the meta file...
+    const metaGlob = await globby(`${cwd}/test-files/*.meta.csv`);
+    const metaGlob2 = metaGlob[0];
+
+    fs.rename(
+      `${metaGlob2}`,
+      `${cwd}/test-files/testfile-${randomId}.meta.csv`,
+      e => (e ? console.error(chalk.red(e)) : ''),
+    );
+  },
+};
+export default commonService;

--- a/useful-scripts/misc-test-utils/src/services/publicationService.ts
+++ b/useful-scripts/misc-test-utils/src/services/publicationService.ts
@@ -1,0 +1,35 @@
+/* eslint-disable no-console */
+import chalk from 'chalk';
+import { v4 } from 'uuid';
+import errorHandler from '../utils/errorHandler';
+import adminApi from '../utils/adminApi';
+
+const { TOPIC_ID } = process.env;
+
+const publicationService = {
+  // eslint-disable-next-line consistent-return
+  createPublication: async () => {
+    console.time('createPublication');
+    try {
+      const res = await adminApi.post('/api/publications', {
+        title: `importer-testing-${v4()}`,
+        topicId: TOPIC_ID,
+        contact: {
+          teamName: 'testing',
+          teamEmail: 'johndoe@gmail.com',
+          contactName: 'John Doe',
+          contactTelNo: '123456789',
+        },
+      });
+      console.timeEnd('createPublication');
+      console.log(
+        chalk.green(`Created publication. Status code ${res.status}`),
+      );
+      return res.data.id;
+    } catch (e) {
+      errorHandler(e);
+    }
+    return null;
+  },
+};
+export default publicationService;

--- a/useful-scripts/misc-test-utils/src/services/publicationService.ts
+++ b/useful-scripts/misc-test-utils/src/services/publicationService.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 import chalk from 'chalk';
 import { v4 } from 'uuid';
-import errorHandler from '../utils/errorHandler';
 import adminApi from '../utils/adminApi';
 
 const { TOPIC_ID } = process.env;
@@ -10,26 +9,19 @@ const publicationService = {
   // eslint-disable-next-line consistent-return
   createPublication: async () => {
     console.time('createPublication');
-    try {
-      const res = await adminApi.post('/api/publications', {
-        title: `importer-testing-${v4()}`,
-        topicId: TOPIC_ID,
-        contact: {
-          teamName: 'testing',
-          teamEmail: 'johndoe@gmail.com',
-          contactName: 'John Doe',
-          contactTelNo: '123456789',
-        },
-      });
-      console.timeEnd('createPublication');
-      console.log(
-        chalk.green(`Created publication. Status code ${res.status}`),
-      );
-      return res.data.id;
-    } catch (e) {
-      errorHandler(e);
-    }
-    return null;
+    const res = await adminApi.post('/api/publications', {
+      title: `importer-testing-${v4()}`,
+      topicId: TOPIC_ID,
+      contact: {
+        teamName: 'testing',
+        teamEmail: 'johndoe@gmail.com',
+        contactName: 'John Doe',
+        contactTelNo: '123456789',
+      },
+    });
+    console.timeEnd('createPublication');
+    console.log(chalk.green(`Created publication. Status code ${res.status}`));
+    return res.data.id;
   },
 };
 export default publicationService;

--- a/useful-scripts/misc-test-utils/src/services/releaseService.ts
+++ b/useful-scripts/misc-test-utils/src/services/releaseService.ts
@@ -2,102 +2,75 @@
 import chalk from 'chalk';
 import sleep from '../utils/sleep';
 import { ReleaseData } from '../types/ReleaseData';
-import errorHandler from '../utils/errorHandler';
 import adminApi from '../utils/adminApi';
 
 const { ADMIN_URL } = process.env;
 const releaseService = {
-  createRelease: async (publicationId: string): Promise<string | null> => {
+  createRelease: async (publicationId: string): Promise<string> => {
     console.time('createRelease');
-    try {
-      const res = await adminApi.post(
-        `/api/publications/${publicationId}/releases`,
-        {
-          timePeriodCoverage: { value: 'AY' },
-          releaseName: 2222,
-          typeId: '1821abb8-68b0-431b-9770-0bea65d02ff0',
-          publicationId: 'c76c1bc4-0a01-4116-74cd-08d8eebbf0c1',
-          templateReleaseId: '',
-        },
-      );
-      console.timeEnd('createRelease');
-      const releaseId = res.data.id;
+    const res = await adminApi.post(
+      `/api/publications/${publicationId}/releases`,
+      {
+        timePeriodCoverage: { value: 'AY' },
+        releaseName: 2222,
+        typeId: '1821abb8-68b0-431b-9770-0bea65d02ff0',
+        publicationId: 'c76c1bc4-0a01-4116-74cd-08d8eebbf0c1',
+        templateReleaseId: '',
+      },
+    );
+    console.timeEnd('createRelease');
+    const releaseId = res.data.id;
 
-      console.log(
-        chalk.green(
-          `Release URL: ${ADMIN_URL}/publication/${publicationId}/release/${releaseId}/data`,
-        ),
-      );
-      return releaseId;
-    } catch (e) {
-      errorHandler(e);
-    }
-    return null;
+    console.log(
+      chalk.green(
+        `Release URL: ${ADMIN_URL}/publication/${publicationId}/release/${releaseId}/data`,
+      ),
+    );
+    return releaseId;
   },
   addMetaGuidance: async (
     subjArr: { id: string; content: string }[],
     releaseId: string,
   ): Promise<boolean> => {
-    try {
-      await adminApi.patch(`/api/release/${releaseId}/meta-guidance`, {
-        content: '<p>testing</p>',
-        subjects: subjArr,
-      });
-      return true;
-    } catch (e) {
-      errorHandler(e);
-    }
-    return false;
+    await adminApi.patch(`/api/release/${releaseId}/meta-guidance`, {
+      content: '<p>testing</p>',
+      subjects: subjArr,
+    });
+    return true;
   },
   getReleaseProgress: async (releaseId: string) => {
-    try {
-      const res = await adminApi.get(
-        `/api/releases/${releaseId}/stage-status`,
-        {
-          maxContentLength: Infinity,
-          maxBodyLength: Infinity,
-        },
-      );
+    const res = await adminApi.get(`/api/releases/${releaseId}/stage-status`, {
+      maxContentLength: Infinity,
+      maxBodyLength: Infinity,
+    });
 
-      // eslint-disable-next-line no-constant-condition
-      while (res.data.overallStage !== 'Complete') {
-        console.log(
-          chalk.blue('overall stage'),
-          chalk.green(res.data.overallStage),
-        );
-        // eslint-disable-next-line no-await-in-loop
-        await sleep(3000);
-        // eslint-disable-next-line no-await-in-loop
-        await releaseService.getReleaseProgress(releaseId);
-      }
-      return res.data;
-    } catch (e) {
-      return errorHandler(e);
+    // eslint-disable-next-line no-constant-condition
+    while (res.data.overallStage !== 'Complete') {
+      console.log(
+        chalk.blue('overall stage'),
+        chalk.green(res.data.overallStage),
+      );
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(3000);
+      // eslint-disable-next-line no-await-in-loop
+      await releaseService.getReleaseProgress(releaseId);
     }
+    return res.data;
   },
   publishRelease: async (obj: ReleaseData, releaseId: string) => {
-    try {
-      await adminApi.post(`/api/releases/${releaseId}/status`, obj);
-    } catch (e) {
-      errorHandler(e);
-    }
+    await adminApi.post(`/api/releases/${releaseId}/status`, obj);
   },
   getRelease: async (releaseId: string) => {
-    try {
-      const res = await adminApi.get(`/api/releases/${releaseId}`);
-      const releaseData: ReleaseData = res.data;
-      await sleep(1000);
-      return {
-        ...releaseData,
-        approvalstatus: 'Approved',
-        amendment: 'false',
-        latestInternalReleaseNote: 'Approved by publisher testing',
-        publishMethod: 'Immediate',
-      };
-    } catch (e) {
-      errorHandler(e);
-      return undefined;
-    }
+    const res = await adminApi.get(`/api/releases/${releaseId}`);
+    const releaseData: ReleaseData = res.data;
+    await sleep(1000);
+    return {
+      ...releaseData,
+      approvalstatus: 'Approved',
+      amendment: 'false',
+      latestInternalReleaseNote: 'Approved by publisher testing',
+      publishMethod: 'Immediate',
+    };
   },
 };
 export default releaseService;

--- a/useful-scripts/misc-test-utils/src/services/releaseService.ts
+++ b/useful-scripts/misc-test-utils/src/services/releaseService.ts
@@ -1,0 +1,103 @@
+/* eslint-disable no-console */
+import chalk from 'chalk';
+import sleep from '../utils/sleep';
+import { ReleaseData } from '../types/ReleaseData';
+import errorHandler from '../utils/errorHandler';
+import adminApi from '../utils/adminApi';
+
+const { ADMIN_URL } = process.env;
+const releaseService = {
+  createRelease: async (publicationId: string): Promise<string | null> => {
+    console.time('createRelease');
+    try {
+      const res = await adminApi.post(
+        `/api/publications/${publicationId}/releases`,
+        {
+          timePeriodCoverage: { value: 'AY' },
+          releaseName: 2222,
+          typeId: '1821abb8-68b0-431b-9770-0bea65d02ff0',
+          publicationId: 'c76c1bc4-0a01-4116-74cd-08d8eebbf0c1',
+          templateReleaseId: '',
+        },
+      );
+      console.timeEnd('createRelease');
+      const releaseId = res.data.id;
+
+      console.log(
+        chalk.green(
+          `Release URL: ${ADMIN_URL}/publication/${publicationId}/release/${releaseId}/data`,
+        ),
+      );
+      return releaseId;
+    } catch (e) {
+      errorHandler(e);
+    }
+    return null;
+  },
+  addMetaGuidance: async (
+    subjArr: { id: string; content: string }[],
+    releaseId: string,
+  ): Promise<boolean> => {
+    try {
+      await adminApi.patch(`/api/release/${releaseId}/meta-guidance`, {
+        content: '<p>testing</p>',
+        subjects: subjArr,
+      });
+      return true;
+    } catch (e) {
+      errorHandler(e);
+    }
+    return false;
+  },
+  getReleaseProgress: async (releaseId: string) => {
+    try {
+      const res = await adminApi.get(
+        `/api/releases/${releaseId}/stage-status`,
+        {
+          maxContentLength: Infinity,
+          maxBodyLength: Infinity,
+        },
+      );
+
+      // eslint-disable-next-line no-constant-condition
+      while (res.data.overallStage !== 'Complete') {
+        console.log(
+          chalk.blue('overall stage'),
+          chalk.green(res.data.overallStage),
+        );
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(3000);
+        // eslint-disable-next-line no-await-in-loop
+        await releaseService.getReleaseProgress(releaseId);
+      }
+      return res.data;
+    } catch (e) {
+      return errorHandler(e);
+    }
+  },
+  publishRelease: async (obj: ReleaseData, releaseId: string) => {
+    try {
+      await adminApi.post(`/api/releases/${releaseId}/status`, obj);
+    } catch (e) {
+      errorHandler(e);
+    }
+  },
+  getRelease: async (releaseId: string) => {
+    try {
+      const res = await adminApi.get(`/api/releases/${releaseId}`);
+      const releaseData: ReleaseData = res.data;
+      await sleep(1000);
+      return {
+        ...releaseData,
+        approvalstatus: 'Approved',
+        amendment: 'false',
+        latestInternalReleaseNote: 'Approved by publisher testing',
+        publishMethod: 'Immediate',
+      };
+    } catch (e) {
+      errorHandler(e);
+      return undefined;
+    }
+  },
+};
+export default releaseService;

--- a/useful-scripts/misc-test-utils/src/services/subjectService.ts
+++ b/useful-scripts/misc-test-utils/src/services/subjectService.ts
@@ -1,0 +1,80 @@
+/* eslint-disable no-console */
+import globby from 'globby';
+import path from 'path';
+import { v4 } from 'uuid';
+import fs from 'fs';
+import FormData from 'form-data';
+import chalk from 'chalk';
+import { projectRoot } from '../config';
+import errorHandler from '../utils/errorHandler';
+import { SubjectData } from '../types/SubjectData';
+import sleep from '../utils/sleep';
+import adminApi from '../utils/adminApi';
+
+const cwd = projectRoot;
+
+const subjectService = {
+  addSubject: async (releaseId: string): Promise<string | null> => {
+    const finalZipFileGlob = await globby(
+      `${cwd}/zip-files/clean-test-zip-*.zip`,
+    );
+    const oldPath = finalZipFileGlob[0];
+    const newPath = path.resolve(oldPath, '..', path.basename(oldPath));
+    fs.renameSync(oldPath, newPath);
+    const form = new FormData();
+    form.append('zipFile', fs.createReadStream(newPath));
+    try {
+      const res = await adminApi.post(
+        `/api/release/${releaseId}/zip-data?title=importer-subject-${v4()}`,
+        form,
+        {
+          headers: {
+            ...form.getHeaders(),
+          },
+        },
+      );
+      console.log(res.data);
+      return res.data.id;
+    } catch (e) {
+      errorHandler(e);
+    }
+    return null;
+  },
+
+  getSubjectIdArr: async (
+    releaseId: string,
+  ): Promise<{ id: string; content: string }[] | null> => {
+    try {
+      const res = await adminApi.get(`/api/release/${releaseId}/meta-guidance`);
+      const subjects: SubjectData[] = res.data?.subjects;
+      const subjArr: { id: string; content: string }[] = [];
+      subjects.forEach(subject => {
+        subjArr.push({ id: subject.id, content: `Hello ${v4()}` });
+      });
+      return subjArr;
+    } catch (e) {
+      errorHandler(e);
+    }
+    return null;
+  },
+  // eslint-disable-next-line consistent-return
+  getSubjectProgress: async (releaseId: string, subjectId: string) => {
+    try {
+      const res = await adminApi.get(
+        `/api/release/${releaseId}/data/${subjectId}/import/status`,
+      );
+      if (!res.data.status) {
+        console.info(
+          chalk.cyan(
+            'No import status available. Waiting 3 seconds before polling the API',
+          ),
+        );
+        await sleep(3000);
+      }
+      return res.data.status;
+    } catch (e) {
+      errorHandler(e);
+    }
+  },
+};
+export default subjectService;

--- a/useful-scripts/misc-test-utils/src/services/subjectService.ts
+++ b/useful-scripts/misc-test-utils/src/services/subjectService.ts
@@ -6,15 +6,15 @@ import fs from 'fs';
 import FormData from 'form-data';
 import chalk from 'chalk';
 import { projectRoot } from '../config';
-import errorHandler from '../utils/errorHandler';
 import { SubjectData } from '../types/SubjectData';
 import sleep from '../utils/sleep';
 import adminApi from '../utils/adminApi';
+import { importStages } from '../modules/subject/uploadSubject';
 
 const cwd = projectRoot;
 
 const subjectService = {
-  addSubject: async (releaseId: string): Promise<string | null> => {
+  addSubject: async (releaseId: string): Promise<string> => {
     const finalZipFileGlob = await globby(
       `${cwd}/zip-files/clean-test-zip-*.zip`,
     );
@@ -23,58 +23,47 @@ const subjectService = {
     fs.renameSync(oldPath, newPath);
     const form = new FormData();
     form.append('zipFile', fs.createReadStream(newPath));
-    try {
-      const res = await adminApi.post(
-        `/api/release/${releaseId}/zip-data?title=importer-subject-${v4()}`,
-        form,
-        {
-          headers: {
-            ...form.getHeaders(),
-          },
+    const res = await adminApi.post(
+      `/api/release/${releaseId}/zip-data?title=importer-subject-${v4()}`,
+      form,
+      {
+        headers: {
+          ...form.getHeaders(),
         },
-      );
-      console.log(res.data);
-      return res.data.id;
-    } catch (e) {
-      errorHandler(e);
-    }
-    return null;
+      },
+    );
+    console.log(res.data);
+    return res.data.id;
   },
 
   getSubjectIdArr: async (
     releaseId: string,
-  ): Promise<{ id: string; content: string }[] | null> => {
-    try {
-      const res = await adminApi.get(`/api/release/${releaseId}/meta-guidance`);
-      const subjects: SubjectData[] = res.data?.subjects;
-      const subjArr: { id: string; content: string }[] = [];
-      subjects.forEach(subject => {
-        subjArr.push({ id: subject.id, content: `Hello ${v4()}` });
-      });
-      return subjArr;
-    } catch (e) {
-      errorHandler(e);
-    }
-    return null;
+  ): Promise<{ id: string; content: string }[]> => {
+    const res = await adminApi.get(`/api/release/${releaseId}/meta-guidance`);
+    const subjects: SubjectData[] = res.data?.subjects;
+    const subjArr: { id: string; content: string }[] = [];
+    subjects.forEach(subject => {
+      subjArr.push({ id: subject.id, content: `Hello ${v4()}` });
+    });
+    return subjArr;
   },
   // eslint-disable-next-line consistent-return
-  getSubjectProgress: async (releaseId: string, subjectId: string) => {
-    try {
-      const res = await adminApi.get(
-        `/api/release/${releaseId}/data/${subjectId}/import/status`,
+  getSubjectProgress: async (
+    releaseId: string,
+    subjectId: string,
+  ): Promise<importStages> => {
+    const res = await adminApi.get(
+      `/api/release/${releaseId}/data/${subjectId}/import/status`,
+    );
+    if (!res.data.status) {
+      console.info(
+        chalk.cyan(
+          'No import status available. Waiting 3 seconds before polling the API',
+        ),
       );
-      if (!res.data.status) {
-        console.info(
-          chalk.cyan(
-            'No import status available. Waiting 3 seconds before polling the API',
-          ),
-        );
-        await sleep(3000);
-      }
-      return res.data.status;
-    } catch (e) {
-      errorHandler(e);
+      await sleep(3000);
     }
+    return res.data.status;
   },
 };
 export default subjectService;

--- a/useful-scripts/misc-test-utils/src/utils/adminApi.ts
+++ b/useful-scripts/misc-test-utils/src/utils/adminApi.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+const { ADMIN_URL, JWT_TOKEN } = process.env;
+
+const adminApi = axios.create({
+  baseURL: ADMIN_URL,
+  headers: {
+    Authorization: `Bearer ${JWT_TOKEN}`,
+  },
+});
+export default adminApi;

--- a/useful-scripts/misc-test-utils/src/utils/zipDirectory.ts
+++ b/useful-scripts/misc-test-utils/src/utils/zipDirectory.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 import archiver from 'archiver';
 import fs from 'fs';
 


### PR DESCRIPTION
This PR splits functionality that each module in this CLI uses into service files. This is to avoid code repetition across the cli. It splits up functionality into 3 services: 
- `releaseService` 
- `commonService`
- `subjectService`