### PR TITLE
EES-2373 allow direct link to release downloads on data catalogue

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/DataCataloguePage.tsx
@@ -14,9 +14,10 @@ import DownloadStep, {
   DownloadFormSubmitHandler,
   SubjectWithDownloadFiles,
 } from '@frontend/modules/data-catalogue/components/DownloadStep';
+import { Dictionary } from '@common/types';
 import ErrorPage from '@frontend/modules/ErrorPage';
 import { GetServerSideProps, NextPage } from 'next';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useRouter } from 'next/router';
 import { useImmer } from 'use-immer';
 
@@ -30,12 +31,14 @@ const fakeReleases: Release[] = [
   } as Release,
   {
     id: 'rel-3',
+    latestRelease: false,
     published: '2021-01-01T11:21:17.7585345',
     slug: 'rel-3-slug',
     title: 'Another Release',
   } as Release,
   {
     id: 'rel-2',
+    latestRelease: false,
     published: '2021-05-30T11:21:17.7585345',
     slug: 'rel-2-slug',
     title: 'Release 2',
@@ -98,38 +101,74 @@ const fakeSubjectsWithDownloadFiles: SubjectWithDownloadFiles[] = [
   },
 ];
 
+export interface SelectedPublication {
+  id: string;
+  title: string;
+  slug: string;
+  selectedRelease?: Release;
+}
+
 interface Props {
+  releases?: Release[];
+  selectedPublication?: SelectedPublication;
+  subjects?: SubjectWithDownloadFiles[];
   themes: DownloadTheme[];
 }
 
 interface DataCatalogueState {
   initialStep: number;
   releases: Release[];
+  subjects: SubjectWithDownloadFiles[];
   query: {
+    publicationId?: string;
     release?: Release;
-    subjects: SubjectWithDownloadFiles[];
   };
 }
 
-const DataCataloguePage: NextPage<Props> = ({ themes }: Props) => {
+const DataCataloguePage: NextPage<Props> = ({
+  releases = [],
+  selectedPublication,
+  subjects = [],
+  themes,
+}: Props) => {
   const router = useRouter();
 
-  const [state, updateState] = useImmer<DataCatalogueState>({
-    initialStep: 1,
-    releases: [],
-    query: {
-      release: undefined,
-      subjects: [],
-    },
-  });
+  const initialState = useMemo<DataCatalogueState>(() => {
+    const getInitialStep = () => {
+      if (selectedPublication && selectedPublication.selectedRelease) {
+        return 3;
+      }
+      if (selectedPublication) {
+        return 2;
+      }
+      return 1;
+    };
+
+    return {
+      initialStep: getInitialStep(),
+      releases,
+      subjects,
+      query: {
+        publicationId: (selectedPublication && selectedPublication.id) || '',
+        release:
+          (selectedPublication && selectedPublication.selectedRelease) ||
+          undefined,
+      },
+    };
+  }, [releases, selectedPublication, subjects]);
+
+  const [state, updateState] = useImmer<DataCatalogueState>(initialState);
 
   const handlePublicationStepBack = () => {
     router.push('/data-catalogue', undefined, { shallow: true });
   };
 
-  const handlePublicationFormSubmit: PublicationFormSubmitHandler = async () => {
+  const handlePublicationFormSubmit: PublicationFormSubmitHandler = async ({
+    publicationId,
+  }) => {
     updateState(draft => {
       draft.releases = fakeReleases;
+      draft.query.publicationId = publicationId;
     });
   };
 
@@ -140,7 +179,7 @@ const DataCataloguePage: NextPage<Props> = ({ themes }: Props) => {
       draft.query.release = draft.releases.find(
         rel => rel.id === selectedReleaseId,
       );
-      draft.query.subjects = fakeSubjectsWithDownloadFiles;
+      draft.subjects = fakeSubjectsWithDownloadFiles;
     });
   };
 
@@ -158,6 +197,9 @@ const DataCataloguePage: NextPage<Props> = ({ themes }: Props) => {
     return (
       <PublicationForm
         {...props}
+        initialValues={{
+          publicationId: state.query.publicationId ?? '',
+        }}
         onSubmit={handlePublicationFormSubmit}
         options={options}
       />
@@ -193,7 +235,7 @@ const DataCataloguePage: NextPage<Props> = ({ themes }: Props) => {
             <DownloadStep
               {...stepProps}
               release={state.query.release}
-              subjects={state.query.subjects}
+              subjects={state.subjects}
               onSubmit={handleDownloadFormSubmit}
             />
           )}
@@ -204,20 +246,61 @@ const DataCataloguePage: NextPage<Props> = ({ themes }: Props) => {
 };
 
 export const getServerSideProps: GetServerSideProps<Props> = async context => {
-  let themes: DownloadTheme[] = [];
-
+  // EES-2007 temp until page is complete
   if (process.env.APP_ENV === 'Production') {
-    // EES-2007 temp until page is complete
     // eslint-disable-next-line no-param-reassign
     context.res.statusCode = 404;
-  } else {
-    themes = await themeService.getDownloadThemes();
+    return {
+      props: {
+        themes: [],
+      },
+    };
+  }
+
+  const {
+    publicationSlug = '',
+    releaseSlug = '',
+  } = context.query as Dictionary<string>;
+
+  const themes = await themeService.getDownloadThemes();
+
+  const selectedPublication = themes
+    .flatMap(option => option.topics)
+    .flatMap(option => option.publications)
+    .find(option => option.slug === publicationSlug) as SelectedPublication;
+
+  // EES-2007 Get real releases here
+  const releases = fakeReleases;
+
+  let selectedRelease: Release | undefined;
+  if (releaseSlug) {
+    selectedRelease = releases.find(rel => rel.slug === releaseSlug);
+    if (selectedPublication && selectedRelease) {
+      selectedPublication.selectedRelease = selectedRelease;
+    }
+  }
+
+  let subjects;
+  if (selectedPublication && selectedRelease) {
+    // EES-2007 Get real subjects here
+    subjects = fakeSubjectsWithDownloadFiles;
+  }
+
+  const props: Props = {
+    releases: releases ?? [],
+    subjects: subjects ?? [],
+    themes,
+  };
+  if (selectedPublication) {
+    props.selectedPublication = selectedPublication;
+
+    if (selectedRelease) {
+      props.selectedPublication.selectedRelease = selectedRelease;
+    }
   }
 
   return {
-    props: {
-      themes,
-    },
+    props,
   };
 };
 

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataCataloguePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataCataloguePage.test.tsx
@@ -1,7 +1,8 @@
-import DataCataloguePage, {
-  SelectedPublication,
-} from '@frontend/modules/data-catalogue/DataCataloguePage';
-import { DownloadTheme } from '@common/services/themeService';
+import DataCataloguePage from '@frontend/modules/data-catalogue/DataCataloguePage';
+import {
+  DownloadTheme,
+  PublicationDownloadSummary,
+} from '@common/services/themeService';
 import { Release } from '@common/services/publicationService';
 import { SubjectWithDownloadFiles } from '@frontend/modules/data-catalogue/components/DownloadStep';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -31,11 +32,11 @@ describe('DataCataloguePage', () => {
     } as DownloadTheme,
   ];
 
-  const testPublication: SelectedPublication = {
+  const testPublication = {
     id: 'publication-1',
     title: 'Test publication',
     slug: 'test-publication',
-  };
+  } as PublicationDownloadSummary;
 
   const testReleases: Release[] = [
     {
@@ -60,11 +61,6 @@ describe('DataCataloguePage', () => {
       title: 'Release 2',
     } as Release,
   ];
-
-  const testPublicationWithReleases = {
-    ...testPublication,
-    selectedRelease: testReleases[0],
-  };
 
   const testSubjects: SubjectWithDownloadFiles[] = [
     {
@@ -227,7 +223,8 @@ describe('DataCataloguePage', () => {
     render(
       <DataCataloguePage
         themes={testThemes}
-        selectedPublication={testPublicationWithReleases}
+        selectedPublication={testPublication}
+        selectedRelease={testReleases[2]}
         releases={testReleases}
         subjects={testSubjects}
       />,

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataCataloguePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataCataloguePage.test.tsx
@@ -1,5 +1,9 @@
-import DataCataloguePage from '@frontend/modules/data-catalogue/DataCataloguePage';
+import DataCataloguePage, {
+  SelectedPublication,
+} from '@frontend/modules/data-catalogue/DataCataloguePage';
 import { DownloadTheme } from '@common/services/themeService';
+import { Release } from '@common/services/publicationService';
+import { SubjectWithDownloadFiles } from '@frontend/modules/data-catalogue/components/DownloadStep';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import preloadAll from 'jest-next-dynamic';
@@ -25,6 +29,98 @@ describe('DataCataloguePage', () => {
         },
       ],
     } as DownloadTheme,
+  ];
+
+  const testPublication: SelectedPublication = {
+    id: 'publication-1',
+    title: 'Test publication',
+    slug: 'test-publication',
+  };
+
+  const testReleases: Release[] = [
+    {
+      id: 'rel-1',
+      latestRelease: true,
+      published: '2021-06-30T11:21:17.7585345',
+      slug: 'rel-1-slug',
+      title: 'Release 1',
+    } as Release,
+    {
+      id: 'rel-3',
+      latestRelease: false,
+      published: '2021-01-01T11:21:17.7585345',
+      slug: 'rel-3-slug',
+      title: 'Another Release',
+    } as Release,
+    {
+      id: 'rel-2',
+      latestRelease: false,
+      published: '2021-05-30T11:21:17.7585345',
+      slug: 'rel-2-slug',
+      title: 'Release 2',
+    } as Release,
+  ];
+
+  const testPublicationWithReleases = {
+    ...testPublication,
+    selectedRelease: testReleases[0],
+  };
+
+  const testSubjects: SubjectWithDownloadFiles[] = [
+    {
+      id: 'subject-1',
+      name: 'Subject 1',
+      content: 'Some content here',
+      geographicLevels: ['SoYo'],
+      timePeriods: {
+        from: '2016',
+        to: '2019',
+      },
+      downloadFile: {
+        id: 'file-1',
+        extension: 'csv',
+        fileName: 'file-1.csv',
+        name: 'File 1',
+        size: '100mb',
+        type: 'Data',
+      },
+    },
+    {
+      id: 'subject-2',
+      name: 'Another Subject',
+      content: 'Some content here',
+      geographicLevels: ['SoYo'],
+      timePeriods: {
+        from: '2016',
+        to: '2019',
+      },
+      downloadFile: {
+        id: 'file-2',
+        extension: 'csv',
+        fileName: 'file-2.csv',
+        name: 'File 2',
+        size: '100mb',
+        type: 'Data',
+      },
+    },
+    {
+      id: 'subject-3',
+      name: 'Subject 3',
+      content: 'Some content here',
+      geographicLevels: ['SoYo'],
+      timePeriods: {
+        from: '2016',
+        to: '2019',
+      },
+      downloadFile: {
+        id: 'file-3',
+        extension: 'csv',
+        fileName: 'file-3.csv',
+        name: 'File 3',
+        size: '100mb',
+        type: 'Data',
+      },
+    },
   ];
 
   beforeAll(preloadAll);
@@ -96,5 +192,64 @@ describe('DataCataloguePage', () => {
     expect(
       screen.getByRole('button', { name: 'Download selected files' }),
     ).toBeInTheDocument();
+  });
+
+  test('direct link to step 2', async () => {
+    render(
+      <DataCataloguePage
+        themes={testThemes}
+        selectedPublication={testPublication}
+        releases={testReleases}
+      />,
+    );
+    expect(screen.getByTestId('wizardStep-1')).not.toHaveAttribute(
+      'aria-current',
+      'step',
+    );
+    expect(screen.getByTestId('wizardStep-2')).toHaveAttribute(
+      'aria-current',
+      'step',
+    );
+    expect(screen.getByText('Choose a release')).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+    expect(
+      screen.getByLabelText('Release 1 (30 June 2021)'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Release 2 (30 May 2021)'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Another Release (1 January 2021)'),
+    ).toBeInTheDocument();
+  });
+
+  test('direct link to step 3', async () => {
+    render(
+      <DataCataloguePage
+        themes={testThemes}
+        selectedPublication={testPublicationWithReleases}
+        releases={testReleases}
+        subjects={testSubjects}
+      />,
+    );
+    expect(screen.getByTestId('wizardStep-1')).not.toHaveAttribute(
+      'aria-current',
+      'step',
+    );
+    expect(screen.getByTestId('wizardStep-2')).not.toHaveAttribute(
+      'aria-current',
+      'step',
+    );
+    expect(screen.getByTestId('wizardStep-3')).toHaveAttribute(
+      'aria-current',
+      'step',
+    );
+    expect(screen.getByText('Choose files to download')).toBeInTheDocument();
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+    expect(
+      screen.getByLabelText('Another Subject (csv, 100mb)'),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Subject 1 (csv, 100mb)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Subject 3 (csv, 100mb)')).toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DownloadStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DownloadStep.tsx
@@ -18,6 +18,7 @@ import Details from '@common/components/Details';
 import { Subject } from '@common/services/tableBuilderService';
 import ContentHtml from '@common/components/ContentHtml';
 import Tag from '@common/components/Tag';
+import useMounted from '@common/hooks/useMounted';
 import React, { useMemo } from 'react';
 import { Formik } from 'formik';
 
@@ -45,6 +46,7 @@ const DownloadStep = ({
   ...stepProps
 }: Props & InjectedWizardProps) => {
   const { isActive, currentStep, stepNumber } = stepProps;
+  const { isMounted } = useMounted();
 
   const stepEnabled = currentStep > stepNumber;
   const stepHeading = (
@@ -129,7 +131,8 @@ const DownloadStep = ({
       onSubmit={handleSubmit}
     >
       {form => {
-        return isActive ? (
+        // isMounted check required as Formik context can be undefined if the step is active on page load.
+        return isActive && isMounted ? (
           <Form id="downloadForm" showSubmitError>
             <FormFieldset id="downloadFiles" legend={stepHeading}>
               {checkboxOptions.length > 0 && (

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/ReleaseForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/ReleaseForm.tsx
@@ -89,8 +89,10 @@ const ReleaseForm = ({
     <Formik<ReleaseFormValues>
       enableReinitialize
       initialValues={{
-        ...initialValues,
-        releaseId: radioOptions.length === 1 ? radioOptions[0].value : '',
+        releaseId:
+          radioOptions.length === 1
+            ? radioOptions[0].value
+            : initialValues.releaseId,
       }}
       validateOnBlur={false}
       validationSchema={Yup.object<ReleaseFormValues>({

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/ReleaseStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/ReleaseStep.tsx
@@ -7,6 +7,7 @@ import { Release } from '@common/services/publicationService';
 import ReleaseForm, {
   ReleaseFormSubmitHandler,
 } from '@frontend/modules/data-catalogue/components/ReleaseForm';
+import useMounted from '@common/hooks/useMounted';
 import React from 'react';
 
 interface Props {
@@ -22,6 +23,7 @@ const ReleaseStep = ({
   ...stepProps
 }: Props & InjectedWizardProps) => {
   const { isActive, currentStep, stepNumber } = stepProps;
+  const { isMounted } = useMounted();
 
   const stepEnabled = currentStep > stepNumber;
   const stepHeading = (
@@ -29,11 +31,14 @@ const ReleaseStep = ({
       Choose a release
     </WizardStepHeading>
   );
-
-  if (isActive) {
+  // isMounted check required as Formik context can be undefined if the step is active on page load.
+  if (isActive && isMounted) {
     return (
       <ReleaseForm
         {...stepProps}
+        initialValues={{
+          releaseId: selectedRelease?.id || '',
+        }}
         options={releases}
         onSubmit={onSubmit}
         legendSize="l"

--- a/src/explore-education-statistics-frontend/src/pages/data-catalogue/[publicationSlug].tsx
+++ b/src/explore-education-statistics-frontend/src/pages/data-catalogue/[publicationSlug].tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  getServerSideProps,
+} from '@frontend/modules/data-catalogue/DataCataloguePage';

--- a/src/explore-education-statistics-frontend/src/pages/data-catalogue/[publicationSlug]/[releaseSlug].tsx
+++ b/src/explore-education-statistics-frontend/src/pages/data-catalogue/[publicationSlug]/[releaseSlug].tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  getServerSideProps,
+} from '@frontend/modules/data-catalogue/DataCataloguePage';


### PR DESCRIPTION
On the data catalogue  page you can directly link to:
- `/data-catalogue/<publication-slug>` -  releases for a publication (step 2)
- `/data-catalogue/<publication-slug>/<release-slug>` - downloads for a release (step 3)

The isMounted check on the release and download steps is because of a weird thing where when components from the frontend repo are active in the wizard on page load formikContext is undefined. Components from the common repo don't require this check. Something to do with how Formik is initialised maybe 🤷 