### PR TITLE
EES-2502 Attempt to fix swap slot issues

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -1151,6 +1151,7 @@
           "httpLoggingEnabled": true,
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
+          "use32BitWorkerProcess": false,
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
@@ -1231,6 +1232,7 @@
           "httpLoggingEnabled": true,
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
+          "use32BitWorkerProcess": false,
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
@@ -1372,6 +1374,7 @@
           "httpLoggingEnabled": true,
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
+          "use32BitWorkerProcess": false,
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",
@@ -1451,6 +1454,7 @@
           "httpLoggingEnabled": true,
           "detailedErrorLoggingEnabled": true,
           "requestTracingEnabled": true,
+          "use32BitWorkerProcess": false,
           "cors": {
             "allowedOrigins": [
               "[concat('https://', parameters('domain'))]",

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/web.config
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/web.config
@@ -17,7 +17,6 @@
     </security>
     <applicationInitialization>
       <add initializationPage="/"/>
-      <add initializationPage="/tools"/>
     </applicationInitialization>
     <rewrite>
       <rules>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/web.config
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/web.config
@@ -17,9 +17,6 @@
     </security>
     <applicationInitialization>
       <add initializationPage="/"/>
-      <add initializationPage="/api/content/tree"/>
-      <add initializationPage="/api/methodology/tree"/>
-      <add initializationPage="/api/download/tree"/>
     </applicationInitialization>
   </system.webServer>
 </configuration>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/web.config
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/web.config
@@ -17,7 +17,6 @@
     </security>
     <applicationInitialization>
       <add initializationPage="/"/>
-      <add initializationPage="/api/debug/report"/>
     </applicationInitialization>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
This PR changes two things:
- Remove applicationInitialization endpoints that no longer exist from web.config files. I discovered these while investigating the swap slot issue. After further investigation, I don't think they're causing our swap slot issue, but there is no reason for us to hit these endpoints before swapping slots, so I've removed them.
- Change the Content and Data apps to be 64bit. This includes changing the settings for their swap slots to also be 64 bit. The swap slot issues we've had have been with Content and Data, not Admin, and the Admin app already uses 64 bit, so I think this is a reasonable first speculative attempt to fix the swap slot issue.