### PR TITLE
EES-2652 (geographic charts) - attempt to fix 'leaflet_pos' undefined…

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -381,9 +381,13 @@ export const MapBlockInternal = ({
 
   // initialise
   useEffect(() => {
-    import('@common/modules/charts/files/ukGeoJson.json').then(imported => {
+    async function addGeo() {
+      const imported = await import(
+        '@common/modules/charts/files/ukGeoJson.json'
+      );
       setUkGeometry(imported.default as FeatureCollection);
-    });
+    }
+    addGeo();
   }, []);
 
   const [intersectionEntry] = useIntersectionObserver(container, {


### PR DESCRIPTION
… typeError

This PR: 
- Attempts to fix a transient Type error that the UI tests encounter in `create_data_block_with_chart.robot` when creating & embedding geographic charts. 

It appears that the latitude, longitude, and boundary for the UK are initialized as null. The ukGeoJson (I think) is then imported to set these initial values. I've changed the `useEffect` that is responsible for initializing these values to use async/await in order to give the compiler more opportunities to optimize things. 