### PR TITLE
EES-2417 Add ability to use the table heading as the chart title

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataBlockServiceTests.cs
@@ -18,11 +18,11 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Database.ContentDbUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -77,7 +77,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(
                     new ReleaseContentBlock
@@ -89,7 +89,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.Get(dataBlock.Id);
@@ -127,7 +127,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             };
 
             var contextId = Guid.NewGuid().ToString();
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(
                     new ReleaseContentBlock
@@ -139,7 +139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.Get(dataBlock.Id);
@@ -159,7 +159,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.Get(Guid.NewGuid());
@@ -178,13 +178,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(dataBlock);
                 await context.SaveChangesAsync();
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.Get(dataBlock.Id);
@@ -283,7 +283,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddRangeAsync(
                     new ReleaseContentBlock
@@ -300,7 +300,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.List(release.Id);
@@ -387,7 +387,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddRangeAsync(
                     new ReleaseContentBlock
@@ -404,7 +404,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.List(release.Id);
@@ -456,7 +456,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(
                     new ReleaseContentBlock
@@ -469,7 +469,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.GetDeletePlan(release.Id, dataBlock.Id);
@@ -500,13 +500,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.GetDeletePlan(release.Id, Guid.NewGuid());
@@ -546,7 +546,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(
                     new ReleaseContentBlock
@@ -559,7 +559,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.GetDeletePlan(Guid.NewGuid(), dataBlock.Id);
@@ -600,7 +600,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(
                     new ReleaseContentBlock
@@ -613,7 +613,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var releaseFileService = new Mock<IReleaseFileService>();
 
@@ -632,7 +632,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 MockUtils.VerifyAllMocks(releaseFileService);
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 Assert.Empty(context.DataBlocks.ToList());
                 Assert.Empty(context.ContentBlocks.ToList());
@@ -647,13 +647,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(release);
                 await context.SaveChangesAsync();
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.Delete(release.Id, Guid.NewGuid());
@@ -669,7 +669,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(
                     new ReleaseContentBlock
@@ -681,7 +681,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.Delete(Guid.NewGuid(), dataBlock.Id);
@@ -697,7 +697,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(release);
                 await context.SaveChangesAsync();
@@ -746,7 +746,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 },
             };
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.Create(release.Id, createRequest);
@@ -767,7 +767,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.NotEqual(createRequest.Heading, viewModel.Charts[0].Title);
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var dataBlocks = context.DataBlocks.ToList();
 
@@ -805,7 +805,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var release = new Release();
 
             var contextId = Guid.NewGuid().ToString();
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(release);
                 await context.SaveChangesAsync();
@@ -825,7 +825,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 },
             };
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.Create(release.Id, createRequest);
@@ -839,7 +839,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(createRequest.Heading, viewModel.Charts[0].Title);
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var dataBlocks = context.DataBlocks.ToList();
 
@@ -862,7 +862,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var createRequest = new DataBlockCreateViewModel();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.Create(Guid.NewGuid(), createRequest);
@@ -870,7 +870,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 result.AssertNotFound();
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var dataBlocks = context.DataBlocks.ToList();
 
@@ -929,7 +929,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(
                     new ReleaseContentBlock
@@ -959,7 +959,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 },
             };
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.Update(dataBlock.Id, updateRequest);
@@ -979,7 +979,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(updateRequest.Charts, result.Right.Charts);
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var updatedDataBlock = await context.DataBlocks.FindAsync(dataBlock.Id);
 
@@ -1015,7 +1015,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             };
 
             var contextId = Guid.NewGuid().ToString();
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(
                     new ReleaseContentBlock
@@ -1041,7 +1041,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 },
             };
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var service = BuildDataBlockService(context);
                 var result = await service.Update(dataBlock.Id, updateRequest);
@@ -1056,7 +1056,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(updateRequest.Heading, viewModel.Charts[0].Title);
             }
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var updatedDataBlock = await context.DataBlocks.FindAsync(dataBlock.Id);
 
@@ -1073,7 +1073,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var contextId = Guid.NewGuid().ToString();
 
-            await using var context = ContentDbUtils.InMemoryContentDbContext(contextId);
+            await using var context = InMemoryContentDbContext(contextId);
 
             var service = BuildDataBlockService(context);
             var result = await service.Update(Guid.NewGuid(), new DataBlockUpdateViewModel());
@@ -1109,7 +1109,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var contextId = Guid.NewGuid().ToString();
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 await context.AddAsync(
                     new ReleaseContentBlock
@@ -1135,7 +1135,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 },
             };
 
-            await using (var context = ContentDbUtils.InMemoryContentDbContext(contextId))
+            await using (var context = InMemoryContentDbContext(contextId))
             {
                 var releaseFileService = new Mock<IReleaseFileService>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/Charts.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/Charts.cs
@@ -10,7 +10,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
     public interface IChart
     {
         ChartType Type { get; }
-        string Title { get; set; }
+        string? Title { get; set; }
         string Alt { get; set; }
         int Height { get; set; }
         int? Width { get; set; }
@@ -22,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
 
     public abstract class Chart : IChart
     {
-        public string Title { get; set; }
+        public string? Title { get; set; }
         public string Alt { get; set; }
         public int Height { get; set; }
         public int? Width { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
 using System.Runtime.Serialization;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Chart;
@@ -98,7 +100,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public ObservationQueryContext Query { get; set; }
 
-        public List<IChart> Charts { get; set; }
+        [JsonIgnore]
+        public List<IChart> Charts
+        {
+            get
+            {
+                return ChartsAlternate.Select(chart =>
+                {
+                    if (chart.Title.IsNullOrEmpty())
+                    {
+                        chart.Title = Heading;
+                    }
+                    return chart;
+                }).ToList();
+
+            }
+            set => ChartsAlternate = value;
+        }
+
+        [JsonProperty("Charts")]
+        [NotMapped]
+        private List<IChart> ChartsAlternate { get; set; } = new();
 
         public DataBlockSummary Summary { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ContentBlock.cs
@@ -105,7 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         {
             get
             {
-                return ChartsAlternate.Select(chart =>
+                return ChartsInternal.Select(chart =>
                 {
                     if (chart.Title.IsNullOrEmpty())
                     {
@@ -115,12 +115,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
                 }).ToList();
 
             }
-            set => ChartsAlternate = value;
+            set => ChartsInternal = value;
         }
 
+        // NOTE: We serialize ChartsInternal into JSON rather than Charts so that a chart title is set to null in the
+        // database JSON. If we serialized Charts, then the serialization would run through Chart's getter, and so set
+        // a chart title that is identical to the table heading. So to keep the database-stored chart JSON pure, we set
+        // this JsonProperty, preventing the need to migrate existing charts, and Chart's getter will provide the table
+        // heading in request responses when necessary.
         [JsonProperty("Charts")]
         [NotMapped]
-        private List<IChart> ChartsAlternate { get; set; } = new();
+        private List<IChart> ChartsInternal { get; set; } = new();
 
         public DataBlockSummary Summary { get; set; }
 

--- a/src/explore-education-statistics-admin/src/pages/release/__data__/testEditableRelease.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/__data__/testEditableRelease.ts
@@ -97,7 +97,7 @@ export const testEditableRelease: EditableRelease = {
           ],
         },
         {
-          heading: "Table showing 'prma' from 'My Pub' in England for 2017/18",
+          heading: "'prma' from 'My Pub' in England for 2017/18",
           name: 'DataBlock 1',
           source: '',
           query: {
@@ -163,7 +163,7 @@ export const testEditableRelease: EditableRelease = {
     content: [
       {
         heading:
-          "Table showing Main reason for issue: Unauthorised family holiday absence for 'prma' from 'My Pub' in England for 2017/18",
+          "Main reason for issue: Unauthorised family holiday absence for 'prma' from 'My Pub' in England for 2017/18",
         name: 'Holiday (Key Stat)',
         source: '',
         query: {
@@ -190,7 +190,7 @@ export const testEditableRelease: EditableRelease = {
       },
       {
         heading:
-          "Table showing Main reason for issue: Arriving late for 'prma' from 'My Pub' in England for 2017/18",
+          "Main reason for issue: Arriving late for 'prma' from 'My Pub' in England for 2017/18",
         name: 'Main Reason (Key Stat)',
         source: '',
         query: {
@@ -217,7 +217,7 @@ export const testEditableRelease: EditableRelease = {
       },
       {
         heading:
-          "Table showing Main reason for issue: Absence due to other unauthorised circumstances for 'prma' from 'My Pub' in England for 2017/18",
+          "Main reason for issue: Absence due to other unauthorised circumstances for 'prma' from 'My Pub' in England for 2017/18",
         name: "Unauth'd (Key Stat)",
         source: '',
         query: {
@@ -250,7 +250,7 @@ export const testEditableRelease: EditableRelease = {
     order: 0,
     content: [
       {
-        heading: "Table showing 'prma' from 'My Pub' in England for 2017/18",
+        heading: "'prma' from 'My Pub' in England for 2017/18",
         name: 'Aggregate table (Secondary)',
         source: '',
         query: {

--- a/src/explore-education-statistics-admin/src/pages/release/content/contexts/__tests__/ReleaseContentContext.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/contexts/__tests__/ReleaseContentContext.test.tsx
@@ -298,7 +298,7 @@ describe('ReleaseContentContext', () => {
     const newContent: EditableBlock[] = [
       {
         name: 'Test datablock',
-        heading: "Table showing 'prma' from 'My Pub' in England for 2017/18",
+        heading: "'prma' from 'My Pub' in England for 2017/18",
         source: '',
         query: {
           subjectId: '36aa28ce-83ca-49b5-8c27-b34e77b062c9',

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -171,14 +171,18 @@ const DataBlockPageTabs = ({
         const majorAxis = draft[0]?.axes?.major;
         const legend = draft[0]?.legend;
 
-        // Remove data sets that are no longer applicable to a given table's subject meta.
+        // If old chart title is the same as the old table title, then the chart title is defaulting to
+        // the table title, so don't inadvertently set the old chart/table title
+        if (dataBlock?.charts[0]?.title === dataBlock?.heading) {
+          draft[0].title = undefined;
+        }
 
+        // Remove data sets that are no longer applicable to a given table's subject meta.
         if (majorAxis?.dataSets) {
           majorAxis.dataSets = majorAxis.dataSets.filter(
             dataSet => !isOrphanedDataSet(dataSet, table.subjectMeta),
           );
         }
-
         if (legend?.items) {
           legend.items = legend.items.filter(
             item => !isOrphanedDataSet(item.dataSet, table.subjectMeta),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockPageTabs.tsx
@@ -173,7 +173,10 @@ const DataBlockPageTabs = ({
 
         // If old chart title is the same as the old table title, then the chart title is defaulting to
         // the table title, so don't inadvertently set the old chart/table title
-        if (dataBlock?.charts[0]?.title === dataBlock?.heading) {
+        if (
+          dataBlock?.charts[0] &&
+          dataBlock?.charts[0]?.title === dataBlock?.heading
+        ) {
           draft[0].title = undefined;
         }
 

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilder.tsx
@@ -67,7 +67,11 @@ const filterChartProps = (props: ChartBuilderChartProps): Chart => {
   const excludedProps: (
     | keyof ChartBuilderChartProps
     | keyof InfographicChartProps
-  )[] = ['data', 'meta', 'getInfographic', 'file'];
+  )[] = ['data', 'meta', 'getInfographic', 'file', 'titleType'];
+
+  if (props.titleType === 'default') {
+    excludedProps.push('title');
+  }
 
   if (props.type !== 'infographic') {
     excludedProps.push('fileId');
@@ -97,6 +101,7 @@ interface Props {
   meta: FullTableMeta;
   releaseId: string;
   initialChart?: Chart;
+  tableTitle: string;
   onChartSave: (chart: Chart, file?: File) => Promise<void>;
   onChartDelete: (chart: Chart) => void;
   onTableQueryUpdate: TableQueryUpdateHandler;
@@ -108,6 +113,7 @@ const ChartBuilder = ({
   meta,
   releaseId,
   initialChart,
+  tableTitle,
   onChartSave,
   onChartDelete,
   onTableQueryUpdate,
@@ -121,6 +127,7 @@ const ChartBuilder = ({
 
   const { state: chartBuilderState, actions } = useChartBuilderReducer(
     initialChart,
+    tableTitle,
   );
 
   const { axes, definition, options, legend } = chartBuilderState;

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartBuilderTabSection.tsx
@@ -115,6 +115,7 @@ const ChartBuilderTabSection = ({
       data={table.results}
       meta={meta}
       initialChart={dataBlock.charts[0]}
+      tableTitle={dataBlock.heading}
       onChartSave={handleChartSave}
       onChartDelete={handleChartDelete}
       onTableQueryUpdate={handleTableQueryUpdate}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -226,6 +226,7 @@ const ChartConfiguration = ({
                     <FormFieldTextInput<FormValues>
                       label="Enter chart title"
                       name="title"
+                      hint="Use a concise descriptive title that summarises the main message in the chart."
                     />
                   ),
                 },

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -2,7 +2,13 @@ import ChartBuilderSaveActions from '@admin/pages/release/datablocks/components/
 import { useChartBuilderFormsContext } from '@admin/pages/release/datablocks/components/chart/contexts/ChartBuilderFormsContext';
 import { ChartOptions } from '@admin/pages/release/datablocks/components/chart/reducers/chartBuilderReducer';
 import Effect from '@common/components/Effect';
-import { Form, FormGroup, FormSelect } from '@common/components/form';
+import {
+  Form,
+  FormFieldRadioGroup,
+  FormFieldTextInput,
+  FormGroup,
+  FormSelect,
+} from '@common/components/form';
 import FormFieldCheckbox from '@common/components/form/FormFieldCheckbox';
 import FormFieldFileInput from '@common/components/form/FormFieldFileInput';
 import FormFieldNumberInput from '@common/components/form/FormFieldNumberInput';
@@ -72,7 +78,16 @@ const ChartConfiguration = ({
 
   const validationSchema = useMemo<ObjectSchema<FormValues>>(() => {
     let schema: ObjectSchema<FormValues> = Yup.object<FormValues>({
-      title: Yup.string().required('Enter chart title'),
+      titleType: Yup.mixed<FormValues['titleType']>()
+        .oneOf(['default', 'alternative'])
+        .required('Choose a title type'),
+      title: Yup.string()
+        .when('titleType', {
+          is: 'alternative',
+          then: Yup.string().required('Enter a chart title'),
+          otherwise: Yup.string,
+        })
+        .required('Enter chart title'),
       alt: Yup.string()
         .required('Enter chart alt text')
         .test({
@@ -195,13 +210,26 @@ const ChartConfiguration = ({
               />
             )}
 
-            <FormFieldTextArea<FormValues>
-              name="title"
-              label="Title"
-              className="govuk-!-width-three-quarters"
-              rows={3}
-              hint="Use a concise descriptive title that summarises the main message in the chart."
-              onChange={replaceNewLines}
+            <FormFieldRadioGroup<FormValues>
+              legend="Chart title"
+              name="titleType"
+              order={[]}
+              options={[
+                {
+                  label: 'Use table title',
+                  value: 'default',
+                },
+                {
+                  label: 'Set an alternative title',
+                  value: 'alternative',
+                  conditional: (
+                    <FormFieldTextInput<FormValues>
+                      label="Enter chart title"
+                      name="title"
+                    />
+                  ),
+                },
+              ]}
             />
 
             <FormFieldTextArea<FormValues>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/__tests__/chartBuilderReducer.test.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/__tests__/chartBuilderReducer.test.ts
@@ -36,6 +36,7 @@ describe('chartBuilderReducer', () => {
     options: {
       defaults: {
         height: 300,
+        titleType: 'default',
       },
     },
     legend: {
@@ -81,6 +82,7 @@ describe('chartBuilderReducer', () => {
       options: {
         height: 300,
         title: '',
+        titleType: 'default',
         alt: '',
       },
     };
@@ -105,6 +107,7 @@ describe('chartBuilderReducer', () => {
       expect(nextState.options).toEqual<ChartOptions>({
         height: 300,
         title: '',
+        titleType: 'default',
         alt: '',
       });
     });
@@ -129,6 +132,7 @@ describe('chartBuilderReducer', () => {
         options: {
           height: 400,
           title: 'Some title',
+          titleType: 'alternative',
           alt: 'Some alt',
         },
         legend: {
@@ -160,6 +164,7 @@ describe('chartBuilderReducer', () => {
         // Height is set to the definition default
         height: 300,
         title: 'Some title',
+        titleType: 'alternative',
         alt: 'Some alt',
       });
       expect(nextState.legend).toEqual<LegendConfiguration>({
@@ -275,6 +280,7 @@ describe('chartBuilderReducer', () => {
       options: {
         height: 300,
         title: '',
+        titleType: 'default',
         alt: '',
       },
     };
@@ -345,6 +351,7 @@ describe('chartBuilderReducer', () => {
       options: {
         height: 300,
         title: '',
+        titleType: 'default',
         alt: '',
       },
     };
@@ -356,6 +363,7 @@ describe('chartBuilderReducer', () => {
           height: 500,
           width: 400,
           title: 'Test title',
+          titleType: 'alternative',
           alt: 'Test alt',
         },
       };
@@ -366,6 +374,7 @@ describe('chartBuilderReducer', () => {
         height: 500,
         width: 400,
         title: 'Test title',
+        titleType: 'alternative',
         alt: 'Test alt',
       });
     });
@@ -376,6 +385,7 @@ describe('chartBuilderReducer', () => {
         options: {
           height: 300,
           title: '',
+          titleType: 'default',
           alt: '',
           stacked: true,
         },
@@ -387,6 +397,7 @@ describe('chartBuilderReducer', () => {
           height: 500,
           width: 400,
           title: '',
+          titleType: 'default',
           alt: '',
         },
       };
@@ -400,6 +411,7 @@ describe('chartBuilderReducer', () => {
         height: 500,
         width: 400,
         title: '',
+        titleType: 'default',
         alt: '',
         stacked: true,
       });
@@ -412,6 +424,7 @@ describe('chartBuilderReducer', () => {
           height: 300,
           width: 400,
           title: '',
+          titleType: 'default',
           alt: '',
         },
       };
@@ -422,6 +435,7 @@ describe('chartBuilderReducer', () => {
           height: 300,
           width: undefined,
           title: '',
+          titleType: 'default',
           alt: '',
         },
       };
@@ -434,6 +448,7 @@ describe('chartBuilderReducer', () => {
       expect(nextState.options).toEqual<ChartOptions>({
         height: 300,
         title: '',
+        titleType: 'default',
         alt: '',
       });
     });
@@ -453,6 +468,7 @@ describe('chartBuilderReducer', () => {
       options: {
         height: 300,
         title: '',
+        titleType: 'default',
         alt: '',
       },
     };
@@ -494,6 +510,7 @@ describe('chartBuilderReducer', () => {
         options: {
           height: 400,
           title: 'Something',
+          titleType: 'alternative',
           alt: 'Some alt',
         },
       };
@@ -504,16 +521,20 @@ describe('chartBuilderReducer', () => {
 
       expect(nextState).toEqual<ChartBuilderState>({
         axes: {},
+        titleType: 'default',
       });
     });
   });
 
   describe('useChartBuilderReducer', () => {
     test('has correct state when no initial configuration', () => {
-      const { result } = renderHook(() => useChartBuilderReducer());
+      const { result } = renderHook(() =>
+        useChartBuilderReducer(undefined, 'Table title'),
+      );
 
       expect(result.current.state).toEqual<ChartBuilderState>({
         axes: {},
+        titleType: 'default',
       });
     });
 
@@ -567,12 +588,12 @@ describe('chartBuilderReducer', () => {
         },
         type: 'line',
         height: 300,
-        title: '',
+        title: 'Table title',
         alt: '',
       };
 
       const { result } = renderHook(() =>
-        useChartBuilderReducer(initialConfiguration),
+        useChartBuilderReducer(initialConfiguration, 'Table title'),
       );
 
       expect(result.current.state).toEqual<ChartBuilderState>({
@@ -625,7 +646,8 @@ describe('chartBuilderReducer', () => {
         definition: lineChartBlockDefinition,
         options: {
           height: 300,
-          title: '',
+          title: 'Table title',
+          titleType: 'default',
           alt: '',
         },
         legend: {
@@ -672,12 +694,12 @@ describe('chartBuilderReducer', () => {
         },
         type: 'line',
         height: 300,
-        title: '',
+        title: 'Table title',
         alt: '',
       };
 
       const { result } = renderHook(() =>
-        useChartBuilderReducer(initialConfiguration),
+        useChartBuilderReducer(initialConfiguration, 'Table title'),
       );
 
       expect(result.current.state).toEqual<ChartBuilderState>({
@@ -724,7 +746,8 @@ describe('chartBuilderReducer', () => {
         definition: lineChartBlockDefinition,
         options: {
           height: 300,
-          title: '',
+          title: 'Table title',
+          titleType: 'default',
           alt: '',
         },
         legend: {
@@ -786,6 +809,125 @@ describe('chartBuilderReducer', () => {
         label: {
           text: '',
           width: 100,
+        },
+      });
+    });
+
+    test('has correct state with initial configuration with custom chart title', () => {
+      const initialConfiguration: Chart = {
+        legend: {
+          position: 'top',
+          items: [],
+        },
+        axes: {
+          major: {
+            type: 'major',
+            groupBy: 'timePeriod',
+            sortBy: 'something',
+            sortAsc: true,
+            dataSets: [
+              {
+                indicator: 'indicator-1',
+                filters: ['filter-1'],
+              },
+            ],
+            referenceLines: [],
+            visible: true,
+            size: 100,
+            showGrid: true,
+            min: 2,
+            max: 10,
+            tickConfig: 'default',
+            unit: '%',
+            label: {
+              text: 'Test major axis label',
+              width: 300,
+            },
+          },
+          minor: {
+            type: 'minor',
+            sortAsc: true,
+            dataSets: [],
+            referenceLines: [],
+            visible: true,
+            size: 75,
+            showGrid: true,
+            min: 500,
+            max: 1000,
+            tickConfig: 'default',
+            label: {
+              text: 'Test minor axis label',
+              rotated: true,
+            },
+          },
+        },
+        type: 'line',
+        height: 300,
+        title: 'Chart title',
+        alt: '',
+      };
+
+      const { result } = renderHook(() =>
+        useChartBuilderReducer(initialConfiguration, 'Table title'),
+      );
+
+      expect(result.current.state).toEqual<ChartBuilderState>({
+        axes: {
+          major: {
+            type: 'major',
+            groupBy: 'timePeriod',
+            sortBy: 'something',
+            sortAsc: true,
+            dataSets: [
+              {
+                indicator: 'indicator-1',
+                filters: ['filter-1'],
+              },
+            ],
+            referenceLines: [],
+            visible: true,
+            showGrid: true,
+            size: 100,
+            min: 2,
+            max: 10,
+            tickConfig: 'default',
+            tickSpacing: 1,
+            unit: '%',
+            label: {
+              text: 'Test major axis label',
+              width: 300,
+            },
+          },
+          minor: {
+            type: 'minor',
+            sortAsc: true,
+            dataSets: [],
+            referenceLines: [],
+            visible: true,
+            showGrid: true,
+            size: 75,
+            min: 500,
+            max: 1000,
+            tickConfig: 'default',
+            tickSpacing: 1,
+            unit: '',
+            label: {
+              text: 'Test minor axis label',
+              rotated: true,
+              width: 100,
+            },
+          },
+        },
+        definition: lineChartBlockDefinition,
+        options: {
+          height: 300,
+          title: 'Chart title',
+          titleType: 'alternative',
+          alt: '',
+        },
+        legend: {
+          position: 'top',
+          items: [],
         },
       });
     });

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/chartBuilderReducer.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/reducers/chartBuilderReducer.ts
@@ -26,6 +26,7 @@ export interface ChartBuilderState {
   options?: ChartOptions;
   axes: AxesConfiguration;
   legend?: LegendConfiguration;
+  titleType?: 'default' | 'alternative';
 }
 
 export type ChartBuilderActions =
@@ -56,6 +57,7 @@ export type ChartBuilderActions =
 const defaultOptions: ChartOptions = {
   height: 300,
   title: '',
+  titleType: 'default',
   alt: '',
 };
 
@@ -96,9 +98,13 @@ const updateAxis = (
   );
 };
 
-const getInitialState = (initialChart?: Chart): ChartBuilderState => {
+const getInitialState = (
+  initialChart?: Chart,
+  tableTitle?: string,
+): ChartBuilderState => {
   if (!initialChart) {
     return {
+      titleType: 'default',
       axes: {},
     };
   }
@@ -111,7 +117,10 @@ const getInitialState = (initialChart?: Chart): ChartBuilderState => {
 
   return {
     definition,
-    options,
+    options: {
+      ...options,
+      titleType: initialChart.title === tableTitle ? 'default' : 'alternative',
+    },
     legend: {
       ...defaultLegend,
       ...(legend ?? {}),
@@ -226,11 +235,18 @@ export const chartBuilderReducer: Reducer<
   return draft;
 };
 
-export function useChartBuilderReducer(initialChart?: Chart) {
+export function useChartBuilderReducer(
+  initialChart?: Chart,
+  tableTitle?: string,
+) {
   const [state, dispatch] = useLoggedImmerReducer<
     ChartBuilderState,
     ChartBuilderActions
-  >('Chart builder', chartBuilderReducer, getInitialState(initialChart));
+  >(
+    'Chart builder',
+    chartBuilderReducer,
+    getInitialState(initialChart, tableTitle),
+  );
 
   const updateDataSets = useCallback(
     (dataSets: DataSet[]) => {

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -345,7 +345,7 @@ describe('PreReleaseTableToolPage', () => {
       );
 
       expect(screen.getByTestId('dataTableCaption')).toHaveTextContent(
-        /Table showing Number of authorised absence sessions for 'Absence by characteristic'/,
+        /Number of authorised absence sessions for 'Absence by characteristic'/,
       );
 
       expect(screen.getByRole('table')).toBeInTheDocument();

--- a/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/chart.ts
@@ -69,7 +69,8 @@ export type AxesConfiguration = {
 export interface ChartProps {
   data: TableDataResult[];
   meta: FullTableMeta;
-  title: string;
+  title?: string;
+  titleType?: 'default' | 'alternative';
   alt: string;
   height: number;
   width?: number;
@@ -100,7 +101,8 @@ export interface ChartDefinitionOptions {
   height: number;
   width?: number;
   barThickness?: number;
-  title: string;
+  title?: string;
+  titleType: 'default' | 'alternative';
   alt: string;
 }
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DataTableCaption.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DataTableCaption.tsx
@@ -46,7 +46,7 @@ export function generateTableTitle({
     .filter(label => label !== 'Total');
   const filterString = filterList.length ? ` for ${commaList(filterList)}` : '';
 
-  return `Table showing ${indicatorString}'${subjectName}'${filterString}${locationsString}${timePeriodString}`;
+  return `${indicatorString}'${subjectName}'${filterString}${locationsString}${timePeriodString}`;
 }
 
 interface Props extends FullTableMeta {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DataTableCaption.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DataTableCaption.test.tsx
@@ -86,7 +86,7 @@ describe('DataTableCaption', () => {
       <strong
         data-testid="dataTableCaption"
       >
-        Table showing Authorised absence rate for 'Absence by characteristic' in England for 2015/16
+        Authorised absence rate for 'Absence by characteristic' in England for 2015/16
       </strong>
     `);
   });
@@ -136,7 +136,7 @@ describe('DataTableCaption', () => {
       <strong
         data-testid="dataTableCaption"
       >
-        Table showing Authorised absence rate for 'Absence by characteristic' for Female, State-funded primary and State-funded secondary in England for 2015/16
+        Authorised absence rate for 'Absence by characteristic' for Female, State-funded primary and State-funded secondary in England for 2015/16
       </strong>
     `);
   });
@@ -172,7 +172,7 @@ describe('DataTableCaption', () => {
       <strong
         data-testid="dataTableCaption"
       >
-        Table showing Authorised absence rate for 'Absence by characteristic' in England between 2015/16 and 2018/19
+        Authorised absence rate for 'Absence by characteristic' in England between 2015/16 and 2018/19
       </strong>
     `);
   });
@@ -210,7 +210,7 @@ describe('DataTableCaption', () => {
       <strong
         data-testid="dataTableCaption"
       >
-        Table showing Authorised absence rate for 'Absence by characteristic' in Adur, Allerdale, Barking and Dagenham, Barnet and England for 2015/16
+        Authorised absence rate for 'Absence by characteristic' in Adur, Allerdale, Barking and Dagenham, Barnet and England for 2015/16
       </strong>
     `);
   });
@@ -283,7 +283,7 @@ describe('DataTableCaption', () => {
       <strong
         data-testid="dataTableCaption"
       >
-        Table showing Authorised absence rate for 'Absence by characteristic' in Eight, Eleven, England, Five, Four, Nine, One, Seven, Six, Ten and 2 other locations... for 2015/16
+        Authorised absence rate for 'Absence by characteristic' in Eight, Eleven, England, Five, Four, Nine, One, Seven, Six, Ten and 2 other locations... for 2015/16
       </strong>
     `);
 
@@ -295,7 +295,7 @@ describe('DataTableCaption', () => {
       <strong
         data-testid="dataTableCaption"
       >
-        Table showing Authorised absence rate for 'Absence by characteristic' in Eight, Eleven, England, Five, Four, Nine, One, Seven, Six, Ten, Three and Two for 2015/16
+        Authorised absence rate for 'Absence by characteristic' in Eight, Eleven, England, Five, Four, Nine, One, Seven, Six, Ten, Three and Two for 2015/16
       </strong>
     `);
 
@@ -307,7 +307,7 @@ describe('DataTableCaption', () => {
       <strong
         data-testid="dataTableCaption"
       >
-        Table showing Authorised absence rate for 'Absence by characteristic' in Eight, Eleven, England, Five, Four, Nine, One, Seven, Six, Ten and 2 other locations... for 2015/16
+        Authorised absence rate for 'Absence by characteristic' in Eight, Eleven, England, Five, Four, Nine, One, Seven, Six, Ten and 2 other locations... for 2015/16
       </strong>
     `);
   });
@@ -331,7 +331,7 @@ describe('DataTableCaption', () => {
       <strong
         data-testid="dataTableCaption"
       >
-        Table showing 'Absence by characteristic' in England for 2015/16
+        'Absence by characteristic' in England for 2015/16
       </strong>
     `);
   });

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DownloadTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/DownloadTable.test.tsx
@@ -140,7 +140,7 @@ describe('DownloadTable', () => {
       const workbook = mockedWriteFile.mock.calls[0][0] as WorkBook;
 
       expect(workbook.Sheets.Sheet1.A1.v).toBe(
-        "Table showing Authorised absence rate for 'The subject' for Female in England for 2015/16",
+        "Authorised absence rate for 'The subject' for Female in England for 2015/16",
       );
       expect(workbook.Sheets.Sheet1.B3.v).toBe('Date 1');
       expect(workbook.Sheets.Sheet1.C3.v).toBe('Date 2');

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
@@ -66,7 +66,7 @@ describe('TimePeriodDataTable', () => {
 
     expect(
       findByText(
-        "Table showing 'Absence by characteristic' from 'Pupil absence' for 2013/14 to 2014/15 for Barnet and Barnsley",
+        "'Absence by characteristic' from 'Pupil absence' for 2013/14 to 2014/15 for Barnet and Barnsley",
       ),
     ).not.toBeNull();
   });
@@ -123,7 +123,7 @@ describe('TimePeriodDataTable', () => {
 
     expect(
       findByText(
-        "Table showing Authorised absence rate for 'Absence by characteristic' from 'Pupil absence' for 2013/14 to 2014/15 for Barnet and Barnsley",
+        "Authorised absence rate for 'Absence by characteristic' from 'Pupil absence' for 2013/14 to 2014/15 for Barnet and Barnsley",
       ),
     ).not.toBeNull();
   });
@@ -180,7 +180,7 @@ describe('TimePeriodDataTable', () => {
 
     expect(
       findByText(
-        "Table showing 'Absence by characteristic' from 'Pupil absence' for 2014/15 for Barnet and Barnsley",
+        "'Absence by characteristic' from 'Pupil absence' for 2014/15 for Barnet and Barnsley",
       ),
     ).not.toBeNull();
   });

--- a/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/PermalinkPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/PermalinkPage.test.tsx
@@ -110,7 +110,7 @@ describe('PermalinkPage', () => {
     );
 
     expect(screen.getByRole('figure')).toHaveTextContent(
-      "Table showing Number of authorised absence sessions for 'Subject 1' for Gender female in Barnet for 2020/21",
+      "Number of authorised absence sessions for 'Subject 1' for Gender female in Barnet for 2020/21",
     );
 
     expect(screen.getByRole('table')).toBeInTheDocument();

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/__tests__/TableToolFinalStep.test.tsx
@@ -48,7 +48,7 @@ describe('TableToolFinalStep', () => {
     // test that the preview table is rendered correctly
     expect(
       screen.queryByText(
-        "Table showing 'dates' for 02/06/2020 and 02/04/2021 in England between 2020 Week 23 and 2020 Week 26",
+        "'dates' for 02/06/2020 and 02/04/2021 in England between 2020 Week 23 and 2020 Week 26",
       ),
     ).toBeInTheDocument();
 

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -77,7 +77,7 @@ Create table
     user clicks element    id:filtersForm-submit
     user waits until results table appears    %{WAIT_LONG}
     user waits until element contains    css:[data-testid="dataTableCaption"]
-    ...    Table showing Admission Numbers for 'UI test subject' in Bolton 001 (E02000984), Bolton 001 (E05000364), Bolton 004 (E02000987), Bolton 004 (E05010450), Nailsea Youngwood and Syon between 2005 and 2020
+    ...    Admission Numbers for 'UI test subject' in Bolton 001 (E02000984), Bolton 001 (E05000364), Bolton 004 (E02000987), Bolton 004 (E05010450), Nailsea Youngwood and Syon between 2005 and 2020
 
 Validate table rows
     user checks table column heading contains    1    1    Admission Numbers

--- a/tests/robot-tests/tests/admin/bau/delete_subject.robot
+++ b/tests/robot-tests/tests/admin/bau/delete_subject.robot
@@ -120,7 +120,7 @@ Create table
     user clicks element    id:filtersForm-submit
     user waits until results table appears    %{WAIT_LONG}
     user waits until element contains    css:[data-testid="dataTableCaption"]
-    ...    Table showing Admission Numbers for 'UI test subject' in Bolton 001 for 2019
+    ...    Admission Numbers for 'UI test subject' in Bolton 001 for 2019
     sleep    1    # Because otherwise the "Set as featured table" checkbox gets checked on CI pipeline?!?!
     user enters text into element    id:dataBlockDetailsForm-name    UI test table name
     user enters text into element    id:dataBlockDetailsForm-heading    UI test table title

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -437,7 +437,7 @@ user chooses location, time period and filters
 user validates table rows
     user waits until results table appears    %{WAIT_LONG}
     user waits until element contains    testid:dataTableCaption
-    ...    Table showing Admission Numbers for 'UI test subject' in Nailsea Youngwood and Syon between 2005 and 2017
+    ...    Admission Numbers for 'UI test subject' in Nailsea Youngwood and Syon between 2005 and 2017
 
     user checks table column heading contains    1    1    Admission Numbers
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -530,7 +530,7 @@ Select table featured table from subjects step
     user clicks link    Test highlight name
     user waits until results table appears    %{WAIT_LONG}
     user waits until page contains element
-    ...    xpath://*[@data-testid="dataTableCaption" and text()="Table showing Admission Numbers for '${SUBJECT_2_NAME}' for Not specified in Bolton 001 (E02000984), Bolton 001 (E05000364), Bolton 004 (E02000987), Bolton 004 (E05010450), Nailsea Youngwood and Syon between 2005 and 2020"]
+    ...    xpath://*[@data-testid="dataTableCaption" and text()="Admission Numbers for '${SUBJECT_2_NAME}' for Not specified in Bolton 001 (E02000984), Bolton 001 (E05000364), Bolton 004 (E02000987), Bolton 004 (E05010450), Nailsea Youngwood and Syon between 2005 and 2020"]
 
 Validate table column headings for featured table
     user checks table column heading contains    1    1    Admission Numbers


### PR DESCRIPTION
This PR allows users to set the chart title to default to using the table heading. Alternatively, users can enter a custom title for a data block's chart.

![image](https://user-images.githubusercontent.com/44812484/131153377-afe79060-39de-4cf6-8f4a-5b40ed77520b.png)

The backend now expects no chart title to be in a request when the chart title should default to the table heading. This can be seen in `ContentBlock.cs`.

But the backend does return the table heading as the chart title in response to a request for a data block. Because of this, the frontend works out whether the data block response is defaulting to the table heading by comparing the table heading with the chart title. If they're equal, it assumes the chart title is inheriting the table title.

An additional wrinkle was that when changing a data block's heading, because the old data block heading was returned as the chart title when saving the new data block heading - i.e. it was also setting the old data block heading as a custom chart title. To counter this, we check whether the old table heading and old chart title are the same, and if they are we omit the chart title when changing a table heading. This can be seen in `DataBlockPageTabs.tsx`.