### PR TITLE
EES-2284 Return MethodologySummaryViewModel  as result of getting the adoptable methodologies

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
@@ -87,7 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             methodologyService
                 .Setup(s => s.GetAdoptableMethodologies(_id))
-                .ReturnsAsync(AsList(new TitleAndIdViewModel()));
+                .ReturnsAsync(AsList(new MethodologySummaryViewModel()));
 
             var controller = SetupMethodologyController(methodologyService.Object);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyController.cs
@@ -53,7 +53,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
         }
 
         [HttpGet("publication/{publicationId}/adoptable-methodologies")]
-        public async Task<ActionResult<List<TitleAndIdViewModel>>> GetAdoptableMethodologies(Guid publicationId)
+        public async Task<ActionResult<List<MethodologySummaryViewModel>>> GetAdoptableMethodologies(Guid publicationId)
         {
             return await _methodologyService
                 .GetAdoptableMethodologies(publicationId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
@@ -17,7 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 
         Task<Either<ActionResult, Unit>> DropMethodology(Guid publicationId, Guid methodologyId);
 
-        Task<Either<ActionResult, List<TitleAndIdViewModel>>> GetAdoptableMethodologies(Guid publicationId);
+        Task<Either<ActionResult, List<MethodologySummaryViewModel>>> GetAdoptableMethodologies(Guid publicationId);
 
         Task<Either<ActionResult, MethodologySummaryViewModel>> GetSummary(Guid id);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologySummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologySummaryViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Newtonsoft.Json;
@@ -10,26 +11,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
     {
         public Guid Id { get; set; }
 
-        public string LatestInternalReleaseNote { get; set; }
+        public Guid MethodologyParentId { get; set; }
+
+        public string? LatestInternalReleaseNote { get; set; }
 
         public TitleAndIdViewModel OwningPublication { get; set; }
 
-        public List<TitleAndIdViewModel> OtherPublications { get; set; }
+        public List<TitleAndIdViewModel> OtherPublications { get; set; } = new List<TitleAndIdViewModel>();
 
         public DateTime? Published { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public MethodologyPublishingStrategy PublishingStrategy { get; set; }
 
-        public TitleAndIdViewModel ScheduledWithRelease { get; set; }
+        public TitleAndIdViewModel? ScheduledWithRelease { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public MethodologyStatus Status { get; set; }
 
-        public string Title { get; set; }
+        public string Title { get; set; } = string.Empty;
 
         public bool Amendment { get; set; }
 
-        public Guid PreviousVersionId { get; set; }
+        public Guid? PreviousVersionId { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyRepository.cs
@@ -9,6 +9,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.In
     {
         Task<Methodology> CreateMethodologyForPublication(Guid publicationId, Guid createdByUserId);
 
+        Task<Methodology> GetLatestByMethodologyParent(Guid methodologyParentId);
+
         Task<List<Methodology>> GetLatestByPublication(Guid publicationId);
 
         Task<Methodology?> GetLatestPublishedByMethodologyParent(Guid methodologyParentId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
@@ -54,10 +54,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
             return methodology;
         }
 
+        public async Task<Methodology> GetLatestByMethodologyParent(Guid methodologyParentId)
+        {
+            var methodology = await _contentDbContext.MethodologyParents
+                .Include(m => m.Versions)
+                .SingleAsync(mp => mp.Id == methodologyParentId);
+
+            return methodology.LatestVersion();
+        }
+
         public async Task<List<Methodology>> GetLatestByPublication(Guid publicationId)
         {
             // First check the publication exists
-            var publication = await _contentDbContext.Publications.SingleAsync(p => p.Id == publicationId);
+            var publication = await _contentDbContext.Publications
+                .SingleAsync(p => p.Id == publicationId);
 
             var methodologyParents = await _methodologyParentRepository.GetByPublication(publication.Id);
             return (await methodologyParents.SelectAsync(async methodologyParent =>


### PR DESCRIPTION
This PR changes the response of the URL `GET /api/publication/{publicationId}/adoptable-methodologies` to return a list of `MethodologySummaryViewModel` resources rather than `TitleAndIdViewModel`.

This is so that future work on the UI to implement managing adoption of methodologies can show additional details about them such as their status, publication, published date, amendment flag, etc.

It also refactors the various methods of `MethodologyService` that now return a `MethodologySummaryViewModel` to use a common method to build the view model.

The unit tests are enhanced around checking the fields of a `MethodologySummaryViewModel` result to ensure the various fields of it are being mapped correctly.