### PR TITLE
EES-68 admin page titles

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationConfigureCharts.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationConfigureCharts.tsx
@@ -52,6 +52,7 @@ const DocumentationManageDataBlock = ({ location: _ }: RouteChildrenProps) => {
         { name: "Administrator's guide", link: '/documentation' },
         { name: 'Configuring charts' },
       ]}
+      title="Configuring charts"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-three-quarters">

--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationCreateNewPublication.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationCreateNewPublication.tsx
@@ -22,6 +22,7 @@ const DocumentationCreateNewRelease = ({ location: _ }: RouteChildrenProps) => {
         { name: "Administrator's guide", link: '/documentation' },
         { name: 'Creating a new publication' },
       ]}
+      title="Creating a new publication"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-three-quarters">

--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationCreateNewRelease.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationCreateNewRelease.tsx
@@ -27,6 +27,7 @@ const DocumentationCreateNewRelease = ({ location: _ }: RouteChildrenProps) => {
         { name: "Administrator's guide", link: '/documentation' },
         { name: 'Creating a new release' },
       ]}
+      title="'Creating a new release"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-three-quarters">

--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationDesignStandards.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationDesignStandards.tsx
@@ -12,6 +12,7 @@ const DocumentationDesignStandards = () => {
         { name: "Administrator's guide", link: '/documentation' },
         { name: 'Content design standards guide' },
       ]}
+      title="Content design standards guide"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">

--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationEditRelease.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationEditRelease.tsx
@@ -24,6 +24,7 @@ const DocumentationCreateNewRelease = ({ location: _ }: RouteChildrenProps) => {
         { name: "Administrator's guide", link: '/documentation' },
         { name: 'Editing a release and updating release status' },
       ]}
+      title="Editing a release and updating release status"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-three-quarters">

--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationGlossary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationGlossary.tsx
@@ -11,6 +11,7 @@ const DocumentationGlossary = () => {
         { name: "Administrator's guide", link: '/documentation' },
         { name: 'Glossary' },
       ]}
+      title="Glossary"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">

--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationHome.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationHome.tsx
@@ -9,6 +9,7 @@ const BrowseReleasesPage = () => {
       breadcrumbs={[
         { name: "Administrator's guide", link: '/prototypes/documentation' },
       ]}
+      title="Documentation"
     >
       <h1>Documentation</h1>
 

--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationManageContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationManageContent.tsx
@@ -36,6 +36,7 @@ const DocumentationManageContent = () => {
         { name: "Administrator's guide", link: '/documentation' },
         { name: 'Managing content' },
       ]}
+      title="Managing content"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-three-quarters">

--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationManageData.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationManageData.tsx
@@ -36,6 +36,7 @@ const DocumentationManageContent = ({ location: _ }: RouteChildrenProps) => {
         { name: "Administrator's guide", link: '/documentation' },
         { name: 'Managing data' },
       ]}
+      title="Managing data"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-three-quarters">

--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationManageDataBlocks.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationManageDataBlocks.tsx
@@ -30,6 +30,7 @@ const DocumentationManageDataBlock = ({ location: _ }: RouteChildrenProps) => {
         { name: "Administrator's guide", link: '/documentation' },
         { name: 'Managing data blocks and creating tables and charts' },
       ]}
+      title="Managing data blocks and creating tables and charts"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-three-quarters">

--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationStyle.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationStyle.tsx
@@ -11,6 +11,7 @@ const DocumentationGlossary = () => {
         { name: "Administrator's guide", link: '/documentation' },
         { name: 'Style guide' },
       ]}
+      title="Style guide"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">

--- a/src/explore-education-statistics-admin/src/pages/documentation/DocumentationUsingDashboard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/documentation/DocumentationUsingDashboard.tsx
@@ -25,6 +25,7 @@ const DocumentationCreateNewRelease = ({ location: _ }: RouteChildrenProps) => {
         { name: "Administrator's guide", link: '/documentation' },
         { name: 'Using your administration dashboard' },
       ]}
+      title="Using your administration dashboard"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-three-quarters">

--- a/src/explore-education-statistics-admin/src/pages/users/InvitedUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/InvitedUsersPage.tsx
@@ -40,6 +40,7 @@ const InvitedUsersPage = () => {
         { name: 'Platform administration', link: '/administration' },
         { name: 'Pending invites' },
       ]}
+      title="Pending invites"
     >
       <h1 className="govuk-heading-xl">
         <span className="govuk-caption-xl">Manage access to the service</span>

--- a/src/explore-education-statistics-admin/src/pages/users/ManageUserPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/ManageUserPage.tsx
@@ -153,6 +153,7 @@ const ManageUserPage = ({ match }: RouteComponentProps<{ userId: string }>) => {
         { name: 'Users', link: '/administration/users' },
         { name: 'Manage user' },
       ]}
+      title="Manage user"
     >
       <h1 className="govuk-heading-xl">
         <span className="govuk-caption-xl">Manage user</span>

--- a/src/explore-education-statistics-admin/src/pages/users/PreReleaseUsersPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/PreReleaseUsersPage.tsx
@@ -17,6 +17,7 @@ const PreReleaseUsersPage = () => {
         { name: 'Platform administration', link: '/administration' },
         { name: 'Pre-release users' },
       ]}
+      title="Pre-release users"
     >
       <h1 className="govuk-heading-xl">
         <span className="govuk-caption-xl">Manage pre-release users</span>

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -68,6 +68,7 @@ const UserInvitePage = ({
         { name: 'Invites', link: '/administration/users/invites' },
         { name: 'Invite user' },
       ]}
+      title="Invite user"
     >
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">


### PR DESCRIPTION
Adds the missing admin page titles for:

- Pre-release users 
- Pending user invites 
- Invite a new user 
- Manage user 
- All documentation pages