### PR TITLE
EES-2600 - updated Previous / Next nav buttons to omit Edit Summary r…

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/MethodologyPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/MethodologyPage.tsx
@@ -17,17 +17,15 @@ import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import React from 'react';
 import { generatePath, Route, RouteComponentProps, Switch } from 'react-router';
 
-const methodologyRoutes: MethodologyRouteProps[] = [
-  methodologySummaryRoute,
-  methodologySummaryEditRoute,
-  methodologyContentRoute,
-  methodologyStatusRoute,
-];
-
 const navRoutes: MethodologyRouteProps[] = [
   methodologySummaryRoute,
   methodologyContentRoute,
   methodologyStatusRoute,
+];
+
+const routes: MethodologyRouteProps[] = [
+  ...navRoutes,
+  methodologySummaryEditRoute,
 ];
 
 const MethodologyPage = ({
@@ -42,7 +40,7 @@ const MethodologyPage = ({
   );
 
   const currentRouteIndex =
-    methodologyRoutes.findIndex(
+    navRoutes.findIndex(
       route =>
         generatePath<MethodologyRouteParams>(route.path, {
           methodologyId,
@@ -50,13 +48,11 @@ const MethodologyPage = ({
     ) || 0;
 
   const previousRoute =
-    currentRouteIndex > 0
-      ? methodologyRoutes[currentRouteIndex - 1]
-      : undefined;
+    currentRouteIndex > 0 ? navRoutes[currentRouteIndex - 1] : undefined;
 
   const nextRoute =
-    currentRouteIndex < methodologyRoutes.length - 1
-      ? methodologyRoutes[currentRouteIndex + 1]
+    currentRouteIndex < navRoutes.length - 1
+      ? navRoutes[currentRouteIndex + 1]
       : undefined;
 
   const previousSection = previousRoute
@@ -111,7 +107,7 @@ const MethodologyPage = ({
             />
 
             <Switch>
-              {methodologyRoutes.map(route => (
+              {routes.map(route => (
                 <Route
                   exact
                   key={route.path}


### PR DESCRIPTION
This PR:
- fixes bug EES-2600 where a user was able to access the editable version of the Methodology screen via the Previous / Next links when viewing a read-only Methodology.  Now only the read-only pages that are part of the main tab navigation of the page are included in the Previous / Next links.

Looks like no Robot tests were using this "Edit summary" link, so I'm happy they don't need updating.