### PR TITLE
EES-2631 fix select all and search issues

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormCheckboxGroup.tsx
@@ -32,6 +32,7 @@ export type CheckboxGroupAllChangeEvent = MouseEvent<HTMLButtonElement>;
 export type CheckboxGroupAllChangeEventHandler = (
   event: CheckboxGroupAllChangeEvent,
   checked: boolean,
+  filteredOptions: CheckboxOption[],
 ) => void;
 
 interface BaseFormCheckboxGroupProps {
@@ -94,10 +95,10 @@ export const BaseFormCheckboxGroup = ({
   const handleAllChange: MouseEventHandler<HTMLButtonElement> = useCallback(
     event => {
       if (onAllChange) {
-        onAllChange(event, isAllChecked);
+        onAllChange(event, isAllChecked, options);
       }
     },
-    [isAllChecked, onAllChange],
+    [isAllChecked, onAllChange, options],
   );
 
   return (

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxGroup.tsx
@@ -23,7 +23,7 @@ function FormFieldCheckboxGroup<FormValues>(props: Props<FormValues>) {
           id={id}
           onAllChange={(event, checked) => {
             if (props.onAllChange) {
-              props.onAllChange(event, checked);
+              props.onAllChange(event, checked, options);
             }
 
             if (event.isDefaultPrevented()) {

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchGroup.tsx
@@ -16,8 +16,6 @@ export type FormFieldCheckboxSearchGroupProps<FormValues> = OmitStrict<
 function FormFieldCheckboxSearchGroup<FormValues>(
   props: FormFieldCheckboxSearchGroupProps<FormValues>,
 ) {
-  const { options } = props;
-
   return (
     <FormField<string[]> {...props}>
       {({ id, field, helpers, meta }) => {
@@ -26,9 +24,9 @@ function FormFieldCheckboxSearchGroup<FormValues>(
             {...props}
             {...field}
             id={id}
-            onAllChange={(event, checked) => {
+            onAllChange={(event, checked, options) => {
               if (props.onAllChange) {
-                props.onAllChange(event, checked);
+                props.onAllChange(event, checked, options);
               }
 
               if (event.isDefaultPrevented()) {

--- a/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchSubGroups.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldCheckboxSearchSubGroups.tsx
@@ -16,8 +16,6 @@ export type FormFieldCheckboxSearchSubGroupsProps<FormValues> = OmitStrict<
 function FormFieldCheckboxSearchSubGroups<FormValues>(
   props: FormFieldCheckboxSearchSubGroupsProps<FormValues>,
 ) {
-  const { options } = props;
-
   return (
     <FormField<string[]> {...props}>
       {({ id, field, helpers, meta }) => {
@@ -27,7 +25,7 @@ function FormFieldCheckboxSearchSubGroups<FormValues>(
             {...field}
             id={id}
             small
-            onAllChange={(event, checked) => {
+            onAllChange={(event, checked, options) => {
               if (event.isDefaultPrevented()) {
                 return;
               }


### PR DESCRIPTION
Fixes problems with select all and search on the table tool:

1. 'Select all' not working for filtered locations and Indicators/Filters with multiple sub-categories
2. Search not working for Indicators/Filters with only one sub-category

The existing unit tests pass, slightly worryingly. They should be updated to cover these scenarios. I can do this next week, either as part of this PR or separately if this gets merged.