### PR TITLE
EES-2602 - remove `notAgainstLocal` tags from UI tests

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -39,7 +39,7 @@ Go to 'Sign Off' page
     Set Suite Variable    ${PUBLIC_RELEASE_LINK}
 
 Go to Public Release Link
-    [Tags]    HappyPath    NotAgainstLocal
+    [Tags]    HappyPath
     # To get around basic auth on public frontend
     user goes to url    %{PUBLIC_URL}
     user waits until h1 is visible    Explore our statistics and data
@@ -128,7 +128,7 @@ Go to public release URL and check release isn't visible
     user waits until page does not contain    ${PUBLICATION_NAME}
 
 Check "Page not found" appears
-    [Tags]    HappyPath    NotAgainstLocal
+    [Tags]    HappyPath
     user waits until page contains    Page not found
 
 Go to admin release summary
@@ -152,6 +152,6 @@ Approve release for immediate publication but don't wait to finish
     user checks summary list contains    Current status    Approved
 
 Go to public release URL and check release isn't visible
-    [Tags]    HappyPath    NotAgainstLocal
+    [Tags]    HappyPath
     user goes to url    ${PUBLIC_RELEASE_LINK}
     user waits until page contains    Page not found

--- a/tests/robot-tests/tests/general_public/download_page.robot
+++ b/tests/robot-tests/tests/general_public/download_page.robot
@@ -18,7 +18,7 @@ Navigate to /download-data page
 
 Validate Pupils and schools contains Pupil absence files
     [Documentation]    EES-562
-    [Tags]    HappyPath    NotAgainstLocal
+    [Tags]    HappyPath
     user waits until page contains accordion section    Pupils and schools
     user waits for page to finish loading
     user opens accordion section    Pupils and schools

--- a/tests/robot-tests/tests/general_public/miscellaneous.robot
+++ b/tests/robot-tests/tests/general_public/miscellaneous.robot
@@ -14,7 +14,7 @@ Verify public page loads
     user waits until element contains    css:body    Explore education statistics
 
 Verify can accept cookie banner
-    [Tags]    HappyPath    NotAgainstLocal
+    [Tags]    HappyPath    
     user checks page contains    We use some essential cookies to make this service work.
 
     cookie should not exist    ees_banner_seen
@@ -65,7 +65,7 @@ Validate Cookies page
     user checks nth breadcrumb contains    2    Cookies
 
 Disable google analytics
-    [Tags]    HappyPath    NotAgainstLocal
+    [Tags]    HappyPath    
     user clicks element    id:cookieSettingsForm-googleAnalytics-off
     user clicks element    xpath://button[text()="Save changes"]
     user waits until page contains    Your cookie settings were saved
@@ -74,7 +74,7 @@ Disable google analytics
     cookie should have value    ees_disable_google_analytics    true
 
 Enable google analytics
-    [Tags]    HappyPath    NotAgainstLocal
+    [Tags]    HappyPath    
     user reloads page
     user checks page does not contain    Your cookie settings were saved
     user waits until h1 is visible    Cookies on Explore education statistics

--- a/useful-scripts/run.js
+++ b/useful-scripts/run.js
@@ -39,6 +39,11 @@ const projects = {
     command: 'npm run start:local',
     colour: chalk.greenBright,
   },
+  frontendProd: {
+    path: path.join(projectRoot, 'src/explore-education-statistics-frontend'),
+    command: 'npm run build && npm run start:prod',
+    colour: chalk.greenBright,
+  },
   content: {
     path: path.join(
       projectRoot,


### PR DESCRIPTION
This PR: 
- Removes instances of `NotAgainstLocal` tags of tests that aren't failing to increase test coverage (as UI tests should be run against a local frontend that is running in a production mode) 
- Adds an argument to the `run.js` script to run the public frontend in production mode