### PR TITLE
EES-2578 indicate when drag table headers outside drop area

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.module.scss
@@ -52,3 +52,8 @@
   outline: $govuk-focus-width solid $govuk-focus-colour;
   outline-offset: 0;
 }
+
+.optionDraggedOutside {
+  opacity: 0.4;
+  outline: none;
+}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormFieldSortableListGroup.tsx
@@ -67,6 +67,9 @@ function FormFieldSortableListGroup<FormValues>({
                       {...draggableProvided.dragHandleProps}
                       className={classNames(styles.list, {
                         [styles.isDragging]: draggableSnapshot.isDragging,
+                        [styles.optionDraggedOutside]:
+                          draggableSnapshot.isDragging &&
+                          !draggableSnapshot.draggingOver,
                       })}
                       ref={draggableProvided.innerRef}
                       role="button"

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormSortableList.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormSortableList.module.scss
@@ -61,6 +61,12 @@
   opacity: 0.5;
 }
 
+.optionDraggedOutside {
+  border: 0;
+  opacity: 0.2;
+  outline: none;
+}
+
 .selectedCount {
   align-items: center;
   background: govuk-colour('yellow');

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FormSortableList.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FormSortableList.tsx
@@ -287,6 +287,9 @@ const FormSortableList = ({
                           selectedIndices.includes(index) &&
                           typeof draggingIndex === 'number' &&
                           draggingIndex !== index,
+                        [styles.optionDraggedOutside]:
+                          draggableSnapshot.isDragging &&
+                          !draggableSnapshot.draggingOver,
                       })}
                       ref={draggableProvided.innerRef}
                       role="button"


### PR DESCRIPTION
Adds styling to visually indicate when a header item or group has been dragged outside the drop area.

https://user-images.githubusercontent.com/81572860/128190915-4727b91b-989c-480f-8d20-38769a84c7b6.mp4

https://user-images.githubusercontent.com/81572860/128190932-d748e2d9-def5-40a7-b111-e5759d00e63a.mp4

