### PR TITLE
EES-2650-2 - disable `methodlogy_page_absence` UI test

### DIFF
--- a/tests/robot-tests/tests/general_public/methodology_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/methodology_page_absence.robot
@@ -4,7 +4,7 @@ Resource            ../libs/public-common.robot
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
 
-Force Tags          GeneralPublic    Local    Dev    Test    Preprod    NotAgainstDev
+Force Tags          GeneralPublic    Local    Test
 
 *** Test Cases ***
 Navigate to Pupil absence in schools in England methodology page


### PR DESCRIPTION
This PR: 
- disables the `methodlogy_page_absence` UI test from running against pre-prod & prod environments. This is due to the test data not being present in both environments.