### PR TITLE
EES-2660 Add the owner and drop permission values to MyPublicationViewModel for each Methodology

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyPublicationMethodologyPermissionsPropertyResolverTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyPublicationMethodologyPermissionsPropertyResolverTest.cs
@@ -1,0 +1,33 @@
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Mappings;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
+{
+    public class MyPublicationMethodologyPermissionsPropertyResolverTest
+    {
+        [Fact]
+        public void ResolvePermissions()
+        {
+            var publicationMethodology = new PublicationMethodology();
+
+            var userService = new Mock<IUserService>(Strict);
+            var resolver = new MyPublicationMethodologyPermissionsPropertyResolver(userService.Object);
+
+            userService.Setup(s =>
+                    s.MatchesPolicy(publicationMethodology, CanDropMethodologyLink))
+                .ReturnsAsync(true);
+
+            var permissions = resolver.Resolve(publicationMethodology, null, null, null);
+            VerifyAllMocks(userService);
+
+            Assert.True(permissions.CanDropMethodology);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DropMethodologyLinkAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DropMethodologyLinkAuthorizationHandlerTests.cs
@@ -1,0 +1,189 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
+    AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public class DropMethodologyLinkAuthorizationHandlerTests
+    {
+        private static readonly Guid UserId = Guid.NewGuid();
+
+        private static readonly PublicationMethodology OwningLink = new()
+        {
+            Owner = true,
+            PublicationId = Guid.NewGuid(),
+            MethodologyParentId = Guid.NewGuid()
+        };
+
+        private static readonly PublicationMethodology NonOwningLink = new()
+        {
+            Owner = false,
+            PublicationId = Guid.NewGuid(),
+            MethodologyParentId = Guid.NewGuid()
+        };
+
+        public class ClaimsTests
+        {
+            [Fact]
+            public async Task NoClaimsAllowDroppingOwningLinks()
+            {
+                await ForEachSecurityClaimAsync(async claim =>
+                {
+                    var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
+
+                    var handler = SetupHandler(userPublicationRoleRepository.Object);
+
+                    var user = CreateClaimsPrincipal(UserId, claim);
+                    var authContext =
+                        CreateAuthorizationHandlerContext<DropMethodologyLinkRequirement, PublicationMethodology>(
+                            user,
+                            OwningLink);
+
+                    await handler.HandleAsync(authContext);
+
+                    VerifyAllMocks(userPublicationRoleRepository);
+
+                    // No claims should allow dropping the link from a methodology to the owning publication
+                    Assert.False(authContext.HasSucceeded);
+                });
+            }
+
+            [Fact]
+            public async Task UserWithCorrectClaimCanDropLinks()
+            {
+                await ForEachSecurityClaimAsync(async claim =>
+                {
+                    var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
+
+                    var handler = SetupHandler(userPublicationRoleRepository.Object);
+
+                    // Only the AdoptAnyMethodology claim should allow dropping methodology links to publications
+                    var expectedToPassByClaimAlone = claim == AdoptAnyMethodology;
+
+                    if (!expectedToPassByClaimAlone)
+                    {
+                        userPublicationRoleRepository.SetupPublicationOwnerRoleExpectations(
+                            UserId,
+                            NonOwningLink.PublicationId,
+                            false);
+                    }
+
+                    var user = CreateClaimsPrincipal(UserId, claim);
+                    var authContext =
+                        CreateAuthorizationHandlerContext<DropMethodologyLinkRequirement, PublicationMethodology>(
+                            user,
+                            NonOwningLink);
+
+                    await handler.HandleAsync(authContext);
+
+                    VerifyAllMocks(userPublicationRoleRepository);
+
+                    Assert.Equal(expectedToPassByClaimAlone, authContext.HasSucceeded);
+                });
+            }
+        }
+
+        public class PublicationRoleTests
+        {
+            [Fact]
+            public async Task NoPublicationRolesAllowDroppingOwningLinks()
+            {
+                var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
+
+                var handler = SetupHandler(userPublicationRoleRepository.Object);
+
+                // Deliberately set no expectations for checking user has any publication owner roles
+
+                var user = CreateClaimsPrincipal(UserId);
+                var authContext =
+                    CreateAuthorizationHandlerContext<DropMethodologyLinkRequirement, PublicationMethodology>(
+                        user,
+                        OwningLink);
+
+                await handler.HandleAsync(authContext);
+
+                VerifyAllMocks(userPublicationRoleRepository);
+
+                // No publication roles should allow dropping the link from a methodology to the owning publication
+                Assert.False(authContext.HasSucceeded);
+            }
+
+            [Fact]
+            public async Task PublicationOwnerCanDropLinks()
+            {
+                await ForEachPublicationRoleAsync(async publicationRole =>
+                {
+                    var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
+
+                    var handler = SetupHandler(userPublicationRoleRepository.Object);
+
+                    userPublicationRoleRepository.SetupPublicationOwnerRoleExpectations(
+                        UserId,
+                        NonOwningLink.PublicationId,
+                        publicationRole == Owner);
+
+                    var user = CreateClaimsPrincipal(UserId);
+                    var authContext =
+                        CreateAuthorizationHandlerContext<DropMethodologyLinkRequirement, PublicationMethodology>(
+                            user,
+                            NonOwningLink);
+
+                    await handler.HandleAsync(authContext);
+
+                    VerifyAllMocks(userPublicationRoleRepository);
+
+                    // If the user has Publication Owner role on the publication they are allowed to drop methodology links
+                    Assert.Equal(publicationRole == Owner, authContext.HasSucceeded);
+                });
+            }
+
+            [Fact]
+            public async Task UsersWithNoRolesOnOwningPublicationsCannotDropLinks()
+            {
+                var userPublicationRoleRepository = new Mock<IUserPublicationRoleRepository>(Strict);
+
+                var handler = SetupHandler(userPublicationRoleRepository.Object);
+
+                userPublicationRoleRepository.SetupPublicationOwnerRoleExpectations(
+                    UserId,
+                    NonOwningLink.PublicationId,
+                    false);
+
+                var user = CreateClaimsPrincipal(UserId);
+                var authContext =
+                    CreateAuthorizationHandlerContext<DropMethodologyLinkRequirement, PublicationMethodology>(
+                        user,
+                        NonOwningLink);
+
+                await handler.HandleAsync(authContext);
+
+                VerifyAllMocks(userPublicationRoleRepository);
+
+                // A user with no role on the owning publication is not allowed to drop methodology links
+                Assert.False(authContext.HasSucceeded);
+            }
+        }
+
+        private static DropMethodologyLinkAuthorizationHandler SetupHandler(
+            IUserPublicationRoleRepository? userPublicationRoleRepository = null
+        )
+        {
+            return new(
+                userPublicationRoleRepository ?? Mock.Of<IUserPublicationRoleRepository>(Strict)
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Extensions/MockUserPublicationRoleRepositoryExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Extensions/MockUserPublicationRoleRepositoryExtensions.cs
@@ -15,7 +15,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Extens
             Publication publication,
             bool hasRole)
         {
-            return service.Setup(s => s.IsUserPublicationOwner(userId, publication.Id))
+            return service.SetupPublicationOwnerRoleExpectations(userId, publication.Id, hasRole);
+        }
+        
+        public static IReturnsResult<IUserPublicationRoleRepository> SetupPublicationOwnerRoleExpectations(
+            this Mock<IUserPublicationRoleRepository> service,
+            Guid userId,
+            Guid publicationId,
+            bool hasRole)
+        {
+            return service.Setup(s => s.IsUserPublicationOwner(userId, publicationId))
                 .ReturnsAsync(hasRole);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MapperUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MapperUtils.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using AutoMapper;
@@ -9,16 +10,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
     public static class MapperUtils
     {
-        public static IMapper AdminMapper() 
+        public static IMapper AdminMapper()
         {
             var serviceLookupByType = new Dictionary<Type, object>
             {
-                { typeof(IMyPublicationPermissionSetPropertyResolver), 
-                    new Mock<IMyPublicationPermissionSetPropertyResolver>().Object },
-                { typeof(IMyReleasePermissionSetPropertyResolver), 
-                    new Mock<IMyReleasePermissionSetPropertyResolver>().Object },
-                { typeof(IMyMethodologyPermissionSetPropertyResolver), 
-                    new Mock<IMyMethodologyPermissionSetPropertyResolver>().Object }
+                {
+                    typeof(IMyPublicationPermissionSetPropertyResolver),
+                    new Mock<IMyPublicationPermissionSetPropertyResolver>().Object
+                },
+                {
+                    typeof(IMyReleasePermissionSetPropertyResolver),
+                    new Mock<IMyReleasePermissionSetPropertyResolver>().Object
+                },
+                {
+                    typeof(IMyPublicationMethodologyPermissionsPropertyResolver),
+                    new Mock<IMyPublicationMethodologyPermissionsPropertyResolver>().Object
+                },
+                {
+                    typeof(IMyMethodologyPermissionSetPropertyResolver),
+                    new Mock<IMyMethodologyPermissionSetPropertyResolver>().Object
+                }
             };
 
             object ServiceLocator(Type serviceType) => serviceLookupByType[serviceType];

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -431,59 +431,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         }
 
         [Fact]
-        public async Task DropMethodology_DropOwnedMethodologyFails()
-        {
-            var publication = new Publication();
-
-            // Setup methodology owned by this publication
-            var methodology = new MethodologyParent
-            {
-                Publications = new List<PublicationMethodology>
-                {
-                    new()
-                    {
-                        Publication = publication,
-                        Owner = true
-                    }
-                }
-            };
-
-            var contentDbContextId = Guid.NewGuid().ToString();
-
-            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                await context.Publications.AddAsync(publication);
-                await context.MethodologyParents.AddAsync(methodology);
-                await context.SaveChangesAsync();
-            }
-
-            var methodologyParentRepository = new Mock<IMethodologyParentRepository>(Strict);
-
-            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var service = SetupMethodologyService(
-                    contentDbContext: context);
-
-                var result = await service.DropMethodology(publication.Id, methodology.Id);
-
-                VerifyAllMocks(methodologyParentRepository);
-
-                result.AssertBadRequest(CannotDropOwnedMethodology);
-            }
-
-            await using (var context = InMemoryApplicationDbContext(contentDbContextId))
-            {
-                var publicationMethodologies = await context.PublicationMethodologies.ToListAsync();
-
-                // Check the relationships between publications and methodologies are not altered
-                Assert.Single(publicationMethodologies);
-                Assert.True(publicationMethodologies.Exists(pm => pm.MethodologyParentId == methodology.Id
-                                                                  && pm.PublicationId == publication.Id
-                                                                  && pm.Owner));
-            }
-        }
-
-        [Fact]
         public async Task DropMethodology_PublicationNotFound()
         {
             var methodology = new MethodologyParent

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationRepositoryTests.cs
@@ -1,9 +1,9 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
-using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Xunit;
@@ -38,7 +38,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             userReleaseRoles.AddRange(new List<UserReleaseRole>
             {
-                new UserReleaseRole
+                new()
                 {
                     Release = new Release
                     {
@@ -49,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     User = user,
                     Role = Contributor
                 },
-                new UserReleaseRole
+                new()
                 {
                     Release = new Release
                     {
@@ -60,7 +60,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     User = user,
                     Role = Viewer
                 },
-                new UserReleaseRole
+                new()
                 {
                     Release = new Release
                     {
@@ -82,12 +82,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Title = "Related publication 2",
                     Releases = new List<Release>
                     {
-                        new Release
+                        new()
                         {
                             ReleaseName = "2015",
                             TimePeriodCoverage = AcademicYear
                         },
-                        new Release
+                        new()
                         {
                             ReleaseName = "2016",
                             TimePeriodCoverage = AcademicYear
@@ -144,7 +144,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Title = "Unrelated publication 2",
                     Releases = new List<Release>
                     {
-                        new Release
+                        new()
                         {
                             ReleaseName = "2012",
                             TimePeriodCoverage = AcademicYear
@@ -196,53 +196,79 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var user = new User();
             var topic = new Topic();
 
-            var methodology1Version1 = new Methodology
-            {
-                Id = Guid.NewGuid(),
-                AlternativeTitle = "Methodology 1 Version 1",
-                Version = 0,
-                Status = Draft,
-            };
-            
-            var methodology2Version1 = new Methodology
-            {
-                Id = Guid.NewGuid(),
-                AlternativeTitle = "Methodology 2 Version 1",
-                Version = 0,
-                Status = Approved,
-            };
-            
-            var methodology2Version2 = new Methodology
-            {
-                Id = Guid.NewGuid(),
-                AlternativeTitle = "Methodology 2 Version 2",
-                Version = 1,
-                Status = Approved,
-                PreviousVersionId = methodology2Version1.Id
-            };
-            
-            // Set up a publication and releases related to the topic that will be granted via a publication role
+            var methodology1Id = Guid.NewGuid();
+            var methodology2Id = Guid.NewGuid();
+            var methodology3Version0Id = Guid.NewGuid();
+            var methodology3Version1Id = Guid.NewGuid();
+
+            // Set up a publication related to the topic granted via a publication role
+            // Include a mix of owned and adopted methodologies that are deliberately not in any title order
             var userPublicationRoles = new List<UserPublicationRole>
             {
-                new UserPublicationRole
+                new()
                 {
                     Publication = new Publication
                     {
                         Title = "Related publication",
                         Methodologies = new List<PublicationMethodology>
                         {
-                            new PublicationMethodology
+                            new()
                             {
+                                Owner = false,
                                 MethodologyParent = new MethodologyParent
                                 {
-                                    Versions = AsList(methodology1Version1)
+                                    Versions = new List<Methodology>
+                                    {
+                                        new()
+                                        {
+                                            Id = methodology2Id,
+                                            AlternativeTitle = "Methodology 2",
+                                            Version = 0,
+                                            Status = Draft
+                                        }
+                                    }
+                                }
+                            },                          
+                            new()
+                            {
+                                Owner = true,
+                                MethodologyParent = new MethodologyParent
+                                {
+                                    Versions = new List<Methodology>
+                                    {
+                                        new()
+                                        {
+                                            Id = methodology1Id,
+                                            AlternativeTitle = "Methodology 1",
+                                            Version = 0,
+                                            Status = Draft
+                                        }
+                                    }
                                 }
                             },
-                            new PublicationMethodology
+                            new()
                             {
+                                Owner = false,
                                 MethodologyParent = new MethodologyParent
                                 {
-                                    Versions = AsList(methodology2Version1, methodology2Version2)
+                                    Versions = new List<Methodology>
+                                    {
+                                        new()
+                                        {
+                                            Id = methodology3Version0Id,
+                                            AlternativeTitle = "Methodology 3 Version 0",
+                                            Version = 0,
+                                            Status = Approved
+                                        },
+                                        new()
+                                        {
+                                            Id = methodology3Version1Id,
+                                            AlternativeTitle = "Methodology 3 Version 1",
+                                            Version = 1,
+                                            Status = Approved,
+                                            PreviousVersionId = methodology3Version0Id
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -270,16 +296,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var publication = Assert.Single(result);
                 Assert.NotNull(publication);
-                Assert.Equal(2, publication.Methodologies.Count);
+                Assert.Equal(3, publication.Methodologies.Count);
 
-                var methodology1 = publication.Methodologies[0];
-                var methodology2 = publication.Methodologies[1];
-                
-                Assert.Equal(methodology1Version1.Id, methodology1.Id);
-                Assert.Equal(methodology2Version2.Id, methodology2.Id);
+                // Check that the latest versions of the methodologies are returned in title order 
+
+                var link1 = publication.Methodologies[0];
+                Assert.True(link1.Owner);
+                Assert.Equal(methodology1Id, link1.Methodology.Id);
+                Assert.Equal("Methodology 1", link1.Methodology.Title);
+
+                var link2 = publication.Methodologies[1];
+                Assert.False(link2.Owner);
+                Assert.Equal(methodology2Id, link2.Methodology.Id);
+                Assert.Equal("Methodology 2", link2.Methodology.Title);
+
+                var link3 = publication.Methodologies[2];
+                Assert.False(link3.Owner);
+                Assert.Equal(methodology3Version1Id, link3.Methodology.Id);
+                Assert.Equal("Methodology 3 Version 1", link3.Methodology.Title);
             }
         }
-        
+
         [Fact]
         public async Task GetPublicationsForTopicRelatedToUser_NoPublicationsForTopic()
         {
@@ -313,7 +350,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Title = "Unrelated publication 2",
                     Releases = new List<Release>
                     {
-                        new Release
+                        new()
                         {
                             ReleaseName = "2012",
                             TimePeriodCoverage = AcademicYear
@@ -378,7 +415,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Title = "Related publication 2",
                     Releases = new List<Release>
                     {
-                        new Release
+                        new()
                         {
                             ReleaseName = "2012",
                             TimePeriodCoverage = AcademicYear
@@ -421,7 +458,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             var userPublicationRoles = new List<UserPublicationRole>
             {
-                new UserPublicationRole
+                new()
                 {
                     Publication = new Publication
                     {
@@ -432,7 +469,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     User = user,
                     Role = Owner
                 },
-                new UserPublicationRole
+                new()
                 {
                     Publication = new Publication
                     {
@@ -495,13 +532,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             userReleaseRoles.AddRange(new List<UserReleaseRole>
             {
-                new UserReleaseRole
+                new()
                 {
                     Release = release,
                     User = user,
                     Role = Contributor
                 },
-                new UserReleaseRole
+                new()
                 {
                     Release = release,
                     User = user,
@@ -542,7 +579,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task ReleasesCorrectlyOrdered()
+        public async Task GetAllPublicationsForTopic_ReleasesCorrectlyOrdered()
         {
             var topicId = Guid.NewGuid();
             var contextId = Guid.NewGuid().ToString();
@@ -554,49 +591,49 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Id = topicId,
                     Publications = new List<Publication>
                     {
-                        new Publication
+                        new()
                         {
                             Id = Guid.NewGuid(),
                             Title = "Publication",
                             TopicId = topicId,
                             Releases = new List<Release>
                             {
-                                new Release
+                                new()
                                 {
                                     Id = Guid.NewGuid(),
                                     ReleaseName = "2000",
                                     TimePeriodCoverage = Week1,
                                     Published = DateTime.UtcNow
                                 },
-                                new Release
+                                new()
                                 {
                                     Id = Guid.NewGuid(),
                                     ReleaseName = "2000",
                                     TimePeriodCoverage = Week11,
                                     Published = DateTime.UtcNow
                                 },
-                                new Release
+                                new()
                                 {
                                     Id = Guid.NewGuid(),
                                     ReleaseName = "2000",
                                     TimePeriodCoverage = Week3,
                                     Published = DateTime.UtcNow
                                 },
-                                new Release
+                                new()
                                 {
                                     Id = Guid.NewGuid(),
                                     ReleaseName = "2000",
                                     TimePeriodCoverage = Week2,
                                     Published = DateTime.UtcNow
                                 },
-                                new Release
+                                new()
                                 {
                                     Id = Guid.NewGuid(),
                                     ReleaseName = "2001",
                                     TimePeriodCoverage = Week1,
                                     Published = DateTime.UtcNow
                                 },
-                                new Release
+                                new()
                                 {
                                     Id = Guid.NewGuid(),
                                     ReleaseName = "1999",
@@ -613,7 +650,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var publicationService = SetupPublicationRepository(context);
-                var publications = await publicationService.GetAllPublicationsForTopicAsync(topicId);
+                var publications = await publicationService.GetAllPublicationsForTopic(topicId);
                 var releases = publications.Single().Releases;
                 Assert.Equal("Week 1 2001", releases[0].Title);
                 Assert.Equal("Week 11 2000", releases[1].Title);
@@ -625,7 +662,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task LatestReleaseCorrectlyReportedInPublication()
+        public async Task GetAllPublicationsForTopic_LatestReleaseCorrectlyReportedInPublication()
         {
             var latestReleaseId = Guid.NewGuid();
             var notLatestReleaseId = Guid.NewGuid();
@@ -639,7 +676,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Id = topicId,
                     Publications = new List<Publication>
                     {
-                        new Publication
+                        new()
                         {
                             Id = Guid.NewGuid(),
                             Title = "Publication",
@@ -659,7 +696,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                                     TimePeriodCoverage = June,
                                     Published = DateTime.UtcNow
                                 }
-                            )    
+                            )
                         }
                     }
                 });
@@ -673,7 +710,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 // Method under test - this return a list of publication for a user. The releases in the publication
                 // should correctly report whether they are the latest or not. Note that this is dependent on the mapper
                 // that we are passing in.
-                var publications = await publicationService.GetAllPublicationsForTopicAsync(topicId);
+                var publications = await publicationService.GetAllPublicationsForTopic(topicId);
                 var releases = publications.Single().Releases;
                 Assert.True(releases.Exists(r => r.Id == latestReleaseId && r.LatestRelease));
                 Assert.True(releases.Exists(r => r.Id == notLatestReleaseId && !r.LatestRelease));
@@ -822,7 +859,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
         private static PublicationRepository SetupPublicationRepository(ContentDbContext contentDbContext)
         {
-            return new PublicationRepository(contentDbContext, AdminMapper());
+            return new(contentDbContext, AdminMapper());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PublicationServicePermissionTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -20,13 +21,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
     public class PublicationServicePermissionTests
     {
-        private readonly Topic _topic = new Topic
+        private readonly Topic _topic = new()
         {
             Id = Guid.NewGuid(),
             Title = "Test topic"
         };
 
-        private readonly Publication _publication = new Publication
+        private readonly Publication _publication = new()
         {
             Id = Guid.NewGuid(),
             Title = "Test publication",
@@ -45,15 +46,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             userService.Setup(s => s.MatchesPolicy(SecurityPolicies.CanAccessSystem)).ReturnsAsync(false);
 
-            var list = new List<MyPublicationViewModel>()
+            var list = new List<MyPublicationViewModel>
             {
-                new MyPublicationViewModel
+                new()
                 {
                     Id = Guid.NewGuid()
                 }
             };
 
-            publicationRepository.Setup(s => s.GetAllPublicationsForTopicAsync(topicId)).ReturnsAsync(list);
+            publicationRepository.Setup(s => s.GetAllPublicationsForTopic(topicId)).ReturnsAsync(list);
 
             var result = publicationService.GetMyPublicationsAndReleasesByTopic(topicId).Result.Left;
             Assert.IsAssignableFrom<ForbidResult>(result);
@@ -80,15 +81,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             userService.Setup(s => s.MatchesPolicy(SecurityPolicies.CanViewAllReleases)).ReturnsAsync(true);
 
-            var list = new List<MyPublicationViewModel>()
+            var list = new List<MyPublicationViewModel>
             {
-                new MyPublicationViewModel
+                new()
                 {
                     Id = Guid.NewGuid()
                 }
             };
 
-            publicationRepository.Setup(s => s.GetAllPublicationsForTopicAsync(topicId)).ReturnsAsync(list);
+            publicationRepository.Setup(s => s.GetAllPublicationsForTopic(topicId)).ReturnsAsync(list);
 
             var result = publicationService.GetMyPublicationsAndReleasesByTopic(topicId).Result.Right;
             Assert.Equal(list, result);
@@ -98,7 +99,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             userService.Verify(s => s.MatchesPolicy(SecurityPolicies.CanViewAllReleases));
             userService.VerifyNoOtherCalls();
 
-            publicationRepository.Verify(s => s.GetAllPublicationsForTopicAsync(topicId));
+            publicationRepository.Verify(s => s.GetAllPublicationsForTopic(topicId));
             publicationRepository.VerifyNoOtherCalls();
         }
 
@@ -120,9 +121,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             userService.Setup(s => s.GetUserId()).Returns(userId);
 
-            var list = new List<MyPublicationViewModel>()
+            var list = new List<MyPublicationViewModel>
             {
-                new MyPublicationViewModel
+                new()
                 {
                     Id = Guid.NewGuid()
                 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/Interfaces/IMyPublicationMethodologyPermissionsPropertyResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/Interfaces/IMyPublicationMethodologyPermissionsPropertyResolver.cs
@@ -1,0 +1,13 @@
+﻿#nullable enable
+using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces
+{
+    public interface IMyPublicationMethodologyPermissionsPropertyResolver :
+        IValueResolver<PublicationMethodology, MyPublicationMethodologyViewModel,
+            MyPublicationMethodologyViewModel.PermissionsSet>
+    {
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -95,6 +95,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                     m => m.MapFrom(model => model.InternalReleaseNote))
                 .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyMethodologyPermissionSetPropertyResolver>());
 
+            CreateMap<PublicationMethodology, MyPublicationMethodologyViewModel>()
+                .ForMember(dest => dest.Methodology,
+                    m => m.MapFrom(pm => pm.MethodologyParent.LatestVersion()));
+
             CreateMap<Publication, MyPublicationViewModel>()
                 .ForMember(
                     dest => dest.ThemeId,
@@ -104,11 +108,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                         .FindAll(r => IsLatestVersionOfRelease(p.Releases, r.Id))
                         .OrderByDescending(r => r.Year)
                         .ThenByDescending(r => r.TimePeriodCoverage)))
-                .ForMember(dest => dest.Methodologies, m => m.MapFrom(p => 
-                    p.Methodologies
-                        .Select(methodologyLink => methodologyLink.MethodologyParent.LatestVersion())
-                        .OrderBy(methodology => methodology.Title)))
-                .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyPublicationPermissionSetPropertyResolver>());
+                .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyPublicationPermissionSetPropertyResolver>())
+                .AfterMap((publication, model) => model.Methodologies = model.Methodologies.OrderBy(m => m.Methodology.Title).ToList());
 
             CreateMap<Contact, ContactViewModel>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -97,7 +97,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
 
             CreateMap<PublicationMethodology, MyPublicationMethodologyViewModel>()
                 .ForMember(dest => dest.Methodology,
-                    m => m.MapFrom(pm => pm.MethodologyParent.LatestVersion()));
+                    m => m.MapFrom(pm => pm.MethodologyParent.LatestVersion()))
+                .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyPublicationMethodologyPermissionsPropertyResolver>());
 
             CreateMap<Publication, MyPublicationViewModel>()
                 .ForMember(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyPublicationMethodologyPermissionsPropertyResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyPublicationMethodologyPermissionsPropertyResolver.cs
@@ -1,0 +1,37 @@
+﻿#nullable enable
+using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using static GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.MyPublicationMethodologyViewModel;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
+{
+    public class MyPublicationMethodologyPermissionsPropertyResolver
+        : IMyPublicationMethodologyPermissionsPropertyResolver
+    {
+        private readonly IUserService _userService;
+
+        public MyPublicationMethodologyPermissionsPropertyResolver(IUserService userService)
+        {
+            _userService = userService;
+        }
+
+        public PermissionsSet Resolve(
+            PublicationMethodology source,
+            MyPublicationMethodologyViewModel destination,
+            PermissionsSet destMember,
+            ResolutionContext context)
+        {
+            return new PermissionsSet
+            {
+                CanDropMethodology = _userService
+                    .CheckCanDropMethodologyLink(source)
+                    .Result
+                    .IsRight
+            };
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/DropMethodologyLinkAuthorizationHandler.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/DropMethodologyLinkAuthorizationHandler.cs
@@ -1,0 +1,53 @@
+﻿#nullable enable
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using Microsoft.AspNetCore.Authorization;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
+{
+    public class DropMethodologyLinkRequirement : IAuthorizationRequirement
+    {
+    }
+
+    public class DropMethodologyLinkAuthorizationHandler
+        : AuthorizationHandler<DropMethodologyLinkRequirement, PublicationMethodology>
+    {
+        private readonly IUserPublicationRoleRepository _userPublicationRoleRepository;
+
+        public DropMethodologyLinkAuthorizationHandler(
+            IUserPublicationRoleRepository userPublicationRoleRepository)
+        {
+            _userPublicationRoleRepository = userPublicationRoleRepository;
+        }
+
+        protected override async Task HandleRequirementAsync(
+            AuthorizationHandlerContext context,
+            DropMethodologyLinkRequirement requirement,
+            PublicationMethodology link)
+        {
+            if (link.Owner)
+            {
+                // No user is allowed to drop the link between a methodology and its owning publication 
+                return;
+            }
+
+            // Allow users who can adopt methodologies to also drop them
+
+            if (SecurityUtils.HasClaim(context.User, AdoptAnyMethodology))
+            {
+                context.Succeed(requirement);
+                return;
+            }
+
+            if (await _userPublicationRoleRepository.IsUserPublicationOwner(
+                context.User.GetUserId(),
+                link.PublicationId))
+            {
+                context.Succeed(requirement);
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityPolicies.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/SecurityPolicies.cs
@@ -63,6 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
          */
         CanAdoptMethodologyForSpecificPublication,
         CanCreateMethodologyForSpecificPublication,
+        CanDropMethodologyLink,
         CanManageExternalMethodologyForSpecificPublication,
         CanViewSpecificMethodology,
         CanUpdateSpecificMethodology,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
@@ -169,6 +169,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
                 options.AddPolicy(SecurityPolicies.CanCreateMethodologyForSpecificPublication.ToString(), policy =>
                     policy.Requirements.Add(new CreateMethodologyForSpecificPublicationRequirement()));
 
+                // does this user have permission to drop a link to an adopted Methodology?
+                options.AddPolicy(SecurityPolicies.CanDropMethodologyLink.ToString(), policy =>
+                    policy.Requirements.Add(new DropMethodologyLinkRequirement()));
+
                 // does this user have permission to manage the external methodology for a specific Publication?
                 options.AddPolicy(SecurityPolicies.CanManageExternalMethodologyForSpecificPublication.ToString(),
                     policy =>
@@ -251,6 +255,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
              * Methodology management
              */
             services.AddTransient<IAuthorizationHandler, AdoptMethodologyForSpecificPublicationAuthorizationHandler>();
+            services.AddTransient<IAuthorizationHandler, DropMethodologyLinkAuthorizationHandler>();
             services.AddTransient<IAuthorizationHandler, ViewSpecificMethodologyAuthorizationHandler>();
             services.AddTransient<IAuthorizationHandler, UpdateSpecificMethodologyAuthorizationHandler>();
             services.AddTransient<IAuthorizationHandler, MethodologyStatusAuthorizationHandlers.MarkSpecificMethodologyAsDraftAuthorizationHandler>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IPublicationRepository.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -8,7 +9,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
 {
     public interface IPublicationRepository
     {
-        Task<List<MyPublicationViewModel>> GetAllPublicationsForTopicAsync(Guid topicId);
+        Task<List<MyPublicationViewModel>> GetAllPublicationsForTopic(Guid topicId);
 
         Task<List<MyPublicationViewModel>> GetPublicationsForTopicRelatedToUser(Guid topicId, Guid userId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
@@ -26,6 +26,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
             return userService.CheckPolicy(SecurityPolicies.CanAccessPrereleasePages);
         }
 
+        public static Task<Either<ActionResult, PublicationMethodology>> CheckCanDropMethodologyLink(
+            this IUserService userService, PublicationMethodology methodology)
+        {
+            return userService.CheckPolicy(methodology, SecurityPolicies.CanDropMethodologyLink);
+        }
+
         public static Task<Either<ActionResult, Unit>> CheckCanManageAllUsers(this IUserService userService)
         {
             return userService.CheckPolicy(SecurityPolicies.CanManageUsersOnSystem);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationRepository.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,12 +25,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             _mapper = mapper;
         }
 
-        public async Task<List<MyPublicationViewModel>> GetAllPublicationsForTopicAsync(Guid topicId)
+        public async Task<List<MyPublicationViewModel>> GetAllPublicationsForTopic(Guid topicId)
         {
             var results = await HydratePublicationForPublicationViewModel(_context.Publications)
                 .Where(publication => publication.TopicId == topicId)
                 .ToListAsync();
-                
+
             return results
                 .Select(publication => _mapper.Map<MyPublicationViewModel>(publication))
                 .ToList();
@@ -92,7 +93,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             var userReleaseIdsForPublication = await _context
                 .UserReleaseRoles
                 .Include(r => r.Release)
-                .Where(r => r.UserId == userId && r.Release.PublicationId == publicationId && r.Role != ReleaseRole.PrereleaseViewer)
+                .Where(r => r.UserId == userId
+                            && r.Release.PublicationId == publicationId
+                            && r.Role != ReleaseRole.PrereleaseViewer)
                 .Select(r => r.ReleaseId)
                 .Distinct()
                 .ToListAsync();
@@ -107,7 +110,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             return _mapper.Map<MyPublicationViewModel>(hydratedPublication);
         }
-        
+
         public async Task<Release?> GetLatestReleaseForPublication(Guid publicationId)
         {
             var publication = await _context
@@ -117,7 +120,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             return publication.LatestRelease();
         }
-
 
         private async Task<MyPublicationViewModel> GetPublicationWithFilteredReleases(Guid publicationId,
             IEnumerable<Guid> releaseIds)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -55,7 +55,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             return await _userService
                 .CheckCanAccessSystem()
                 .OnSuccess(_ => _userService.CheckCanViewAllReleases()
-                    .OnSuccess(() => _publicationRepository.GetAllPublicationsForTopicAsync(topicId))
+                    .OnSuccess(() => _publicationRepository.GetAllPublicationsForTopic(topicId))
                     .OrElse(() => _publicationRepository.GetPublicationsForTopicRelatedToUser(topicId, userId))
                 );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -203,9 +203,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.Configure<RouteOptions>(options => options.LowercaseUrls = true);
 
             services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
-            services.AddTransient<IMyReleasePermissionSetPropertyResolver, MyReleasePermissionSetPropertyResolver>();
-            services.AddTransient<IMyPublicationPermissionSetPropertyResolver, MyPublicationPermissionSetPropertyResolver>();
-            services.AddTransient<IMyMethodologyPermissionSetPropertyResolver, MyMethodologyPermissionSetPropertyResolver>();
+            services.AddTransient<IMyReleasePermissionSetPropertyResolver,
+                MyReleasePermissionSetPropertyResolver>();
+            services.AddTransient<IMyPublicationPermissionSetPropertyResolver,
+                MyPublicationPermissionSetPropertyResolver>();
+            services.AddTransient<IMyPublicationMethodologyPermissionsPropertyResolver,
+                MyPublicationMethodologyPermissionsPropertyResolver>();
+            services.AddTransient<IMyMethodologyPermissionSetPropertyResolver,
+                MyMethodologyPermissionSetPropertyResolver>();
 
             services.AddMvc(options =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -99,7 +99,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         MethodologyCannotDependOnPublishedRelease,
         MethodologyCannotDependOnRelease,
         CannotAdoptMethodologyAlreadyLinkedToPublication,
-        CannotDropOwnedMethodology,
 
         // Theme
         ThemeDoesNotExist,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyMethodologyViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyMethodologyViewModel.cs
@@ -12,9 +12,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         [JsonConverter(typeof(StringEnumConverter))]
         public MethodologyStatus Status { get; set; }
-        
+
         public bool Amendment { get; set; }
-        
+
         public Guid PreviousVersionId { get; set; }
 
         public DateTime? Published { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationMethodologyViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationMethodologyViewModel.cs
@@ -1,0 +1,10 @@
+﻿#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
+{
+    public class MyPublicationMethodologyViewModel
+    {
+        public bool Owner { get; set; }
+
+        public MyMethodologyViewModel Methodology { get; set; } = null!;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationMethodologyViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationMethodologyViewModel.cs
@@ -6,5 +6,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public bool Owner { get; set; }
 
         public MyMethodologyViewModel Methodology { get; set; } = null!;
+
+        public PermissionsSet Permissions { get; set; } = new PermissionsSet();
+
+        public class PermissionsSet
+        {
+            public bool CanDropMethodology { get; set; }
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationViewModel.cs
@@ -13,8 +13,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public DateTime? NextUpdate { get; set; }
 
         public List<MyReleaseViewModel> Releases { get; set; }
-        
-        public List<MyMethodologyViewModel> Methodologies { get; set; }
+
+        public List<MyPublicationMethodologyViewModel> Methodologies { get; set; }
 
         public ExternalMethodology ExternalMethodology { get; set; }
         

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -223,8 +223,9 @@ const MethodologySummary = ({
               data-testid={`Create methodology for ${title}`}
               disabled={showAddEditExternalMethodologyForm}
               onClick={async () => {
-                const { id: methodologyId } =
-                  await methodologyService.createMethodology(publicationId);
+                const {
+                  id: methodologyId,
+                } = await methodologyService.createMethodology(publicationId);
                 history.push(
                   generatePath<MethodologyRouteParams>(
                     methodologySummaryRoute.path,
@@ -294,10 +295,9 @@ const MethodologySummary = ({
         <ModalConfirm
           title="Confirm you want to amend this live methodology"
           onConfirm={async () => {
-            const amendment =
-              await methodologyService.createMethodologyAmendment(
-                amendMethodologyId,
-              );
+            const amendment = await methodologyService.createMethodologyAmendment(
+              amendMethodologyId,
+            );
             history.push(
               generatePath<MethodologyRouteParams>(
                 methodologySummaryRoute.path,

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/MethodologySummary.tsx
@@ -102,7 +102,9 @@ const MethodologySummary = ({
 
   return (
     <>
-      {methodologies.map(methodology => {
+      {methodologies.map(publicationMethodologyLink => {
+        const { methodology } = publicationMethodologyLink;
+
         const canEdit =
           methodology.permissions.canApproveMethodology ||
           methodology.permissions.canMarkMethodologyAsDraft ||
@@ -221,9 +223,8 @@ const MethodologySummary = ({
               data-testid={`Create methodology for ${title}`}
               disabled={showAddEditExternalMethodologyForm}
               onClick={async () => {
-                const {
-                  id: methodologyId,
-                } = await methodologyService.createMethodology(publicationId);
+                const { id: methodologyId } =
+                  await methodologyService.createMethodology(publicationId);
                 history.push(
                   generatePath<MethodologyRouteParams>(
                     methodologySummaryRoute.path,
@@ -293,9 +294,10 @@ const MethodologySummary = ({
         <ModalConfirm
           title="Confirm you want to amend this live methodology"
           onConfirm={async () => {
-            const amendment = await methodologyService.createMethodologyAmendment(
-              amendMethodologyId,
-            );
+            const amendment =
+              await methodologyService.createMethodologyAmendment(
+                amendMethodologyId,
+              );
             history.push(
               generatePath<MethodologyRouteParams>(
                 methodologySummaryRoute.path,

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -103,17 +103,17 @@ const testPublicationNoMethodology: MyPublication = {
 
 const testPublicationWithMethodology = {
   ...testPublicationNoMethodology,
-  methodologies: [testMethodology],
+  methodologies: [{ owner: true, methodology: testMethodology }],
 };
 
 const testPublicationWithDraftMethodology = {
   ...testPublicationWithMethodology,
-  methodologies: [testDraftMethodology],
+  methodologies: [{ owner: true, methodology: testDraftMethodology }],
 };
 
 const testPublicationWithAmendmentMethodology = {
   ...testPublicationWithMethodology,
-  methodologies: [testAmendmentMethodology],
+  methodologies: [{ owner: true, methodology: testAmendmentMethodology }],
 };
 
 const testPublicationWithExternalMethodology = {
@@ -122,15 +122,17 @@ const testPublicationWithExternalMethodology = {
 };
 const testPublicationWithMethodologyCanAmend = {
   ...testPublicationWithMethodology,
-  methodologies: [testMethodologyCanAmend],
+  methodologies: [{ owner: true, methodology: testMethodologyCanAmend }],
 };
 const testPublicationWithMethodologyCanCancelAmend = {
   ...testPublicationWithMethodology,
-  methodologies: [testMethodologyCanRemoveAmendment],
+  methodologies: [
+    { owner: true, methodology: testMethodologyCanRemoveAmendment },
+  ],
 };
 const testPublicationWithMethodologyCanRemove = {
   ...testPublicationWithMethodology,
-  methodologies: [testMethodologyCanRemove],
+  methodologies: [{ owner: true, methodology: testMethodologyCanRemove }],
 };
 
 const testTopicId = 'topic-id';
@@ -363,10 +365,13 @@ describe('MethodologySummary', () => {
               ...testPublicationNoMethodology,
               methodologies: [
                 {
-                  ...testMethodology,
-                  permissions: {
-                    ...testMethodology.permissions,
-                    canApproveMethodology: true,
+                  owner: true,
+                  methodology: {
+                    ...testMethodology,
+                    permissions: {
+                      ...testMethodology.permissions,
+                      canApproveMethodology: true,
+                    },
                   },
                 },
               ],
@@ -398,10 +403,13 @@ describe('MethodologySummary', () => {
               ...testPublicationNoMethodology,
               methodologies: [
                 {
-                  ...testMethodology,
-                  permissions: {
-                    ...testMethodology.permissions,
-                    canMarkMethodologyAsDraft: true,
+                  owner: true,
+                  methodology: {
+                    ...testMethodology,
+                    permissions: {
+                      ...testMethodology.permissions,
+                      canMarkMethodologyAsDraft: true,
+                    },
                   },
                 },
               ],
@@ -433,10 +441,13 @@ describe('MethodologySummary', () => {
               ...testPublicationNoMethodology,
               methodologies: [
                 {
-                  ...testMethodology,
-                  permissions: {
-                    ...testMethodology.permissions,
-                    canUpdateMethodology: true,
+                  owner: true,
+                  methodology: {
+                    ...testMethodology,
+                    permissions: {
+                      ...testMethodology.permissions,
+                      canUpdateMethodology: true,
+                    },
                   },
                 },
               ],
@@ -516,11 +527,14 @@ describe('MethodologySummary', () => {
               ...testPublicationNoMethodology,
               methodologies: [
                 {
-                  ...testMethodology,
-                  amendment: true,
-                  permissions: {
-                    ...testMethodology.permissions,
-                    canApproveMethodology: true,
+                  owner: true,
+                  methodology: {
+                    ...testMethodology,
+                    amendment: true,
+                    permissions: {
+                      ...testMethodology.permissions,
+                      canApproveMethodology: true,
+                    },
                   },
                 },
               ],
@@ -552,11 +566,14 @@ describe('MethodologySummary', () => {
               ...testPublicationNoMethodology,
               methodologies: [
                 {
-                  ...testMethodology,
-                  amendment: true,
-                  permissions: {
-                    ...testMethodology.permissions,
-                    canMarkMethodologyAsDraft: true,
+                  owner: true,
+                  methodology: {
+                    ...testMethodology,
+                    amendment: true,
+                    permissions: {
+                      ...testMethodology.permissions,
+                      canMarkMethodologyAsDraft: true,
+                    },
                   },
                 },
               ],
@@ -588,11 +605,14 @@ describe('MethodologySummary', () => {
               ...testPublicationNoMethodology,
               methodologies: [
                 {
-                  ...testMethodology,
-                  amendment: true,
-                  permissions: {
-                    ...testMethodology.permissions,
-                    canUpdateMethodology: true,
+                  owner: true,
+                  methodology: {
+                    ...testMethodology,
+                    amendment: true,
+                    permissions: {
+                      ...testMethodology.permissions,
+                      canUpdateMethodology: true,
+                    },
                   },
                 },
               ],
@@ -775,7 +795,8 @@ describe('MethodologySummary', () => {
 
       await waitFor(() => {
         expect(methodologyService.deleteMethodology).toHaveBeenCalledWith(
-          testPublicationWithMethodologyCanAmend.methodologies[0].id,
+          testPublicationWithMethodologyCanAmend.methodologies[0].methodology
+            .id,
         );
       });
     });
@@ -895,7 +916,8 @@ describe('MethodologySummary', () => {
         expect(
           methodologyService.createMethodologyAmendment,
         ).toHaveBeenCalledWith(
-          testPublicationWithMethodologyCanAmend.methodologies[0].id,
+          testPublicationWithMethodologyCanAmend.methodologies[0].methodology
+            .id,
         );
         expect(history.push).toBeCalledWith(
           `/methodology/${mockMethodology.id}/summary`,
@@ -990,7 +1012,8 @@ describe('MethodologySummary', () => {
 
       await waitFor(() => {
         expect(methodologyService.deleteMethodology).toHaveBeenCalledWith(
-          testPublicationWithMethodologyCanAmend.methodologies[0].id,
+          testPublicationWithMethodologyCanAmend.methodologies[0].methodology
+            .id,
         );
       });
     });

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -103,17 +103,35 @@ const testPublicationNoMethodology: MyPublication = {
 
 const testPublicationWithMethodology = {
   ...testPublicationNoMethodology,
-  methodologies: [{ owner: true, methodology: testMethodology }],
+  methodologies: [
+    {
+      owner: true,
+      permissions: { canDropMethodology: false },
+      methodology: testMethodology,
+    },
+  ],
 };
 
 const testPublicationWithDraftMethodology = {
   ...testPublicationWithMethodology,
-  methodologies: [{ owner: true, methodology: testDraftMethodology }],
+  methodologies: [
+    {
+      owner: true,
+      permissions: { canDropMethodology: false },
+      methodology: testDraftMethodology,
+    },
+  ],
 };
 
 const testPublicationWithAmendmentMethodology = {
   ...testPublicationWithMethodology,
-  methodologies: [{ owner: true, methodology: testAmendmentMethodology }],
+  methodologies: [
+    {
+      owner: true,
+      permissions: { canDropMethodology: false },
+      methodology: testAmendmentMethodology,
+    },
+  ],
 };
 
 const testPublicationWithExternalMethodology = {
@@ -122,17 +140,33 @@ const testPublicationWithExternalMethodology = {
 };
 const testPublicationWithMethodologyCanAmend = {
   ...testPublicationWithMethodology,
-  methodologies: [{ owner: true, methodology: testMethodologyCanAmend }],
+  methodologies: [
+    {
+      owner: true,
+      permissions: { canDropMethodology: false },
+      methodology: testMethodologyCanAmend,
+    },
+  ],
 };
 const testPublicationWithMethodologyCanCancelAmend = {
   ...testPublicationWithMethodology,
   methodologies: [
-    { owner: true, methodology: testMethodologyCanRemoveAmendment },
+    {
+      owner: true,
+      permissions: { canDropMethodology: false },
+      methodology: testMethodologyCanRemoveAmendment,
+    },
   ],
 };
 const testPublicationWithMethodologyCanRemove = {
   ...testPublicationWithMethodology,
-  methodologies: [{ owner: true, methodology: testMethodologyCanRemove }],
+  methodologies: [
+    {
+      owner: true,
+      permissions: { canDropMethodology: false },
+      methodology: testMethodologyCanRemove,
+    },
+  ],
 };
 
 const testTopicId = 'topic-id';
@@ -365,13 +399,16 @@ describe('MethodologySummary', () => {
               ...testPublicationNoMethodology,
               methodologies: [
                 {
-                  owner: true,
                   methodology: {
                     ...testMethodology,
                     permissions: {
                       ...testMethodology.permissions,
                       canApproveMethodology: true,
                     },
+                  },
+                  owner: true,
+                  permissions: {
+                    canDropMethodology: false,
                   },
                 },
               ],
@@ -403,13 +440,16 @@ describe('MethodologySummary', () => {
               ...testPublicationNoMethodology,
               methodologies: [
                 {
-                  owner: true,
                   methodology: {
                     ...testMethodology,
                     permissions: {
                       ...testMethodology.permissions,
                       canMarkMethodologyAsDraft: true,
                     },
+                  },
+                  owner: true,
+                  permissions: {
+                    canDropMethodology: false,
                   },
                 },
               ],
@@ -441,13 +481,16 @@ describe('MethodologySummary', () => {
               ...testPublicationNoMethodology,
               methodologies: [
                 {
-                  owner: true,
                   methodology: {
                     ...testMethodology,
                     permissions: {
                       ...testMethodology.permissions,
                       canUpdateMethodology: true,
                     },
+                  },
+                  owner: true,
+                  permissions: {
+                    canDropMethodology: false,
                   },
                 },
               ],
@@ -527,7 +570,6 @@ describe('MethodologySummary', () => {
               ...testPublicationNoMethodology,
               methodologies: [
                 {
-                  owner: true,
                   methodology: {
                     ...testMethodology,
                     amendment: true,
@@ -535,6 +577,10 @@ describe('MethodologySummary', () => {
                       ...testMethodology.permissions,
                       canApproveMethodology: true,
                     },
+                  },
+                  owner: true,
+                  permissions: {
+                    canDropMethodology: false,
                   },
                 },
               ],
@@ -566,7 +612,6 @@ describe('MethodologySummary', () => {
               ...testPublicationNoMethodology,
               methodologies: [
                 {
-                  owner: true,
                   methodology: {
                     ...testMethodology,
                     amendment: true,
@@ -574,6 +619,10 @@ describe('MethodologySummary', () => {
                       ...testMethodology.permissions,
                       canMarkMethodologyAsDraft: true,
                     },
+                  },
+                  owner: true,
+                  permissions: {
+                    canDropMethodology: false,
                   },
                 },
               ],
@@ -605,7 +654,6 @@ describe('MethodologySummary', () => {
               ...testPublicationNoMethodology,
               methodologies: [
                 {
-                  owner: true,
                   methodology: {
                     ...testMethodology,
                     amendment: true,
@@ -613,6 +661,10 @@ describe('MethodologySummary', () => {
                       ...testMethodology.permissions,
                       canUpdateMethodology: true,
                     },
+                  },
+                  owner: true,
+                  permissions: {
+                    canDropMethodology: false,
                   },
                 },
               ],

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -34,7 +34,7 @@ export interface ExternalMethodology {
 export interface MyPublication {
   id: string;
   title: string;
-  methodologies: MyMethodology[];
+  methodologies: MyPublicationMethodology[];
   externalMethodology?: ExternalMethodology;
   releases: MyRelease[];
   contact?: PublicationContactDetails;
@@ -44,6 +44,11 @@ export interface MyPublication {
     canCreateMethodologies: boolean;
     canManageExternalMethodology: boolean;
   };
+}
+
+export interface MyPublicationMethodology {
+  owner: boolean;
+  methodology: MyMethodology;
 }
 
 export interface BasicPublicationDetails {

--- a/src/explore-education-statistics-admin/src/services/publicationService.ts
+++ b/src/explore-education-statistics-admin/src/services/publicationService.ts
@@ -49,6 +49,9 @@ export interface MyPublication {
 export interface MyPublicationMethodology {
   owner: boolean;
   methodology: MyMethodology;
+  permissions: {
+    canDropMethodology: boolean;
+  };
 }
 
 export interface BasicPublicationDetails {


### PR DESCRIPTION
This PR alters the `MyPublicationViewModel` to change the list of methodologies to be a list of `MyPublicationMethodologyViewModel` representing the links between publications and methodologies.

This has the `Owner` property which is true if this publication owns the methodology and will allow the front end to distinguish the methodology for a publication as the primary methodology from other adopted methodologies.

It also has a `Permissions` property with a permission `CanDropMethodology`. This allows a front end decision to be made on whether to allow dropping the link.

Here is a sample back end response (abbreviated) showing what this would appear as for two methodologies, one owned by the publication and the other adopted from a different publication, where the user is a BAU user or a Publication Owner who has permission to drop methodology links:

```
"methodologies": [
    {
      "owner": false,
      "methodology": {
        "id": "",
        "title": "Another methodology"
      },
      "permissions": { "canDropMethodology": true }
    },
    {
      "owner": true,
      "methodology": {
        "id": "33da002a-f0ef-4605-0676-08d96c728f61",
        "title": "Methodology owned by this publication"
      },
      "permissions": { "canDropMethodology": false }
    }
  ],
```

