### PR TITLE
EES-2268 Order unpublished releases by most recent first

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -267,19 +267,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 // Check that only unpublished Releases are included and that they are in the correct order
 
                 var expectedReleaseAtIndex0 = adoptingPublication.Releases.Single(r =>
-                    r.Year == 2020 && r.TimePeriodCoverage == FinancialYearQ4);
+                    r.Year == 2021 && r.TimePeriodCoverage == FinancialYearQ2);
 
                 var expectedReleaseAtIndex1 = adoptingPublication.Releases.Single(r =>
                     r.Year == 2021 && r.TimePeriodCoverage == FinancialYearQ1);
 
                 var expectedReleaseAtIndex2 = adoptingPublication.Releases.Single(r =>
-                    r.Year == 2021 && r.TimePeriodCoverage == FinancialYearQ2);
+                    r.Year == 2020 && r.TimePeriodCoverage == FinancialYearQ4);
 
                 var expectedReleaseAtIndex3 = owningPublication.Releases.Single(r =>
-                    r.Year == 2020 && r.TimePeriodCoverage == CalendarYear);
+                    r.Year == 2021 && r.TimePeriodCoverage == CalendarYear);
 
                 var expectedReleaseAtIndex4 = owningPublication.Releases.Single(r =>
-                    r.Year == 2021 && r.TimePeriodCoverage == CalendarYear);
+                    r.Year == 2020 && r.TimePeriodCoverage == CalendarYear);
 
                 Assert.Equal(5, result.Count);
 
@@ -289,11 +289,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.Equal(expectedReleaseAtIndex3.Id, result[3].Id);
                 Assert.Equal(expectedReleaseAtIndex4.Id, result[4].Id);
 
-                Assert.Equal("Publication A - Financial Year Q4 2020-21", result[0].Title);
+                Assert.Equal("Publication A - Financial Year Q2 2021-22", result[0].Title);
                 Assert.Equal("Publication A - Financial Year Q1 2021-22", result[1].Title);
-                Assert.Equal("Publication A - Financial Year Q2 2021-22", result[2].Title);
-                Assert.Equal("Publication B - Calendar Year 2020", result[3].Title);
-                Assert.Equal("Publication B - Calendar Year 2021", result[4].Title);
+                Assert.Equal("Publication A - Financial Year Q4 2020-21", result[2].Title);
+                Assert.Equal("Publication B - Calendar Year 2021", result[3].Title);
+                Assert.Equal("Publication B - Calendar Year 2020", result[4].Title);
+
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -141,8 +141,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                     // Return an ordered list of the Releases that are not published
                     return releases.Where(r => !r.Live)
                         .OrderBy(r => r.Publication.Title)
-                        .ThenBy(r => r.Year)
-                        .ThenBy(r => r.TimePeriodCoverage)
+                        .ThenByDescending(r => r.Year)
+                        .ThenByDescending(r => r.TimePeriodCoverage)
                         .Select(r => new TitleAndIdViewModel(r.Id, $"{r.Publication.Title} - {r.Title}"))
                         .ToList();
                 });

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/MethodolodyStatusForm.tsx
@@ -7,7 +7,7 @@ import { IdTitlePair } from '@admin/services/types/common';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
-import { Form, FormFieldRadioGroup } from '@common/components/form';
+import { Form, FormFieldRadioGroup, FormSelect } from '@common/components/form';
 import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
 import FormFieldSelect from '@common/components/form/FormFieldSelect';
 import Yup from '@common/validation/yup';
@@ -104,7 +104,7 @@ const MethodologyStatusForm = ({
                 legend="When to publish"
                 legendSize="m"
                 hint="Do you want to publish this methodology with a specific release or immediately?"
-                order={[]}
+                order={FormSelect.unordered}
                 options={[
                   {
                     label: 'With a specific release',
@@ -113,6 +113,7 @@ const MethodologyStatusForm = ({
                       <FormFieldSelect<FormValues>
                         label="Select release"
                         name="withReleaseId"
+                        order={FormSelect.unordered}
                         options={unpublishedReleases.map(release => {
                           return {
                             label: release.title,

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/components/__tests__/MethodologyStatusForm.test.tsx
@@ -125,10 +125,10 @@ describe('MethodologyStatusForm', () => {
     expect(releaseSelect.children.length).toBe(3);
     expect(releaseSelect.children[0]).toHaveTextContent('Choose a release');
     expect(releaseSelect.children[0]).toHaveValue('');
-    expect(releaseSelect.children[1]).toHaveTextContent('Test Release 1');
-    expect(releaseSelect.children[1]).toHaveValue('test-release-1');
-    expect(releaseSelect.children[2]).toHaveTextContent('Test Release 2');
-    expect(releaseSelect.children[2]).toHaveValue('test-release-2');
+    expect(releaseSelect.children[1]).toHaveTextContent('Test Release 2');
+    expect(releaseSelect.children[1]).toHaveValue('test-release-2');
+    expect(releaseSelect.children[2]).toHaveTextContent('Test Release 1');
+    expect(releaseSelect.children[2]).toHaveValue('test-release-1');
 
     expect(releaseSelect).toHaveDisplayValue('Test Release 2');
     expect(releaseSelect).toHaveValue('test-release-2');


### PR DESCRIPTION
This PR changes the list of unpublished releases shown on the methodology sign off tab.

After this change, unpublished releases are ordered beginning with the most recent first, though still ordered by publication if the methodology is used by multiple publications.