### PR TITLE
EES-2651 fix maps

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/ChartRenderer.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/ChartRenderer.tsx
@@ -62,7 +62,7 @@ function ChartRenderer({
         return <p>Unable to render invalid chart type</p>;
     }
   }, [id, props]);
-  const { footnotes } = meta;
+  const footnotes = [...meta.footnotes];
 
   const boundaryFootnoteId = 'map-footnote';
   if (


### PR DESCRIPTION
Adding and viewing maps was broken because of adding boundary footnote, this clones the footnotes array so it can be updated.