### PR TITLE
EES-2622 update methodology status tags ui tests

### DIFF
--- a/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
@@ -122,8 +122,9 @@ Edit the Amendment's summary to return the Methodology's title to the same as it
     user verifies methodology summary details
     ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME}
-    ...    Draft Amendment
+    ...    Draft
     ...    Not yet published
+    user checks page contains tag    Amendment
     user clicks link    Edit summary
     user waits until h2 is visible    Edit methodology summary
     # Double check that the front end is now showing the Methodology's title as being "Use publication title" when

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -214,9 +214,9 @@ user verifies methodology summary details
     ...    ${published_on}=Not yet published
     user waits until h2 is visible    Methodology summary
     user checks summary list contains    Title    ${methodology_title}
-    user checks summary list contains    Status    ${status}
     user checks summary list contains    Published on    ${published_on}
     user checks summary list contains    Owning publication    ${publication}
+    user checks page contains tag    ${status}
 
 user approves methodology for publication
     [Arguments]


### PR DESCRIPTION
Updates the UI tests related to methodology status tags.

The ones that expect the tag to update to approved when the methodology is signed off still fail as this isn't currently working,  ticket to fix it: https://dfedigital.atlassian.net/browse/EES-2599