### PR TITLE
EES-2657 Add Content API endpoint to query a publication's releases

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/PartialDateTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/PartialDateTest.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Xunit;
 
@@ -11,30 +12,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model
             Assert.True(new PartialDate {Year = "2019", Month = "1", Day = "1"}.IsValid());
             Assert.True(new PartialDate {Year = "2019", Month = "01", Day = "01"}.IsValid());
 
-            Assert.True(new PartialDate {Year = "", Month = "1", Day = "1"}.IsValid());
-            Assert.True(new PartialDate {Year = null, Month = "1", Day = "1"}.IsValid());
-            Assert.True(new PartialDate {Year = "2019", Month = "", Day = "1"}.IsValid());
-            Assert.True(new PartialDate {Year = "2019", Month = null, Day = "1"}.IsValid());
             Assert.True(new PartialDate {Year = "2019", Month = "1", Day = ""}.IsValid());
-            Assert.True(new PartialDate {Year = "2019", Month = "1", Day = null}.IsValid());
+            Assert.True(new PartialDate {Year = "2019", Month = "1"}.IsValid());
 
             Assert.True(new PartialDate {Year = "2019", Month = "", Day = ""}.IsValid());
-            Assert.True(new PartialDate {Year = "2019", Month = null, Day = null}.IsValid());
-            Assert.True(new PartialDate {Year = "", Month = "1", Day = ""}.IsValid());
-            Assert.True(new PartialDate {Year = null, Month = "1", Day = null}.IsValid());
-            Assert.True(new PartialDate {Year = "", Month = "", Day = "1"}.IsValid());
-            Assert.True(new PartialDate {Year = null, Month = null, Day = "1"}.IsValid());
+            Assert.True(new PartialDate {Year = "2019"}.IsValid());
 
-            Assert.True(new PartialDate {Year = "", Month = "", Day = ""}.IsValid());
-            Assert.True(new PartialDate {Year = null, Month = null, Day = null}.IsValid());
-
-            Assert.True(new PartialDate {Year = "", Month = "2", Day = "29"}.IsValid());
             Assert.True(new PartialDate {Year = "2016", Month = "2", Day = "29"}.IsValid()); // Leap year
         }
 
         [Fact]
         public void TestUnacceptablePartialDates()
         {
+            Assert.False(new PartialDate {Year = "2019", Month = "", Day = "1"}.IsValid());
+            Assert.False(new PartialDate {Year = "2019", Day = "1"}.IsValid());
+            Assert.False(new PartialDate {Year = "", Month = "", Day = ""}.IsValid());
+            Assert.False(new PartialDate {Year = "", Month = "", Day = "1"}.IsValid());
+            Assert.False(new PartialDate {Year = "", Month = "1", Day = "1"}.IsValid());
+            Assert.False(new PartialDate {Year = "", Month = "1", Day = ""}.IsValid());
+            Assert.False(new PartialDate {Month = "1", Day = "1"}.IsValid());
+            Assert.False(new PartialDate {Month = "1"}.IsValid());
+            Assert.False(new PartialDate {Day = "1"}.IsValid());
+            Assert.False(new PartialDate().IsValid());
+
             Assert.False(new PartialDate {Year = "Hello", Month = "1", Day = "1"}.IsValid());
             Assert.False(new PartialDate {Year = "2019", Month = "Hello", Day = "1"}.IsValid());
             Assert.False(new PartialDate {Year = "2019", Month = "1", Day = "Hello"}.IsValid());

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DbContextExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/DbContextExtensions.cs
@@ -1,0 +1,69 @@
+#nullable enable
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
+{
+    public static class DbContextExtensions
+    {
+        /// <summary>
+        /// Reload an entity into the context if it has been detached.
+        /// </summary>
+        /// <remarks>
+        /// If it has been deleted, or cannot be reloaded, we return null as the
+        /// entity would be unsafe to work with.
+        /// <para>
+        /// This is most useful in code where we receive an entity from some other
+        /// service (e.g. in authorization handlers). As we cannot be sure about the
+        /// tracking state of the entity, it is recommended to call this method to
+        /// ensure that it is not stale and has not been deleted.
+        /// </para>
+        /// </remarks>
+        public static T? ReloadEntity<T>(this DbContext context, T entity) where T : class
+        {
+            var entry = context.Entry(entity);
+
+            // The entity has been detached from the context
+            // and may be stale, so we need to reload it for
+            // the most up-to-date version.
+            if (entry.State == EntityState.Detached)
+            {
+                entry.Reload();
+            }
+
+            if (entry.State == EntityState.Deleted)
+            {
+                return null;
+            }
+
+            // If entry is still detached, we can only assume
+            // it does not exist in the database anymore and
+            // is now unsafe to work with (it should be null).
+            if (entry.State == EntityState.Detached)
+            {
+                return null;
+            }
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Try to reload an entity, returning false if it cannot be reloaded.
+        /// </summary>
+        public static bool TryReloadEntity<T>(this DbContext context, T entity, out T reloadedEntity)
+            where T : class
+        {
+            reloadedEntity = entity;
+
+            var reloaded = context.ReloadEntity(entity);
+
+            if (reloaded is null)
+            {
+                return false;
+            }
+
+            reloadedEntity = reloaded;
+            return true;
+        }
+
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/PartialDate.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/PartialDate.cs
@@ -1,42 +1,54 @@
+#nullable enable
 using System;
 using System.Text.RegularExpressions;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using static System.Int32;
 using static System.String;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 {
-    public class PartialDate
+    public record PartialDate
     {
-        public static readonly Regex YearRegex = new Regex(@"^([0-9]{4})?$");
-        public static readonly Regex MonthRegex = new Regex(@"^([0-9]{1,2})?$");
-        public static readonly Regex DayRegex = new Regex(@"^([0-9]{1,2})?$");
-        private string _year;
-        private string _month;
-        private string _day;
+        public static readonly Regex YearRegex = new(@"^([0-9]{4})?$");
+        public static readonly Regex MonthRegex = new(@"^([0-9]{1,2})?$");
+        public static readonly Regex DayRegex = new(@"^([0-9]{1,2})?$");
 
-        public string Year
-        {
-            get => _year ?? "";
-            set => _year = value;
-        }
-        
+        private readonly string? _month;
+        private readonly string? _day;
+
+        public string Year { get; init; } = Empty;
+
         public string Month
         {
-            get => _month ?? "";
-            set => _month = value;
+            get => _month ?? Empty;
+            init => _month = value;
         }
-        
+
         public string Day
         {
-            get => _day ?? "";
-            set => _day = value;
+            get => _day ?? Empty;
+            init => _day = value;
         }
 
         public bool IsValid()
         {
+            var hasYear = !Year.IsNullOrWhitespace();
+            var hasMonth = !Month.IsNullOrWhitespace();
+            var hasDay = !Day.IsNullOrWhitespace();
+
+            if (!hasYear)
+            {
+                return false;
+            }
+
+            if (hasDay && !hasMonth)
+            {
+                return false;
+            }
+
             if (!YearRegex.Match(Year).Success || !MonthRegex.Match(Month).Success || !DayRegex.Match(Day).Success)
             {
-                return false; // Failed rudimentary number validation  
+                return false; // Failed rudimentary number validation
             }
 
             if (!EmptyOrBetween(Month, 1, 12) || !EmptyOrBetween(Day, 1, 31))
@@ -44,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
                 return false; // Failed more precise number validation
             }
 
-            if (!IsNullOrEmpty(Month) && !IsNullOrEmpty(Day))
+            if (hasMonth && hasDay)
             {
                 // We at least have a month and a day so at the very least we can check that they are acceptable
                 // together. If we have a year we can do even more if we do not then we use a leap year as this gives a

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/ReleaseController.cs
@@ -1,3 +1,5 @@
+#nullable enable
+using System.Collections.Generic;
 using System.Net.Mime;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
@@ -17,6 +19,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         public ReleaseController(IReleaseService releaseService)
         {
             _releaseService = releaseService;
+        }
+
+        [HttpGet("publications/{publicationSlug}/releases")]
+        public async Task<ActionResult<List<ReleaseSummaryViewModel>>> ListReleases(string publicationSlug)
+        {
+            return await _releaseService.List(publicationSlug)
+                .HandleFailuresOrOk();
         }
 
         [HttpGet("publications/{publicationSlug}/releases/latest")]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -127,11 +127,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
 
             services.AddAuthorization(options =>
             {
+                // does this use have permission to view a specific Publication?
+                options.AddPolicy(ContentSecurityPolicies.CanViewSpecificPublication.ToString(), policy =>
+                    policy.Requirements.Add(new ViewPublicationRequirement()));
+
                 // does this use have permission to view a specific Release?
                 options.AddPolicy(ContentSecurityPolicies.CanViewSpecificRelease.ToString(), policy =>
                     policy.Requirements.Add(new ViewReleaseRequirement()));
             });
 
+            services.AddTransient<IAuthorizationHandler, ViewPublicationAuthorizationHandler>();
             services.AddTransient<IAuthorizationHandler, ViewReleaseAuthorizationHandler>();
 
             AddPersistenceHelper<ContentDbContext>(services);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ReleaseTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/ReleaseTests.cs
@@ -44,7 +44,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
         [Fact]
         public void NextReleaseDate_Ok()
         {
-            var releaseDate = new PartialDate {Day = "01"};
+            var releaseDate = new PartialDate {Year = "2021", Month = "1"};
             var release = new Release
             {
                 NextReleaseDate = releaseDate

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewPublicationAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security.Tests/AuthorizationHandlers/ViewPublicationAuthorizationHandlerTests.cs
@@ -1,0 +1,210 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Database.ContentDbUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Tests.AuthorizationHandlers
+{
+    public class ViewPublicationAuthorizationHandlerTests
+    {
+        [Fact]
+        public async Task HasLiveRelease()
+        {
+            var release = new Release
+            {
+                Published = new DateTime(2021, 1, 1),
+                ReleaseName = "2021",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear
+            };
+            var publication = new Publication
+            {
+                Releases = ListOf(release)
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(publication);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contextId))
+            {
+                var handler = new ViewPublicationAuthorizationHandler(contentDbContext);
+
+                var authContext = new AuthorizationHandlerContext(
+                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewPublicationRequirement>() },
+                    null,
+                    publication
+                );
+
+                await handler.HandleAsync(authContext);
+
+                Assert.True(authContext.HasSucceeded);
+            }
+        }
+
+        [Fact]
+        public async Task HasLiveReleaseWithDraftAmendment()
+        {
+            var originalRelease = new Release
+            {
+                ReleaseName = "2020",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                Published = new DateTime(2020, 1, 1),
+            };
+            var amendedRelease = new Release
+            {
+                ReleaseName = "2021",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                PreviousVersion = originalRelease,
+            };
+
+            var publication = new Publication
+            {
+                Releases = ListOf(originalRelease, amendedRelease)
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(publication);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contextId))
+            {
+                var handler = new ViewPublicationAuthorizationHandler(contentDbContext);
+
+                var authContext = new AuthorizationHandlerContext(
+                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewPublicationRequirement>() },
+                    null,
+                    publication
+                );
+
+                await handler.HandleAsync(authContext);
+
+                Assert.True(authContext.HasSucceeded);
+            }
+        }
+
+        [Fact]
+        public async Task HasLiveReleaseAndNewerDraftRelease()
+        {
+            var olderRelease = new Release
+            {
+                ReleaseName = "2020",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+                Published = new DateTime(2020, 1, 1),
+            };
+            var newerRelease = new Release
+            {
+                ReleaseName = "2021",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear
+            };
+
+            var publication = new Publication
+            {
+                Releases = ListOf(olderRelease, newerRelease)
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(publication);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contextId))
+            {
+                var handler = new ViewPublicationAuthorizationHandler(contentDbContext);
+
+                var authContext = new AuthorizationHandlerContext(
+                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewPublicationRequirement>() },
+                    null,
+                    publication
+                );
+
+                await handler.HandleAsync(authContext);
+
+                Assert.True(authContext.HasSucceeded);
+            }
+        }
+
+        [Fact]
+        public async Task HasNoLiveReleases()
+        {
+            var release = new Release
+            {
+                ReleaseName = "2021",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+            };
+
+            var publication = new Publication
+            {
+                Releases = ListOf(release)
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contextId))
+            {
+                await contentDbContext.AddAsync(publication);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contextId))
+            {
+                var handler = new ViewPublicationAuthorizationHandler(contentDbContext);
+
+                var authContext = new AuthorizationHandlerContext(
+                    new IAuthorizationRequirement[] { Activator.CreateInstance<ViewPublicationRequirement>() },
+                    null,
+                    publication
+                );
+
+                await handler.HandleAsync(authContext);
+
+                Assert.False(authContext.HasSucceeded);
+            }
+        }
+
+        [Fact]
+        public async Task DoesNotExist()
+        {
+            var release = new Release
+            {
+                ReleaseName = "2021",
+                TimePeriodCoverage = TimeIdentifier.CalendarYear,
+            };
+
+            var publication = new Publication
+            {
+                Releases = ListOf(release)
+            };
+
+            await using var contentDbContext = InMemoryContentDbContext();
+
+            var handler = new ViewPublicationAuthorizationHandler(contentDbContext);
+
+            var authContext = new AuthorizationHandlerContext(
+                new IAuthorizationRequirement[] { Activator.CreateInstance<ViewPublicationRequirement>() },
+                null,
+                publication
+            );
+
+            await handler.HandleAsync(authContext);
+
+            Assert.False(authContext.HasSucceeded);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/AuthorizationHandlers/ViewPublicationAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/AuthorizationHandlers/ViewPublicationAuthorizationHandler.cs
@@ -1,0 +1,46 @@
+#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Authorization;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers
+{
+    public class ViewPublicationRequirement : IAuthorizationRequirement
+    {
+    }
+
+    public class ViewPublicationAuthorizationHandler
+        : AuthorizationHandler<ViewPublicationRequirement, Publication>
+    {
+        private readonly ContentDbContext _context;
+
+        public ViewPublicationAuthorizationHandler(ContentDbContext context)
+        {
+            _context = context;
+        }
+
+        protected override async Task HandleRequirementAsync(
+            AuthorizationHandlerContext authContext,
+            ViewPublicationRequirement requirement,
+            Publication publication)
+        {
+            if (!_context.TryReloadEntity(publication, out var loadedPublication))
+            {
+                return;
+            }
+
+            await _context.Entry(loadedPublication)
+                .Collection(p => p.Releases)
+                .LoadAsync();
+
+            var release = loadedPublication.LatestPublishedRelease();
+
+            if (release is not null)
+            {
+                authContext.Succeed(requirement);
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/ContentSecurityPolicies.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/ContentSecurityPolicies.cs
@@ -1,7 +1,9 @@
+#nullable enable
 namespace GovUk.Education.ExploreEducationStatistics.Content.Security
 {
     public enum ContentSecurityPolicies
     {
+        CanViewSpecificPublication,
         CanViewSpecificRelease
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Security/Extensions/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Security/Extensions/UserServiceExtensions.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
@@ -8,6 +9,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Security.Extensions
 {
     public static class UserServiceExtensions
     {
+        public static Task<Either<ActionResult, Publication>> CheckCanViewPublication(
+            this IUserService userService,
+            Publication publication)
+        {
+            return userService.CheckPolicy(publication, ContentSecurityPolicies.CanViewSpecificPublication);
+        }
+
         public static Task<Either<ActionResult, Release>> CheckCanViewRelease(
             this IUserService userService,
             Release release)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IReleaseService.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
@@ -11,5 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces
         Task<Either<ActionResult, ReleaseViewModel>> Get(string publicationPath, string releasePath);
 
         Task<Either<ActionResult, ReleaseSummaryViewModel>> GetSummary(string publicationPath, string releasePath);
+
+        Task<Either<ActionResult, List<ReleaseSummaryViewModel>>> List(string publicationSlug);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/MetaGuidanceViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/MetaGuidanceViewModel.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 {
-    public class MetaGuidanceViewModel : ReleaseSummaryViewModel
+    public record MetaGuidanceViewModel : ReleaseSummaryViewModel
     {
         public string MetaGuidance { get;  }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PreReleaseAccessListViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PreReleaseAccessListViewModel.cs
@@ -1,8 +1,9 @@
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 {
-    public class PreReleaseAccessListViewModel : ReleaseSummaryViewModel
+    public record PreReleaseAccessListViewModel : ReleaseSummaryViewModel
     {
         public string PreReleaseAccessList { get; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ReleaseSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/ReleaseSummaryViewModel.cs
@@ -1,10 +1,13 @@
+#nullable enable
 using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 {
-    public class ReleaseSummaryViewModel
+    public record ReleaseSummaryViewModel
     {
         public Guid Id { get; }
 
@@ -28,7 +31,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 
         public DateTime? DataLastPublished { get; }
 
-        public PublicationSummaryViewModel Publication { get; }
+        public PublicationSummaryViewModel? Publication { get; }
 
         public ReleaseSummaryViewModel(CachedReleaseViewModel release, CachedPublicationViewModel publication)
         {
@@ -44,6 +47,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
             LatestRelease = Id == publication.LatestReleaseId;
             DataLastPublished = release.DataLastPublished;
             Publication = new PublicationSummaryViewModel(publication);
+        }
+
+        public ReleaseSummaryViewModel(Release release)
+        {
+            Id = release.Id;
+            Title = release.Title;
+            Slug = release.Slug;
+            YearTitle = release.YearTitle;
+            CoverageTitle = release.TimePeriodCoverage.GetEnumLabel();
+            Published = release.Published;
+            ReleaseName = release.ReleaseName;
+            NextReleaseDate = release.NextReleaseDate;
+            Type = new ReleaseTypeViewModel {
+                Id = release.Type.Id,
+                Title = release.Type.Title
+            };
+            LatestRelease = Id == release.Publication.LatestPublishedRelease()?.Id;
+            DataLastPublished = release.DataLastPublished;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/ReleaseTypeViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Model/ViewModels/ReleaseTypeViewModel.cs
@@ -1,11 +1,13 @@
-﻿using System;
+﻿#nullable enable
+using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels
 {
-    public class ReleaseTypeViewModel
+    public record ReleaseTypeViewModel
     {
-        public Guid Id { get; set; }
+        public Guid Id { get; init; }
 
-        public string Title { get; set; }
+        public string Title { get; init; } = string.Empty;
+
     }
 }

--- a/src/explore-education-statistics-common/src/services/publicationService.ts
+++ b/src/explore-education-statistics-common/src/services/publicationService.ts
@@ -138,11 +138,15 @@ export interface ReleaseSummary {
     title: ReleaseType;
   };
   latestRelease: boolean;
-  publication: PublicationSummary;
   dataLastPublished: string;
 }
 
+export interface PublicationReleaseSummary extends ReleaseSummary {
+  publication: PublicationSummary;
+}
+
 export interface PreReleaseAccessListSummary extends ReleaseSummary {
+  publication: PublicationSummary;
   preReleaseAccessList: string;
 }
 
@@ -150,12 +154,15 @@ export default {
   getPublicationTitle(publicationSlug: string): Promise<PublicationTitle> {
     return contentApi.get(`/publications/${publicationSlug}/title`);
   },
+  listReleases(publicationSlug: string): Promise<ReleaseSummary[]> {
+    return contentApi.get(`/publications/${publicationSlug}/releases`);
+  },
   getLatestPublicationRelease(publicationSlug: string): Promise<Release> {
     return contentApi.get(`/publications/${publicationSlug}/releases/latest`);
   },
   getLatestPublicationReleaseSummary(
     publicationSlug: string,
-  ): Promise<ReleaseSummary> {
+  ): Promise<PublicationReleaseSummary> {
     return contentApi.get(
       `/publications/${publicationSlug}/releases/latest/summary`,
     );
@@ -171,7 +178,7 @@ export default {
   getPublicationReleaseSummary(
     publicationSlug: string,
     releaseSlug: string,
-  ): Promise<ReleaseSummary> {
+  ): Promise<PublicationReleaseSummary> {
     return contentApi.get(
       `/publications/${publicationSlug}/releases/${releaseSlug}/summary`,
     );

--- a/src/explore-education-statistics-common/src/services/releaseMetaGuidanceService.ts
+++ b/src/explore-education-statistics-common/src/services/releaseMetaGuidanceService.ts
@@ -1,5 +1,8 @@
 import { contentApi } from '@common/services/api';
-import { ReleaseSummary } from '@common/services/publicationService';
+import {
+  PublicationSummary,
+  ReleaseSummary,
+} from '@common/services/publicationService';
 
 export interface SubjectMetaGuidance {
   id: string;
@@ -22,6 +25,7 @@ export interface SubjectMetaGuidance {
 }
 
 export interface ReleaseMetaGuidanceSummary extends ReleaseSummary {
+  publication: PublicationSummary;
   metaGuidance: string;
   subjects: SubjectMetaGuidance[];
 }

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataCataloguePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/__tests__/DataCataloguePage.test.tsx
@@ -4,12 +4,20 @@ import {
   PublicationSummary,
   Theme,
 } from '@common/services/themeService';
-import { Release } from '@common/services/publicationService';
+import _publicationService, {
+  ReleaseSummary,
+} from '@common/services/publicationService';
 import { SubjectWithDownloadFiles } from '@frontend/modules/data-catalogue/components/DownloadStep';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import preloadAll from 'jest-next-dynamic';
 import React from 'react';
+
+jest.mock('@common/services/publicationService');
+
+const publicationService = _publicationService as jest.Mocked<
+  typeof _publicationService
+>;
 
 describe('DataCataloguePage', () => {
   const testThemes: Theme[] = [
@@ -38,28 +46,28 @@ describe('DataCataloguePage', () => {
     slug: 'test-publication',
   } as PublicationSummary;
 
-  const testReleases: Release[] = [
+  const testReleases: ReleaseSummary[] = [
     {
       id: 'rel-1',
       latestRelease: true,
-      published: '2021-06-30T11:21:17.7585345',
+      published: '2021-06-30T11:21:17',
       slug: 'rel-1-slug',
       title: 'Release 1',
-    } as Release,
+    } as ReleaseSummary,
     {
       id: 'rel-3',
       latestRelease: false,
-      published: '2021-01-01T11:21:17.7585345',
+      published: '2021-01-01T11:21:17',
       slug: 'rel-3-slug',
       title: 'Another Release',
-    } as Release,
+    } as ReleaseSummary,
     {
       id: 'rel-2',
       latestRelease: false,
-      published: '2021-05-30T11:21:17.7585345',
+      published: '2021-05-30T11:21:17',
       slug: 'rel-2-slug',
       title: 'Release 2',
-    } as Release,
+    } as ReleaseSummary,
   ];
 
   const testSubjects: SubjectWithDownloadFiles[] = [
@@ -140,8 +148,9 @@ describe('DataCataloguePage', () => {
     expect(screen.getByLabelText('Test publication')).toBeVisible();
   });
 
-  // EES-2207 this test will need to be updated to mock the api responses insted of using the fake data
   test('can go through all the steps to get to download files', async () => {
+    publicationService.listReleases.mockResolvedValue(testReleases);
+
     render(<DataCataloguePage themes={testThemes} />);
 
     expect(screen.getByText('Choose a publication')).toBeInTheDocument();

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DownloadStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DownloadStep.tsx
@@ -9,7 +9,7 @@ import WizardStepHeading from '@common/modules/table-tool/components/WizardStepH
 import WizardStepFormActions from '@common/modules/table-tool/components/WizardStepFormActions';
 import ResetFormOnPreviousStep from '@common/modules/table-tool/components/ResetFormOnPreviousStep';
 import { FileInfo } from '@common/services/types/file';
-import { Release } from '@common/services/publicationService';
+import { ReleaseSummary } from '@common/services/publicationService';
 import Yup from '@common/validation/yup';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
@@ -32,7 +32,7 @@ export interface SubjectWithDownloadFiles extends Subject {
 }
 
 interface Props {
-  release?: Release;
+  release?: ReleaseSummary;
   subjects: SubjectWithDownloadFiles[];
   initialValues?: { files: string[] };
   onSubmit: DownloadFormSubmitHandler;

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/ReleaseForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/ReleaseForm.tsx
@@ -12,7 +12,7 @@ import Yup from '@common/validation/yup';
 import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
 import WizardStepFormActions from '@common/modules/table-tool/components/WizardStepFormActions';
 import createErrorHelper from '@common/validation/createErrorHelper';
-import { Release } from '@common/services/publicationService';
+import { ReleaseSummary } from '@common/services/publicationService';
 import Tag from '@common/components/Tag';
 import useFormSubmit from '@common/hooks/useFormSubmit';
 import { format } from 'date-fns';
@@ -34,7 +34,7 @@ interface Props {
   legendHint?: string;
   initialValues?: { releaseId: string };
   onSubmit: ReleaseFormSubmitHandler;
-  options: Release[];
+  options: ReleaseSummary[];
 }
 
 const ReleaseForm = ({
@@ -67,7 +67,7 @@ const ReleaseForm = ({
         .map(option => {
           return {
             label: `${option.title} (${format(
-              new Date(option.published),
+              new Date(option.published ?? ''),
               'd MMMM yyyy',
             )})`,
             hint: option.latestRelease ? (

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/ReleaseStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/ReleaseStep.tsx
@@ -1,18 +1,18 @@
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
+import useMounted from '@common/hooks/useMounted';
+import WizardStepEditButton from '@common/modules/table-tool/components//WizardStepEditButton';
 import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
 import WizardStepHeading from '@common/modules/table-tool/components/WizardStepHeading';
-import WizardStepEditButton from '@common/modules/table-tool/components//WizardStepEditButton';
-import { Release } from '@common/services/publicationService';
+import { ReleaseSummary } from '@common/services/publicationService';
 import ReleaseForm, {
   ReleaseFormSubmitHandler,
 } from '@frontend/modules/data-catalogue/components/ReleaseForm';
-import useMounted from '@common/hooks/useMounted';
 import React from 'react';
 
 interface Props {
-  releases: Release[];
-  selectedRelease?: Release;
+  releases: ReleaseSummary[];
+  selectedRelease?: ReleaseSummary;
   onSubmit: ReleaseFormSubmitHandler;
 }
 

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DownloadStep.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/DownloadStep.test.tsx
@@ -3,7 +3,7 @@ import DownloadStep, {
 } from '@frontend/modules/data-catalogue/components/DownloadStep';
 import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
 import { getDescribedBy } from '@common-test/queries';
-import { Release } from '@common/services/publicationService';
+import { ReleaseSummary } from '@common/services/publicationService';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -81,12 +81,12 @@ describe('DownloadStep', () => {
   const testNotLatestRelease = {
     id: 'release-1',
     latestRelease: false,
-  } as Release;
+  } as ReleaseSummary;
 
   const testLatestRelease = {
     id: 'release-2',
     latestRelease: true,
-  } as Release;
+  } as ReleaseSummary;
 
   test('renders with downloads', () => {
     const { container } = render(

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/ReleaseStep.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/ReleaseStep.test.tsx
@@ -1,32 +1,32 @@
 import ReleaseStep from '@frontend/modules/data-catalogue/components/ReleaseStep';
 import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
-import { Release } from '@common/services/publicationService';
+import { ReleaseSummary } from '@common/services/publicationService';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import noop from 'lodash/noop';
 
 describe('ReleaseStep', () => {
-  const testReleases: Release[] = [
+  const testReleases: ReleaseSummary[] = [
     {
       id: 'test-rel-3',
-      published: '2021-01-01T11:21:17.7585345',
+      published: '2021-01-01T11:21:17',
       slug: 'test-rel-3-slug',
       title: 'Another Release',
-    } as Release,
+    } as ReleaseSummary,
     {
       id: 'test-rel-1',
       latestRelease: true,
-      published: '2021-06-30T11:21:17.7585345',
+      published: '2021-06-30T11:21:17',
       slug: 'test-rel-1-slug',
       title: 'Release 1',
-    } as Release,
+    } as ReleaseSummary,
     {
       id: 'test-rel-2',
-      published: '2021-05-30T11:21:17.7585345',
+      published: '2021-05-30T11:21:17',
       slug: 'test-rel-2-slug',
       title: 'Release 2',
-    } as Release,
+    } as ReleaseSummary,
   ];
 
   const wizardProps: InjectedWizardProps = {


### PR DESCRIPTION
# :warning: Depends on #2827 

This PR adds a new Content API endpoint (`/publications/{publicationId}/releases`) that fetches a publication's published releases.

## Related changes

- Added `ViewPublicationAuthorizationHandler` to secure the new endpoint.
- Added new `TryReloadEntity` and `ReloadEntity` extension methods for `DbContext`. These are intended to try to ensure that entities passed to a service method are actually up-to-date and have not been detached from the context or have been deleted from the database. 
  
  This is a common issue whilst passing raw database entities between various service classes and it is recommended that we use when we can't 100% know the state of the entity before it is received by the service e.g. authorization handlers.

## Other changes

- Enabled nullable on `PartialDate` and fixed various issues with it potentially having invalid values if the year component has not been populated.