### PR TITLE
Ees 2662 locations with duplicate codes removed from table tool as hotfix

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -634,11 +634,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var mocks = Mocks();
 
             mocks.locationRepository.Setup(service => service.GetObservationalUnits(replacementSubject.Id))
-                .Returns(new Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>>());
+                .Returns(new Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>>());
 
             mocks.locationRepository
                 .Setup(s => s.GetObservationalUnits(GeographicLevel.Country, new [] { CountryCodeEngland }))
-                .Returns(new List<IObservationalUnit>(new List<IObservationalUnit>
+                .Returns(new List<ObservationalUnit>(new List<ObservationalUnit>
                 {
                     country
                 }));
@@ -1085,7 +1085,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var mocks = Mocks();
 
             mocks.locationRepository.Setup(service => service.GetObservationalUnits(replacementSubject.Id))
-                .Returns(new Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>>
+                .Returns(new Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>>
                 {
                     {
                         GeographicLevel.Country,
@@ -1098,7 +1098,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             mocks.locationRepository
                 .Setup(service => service.GetObservationalUnits(GeographicLevel.Country, new []{ CountryCodeEngland }))
-                .Returns(new List<IObservationalUnit>
+                .Returns(new List<ObservationalUnit>
                 {
                     country
                 });
@@ -1358,7 +1358,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var mocks = Mocks();
 
             mocks.locationRepository.Setup(service => service.GetObservationalUnits(replacementSubject.Id))
-                .Returns(new Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>>
+                .Returns(new Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>>
                 {
                     {
                         GeographicLevel.Country,
@@ -1371,7 +1371,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             mocks.locationRepository
                 .Setup(service => service.GetObservationalUnits(GeographicLevel.Country, new []{ CountryCodeEngland }))
-                .Returns(new List<IObservationalUnit>
+                .Returns(new List<ObservationalUnit>
                 {
                     country
                 });
@@ -1656,7 +1656,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var mocks = Mocks();
 
             mocks.locationRepository.Setup(service => service.GetObservationalUnits(replacementSubject.Id))
-                .Returns(new Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>>
+                .Returns(new Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>>
                 {
                     {
                         GeographicLevel.Country,
@@ -1669,7 +1669,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             mocks.locationRepository
                 .Setup(service => service.GetObservationalUnits(GeographicLevel.Country, new []{ CountryCodeEngland }))
-                .Returns(new List<IObservationalUnit>
+                .Returns(new List<ObservationalUnit>
                 {
                     country
                 });
@@ -2076,7 +2076,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var mocks = Mocks();
 
             mocks.locationRepository.Setup(service => service.GetObservationalUnits(replacementSubject.Id))
-                .Returns(new Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>>
+                .Returns(new Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>>
                 {
                     {
                         GeographicLevel.Country,
@@ -2089,7 +2089,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             mocks.locationRepository
                 .Setup(service => service.GetObservationalUnits(GeographicLevel.Country, new []{ CountryCodeEngland }))
-                .Returns(new List<IObservationalUnit>
+                .Returns(new List<ObservationalUnit>
                 {
                     country
                 });
@@ -2465,7 +2465,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var mocks = Mocks();
 
             mocks.locationRepository.Setup(service => service.GetObservationalUnits(replacementSubject.Id))
-                .Returns(new Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>>());
+                .Returns(new Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>>());
 
             mocks.TimePeriodService.Setup(service => service.GetTimePeriods(replacementSubject.Id))
                 .Returns(new List<(int Year, TimeIdentifier TimeIdentifier)>());
@@ -2887,7 +2887,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var mocks = Mocks();
 
             mocks.locationRepository.Setup(service => service.GetObservationalUnits(replacementSubject.Id))
-                .Returns(new Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>>
+                .Returns(new Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>>
                 {
                     {
                         GeographicLevel.Country,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -510,7 +510,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             var locations = _locationRepository.GetObservationalUnits(geographicLevel, originalCodes);
             var replacementLocations = replacementSubjectMeta.ObservationalUnits
                 .GetValueOrDefault(geographicLevel)
-                ?.ToDictionary(location => location.Code) ?? new Dictionary<string, IObservationalUnit>();
+                ?.ToDictionary(location => location.Code) ?? new Dictionary<string, ObservationalUnit>();
 
             return new LocationReplacementViewModel(
                 label: geographicLevel.GetEnumLabel(),
@@ -521,8 +521,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         private static ObservationalUnitReplacementViewModel ValidateLocationForReplacement(
-            IObservationalUnit location,
-            Dictionary<string, IObservationalUnit> replacementLocations)
+            ObservationalUnit location,
+            Dictionary<string, ObservationalUnit> replacementLocations)
         {
             return new ObservationalUnitReplacementViewModel(
                 label: location.Name,
@@ -928,7 +928,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             public Dictionary<string, Filter> Filters { get; set; }
             public Dictionary<string, Indicator> Indicators { get; set; }
-            public Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>> ObservationalUnits { get; set; }
+            public Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>> ObservationalUnits { get; set; }
             public IEnumerable<(int Year, TimeIdentifier TimeIdentifier)> TimePeriods { get; set; }
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Country.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Country.cs
@@ -1,41 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class Country : IObservationalUnit
+    public class Country : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private Country()
+        public Country()
         {
         }
-
-        public Country(string code, string name)
+        
+        public Country(string code, string name) : base(code, name)
         {
-            Code = code;
-            Name = name;
-        }
-
-        public static Country Empty()
-        {
-            return new Country(null, null);
-        }
-
-        protected bool Equals(Country other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((Country) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Country.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Country.cs
@@ -2,12 +2,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class Country : ObservationalUnit
     {
-        public Country()
+        public Country(string code, string name) : base(code, name)
         {
         }
         
-        public Country(string code, string name) : base(code, name)
+        public static Country Empty()
         {
+            return new Country(null, null);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/EnglishDevolvedArea.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/EnglishDevolvedArea.cs
@@ -1,37 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class EnglishDevolvedArea : IObservationalUnit
+    public class EnglishDevolvedArea : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        public EnglishDevolvedArea(string code, string name)
+        public EnglishDevolvedArea()
         {
-            Code = code;
-            Name = name;
         }
-
-        public static EnglishDevolvedArea Empty()
+        
+        public EnglishDevolvedArea(string code, string name) : base(code, name)
         {
-            return new EnglishDevolvedArea(null, null);
-        }
-
-        protected bool Equals(EnglishDevolvedArea other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((EnglishDevolvedArea) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return Code != null ? Code.GetHashCode() : 0;
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/EnglishDevolvedArea.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/EnglishDevolvedArea.cs
@@ -2,12 +2,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class EnglishDevolvedArea : ObservationalUnit
     {
-        public EnglishDevolvedArea()
-        {
-        }
-        
         public EnglishDevolvedArea(string code, string name) : base(code, name)
         {
+        }
+
+        public static EnglishDevolvedArea Empty()
+        {
+            return new EnglishDevolvedArea(null, null);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/IObservationalUnit.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/IObservationalUnit.cs
@@ -1,8 +1,0 @@
-namespace GovUk.Education.ExploreEducationStatistics.Data.Model
-{
-    public interface IObservationalUnit
-    {
-        string Code { get; set; }
-        string Name { get; }
-    }
-}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Institution.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Institution.cs
@@ -1,41 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class Institution : IObservationalUnit
+    public class Institution : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private Institution()
+        public Institution()
         {
         }
-
-        public Institution(string code, string name)
+        
+        public Institution(string code, string name) : base(code, name)
         {
-            Code = code;
-            Name = name;
-        }
-
-        public static Institution Empty()
-        {
-            return new Institution(null, null);
-        }
-
-        protected bool Equals(Institution other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((Institution) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Institution.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Institution.cs
@@ -2,12 +2,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class Institution : ObservationalUnit
     {
-        public Institution()
+        public Institution(string code, string name) : base(code, name)
         {
         }
         
-        public Institution(string code, string name) : base(code, name)
+        public static Institution Empty()
         {
+            return new Institution(null, null);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthority.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthority.cs
@@ -3,49 +3,22 @@ using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class LocalAuthority : IObservationalUnit
+    public class LocalAuthority : ObservationalUnit
     {
-        public string Code { get; set; }
-        [JsonIgnore] public string OldCode { get; set; }
-        public string Name { get; set; }
+        [JsonIgnore] public string OldCode { get; }
 
         public LocalAuthority()
         {
         }
 
-        public LocalAuthority(string code, string oldCode, string name)
+        public LocalAuthority(string code, string oldCode, string name) : base(code, name)
         {
-            Code = code;
             OldCode = oldCode;
-            Name = name;
-        }
-
-        public static LocalAuthority Empty()
-        {
-            return new LocalAuthority(null, null, null);
         }
 
         public string GetCodeOrOldCodeIfEmpty()
         {
             return Code.IsNullOrEmpty() ? OldCode : Code;
-        }
-
-        protected bool Equals(LocalAuthority other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((LocalAuthority) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthority.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthority.cs
@@ -5,7 +5,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class LocalAuthority : ObservationalUnit
     {
-        [JsonIgnore] public string OldCode { get; }
+        public string OldCode { get; }
 
         public LocalAuthority()
         {
@@ -19,6 +19,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public string GetCodeOrOldCodeIfEmpty()
         {
             return Code.IsNullOrEmpty() ? OldCode : Code;
+        }
+        
+        public static LocalAuthority Empty()
+        {
+            return new LocalAuthority(null, null, null);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthority.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthority.cs
@@ -7,10 +7,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
     {
         public string OldCode { get; }
 
-        public LocalAuthority()
-        {
-        }
-
         public LocalAuthority(string code, string oldCode, string name) : base(code, name)
         {
             OldCode = oldCode;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthorityDistrict.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthorityDistrict.cs
@@ -2,10 +2,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class LocalAuthorityDistrict : ObservationalUnit
     {
-        public LocalAuthorityDistrict()
-        {
-        }
-        
         public LocalAuthorityDistrict(string code, string name) : base(code, name)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthorityDistrict.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthorityDistrict.cs
@@ -1,41 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class LocalAuthorityDistrict: IObservationalUnit
+    public class LocalAuthorityDistrict : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private LocalAuthorityDistrict()
+        public LocalAuthorityDistrict()
         {
         }
-
-        public LocalAuthorityDistrict(string code, string name)
+        
+        public LocalAuthorityDistrict(string code, string name) : base(code, name)
         {
-            Code = code;
-            Name = name;
-        }
-
-        public static LocalAuthorityDistrict Empty()
-        {
-            return new LocalAuthorityDistrict(null, null);
-        }
-
-        protected bool Equals(LocalAuthorityDistrict other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((LocalAuthorityDistrict) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthorityDistrict.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthorityDistrict.cs
@@ -9,5 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public LocalAuthorityDistrict(string code, string name) : base(code, name)
         {
         }
+        
+        public static LocalAuthorityDistrict Empty()
+        {
+            return new LocalAuthorityDistrict(null, null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalEnterprisePartnership.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalEnterprisePartnership.cs
@@ -2,10 +2,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class LocalEnterprisePartnership : ObservationalUnit
     {
-        public LocalEnterprisePartnership()
-        {
-        }
-        
         public LocalEnterprisePartnership(string code, string name) : base(code, name)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalEnterprisePartnership.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalEnterprisePartnership.cs
@@ -9,5 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public LocalEnterprisePartnership(string code, string name) : base(code, name)
         {
         }
+        
+        public static LocalEnterprisePartnership Empty()
+        {
+            return new LocalEnterprisePartnership(null, null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalEnterprisePartnership.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalEnterprisePartnership.cs
@@ -1,41 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class LocalEnterprisePartnership : IObservationalUnit
+    public class LocalEnterprisePartnership : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private LocalEnterprisePartnership()
+        public LocalEnterprisePartnership()
         {
         }
-
-        public LocalEnterprisePartnership(string code, string name)
+        
+        public LocalEnterprisePartnership(string code, string name) : base(code, name)
         {
-            Code = code;
-            Name = name;
-        }
-
-        public static LocalEnterprisePartnership Empty()
-        {
-            return new LocalEnterprisePartnership(null, null);
-        }
-
-        protected bool Equals(LocalEnterprisePartnership other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((LocalEnterprisePartnership) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Mat.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Mat.cs
@@ -5,10 +5,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
     /// </summary>
     public class Mat : ObservationalUnit
     {
-        public Mat()
-        {
-        }
-        
         public Mat(string code, string name) : base(code, name)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Mat.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Mat.cs
@@ -12,5 +12,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public Mat(string code, string name) : base(code, name)
         {
         }
+        
+        public static Mat Empty()
+        {
+            return new Mat(null, null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Mat.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Mat.cs
@@ -3,42 +3,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
     /// <summary>
     /// Multi academy trust
     /// </summary>
-    public class Mat : IObservationalUnit
+    public class Mat : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private Mat()
+        public Mat()
         {
         }
-
-        public Mat(string code, string name)
+        
+        public Mat(string code, string name) : base(code, name)
         {
-            Code = code;
-            Name = name;
-        }
-
-        public static Mat Empty()
-        {
-            return new Mat(null, null);
-        }
-
-        protected bool Equals(Mat other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((Mat) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/MayoralCombinedAuthority.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/MayoralCombinedAuthority.cs
@@ -1,41 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class MayoralCombinedAuthority : IObservationalUnit
+    public class MayoralCombinedAuthority : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private MayoralCombinedAuthority()
+        public MayoralCombinedAuthority()
         {
         }
-
-        public MayoralCombinedAuthority(string code, string name)
+        
+        public MayoralCombinedAuthority(string code, string name) : base(code, name)
         {
-            Code = code;
-            Name = name;
-        }
-
-        public static MayoralCombinedAuthority Empty()
-        {
-            return new MayoralCombinedAuthority(null, null);
-        }
-
-        protected bool Equals(MayoralCombinedAuthority other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((MayoralCombinedAuthority) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/MayoralCombinedAuthority.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/MayoralCombinedAuthority.cs
@@ -9,5 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public MayoralCombinedAuthority(string code, string name) : base(code, name)
         {
         }
+        
+        public static MayoralCombinedAuthority Empty()
+        {
+            return new MayoralCombinedAuthority(null, null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/MayoralCombinedAuthority.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/MayoralCombinedAuthority.cs
@@ -2,10 +2,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class MayoralCombinedAuthority : ObservationalUnit
     {
-        public MayoralCombinedAuthority()
-        {
-        }
-        
         public MayoralCombinedAuthority(string code, string name) : base(code, name)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ObservationalUnit.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ObservationalUnit.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model
+{
+    public abstract class ObservationalUnit
+    {
+        public string Code { get; }
+        public string Name { get; }
+        
+        protected ObservationalUnit()
+        {
+        }
+
+        protected ObservationalUnit(string code, string name)
+        {
+            Code = code;
+            Name = name;
+        }
+        
+        protected bool Equals(ObservationalUnit other)
+        {
+            return Code == other.Code && Name == other.Name;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((ObservationalUnit)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Code, Name);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/OpportunityArea.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/OpportunityArea.cs
@@ -9,5 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public OpportunityArea(string code, string name) : base(code, name)
         {
         }
+        
+        public static OpportunityArea Empty()
+        {
+            return new OpportunityArea(null, null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/OpportunityArea.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/OpportunityArea.cs
@@ -1,41 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class OpportunityArea : IObservationalUnit
+    public class OpportunityArea : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private OpportunityArea()
+        public OpportunityArea()
         {
         }
-
-        public OpportunityArea(string code, string name)
+        
+        public OpportunityArea(string code, string name) : base(code, name)
         {
-            Code = code;
-            Name = name;
-        }
-
-        public static OpportunityArea Empty()
-        {
-            return new OpportunityArea(null, null);
-        }
-
-        protected bool Equals(OpportunityArea other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((OpportunityArea) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/OpportunityArea.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/OpportunityArea.cs
@@ -2,10 +2,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class OpportunityArea : ObservationalUnit
     {
-        public OpportunityArea()
-        {
-        }
-        
         public OpportunityArea(string code, string name) : base(code, name)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ParliamentaryConstituency.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ParliamentaryConstituency.cs
@@ -9,5 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public ParliamentaryConstituency(string code, string name) : base(code, name)
         {
         }
+        
+        public static ParliamentaryConstituency Empty()
+        {
+            return new ParliamentaryConstituency(null, null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ParliamentaryConstituency.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ParliamentaryConstituency.cs
@@ -1,41 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class ParliamentaryConstituency : IObservationalUnit
+    public class ParliamentaryConstituency : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private ParliamentaryConstituency()
+        public ParliamentaryConstituency()
         {
         }
-
-        public ParliamentaryConstituency(string code, string name)
+        
+        public ParliamentaryConstituency(string code, string name) : base(code, name)
         {
-            Code = code;
-            Name = name;
-        }
-
-        public static ParliamentaryConstituency Empty()
-        {
-            return new ParliamentaryConstituency(null, null);
-        }
-
-        protected bool Equals(ParliamentaryConstituency other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((ParliamentaryConstituency) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ParliamentaryConstituency.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ParliamentaryConstituency.cs
@@ -2,10 +2,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class ParliamentaryConstituency : ObservationalUnit
     {
-        public ParliamentaryConstituency()
-        {
-        }
-        
         public ParliamentaryConstituency(string code, string name) : base(code, name)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/PlanningArea.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/PlanningArea.cs
@@ -2,10 +2,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class PlanningArea: ObservationalUnit
     {
-        public PlanningArea()
-        {
-        }
-        
         public PlanningArea(string code, string name) : base(code, name)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/PlanningArea.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/PlanningArea.cs
@@ -9,5 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public PlanningArea(string code, string name) : base(code, name)
         {
         }
+        
+        public static PlanningArea Empty()
+        {
+            return new PlanningArea(null, null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/PlanningArea.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/PlanningArea.cs
@@ -1,41 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class PlanningArea: IObservationalUnit
+    public class PlanningArea: ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private PlanningArea()
+        public PlanningArea()
         {
         }
-
-        public PlanningArea(string code, string name)
+        
+        public PlanningArea(string code, string name) : base(code, name)
         {
-            Code = code;
-            Name = name;
-        }
-
-        public static PlanningArea Empty()
-        {
-            return new PlanningArea(null, null);
-        }
-
-        protected bool Equals(PlanningArea other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((PlanningArea) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Provider.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Provider.cs
@@ -1,41 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class Provider : IObservationalUnit
+    public class Provider : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private Provider()
+        public Provider()
         {
         }
-
-        public Provider(string ukprn, string name)
+        
+        public Provider(string ukprn, string name) : base(ukprn, name)
         {
-            Code = ukprn;
-            Name = name;
-        }
-
-        public static Provider Empty()
-        {
-            return new Provider(null, null);
-        }
-
-        protected bool Equals(Provider other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((Provider) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Provider.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Provider.cs
@@ -9,5 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public Provider(string ukprn, string name) : base(ukprn, name)
         {
         }
+        
+        public static Provider Empty()
+        {
+            return new Provider(null, null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Provider.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Provider.cs
@@ -2,10 +2,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class Provider : ObservationalUnit
     {
-        public Provider()
-        {
-        }
-        
         public Provider(string ukprn, string name) : base(ukprn, name)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Region.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Region.cs
@@ -1,41 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class Region : IObservationalUnit
+    public class Region : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private Region()
+        public Region()
         {
         }
-
-        public Region(string code, string name)
+        
+        public Region(string code, string name) : base(code, name)
         {
-            Code = code;
-            Name = name;
-        }
-
-        public static Region Empty()
-        {
-            return new Region(null, null);
-        }
-
-        protected bool Equals(Region other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((Region) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Region.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Region.cs
@@ -2,10 +2,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class Region : ObservationalUnit
     {
-        public Region()
-        {
-        }
-        
         public Region(string code, string name) : base(code, name)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Region.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Region.cs
@@ -9,5 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public Region(string code, string name) : base(code, name)
         {
         }
+        
+        public static Region Empty()
+        {
+            return new Region(null, null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/ILocationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/ILocationRepository.cs
@@ -7,11 +7,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Inter
 {
     public interface ILocationRepository : IRepository<Location, Guid>
     {
-        Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>> GetObservationalUnits(Guid subjectId);
+        Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>> GetObservationalUnits(Guid subjectId);
 
-        Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>> GetObservationalUnits(
+        Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>> GetObservationalUnits(
             IQueryable<Observation> observations);
 
-        IEnumerable<IObservationalUnit> GetObservationalUnits(GeographicLevel level, IEnumerable<string> codes);
+        IEnumerable<ObservationalUnit> GetObservationalUnits(GeographicLevel level, IEnumerable<string> codes);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/LocationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/LocationRepository.cs
@@ -14,14 +14,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
         {
         }
 
-        public Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>> GetObservationalUnits(Guid subjectId)
+        public Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>> GetObservationalUnits(Guid subjectId)
         {
             var observations = _context.Observation
                 .Where(o => o.SubjectId == subjectId);
             return GetObservationalUnits(observations);
         }
 
-        public Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>> GetObservationalUnits(
+        public Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>> GetObservationalUnits(
             IQueryable<Observation> observations)
         {
             var list = observations
@@ -61,9 +61,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
                     });
         }
 
-        public IEnumerable<IObservationalUnit> GetObservationalUnits(GeographicLevel level, IEnumerable<string> codes)
+        public IEnumerable<ObservationalUnit> GetObservationalUnits(GeographicLevel level, IEnumerable<string> codes)
         {
-            IQueryable<IObservationalUnit> query = level switch
+            IQueryable<ObservationalUnit> query = level switch
             {
                 GeographicLevel.EnglishDevolvedArea =>
                     _context.Location
@@ -156,7 +156,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
             return query.ToList();
         }
 
-        private static IObservationalUnit GetObservationalUnit(GeographicLevel geographicLevel, Location location)
+        private static ObservationalUnit GetObservationalUnit(GeographicLevel geographicLevel, Location location)
         {
             switch (geographicLevel)
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/RscRegion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/RscRegion.cs
@@ -14,5 +14,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public RscRegion(string code) : base(code, code)
         {
         }
+        
+        public static RscRegion Empty()
+        {
+            return new RscRegion(null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/RscRegion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/RscRegion.cs
@@ -7,10 +7,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
      */
     public class RscRegion : ObservationalUnit
     {
-        public RscRegion()
-        {
-        }
-        
         public RscRegion(string code) : base(code, code)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/RscRegion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/RscRegion.cs
@@ -5,43 +5,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
     /**
      * Regional School Commissioner Region
      */
-    public class RscRegion : IObservationalUnit
+    public class RscRegion : ObservationalUnit
     {
-        [JsonIgnore] public string Code { get; set; }
-
-        [JsonProperty(PropertyName = "rsc_region_lead_name")]
-        public string Name => Code;
-
-        public RscRegion(string code)
-        {
-            Code = code;
-        }
-
-        private RscRegion()
+        public RscRegion()
         {
         }
-
-        public static RscRegion Empty()
+        
+        public RscRegion(string code) : base(code, code)
         {
-            return new RscRegion(null);
-        }
-
-        protected bool Equals(RscRegion other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((RscRegion) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/School.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/School.cs
@@ -5,10 +5,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class School : ObservationalUnit
     {
-        public School()
-        {
-        }
-        
         public School(string urn, string name) : base(urn, name)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/School.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/School.cs
@@ -12,5 +12,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public School(string urn, string name) : base(urn, name)
         {
         }
+        
+        public static School Empty()
+        {
+            return new School(null, null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/School.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/School.cs
@@ -3,42 +3,14 @@ using Newtonsoft.Json;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class School : IObservationalUnit
+    public class School : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
         public School()
         {
         }
-
-        public School(string urn, string name)
+        
+        public School(string urn, string name) : base(urn, name)
         {
-            Code = urn;
-            Name = name;
-        }
-
-        public static School Empty()
-        {
-            return new School(null, null);
-        }
-
-        protected bool Equals(School other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((School) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Sponsor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Sponsor.cs
@@ -2,10 +2,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class Sponsor : ObservationalUnit
     {
-        public Sponsor()
-        {
-        }
-        
         public Sponsor(string code, string name) : base(code, name)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Sponsor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Sponsor.cs
@@ -9,5 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public Sponsor(string code, string name) : base(code, name)
         {
         }
+        
+        public static Sponsor Empty()
+        {
+            return new Sponsor(null, null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Sponsor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Sponsor.cs
@@ -1,41 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class Sponsor : IObservationalUnit
+    public class Sponsor : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private Sponsor()
+        public Sponsor()
         {
         }
-
-        public Sponsor(string code, string name)
+        
+        public Sponsor(string code, string name) : base(code, name)
         {
-            Code = code;
-            Name = name;
-        }
-
-        public static Sponsor Empty()
-        {
-            return new Sponsor(null, null);
-        }
-
-        protected bool Equals(Sponsor other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((Sponsor) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Ward.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Ward.cs
@@ -9,5 +9,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
         public Ward(string code, string name) : base(code, name)
         {
         }
+        
+        public static Ward Empty()
+        {
+            return new Ward(null, null);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Ward.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Ward.cs
@@ -2,10 +2,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
     public class Ward : ObservationalUnit
     {
-        public Ward()
-        {
-        }
-        
         public Ward(string code, string name) : base(code, name)
         {
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Ward.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Ward.cs
@@ -1,41 +1,13 @@
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 {
-    public class Ward : IObservationalUnit
+    public class Ward : ObservationalUnit
     {
-        public string Code { get; set; }
-        public string Name { get; set; }
-
-        private Ward()
+        public Ward()
         {
         }
-
-        public Ward(string code, string name)
+        
+        public Ward(string code, string name) : base(code, name)
         {
-            Code = code;
-            Name = name;
-        }
-
-        public static Ward Empty()
-        {
-            return new Ward(null, null);
-        }
-
-        protected bool Equals(Ward other)
-        {
-            return string.Equals(Code, other.Code);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
-            return Equals((Ward) obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return (Code != null ? Code.GetHashCode() : 0);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterLocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterLocationService.cs
@@ -179,23 +179,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 var entityEntry = context.Location.Add(new Location
                 {
                     Id = _guidGenerator.NewGuid(),
-                    Country = country ?? new Country(),
-                    EnglishDevolvedArea = englishDevolvedArea ?? new EnglishDevolvedArea(),
-                    Institution = institution ?? new Institution(),
-                    LocalAuthority = localAuthority ?? new LocalAuthority(),
-                    LocalAuthorityDistrict = localAuthorityDistrict ?? new LocalAuthorityDistrict(),
-                    LocalEnterprisePartnership = localEnterprisePartnership ?? new LocalEnterprisePartnership(),
-                    MayoralCombinedAuthority = mayoralCombinedAuthority ?? new MayoralCombinedAuthority(),
-                    MultiAcademyTrust = multiAcademyTrust ?? new Mat(),
-                    OpportunityArea = opportunityArea ?? new OpportunityArea(),
-                    ParliamentaryConstituency = parliamentaryConstituency ?? new ParliamentaryConstituency(),
-                    Provider = provider ?? new Provider(),
-                    Region = region ?? new Region(),
-                    RscRegion = rscRegion ?? new RscRegion(),
-                    School = school ?? new School(),
-                    Sponsor = sponsor ?? new Sponsor(),
-                    Ward = ward ?? new Ward(),
-                    PlanningArea = planningArea ?? new PlanningArea()
+                    Country = country ?? Country.Empty(),
+                    EnglishDevolvedArea = englishDevolvedArea ?? EnglishDevolvedArea.Empty(),
+                    Institution = institution ?? Institution.Empty(),
+                    LocalAuthority = localAuthority ?? LocalAuthority.Empty(),
+                    LocalAuthorityDistrict = localAuthorityDistrict ?? LocalAuthorityDistrict.Empty(),
+                    LocalEnterprisePartnership = localEnterprisePartnership ?? LocalEnterprisePartnership.Empty(),
+                    MayoralCombinedAuthority = mayoralCombinedAuthority ?? MayoralCombinedAuthority.Empty(),
+                    MultiAcademyTrust = multiAcademyTrust ?? Mat.Empty(),
+                    OpportunityArea = opportunityArea ?? OpportunityArea.Empty(),
+                    ParliamentaryConstituency = parliamentaryConstituency ?? ParliamentaryConstituency.Empty(),
+                    Provider = provider ?? Provider.Empty(),
+                    Region = region ?? Region.Empty(),
+                    RscRegion = rscRegion ?? RscRegion.Empty(),
+                    School = school ?? School.Empty(),
+                    Sponsor = sponsor ?? Sponsor.Empty(),
+                    Ward = ward ?? Ward.Empty(),
+                    PlanningArea = planningArea ?? PlanningArea.Empty()
                 });
 
                 return entityEntry.Entity;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterLocationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Services/ImporterLocationService.cs
@@ -105,7 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
             Ward ward,
             PlanningArea planningArea)
         {
-            var observationalUnits = new IObservationalUnit[]
+            var observationalUnits = new ObservationalUnit[]
             {
                 country,
                 englishDevolvedArea,
@@ -179,23 +179,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Services
                 var entityEntry = context.Location.Add(new Location
                 {
                     Id = _guidGenerator.NewGuid(),
-                    Country = country ?? Country.Empty(),
-                    EnglishDevolvedArea = englishDevolvedArea ?? EnglishDevolvedArea.Empty(),
-                    Institution = institution ?? Institution.Empty(),
-                    LocalAuthority = localAuthority ?? LocalAuthority.Empty(),
-                    LocalAuthorityDistrict = localAuthorityDistrict ?? LocalAuthorityDistrict.Empty(),
-                    LocalEnterprisePartnership = localEnterprisePartnership ?? LocalEnterprisePartnership.Empty(),
-                    MayoralCombinedAuthority = mayoralCombinedAuthority ?? MayoralCombinedAuthority.Empty(),
-                    MultiAcademyTrust = multiAcademyTrust ?? Mat.Empty(),
-                    OpportunityArea = opportunityArea ?? OpportunityArea.Empty(),
-                    ParliamentaryConstituency = parliamentaryConstituency ?? ParliamentaryConstituency.Empty(),
-                    Provider = provider ?? Provider.Empty(),
-                    Region = region ?? Region.Empty(),
-                    RscRegion = rscRegion ?? RscRegion.Empty(),
-                    School = school ?? School.Empty(),
-                    Sponsor = sponsor ?? Sponsor.Empty(),
-                    Ward = ward ?? Ward.Empty(),
-                    PlanningArea = planningArea ?? PlanningArea.Empty()
+                    Country = country ?? new Country(),
+                    EnglishDevolvedArea = englishDevolvedArea ?? new EnglishDevolvedArea(),
+                    Institution = institution ?? new Institution(),
+                    LocalAuthority = localAuthority ?? new LocalAuthority(),
+                    LocalAuthorityDistrict = localAuthorityDistrict ?? new LocalAuthorityDistrict(),
+                    LocalEnterprisePartnership = localEnterprisePartnership ?? new LocalEnterprisePartnership(),
+                    MayoralCombinedAuthority = mayoralCombinedAuthority ?? new MayoralCombinedAuthority(),
+                    MultiAcademyTrust = multiAcademyTrust ?? new Mat(),
+                    OpportunityArea = opportunityArea ?? new OpportunityArea(),
+                    ParliamentaryConstituency = parliamentaryConstituency ?? new ParliamentaryConstituency(),
+                    Provider = provider ?? new Provider(),
+                    Region = region ?? new Region(),
+                    RscRegion = rscRegion ?? new RscRegion(),
+                    School = school ?? new School(),
+                    Sponsor = sponsor ?? new Sponsor(),
+                    Ward = ward ?? new Ward(),
+                    PlanningArea = planningArea ?? new PlanningArea()
                 });
 
                 return entityEntry.Entity;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderSubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderSubjectMetaServiceTests.cs
@@ -138,7 +138,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 filterRepository.Setup(s => s.GetFiltersIncludingItems(subject.Id)).Returns(Enumerable.Empty<Filter>());
                 indicatorGroupRepository.Setup(s => s.GetIndicatorGroups(subject.Id)).Returns(Enumerable.Empty<IndicatorGroup>());
-                locationRepository.Setup(s => s.GetObservationalUnits(subject.Id)).Returns(new Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>>());
+                locationRepository.Setup(s => s.GetObservationalUnits(subject.Id)).Returns(new Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>>());
                 timePeriodService.Setup(s => s.GetTimePeriods(subject.Id)).Returns(Enumerable.Empty<(int Year, TimeIdentifier TimeIdentifier)>());
 
                 var service = new SubjectMetaService(boundaryLevelRepository.Object,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/AbstractSubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/AbstractSubjectMetaService.cs
@@ -58,7 +58,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         protected IEnumerable<ObservationalUnitMetaViewModel> BuildObservationalUnitMetaViewModelsWithGeoJsonIfAvailable(
             GeographicLevel geographicLevel,
-            ICollection<IObservationalUnit> observationalUnits,
+            ICollection<ObservationalUnit> observationalUnits,
             bool geoJsonRequested,
             long? boundaryLevelId)
         {
@@ -95,7 +95,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         }
 
         protected bool HasBoundaryLevelDataForAnyObservationalUnits(
-            Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>> observationalUnits)
+            Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>> observationalUnits)
         {
             return observationalUnits.Any(pair => HasBoundaryLevelForGeographicLevel(pair.Key));
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Mappings/DataServiceMappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Mappings/DataServiceMappingProfiles.cs
@@ -18,7 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Mappings
             CreateMap<Location, LocationViewModel>();
 
             AppDomain.CurrentDomain.GetAssemblies().SelectMany(GetTypesFromAssembly)
-                .Where(p => typeof(ObservationalUnit).IsAssignableFrom(p))
+                .Where(p => p.IsSubclassOf(typeof(ObservationalUnit)))
                 .ToList().ForEach(type =>
                 {
                     if (type == typeof(LocalAuthority))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Mappings/DataServiceMappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Mappings/DataServiceMappingProfiles.cs
@@ -18,7 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Mappings
             CreateMap<Location, LocationViewModel>();
 
             AppDomain.CurrentDomain.GetAssemblies().SelectMany(GetTypesFromAssembly)
-                .Where(p => typeof(IObservationalUnit).IsAssignableFrom(p))
+                .Where(p => typeof(ObservationalUnit).IsAssignableFrom(p))
                 .ToList().ForEach(type =>
                 {
                     if (type == typeof(LocalAuthority))

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
@@ -141,7 +141,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         }
 
         private IEnumerable<ObservationalUnitMetaViewModel> GetGeoJsonObservationalUnits(
-            Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>> observationalUnits,
+            Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>> observationalUnits,
             bool geoJsonRequested,
             long? boundaryLevelId)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -205,7 +205,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         }
 
         private static Dictionary<string, ObservationalUnitsMetaViewModel> BuildObservationalUnitsViewModels(
-            Dictionary<GeographicLevel, IEnumerable<IObservationalUnit>> observationalUnits)
+            Dictionary<GeographicLevel, IEnumerable<ObservationalUnit>> observationalUnits)
         {
             var viewModels = observationalUnits
                 .OrderBy(pair => pair.Key.GetEnumLabel())
@@ -244,7 +244,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             return _filterItemRepository.GetTotal(filter)?.Id.ToString() ?? string.Empty;
         }
 
-        private static LabelValue MapObservationalUnitToLabelValue(IObservationalUnit unit)
+        private static LabelValue MapObservationalUnitToLabelValue(ObservationalUnit unit)
         {
             var value = unit is LocalAuthority localAuthority ? localAuthority.GetCodeOrOldCodeIfEmpty() : unit.Code;
             return new LabelValue


### PR DESCRIPTION
This PR:
- fixes a bug whereby Locations with duplicate codes but different names were not being returned via the API to the table tool

The cause of the bug was a very innocent Distinct() call on a list of IObservationalUnits. The real bug was that the Observational Units in questions implemented Equals() and hashcode methods that only operated on Code, and not the combination of Code and Name.

I've restructured the various Observational Units to extend a common base class that holds Code and Name and the equality members. The various subclasses are now all much smaller.

I have also removed some JSON annotations on RscRegion, which after speaking with Ben, we believe to be redundant nowadays. Still, some good testing with all sorts of Location types will be required.