### PR TITLE
EES-2648 show correct error when no subject meta returned in table response

### DIFF
--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -212,6 +212,10 @@ function generateMergedLocation<T extends LocationOption | FilterOption>(
 function mergeDuplicateLocationsInTableDataResponse(
   tableData: TableDataResponse,
 ): TableDataResponse {
+  if (!tableData.subjectMeta) {
+    return tableData;
+  }
+
   const locationsGroupedByLevelAndCode = groupBy(
     tableData.subjectMeta.locations,
     location => `${location.level}_${location.value}`,


### PR DESCRIPTION
Fixes bug where an error is shown in the table tool when there is no table response. Instead the correct message  'No data available for the options selected. Please try again with different options.' is shown.