### PR TITLE
EEs-2234 remove metaguidance link from useful info

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -190,26 +190,6 @@ const ReleaseContent = () => {
                   View data and files
                 </a>
               </li>
-              {release.hasMetaGuidance && (
-                <li>
-                  <Link
-                    to={{
-                      pathname: generatePath<ReleaseRouteParams>(
-                        releaseMetaGuidanceRoute.path,
-                        {
-                          publicationId: release.publication.id,
-                          releaseId: release.id,
-                        },
-                      ),
-                      state: {
-                        backLink: location.pathname,
-                      },
-                    }}
-                  >
-                    Metadata guidance document
-                  </Link>
-                </li>
-              )}
               {release.hasPreReleaseAccessList && (
                 <li>
                   <Link

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -193,24 +193,6 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                     View data and files
                   </a>
                 </li>
-                {release.hasMetaGuidance && (
-                  <li>
-                    <Link
-                      to={
-                        release.latestRelease
-                          ? '/find-statistics/[publication]/meta-guidance'
-                          : '/find-statistics/[publication]/[release]/meta-guidance'
-                      }
-                      as={
-                        release.latestRelease
-                          ? `/find-statistics/${release.publication.slug}/meta-guidance`
-                          : `/find-statistics/${release.publication.slug}/${release.slug}/meta-guidance`
-                      }
-                    >
-                      Metadata guidance document
-                    </Link>
-                  </li>
-                )}
                 {release.hasPreReleaseAccessList && (
                   <li>
                     <Link

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -219,7 +219,9 @@ Validate prerelease has started
     ...    60
 
 Validate metadata guidance page
-    user clicks link    Metadata guidance document
+    user opens accordion section    Explore data and files
+    user waits until h3 is visible    Open data
+    user clicks link    data files guide
 
     user waits until page contains title caption    Calendar Year 2000    60
     user waits until h1 is visible    ${PUBLICATION_NAME}    60
@@ -314,7 +316,9 @@ Validate prerelease has started for Analyst user
     user waits until element contains    id:releaseHeadlines    Test headlines summary text for ${PUBLICATION_NAME}
 
 Validate public metdata guidance for Analyst user
-    user clicks link    Metadata guidance document
+    user opens accordion section    Explore data and files
+    user waits until h3 is visible    Open data
+    user clicks link    data files guide
 
     user waits until page contains title caption    Calendar Year 2000    60
     user waits until h1 is visible    ${PUBLICATION_NAME}    60

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -604,7 +604,9 @@ Go to release page
     user waits until page contains title caption    ${RELEASE_2_NAME}
 
 Go to meta guidance document
-    user clicks link    Metadata guidance document
+    user opens accordion section    Explore data and files
+    user waits until h3 is visible    Open data
+    user clicks link    data files guide
 
     user waits until page contains title caption    ${RELEASE_2_NAME}
     user waits until h1 is visible    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -241,7 +241,9 @@ Verify release associated files
     downloaded file should have first line    test_ancillary_file_1.txt    Test file 1
 
 Verify public metadata guidance document
-    user clicks link    Metadata guidance document
+    user opens accordion section    Explore data and files
+    user waits until h3 is visible    Open data
+    user clicks link    data files guide
 
     user checks breadcrumb count should be    4
     user checks nth breadcrumb contains    1    Home
@@ -581,7 +583,9 @@ Verify amendment files
     downloaded file should have first line    test_ancillary_file_2.txt    Test file 2
 
 Verify amendment public metadata guidance document
-    user clicks link    Metadata guidance document
+    user opens accordion section    Explore data and files
+    user waits until h3 is visible    Open data
+    user clicks link    data files guide
 
     user checks breadcrumb count should be    4
     user checks nth breadcrumb contains    1    Home


### PR DESCRIPTION
On the public frontend and the release edit / preview in the admin.