### PR TITLE
EES-2467 chart group by filters

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
@@ -109,17 +109,16 @@ const ChartAxisConfiguration = ({
     if (canGroupByFilters) {
       // EES-2467 remove this check when BE done.
       if (showGroupByFilter) {
-        const categories: SelectOption[] = Object.keys(meta.filters)
-          .filter(filter => {
-            return meta.filters[filter].options.length > 1;
-          })
-          .map(filter => {
+        const categories: SelectOption[] = Object.entries(meta.filters)
+          .filter(([, value]) => value.options.length > 1)
+          .map(([key, value]) => {
             return {
-              label: filter,
-              value: meta.filters[filter].name,
+              label: key,
+              value: value.name,
             };
           });
-        categories.push({ label: 'All filters', value: '' });
+
+        categories.unshift({ label: 'All filters', value: '' });
 
         options.push({
           label: 'Filters',
@@ -129,6 +128,7 @@ const ChartAxisConfiguration = ({
               label="Select a filter"
               name="groupByFilter"
               options={categories}
+              order={[]}
             />
           ),
         });
@@ -388,14 +388,12 @@ const ChartAxisConfiguration = ({
                 )}
 
                 {validationSchema.fields.groupBy && (
-                  <>
-                    <FormFieldRadioGroup<AxisConfiguration>
-                      legend="Group data by"
-                      legendSize="s"
-                      name="groupBy"
-                      options={groupByOptions}
-                    />
-                  </>
+                  <FormFieldRadioGroup<AxisConfiguration>
+                    legend="Group data by"
+                    legendSize="s"
+                    name="groupBy"
+                    options={groupByOptions}
+                  />
                 )}
 
                 <FormFieldset id="labels" legend="Labels" legendSize="s">

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartAxisConfiguration.tsx
@@ -14,7 +14,7 @@ import {
 import FormFieldCheckbox from '@common/components/form/FormFieldCheckbox';
 import FormFieldNumberInput from '@common/components/form/FormFieldNumberInput';
 import FormNumberInput from '@common/components/form/FormNumberInput';
-
+import { RadioOption } from '@common/components/form/FormRadioGroup';
 import FormSelect, { SelectOption } from '@common/components/form/FormSelect';
 import {
   AxisConfiguration,
@@ -49,6 +49,7 @@ interface Props {
   definition: ChartDefinition;
   data: TableDataResult[];
   meta: FullTableMeta;
+  showGroupByFilter?: boolean;
   onChange: (configuration: AxisConfiguration) => void;
   onSubmit: (configuration: AxisConfiguration) => void;
 }
@@ -60,6 +61,7 @@ const ChartAxisConfiguration = ({
   id,
   data,
   meta,
+  showGroupByFilter = false, // EES-2467 remove when BE done.
   type,
   onChange,
   onSubmit,
@@ -82,8 +84,8 @@ const ChartAxisConfiguration = ({
     return createDataSetCategories(config, data, meta);
   }, [configuration, data, meta, type]);
 
-  const groupByOptions = useMemo<SelectOption<AxisGroupBy>[]>(() => {
-    const options: SelectOption<AxisGroupBy>[] = [
+  const groupByOptions = useMemo<RadioOption<AxisGroupBy>[]>(() => {
+    const options: RadioOption<AxisGroupBy>[] = [
       {
         label: 'Time periods',
         value: 'timePeriod',
@@ -105,14 +107,41 @@ const ChartAxisConfiguration = ({
     );
 
     if (canGroupByFilters) {
-      options.push({
-        label: 'Filters',
-        value: 'filters',
-      });
+      // EES-2467 remove this check when BE done.
+      if (showGroupByFilter) {
+        const categories: SelectOption[] = Object.keys(meta.filters)
+          .filter(filter => {
+            return meta.filters[filter].options.length > 1;
+          })
+          .map(filter => {
+            return {
+              label: filter,
+              value: meta.filters[filter].name,
+            };
+          });
+        categories.push({ label: 'All filters', value: '' });
+
+        options.push({
+          label: 'Filters',
+          value: 'filters',
+          conditional: (
+            <FormFieldSelect<AxisConfiguration>
+              label="Select a filter"
+              name="groupByFilter"
+              options={categories}
+            />
+          ),
+        });
+      } else {
+        options.push({
+          label: 'Filters',
+          value: 'filters',
+        });
+      }
     }
 
     return options;
-  }, [meta.filters]);
+  }, [meta.filters, showGroupByFilter]);
 
   // TODO EES-721: Figure out how we should sort data
   // const sortOptions = useMemo<SelectOption[]>(() => {
@@ -334,14 +363,6 @@ const ChartAxisConfiguration = ({
                   />
                 )}
 
-                {validationSchema.fields.groupBy && (
-                  <FormFieldSelect<AxisConfiguration>
-                    label="Group data by"
-                    name="groupBy"
-                    options={groupByOptions}
-                  />
-                )}
-
                 {validationSchema.fields.showGrid && (
                   <FormFieldCheckbox<AxisConfiguration>
                     name="showGrid"
@@ -364,6 +385,17 @@ const ChartAxisConfiguration = ({
                       </>
                     }
                   />
+                )}
+
+                {validationSchema.fields.groupBy && (
+                  <>
+                    <FormFieldRadioGroup<AxisConfiguration>
+                      legend="Group data by"
+                      legendSize="s"
+                      name="groupBy"
+                      options={groupByOptions}
+                    />
+                  </>
                 )}
 
                 <FormFieldset id="labels" legend="Labels" legendSize="s">

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
@@ -1,0 +1,521 @@
+import ChartAxisConfiguration from '@admin/pages/release/datablocks/components/chart/ChartAxisConfiguration';
+import { testTableData } from '@admin/pages/release/datablocks/components/chart/__tests__/__data__/testTableData';
+import {
+  ChartBuilderForms,
+  ChartBuilderFormsContextProvider,
+} from '@admin/pages/release/datablocks/components/chart/contexts/ChartBuilderFormsContext';
+import { verticalBarBlockDefinition } from '@common/modules/charts/components/VerticalBarBlock';
+import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
+import { AxisConfiguration } from '@common/modules/charts/types/chart';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import noop from 'lodash/noop';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+
+describe('ChartAxisConfiguration', () => {
+  const testFormState: ChartBuilderForms = {
+    options: {
+      isValid: true,
+      submitCount: 0,
+      id: 'options',
+      title: 'Options',
+    },
+    legend: {
+      isValid: true,
+      submitCount: 0,
+      id: 'legend',
+      title: 'Legend',
+    },
+    major: {
+      id: 'chartBuilder-major',
+      isValid: true,
+      submitCount: 0,
+      title: 'X Axis (major axis)',
+    },
+  };
+
+  const testAxisConfiguration: AxisConfiguration = {
+    dataSets: [],
+    groupBy: 'timePeriod',
+    min: 0,
+    referenceLines: [],
+    showGrid: true,
+    size: 50,
+    sortAsc: true,
+    sortBy: 'name',
+    tickConfig: 'default',
+    tickSpacing: 1,
+    type: 'major',
+    visible: true,
+    unit: '',
+    label: {
+      text: '',
+    },
+  };
+
+  const testAxisConfigurationWithReferenceLines = {
+    ...testAxisConfiguration,
+    referenceLines: [
+      {
+        label: 'I am label',
+        position: '2014_AY',
+      },
+    ],
+  };
+
+  const testTable = mapFullTable(testTableData);
+
+  test('renders correctly with initial values', () => {
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartAxisConfiguration
+          id="chartBuilder-major"
+          type="major"
+          configuration={testAxisConfiguration}
+          definition={verticalBarBlockDefinition}
+          data={testTable.results}
+          meta={testTable.subjectMeta}
+          onChange={noop}
+          onSubmit={noop}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    const generalSection = within(
+      screen.getByRole('group', { name: 'General' }),
+    );
+    expect(generalSection.getByLabelText('Size of axis (px)')).toHaveValue(50);
+    expect(generalSection.getByLabelText('Show grid lines')).toBeChecked();
+    expect(generalSection.getByLabelText('Show axis')).toBeChecked();
+    expect(generalSection.getByLabelText('Displayed unit')).toHaveValue('');
+
+    const groupBySection = within(
+      screen.getByRole('group', { name: 'Group data by' }),
+    );
+    const groupByOptions = groupBySection.getAllByRole('radio');
+    expect(groupByOptions).toHaveLength(4);
+    expect(groupByOptions[0]).toHaveAttribute('value', 'filters');
+    expect(groupByOptions[0]).toBeEnabled();
+    expect(groupByOptions[0]).not.toBeChecked();
+    expect(groupByOptions[0]).toEqual(groupBySection.getByLabelText('Filters'));
+    expect(groupByOptions[1]).toHaveAttribute('value', 'indicators');
+    expect(groupByOptions[1]).toBeEnabled();
+    expect(groupByOptions[1]).not.toBeChecked();
+    expect(groupByOptions[1]).toEqual(
+      groupBySection.getByLabelText('Indicators'),
+    );
+    expect(groupByOptions[2]).toHaveAttribute('value', 'locations');
+    expect(groupByOptions[2]).toBeEnabled();
+    expect(groupByOptions[2]).not.toBeChecked();
+    expect(groupByOptions[2]).toEqual(
+      groupBySection.getByLabelText('Locations'),
+    );
+    expect(groupByOptions[3]).toHaveAttribute('value', 'timePeriod');
+    expect(groupByOptions[3]).toBeEnabled();
+    expect(groupByOptions[3]).toBeChecked();
+    expect(groupByOptions[3]).toEqual(
+      groupBySection.getByLabelText('Time periods'),
+    );
+
+    const labelsSection = within(screen.getByRole('group', { name: 'Labels' }));
+    expect(labelsSection.getByLabelText('Label')).toHaveValue('');
+    expect(labelsSection.getByLabelText('Width (px)')).toHaveValue(null);
+
+    const sortingSection = within(
+      screen.getByRole('group', { name: 'Sorting' }),
+    );
+    expect(sortingSection.getByLabelText('Sort ascending')).toBeChecked();
+
+    const tickSection = within(
+      screen.getByRole('group', { name: 'Tick display type' }),
+    );
+    const tickOptions = tickSection.getAllByRole('radio');
+    expect(tickOptions).toHaveLength(3);
+    expect(tickOptions[0]).toHaveAttribute('value', 'default');
+    expect(tickOptions[0]).toBeEnabled();
+    expect(tickOptions[0]).toBeChecked();
+    expect(tickOptions[0]).toEqual(tickSection.getByLabelText('Automatic'));
+    expect(tickOptions[1]).toHaveAttribute('value', 'startEnd');
+    expect(tickOptions[1]).toBeEnabled();
+    expect(tickOptions[1]).not.toBeChecked();
+    expect(tickOptions[1]).toEqual(
+      tickSection.getByLabelText('Start and end only'),
+    );
+    expect(tickOptions[2]).toHaveAttribute('value', 'custom');
+    expect(tickOptions[2]).toBeEnabled();
+    expect(tickOptions[2]).not.toBeChecked();
+    expect(tickOptions[2]).toEqual(tickSection.getByLabelText('Custom'));
+
+    const axisSection = within(
+      screen.getByRole('group', { name: 'Axis range' }),
+    );
+    expect(axisSection.getByLabelText('Minimum')).toHaveValue('');
+    expect(axisSection.getByLabelText('Maximum')).toHaveValue('');
+
+    const referenceLinesSection = within(
+      screen.getByRole('table', { name: 'Reference lines' }),
+    );
+    expect(referenceLinesSection.getAllByRole('row')).toHaveLength(2);
+    expect(referenceLinesSection.getByLabelText('Position')).toHaveValue('');
+    expect(referenceLinesSection.getByLabelText('Label')).toHaveValue('');
+  });
+
+  test('shows validation error if invalid custom tick spacing given', async () => {
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartAxisConfiguration
+          id="chartBuilder-major"
+          type="major"
+          configuration={testAxisConfiguration}
+          definition={verticalBarBlockDefinition}
+          data={testTable.results}
+          meta={testTable.subjectMeta}
+          onChange={noop}
+          onSubmit={noop}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    userEvent.click(screen.getByLabelText('Custom'));
+    await userEvent.type(screen.getByLabelText('Every nth value'), 'x');
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Enter tick spacing' }),
+      ).toHaveAttribute('href', '#chartBuilder-major-tickSpacing');
+    });
+
+    await userEvent.type(screen.getByLabelText('Every nth value'), '-1');
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Tick spacing must be positive' }),
+      ).toHaveAttribute('href', '#chartBuilder-major-tickSpacing');
+    });
+  });
+
+  test('shows validation error if invalid label width given', async () => {
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartAxisConfiguration
+          id="chartBuilder-major"
+          type="major"
+          configuration={testAxisConfiguration}
+          definition={verticalBarBlockDefinition}
+          data={testTable.results}
+          meta={testTable.subjectMeta}
+          onChange={noop}
+          onSubmit={noop}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    await userEvent.type(screen.getByLabelText('Width (px)'), '-1');
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Label width must be positive' }),
+      ).toHaveAttribute('href', '#chartBuilder-major-labelWidth');
+    });
+  });
+
+  test('shows validation error if invalid axis width given', async () => {
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartAxisConfiguration
+          id="chartBuilder-major"
+          type="major"
+          configuration={testAxisConfiguration}
+          definition={verticalBarBlockDefinition}
+          data={testTable.results}
+          meta={testTable.subjectMeta}
+          onChange={noop}
+          onSubmit={noop}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    await userEvent.type(screen.getByLabelText('Size of axis (px)'), '-1');
+    userEvent.tab();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('link', { name: 'Size of axis must be positive' }),
+      ).toHaveAttribute('href', '#chartBuilder-major-size');
+    });
+  });
+
+  test('submitting fails with invalid values', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartAxisConfiguration
+          id="chartBuilder-major"
+          type="major"
+          configuration={testAxisConfiguration}
+          definition={verticalBarBlockDefinition}
+          data={testTable.results}
+          meta={testTable.subjectMeta}
+          onChange={noop}
+          onSubmit={handleSubmit}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    await userEvent.type(screen.getByLabelText('Width (px)'), '-1');
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+
+    userEvent.click(screen.getByRole('button', { name: 'Save chart options' }));
+
+    await waitFor(() => {
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  test('submitting succeeds with valid values', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartAxisConfiguration
+          id="chartBuilder-major"
+          type="major"
+          configuration={testAxisConfiguration}
+          definition={verticalBarBlockDefinition}
+          data={testTable.results}
+          meta={testTable.subjectMeta}
+          onChange={noop}
+          onSubmit={handleSubmit}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    userEvent.clear(screen.getByLabelText('Size of axis (px)'));
+    await userEvent.type(screen.getByLabelText('Size of axis (px)'), '100');
+
+    userEvent.click(screen.getByRole('checkbox', { name: 'Sort ascending' }));
+
+    userEvent.click(screen.getByRole('button', { name: 'Save chart options' }));
+
+    await waitFor(() => {
+      const formValues: AxisConfiguration = {
+        dataSets: [],
+        groupBy: 'timePeriod',
+        min: 0,
+        max: undefined,
+        referenceLines: [],
+        showGrid: true,
+        size: 100,
+        sortAsc: false,
+        sortBy: 'name',
+        tickConfig: 'default',
+        tickSpacing: 1,
+        type: 'major',
+        visible: true,
+        unit: '',
+        label: {
+          text: '',
+        },
+      };
+      expect(handleSubmit).toHaveBeenCalledWith(formValues);
+    });
+  });
+
+  test('submitting succeeds with a group by a specific filter selected', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartAxisConfiguration
+          id="chartBuilder-major"
+          type="major"
+          configuration={testAxisConfiguration}
+          definition={verticalBarBlockDefinition}
+          data={testTable.results}
+          meta={testTable.subjectMeta}
+          showGroupByFilter // EES-2467 remove this when BE done.
+          onChange={noop}
+          onSubmit={handleSubmit}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    userEvent.click(screen.getByRole('radio', { name: 'Filters' }));
+
+    fireEvent.change(screen.getByLabelText('Select a filter'), {
+      target: { value: 'school_type' },
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Save chart options' }));
+
+    await waitFor(() => {
+      const formValues: AxisConfiguration = {
+        dataSets: [],
+        groupBy: 'filters',
+        groupByFilter: 'school_type',
+        min: 0,
+        max: undefined,
+        referenceLines: [],
+        showGrid: true,
+        size: 50,
+        sortAsc: true,
+        sortBy: 'name',
+        tickConfig: 'default',
+        tickSpacing: 1,
+        type: 'major',
+        visible: true,
+        unit: '',
+        label: {
+          text: '',
+        },
+      };
+      expect(handleSubmit).toHaveBeenCalledWith(formValues);
+    });
+  });
+
+  test('adding reference lines', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartAxisConfiguration
+          id="chartBuilder-major"
+          type="major"
+          configuration={testAxisConfiguration}
+          definition={verticalBarBlockDefinition}
+          data={testTable.results}
+          meta={testTable.subjectMeta}
+          onChange={noop}
+          onSubmit={handleSubmit}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    const referenceLinesSection = within(
+      screen.getByRole('table', { name: 'Reference lines' }),
+    );
+    expect(referenceLinesSection.getAllByRole('row')).toHaveLength(2);
+
+    fireEvent.change(referenceLinesSection.getByLabelText('Position'), {
+      target: { value: '2014_AY' },
+    });
+
+    await userEvent.type(
+      referenceLinesSection.getByLabelText('Label'),
+      'I am label',
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Add line' }));
+
+    await waitFor(() => {
+      const rows = referenceLinesSection.getAllByRole('row');
+      expect(rows).toHaveLength(3);
+      expect(rows[1]).toHaveTextContent('2014_AY');
+      expect(rows[1]).toHaveTextContent('I am label');
+      expect(within(rows[1]).getByRole('button', { name: 'Remove' }));
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Save chart options' }));
+
+    await waitFor(() => {
+      const formValues: AxisConfiguration = {
+        dataSets: [],
+        groupBy: 'timePeriod',
+        min: 0,
+        max: undefined,
+        referenceLines: [
+          {
+            label: 'I am label',
+            position: '2014_AY',
+          },
+        ],
+        showGrid: true,
+        size: 50,
+        sortAsc: true,
+        sortBy: 'name',
+        tickConfig: 'default',
+        tickSpacing: 1,
+        type: 'major',
+        visible: true,
+        unit: '',
+        label: {
+          text: '',
+        },
+      };
+      expect(handleSubmit).toHaveBeenCalledWith(formValues);
+    });
+  });
+
+  test('removing reference lines', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartAxisConfiguration
+          id="chartBuilder-major"
+          type="major"
+          configuration={testAxisConfigurationWithReferenceLines}
+          definition={verticalBarBlockDefinition}
+          data={testTable.results}
+          meta={testTable.subjectMeta}
+          onChange={noop}
+          onSubmit={handleSubmit}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    const referenceLinesSection = within(
+      screen.getByRole('table', { name: 'Reference lines' }),
+    );
+    expect(referenceLinesSection.getAllByRole('row')).toHaveLength(3);
+
+    userEvent.click(
+      referenceLinesSection.getByRole('button', { name: 'Remove' }),
+    );
+
+    await waitFor(() => {
+      const rows = referenceLinesSection.getAllByRole('row');
+      expect(rows).toHaveLength(2);
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Save chart options' }));
+
+    await waitFor(() => {
+      const formValues: AxisConfiguration = {
+        dataSets: [],
+        groupBy: 'timePeriod',
+        min: 0,
+        max: undefined,
+        referenceLines: [],
+        showGrid: true,
+        size: 50,
+        sortAsc: true,
+        sortBy: 'name',
+        tickConfig: 'default',
+        tickSpacing: 1,
+        type: 'major',
+        visible: true,
+        unit: '',
+        label: {
+          text: '',
+        },
+      };
+      expect(handleSubmit).toHaveBeenCalledWith(formValues);
+    });
+  });
+});
+
+// reference lines
+
+// group by

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartAxisConfiguration.test.tsx
@@ -26,12 +26,6 @@ describe('ChartAxisConfiguration', () => {
       id: 'options',
       title: 'Options',
     },
-    legend: {
-      isValid: true,
-      submitCount: 0,
-      id: 'legend',
-      title: 'Legend',
-    },
     major: {
       id: 'chartBuilder-major',
       isValid: true,
@@ -332,190 +326,308 @@ describe('ChartAxisConfiguration', () => {
     });
   });
 
-  test('submitting succeeds with a group by a specific filter selected', async () => {
-    const handleSubmit = jest.fn();
+  describe('Group data by', () => {
+    test('submitting succeeds with the group data by option changed', async () => {
+      const handleSubmit = jest.fn();
 
-    render(
-      <ChartBuilderFormsContextProvider initialForms={testFormState}>
-        <ChartAxisConfiguration
-          id="chartBuilder-major"
-          type="major"
-          configuration={testAxisConfiguration}
-          definition={verticalBarBlockDefinition}
-          data={testTable.results}
-          meta={testTable.subjectMeta}
-          showGroupByFilter // EES-2467 remove this when BE done.
-          onChange={noop}
-          onSubmit={handleSubmit}
-        />
-      </ChartBuilderFormsContextProvider>,
-    );
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-major"
+            type="major"
+            configuration={testAxisConfiguration}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            showGroupByFilter // EES-2467 remove this when BE done.
+            onChange={noop}
+            onSubmit={handleSubmit}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
 
-    userEvent.click(screen.getByRole('radio', { name: 'Filters' }));
+      userEvent.click(screen.getByRole('radio', { name: 'Locations' }));
 
-    fireEvent.change(screen.getByLabelText('Select a filter'), {
-      target: { value: 'school_type' },
-    });
+      userEvent.click(
+        screen.getByRole('button', { name: 'Save chart options' }),
+      );
 
-    userEvent.click(screen.getByRole('button', { name: 'Save chart options' }));
-
-    await waitFor(() => {
-      const formValues: AxisConfiguration = {
-        dataSets: [],
-        groupBy: 'filters',
-        groupByFilter: 'school_type',
-        min: 0,
-        max: undefined,
-        referenceLines: [],
-        showGrid: true,
-        size: 50,
-        sortAsc: true,
-        sortBy: 'name',
-        tickConfig: 'default',
-        tickSpacing: 1,
-        type: 'major',
-        visible: true,
-        unit: '',
-        label: {
-          text: '',
-        },
-      };
-      expect(handleSubmit).toHaveBeenCalledWith(formValues);
-    });
-  });
-
-  test('adding reference lines', async () => {
-    const handleSubmit = jest.fn();
-
-    render(
-      <ChartBuilderFormsContextProvider initialForms={testFormState}>
-        <ChartAxisConfiguration
-          id="chartBuilder-major"
-          type="major"
-          configuration={testAxisConfiguration}
-          definition={verticalBarBlockDefinition}
-          data={testTable.results}
-          meta={testTable.subjectMeta}
-          onChange={noop}
-          onSubmit={handleSubmit}
-        />
-      </ChartBuilderFormsContextProvider>,
-    );
-
-    const referenceLinesSection = within(
-      screen.getByRole('table', { name: 'Reference lines' }),
-    );
-    expect(referenceLinesSection.getAllByRole('row')).toHaveLength(2);
-
-    fireEvent.change(referenceLinesSection.getByLabelText('Position'), {
-      target: { value: '2014_AY' },
-    });
-
-    await userEvent.type(
-      referenceLinesSection.getByLabelText('Label'),
-      'I am label',
-    );
-
-    userEvent.click(screen.getByRole('button', { name: 'Add line' }));
-
-    await waitFor(() => {
-      const rows = referenceLinesSection.getAllByRole('row');
-      expect(rows).toHaveLength(3);
-      expect(rows[1]).toHaveTextContent('2014_AY');
-      expect(rows[1]).toHaveTextContent('I am label');
-      expect(within(rows[1]).getByRole('button', { name: 'Remove' }));
-    });
-
-    userEvent.click(screen.getByRole('button', { name: 'Save chart options' }));
-
-    await waitFor(() => {
-      const formValues: AxisConfiguration = {
-        dataSets: [],
-        groupBy: 'timePeriod',
-        min: 0,
-        max: undefined,
-        referenceLines: [
-          {
-            label: 'I am label',
-            position: '2014_AY',
+      await waitFor(() => {
+        const formValues: AxisConfiguration = {
+          dataSets: [],
+          groupBy: 'locations',
+          min: 0,
+          max: undefined,
+          referenceLines: [],
+          showGrid: true,
+          size: 50,
+          sortAsc: true,
+          sortBy: 'name',
+          tickConfig: 'default',
+          tickSpacing: 1,
+          type: 'major',
+          visible: true,
+          unit: '',
+          label: {
+            text: '',
           },
-        ],
-        showGrid: true,
-        size: 50,
-        sortAsc: true,
-        sortBy: 'name',
-        tickConfig: 'default',
-        tickSpacing: 1,
-        type: 'major',
-        visible: true,
-        unit: '',
-        label: {
-          text: '',
-        },
-      };
-      expect(handleSubmit).toHaveBeenCalledWith(formValues);
+        };
+        expect(handleSubmit).toHaveBeenCalledWith(formValues);
+      });
+    });
+
+    test('submitting succeeds with group by a specific filter selected', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-major"
+            type="major"
+            configuration={testAxisConfiguration}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            showGroupByFilter // EES-2467 remove this when BE done.
+            onChange={noop}
+            onSubmit={handleSubmit}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+
+      userEvent.click(screen.getByRole('radio', { name: 'Filters' }));
+
+      fireEvent.change(screen.getByLabelText('Select a filter'), {
+        target: { value: 'school_type' },
+      });
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Save chart options' }),
+      );
+
+      await waitFor(() => {
+        const formValues: AxisConfiguration = {
+          dataSets: [],
+          groupBy: 'filters',
+          groupByFilter: 'school_type',
+          min: 0,
+          max: undefined,
+          referenceLines: [],
+          showGrid: true,
+          size: 50,
+          sortAsc: true,
+          sortBy: 'name',
+          tickConfig: 'default',
+          tickSpacing: 1,
+          type: 'major',
+          visible: true,
+          unit: '',
+          label: {
+            text: '',
+          },
+        };
+        expect(handleSubmit).toHaveBeenCalledWith(formValues);
+      });
     });
   });
 
-  test('removing reference lines', async () => {
-    const handleSubmit = jest.fn();
+  describe('Reference lines', () => {
+    test('adding reference lines', async () => {
+      const handleSubmit = jest.fn();
 
-    render(
-      <ChartBuilderFormsContextProvider initialForms={testFormState}>
-        <ChartAxisConfiguration
-          id="chartBuilder-major"
-          type="major"
-          configuration={testAxisConfigurationWithReferenceLines}
-          definition={verticalBarBlockDefinition}
-          data={testTable.results}
-          meta={testTable.subjectMeta}
-          onChange={noop}
-          onSubmit={handleSubmit}
-        />
-      </ChartBuilderFormsContextProvider>,
-    );
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-major"
+            type="major"
+            configuration={testAxisConfiguration}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            onChange={noop}
+            onSubmit={handleSubmit}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
 
-    const referenceLinesSection = within(
-      screen.getByRole('table', { name: 'Reference lines' }),
-    );
-    expect(referenceLinesSection.getAllByRole('row')).toHaveLength(3);
+      const referenceLinesSection = within(
+        screen.getByRole('table', { name: 'Reference lines' }),
+      );
+      expect(referenceLinesSection.getAllByRole('row')).toHaveLength(2);
 
-    userEvent.click(
-      referenceLinesSection.getByRole('button', { name: 'Remove' }),
-    );
+      fireEvent.change(referenceLinesSection.getByLabelText('Position'), {
+        target: { value: '2014_AY' },
+      });
 
-    await waitFor(() => {
-      const rows = referenceLinesSection.getAllByRole('row');
-      expect(rows).toHaveLength(2);
+      await userEvent.type(
+        referenceLinesSection.getByLabelText('Label'),
+        'I am label',
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Add line' }));
+
+      await waitFor(() => {
+        const rows = referenceLinesSection.getAllByRole('row');
+        expect(rows).toHaveLength(3);
+        expect(rows[1]).toHaveTextContent('2014_AY');
+        expect(rows[1]).toHaveTextContent('I am label');
+        expect(within(rows[1]).getByRole('button', { name: 'Remove' }));
+      });
     });
 
-    userEvent.click(screen.getByRole('button', { name: 'Save chart options' }));
+    test('successfully submitting with reference lines', async () => {
+      const handleSubmit = jest.fn();
 
-    await waitFor(() => {
-      const formValues: AxisConfiguration = {
-        dataSets: [],
-        groupBy: 'timePeriod',
-        min: 0,
-        max: undefined,
-        referenceLines: [],
-        showGrid: true,
-        size: 50,
-        sortAsc: true,
-        sortBy: 'name',
-        tickConfig: 'default',
-        tickSpacing: 1,
-        type: 'major',
-        visible: true,
-        unit: '',
-        label: {
-          text: '',
-        },
-      };
-      expect(handleSubmit).toHaveBeenCalledWith(formValues);
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-major"
+            type="major"
+            configuration={testAxisConfiguration}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            onChange={noop}
+            onSubmit={handleSubmit}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+
+      const referenceLinesSection = within(
+        screen.getByRole('table', { name: 'Reference lines' }),
+      );
+      expect(referenceLinesSection.getAllByRole('row')).toHaveLength(2);
+
+      fireEvent.change(referenceLinesSection.getByLabelText('Position'), {
+        target: { value: '2014_AY' },
+      });
+
+      await userEvent.type(
+        referenceLinesSection.getByLabelText('Label'),
+        'I am label',
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Add line' }));
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Save chart options' }),
+      );
+
+      await waitFor(() => {
+        const formValues: AxisConfiguration = {
+          dataSets: [],
+          groupBy: 'timePeriod',
+          min: 0,
+          max: undefined,
+          referenceLines: [
+            {
+              label: 'I am label',
+              position: '2014_AY',
+            },
+          ],
+          showGrid: true,
+          size: 50,
+          sortAsc: true,
+          sortBy: 'name',
+          tickConfig: 'default',
+          tickSpacing: 1,
+          type: 'major',
+          visible: true,
+          unit: '',
+          label: {
+            text: '',
+          },
+        };
+        expect(handleSubmit).toHaveBeenCalledWith(formValues);
+      });
+    });
+
+    test('removing reference lines', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-major"
+            type="major"
+            configuration={testAxisConfigurationWithReferenceLines}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            onChange={noop}
+            onSubmit={handleSubmit}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+
+      const referenceLinesSection = within(
+        screen.getByRole('table', { name: 'Reference lines' }),
+      );
+      expect(referenceLinesSection.getAllByRole('row')).toHaveLength(3);
+
+      userEvent.click(
+        referenceLinesSection.getByRole('button', { name: 'Remove' }),
+      );
+
+      await waitFor(() => {
+        const rows = referenceLinesSection.getAllByRole('row');
+        expect(rows).toHaveLength(2);
+      });
+    });
+
+    test('successfully submit with reference lines removed', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <ChartBuilderFormsContextProvider initialForms={testFormState}>
+          <ChartAxisConfiguration
+            id="chartBuilder-major"
+            type="major"
+            configuration={testAxisConfigurationWithReferenceLines}
+            definition={verticalBarBlockDefinition}
+            data={testTable.results}
+            meta={testTable.subjectMeta}
+            onChange={noop}
+            onSubmit={handleSubmit}
+          />
+        </ChartBuilderFormsContextProvider>,
+      );
+
+      const referenceLinesSection = within(
+        screen.getByRole('table', { name: 'Reference lines' }),
+      );
+      expect(referenceLinesSection.getAllByRole('row')).toHaveLength(3);
+
+      userEvent.click(
+        referenceLinesSection.getByRole('button', { name: 'Remove' }),
+      );
+
+      userEvent.click(
+        screen.getByRole('button', { name: 'Save chart options' }),
+      );
+
+      await waitFor(() => {
+        const formValues: AxisConfiguration = {
+          dataSets: [],
+          groupBy: 'timePeriod',
+          min: 0,
+          max: undefined,
+          referenceLines: [],
+          showGrid: true,
+          size: 50,
+          sortAsc: true,
+          sortBy: 'name',
+          tickConfig: 'default',
+          tickSpacing: 1,
+          type: 'major',
+          visible: true,
+          unit: '',
+          label: {
+            text: '',
+          },
+        };
+        expect(handleSubmit).toHaveBeenCalledWith(formValues);
+      });
     });
   });
 });
-
-// reference lines
-
-// group by

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -46,6 +46,7 @@ export interface Label {
 export interface AxisConfiguration {
   type: AxisType;
   groupBy?: AxisGroupBy;
+  groupByFilter?: string;
   sortBy?: string;
   sortAsc?: boolean;
   dataSets: DataSet[];

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
@@ -3,6 +3,7 @@ import { DataSet } from '@common/modules/charts/types/dataSet';
 import createDataSetCategories from '@common/modules/charts/util/createDataSetCategories';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import { TableDataResponse } from '@common/services/tableBuilderService';
+import produce from 'immer';
 
 describe('createDataSetCategories', () => {
   const testTable: TableDataResponse = {
@@ -1064,29 +1065,15 @@ describe('createDataSetCategories', () => {
       min: 0,
     };
 
-    const fullTable = mapFullTable({
-      ...testTable,
-      subjectMeta: {
-        ...testTable.subjectMeta,
-        filters: {
-          ...testTable.subjectMeta.filters,
-          SchoolType: {
-            ...testTable.subjectMeta.filters.SchoolType,
-            options: {
-              Default: {
-                ...testTable.subjectMeta.filters.SchoolType.options.Default,
-                options: [
-                  {
-                    label: 'State-funded primary',
-                    value: 'state-funded-primary',
-                  },
-                ],
-              },
-            },
-          },
+    const updatedTestTable = produce(testTable, draft => {
+      draft.subjectMeta.filters.SchoolType.options.Default.options = [
+        {
+          label: 'State-funded primary',
+          value: 'state-funded-primary',
         },
-      },
-    } as TableDataResponse);
+      ];
+    });
+    const fullTable = mapFullTable(updatedTestTable);
 
     const dataSetCategories = createDataSetCategories(
       axisConfiguration,
@@ -1117,43 +1104,21 @@ describe('createDataSetCategories', () => {
       min: 0,
     };
 
-    const fullTable = mapFullTable({
-      ...testTable,
-      subjectMeta: {
-        ...testTable.subjectMeta,
-        filters: {
-          Characteristic: {
-            ...testTable.subjectMeta.filters.Characteristic,
-            options: {
-              EthnicGroupMajor: {
-                ...testTable.subjectMeta.filters.Characteristic.options
-                  .EthnicGroupMajor,
-                options: [
-                  {
-                    label: 'Ethnicity Major Chinese',
-                    value: 'ethnicity-major-chinese',
-                  },
-                ],
-              },
-            },
-          },
-          SchoolType: {
-            ...testTable.subjectMeta.filters.SchoolType,
-            options: {
-              Default: {
-                ...testTable.subjectMeta.filters.SchoolType.options.Default,
-                options: [
-                  {
-                    label: 'State-funded primary',
-                    value: 'state-funded-primary',
-                  },
-                ],
-              },
-            },
-          },
+    const updatedTestTable = produce(testTable, draft => {
+      draft.subjectMeta.filters.Characteristic.options.EthnicGroupMajor.options = [
+        {
+          label: 'Ethnicity Major Chinese',
+          value: 'ethnicity-major-chinese',
         },
-      },
-    } as TableDataResponse);
+      ];
+      draft.subjectMeta.filters.SchoolType.options.Default.options = [
+        {
+          label: 'State-funded primary',
+          value: 'state-funded-primary',
+        },
+      ];
+    });
+    const fullTable = mapFullTable(updatedTestTable);
 
     const dataSetCategories = createDataSetCategories(
       axisConfiguration,
@@ -1277,7 +1242,7 @@ describe('createDataSetCategories', () => {
           timePeriod: '2015_AY',
         },
       ],
-    } as TableDataResponse);
+    });
 
     const dataSetCategories = createDataSetCategories(
       axisConfiguration,
@@ -1339,51 +1304,29 @@ describe('createDataSetCategories', () => {
       min: 0,
     };
 
-    const fullTable = mapFullTable({
-      ...testTable,
-      subjectMeta: {
-        ...testTable.subjectMeta,
-        filters: {
-          Characteristic: {
-            ...testTable.subjectMeta.filters.Characteristic,
-            options: {
-              EthnicGroupMajor: {
-                ...testTable.subjectMeta.filters.Characteristic.options
-                  .EthnicGroupMajor,
-                options: [
-                  {
-                    label: 'Ethnicity Major Chinese',
-                    value: 'ethnicity-major-chinese',
-                  },
-                  {
-                    label: 'Ethnicity another',
-                    value: 'ethnicity-another',
-                  },
-                ],
-              },
-            },
-          },
-          SchoolType: {
-            ...testTable.subjectMeta.filters.SchoolType,
-            options: {
-              Default: {
-                ...testTable.subjectMeta.filters.SchoolType.options.Default,
-                options: [
-                  {
-                    label: 'State-funded primary',
-                    value: 'state-funded-primary',
-                  },
-                  {
-                    label: 'State-funded secondary',
-                    value: 'state-funded-secondary',
-                  },
-                ],
-              },
-            },
-          },
+    const updatedTestTable = produce(testTable, draft => {
+      draft.subjectMeta.filters.Characteristic.options.EthnicGroupMajor.options = [
+        {
+          label: 'Ethnicity Major Chinese',
+          value: 'ethnicity-major-chinese',
         },
-      },
-    } as TableDataResponse);
+        {
+          label: 'Ethnicity another',
+          value: 'ethnicity-another',
+        },
+      ];
+      draft.subjectMeta.filters.SchoolType.options.Default.options = [
+        {
+          label: 'State-funded primary',
+          value: 'state-funded-primary',
+        },
+        {
+          label: 'State-funded secondary',
+          value: 'state-funded-secondary',
+        },
+      ];
+    });
+    const fullTable = mapFullTable(updatedTestTable);
 
     const dataSetCategories = createDataSetCategories(
       axisConfiguration,

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
@@ -1315,4 +1315,84 @@ describe('createDataSetCategories', () => {
       timePeriod: '2015_AY',
     });
   });
+
+  test('group by specific filter category', () => {
+    const axisConfiguration: AxisConfiguration = {
+      type: 'major',
+      groupBy: 'filters',
+      groupByFilter: 'school_type',
+      sortBy: 'name',
+      sortAsc: true,
+      dataSets: [
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        },
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-secondary'],
+        },
+      ],
+      referenceLines: [],
+      visible: true,
+      unit: '',
+      min: 0,
+    };
+
+    const fullTable = mapFullTable({
+      ...testTable,
+      subjectMeta: {
+        ...testTable.subjectMeta,
+        filters: {
+          Characteristic: {
+            ...testTable.subjectMeta.filters.Characteristic,
+            options: {
+              EthnicGroupMajor: {
+                ...testTable.subjectMeta.filters.Characteristic.options
+                  .EthnicGroupMajor,
+                options: [
+                  {
+                    label: 'Ethnicity Major Chinese',
+                    value: 'ethnicity-major-chinese',
+                  },
+                  {
+                    label: 'Ethnicity another',
+                    value: 'ethnicity-another',
+                  },
+                ],
+              },
+            },
+          },
+          SchoolType: {
+            ...testTable.subjectMeta.filters.SchoolType,
+            options: {
+              Default: {
+                ...testTable.subjectMeta.filters.SchoolType.options.Default,
+                options: [
+                  {
+                    label: 'State-funded primary',
+                    value: 'state-funded-primary',
+                  },
+                  {
+                    label: 'State-funded secondary',
+                    value: 'state-funded-secondary',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    } as TableDataResponse);
+
+    const dataSetCategories = createDataSetCategories(
+      axisConfiguration,
+      fullTable.results,
+      fullTable.subjectMeta,
+    );
+
+    expect(dataSetCategories).toHaveLength(2);
+    expect(dataSetCategories[0].filter.label).toBe('State-funded primary');
+    expect(dataSetCategories[1].filter.label).toBe('State-funded secondary');
+  });
 });

--- a/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
@@ -140,7 +140,7 @@ function getCategoryFilters(
   axisConfiguration: AxisConfiguration,
   meta: FullTableMeta,
 ): Filter[] {
-  const { groupBy: axisGroupBy } = axisConfiguration;
+  const { groupBy: axisGroupBy, groupByFilter } = axisConfiguration;
 
   let filters: Filter[] = [];
 
@@ -151,8 +151,17 @@ function getCategoryFilters(
       // We want to try and remove any filter groups with only
       // one filter as these don't really make sense to display
       // on the chart (this is similar to what we do in table tool).
+      // Also take into account the specific filter category it's grouped by.
       const filteredFilters = filterGroups
-        .filter(filterGroup => filterGroup.options.length > 1)
+        .filter(filterGroup => {
+          if (groupByFilter) {
+            return (
+              filterGroup.options.length > 1 &&
+              filterGroup.name === groupByFilter
+            );
+          }
+          return filterGroup.options.length > 1;
+        })
         .flatMap(filterGroup => filterGroup.options);
 
       // If there are no filtered filters, we need to at least


### PR DESCRIPTION
Adds an option to select a specific filter when grouping a chart by filter.

Changes the group by options to a radio group as that works best with conditionally showing the filters dropdown.

The filters dropdown is hidden behind the `showGroupByFilter` flag as backend work to store the value is required (EES-2620)

![groupby](https://user-images.githubusercontent.com/81572860/129747563-1851f525-7dbf-47e6-9853-e033226e1822.png)
