### PR TITLE
EES-2548 Fix intermittent caching test failures

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/BlobCacheAttributeTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/BlobCacheAttributeTests.cs
@@ -5,25 +5,25 @@ using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using Moq;
 using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
 {
-    public class BlobCacheAttributeTests : IDisposable
+    [Collection(CacheTestFixture.CollectionName)]
+    public class BlobCacheAttributeTests : IClassFixture<CacheTestFixture>, IDisposable
     {
         private readonly Mock<IBlobCacheService> _blobCacheService = new(MockBehavior.Strict);
 
         public BlobCacheAttributeTests()
         {
-            CacheAspect.Enabled = true;
             BlobCacheAttribute.AddService("default", _blobCacheService.Object);
         }
 
         public void Dispose()
         {
-            CacheAspect.Enabled = false;
             BlobCacheAttribute.ClearServices();
 
             _blobCacheService.Reset();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/CacheAspectTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Cache/CacheAspectTests.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
@@ -16,18 +17,13 @@ using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Cache
 {
-    public class CacheAspectTests : IDisposable
+    [Collection(CacheTestFixture.CollectionName)]
+    public class CacheAspectTests : IClassFixture<CacheTestFixture>
     {
-        private static Mock<ICacheService<ICacheKey>> CacheService { get; } = new(MockBehavior.Strict);
+        private static readonly Mock<ICacheService<ICacheKey>> CacheService = new(MockBehavior.Strict);
 
         public CacheAspectTests()
         {
-            CacheAspect.Enabled = true;
-        }
-
-        public void Dispose()
-        {
-            CacheAspect.Enabled = false;
             CacheService.Reset();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/CacheTestFixture.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Fixtures/CacheTestFixture.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Fixtures
+{
+    /// <summary>
+    /// Simple class fixture for enabling/disabling
+    /// caching before and after a test suite.
+    /// </summary>
+    public class CacheTestFixture : IDisposable
+    {
+        public const string CollectionName = "Cache tests";
+
+        public CacheTestFixture()
+        {
+            CacheAspect.Enabled = true;
+        }
+
+        public void Dispose()
+        {
+            CacheAspect.Enabled = false;
+        }
+    }
+}


### PR DESCRIPTION
This uses a combination of xUnit collections (so that the caching tests don't run in parallel), and a class fixture `CacheTestFixture` to enable/disable caching.