### PR TITLE
EES-2348 Upgrade .NET Core 3.1.5 to 3.1.18

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
@@ -16,11 +16,11 @@
 
   <ItemGroup>
     <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -47,19 +47,19 @@
     <PackageReference Include="JWT" Version="7.3.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.18" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.18" />
+    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="3.1.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.18" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.7" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.5" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.18" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
   </ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="Snapshooter.Xunit" Version="0.6.2" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -11,11 +11,11 @@
         <PackageReference Include="AutoMapper" Version="9.0.0" />
         <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.18" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
         <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="1.3.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.18" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.18" />
         <PackageReference Include="Namotion.Reflection" Version="2.0.1" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.7" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
@@ -14,10 +14,10 @@
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
         <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.7" />
         <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.7" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.5" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.18" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.18" />
+        <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.18" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.18" />
         <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     </ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
     </ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/GovUk.Education.ExploreEducationStatistics.Content.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/GovUk.Education.ExploreEducationStatistics.Content.Model.csproj
@@ -7,8 +7,8 @@
     <ItemGroup>
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="JsonKnownTypes" Version="0.4.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.18" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.18" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.csproj
@@ -7,11 +7,11 @@
 
     <ItemGroup>
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.18" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/GovUk.Education.ExploreEducationStatistics.Content.Security.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/GovUk.Education.ExploreEducationStatistics.Content.Security.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.18" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/GovUk.Education.ExploreEducationStatistics.Data.Api.csproj
@@ -16,12 +16,12 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.18" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.18" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
   </ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests.csproj
@@ -7,9 +7,9 @@
 
     <ItemGroup>
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.18" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.18" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/GovUk.Education.ExploreEducationStatistics.Data.Model.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.18" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.csproj
@@ -8,9 +8,9 @@
 
     <ItemGroup>
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.18" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.18" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/GovUk.Education.ExploreEducationStatistics.Data.Processor.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/GovUk.Education.ExploreEducationStatistics.Data.Processor.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.12" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.18" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.csproj
@@ -8,9 +8,9 @@
 
     <ItemGroup>
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.18" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.18" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/GovUk.Education.ExploreEducationStatistics.Data.Services.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/GovUk.Education.ExploreEducationStatistics.Data.Services.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="AutoMapper" Version="9.0.0" />
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="3.1.18" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     </ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/GovUk.Education.ExploreEducationStatistics.Publisher.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/GovUk.Education.ExploreEducationStatistics.Publisher.Tests.csproj
@@ -8,12 +8,12 @@
 
     <ItemGroup>
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="Snapshooter.Xunit" Version="0.6.2" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.18" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="1.3.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.18" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.6" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
We are holding back from a .NET 6 upgrade until its final release, scheduled for November 2021.

@ntsim attempted a .NET 5 upgrade but found a problem with Azure Functions mentioned in the description of https://github.com/dfe-analytical-services/explore-education-statistics/pull/2737 which upgraded to C# 9.

This PR upgrades all project dependencies from .NET Core 3.1.5 released June 2020 to 3.1.18 released in the [August 2021 updates](https://devblogs.microsoft.com/dotnet/net-august-2021/).

This upgrade was made as part of trying to solve a bug found during the testing of https://github.com/dfe-analytical-services/explore-education-statistics/pull/2785. The bug was elsewhere.

As there appear to be no breakages (see the test results attached here run with latest code from `dev`), it seems a safe upgrade, hence this PR*.

<sub>*UI tests run with a local change to `MethodologySummaryPage.tsx` to workaround known test failures caused by EES-2599.</sub>

![image](https://user-images.githubusercontent.com/4147126/129801542-e07c265d-39a8-41cb-b648-ee1200673d11.png)
