### PR TITLE
Ees 2547 tidy up tasks for 2156

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyContentServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyContentServicePermissionTests.cs
@@ -10,7 +10,6 @@ using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
-using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
@@ -24,7 +23,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         [Fact]
         public async Task GetContent()
         {
-            var methodology = new Methodology();
+            var methodology = new Methodology
+            {
+                MethodologyParent = new MethodologyParent()
+            };
             var contentDbContextId = Guid.NewGuid().ToString();
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -162,7 +162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             }
         }
 
-        // TODO SOW4 EES-2156 - add test for updating AlternativeTitles explicitly
+        // TODO SOW4 EES-2159 - add test for updating AlternativeTitles explicitly
         [Fact]
         public async Task UpdateMethodology()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyFileRepository.cs
@@ -25,6 +25,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 
         public Task<List<MethodologyFile>> GetByFileType(Guid methodologyId, params FileType[] types);
         
-        public Task<List<MethodologyFile>> GetMethodologyLinksToFile(Guid fileId);
+        public Task<List<MethodologyFile>> GetByFile(Guid fileId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
@@ -15,6 +15,8 @@ using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ContentBlockUtil;
 
@@ -53,9 +55,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         public Task<Either<ActionResult, ManageMethodologyContentViewModel>> GetContent(Guid methodologyId)
         {
             return _persistenceHelper
-                .CheckEntityExists<Methodology>(methodologyId)
+                .CheckEntityExists<Methodology>(methodologyId, HydrateMethodologyForManageMethodologyContentViewModel)
                 .OnSuccess(CheckCanViewMethodology)
-                .OnSuccess(HydrateMethodologyForManageMethodologyContentViewModel)
                 .OnSuccess(_mapper.Map<ManageMethodologyContentViewModel>);
         }
 
@@ -450,18 +451,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             return tuple;
         }
 
-        private async Task<Either<ActionResult, Methodology>> HydrateMethodologyForManageMethodologyContentViewModel(
-            Methodology methodology)
-        {
-            // Load the MethodologyParent so that Methodology Title and Slug can be provided by the MethodologyParent.
-            await _context
-                .Entry(methodology)
-                .Reference(m => m.MethodologyParent)
-                .LoadAsync();
-
-            return methodology;
-        }
-
         private Either<ActionResult, Tuple<Methodology, List<ContentSection>>> FindContentList(Methodology methodology,
             params Guid[] contentSectionIds)
         {
@@ -500,6 +489,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
             var sectionsListIds = sectionsList.Select(section => section.Id);
             return contentSectionIds.All(id => sectionsListIds.Contains(id));
+        }
+
+        private static IIncludableQueryable<Methodology, MethodologyParent> 
+            HydrateMethodologyForManageMethodologyContentViewModel(IQueryable<Methodology> query)
+        {
+            return query.Include(m => m.MethodologyParent);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyContentService.cs
@@ -494,6 +494,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         private static IIncludableQueryable<Methodology, MethodologyParent> 
             HydrateMethodologyForManageMethodologyContentViewModel(IQueryable<Methodology> query)
         {
+            // Load the MethodologyParent so that Methodology Title and Slug can be provided by the MethodologyParent.
             return query.Include(m => m.MethodologyParent);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyFileRepository.cs
@@ -105,7 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 .ToListAsync();
         }
 
-        public Task<List<MethodologyFile>> GetMethodologyLinksToFile(Guid fileId)
+        public Task<List<MethodologyFile>> GetByFile(Guid fileId)
         {
             return _contentDbContext
                 .MethodologyFiles

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyImageService.cs
@@ -63,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 {
                     await files.ForEachAsync(async file =>
                     {
-                        var methodologyLinks = await _methodologyFileRepository.GetMethodologyLinksToFile(file.Id);
+                        var methodologyLinks = await _methodologyFileRepository.GetByFile(file.Id);
 
                         await _methodologyFileRepository.Delete(methodologyId, file.Id);
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -26,14 +26,12 @@ export interface Props {
   publication: MyPublication;
   topicId: string;
   onChangePublication: () => void;
-  allowAmendments?: boolean;
 }
 
 const MethodologySummary = ({
   publication,
   topicId,
   onChangePublication,
-  allowAmendments = true,
 }: Props) => {
   const history = useHistory();
   const [
@@ -172,19 +170,16 @@ const MethodologySummary = ({
                           ? 'Edit this methodology'
                           : 'View this methodology'}
                       </ButtonLink>
-                      {allowAmendments &&
-                        methodology.permissions
-                          .canMakeAmendmentOfMethodology && (
-                          <Button
-                            type="button"
-                            onClick={() =>
-                              setAmendMethodologyId(methodology.id)
-                            }
-                            variant="secondary"
-                          >
-                            Amend methodology
-                          </Button>
-                        )}
+                      {methodology.permissions
+                        .canMakeAmendmentOfMethodology && (
+                        <Button
+                          type="button"
+                          onClick={() => setAmendMethodologyId(methodology.id)}
+                          variant="secondary"
+                        >
+                          Amend methodology
+                        </Button>
+                      )}
                     </ButtonGroup>
                   </>
                 )}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -186,7 +186,7 @@ describe('MethodologySummary', () => {
       ).not.toBeInTheDocument();
 
       expect(
-        screen.queryByRole('button', {
+        screen.getByRole('button', {
           name: 'Link to an externally hosted methodology',
         }),
       ).toBeInTheDocument();
@@ -210,11 +210,11 @@ describe('MethodologySummary', () => {
       ).not.toBeInTheDocument();
 
       expect(
-        screen.queryByRole('button', { name: 'Create methodology' }),
+        screen.getByRole('button', { name: 'Create methodology' }),
       ).toBeInTheDocument();
 
       expect(
-        screen.queryByRole('button', {
+        screen.getByRole('button', {
           name: 'Link to an externally hosted methodology',
         }),
       ).toBeInTheDocument();
@@ -256,7 +256,7 @@ describe('MethodologySummary', () => {
         }),
       ).not.toBeInTheDocument();
 
-      expect(screen.queryByText('No methodologies added.')).toBeInTheDocument();
+      expect(screen.getByText('No methodologies added.')).toBeInTheDocument();
     });
 
     test('clicking the link external methodology button shows the form', async () => {
@@ -278,7 +278,7 @@ describe('MethodologySummary', () => {
 
       await waitFor(() => {
         expect(
-          screen.queryByText('Link to an externally hosted methodology', {
+          screen.getByText('Link to an externally hosted methodology', {
             selector: 'legend',
           }),
         ).toBeInTheDocument();
@@ -302,16 +302,14 @@ describe('MethodologySummary', () => {
         </MemoryRouter>,
       );
 
-      expect(screen.queryByText(testMethodology.title)).toBeInTheDocument();
+      expect(screen.getByText(testMethodology.title)).toBeInTheDocument();
 
-      expect(screen.queryByText('8 June 2021')).toBeInTheDocument();
+      expect(screen.getByText('8 June 2021')).toBeInTheDocument();
 
-      expect(
-        screen.queryByText('this is the release note'),
-      ).toBeInTheDocument();
+      expect(screen.getByText('this is the release note')).toBeInTheDocument();
 
       expect(
-        screen.queryByText('View this methodology', { selector: 'a' }),
+        screen.getByText('View this methodology', { selector: 'a' }),
       ).toBeInTheDocument();
     });
 
@@ -327,7 +325,7 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.queryByText('Approved', { selector: 'span' }),
+        screen.getByText('Approved', { selector: 'span' }),
       ).toBeInTheDocument();
     });
 
@@ -343,7 +341,7 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.queryByText('Draft', { selector: 'span' }),
+        screen.getByText('Draft', { selector: 'span' }),
       ).toBeInTheDocument();
     });
 
@@ -359,7 +357,7 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.queryByText('Amendment', { selector: 'span' }),
+        screen.getByText('Amendment', { selector: 'span' }),
       ).toBeInTheDocument();
     });
   });
@@ -380,7 +378,7 @@ describe('MethodologySummary', () => {
         );
 
         expect(
-          screen.queryByText('Ext methodolology title (external methodology)', {
+          screen.getByText('Ext methodolology title (external methodology)', {
             selector: 'a',
           }),
         ).toBeInTheDocument();
@@ -418,7 +416,7 @@ describe('MethodologySummary', () => {
         );
 
         expect(
-          screen.queryByText('Ext methodolology title (external methodology)'),
+          screen.getByText('Ext methodolology title (external methodology)'),
         ).toBeInTheDocument();
 
         expect(
@@ -435,7 +433,7 @@ describe('MethodologySummary', () => {
   });
 
   describe('Removing a non-amendment methodology', () => {
-    test('the remove methodology button is shown if user has permission', () => {
+    test('the remove methodology button is shown if user has permission', async () => {
       render(
         <MemoryRouter>
           <MethodologySummary
@@ -446,13 +444,19 @@ describe('MethodologySummary', () => {
         </MemoryRouter>,
       );
 
-      expect(
-        screen.queryByText('Remove', { selector: 'button' }),
-      ).toBeInTheDocument();
+      userEvent.click(
+        screen.getByTestId('Expand Details Section I am a methodology'),
+      );
 
-      expect(
-        screen.queryByText('Amend methodology', { selector: 'button' }),
-      ).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Remove' }),
+        ).toBeInTheDocument();
+
+        expect(
+          screen.queryByRole('button', { name: 'Amend methodology' }),
+        ).not.toBeInTheDocument();
+      });
     });
 
     test('shows the confirm modal when clicking the Remove button', async () => {
@@ -466,20 +470,25 @@ describe('MethodologySummary', () => {
         </MemoryRouter>,
       );
 
-      userEvent.click(screen.getByText('Remove', { selector: 'button' }));
+      userEvent.click(
+        screen.getByTestId('Expand Details Section I am a methodology'),
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
       await waitFor(() => {
         expect(
-          screen.queryByText('Confirm you want to remove this methodology'),
+          screen.getByText('Confirm you want to remove this methodology'),
         ).toBeInTheDocument();
 
         expect(
-          screen.queryByText(
+          screen.getByText(
             'By removing this methodology you will lose any changes made.',
           ),
         ).toBeInTheDocument();
 
         expect(
-          screen.getByText('Confirm', { selector: 'button' }),
+          screen.getByRole('button', { name: 'Confirm' }),
         ).toBeInTheDocument();
       });
     });
@@ -494,13 +503,19 @@ describe('MethodologySummary', () => {
           />
         </MemoryRouter>,
       );
-      userEvent.click(screen.getByText('Remove', { selector: 'button' }));
+
+      userEvent.click(
+        screen.getByTestId('Expand Details Section I am a methodology'),
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
       await waitFor(() => {
         expect(
-          screen.getByText('Confirm', { selector: 'button' }),
+          screen.getByRole('button', { name: 'Confirm' }),
         ).toBeInTheDocument();
 
-        userEvent.click(screen.getByText('Confirm', { selector: 'button' }));
+        userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
       });
 
       await waitFor(() => {
@@ -523,8 +538,12 @@ describe('MethodologySummary', () => {
         </MemoryRouter>,
       );
 
+      userEvent.click(
+        screen.getByTestId('Expand Details Section I am a methodology'),
+      );
+
       expect(
-        screen.getByText('Amend methodology', { selector: 'button' }),
+        screen.getByRole('button', { name: 'Amend methodology' }),
       ).toBeInTheDocument();
     });
 
@@ -540,7 +559,7 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.queryByText('Amend methodology', { selector: 'button' }),
+        screen.queryByRole('button', { name: 'Amend methodology' }),
       ).not.toBeInTheDocument();
     });
 
@@ -556,15 +575,19 @@ describe('MethodologySummary', () => {
       );
 
       userEvent.click(
-        screen.getByText('Amend methodology', { selector: 'button' }),
+        screen.getByTestId('Expand Details Section I am a methodology'),
+      );
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Amend methodology' }),
       );
       await waitFor(() => {
         expect(
-          screen.queryByText('Confirm you want to amend this live methodology'),
+          screen.getByText('Confirm you want to amend this live methodology'),
         ).toBeInTheDocument();
 
         expect(
-          screen.getByText('Confirm', { selector: 'button' }),
+          screen.getByRole('button', { name: 'Confirm' }),
         ).toBeInTheDocument();
       });
     });
@@ -599,7 +622,11 @@ describe('MethodologySummary', () => {
       );
 
       userEvent.click(
-        screen.getByText('Amend methodology', { selector: 'button' }),
+        screen.getByTestId('Expand Details Section I am a methodology'),
+      );
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Amend methodology' }),
       );
       await waitFor(() => {
         expect(
@@ -634,12 +661,16 @@ describe('MethodologySummary', () => {
         </MemoryRouter>,
       );
 
+      userEvent.click(
+        screen.getByTestId('Expand Details Section I am a methodology'),
+      );
+
       expect(
-        screen.queryByText('Cancel amendment', { selector: 'button' }),
+        screen.getByRole('button', { name: 'Cancel amendment' }),
       ).toBeInTheDocument();
 
       expect(
-        screen.queryByText('Remove', { selector: 'button' }),
+        screen.queryByRole('button', { name: 'Remove' }),
       ).not.toBeInTheDocument();
     });
 
@@ -655,23 +686,25 @@ describe('MethodologySummary', () => {
       );
 
       userEvent.click(
-        screen.getByText('Cancel amendment', { selector: 'button' }),
+        screen.getByTestId('Expand Details Section I am a methodology'),
       );
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel amendment' }));
       await waitFor(() => {
         expect(
-          screen.queryByText(
+          screen.getByText(
             'Confirm you want to cancel this amended methodology',
           ),
         ).toBeInTheDocument();
 
         expect(
-          screen.queryByText(
+          screen.getByText(
             'By cancelling the amendments you will lose any changes made, and the original methodology will remain unchanged.',
           ),
         ).toBeInTheDocument();
 
         expect(
-          screen.getByText('Confirm', { selector: 'button' }),
+          screen.getByRole('button', { name: 'Confirm' }),
         ).toBeInTheDocument();
       });
     });
@@ -686,15 +719,18 @@ describe('MethodologySummary', () => {
           />
         </MemoryRouter>,
       );
+
       userEvent.click(
-        screen.getByText('Cancel amendment', { selector: 'button' }),
+        screen.getByTestId('Expand Details Section I am a methodology'),
       );
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel amendment' }));
       await waitFor(() => {
         expect(
-          screen.getByText('Confirm', { selector: 'button' }),
+          screen.getByRole('button', { name: 'Confirm' }),
         ).toBeInTheDocument();
 
-        userEvent.click(screen.getByText('Confirm', { selector: 'button' }));
+        userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
       });
 
       await waitFor(() => {


### PR DESCRIPTION
This PR:
- removes the `allowAmendment` flag now that amendments are ready
- addresses leftover comments from original 2156 PR
- addresses leftover TODO to add Jest tests around removing a non-Amendment Methodology from a Publication