### PR TITLE
EES-2164 Allow approving methodology for publishing in combination with a Release

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
@@ -1,13 +1,16 @@
+#nullable enable
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;
 
@@ -26,16 +29,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             methodologyService
                 .Setup(s => s.CreateMethodology(_id))
                 .ReturnsAsync(new MethodologySummaryViewModel());
-            
+
             var controller = new MethodologyController(methodologyService.Object, methodologyAmendmentService.Object);
 
             // Method under test
             var result = await controller.CreateMethodology(_id);
             result.AssertOkResult();
-            
+
             VerifyAllMocks(methodologyService, methodologyAmendmentService);
         }
-        
+
         [Fact]
         public async Task GetMethodologySummary_Returns_Ok()
         {
@@ -45,13 +48,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             methodologyService
                 .Setup(s => s.GetSummary(_id))
                 .ReturnsAsync(new MethodologySummaryViewModel());
-            
+
             var controller = new MethodologyController(methodologyService.Object, methodologyAmendmentService.Object);
 
             // Method under test
             var result = await controller.GetMethodologySummary(_id);
             result.AssertOkResult();
-            
+
             VerifyAllMocks(methodologyService, methodologyAmendmentService);
         }
 
@@ -64,13 +67,49 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             methodologyService
                 .Setup(s => s.GetSummary(_id))
                 .ReturnsAsync(new NotFoundResult());
-            
+
             var controller = new MethodologyController(methodologyService.Object, methodologyAmendmentService.Object);
 
             // Method under test
             var result = await controller.GetMethodologySummary(_id);
             result.AssertNotFoundResult();
-            
+
+            VerifyAllMocks(methodologyService, methodologyAmendmentService);
+        }
+
+        [Fact]
+        public async Task GetUnpublishedReleasesUsingMethodology_Returns_Ok()
+        {
+            var methodologyService = new Mock<IMethodologyService>(Strict);
+            var methodologyAmendmentService = new Mock<IMethodologyAmendmentService>(Strict);
+
+            methodologyService
+                .Setup(s => s.GetUnpublishedReleasesUsingMethodology(_id))
+                .ReturnsAsync(AsList(new TitleAndIdViewModel()));
+
+            var controller = new MethodologyController(methodologyService.Object, methodologyAmendmentService.Object);
+
+            var result = await controller.GetUnpublishedReleasesUsingMethodology(_id);
+            result.AssertOkResult();
+
+            VerifyAllMocks(methodologyService, methodologyAmendmentService);
+        }
+
+        [Fact]
+        public async Task GetUnpublishedReleasesUsingMethodology_Returns_NotFound()
+        {
+            var methodologyService = new Mock<IMethodologyService>(Strict);
+            var methodologyAmendmentService = new Mock<IMethodologyAmendmentService>(Strict);
+
+            methodologyService
+                .Setup(s => s.GetUnpublishedReleasesUsingMethodology(_id))
+                .ReturnsAsync(new NotFoundResult());
+
+            var controller = new MethodologyController(methodologyService.Object, methodologyAmendmentService.Object);
+
+            var result = await controller.GetUnpublishedReleasesUsingMethodology(_id);
+            result.AssertNotFoundResult();
+
             VerifyAllMocks(methodologyService, methodologyAmendmentService);
         }
 
@@ -85,13 +124,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             methodologyService
                 .Setup(s => s.UpdateMethodology(_id, request))
                 .ReturnsAsync(new Either<ActionResult, MethodologySummaryViewModel>(new MethodologySummaryViewModel()));
-            
+
             var controller = new MethodologyController(methodologyService.Object, methodologyAmendmentService.Object);
 
             // Method under test
             var result = await controller.UpdateMethodology(_id, request);
             result.AssertOkResult();
-            
+
             VerifyAllMocks(methodologyService, methodologyAmendmentService);
         }
 
@@ -104,13 +143,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             methodologyAmendmentService
                 .Setup(s => s.CreateMethodologyAmendment(_id))
                 .ReturnsAsync(new Either<ActionResult, MethodologySummaryViewModel>(new MethodologySummaryViewModel()));
-            
+
             var controller = new MethodologyController(methodologyService.Object, methodologyAmendmentService.Object);
 
             // Method under test
             var result = await controller.CreateMethodologyAmendment(_id);
             result.AssertOkResult();
-            
+
             VerifyAllMocks(methodologyService, methodologyAmendmentService);
         }
 
@@ -123,13 +162,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             methodologyService
                 .Setup(s => s.DeleteMethodology(_id, false))
                 .ReturnsAsync(new Either<ActionResult, Unit>(Unit.Instance));
-            
+
             var controller = new MethodologyController(methodologyService.Object, methodologyAmendmentService.Object);
 
             // Method under test
             var result = await controller.DeleteMethodology(_id);
             result.AssertNoContentResult();
-            
+
             VerifyAllMocks(methodologyService, methodologyAmendmentService);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -300,6 +300,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(methodology.Id, viewModel.Id);
                 Assert.Null(viewModel.InternalReleaseNote);
                 Assert.Null(viewModel.Published);
+                Assert.Equal(Immediately, viewModel.PublishingStrategy);
+                Assert.Null(viewModel.ScheduledWithRelease);
                 Assert.Equal(request.Status, viewModel.Status);
                 Assert.Equal(request.Title, viewModel.Title);
                 Assert.Equal(publication.Id, viewModel.OwningPublication.Id);
@@ -498,6 +500,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(methodology.Id, viewModel.Id);
                 Assert.Null(viewModel.InternalReleaseNote);
                 Assert.Null(viewModel.Published);
+                Assert.Equal(Immediately, viewModel.PublishingStrategy);
+                Assert.Null(viewModel.ScheduledWithRelease);
                 Assert.Equal(request.Status, viewModel.Status);
                 Assert.Equal(request.Title, viewModel.Title);
                 Assert.Equal(publication.Id, viewModel.OwningPublication.Id);
@@ -600,6 +604,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(methodology.Id, viewModel.Id);
                 Assert.Null(viewModel.InternalReleaseNote);
                 Assert.Null(viewModel.Published);
+                Assert.Equal(Immediately, viewModel.PublishingStrategy);
+                Assert.Null(viewModel.ScheduledWithRelease);
                 Assert.Equal(request.Status, viewModel.Status);
                 Assert.Equal(request.Title, viewModel.Title);
                 Assert.Equal(publication.Id, viewModel.OwningPublication.Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -321,7 +322,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal("updated-methodology-title", updatedMethodology.Slug);
                 Assert.Equal("updated-methodology-title", updatedMethodology.MethodologyParent.Slug);
                 Assert.True(updatedMethodology.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated.Value).Milliseconds, 0, 1500);
+                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
             }
 
             VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
@@ -421,7 +422,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal("test-publication", updatedMethodology.Slug);
                 Assert.Equal("test-publication", updatedMethodology.MethodologyParent.Slug);
                 Assert.True(updatedMethodology.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated.Value).Milliseconds, 0, 1500);
+                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
             }
 
             VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
@@ -522,7 +523,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal("test-publication", updatedMethodology.Slug);
                 Assert.Equal("test-publication", updatedMethodology.MethodologyParent.Slug);
                 Assert.True(updatedMethodology.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated.Value).Milliseconds, 0, 1500);
+                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
             }
 
             VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
@@ -624,7 +625,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal("alternative-methodology-title", updatedMethodology.Slug);
                 Assert.Equal("alternative-methodology-title", updatedMethodology.MethodologyParent.Slug);
                 Assert.True(updatedMethodology.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated.Value).Milliseconds, 0, 1500);
+                Assert.InRange(DateTime.UtcNow.Subtract(updatedMethodology.Updated!.Value).Milliseconds, 0, 1500);
             }
 
             VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
@@ -743,7 +744,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(Immediately, model.PublishingStrategy);
                 Assert.Equal("pupil-absence-statistics-updated-methodology", model.Slug);
                 Assert.True(model.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
+                Assert.InRange(DateTime.UtcNow.Subtract(model.Updated!.Value).Milliseconds, 0, 1500);
             }
 
             VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
@@ -869,7 +870,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(Immediately, model.PublishingStrategy);
                 Assert.Equal("pupil-absence-statistics-updated-methodology", model.Slug);
                 Assert.True(model.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
+                Assert.InRange(DateTime.UtcNow.Subtract(model.Updated!.Value).Milliseconds, 0, 1500);
             }
 
             VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
@@ -950,9 +951,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(methodology.Id, viewModel.Id);
                 Assert.Equal("Test approval", viewModel.InternalReleaseNote);
                 Assert.True(viewModel.Published.HasValue);
+                Assert.InRange(DateTime.UtcNow.Subtract(viewModel.Published!.Value).Milliseconds, 0, 1500);
                 Assert.Equal(Immediately, viewModel.PublishingStrategy);
                 Assert.Null(viewModel.ScheduledWithRelease);
-                Assert.InRange(DateTime.UtcNow.Subtract(viewModel.Published.Value).Milliseconds, 0, 1500);
                 Assert.Equal(request.Status, viewModel.Status);
                 Assert.Equal(request.Title, viewModel.Title);
             }
@@ -965,12 +966,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     .SingleAsync(m => m.Id == methodology.Id);
 
                 Assert.True(model.Published.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(model.Published.Value).Milliseconds, 0, 1500);
+                Assert.InRange(DateTime.UtcNow.Subtract(model.Published!.Value).Milliseconds, 0, 1500);
                 Assert.Equal(Approved, model.Status);
                 Assert.Equal(Immediately, model.PublishingStrategy);
                 Assert.Equal("pupil-absence-statistics-updated-methodology", model.Slug);
                 Assert.True(model.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
+                Assert.InRange(DateTime.UtcNow.Subtract(model.Updated!.Value).Milliseconds, 0, 1500);
             }
         }
 
@@ -1077,7 +1078,258 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(scheduledWithRelease.Id, model.ScheduledWithReleaseId);
                 Assert.Equal("pupil-absence-statistics-updated-methodology", model.Slug);
                 Assert.True(model.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
+                Assert.InRange(DateTime.UtcNow.Subtract(model.Updated!.Value).Milliseconds, 0, 1500);
+            }
+
+            VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
+        }
+
+        [Fact]
+        public async Task UpdateMethodology_ApprovingUsingWithReleaseStrategy_ReleaseIdMissing()
+        {
+            var methodology = new Methodology
+            {
+                PublishingStrategy = Immediately,
+                Status = Draft,
+                MethodologyParent = new MethodologyParent
+                {
+                    Publications = AsList(new PublicationMethodology
+                    {
+                        Owner = true,
+                        Publication = new Publication()
+                    })
+                }
+            };
+
+            // Create a request with a release Id that is null
+            var request = new MethodologyUpdateRequest
+            {
+                LatestInternalReleaseNote = "Test approval",
+                PublishingStrategy = WithRelease,
+                WithReleaseId = null,
+                Status = Approved,
+                Title = "Title"
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await context.Methodologies.AddAsync(methodology);
+                await context.SaveChangesAsync();
+            }
+
+            var cacheService = new Mock<ICacheService>(Strict);
+            var contentService = new Mock<IMethodologyContentService>(Strict);
+            var imageService = new Mock<IMethodologyImageService>(Strict);
+            var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
+            var publishingService = new Mock<IPublishingService>(Strict);
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyService(contentDbContext: context,
+                    cacheService: cacheService.Object,
+                    methodologyContentService: contentService.Object,
+                    methodologyImageService: imageService.Object,
+                    methodologyRepository: methodologyRepository.Object,
+                    publishingService: publishingService.Object);
+
+                var result = await service.UpdateMethodology(methodology.Id, request);
+                result.AssertNotFound();
+            }
+
+            VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
+        }
+
+        [Fact]
+        public async Task UpdateMethodology_ApprovingUsingWithReleaseStrategy_ReleaseIdNotFound()
+        {
+            var methodology = new Methodology
+            {
+                PublishingStrategy = Immediately,
+                Status = Draft,
+                MethodologyParent = new MethodologyParent
+                {
+                    Publications = AsList(new PublicationMethodology
+                    {
+                        Owner = true,
+                        Publication = new Publication()
+                    })
+                }
+            };
+
+            // Create a request with a random release Id that won't exist
+            var request = new MethodologyUpdateRequest
+            {
+                LatestInternalReleaseNote = "Test approval",
+                PublishingStrategy = WithRelease,
+                WithReleaseId = Guid.NewGuid(),
+                Status = Approved,
+                Title = "Title"
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await context.Methodologies.AddAsync(methodology);
+                await context.SaveChangesAsync();
+            }
+
+            var cacheService = new Mock<ICacheService>(Strict);
+            var contentService = new Mock<IMethodologyContentService>(Strict);
+            var imageService = new Mock<IMethodologyImageService>(Strict);
+            var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
+            var publishingService = new Mock<IPublishingService>(Strict);
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyService(contentDbContext: context,
+                    cacheService: cacheService.Object,
+                    methodologyContentService: contentService.Object,
+                    methodologyImageService: imageService.Object,
+                    methodologyRepository: methodologyRepository.Object,
+                    publishingService: publishingService.Object);
+
+                var result = await service.UpdateMethodology(methodology.Id, request);
+                result.AssertNotFound();
+            }
+
+            VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
+        }
+
+        [Fact]
+        public async Task UpdateMethodology_ApprovingUsingWithReleaseStrategy_ReleaseAlreadyPublished()
+        {
+            var publication = new Publication();
+
+            // Create a release that is already published which the methodology cannot be made dependant on
+            var scheduledWithRelease = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = publication,
+                TimePeriodCoverage = CalendarYear,
+                ReleaseName = "2021",
+                Published = DateTime.UtcNow
+            };
+
+            var methodology = new Methodology
+            {
+                PublishingStrategy = Immediately,
+                Status = Draft,
+                MethodologyParent = new MethodologyParent
+                {
+                    Publications = AsList(new PublicationMethodology
+                    {
+                        Owner = true,
+                        Publication = publication
+                    })
+                }
+            };
+
+            var request = new MethodologyUpdateRequest
+            {
+                LatestInternalReleaseNote = "Test approval",
+                PublishingStrategy = WithRelease,
+                WithReleaseId = scheduledWithRelease.Id,
+                Status = Approved,
+                Title = "Title"
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await context.Methodologies.AddAsync(methodology);
+                await context.Releases.AddAsync(scheduledWithRelease);
+                await context.SaveChangesAsync();
+            }
+
+            var cacheService = new Mock<ICacheService>(Strict);
+            var contentService = new Mock<IMethodologyContentService>(Strict);
+            var imageService = new Mock<IMethodologyImageService>(Strict);
+            var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
+            var publishingService = new Mock<IPublishingService>(Strict);
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyService(contentDbContext: context,
+                    cacheService: cacheService.Object,
+                    methodologyContentService: contentService.Object,
+                    methodologyImageService: imageService.Object,
+                    methodologyRepository: methodologyRepository.Object,
+                    publishingService: publishingService.Object);
+
+                var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+                    service.UpdateMethodology(methodology.Id, request));
+                Assert.Equal("Methodology cannot depend on a published Release", ex.Message);
+            }
+
+            VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
+        }
+
+        [Fact]
+        public async Task UpdateMethodology_ApprovingUsingWithReleaseStrategy_ReleaseNotRelated()
+        {
+            // Release is not from the same publication as the one linked to the methodology 
+            var scheduledWithRelease = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = new Publication(),
+                TimePeriodCoverage = CalendarYear,
+                ReleaseName = "2021"
+            };
+
+            var methodology = new Methodology
+            {
+                PublishingStrategy = Immediately,
+                Status = Draft,
+                MethodologyParent = new MethodologyParent
+                {
+                    Publications = AsList(new PublicationMethodology
+                    {
+                        Owner = true,
+                        Publication = new Publication()
+                    })
+                }
+            };
+
+            var request = new MethodologyUpdateRequest
+            {
+                LatestInternalReleaseNote = "Test approval",
+                PublishingStrategy = WithRelease,
+                WithReleaseId = scheduledWithRelease.Id,
+                Status = Approved,
+                Title = "Title"
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await context.Methodologies.AddAsync(methodology);
+                await context.Releases.AddAsync(scheduledWithRelease);
+                await context.SaveChangesAsync();
+            }
+
+            var cacheService = new Mock<ICacheService>(Strict);
+            var contentService = new Mock<IMethodologyContentService>(Strict);
+            var imageService = new Mock<IMethodologyImageService>(Strict);
+            var methodologyRepository = new Mock<IMethodologyRepository>(Strict);
+            var publishingService = new Mock<IPublishingService>(Strict);
+
+            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyService(contentDbContext: context,
+                    cacheService: cacheService.Object,
+                    methodologyContentService: contentService.Object,
+                    methodologyImageService: imageService.Object,
+                    methodologyRepository: methodologyRepository.Object,
+                    publishingService: publishingService.Object);
+
+                var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+                    service.UpdateMethodology(methodology.Id, request));
+                Assert.Equal("Methodology cannot depend on a Release that it's not used by", ex.Message);
             }
         }
 
@@ -1171,7 +1423,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 // Slug remains unchanged
                 Assert.Equal("pupil-absence-statistics-methodology", model.Slug);
                 Assert.True(model.Updated.HasValue);
-                Assert.InRange(DateTime.UtcNow.Subtract(model.Updated.Value).Milliseconds, 0, 1500);
+                Assert.InRange(DateTime.UtcNow.Subtract(model.Updated!.Value).Milliseconds, 0, 1500);
             }
 
             VerifyAllMocks(cacheService, contentService, imageService, methodologyRepository, publishingService);
@@ -1571,14 +1823,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
         private static MethodologyService SetupMethodologyService(
             ContentDbContext contentDbContext,
-            IPersistenceHelper<ContentDbContext> persistenceHelper = null,
-            ICacheService cacheService = null,
-            IMethodologyContentService methodologyContentService = null,
-            IMethodologyFileRepository methodologyFileRepository = null,
-            IMethodologyRepository methodologyRepository = null,
-            IMethodologyImageService methodologyImageService = null,
-            IPublishingService publishingService = null,
-            IUserService userService = null)
+            IPersistenceHelper<ContentDbContext>? persistenceHelper = null,
+            ICacheService? cacheService = null,
+            IMethodologyContentService? methodologyContentService = null,
+            IMethodologyFileRepository? methodologyFileRepository = null,
+            IMethodologyRepository? methodologyRepository = null,
+            IMethodologyImageService? methodologyImageService = null,
+            IPublishingService? publishingService = null,
+            IUserService? userService = null)
         {
             return new(
                 persistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyController.cs
@@ -1,6 +1,9 @@
+#nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using Microsoft.AspNetCore.Authorization;
@@ -10,32 +13,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
 {
     [Authorize]
     [ApiController]
+    [Route("api")]
     public class MethodologyController : ControllerBase
     {
         private readonly IMethodologyService _methodologyService;
         private readonly IMethodologyAmendmentService _methodologyAmendmentService;
 
         public MethodologyController(
-            IMethodologyService methodologyService, 
+            IMethodologyService methodologyService,
             IMethodologyAmendmentService methodologyAmendmentService)
         {
             _methodologyService = methodologyService;
             _methodologyAmendmentService = methodologyAmendmentService;
         }
 
-        [Produces("application/json")]
-        [ProducesResponseType(typeof(MethodologySummaryViewModel), 200)]
-        [ProducesResponseType(typeof(ValidationProblemDetails), 400)]
-        [HttpPost("api/publication/{publicationId}/methodology")]
+        [HttpPost("publication/{publicationId}/methodology")]
         public Task<ActionResult<MethodologySummaryViewModel>> CreateMethodology(Guid publicationId)
         {
             return _methodologyService
                 .CreateMethodology(publicationId)
                 .HandleFailuresOrOk();
         }
-        
-        [Produces("application/json")]
-        [HttpGet("api/methodology/{methodologyId}/summary")]
+
+        [HttpGet("methodology/{methodologyId}/summary")]
         public async Task<ActionResult<MethodologySummaryViewModel>> GetMethodologySummary(Guid methodologyId)
         {
             return await _methodologyService
@@ -43,8 +43,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
                 .HandleFailuresOrOk();
         }
 
-        [Produces("application/json")]
-        [HttpPut("api/methodology/{methodologyId}")]
+        [HttpGet("methodology/{methodologyId}/unpublished-releases")]
+        public async Task<ActionResult<List<TitleAndIdViewModel>>> GetUnpublishedReleasesUsingMethodology(
+            Guid methodologyId)
+        {
+            return await _methodologyService
+                .GetUnpublishedReleasesUsingMethodology(methodologyId)
+                .HandleFailuresOrOk();
+        }
+
+        [HttpPut("methodology/{methodologyId}")]
         public async Task<ActionResult<MethodologySummaryViewModel>> UpdateMethodology(Guid methodologyId,
             MethodologyUpdateRequest request)
         {
@@ -53,10 +61,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
                 .HandleFailuresOrOk();
         }
 
-        [Produces("application/json")]
-        [ProducesResponseType(typeof(MethodologySummaryViewModel), 200)]
-        [ProducesResponseType(typeof(ValidationProblemDetails), 400)]
-        [HttpPost("api/methodology/{methodologyId}/amendment")]
+        [HttpPost("methodology/{methodologyId}/amendment")]
         public Task<ActionResult<MethodologySummaryViewModel>> CreateMethodologyAmendment(Guid methodologyId)
         {
             return _methodologyAmendmentService
@@ -64,7 +69,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
                 .HandleFailuresOrOk();
         }
 
-        [HttpDelete("api/methodology/{methodologyId}")]
+        [HttpDelete("methodology/{methodologyId}")]
         public Task<ActionResult> DeleteMethodology(Guid methodologyId)
         {
             return _methodologyService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -66,7 +66,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
             CreateMap<ReleaseStatus, ReleasePublishingStatusViewModel>()
                 .ForMember(model => model.LastUpdated, m => m.MapFrom(status => status.Timestamp));
 
-            CreateMap<Methodology, MethodologySummaryViewModel>();
+            CreateMap<Methodology, MethodologySummaryViewModel>()
+                .ForMember(dest => dest.ScheduledWithRelease,
+                    m => m.Ignore());
 
             CreateMap<Methodology, TitleAndIdViewModel>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
@@ -1,5 +1,8 @@
-﻿using System;
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +14,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
         Task<Either<ActionResult, MethodologySummaryViewModel>> CreateMethodology(Guid publicationId);
 
         Task<Either<ActionResult, MethodologySummaryViewModel>> GetSummary(Guid id);
+
+        Task<Either<ActionResult, List<TitleAndIdViewModel>>> GetUnpublishedReleasesUsingMethodology(Guid id);
 
         Task<Either<ActionResult, MethodologySummaryViewModel>> UpdateMethodology(Guid id,
             MethodologyUpdateRequest request);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -272,11 +272,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
             // Check that this release exists, that it's not already published, and that it's using the methodology
             return await _persistenceHelper.CheckEntityExists<Release>(request.WithReleaseId.Value)
-                .OnSuccess(async release =>
+                .OnSuccess<ActionResult, Release, Unit>(async release =>
                 {
                     if (release.Live)
                     {
-                        throw new ArgumentException("Methodology cannot depend on a published Release");
+                        return ValidationActionResult(MethodologyCannotDependOnPublishedRelease);
                     }
 
                     await _context.Entry(methodology)
@@ -293,7 +293,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
 
                     if (!publicationIds.Contains(release.PublicationId))
                     {
-                        throw new ArgumentException("Methodology cannot depend on a Release that it's not used by");
+                        return ValidationActionResult(MethodologyCannotDependOnRelease);
                     }
 
                     return Unit.Instance;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -97,6 +97,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         // Methodology
         MethodologyMustBeDraft,
         MethodologyMustBeApproved,
+        MethodologyCannotDependOnPublishedRelease,
+        MethodologyCannotDependOnRelease,
 
         // Theme
         ThemeDoesNotExist,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologySummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologySummaryViewModel.cs
@@ -18,13 +18,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
 
         public DateTime? Published { get; set; }
 
+        public TitleAndIdViewModel ScheduledWithRelease { get; set; }
+
         [JsonConverter(typeof(StringEnumConverter))]
         public MethodologyStatus Status { get; set; }
 
         public string Title { get; set; }
-        
+
         public bool Amendment { get; set; }
-        
+
         public Guid PreviousVersionId { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologySummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologySummaryViewModel.cs
@@ -18,6 +18,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
 
         public DateTime? Published { get; set; }
 
+        [JsonConverter(typeof(StringEnumConverter))]
+        public MethodologyPublishingStrategy PublishingStrategy { get; set; }
+
         public TitleAndIdViewModel ScheduledWithRelease { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyUpdateRequest.cs
@@ -1,3 +1,5 @@
+#nullable enable
+using System;
 using System.ComponentModel.DataAnnotations;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
@@ -7,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
 {
     public class MethodologyUpdateRequest
     {
-        public string LatestInternalReleaseNote { get; set; }
+        public string? LatestInternalReleaseNote { get; set; }
 
         // TODO SOW4 EES-2212 - update to AlternativeTitle
         [Required] public string Title { get; set; }
@@ -17,5 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
 
         [JsonConverter(typeof(StringEnumConverter))]
         public MethodologyPublishingStrategy PublishingStrategy { get; set; }
+
+        public Guid? ScheduledWithReleaseId { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyUpdateRequest.cs
@@ -20,6 +20,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
         [JsonConverter(typeof(StringEnumConverter))]
         public MethodologyPublishingStrategy PublishingStrategy { get; set; }
 
-        public Guid? ScheduledWithReleaseId { get; set; }
+        public Guid? WithReleaseId { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
@@ -13,7 +14,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
         {
             var methodology = new Methodology
             {
-                Status = Approved,
                 PublishingStrategy = Immediately
             };
 
@@ -23,21 +23,48 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
         [Fact]
         public void ScheduledForPublishingImmediately_FalseWhenPublishingStrategyIsWithRelease()
         {
-            var liveRelease = new Release
+            var release = new Release
             {
-                Id = Guid.NewGuid(),
-                Published = DateTime.UtcNow
+                Id = Guid.NewGuid()
             };
 
             var methodology = new Methodology
             {
-                Status = Approved,
                 PublishingStrategy = WithRelease,
-                ScheduledWithReleaseId = liveRelease.Id,
-                ScheduledWithRelease = liveRelease
+                ScheduledWithReleaseId = release.Id,
+                ScheduledWithRelease = release
             };
 
             Assert.False(methodology.ScheduledForPublishingImmediately);
+        }
+
+        [Fact]
+        public void ScheduledForPublishingWithRelease_FalseWhenPublishingStrategyIsImmediately()
+        {
+            var methodology = new Methodology
+            {
+                PublishingStrategy = Immediately
+            };
+
+            Assert.False(methodology.ScheduledForPublishingWithRelease);
+        }
+
+        [Fact]
+        public void ScheduledForPublishingWithRelease_TrueWhenPublishingStrategyIsWithRelease()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var methodology = new Methodology
+            {
+                PublishingStrategy = WithRelease,
+                ScheduledWithReleaseId = release.Id,
+                ScheduledWithRelease = release
+            };
+
+            Assert.True(methodology.ScheduledForPublishingWithRelease);
         }
 
         [Fact]
@@ -93,7 +120,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
         {
             var methodology = new Methodology
             {
-                Status = Approved,
                 PublishingStrategy = WithRelease,
                 ScheduledWithReleaseId = Guid.NewGuid()
             };

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Methodology.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
@@ -14,7 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         Draft,
         Approved
     }
-    
+
     public enum MethodologyPublishingStrategy
     {
         Immediately,
@@ -23,9 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
     public class Methodology
     {
-        [Key] 
-        [Required] 
-        public Guid Id { get; set; }
+        [Key] [Required] public Guid Id { get; set; }
 
         public string Title => AlternativeTitle ?? MethodologyParent.OwningPublicationTitle;
 
@@ -69,22 +66,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public bool Approved => Status == MethodologyStatus.Approved;
 
-        public bool ScheduledForPublishingImmediately => PublishingStrategy == MethodologyPublishingStrategy.Immediately;
+        public bool ScheduledForPublishingWithRelease => PublishingStrategy == WithRelease;
+
+        public bool ScheduledForPublishingImmediately => PublishingStrategy == Immediately;
 
         public bool ScheduledForPublishingWithPublishedRelease
         {
             get
             {
-                if (PublishingStrategy != MethodologyPublishingStrategy.WithRelease)
+                if (PublishingStrategy != WithRelease)
                 {
                     return false;
                 }
-                
-                if (ScheduledWithReleaseId != null && ScheduledWithRelease == null)
+
+                if (ScheduledWithReleaseId == null || ScheduledWithRelease == null)
                 {
                     throw new InvalidOperationException("ScheduledWithRelease field not included in Methodology");
                 }
-                
+
                 return ScheduledWithRelease.Live;
             }
         }
@@ -115,11 +114,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
             copy.Annexes = Annexes
                 .Select(c => c.Clone(createdDate))
                 .ToList();
-            
+
             copy.Content = Content
                 .Select(c => c.Clone(createdDate))
                 .ToList();
-            
+
             return copy;
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/PublishingService.cs
@@ -13,7 +13,6 @@ using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
-using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Utils.CopyDirectoryCallbacks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
@@ -93,7 +92,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
                         // Include methodologies scheduled to be published with this release
                         var methodologyScheduledWithThisRelease =
-                            methodology.PublishingStrategy == WithRelease
+                            methodology.ScheduledForPublishingWithRelease
                             && methodology.ScheduledWithReleaseId == releaseId;
 
                         if (firstReleaseAndMethodologyScheduledImmediately ||

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusEditPage.tsx
@@ -1,0 +1,55 @@
+import methodologyService, {
+  BasicMethodology,
+  MethodologyStatus,
+} from '@admin/services/methodologyService';
+import LoadingSpinner from '@common/components/LoadingSpinner';
+import WarningMessage from '@common/components/WarningMessage';
+import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
+import MethodologyStatusForm from '@admin/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm';
+import React from 'react';
+
+interface FormValues {
+  status: MethodologyStatus;
+  latestInternalReleaseNote: string;
+  publishingStrategy?: 'WithRelease' | 'Immediately';
+  withReleaseId?: string;
+}
+
+interface Props {
+  methodologySummary: BasicMethodology;
+  onCancel: () => void;
+  onSubmit: (values: FormValues) => void;
+}
+
+const MethodologyStatusEditPage = ({
+  methodologySummary,
+  onCancel,
+  onSubmit,
+}: Props) => {
+  const {
+    value: unpublishedReleases,
+    isLoading,
+  } = useAsyncHandledRetry(
+    async () =>
+      methodologyService.getUnpublishedReleases(methodologySummary.id),
+    [methodologySummary.id],
+  );
+
+  return (
+    <LoadingSpinner loading={isLoading}>
+      {unpublishedReleases ? (
+        <MethodologyStatusForm
+          isPublished={methodologySummary.published}
+          methodologySummary={methodologySummary}
+          unpublishedReleases={unpublishedReleases}
+          onCancel={onCancel}
+          onSubmit={onSubmit}
+        />
+      ) : (
+        <WarningMessage>Could not load unpublished releases</WarningMessage>
+      )}
+    </LoadingSpinner>
+  );
+};
+
+export default MethodologyStatusEditPage;

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -106,7 +106,7 @@ const MethodologyStatusPage = ({
                     <>
                       <SummaryListItem term="When to publish">
                         {model.summary.publishingStrategy === 'WithRelease'
-                          ? 'With specific release'
+                          ? 'With a specific release'
                           : model.summary.publishingStrategy}
                       </SummaryListItem>
                       {model.summary.publishingStrategy === 'WithRelease' && (

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -10,11 +10,11 @@ import WarningMessage from '@common/components/WarningMessage';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
 import useToggle from '@common/hooks/useToggle';
 import { Dictionary } from '@common/types';
-import MethodologyStatusForm from '@admin/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
+import MethodologyStatusEditPage from './MethodologyStatusEditPage';
 
 interface FormValues {
   status: MethodologyStatus;
@@ -33,28 +33,21 @@ const MethodologyStatusPage = ({
 }: RouteComponentProps<MethodologyRouteParams>) => {
   const { methodologyId } = match.params;
 
-  const [showForm, toggleForm] = useToggle(false);
+  const [isEditing, toggleForm] = useToggle(false);
 
   const {
     value: model,
     setState: setModel,
     isLoading,
   } = useAsyncRetry(async () => {
-    const [
-      summary,
-      unpublishedReleases,
-      canApprove,
-      canMarkAsDraft,
-    ] = await Promise.all([
+    const [summary, canApprove, canMarkAsDraft] = await Promise.all([
       methodologyService.getMethodology(methodologyId),
-      methodologyService.getUnpublishedReleases(methodologyId),
       permissionService.canApproveMethodology(methodologyId),
       permissionService.canMarkMethodologyAsDraft(methodologyId),
     ]);
 
     return {
       summary,
-      unpublishedReleases,
       canApprove,
       canMarkAsDraft,
     };
@@ -87,14 +80,13 @@ const MethodologyStatusPage = ({
   };
 
   const isEditable = model?.canApprove || model?.canMarkAsDraft;
-  const isPublished = model?.summary.published;
 
   return (
     <>
       <LoadingSpinner loading={isLoading}>
         {model ? (
           <>
-            {!showForm ? (
+            {!isEditing ? (
               <>
                 <h2>Sign off</h2>
 
@@ -128,10 +120,8 @@ const MethodologyStatusPage = ({
                 )}
               </>
             ) : (
-              <MethodologyStatusForm
-                isPublished={isPublished}
+              <MethodologyStatusEditPage
                 methodologySummary={model.summary}
-                unpublishedReleases={model.unpublishedReleases}
                 onCancel={toggleForm.off}
                 onSubmit={handleSubmit}
               />

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm.tsx
@@ -3,7 +3,7 @@ import {
   MethodologyPublishingStrategy,
   MethodologyStatus,
 } from '@admin/services/methodologyService';
-import { Release } from '@admin/services/releaseService';
+import { IdTitlePair } from '@admin/services/types/common';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
@@ -23,23 +23,10 @@ export interface FormValues {
   withReleaseId?: string;
 }
 
-// EES-2163 Replace with real list when EES-2264 done.
-const fakeUnpublishedReleases: Release[] = [
-  {
-    id: 'rel-1',
-    title: 'Release 1',
-  } as Release,
-  {
-    id: 'rel-2',
-    title: 'Release 2',
-  } as Release,
-];
-
 interface Props {
   isPublished?: string;
   methodologySummary: BasicMethodology;
-  showWithRelease?: boolean; // EES-2163 - flag for showing publishing strategy sections for testing, remove when BE done.
-  unPublishedReleases?: Release[];
+  unpublishedReleases: IdTitlePair[];
   onCancel: () => void;
   onSubmit: (values: FormValues) => void;
 }
@@ -47,8 +34,7 @@ interface Props {
 const MethodologyStatusForm = ({
   isPublished,
   methodologySummary,
-  showWithRelease = false,
-  unPublishedReleases = fakeUnpublishedReleases, // EES-2163 use fake for now.
+  unpublishedReleases,
   onCancel,
   onSubmit,
 }: Props) => {
@@ -60,7 +46,7 @@ const MethodologyStatusForm = ({
           methodologySummary.latestInternalReleaseNote ?? '',
         publishingStrategy:
           methodologySummary.publishingStrategy ?? 'Immediately',
-        withReleaseId: methodologySummary.withReleaseId,
+        withReleaseId: methodologySummary.scheduledWithRelease?.id,
       }}
       onSubmit={useFormSubmit<FormValues>(onSubmit)}
       validationSchema={Yup.object<FormValues>({
@@ -112,7 +98,7 @@ const MethodologyStatusForm = ({
               ]}
               order={[]}
             />
-            {form.values.status === 'Approved' && showWithRelease && (
+            {form.values.status === 'Approved' && (
               <FormFieldRadioGroup<FormValues>
                 name="publishingStrategy"
                 legend="When to publish"
@@ -127,7 +113,7 @@ const MethodologyStatusForm = ({
                       <FormFieldSelect<FormValues>
                         label="Select release"
                         name="withReleaseId"
-                        options={unPublishedReleases.map(release => {
+                        options={unpublishedReleases.map(release => {
                           return {
                             label: release.title,
                             value: release.id,

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
@@ -1,7 +1,7 @@
 import MethodologyStatusForm, {
   FormValues,
 } from '@admin/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm';
-import { Release } from '@admin/services/releaseService';
+import { IdTitlePair } from '@admin/services/types/common';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -9,15 +9,15 @@ import noop from 'lodash/noop';
 import { BasicMethodology } from 'src/services/methodologyService';
 
 describe('MethodologyStatusForm', () => {
-  const testUnpublishedReleases: Release[] = [
+  const testUnpublishedReleases: IdTitlePair[] = [
     {
       id: 'test-release-2',
       title: 'Test Release 2',
-    } as Release,
+    },
     {
       id: 'test-release-1',
       title: 'Test Release 1',
-    } as Release,
+    },
   ];
 
   test('renders the form with draft initial values', () => {
@@ -28,7 +28,7 @@ describe('MethodologyStatusForm', () => {
             status: 'Draft',
           } as BasicMethodology
         }
-        showWithRelease // EES-2163 flag
+        unpublishedReleases={testUnpublishedReleases}
         onCancel={noop}
         onSubmit={noop}
       />,
@@ -66,7 +66,7 @@ describe('MethodologyStatusForm', () => {
             latestInternalReleaseNote: 'The latest note',
           } as BasicMethodology
         }
-        showWithRelease // EES-2163 flag
+        unpublishedReleases={testUnpublishedReleases}
         onCancel={noop}
         onSubmit={noop}
       />,
@@ -91,11 +91,12 @@ describe('MethodologyStatusForm', () => {
             status: 'Approved',
             latestInternalReleaseNote: 'The latest note',
             publishingStrategy: 'WithRelease',
-            withReleaseId: 'test-release-2',
+            scheduledWithRelease: {
+              id: 'test-release-2',
+            },
           } as BasicMethodology
         }
-        showWithRelease // EES-2163 flag
-        unPublishedReleases={testUnpublishedReleases}
+        unpublishedReleases={testUnpublishedReleases}
         onCancel={noop}
         onSubmit={noop}
       />,
@@ -141,7 +142,7 @@ describe('MethodologyStatusForm', () => {
             status: 'Draft',
           } as BasicMethodology
         }
-        showWithRelease // EES-2163 flag
+        unpublishedReleases={testUnpublishedReleases}
         onCancel={noop}
         onSubmit={noop}
       />,
@@ -169,8 +170,7 @@ describe('MethodologyStatusForm', () => {
             status: 'Approved',
           } as BasicMethodology
         }
-        showWithRelease // EES-2163 flag
-        unPublishedReleases={testUnpublishedReleases}
+        unpublishedReleases={testUnpublishedReleases}
         onCancel={noop}
         onSubmit={noop}
       />,
@@ -198,8 +198,7 @@ describe('MethodologyStatusForm', () => {
             publishingStrategy: 'WithRelease',
           } as BasicMethodology
         }
-        showWithRelease // EES-2163 flag
-        unPublishedReleases={testUnpublishedReleases}
+        unpublishedReleases={testUnpublishedReleases}
         onCancel={noop}
         onSubmit={handleSubmit}
       />,
@@ -231,8 +230,7 @@ describe('MethodologyStatusForm', () => {
             publishingStrategy: 'WithRelease',
           } as BasicMethodology
         }
-        showWithRelease // EES-2163 flag
-        unPublishedReleases={testUnpublishedReleases}
+        unpublishedReleases={testUnpublishedReleases}
         onCancel={noop}
         onSubmit={handleSubmit}
       />,

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusPageTest.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusPageTest.test.tsx
@@ -6,7 +6,6 @@ import _methodologyService, {
 import _permissionService from '@admin/services/permissionService';
 import { generatePath, MemoryRouter } from 'react-router';
 import MethodologyStatusPage from '@admin/pages/methodology/edit-methodology/status/MethodologyStatusPage';
-import { IdTitlePair } from '@admin/services/types/common';
 import {
   MethodologyRouteParams,
   methodologyStatusRoute,

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusPageTest.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusPageTest.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import _methodologyService, {
+  BasicMethodology,
+} from '@admin/services/methodologyService';
+import _permissionService from '@admin/services/permissionService';
+import { generatePath, MemoryRouter } from 'react-router';
+import MethodologyStatusPage from '@admin/pages/methodology/edit-methodology/status/MethodologyStatusPage';
+import { IdTitlePair } from '@admin/services/types/common';
+import {
+  MethodologyRouteParams,
+  methodologyStatusRoute,
+} from '@admin/routes/methodologyRoutes';
+import userEvent from '@testing-library/user-event';
+import { Route } from 'react-router-dom';
+
+jest.mock('@admin/services/methodologyService');
+jest.mock('@admin/services/permissionService');
+
+const methodologyService = _methodologyService as jest.Mocked<
+  typeof _methodologyService
+>;
+const permissionService = _permissionService as jest.Mocked<
+  typeof _permissionService
+>;
+
+describe('MethodologyStatusPage', () => {
+  const testMethodology: BasicMethodology = {
+    id: 'm1',
+    title: 'Test methodology',
+    slug: 'test-methodology',
+    publication: {
+      id: 'p1',
+      title: 'Publication title',
+    },
+  } as BasicMethodology;
+
+  test('renders Draft status details', async () => {
+    methodologyService.getMethodology.mockResolvedValue({
+      ...testMethodology,
+      status: 'Draft',
+      publishingStrategy: 'WithRelease',
+    });
+    permissionService.canApproveMethodology.mockResolvedValue(false);
+    permissionService.canMarkMethodologyAsDraft.mockResolvedValue(false);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign off')).toBeInTheDocument();
+
+      expect(screen.getByTestId('Status-key')).toHaveTextContent('Status');
+      expect(screen.getByTestId('Status-value')).toHaveTextContent('In Draft');
+    });
+
+    expect(screen.queryByTestId('When to publish-key')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('Publish with release-key'),
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByText('Edit status')).not.toBeInTheDocument();
+  });
+
+  test('renders Approved details for publishing immediatately', async () => {
+    methodologyService.getMethodology.mockResolvedValue({
+      ...testMethodology,
+      status: 'Approved',
+      publishingStrategy: 'Immediately',
+    });
+    permissionService.canApproveMethodology.mockResolvedValue(false);
+    permissionService.canMarkMethodologyAsDraft.mockResolvedValue(false);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign off')).toBeInTheDocument();
+
+      expect(screen.getByTestId('Status-key')).toHaveTextContent('Status');
+      expect(screen.getByTestId('Status-value')).toHaveTextContent('Approved');
+
+      expect(screen.getByTestId('When to publish-key')).toHaveTextContent(
+        'When to publish',
+      );
+      expect(screen.getByTestId('When to publish-value')).toHaveTextContent(
+        'Immediately',
+      );
+    });
+
+    expect(
+      screen.queryByTestId('Publish with release-key'),
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByText('Edit status')).not.toBeInTheDocument();
+  });
+
+  test('renders Approved details for publishing with release', async () => {
+    methodologyService.getMethodology.mockResolvedValue({
+      ...testMethodology,
+      status: 'Approved',
+      publishingStrategy: 'WithRelease',
+      scheduledWithRelease: {
+        id: 'dependant-release',
+        title: 'Dependant Release',
+      },
+    });
+    permissionService.canApproveMethodology.mockResolvedValue(false);
+    permissionService.canMarkMethodologyAsDraft.mockResolvedValue(false);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign off')).toBeInTheDocument();
+
+      expect(screen.getByTestId('Status-key')).toHaveTextContent('Status');
+      expect(screen.getByTestId('Status-value')).toHaveTextContent('Approved');
+
+      expect(screen.getByTestId('When to publish-key')).toHaveTextContent(
+        'When to publish',
+      );
+      expect(screen.getByTestId('When to publish-value')).toHaveTextContent(
+        'With a specific release',
+      );
+
+      expect(screen.getByTestId('Publish with release-key')).toHaveTextContent(
+        'Publish with release',
+      );
+      expect(
+        screen.getByTestId('Publish with release-value'),
+      ).toHaveTextContent('Dependant Release');
+    });
+
+    expect(screen.queryByText('Edit status')).not.toBeInTheDocument();
+  });
+
+  test('renders Edit status button if user can approve methodology', async () => {
+    methodologyService.getMethodology.mockResolvedValue(testMethodology);
+    permissionService.canApproveMethodology.mockResolvedValue(true);
+    permissionService.canMarkMethodologyAsDraft.mockResolvedValue(false);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign off')).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', { name: 'Edit status' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('renders Edit status button if user can mark methodology as draft', async () => {
+    methodologyService.getMethodology.mockResolvedValue(testMethodology);
+    permissionService.canApproveMethodology.mockResolvedValue(false);
+    permissionService.canMarkMethodologyAsDraft.mockResolvedValue(true);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign off')).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', { name: 'Edit status' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('renders status form when Edit button is clicked', async () => {
+    methodologyService.getMethodology.mockResolvedValue(testMethodology);
+    methodologyService.getUnpublishedReleases.mockResolvedValue([]);
+    permissionService.canApproveMethodology.mockResolvedValue(true);
+    permissionService.canMarkMethodologyAsDraft.mockResolvedValue(false);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign off')).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', { name: 'Edit status' }),
+      ).toBeInTheDocument();
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Edit status' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit methodology status')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Update status' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  function renderPage() {
+    render(
+      <MemoryRouter
+        initialEntries={[
+          generatePath<MethodologyRouteParams>(methodologyStatusRoute.path, {
+            methodologyId: testMethodology.id,
+          }),
+        ]}
+      >
+        <Route
+          path={methodologyStatusRoute.path}
+          component={MethodologyStatusPage}
+        />
+      </MemoryRouter>,
+    );
+  }
+});

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusPageTest.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusPageTest.test.tsx
@@ -26,9 +26,10 @@ const permissionService = _permissionService as jest.Mocked<
 describe('MethodologyStatusPage', () => {
   const testMethodology: BasicMethodology = {
     id: 'm1',
+    amendment: false,
     title: 'Test methodology',
     slug: 'test-methodology',
-    publication: {
+    owningPublication: {
       id: 'p1',
       title: 'Publication title',
     },

--- a/src/explore-education-statistics-admin/src/services/methodologyService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyService.ts
@@ -1,4 +1,5 @@
 import client from '@admin/services/utils/service';
+import { IdTitlePair } from '@admin/services/types/common';
 
 export type UpdateMethodology = {
   title: string;
@@ -25,7 +26,7 @@ export interface BasicMethodology {
   published?: string;
   owningPublication: MethodologyPublication;
   otherPublications?: MethodologyPublication[];
-  withReleaseId?: string;
+  scheduledWithRelease?: IdTitlePair;
 }
 
 export interface MyMethodology extends BasicMethodology {
@@ -51,6 +52,12 @@ const methodologyService = {
   getMethodology(methodologyId: string): Promise<BasicMethodology> {
     return client.get<BasicMethodology>(
       `/methodology/${methodologyId}/summary`,
+    );
+  },
+
+  getUnpublishedReleases(methodologyId: string): Promise<IdTitlePair[]> {
+    return client.get<IdTitlePair[]>(
+      `/methodology/${methodologyId}/unpublished-releases`,
     );
   },
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -1,0 +1,100 @@
+*** Settings ***
+Library             ../../libs/admin_api.py
+Resource            ../../libs/admin-common.robot
+Resource            ../../libs/admin/manage-content-common.robot
+Resource            ../../libs/public-common.robot
+
+Suite Setup         user signs in as bau1
+Suite Teardown      user closes the browser
+
+Force Tags          Admin    Local    Dev    AltersData
+
+*** Variables ***
+${PUBLICATION_NAME}=            UI tests - publish methodology %{RUN_IDENTIFIER}
+${PUBLIC_METHODOLOGY_URL}=      %{PUBLIC_URL}/methodology/ui-tests-publish-methodology-%{RUN_IDENTIFIER}
+
+*** Test Cases ***
+Create a draft release
+    ${PUBLICATION_ID}=    user creates test publication via api    ${PUBLICATION_NAME}
+    user create test release via api    ${PUBLICATION_ID}    AY    2021
+
+Approve a methodology for publishing immediately
+    user creates approved methodology for publication    ${PUBLICATION_NAME}
+
+Verify that the publication is not visible on the public methodologies page without a published release
+    user navigates to methodologies page
+    user checks page does not contain    ${PUBLICATION_NAME}
+
+Verify that the methodology is not publicly accessible by URL without a published release
+    user goes to url    ${PUBLIC_METHODOLOGY_URL}
+    user waits until page contains    Page not found
+
+Alter the approval to publish the methodology with the release
+    user approves methodology for publication
+    ...    publication=${PUBLICATION_NAME}
+    ...    publishing_strategy=WithRelease
+    ...    with_release=${PUBLICATION_NAME} - Academic Year 2021/22
+
+Verify that the publication is still not visible on the public methodologies page without publishing the release
+    user navigates to methodologies page
+    user checks page does not contain    ${PUBLICATION_NAME}
+
+Verify that the methodology is still not publicly accessible by URL without publishing the release
+    user goes to url    ${PUBLIC_METHODOLOGY_URL}
+    user waits until page contains    Page not found
+
+Approve the release
+    user navigates to editable release summary from admin dashboard    ${PUBLICATION_NAME}
+    ...    Academic Year 2021/22 (not Live)
+    user approves release for immediate publication
+
+Verify that the methodology is visible on the public methodologies page with the expected URL
+    user navigates to methodologies page
+    user waits until page contains accordion section    %{TEST_THEME_NAME}
+    user opens accordion section    %{TEST_THEME_NAME}
+    user opens details dropdown    %{TEST_TOPIC_NAME}
+    user checks page contains methodology link
+    ...    %{TEST_TOPIC_NAME}
+    ...    ${PUBLICATION_NAME}
+    ...    ${PUBLICATION_NAME}
+    ...    ${PUBLIC_METHODOLOGY_URL}
+
+Verify that the methodology is publicly accessible
+    user clicks methodology link
+    ...    %{TEST_TOPIC_NAME}
+    ...    ${PUBLICATION_NAME}
+    ...    ${PUBLICATION_NAME}
+    user waits until h1 is visible    ${PUBLICATION_NAME}
+    user waits until page contains title caption    Methodology
+
+Amend the methodology in preparation to test publishing immediately
+    user creates methodology amendment for publication    ${PUBLICATION_NAME}
+    user edits methodology summary for publication
+    ...    ${PUBLICATION_NAME}
+    ...    ${PUBLICATION_NAME}
+    ...    ${PUBLICATION_NAME} - Amended methodology
+    ...    Edit this amendment
+
+Approve the amendment for publishing immediately
+    user approves methodology amendment for publication
+    ...    ${PUBLICATION_NAME}
+    ...    ${PUBLICATION_NAME} - Amended methodology
+
+Verify that the amended methodology is visible on the public methodologies page immediately
+    user navigates to methodologies page
+    user waits until page contains accordion section    %{TEST_THEME_NAME}
+    user opens accordion section    %{TEST_THEME_NAME}
+    user opens details dropdown    %{TEST_TOPIC_NAME}
+    user checks page contains methodology link
+    ...    %{TEST_TOPIC_NAME}
+    ...    ${PUBLICATION_NAME}
+    ...    ${PUBLICATION_NAME} - Amended methodology
+    ...    ${PUBLIC_METHODOLOGY_URL}
+
+Verify that the amended methodology is publicly accessible immediately
+    user clicks methodology link
+    ...    %{TEST_TOPIC_NAME}
+    ...    ${PUBLICATION_NAME}
+    ...    ${PUBLICATION_NAME} - Amended methodology
+    user waits until h1 is visible    ${PUBLICATION_NAME} - Amended methodology
+    user waits until page contains title caption    Methodology

--- a/tests/robot-tests/tests/general_public/methodologies_page.robot
+++ b/tests/robot-tests/tests/general_public/methodologies_page.robot
@@ -9,10 +9,7 @@ Suite Teardown      user closes the browser
 *** Test Cases ***
 Navigate to /methodology page
     [Tags]    HappyPath
-    environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}/methodology
-    user waits until h1 is visible    Methodologies
-    user waits for page to finish loading
+    user navigates to methodologies page
 
 Validate page contents
     [Tags]    HappyPath

--- a/tests/robot-tests/tests/general_public/methodology_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/methodology_page_absence.robot
@@ -9,11 +9,7 @@ Force Tags          GeneralPublic    Local    Dev    Test    Preprod    NotAgain
 *** Test Cases ***
 Navigate to Pupil absence in schools in England methodology page
     [Tags]    HappyPath
-    environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}/methodology
-    user waits until h1 is visible    Methodologies
-    user waits for page to finish loading
-
+    user navigates to methodologies page
     user opens accordion section    Pupils and schools
     user opens details dropdown    Pupil absence
 

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -557,14 +557,14 @@ user changes methodology status to Approved
     user clicks element    id:methodologyStatusForm-status-Approved
     user enters text into element    id:methodologyStatusForm-latestInternalReleaseNote    Approved by UI tests
     user clicks element    id:methodologyStatusForm-publishingStrategy-${publishing_strategy}
-    IF    '${publishing_strategy}' == 'WithRelease'
+    IF    ${is_publishing_strategy_with_release} is ${TRUE}
         user waits until element is enabled    css:[name="withReleaseId"]
         user chooses select option    css:[name="withReleaseId"]    ${with_release}
     END
     user clicks button    Update status
     user waits until h2 is visible    Sign off
     user checks summary list contains    Status    Approved
-    IF    '${publishing_strategy}' == 'WithRelease'
+    IF    ${is_publishing_strategy_with_release} is ${TRUE}
         user checks summary list contains    When to publish    With a specific release
         user checks summary list contains    Publish with release    ${with_release}
     ELSE

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -224,11 +224,13 @@ user approves methodology for publication
     ...    ${methodology_title}=${publication}
     ...    ${theme}=%{TEST_THEME_NAME}
     ...    ${topic}=%{TEST_TOPIC_NAME}
+    ...    ${publishing_strategy}=Immediately
+    ...    ${with_release}=
 
     ${accordion}=    user opens publication on the admin dashboard    ${publication}    ${theme}    ${topic}
     user opens details dropdown    ${methodology_title}    ${accordion}
     user clicks link    Edit this methodology    ${accordion}
-    approve methodology from methodology view
+    approve methodology from methodology view    ${publishing_strategy}    ${with_release}
 
 user approves methodology amendment for publication
     [Arguments]
@@ -236,15 +238,20 @@ user approves methodology amendment for publication
     ...    ${methodology_title}=${publication}
     ...    ${theme}=%{TEST_THEME_NAME}
     ...    ${topic}=%{TEST_TOPIC_NAME}
+    ...    ${publishing_strategy}=Immediately
+    ...    ${with_release}=
 
     ${accordion}=    user opens publication on the admin dashboard    ${publication}    ${theme}    ${topic}
     user opens details dropdown    ${methodology_title}    ${accordion}
     user clicks link    Edit this amendment    ${accordion}
-    approve methodology from methodology view
+    approve methodology from methodology view    ${publishing_strategy}    ${with_release}
 
 approve methodology from methodology view
+    [Arguments]
+    ...    ${publishing_strategy}
+    ...    ${with_release}
     user clicks link    Sign off
-    user changes methodology status to Approved
+    user changes methodology status to Approved    ${publishing_strategy}    ${with_release}
 
 user creates approved methodology for publication
     [Arguments]
@@ -542,18 +549,33 @@ user verifies release summary
     user checks summary list contains    Release type    ${RELEASE_TYPE}
 
 user changes methodology status to Approved
+    [Arguments]
+    ...    ${publishing_strategy}=Immediately
+    ...    ${with_release}=
+    ${is_publishing_strategy_with_release}=    Evaluate    '${publishing_strategy}' == 'WithRelease'
     user clicks button    Edit status
     user clicks element    id:methodologyStatusForm-status-Approved
     user enters text into element    id:methodologyStatusForm-latestInternalReleaseNote    Approved by UI tests
+    user clicks element    id:methodologyStatusForm-publishingStrategy-${publishing_strategy}
+    IF    '${publishing_strategy}' == 'WithRelease'
+        user waits until element is enabled    css:[name="withReleaseId"]
+        user chooses select option    css:[name="withReleaseId"]    ${with_release}
+    END
     user clicks button    Update status
-    user waits until h2 is visible    Methodology status
-    user checks page contains tag    Approved
+    user waits until h2 is visible    Sign off
+    user checks summary list contains    Status    Approved
+    IF    '${publishing_strategy}' == 'WithRelease'
+        user checks summary list contains    When to publish    With a specific release
+        user checks summary list contains    Publish with release    ${with_release}
+    ELSE
+        user checks summary list contains    When to publish    ${publishing_strategy}
+    END
 
 user changes methodology status to Draft
     user clicks button    Edit status
     user clicks element    id:methodologyStatusForm-status-Draft
     user clicks button    Update status
-    user waits until h2 is visible    Methodology status
+    user waits until h2 is visible    Sign off
     user checks page contains tag    In Draft
 
 user gives analyst publication owner access

--- a/tests/robot-tests/tests/libs/public-common.robot
+++ b/tests/robot-tests/tests/libs/public-common.robot
@@ -33,3 +33,9 @@ user goes to release page via breadcrumb
 
     user waits until h1 is visible    ${publication}
     user waits until page contains title caption    ${release}
+
+user navigates to methodologies page
+    environment variable should be set    PUBLIC_URL
+    user goes to url    %{PUBLIC_URL}/methodology
+    user waits until h1 is visible    Methodologies
+    user waits for page to finish loading


### PR DESCRIPTION
This PR:

- Adds a new Admin API endpoint `/api/methodology/{methodologyId}/unpublished-releases`  returning an ordered list of unpublished Releases for the owning or adopting publications using the methodology.
- Allows setting the chosen publishing strategy when approving a Release - Immediately or With a specifc release.
- Alters the Admin `UpdateMethodology` method to allow setting the chosen release id when approving with a specific release.
- Validates that the methodology can depend on a chosen release for publishing, i.e. checks that this release exists, that it's not already published, and that it's still linked via its publication to the methodology.
- Hooks up the FE work for this feature covered by @amyb-hiveit  in https://github.com/dfe-analytical-services/explore-education-statistics/pull/2733
- Renames the title on the Methodology Sign Off tab to Sign Off to make it consistent with release pages.
- Add a summary list to the read only view of the Methodology Sign off tab to contain the status, publishing strategy, and any release that's been chosen.
- Adds a new Jest test for MethodologyStatusPage which previously had no coverage.
- Adds a new Robot test suite `publish_methodology.robot` to test methodologies are publicly accessible when they should be.

A new endpoint for the list of unpublished methodologies was chosen rather than add this list to the existing  `Methodology SummaryViewModel`. This was to:
 - Avoid additional overhead in calculating this list which isn't always necessary - e.g. creating methodology, updating methodology, and making methodology amendments all return `MethodologySummaryViewModel`.
 - Make the unit test for this functionality clearly defined, avoiding changes to all of the existing tests for creating and updating methodologies which return `MethodologySummaryViewModel`.

![image](https://user-images.githubusercontent.com/4147126/128336247-766cdfe8-a327-45f8-9ac2-562fbb419e0a.png)

![image](https://user-images.githubusercontent.com/4147126/128336332-fe05e4c8-4bcd-417a-850a-3e484b73b36e.png)
