### PR TITLE
EES-2555 location type in map dropdown label

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -30,6 +30,7 @@ import formatPretty, {
   defaultMaxDecimalPlaces,
 } from '@common/utils/number/formatPretty';
 import { roundDownToNearest } from '@common/utils/number/roundNearest';
+import { LocationFilter } from '@common/modules/table-tool/types/filters';
 import classNames from 'classnames';
 import { Feature, FeatureCollection, Geometry } from 'geojson';
 import { Layer, Path, PathOptions, Polyline } from 'leaflet';
@@ -65,6 +66,7 @@ interface LegendEntry {
 
 interface MapDataSetCategory extends DataSetCategory {
   geoJson: GeoJsonFeature;
+  filter: LocationFilter;
 }
 
 function calculateScaledColour({
@@ -360,6 +362,33 @@ export const MapBlockInternal = ({
     return locations;
   }, [dataSetCategories]);
 
+  const locationType = useMemo(() => {
+    const locationLevelsMap: Dictionary<string> = {
+      country: 'Country',
+      englishDevolvedArea: 'English Devolved Area',
+      institution: 'Institution',
+      localAuthority: 'Local Authority',
+      localAuthorityDistrict: 'Local Authority District',
+      localEnterprisePartnership: 'Local Enterprise Partnership',
+      mayoralCombinedAuthority: 'Mayoral Combined Authority',
+      multiAcademyTrust: 'Multi Academy Trust',
+      opportunityArea: 'Opportunity Area',
+      parliamentaryConstituency: 'Parliamentary Constituency',
+      provider: 'Provider',
+      region: 'Region',
+      rscRegion: 'RSC Region',
+      school: 'School',
+      sponsor: 'Sponsor',
+      ward: 'Ward',
+      planningArea: 'Planning Area',
+    };
+    const levels = dataSetCategories.map(category => category.filter.level);
+    return !levels.every(level => level === levels[0]) ||
+      !locationLevelsMap[levels[0]]
+      ? 'location'
+      : locationLevelsMap[levels[0]];
+  }, [dataSetCategories]);
+
   const [selectedDataSetKey, setSelectedDataSetKey] = useState<string>(
     (dataSetOptions[0]?.value as string) ?? '',
   );
@@ -575,7 +604,7 @@ export const MapBlockInternal = ({
             <FormSelect
               name="selectedLocation"
               id={`${id}-selectedLocation`}
-              label="2. Select a location"
+              label={`2. Select a ${locationType}`}
               value={selectedFeature?.id?.toString()}
               options={locationOptions}
               order={FormSelect.unordered}

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -363,29 +363,81 @@ export const MapBlockInternal = ({
   }, [dataSetCategories]);
 
   const locationType = useMemo(() => {
-    const locationLevelsMap: Dictionary<string> = {
-      country: 'Country',
-      englishDevolvedArea: 'English Devolved Area',
-      institution: 'Institution',
-      localAuthority: 'Local Authority',
-      localAuthorityDistrict: 'Local Authority District',
-      localEnterprisePartnership: 'Local Enterprise Partnership',
-      mayoralCombinedAuthority: 'Mayoral Combined Authority',
-      multiAcademyTrust: 'Multi Academy Trust',
-      opportunityArea: 'Opportunity Area',
-      parliamentaryConstituency: 'Parliamentary Constituency',
-      provider: 'Provider',
-      region: 'Region',
-      rscRegion: 'RSC Region',
-      school: 'School',
-      sponsor: 'Sponsor',
-      ward: 'Ward',
-      planningArea: 'Planning Area',
+    const locationLevelsMap: Dictionary<Dictionary<string>> = {
+      country: {
+        label: 'Country',
+        prefix: 'a',
+      },
+      englishDevolvedArea: {
+        label: 'English Devolved Area',
+        prefix: 'an',
+      },
+      institution: {
+        label: 'Institution',
+        prefix: 'an',
+      },
+      localAuthority: {
+        label: 'Local Authority',
+        prefix: 'a',
+      },
+      localAuthorityDistrict: {
+        label: 'Local Authority District',
+        prefix: 'a',
+      },
+      localEnterprisePartnership: {
+        label: 'Local Enterprise Partnership',
+        prefix: 'a',
+      },
+      mayoralCombinedAuthority: {
+        label: 'Mayoral Combined Authority',
+        prefix: 'a',
+      },
+      multiAcademyTrust: {
+        label: 'Multi Academy Trust',
+        prefix: 'a',
+      },
+      opportunityArea: {
+        label: 'Opportunity Area',
+        prefix: 'an',
+      },
+      parliamentaryConstituency: {
+        label: 'Parliamentary Constituency',
+        prefix: 'a',
+      },
+      provider: {
+        label: 'Provider',
+        prefix: 'a',
+      },
+      region: {
+        label: 'Region',
+        prefix: 'a',
+      },
+      rscRegion: {
+        label: 'RSC Region',
+        prefix: 'an',
+      },
+      school: {
+        label: 'School',
+        prefix: 'a',
+      },
+      sponsor: {
+        label: 'Sponsor',
+        prefix: 'a',
+      },
+      ward: {
+        label: 'Ward',
+        prefix: 'a',
+      },
+      planningArea: {
+        label: 'Planning Area',
+        prefix: 'a',
+      },
     };
+
     const levels = dataSetCategories.map(category => category.filter.level);
     return !levels.every(level => level === levels[0]) ||
       !locationLevelsMap[levels[0]]
-      ? 'location'
+      ? { label: 'location', prefix: 'a' }
       : locationLevelsMap[levels[0]];
   }, [dataSetCategories]);
 
@@ -604,7 +656,7 @@ export const MapBlockInternal = ({
             <FormSelect
               name="selectedLocation"
               id={`${id}-selectedLocation`}
-              label={`2. Select a ${locationType}`}
+              label={`2. Select ${locationType.prefix} ${locationType.label}`}
               value={selectedFeature?.id?.toString()}
               options={locationOptions}
               order={FormSelect.unordered}

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlock.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlock.test.tsx
@@ -1,6 +1,8 @@
 import {
   testMapConfiguration,
   testMapTableData,
+  testMapTableDataRegion,
+  testMapTableDataMixed,
 } from '@common/modules/charts/components/__tests__/__data__/testMapBlockData';
 import MapBlock, {
   MapBlockProps,
@@ -115,7 +117,9 @@ describe('MapBlock', () => {
     render(<MapBlock {...testBlockProps} />);
 
     await waitFor(() => {
-      const select = screen.getByLabelText('2. Select a location');
+      const select = screen.getByLabelText(
+        '2. Select a Local Authority District',
+      );
 
       expect(select).toBeVisible();
 
@@ -173,10 +177,14 @@ describe('MapBlock', () => {
     const { container } = render(<MapBlock {...testBlockProps} />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('2. Select a location')).toBeInTheDocument();
+      expect(
+        screen.getByLabelText('2. Select a Local Authority District'),
+      ).toBeInTheDocument();
     });
 
-    const select = screen.getByLabelText('2. Select a location');
+    const select = screen.getByLabelText(
+      '2. Select a Local Authority District',
+    );
 
     expect(select.children[1]).toHaveTextContent('Leeds');
 
@@ -199,10 +207,14 @@ describe('MapBlock', () => {
     render(<MapBlock {...testBlockProps} />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('2. Select a location')).toBeInTheDocument();
+      expect(
+        screen.getByLabelText('2. Select a Local Authority District'),
+      ).toBeInTheDocument();
     });
 
-    const select = screen.getByLabelText('2. Select a location');
+    const select = screen.getByLabelText(
+      '2. Select a Local Authority District',
+    );
 
     userEvent.selectOptions(select, select.children[1] as HTMLElement);
 
@@ -248,10 +260,14 @@ describe('MapBlock', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByLabelText('2. Select a location')).toBeInTheDocument();
+      expect(
+        screen.getByLabelText('2. Select a Local Authority District'),
+      ).toBeInTheDocument();
     });
 
-    const select = screen.getByLabelText('2. Select a location');
+    const select = screen.getByLabelText(
+      '2. Select a Local Authority District',
+    );
 
     userEvent.selectOptions(select, select.children[1] as HTMLElement);
 
@@ -288,10 +304,14 @@ describe('MapBlock', () => {
     const { container } = render(<MapBlock {...testBlockProps} />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('2. Select a location')).toBeInTheDocument();
+      expect(
+        screen.getByLabelText('2. Select a Local Authority District'),
+      ).toBeInTheDocument();
     });
 
-    const select = screen.getByLabelText('2. Select a location');
+    const select = screen.getByLabelText(
+      '2. Select a Local Authority District',
+    );
 
     userEvent.selectOptions(select, select.children[1] as HTMLElement);
 
@@ -303,5 +323,39 @@ describe('MapBlock', () => {
 
     userEvent.selectOptions(select, select.children[0] as HTMLElement);
     expect(paths[3]).not.toHaveClass('selected');
+  });
+
+  describe('Location dropdown', () => {
+    test('shows the data set location type in the label', async () => {
+      const testFullTableRegion = mapFullTable(testMapTableDataRegion);
+
+      const testBlockPropsRegion = produce(testBlockProps, draft => {
+        draft.meta = testFullTableRegion.subjectMeta;
+        draft.data = testFullTableRegion.results;
+      });
+
+      render(<MapBlock {...testBlockPropsRegion} />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('2. Select a Region')).toBeInTheDocument();
+      });
+    });
+
+    test('shows the default label if the data set contains multiple types', async () => {
+      const testFullTableRegion = mapFullTable(testMapTableDataMixed);
+
+      const testBlockPropsRegion = produce(testBlockProps, draft => {
+        draft.meta = testFullTableRegion.subjectMeta;
+        draft.data = testFullTableRegion.results;
+      });
+
+      render(<MapBlock {...testBlockPropsRegion} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('2. Select a location'),
+        ).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
@@ -1,5 +1,6 @@
 import { TableDataResponse } from '@common/services/tableBuilderService';
 import { Chart } from '@common/services/types/blocks';
+import produce from 'immer';
 
 export const testMapConfiguration: Chart = {
   axes: {
@@ -406,3 +407,221 @@ export const testMapTableData: TableDataResponse = {
     },
   ],
 };
+
+export const testMapTableDataRegion = produce(testMapTableData, draft => {
+  draft.subjectMeta.locations = [
+    {
+      level: 'region',
+      geoJson: [
+        {
+          type: 'Feature',
+          properties: {
+            code: 'region-1-value',
+            lat: 53.8227005,
+            long: -1.50735998,
+            name: 'Region 1',
+          },
+          geometry: {
+            type: 'Polygon',
+            coordinates: [],
+          },
+        },
+      ],
+      label: 'Region 1',
+      value: 'region-1-value',
+    },
+    {
+      level: 'region',
+      geoJson: [
+        {
+          type: 'Feature',
+          properties: {
+            code: 'region-2-value',
+            lat: 53.4701004,
+            long: -2.23358989,
+            name: 'Region 2',
+          },
+          geometry: {
+            type: 'Polygon',
+            coordinates: [],
+          },
+        },
+      ],
+      label: 'Region 2',
+      value: 'region-2-value',
+    },
+    {
+      level: 'region',
+      geoJson: [
+        {
+          type: 'Feature',
+          properties: {
+            code: 'region-3-value',
+            lat: 53.40359879,
+            long: -1.54253995,
+            name: 'Region 3',
+          },
+          geometry: {
+            type: 'Polygon',
+            coordinates: [],
+          },
+        },
+      ],
+      label: 'Region 3',
+      value: 'region-3-value',
+    },
+  ];
+  draft.results = [
+    {
+      filters: ['characteristic-total', 'school-type-total'],
+      geographicLevel: 'region',
+      location: {
+        country: { code: 'E92000001', name: 'England' },
+        region: { code: 'region-1-value', name: 'Region 1' },
+      },
+      measures: {
+        'authorised-absence-rate': '3.5',
+        'overall-absence-rate': '4.8',
+        'unauthorised-absence-rate': '1.7',
+      },
+      timePeriod: '2016_AY',
+    },
+    {
+      filters: ['characteristic-total', 'school-type-total'],
+      geographicLevel: 'region',
+      location: {
+        country: { code: 'E92000001', name: 'England' },
+        region: { code: 'region-2-value', name: 'Region 2' },
+      },
+      measures: {
+        'authorised-absence-rate': '3',
+        'overall-absence-rate': '4.7',
+        'unauthorised-absence-rate': '1.6',
+      },
+      timePeriod: '2016_AY',
+    },
+    {
+      filters: ['characteristic-total', 'school-type-total'],
+      geographicLevel: 'region',
+      location: {
+        country: { code: 'E92000001', name: 'England' },
+        region: { code: 'region-3-value', name: 'Region 3' },
+      },
+      measures: {
+        'authorised-absence-rate': '4',
+        'overall-absence-rate': '5.1',
+        'unauthorised-absence-rate': '2',
+      },
+      timePeriod: '2016_AY',
+    },
+  ];
+});
+
+export const testMapTableDataMixed = produce(testMapTableData, draft => {
+  draft.subjectMeta.locations = [
+    {
+      level: 'localAuthority',
+      geoJson: [
+        {
+          type: 'Feature',
+          properties: {
+            code: 'la-1-value',
+            lat: 53.8227005,
+            long: -1.50735998,
+            name: 'Region 1',
+          },
+          geometry: {
+            type: 'Polygon',
+            coordinates: [],
+          },
+        },
+      ],
+      label: 'LA 1',
+      value: 'la-1-value',
+    },
+    {
+      level: 'country',
+      geoJson: [
+        {
+          type: 'Feature',
+          properties: {
+            code: 'country-1-value',
+            lat: 53.4701004,
+            long: -2.23358989,
+            name: 'Country 1',
+          },
+          geometry: {
+            type: 'Polygon',
+            coordinates: [],
+          },
+        },
+      ],
+      label: 'Region 2',
+      value: 'region-2-value',
+    },
+    {
+      level: 'region',
+      geoJson: [
+        {
+          type: 'Feature',
+          properties: {
+            code: 'region-3-value',
+            lat: 53.40359879,
+            long: -1.54253995,
+            name: 'Region 3',
+          },
+          geometry: {
+            type: 'Polygon',
+            coordinates: [],
+          },
+        },
+      ],
+      label: 'Region 3',
+      value: 'region-3-value',
+    },
+  ];
+  draft.results = [
+    {
+      filters: ['characteristic-total', 'school-type-total'],
+      geographicLevel: 'localAuthority',
+      location: {
+        country: { code: 'country-1-value', name: 'Country' },
+        region: { code: 'region-1-value', name: 'Region 1' },
+        localAuthority: { code: 'la-1-value', name: 'LA 1' },
+      },
+      measures: {
+        'authorised-absence-rate': '3.5',
+        'overall-absence-rate': '4.8',
+        'unauthorised-absence-rate': '1.7',
+      },
+      timePeriod: '2016_AY',
+    },
+    {
+      filters: ['characteristic-total', 'school-type-total'],
+      geographicLevel: 'country',
+      location: {
+        country: { code: 'country-1-value', name: 'Country' },
+      },
+      measures: {
+        'authorised-absence-rate': '3',
+        'overall-absence-rate': '4.7',
+        'unauthorised-absence-rate': '1.6',
+      },
+      timePeriod: '2016_AY',
+    },
+    {
+      filters: ['characteristic-total', 'school-type-total'],
+      geographicLevel: 'region',
+      location: {
+        country: { code: 'country-1-value', name: 'Country' },
+        region: { code: 'region-3-value', name: 'Region 3' },
+      },
+      measures: {
+        'authorised-absence-rate': '4',
+        'overall-absence-rate': '5.1',
+        'unauthorised-absence-rate': '2',
+      },
+      timePeriod: '2016_AY',
+    },
+  ];
+});


### PR DESCRIPTION
Updates the 'Select a location' dropdown label on maps to show the specific level of location, eg 'Select a Local Authority'. If more than one level is in the dataset then 'Select a location' is shown.

![location](https://user-images.githubusercontent.com/81572860/130963224-75b583ba-e6c7-4801-89b0-af5166365a36.PNG)
