### PR TITLE
EES-2553 Publication owners should be able to manage legacy releases

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/LegacyReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/LegacyReleaseAuthorizationHandlersTests.cs
@@ -1,8 +1,10 @@
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.ReleaseAuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
@@ -12,37 +14,52 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         public class CreateLegacyReleaseAuthorizationHandlerTests
         {
             [Fact]
-            public async Task CanCreateAnyLegacyRelease()
+            public async Task CreateLegacyRelease()
             {
-                await AssertReleaseHandlerSucceedsWithCorrectClaims<CreateLegacyReleaseRequirement>(
-                    new CreateLegacyReleaseAuthorizationHandler.CanCreateAnyLegacyRelease(), 
+                await AssertHandlerSucceedsWithCorrectClaims<Publication, CreateLegacyReleaseRequirement>(
+                    contentDbContext =>
+                        new CreateLegacyReleaseAuthorizationHandler(
+                            new UserPublicationRoleRepository(contentDbContext)),
+                    new Publication(),
                     CreateAnyRelease
                 );
             }
+
+            // TODO Publication owner test @MarkFix
         }
 
         public class ViewLegacyReleaseAuthorizationHandlerTests
         {
             [Fact]
-            public async Task CanViewAllLegacyReleases()
+            public async Task ViewLegacyRelease()
             {
-                await AssertReleaseHandlerSucceedsWithCorrectClaims<ViewLegacyReleaseRequirement>(
-                    new ViewLegacyReleaseAuthorizationHandler.CanViewAllLegacyReleases(), 
+                await AssertHandlerSucceedsWithCorrectClaims<LegacyRelease, ViewLegacyReleaseRequirement>(
+                    contentDbContext =>
+                        new ViewLegacyReleaseAuthorizationHandler(
+                            new UserPublicationRoleRepository(contentDbContext)),
+                    new LegacyRelease(),
                     AccessAllReleases
                 );
             }
+
+            // TODO Publication owner test @MarkFix
         }
 
         public class UpdateLegacyReleaseAuthorizationHandlerTests
         {
             [Fact]
-            public async Task CanUpdateAllLegacyReleases()
+            public async Task UpdateLegacyRelease()
             {
-                await AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateLegacyReleaseRequirement>(
-                    new UpdateLegacyReleaseAuthorizationHandler.CanUpdateAllLegacyReleases(), 
+                await AssertHandlerSucceedsWithCorrectClaims<LegacyRelease, UpdateLegacyReleaseRequirement>(
+                    contentDbContext =>
+                        new UpdateLegacyReleaseAuthorizationHandler(
+                            new UserPublicationRoleRepository(contentDbContext)),
+                    new LegacyRelease(),
                     UpdateAllReleases
                 );
             }
+
+            // TODO Publication owner test @MarkFix
         }
 
         public class DeleteLegacyReleaseAuthorizationHandlerTests
@@ -50,11 +67,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task CanDeleteAllLegacyReleases()
             {
-                await AssertReleaseHandlerSucceedsWithCorrectClaims<DeleteLegacyReleaseRequirement>(
-                    new DeleteLegacyReleaseAuthorizationHandler.CanDeleteAllLegacyReleases(), 
+                await AssertHandlerSucceedsWithCorrectClaims<LegacyRelease, DeleteLegacyReleaseRequirement>(
+                    contentDbContext =>
+                        new DeleteLegacyReleaseAuthorizationHandler(
+                            new UserPublicationRoleRepository(contentDbContext)),
+                    new LegacyRelease(),
                     UpdateAllReleases
                 );
             }
+
+            // TODO Publication owner test @MarkFix
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/LegacyReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/LegacyReleaseAuthorizationHandlersTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
@@ -5,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.PublicationAuthorizationHandlersTestUtil;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {
@@ -14,7 +16,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         public class CreateLegacyReleaseAuthorizationHandlerTests
         {
             [Fact]
-            public async Task CreateLegacyRelease()
+            public async Task CreateLegacyRelease_Claims()
             {
                 await AssertHandlerSucceedsWithCorrectClaims<Publication, CreateLegacyReleaseRequirement>(
                     contentDbContext =>
@@ -25,13 +27,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 );
             }
 
-            // TODO Publication owner test @MarkFix
+            [Fact]
+            public async Task CreateLegacyRelease_PublicationRoles()
+            {
+                await AssertPublicationHandlerSucceedsWithPublicationOwnerRole<CreateLegacyReleaseRequirement>(
+                    contentDbContext =>
+                        new CreateLegacyReleaseAuthorizationHandler(
+                            new UserPublicationRoleRepository(contentDbContext)));
+            }
         }
 
         public class ViewLegacyReleaseAuthorizationHandlerTests
         {
             [Fact]
-            public async Task ViewLegacyRelease()
+            public async Task ViewLegacyRelease_Claims()
             {
                 await AssertHandlerSucceedsWithCorrectClaims<LegacyRelease, ViewLegacyReleaseRequirement>(
                     contentDbContext =>
@@ -42,13 +51,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 );
             }
 
-            // TODO Publication owner test @MarkFix
+            [Fact]
+            public void ViewLegacyRelease_PublicationRoles()
+            {
+                var legacyRelease = new LegacyRelease
+                {
+                    PublicationId = Guid.NewGuid(),
+                };
+
+                AssertHandlerOnlySucceedsWithPublicationRole<
+                   ViewLegacyReleaseRequirement,
+                   LegacyRelease>(
+                   legacyRelease.PublicationId,
+                   legacyRelease,
+                   contentDbContext =>
+                       new ViewLegacyReleaseAuthorizationHandler(
+                           new UserPublicationRoleRepository(contentDbContext)),
+                   PublicationRole.Owner);
+            }
         }
 
         public class UpdateLegacyReleaseAuthorizationHandlerTests
         {
             [Fact]
-            public async Task UpdateLegacyRelease()
+            public async Task UpdateLegacyRelease_Claims()
             {
                 await AssertHandlerSucceedsWithCorrectClaims<LegacyRelease, UpdateLegacyReleaseRequirement>(
                     contentDbContext =>
@@ -59,13 +85,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 );
             }
 
-            // TODO Publication owner test @MarkFix
+            [Fact]
+            public void UpdateLegacyRelease_PublicationRoles()
+            {
+                var legacyRelease = new LegacyRelease
+                {
+                    PublicationId = Guid.NewGuid(),
+                };
+
+                AssertHandlerOnlySucceedsWithPublicationRole<
+                   UpdateLegacyReleaseRequirement,
+                   LegacyRelease>(
+                   legacyRelease.PublicationId,
+                   legacyRelease,
+                   contentDbContext =>
+                       new UpdateLegacyReleaseAuthorizationHandler(
+                           new UserPublicationRoleRepository(contentDbContext)),
+                   PublicationRole.Owner);
+            }
         }
 
         public class DeleteLegacyReleaseAuthorizationHandlerTests
         {
             [Fact]
-            public async Task CanDeleteAllLegacyReleases()
+            public async Task DeleteLegacyRelease_Claims()
             {
                 await AssertHandlerSucceedsWithCorrectClaims<LegacyRelease, DeleteLegacyReleaseRequirement>(
                     contentDbContext =>
@@ -76,7 +119,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 );
             }
 
-            // TODO Publication owner test @MarkFix
+            [Fact]
+            public void DeleteLegacyRelease_PublicationRoles()
+            {
+                var legacyRelease = new LegacyRelease
+                {
+                    PublicationId = Guid.NewGuid(),
+                };
+
+                AssertHandlerOnlySucceedsWithPublicationRole<
+                   DeleteLegacyReleaseRequirement,
+                   LegacyRelease>(
+                   legacyRelease.PublicationId,
+                   legacyRelease,
+                   contentDbContext =>
+                       new DeleteLegacyReleaseAuthorizationHandler(
+                           new UserPublicationRoleRepository(contentDbContext)),
+                   PublicationRole.Owner);
+            }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/LegacyReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/LegacyReleaseAuthorizationHandlersTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/PublicationAuthorizationHandlersTestUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/PublicationAuthorizationHandlersTestUtil.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
+using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils
@@ -117,12 +120,83 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             });
         }
         
+        public class PublicationHandlerTestScenario : HandlerTestScenario
+        {
+            public List<UserPublicationRole> UserPublicationRoles { get; set; }
+        }
+
+        public static async void AssertHandlerOnlySucceedsWithPublicationRole<TRequirement, TEntity>(
+            Guid publicationId,
+            TEntity handleRequirementArgument,
+            Func<ContentDbContext, IAuthorizationHandler> handlerSupplier,
+            params PublicationRole[] successfulRoles)
+            where TRequirement : IAuthorizationRequirement
+        {
+            var allPublicationRoles = GetEnumValues<PublicationRole>();
+            var userId = Guid.NewGuid();
+
+            allPublicationRoles.ForEach(async role =>
+            {
+                var contentDbContextId = Guid.NewGuid().ToString();
+                using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+                {
+                    await contentDbContext.AddAsync(handleRequirementArgument);
+                    await contentDbContext.AddAsync(new UserPublicationRole
+                    {
+                        UserId = userId,
+                        Role = role,
+                        PublicationId = publicationId,
+                    });
+                    await contentDbContext.SaveChangesAsync();
+                }
+
+                using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+                {
+                    var user = CreateClaimsPrincipal(userId);
+                    var authContext = new AuthorizationHandlerContext(
+                        new IAuthorizationRequirement[] {Activator.CreateInstance<TRequirement>()},
+                        user, handleRequirementArgument);
+
+                    var handler = handlerSupplier(contentDbContext);
+                    await handler.HandleAsync(authContext);
+                    if (successfulRoles.Contains(role))
+                    {
+                        Assert.True(authContext.HasSucceeded, $"Should succeed with role {role.ToString()}");
+                    }
+                    else
+                    {
+                        Assert.False(authContext.HasSucceeded, $"Should fail with role {role.ToString()}");
+                    }
+                }
+            });
+
+            // NOTE: Permission should fail if user no publication role
+            using (var contentDbContext = InMemoryApplicationDbContext("no-publication-role"))
+            {
+                await contentDbContext.AddRangeAsync(
+                    handleRequirementArgument);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            using (var contentDbContext = InMemoryApplicationDbContext("no-publication-role"))
+            {
+                var user = CreateClaimsPrincipal(userId);
+                var authContext = new AuthorizationHandlerContext(
+                    new IAuthorizationRequirement[] {Activator.CreateInstance<TRequirement>()},
+                    user, handleRequirementArgument);
+
+                var handler = handlerSupplier(contentDbContext);
+                await handler.HandleAsync(authContext);
+                Assert.False(authContext.HasSucceeded, $"Should fail when user has no publication role");
+            }
+        }
+
         private static async Task AssertPublicationHandlerHandlesScenarioSuccessfully<TRequirement>(
             Func<ContentDbContext, IAuthorizationHandler> handlerSupplier,
             PublicationHandlerTestScenario scenario) where TRequirement : IAuthorizationRequirement
         {
             var contextId = Guid.NewGuid().ToString();
-        
+
             using (var context = InMemoryApplicationDbContext(contextId))
             {
                 if (scenario.UserPublicationRoles != null)
@@ -131,17 +205,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     await context.SaveChangesAsync();
                 }
             }
-        
+
             using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var handler = handlerSupplier(context);
                 await AssertHandlerHandlesScenarioSuccessfully<TRequirement>(handler, scenario);
             }
-        }
-
-        public class PublicationHandlerTestScenario : HandlerTestScenario
-        {
-            public List<UserPublicationRole> UserPublicationRoles { get; set; }
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/PublicationAuthorizationHandlersTestUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/PublicationAuthorizationHandlersTestUtil.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -122,7 +123,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         
         public class PublicationHandlerTestScenario : HandlerTestScenario
         {
-            public List<UserPublicationRole> UserPublicationRoles { get; set; }
+            public List<UserPublicationRole>? UserPublicationRoles { get; set; }
         }
 
         public static async void AssertHandlerOnlySucceedsWithPublicationRole<TRequirement, TEntity>(
@@ -140,7 +141,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 var contentDbContextId = Guid.NewGuid().ToString();
                 using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
                 {
-                    await contentDbContext.AddAsync(handleRequirementArgument);
+                    await contentDbContext.AddAsync(handleRequirementArgument!);
                     await contentDbContext.AddAsync(new UserPublicationRole
                     {
                         UserId = userId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/LegacyReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/LegacyReleaseAuthorizationHandlers.cs
@@ -1,9 +1,9 @@
+#nullable enable
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Authorization;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
@@ -32,10 +32,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 return;
             }
 
-            var publicationRoles = await _userPublicationRoleRepository
-                .GetAllRolesByUser(context.User.GetUserId(), publication.Id);
-
-            if (ContainPublicationOwnerRole(publicationRoles))
+            var isUserPublicationOwner = await _userPublicationRoleRepository.IsUserPublicationOwner(
+                context.User.GetUserId(),
+                publication.Id);
+            if (isUserPublicationOwner)
             {
                 context.Succeed(requirement);
             }
@@ -65,10 +65,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 return;
             }
 
-            var publicationRoles = await _userPublicationRoleRepository
-                .GetAllRolesByUser(context.User.GetUserId(), legacyRelease.PublicationId);
-
-            if (ContainPublicationOwnerRole(publicationRoles))
+            var isUserPublicationOwner = await _userPublicationRoleRepository.IsUserPublicationOwner(
+                context.User.GetUserId(),
+                legacyRelease.PublicationId);
+            if (isUserPublicationOwner)
             {
                 context.Succeed(requirement);
             }
@@ -98,10 +98,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 return;
             }
 
-            var publicationRoles = await _userPublicationRoleRepository
-                .GetAllRolesByUser(context.User.GetUserId(), legacyRelease.PublicationId);
-
-            if (ContainPublicationOwnerRole(publicationRoles))
+            var isUserPublicationOwner = await _userPublicationRoleRepository.IsUserPublicationOwner(
+                context.User.GetUserId(),
+                legacyRelease.PublicationId);
+            if (isUserPublicationOwner)
             {
                 context.Succeed(requirement);
             }
@@ -131,10 +131,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 return;
             }
 
-            var publicationRoles = await _userPublicationRoleRepository
-                .GetAllRolesByUser(context.User.GetUserId(), legacyRelease.PublicationId);
-
-            if (ContainPublicationOwnerRole(publicationRoles))
+            var isUserPublicationOwner = await _userPublicationRoleRepository.IsUserPublicationOwner(
+                context.User.GetUserId(),
+                legacyRelease.PublicationId);
+            if (isUserPublicationOwner)
             {
                 context.Succeed(requirement);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/LegacyReleaseAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/LegacyReleaseAuthorizationHandlers.cs
@@ -1,89 +1,143 @@
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Authorization;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
     // Create
-
     public class CreateLegacyReleaseRequirement : IAuthorizationRequirement
     {}
 
     public class CreateLegacyReleaseAuthorizationHandler 
-        : CompoundAuthorizationHandler<CreateLegacyReleaseRequirement, Publication>
+        : AuthorizationHandler<CreateLegacyReleaseRequirement, Publication>
     {
-        public CreateLegacyReleaseAuthorizationHandler() : base(
-            new CanCreateAnyLegacyRelease()
-        )
-        {}
-    
-        public class CanCreateAnyLegacyRelease : 
-            HasClaimAuthorizationHandler<CreateLegacyReleaseRequirement>
+        private readonly IUserPublicationRoleRepository _userPublicationRoleRepository;
+
+        public CreateLegacyReleaseAuthorizationHandler(IUserPublicationRoleRepository userPublicationRoleRepository)
         {
-            public CanCreateAnyLegacyRelease() 
-                : base(SecurityClaimTypes.CreateAnyRelease) {}
+            _userPublicationRoleRepository = userPublicationRoleRepository;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context,
+            CreateLegacyReleaseRequirement requirement,
+            Publication publication)
+        {
+            if (SecurityUtils.HasClaim(context.User, CreateAnyRelease))
+            {
+                context.Succeed(requirement);
+                return;
+            }
+
+            var publicationRoles = await _userPublicationRoleRepository
+                .GetAllRolesByUser(context.User.GetUserId(), publication.Id);
+
+            if (ContainPublicationOwnerRole(publicationRoles))
+            {
+                context.Succeed(requirement);
+            }
         }
     }
 
     // View
-
     public class ViewLegacyReleaseRequirement : IAuthorizationRequirement
     {}
 
     public class ViewLegacyReleaseAuthorizationHandler 
-        : CompoundAuthorizationHandler<ViewLegacyReleaseRequirement, LegacyRelease>
+        : AuthorizationHandler<ViewLegacyReleaseRequirement, LegacyRelease>
     {
-        public ViewLegacyReleaseAuthorizationHandler() : base(
-            new CanViewAllLegacyReleases()
-        )
-        {}
-    
-        public class CanViewAllLegacyReleases : 
-            HasClaimAuthorizationHandler<ViewLegacyReleaseRequirement>
+        private readonly IUserPublicationRoleRepository _userPublicationRoleRepository;
+        public ViewLegacyReleaseAuthorizationHandler(IUserPublicationRoleRepository userPublicationRoleRepository)
         {
-            public CanViewAllLegacyReleases() 
-                : base(SecurityClaimTypes.AccessAllReleases) {}
+            _userPublicationRoleRepository = userPublicationRoleRepository;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context,
+            ViewLegacyReleaseRequirement requirement,
+            LegacyRelease legacyRelease)
+        {
+            if (SecurityUtils.HasClaim(context.User, AccessAllReleases))
+            {
+                context.Succeed(requirement);
+                return;
+            }
+
+            var publicationRoles = await _userPublicationRoleRepository
+                .GetAllRolesByUser(context.User.GetUserId(), legacyRelease.PublicationId);
+
+            if (ContainPublicationOwnerRole(publicationRoles))
+            {
+                context.Succeed(requirement);
+            }
         }
     }
 
     // Update
-
     public class UpdateLegacyReleaseRequirement : IAuthorizationRequirement
     {}
 
     public class UpdateLegacyReleaseAuthorizationHandler 
-        : CompoundAuthorizationHandler<UpdateLegacyReleaseRequirement, LegacyRelease>
+        : AuthorizationHandler<UpdateLegacyReleaseRequirement, LegacyRelease>
     {
-        public UpdateLegacyReleaseAuthorizationHandler() : base(
-            new CanUpdateAllLegacyReleases()
-        )
-        {}
-    
-        public class CanUpdateAllLegacyReleases : 
-            HasClaimAuthorizationHandler<UpdateLegacyReleaseRequirement>
+        private readonly IUserPublicationRoleRepository _userPublicationRoleRepository;
+        public UpdateLegacyReleaseAuthorizationHandler(IUserPublicationRoleRepository userPublicationRoleRepository)
         {
-            public CanUpdateAllLegacyReleases() 
-                : base(SecurityClaimTypes.UpdateAllReleases) {}
+            _userPublicationRoleRepository = userPublicationRoleRepository;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context,
+            UpdateLegacyReleaseRequirement requirement,
+            LegacyRelease legacyRelease)
+        {
+            if (SecurityUtils.HasClaim(context.User, UpdateAllReleases))
+            {
+                context.Succeed(requirement);
+                return;
+            }
+
+            var publicationRoles = await _userPublicationRoleRepository
+                .GetAllRolesByUser(context.User.GetUserId(), legacyRelease.PublicationId);
+
+            if (ContainPublicationOwnerRole(publicationRoles))
+            {
+                context.Succeed(requirement);
+            }
         }
     }
 
     // Delete
-
     public class DeleteLegacyReleaseRequirement : IAuthorizationRequirement
     {}
 
     public class DeleteLegacyReleaseAuthorizationHandler 
-        : CompoundAuthorizationHandler<DeleteLegacyReleaseRequirement, LegacyRelease>
+        : AuthorizationHandler<DeleteLegacyReleaseRequirement, LegacyRelease>
     {
-        public DeleteLegacyReleaseAuthorizationHandler() : base(
-            new CanDeleteAllLegacyReleases()
-        )
-        {}
-    
-        public class CanDeleteAllLegacyReleases : 
-            HasClaimAuthorizationHandler<DeleteLegacyReleaseRequirement>
+        private readonly IUserPublicationRoleRepository _userPublicationRoleRepository;
+        public DeleteLegacyReleaseAuthorizationHandler(IUserPublicationRoleRepository userPublicationRoleRepository)
         {
-            public CanDeleteAllLegacyReleases()
-                : base(SecurityClaimTypes.UpdateAllReleases) {}
+            _userPublicationRoleRepository = userPublicationRoleRepository;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context,
+            DeleteLegacyReleaseRequirement requirement,
+            LegacyRelease legacyRelease)
+        {
+            if (SecurityUtils.HasClaim(context.User, UpdateAllReleases))
+            {
+                context.Succeed(requirement);
+                return;
+            }
+
+            var publicationRoles = await _userPublicationRoleRepository
+                .GetAllRolesByUser(context.User.GetUserId(), legacyRelease.PublicationId);
+
+            if (ContainPublicationOwnerRole(publicationRoles))
+            {
+                context.Succeed(requirement);
+            }
         }
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationEditPage.tsx
@@ -95,12 +95,8 @@ const PublicationEditPage = ({
             }}
             confirmOnSubmit
           />
-          {user?.permissions.canAccessUserAdministrationPages && (
-            <>
-              <h2>Manage legacy releases</h2>
-              <LegacyReleasesTable publication={publication} />
-            </>
-          )}
+          <h2>Manage legacy releases</h2>
+          <LegacyReleasesTable publication={publication} />
         </div>
       </div>
     </Page>

--- a/src/explore-education-statistics-admin/src/routes/legacyReleaseRoutes.tsx
+++ b/src/explore-education-statistics-admin/src/routes/legacyReleaseRoutes.tsx
@@ -5,13 +5,13 @@ import LegacyReleaseEditPage from '@admin/pages/legacy-releases/LegacyReleaseEdi
 export const legacyReleaseCreateRoute: ProtectedRouteProps = {
   path: '/publication/:publicationId/legacy-releases/create',
   component: LegacyReleaseCreatePage,
-  protectionAction: user => user.permissions.canAccessUserAdministrationPages,
+  protectionAction: user => user.permissions.canAccessAnalystPages,
   exact: true,
 };
 
 export const legacyReleaseEditRoute: ProtectedRouteProps = {
   path: '/publication/:publicationId/legacy-releases/:legacyReleaseId/edit',
   component: LegacyReleaseEditPage,
-  protectionAction: user => user.permissions.canAccessUserAdministrationPages,
+  protectionAction: user => user.permissions.canAccessAnalystPages,
   exact: true,
 };

--- a/src/explore-education-statistics-admin/src/routes/routes.ts
+++ b/src/explore-education-statistics-admin/src/routes/routes.ts
@@ -127,7 +127,7 @@ export const releaseCreateRoute: ProtectedRouteProps = {
 export const legacyReleasesRoute: ProtectedRouteProps = {
   path: '/publication/:publicationId/legacy-releases',
   component: LegacyReleasesPageContainer,
-  protectionAction: user => user.permissions.canAccessUserAdministrationPages,
+  protectionAction: user => user.permissions.canAccessAnalystPages,
 };
 
 export const preReleaseRoute: ProtectedRouteProps = {


### PR DESCRIPTION
This PR allows publication owners to manage legacy releases.

Now that users manage legacy releases on the Manage publication page, besides adding permissions for publication owners, the permissions have been aligned with the rest of the manage publication page.

Since the HandleRequirementAsync override for the manage legacy releases authorization handlers takes a LegacyRelease object, not a Release or Publication, I've created a new method to test all different publication roles for that.