### PR TITLE
EES-968 Notifying subscribers for amendment release publication now optional

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -909,6 +909,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(new DateTime(2051, 6, 30, 0, 0, 0, DateTimeKind.Unspecified),
                     viewModel.PublishScheduled);
                 Assert.Equal(nextReleaseDateEdited, viewModel.NextReleaseDate);
+                Assert.False(viewModel.NotifySubscribers);
                 Assert.Equal(adHocReleaseType, viewModel.Type);
                 Assert.Equal("2030", viewModel.ReleaseName);
                 Assert.Equal(TimeIdentifier.March, viewModel.TimePeriodCoverage);
@@ -1181,6 +1182,282 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task CreateReleaseStatus_Approved_NotifySubscribers()
+        {
+            var release = new Release
+            {
+                Type = new ReleaseType {Title = "Ad Hoc"},
+                Publication = new Publication {Title = "Old publication"},
+                ReleaseName = "2030",
+                Slug = "2030",
+                PublishScheduled = DateTime.UtcNow,
+                Version = 0,
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                await context.AddAsync(release);
+                await context.SaveChangesAsync();
+            }
+
+            var releaseChecklistService = new Mock<IReleaseChecklistService>(MockBehavior.Strict);
+            var contentService = new Mock<IContentService>(MockBehavior.Strict);
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                releaseChecklistService
+                    .Setup(s =>
+                        s.GetErrors(It.Is<Release>(r => r.Id == release.Id)))
+                    .ReturnsAsync(
+                        new List<ReleaseChecklistIssue>()
+                    );
+
+                contentService.Setup(mock =>
+                        mock.GetContentBlocks<HtmlBlock>(release.Id))
+                    .ReturnsAsync(new List<HtmlBlock>());
+
+                var releaseService = BuildReleaseService(contentDbContext: context,
+                    releaseChecklistService: releaseChecklistService.Object,
+                    contentService: contentService.Object);
+
+                var result = await releaseService
+                    .CreateReleaseStatus(
+                        release.Id,
+                        new ReleaseStatusCreateViewModel
+                        {
+                            ApprovalStatus = ReleaseApprovalStatus.Approved,
+                            LatestInternalReleaseNote = "Test note",
+                            // No need to include NotifySubscribers - should default to true for original releases
+                            PublishMethod = PublishMethod.Scheduled,
+                            PublishScheduled = "2051-06-30",
+                            NextReleaseDate = new PartialDate {Month="12", Year="2000"}
+                        }
+                    );
+
+                MockUtils.VerifyAllMocks(releaseChecklistService, contentService);
+
+                var viewModel = result.AssertRight();
+
+                Assert.True(viewModel.NotifySubscribers);
+            }
+        }
+
+        [Fact]
+        public async Task CreateReleaseStatus_Amendment_NotifySubscribers_False()
+        {
+            var releaseType = new ReleaseType {Title = "Ad Hoc"};
+
+            var publication = new Publication();
+
+            var initialReleaseId = Guid.NewGuid();
+            var initialRelease = new Release
+            {
+                Id = initialReleaseId,
+                Type = releaseType,
+                TimePeriodCoverage = TimeIdentifier.TaxYear,
+                Publication = publication,
+                ReleaseName = "2035",
+                Slug = "2035",
+                PublishScheduled = DateTime.UtcNow,
+                Version = 0,
+                PreviousVersionId = initialReleaseId
+            };
+
+            var amendedRelease = new Release
+            {
+                Type = releaseType,
+                TimePeriodCoverage = TimeIdentifier.TaxYear,
+                Publication = publication,
+                ReleaseName = "2035",
+                Slug = "2035",
+                PublishScheduled = DateTime.UtcNow,
+                Version = 1,
+                PreviousVersionId = initialReleaseId
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                await context.AddAsync(releaseType);
+                await context.AddRangeAsync(amendedRelease, initialRelease);
+                await context.SaveChangesAsync();
+            }
+
+            var releaseChecklistService = new Mock<IReleaseChecklistService>(MockBehavior.Strict);
+            var contentService = new Mock<IContentService>(MockBehavior.Strict);
+            var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
+
+            releaseChecklistService
+                .Setup(s =>
+                    s.GetErrors(It.Is<Release>(r => r.Id == amendedRelease.Id)))
+                .ReturnsAsync(
+                    new List<ReleaseChecklistIssue>()
+                );
+
+            contentService.Setup(mock =>
+                    mock.GetContentBlocks<HtmlBlock>(amendedRelease.Id))
+                .ReturnsAsync(new List<HtmlBlock>());
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var releaseService = BuildReleaseService(contentDbContext: context,
+                    releaseChecklistService: releaseChecklistService.Object,
+                    contentService: contentService.Object,
+                    releaseFileService: releaseFileService.Object);
+
+                var result = await releaseService
+                    .CreateReleaseStatus(
+                        amendedRelease.Id,
+                        new ReleaseStatusCreateViewModel
+                        {
+                            PublishScheduled = "2051-06-30",
+                            ApprovalStatus = ReleaseApprovalStatus.Approved,
+                            NotifySubscribers = false,
+                        }
+                    );
+
+                MockUtils.VerifyAllMocks(contentService, releaseFileService);
+
+                var viewModel = result.AssertRight();
+
+                Assert.False(viewModel.NotifySubscribers);
+            }
+        }
+
+        [Fact]
+        public async Task CreateReleaseStatus_Amendment_NotifySubscribers_True()
+        {
+            var releaseType = new ReleaseType {Title = "Ad Hoc"};
+
+            var publication = new Publication();
+
+            var initialReleaseId = Guid.NewGuid();
+            var initialRelease = new Release
+            {
+                Id = initialReleaseId,
+                Type = releaseType,
+                TimePeriodCoverage = TimeIdentifier.TaxYear,
+                Publication = publication,
+                ReleaseName = "2035",
+                Slug = "2035",
+                PublishScheduled = DateTime.UtcNow,
+                Version = 0,
+                PreviousVersionId = initialReleaseId
+            };
+
+            var amendedRelease = new Release
+            {
+                Type = releaseType,
+                TimePeriodCoverage = TimeIdentifier.TaxYear,
+                Publication = publication,
+                ReleaseName = "2035",
+                Slug = "2035",
+                PublishScheduled = DateTime.UtcNow,
+                Version = 1,
+                PreviousVersionId = initialReleaseId
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                await context.AddAsync(releaseType);
+                await context.AddRangeAsync(amendedRelease, initialRelease);
+                await context.SaveChangesAsync();
+            }
+
+            var releaseChecklistService = new Mock<IReleaseChecklistService>(MockBehavior.Strict);
+            var contentService = new Mock<IContentService>(MockBehavior.Strict);
+            var releaseFileService = new Mock<IReleaseFileService>(MockBehavior.Strict);
+
+            releaseChecklistService
+                .Setup(s =>
+                    s.GetErrors(It.Is<Release>(r => r.Id == amendedRelease.Id)))
+                .ReturnsAsync(
+                    new List<ReleaseChecklistIssue>()
+                );
+
+            contentService.Setup(mock =>
+                    mock.GetContentBlocks<HtmlBlock>(amendedRelease.Id))
+                .ReturnsAsync(new List<HtmlBlock>());
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                var releaseService = BuildReleaseService(contentDbContext: context,
+                    releaseChecklistService: releaseChecklistService.Object,
+                    contentService: contentService.Object,
+                    releaseFileService: releaseFileService.Object);
+
+                var result = await releaseService
+                    .CreateReleaseStatus(
+                        amendedRelease.Id,
+                        new ReleaseStatusCreateViewModel
+                        {
+                            PublishScheduled = "2051-06-30",
+                            ApprovalStatus = ReleaseApprovalStatus.Approved,
+                            NotifySubscribers = true,
+                        }
+                    );
+
+                MockUtils.VerifyAllMocks(contentService, releaseFileService);
+
+                var viewModel = result.AssertRight();
+
+                Assert.True(viewModel.NotifySubscribers);
+            }
+        }
+
+        [Fact]
+        public async Task CreateReleaseStatus_Draft_NotifySubscribers()
+        {
+            var release = new Release
+            {
+                Type = new ReleaseType {Title = "Ad Hoc"},
+                Publication = new Publication {Title = "Old publication"},
+                ReleaseName = "2030",
+                Slug = "2030",
+                Version = 0,
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                await context.AddAsync(release);
+                await context.SaveChangesAsync();
+            }
+
+            var contentService = new Mock<IContentService>(MockBehavior.Strict);
+
+            await using (var context = InMemoryApplicationDbContext(contextId))
+            {
+                contentService.Setup(mock =>
+                        mock.GetContentBlocks<HtmlBlock>(release.Id))
+                    .ReturnsAsync(new List<HtmlBlock>());
+
+                var releaseService = BuildReleaseService(contentDbContext: context,
+                    contentService: contentService.Object);
+
+                var result = await releaseService
+                    .CreateReleaseStatus(
+                        release.Id,
+                        new ReleaseStatusCreateViewModel
+                        {
+                            ApprovalStatus = ReleaseApprovalStatus.Draft,
+                            LatestInternalReleaseNote = "Test note",
+                        }
+                    );
+
+                MockUtils.VerifyAllMocks(contentService);
+
+                var viewModel = result.AssertRight();
+
+                Assert.False(viewModel.NotifySubscribers);
+            }
+        }
+
+        [Fact]
         public async Task CreateReleaseStatus_Draft_DoNotSendPreReleaseEmails()
         {
             var release = new Release
@@ -1321,6 +1598,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     viewModel.PublishScheduled);
                 Assert.Equal(nextReleaseDateEdited, viewModel.NextReleaseDate);
                 Assert.Equal(ReleaseApprovalStatus.HigherLevelReview, viewModel.ApprovalStatus);
+                Assert.False(viewModel.NotifySubscribers);
 
                 Assert.Equal(release.Publication.Id, viewModel.PublicationId);
                 Assert.Equal(release.Type, viewModel.Type);
@@ -1455,6 +1733,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(release.Publication.Id, viewModel.PublicationId);
                 Assert.Equal(new DateTime(2051, 6, 30, 0, 0, 0, DateTimeKind.Unspecified),
                     viewModel.PublishScheduled);
+                Assert.False(viewModel.NotifySubscribers);
                 Assert.Equal(nextReleaseDateEdited, viewModel.NextReleaseDate);
                 Assert.Equal("2030", viewModel.ReleaseName);
                 Assert.Equal(TimeIdentifier.March, viewModel.TimePeriodCoverage);
@@ -1479,6 +1758,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var savedStatus = saved.ReleaseStatuses[0];
                 Assert.Equal(ReleaseApprovalStatus.HigherLevelReview, savedStatus.ApprovalStatus);
                 Assert.Equal("Test internal note", savedStatus.InternalReleaseNote);
+                Assert.False(savedStatus.NotifySubscribers);
                 Assert.NotNull(savedStatus.Created);
                 Assert.InRange(DateTime.UtcNow
                     .Subtract(savedStatus.Created ?? new DateTime()).Milliseconds, 0, 1500);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -1410,54 +1410,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task CreateReleaseStatus_Draft_NotifySubscribers()
-        {
-            var release = new Release
-            {
-                Type = new ReleaseType {Title = "Ad Hoc"},
-                Publication = new Publication {Title = "Old publication"},
-                ReleaseName = "2030",
-                Slug = "2030",
-                Version = 0,
-            };
-
-            var contextId = Guid.NewGuid().ToString();
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                await context.AddAsync(release);
-                await context.SaveChangesAsync();
-            }
-
-            var contentService = new Mock<IContentService>(MockBehavior.Strict);
-
-            await using (var context = InMemoryApplicationDbContext(contextId))
-            {
-                contentService.Setup(mock =>
-                        mock.GetContentBlocks<HtmlBlock>(release.Id))
-                    .ReturnsAsync(new List<HtmlBlock>());
-
-                var releaseService = BuildReleaseService(contentDbContext: context,
-                    contentService: contentService.Object);
-
-                var result = await releaseService
-                    .CreateReleaseStatus(
-                        release.Id,
-                        new ReleaseStatusCreateViewModel
-                        {
-                            ApprovalStatus = ReleaseApprovalStatus.Draft,
-                            LatestInternalReleaseNote = "Test note",
-                        }
-                    );
-
-                MockUtils.VerifyAllMocks(contentService);
-
-                var viewModel = result.AssertRight();
-
-                Assert.False(viewModel.NotifySubscribers);
-            }
-        }
-
-        [Fact]
         public async Task CreateReleaseStatus_Draft_DoNotSendPreReleaseEmails()
         {
             var release = new Release

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210906084644_EES968AddNotifySubscribersColumnToReleaseStatus.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210906084644_EES968AddNotifySubscribersColumnToReleaseStatus.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210906084644_EES968AddNotifySubscribersColumnToReleaseStatus")]
+    partial class EES968AddNotifySubscribersColumnToReleaseStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -270,37 +272,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.ToTable("Files");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.GlossaryEntry", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("Body")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime>("Created")
-                        .HasColumnType("datetime2");
-
-                    b.Property<Guid>("CreatedById")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("Slug")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Title")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CreatedById");
-
-                    b.ToTable("GlossaryEntries");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.LegacyRelease", b =>
                 {
                     b.Property<Guid>("Id")
@@ -334,46 +305,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("OwningPublicationTitle")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Slug")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("Methodologies");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyFile", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid>("FileId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid>("MethodologyVersionId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("FileId");
-
-                    b.HasIndex("MethodologyVersionId");
-
-                    b.ToTable("MethodologyFiles");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
                     b.Property<string>("AlternativeTitle")
                         .HasColumnType("nvarchar(max)");
 
@@ -394,7 +325,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<string>("InternalReleaseNote")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<Guid>("MethodologyId")
+                    b.Property<Guid>("MethodologyParentId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid?>("PreviousVersionId")
@@ -424,13 +355,53 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.HasIndex("CreatedById");
 
-                    b.HasIndex("MethodologyId");
+                    b.HasIndex("MethodologyParentId");
 
                     b.HasIndex("PreviousVersionId");
 
                     b.HasIndex("ScheduledWithReleaseId");
 
-                    b.ToTable("MethodologyVersions");
+                    b.ToTable("Methodologies");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyFile", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid>("FileId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid>("MethodologyId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("FileId");
+
+                    b.HasIndex("MethodologyId");
+
+                    b.ToTable("MethodologyFiles");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyParent", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("OwningPublicationTitle")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Slug")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("MethodologyParents");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", b =>
@@ -484,15 +455,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<Guid>("PublicationId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("MethodologyId")
+                    b.Property<Guid>("MethodologyParentId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<bool>("Owner")
                         .HasColumnType("bit");
 
-                    b.HasKey("PublicationId", "MethodologyId");
+                    b.HasKey("PublicationId", "MethodologyParentId");
 
-                    b.HasIndex("MethodologyId");
+                    b.HasIndex("MethodologyParentId");
 
                     b.ToTable("PublicationMethodologies");
                 });
@@ -1030,15 +1001,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .HasForeignKey("SourceId");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.GlossaryEntry", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "CreatedBy")
-                        .WithMany()
-                        .HasForeignKey("CreatedById")
-                        .OnDelete(DeleteBehavior.NoAction)
-                        .IsRequired();
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.LegacyRelease", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", "Publication")
@@ -1046,6 +1008,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .HasForeignKey("PublicationId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "CreatedBy")
+                        .WithMany()
+                        .HasForeignKey("CreatedById")
+                        .OnDelete(DeleteBehavior.NoAction);
+
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyParent", "MethodologyParent")
+                        .WithMany("Versions")
+                        .HasForeignKey("MethodologyParentId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", "PreviousVersion")
+                        .WithMany()
+                        .HasForeignKey("PreviousVersionId");
+
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Release", "ScheduledWithRelease")
+                        .WithMany()
+                        .HasForeignKey("ScheduledWithReleaseId");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyFile", b =>
@@ -1056,33 +1040,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .OnDelete(DeleteBehavior.NoAction)
                         .IsRequired();
 
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", "MethodologyVersion")
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", "Methodology")
                         .WithMany()
-                        .HasForeignKey("MethodologyVersionId")
+                        .HasForeignKey("MethodologyId")
                         .OnDelete(DeleteBehavior.NoAction)
                         .IsRequired();
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "CreatedBy")
-                        .WithMany()
-                        .HasForeignKey("CreatedById")
-                        .OnDelete(DeleteBehavior.NoAction);
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", "Methodology")
-                        .WithMany("Versions")
-                        .HasForeignKey("MethodologyId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", "PreviousVersion")
-                        .WithMany()
-                        .HasForeignKey("PreviousVersionId");
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Release", "ScheduledWithRelease")
-                        .WithMany()
-                        .HasForeignKey("ScheduledWithReleaseId");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", b =>
@@ -1121,9 +1083,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationMethodology", b =>
                 {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", "Methodology")
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyParent", "MethodologyParent")
                         .WithMany("Publications")
-                        .HasForeignKey("MethodologyId")
+                        .HasForeignKey("MethodologyParentId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210906084644_EES968AddNotifySubscribersColumnToReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210906084644_EES968AddNotifySubscribersColumnToReleaseStatus.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES968AddNotifySubscribersColumnToReleaseStatus : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "NotifySubscribers",
+                table: "ReleaseStatus",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NotifySubscribers",
+                table: "ReleaseStatus");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210913090611_EES968AddNotifiedOnColumnToReleaseStatus.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210913090611_EES968AddNotifiedOnColumnToReleaseStatus.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210913090611_EES968AddNotifiedOnColumnToReleaseStatus")]
+    partial class EES968AddNotifiedOnColumnToReleaseStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -270,37 +272,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.ToTable("Files");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.GlossaryEntry", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("Body")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime>("Created")
-                        .HasColumnType("datetime2");
-
-                    b.Property<Guid>("CreatedById")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("Slug")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Title")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CreatedById");
-
-                    b.ToTable("GlossaryEntries");
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.LegacyRelease", b =>
                 {
                     b.Property<Guid>("Id")
@@ -334,46 +305,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("OwningPublicationTitle")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Slug")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.HasKey("Id");
-
-                    b.ToTable("Methodologies");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyFile", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid>("FileId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid>("MethodologyVersionId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("FileId");
-
-                    b.HasIndex("MethodologyVersionId");
-
-                    b.ToTable("MethodologyFiles");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
                     b.Property<string>("AlternativeTitle")
                         .HasColumnType("nvarchar(max)");
 
@@ -394,7 +325,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<string>("InternalReleaseNote")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<Guid>("MethodologyId")
+                    b.Property<Guid>("MethodologyParentId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid?>("PreviousVersionId")
@@ -424,13 +355,53 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
                     b.HasIndex("CreatedById");
 
-                    b.HasIndex("MethodologyId");
+                    b.HasIndex("MethodologyParentId");
 
                     b.HasIndex("PreviousVersionId");
 
                     b.HasIndex("ScheduledWithReleaseId");
 
-                    b.ToTable("MethodologyVersions");
+                    b.ToTable("Methodologies");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyFile", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid>("FileId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid>("MethodologyId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("FileId");
+
+                    b.HasIndex("MethodologyId");
+
+                    b.ToTable("MethodologyFiles");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyParent", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("OwningPublicationTitle")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Slug")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("MethodologyParents");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", b =>
@@ -484,15 +455,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.Property<Guid>("PublicationId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("MethodologyId")
+                    b.Property<Guid>("MethodologyParentId")
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<bool>("Owner")
                         .HasColumnType("bit");
 
-                    b.HasKey("PublicationId", "MethodologyId");
+                    b.HasKey("PublicationId", "MethodologyParentId");
 
-                    b.HasIndex("MethodologyId");
+                    b.HasIndex("MethodologyParentId");
 
                     b.ToTable("PublicationMethodologies");
                 });
@@ -1033,15 +1004,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .HasForeignKey("SourceId");
                 });
 
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.GlossaryEntry", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "CreatedBy")
-                        .WithMany()
-                        .HasForeignKey("CreatedById")
-                        .OnDelete(DeleteBehavior.NoAction)
-                        .IsRequired();
-                });
-
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.LegacyRelease", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", "Publication")
@@ -1049,6 +1011,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .HasForeignKey("PublicationId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "CreatedBy")
+                        .WithMany()
+                        .HasForeignKey("CreatedById")
+                        .OnDelete(DeleteBehavior.NoAction);
+
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyParent", "MethodologyParent")
+                        .WithMany("Versions")
+                        .HasForeignKey("MethodologyParentId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", "PreviousVersion")
+                        .WithMany()
+                        .HasForeignKey("PreviousVersionId");
+
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Release", "ScheduledWithRelease")
+                        .WithMany()
+                        .HasForeignKey("ScheduledWithReleaseId");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyFile", b =>
@@ -1059,33 +1043,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .OnDelete(DeleteBehavior.NoAction)
                         .IsRequired();
 
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", "MethodologyVersion")
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", "Methodology")
                         .WithMany()
-                        .HasForeignKey("MethodologyVersionId")
+                        .HasForeignKey("MethodologyId")
                         .OnDelete(DeleteBehavior.NoAction)
                         .IsRequired();
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "CreatedBy")
-                        .WithMany()
-                        .HasForeignKey("CreatedById")
-                        .OnDelete(DeleteBehavior.NoAction);
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", "Methodology")
-                        .WithMany("Versions")
-                        .HasForeignKey("MethodologyId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", "PreviousVersion")
-                        .WithMany()
-                        .HasForeignKey("PreviousVersionId");
-
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Release", "ScheduledWithRelease")
-                        .WithMany()
-                        .HasForeignKey("ScheduledWithReleaseId");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", b =>
@@ -1124,9 +1086,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationMethodology", b =>
                 {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Methodology", "Methodology")
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyParent", "MethodologyParent")
                         .WithMany("Publications")
-                        .HasForeignKey("MethodologyId")
+                        .HasForeignKey("MethodologyParentId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210913090611_EES968AddNotifiedOnColumnToReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210913090611_EES968AddNotifiedOnColumnToReleaseStatus.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES968AddNotifiedOnColumnToReleaseStatus : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "NotifiedOn",
+                table: "ReleaseStatus",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NotifiedOn",
+                table: "ReleaseStatus");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -379,10 +379,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         ? DateTime.UtcNow
                         : request.PublishScheduledDate;
 
+                    // NOTE: Subscribers should be notified if the release is approved and isn't amended,
+                    //       OR if the release is an amendment, is approved, and NotifySubscribers is true
+                    var notifySubscribers = request.ApprovalStatus == ReleaseApprovalStatus.Approved &&
+                        (!release.Amendment || (request.NotifySubscribers.HasValue && request.NotifySubscribers.Value));
+
                     var releaseStatus = new ReleaseStatus
                     {
                         Release = release,
                         InternalReleaseNote = request.LatestInternalReleaseNote,
+                        NotifySubscribers = notifySubscribers,
                         ApprovalStatus = request.ApprovalStatus,
                         Created = DateTime.UtcNow,
                         CreatedById = _userService.GetUserId()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -1,5 +1,5 @@
+#enable nullable
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using GovUk.Education.ExploreEducationStatistics.Admin.Validators;
@@ -136,6 +136,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
         public ReleaseApprovalStatus ApprovalStatus { get; set; }
 
         public string LatestInternalReleaseNote { get; set; }
+
+        public bool? NotifySubscribers { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public PublishMethod? PublishMethod { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/ReleaseViewModels.cs
@@ -1,4 +1,3 @@
-#enable nullable
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
@@ -57,6 +56,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 
         [JsonConverter(typeof(StringEnumConverter))]
         public ReleaseApprovalStatus ApprovalStatus { get; set; }
+
+        public bool NotifySubscribers { get; set; }
 
         public string LatestInternalReleaseNote { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -192,12 +192,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
                 .Property(rs => rs.Created)
                 .HasConversion(
                     v => v,
-                    v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : (DateTime?) null);
+                    v => v.HasValue
+                        ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
+                        : (DateTime?) null);
 
             modelBuilder.Entity<ReleaseStatus>()
                 .HasOne(rs => rs.CreatedBy)
                 .WithMany()
                 .OnDelete(DeleteBehavior.NoAction);
+
+            modelBuilder.Entity<ReleaseStatus>()
+                .Property(rs => rs.NotifiedOn)
+                .HasConversion(
+                    v => v,
+                    v => v.HasValue
+                        ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc)
+                        : (DateTime?) null);
 
             modelBuilder.Entity<ReleaseStatus>()
                 .Property(rs => rs.ApprovalStatus)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -66,6 +66,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<ReleaseStatus> ReleaseStatuses { get; set; }
 
+        public bool NotifySubscribers
+        {
+            get
+            {
+                return ReleaseStatuses.Any(rs => rs.ApprovalStatus == ReleaseApprovalStatus.Approved)
+                       && ReleaseStatuses
+                           .Where(rs => rs.ApprovalStatus == ReleaseApprovalStatus.Approved)
+                           .OrderBy(rs => rs.Created)
+                           .Last()
+                           .NotifySubscribers;
+            }
+        }
+
         public string LatestInternalReleaseNote
         {
             get

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Release.cs
@@ -70,12 +70,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         {
             get
             {
-                return ReleaseStatuses.Any(rs => rs.ApprovalStatus == ReleaseApprovalStatus.Approved)
-                       && ReleaseStatuses
-                           .Where(rs => rs.ApprovalStatus == ReleaseApprovalStatus.Approved)
+                var status = ReleaseStatuses
                            .OrderBy(rs => rs.Created)
-                           .Last()
-                           .NotifySubscribers;
+                           .LastOrDefault();
+                return status != null
+                       && status.NotifySubscribers
+                       && status.NotifiedOn == null;
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseStatus.cs
@@ -16,6 +16,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public bool NotifySubscribers { get; set; }
 
+        public DateTime? NotifiedOn { get; set; }
+
         public ReleaseApprovalStatus ApprovalStatus { get; set; }
 
         public DateTime? Created { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseStatus.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/ReleaseStatus.cs
@@ -10,9 +10,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public Guid ReleaseId { get; set; }
 
-        public Release Release { get; set; }
+        public Release Release { get; set; } = null!;
 
-        public string InternalReleaseNote { get; set; }
+        public string InternalReleaseNote { get; set; } = null!;
+
+        public bool NotifySubscribers { get; set; }
 
         public ReleaseApprovalStatus ApprovalStatus { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/PublicationNotificationMessage.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier.Model/PublicationNotificationMessage.cs
@@ -7,5 +7,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Notifier.Model
         public Guid PublicationId { get; set; }
         public string Name { get; set; }
         public string Slug { get; set; }
+
+        protected bool Equals(PublicationNotificationMessage other)
+        {
+            return Name == other.Name && PublicationId.Equals(other.PublicationId) && Slug == other.Slug;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((PublicationNotificationMessage) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Name, PublicationId, Slug);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/NotificationsServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher.Tests/Services/NotificationsServiceTests.cs
@@ -1,0 +1,198 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Notifier.Model;
+using GovUk.Education.ExploreEducationStatistics.Publisher.Services;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Database.ContentDbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Notifier.Model.NotifierQueues;
+
+namespace GovUk.Education.ExploreEducationStatistics.Publisher.Tests.Services
+{
+    public class NotificationsServiceTests
+    {
+        [Fact]
+        public async Task NotifySubscribersIfApplicable()
+        {
+            var release1 = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = new Publication
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "pub1 title",
+                    Slug = "pub1-slug",
+                },
+                ReleaseStatuses = new List<ReleaseStatus>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        ApprovalStatus = ReleaseApprovalStatus.Approved,
+                        Created = DateTime.UtcNow,
+                        NotifySubscribers = true,
+                    },
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        ApprovalStatus = ReleaseApprovalStatus.Draft,
+                        Created = DateTime.UtcNow.AddDays(-1),
+                        NotifySubscribers = false,
+                    },
+                },
+            };
+
+            var release2 = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = new Publication
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "pub2 title",
+                    Slug = "pub2-slug",
+                },
+                ReleaseStatuses = new List<ReleaseStatus>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        ApprovalStatus = ReleaseApprovalStatus.Approved,
+                        Created = DateTime.UtcNow,
+                        NotifySubscribers = false,
+                    },
+                },
+            };
+
+            var release3 = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = new Publication
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "pub3 title",
+                    Slug = "pub3-slug",
+                },
+                ReleaseStatuses = new List<ReleaseStatus>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        ApprovalStatus = ReleaseApprovalStatus.Approved,
+                        Created = DateTime.UtcNow,
+                        NotifySubscribers = true,
+                    },
+                },
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.AddRangeAsync(release1, release2, release3);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var storageQueueService = new Mock<IStorageQueueService>(MockBehavior.Strict);
+            storageQueueService.Setup(mock => mock.AddMessages(
+                PublicationQueue,
+                It.IsAny<List<PublicationNotificationMessage>>()))
+                .Returns(Task.CompletedTask);
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var notificationsService = BuildNotificationsService(
+                    contentDbContext, storageQueueService.Object);
+
+                await notificationsService.NotifySubscribersIfApplicable(release1.Id, release2.Id, release3.Id);
+
+                storageQueueService.Verify(mock => mock.AddMessages(
+                    PublicationQueue,
+                new List<PublicationNotificationMessage>
+                    {
+                        new()
+                        {
+                            Name = release1.Publication.Title,
+                            PublicationId = release1.Publication.Id,
+                            Slug = release1.Publication.Slug,
+                        },
+                        new()
+                        {
+                            Name = release3.Publication.Title,
+                            PublicationId = release3.Publication.Id,
+                            Slug = release3.Publication.Slug,
+                        },
+                    }), Times.Once);
+            }
+
+            MockUtils.VerifyAllMocks(storageQueueService);
+        }
+
+        [Fact]
+        public async Task NotifySubscribersIfApplicable_NotifyOnSet()
+        {
+            var release = new Release
+            {
+                Id = Guid.NewGuid(),
+                Publication = new Publication
+                {
+                    Id = Guid.NewGuid(),
+                    Title = "pub title",
+                    Slug = "pub-slug",
+                },
+                ReleaseStatuses = new List<ReleaseStatus>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        ApprovalStatus = ReleaseApprovalStatus.Approved,
+                        Created = DateTime.UtcNow,
+                        NotifySubscribers = true,
+                        NotifiedOn = DateTime.UtcNow,
+                    },
+                },
+            };
+            var contentDbContextId = Guid.NewGuid().ToString();
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.AddRangeAsync(release);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var notificationsService = BuildNotificationsService(contentDbContext);
+
+                await notificationsService.NotifySubscribersIfApplicable(release.Id);
+
+                // No interaction with storage queue service expected as NotifyOn is set
+                // in ReleaseStatus.
+            }
+        }
+
+        [Fact]
+        public async Task NotifySubscribersIfApplicable_NoReleaseIds()
+        {
+            await using var contentDbContext = InMemoryContentDbContext();
+            var notificationsService = BuildNotificationsService(contentDbContext);
+
+            await notificationsService.NotifySubscribersIfApplicable();
+
+            // No interaction with the storage queue service is expected
+            // since no releases are being published.
+        }
+
+        private static NotificationsService BuildNotificationsService(
+            ContentDbContext contentDbContext,
+            IStorageQueueService? storageQueueService = null)
+        {
+            return new (
+                contentDbContext,
+                storageQueueService ?? Mock.Of<IStorageQueueService>(MockBehavior.Strict));
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishReleaseContentFunction.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
@@ -11,7 +9,6 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Utils;
 using Microsoft.Azure.WebJobs;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 
@@ -25,22 +22,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
         private readonly INotificationsService _notificationsService;
         private readonly IReleaseService _releaseService;
         private readonly IReleaseStatusService _releaseStatusService;
-        private readonly ContentDbContext _contentDbContext;
 
         public PublishReleaseContentFunction(
             IBlobCacheService blobCacheService,
             IContentService contentService,
             INotificationsService notificationsService,
             IReleaseService releaseService,
-            IReleaseStatusService releaseStatusService,
-            ContentDbContext contentDbContext)
+            IReleaseStatusService releaseStatusService)
         {
             _blobCacheService = blobCacheService;
             _contentService = contentService;
             _notificationsService = notificationsService;
             _releaseService = releaseService;
             _releaseStatusService = releaseStatusService;
-            _contentDbContext = contentDbContext;
         }
 
         /// <summary>
@@ -90,13 +84,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 await _contentService.DeletePreviousVersionsDownloadFiles(message.ReleaseId);
                 await _contentService.DeletePreviousVersionsContent(message.ReleaseId);
 
-                var release = _contentDbContext.Releases
-                    .Include(r => r.ReleaseStatuses)
-                    .Single(r => r.Id == message.ReleaseId);
-                if (release.NotifySubscribers)
-                {
-                    await _notificationsService.NotifySubscribers(message.ReleaseId);
-                }
+                await _notificationsService.NotifySubscribersIfApplicable(message.ReleaseId);
 
                 await UpdateStage(message.ReleaseId, message.ReleaseStatusId, State.Complete);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/INotificationsService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/INotificationsService.cs
@@ -5,6 +5,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 {
     public interface INotificationsService
     {
-        Task NotifySubscribers(params Guid[] releaseIds);
+        Task NotifySubscribersIfApplicable(params Guid[] releaseIds);
     }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -3,7 +3,11 @@ import { Release } from '@admin/services/releaseService';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
-import { Form, FormFieldRadioGroup } from '@common/components/form';
+import {
+  Form,
+  FormFieldCheckbox,
+  FormFieldRadioGroup,
+} from '@common/components/form';
 import FormFieldDateInput from '@common/components/form/FormFieldDateInput';
 import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
 import WarningMessage from '@common/components/WarningMessage';
@@ -29,6 +33,7 @@ export interface ReleaseStatusFormValues {
   publishScheduled?: Date;
   nextReleaseDate?: PartialDate;
   approvalStatus: ReleaseApprovalStatus;
+  notifySubscribers?: boolean;
   latestInternalReleaseNote: string;
 }
 
@@ -103,6 +108,7 @@ const ReleaseStatusForm = ({
       enableReinitialize
       initialValues={{
         approvalStatus: release.approvalStatus,
+        notifySubscribers: release.notifySubscribers,
         latestInternalReleaseNote: release.latestInternalReleaseNote ?? '',
         publishMethod: release.publishScheduled ? 'Scheduled' : undefined,
         publishScheduled: release.publishScheduled
@@ -115,6 +121,10 @@ const ReleaseStatusForm = ({
         approvalStatus: Yup.string().required(
           'Choose a status',
         ) as StringSchema<ReleaseStatusFormValues['approvalStatus']>,
+        notifySubscribers: Yup.boolean().when('approvalStatus', {
+          is: value => value === 'Approved',
+          then: Yup.boolean().required(),
+        }),
         latestInternalReleaseNote: Yup.string().when('approvalStatus', {
           is: value => ['Approved', 'HigherLevelReview'].includes(value),
           then: Yup.string().required('Enter an internal note'),
@@ -185,6 +195,11 @@ const ReleaseStatusForm = ({
                   disabled: !statusPermissions?.canMarkApproved,
                 },
               ]}
+              onChange={element => {
+                if (element.target.value === 'Approved') {
+                  form.setFieldValue('notifySubscribers', true);
+                }
+              }}
             />
 
             <FormFieldTextArea<ReleaseStatusFormValues>
@@ -194,6 +209,13 @@ const ReleaseStatusForm = ({
               hint="Please include any relevant information"
               rows={3}
             />
+
+            {form.values.approvalStatus === 'Approved' && release.amendment && (
+              <FormFieldCheckbox
+                name="notifySubscribers"
+                label="Notify subscribers by email"
+              />
+            )}
 
             {form.values.approvalStatus === 'Approved' && (
               <FormFieldRadioGroup<ReleaseStatusFormValues>
@@ -243,6 +265,9 @@ const ReleaseStatusForm = ({
                 disabled={form.isSubmitting}
                 onClick={e => {
                   e.preventDefault();
+                  if (form.values.approvalStatus !== 'Approved') {
+                    form.setFieldValue('notifySubscribers', undefined);
+                  }
                   if (
                     form.values.approvalStatus === 'Approved' &&
                     form.values.publishMethod === 'Scheduled' &&

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -644,6 +644,7 @@ describe('ReleaseStatusForm', () => {
           release={{
             ...testRelease,
             approvalStatus: 'Approved',
+            notifySubscribers: true,
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -680,6 +681,7 @@ describe('ReleaseStatusForm', () => {
       const expectedValues: ReleaseStatusFormValues = {
         latestInternalReleaseNote: 'Test release note',
         approvalStatus: 'Approved',
+        notifySubscribers: true,
         publishScheduled: new Date('2022-10-10'),
         publishMethod: 'Scheduled',
         nextReleaseDate: {
@@ -708,6 +710,7 @@ describe('ReleaseStatusForm', () => {
           release={{
             ...testRelease,
             approvalStatus: 'Approved',
+            notifySubscribers: true,
           }}
           statusPermissions={testStatusPermissions}
           onCancel={noop}
@@ -736,11 +739,62 @@ describe('ReleaseStatusForm', () => {
       const expectedValues: ReleaseStatusFormValues = {
         latestInternalReleaseNote: 'Test release note',
         approvalStatus: 'Approved',
+        notifySubscribers: true,
         publishMethod: 'Immediate',
         nextReleaseDate: {
           month: 5,
           year: 2021,
         },
+      };
+
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledWith(expectedValues);
+      });
+    });
+
+    test('Amendment should have "Notify subscribers by email" checkbox', async () => {
+      const handleSubmit = jest.fn();
+
+      render(
+        <ReleaseStatusForm
+          release={{
+            ...testRelease,
+            approvalStatus: 'Approved',
+            amendment: true,
+            notifySubscribers: true,
+          }}
+          statusPermissions={testStatusPermissions}
+          onCancel={noop}
+          onSubmit={handleSubmit}
+        />,
+      );
+
+      await userEvent.type(
+        screen.getByLabelText('Internal note'),
+        'Test release note',
+      );
+
+      expect(
+        screen.getByLabelText('Notify subscribers by email'),
+      ).toBeChecked();
+
+      userEvent.click(screen.getByLabelText('Notify subscribers by email'));
+
+      expect(
+        screen.getByLabelText('Notify subscribers by email'),
+      ).not.toBeChecked();
+
+      userEvent.click(screen.getByLabelText('Immediately'));
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+      const expectedValues: ReleaseStatusFormValues = {
+        latestInternalReleaseNote: 'Test release note',
+        approvalStatus: 'Approved',
+        notifySubscribers: false,
+        publishMethod: 'Immediate',
       };
 
       await waitFor(() => {

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -8,6 +8,7 @@ export interface Release {
   id: string;
   slug: string;
   approvalStatus: ReleaseApprovalStatus;
+  notifySubscribers?: boolean;
   latestRelease: boolean;
   live: boolean;
   amendment: boolean;
@@ -165,6 +166,7 @@ export interface ReleaseStatus {
   releaseStatusId: string;
   internalReleaseNote: string;
   approvalStatus: ReleaseApprovalStatus;
+  notifySubscribers: boolean;
   created: string;
   createdByEmail: string;
 }

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -162,7 +162,7 @@ Check release approver can create a release note
 
 Check release approver can publish a release
     user clicks link    Sign off
-    user approves release for immediate publication
+    user approves original release for immediate publication
 
 Navigate to administration as bau1 and swap release approver role for publication owner now that the publication is live
     user changes to bau1

--- a/tests/robot-tests/tests/admin/bau/comments.robot
+++ b/tests/robot-tests/tests/admin/bau/comments.robot
@@ -198,4 +198,4 @@ Switch to bau1 to approve release for immediate publication
     ${details}=    user gets details content element    ${RELEASE_NAME} (not Live)    ${accordion}
     user waits until parent contains element    ${details}    xpath:.//a[text()="Edit this release"]
     user clicks link    Edit this release
-    user approves release for immediate publication
+    user approves original release for immediate publication

--- a/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
@@ -18,7 +18,7 @@ Create publicly accessible Publication
     user create test release via api    ${PUBLICATION_ID}    AY    2021
     user navigates to editable release summary from admin dashboard    ${PUBLICATION_NAME}
     ...    Academic Year 2021/22 (not Live)
-    user approves release for immediate publication
+    user approves original release for immediate publication
 
 Create Methodology with some content and images
     user creates methodology for publication    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -50,7 +50,7 @@ Add public prerelease access list
 
 Go to "Sign off" page and approve release
     user clicks link    Sign off
-    user approves release for immediate publication
+    user approves original release for immediate publication
 
 Create another release for the same publication
     user selects theme and topic from admin dashboard    %{TEST_THEME_NAME}    ${TOPIC_NAME}
@@ -403,7 +403,7 @@ Add public prerelease access list for release
 
 Approve release
     user clicks link    Sign off
-    user approves release for immediate publication
+    user approves original release for immediate publication
 
 User goes to public Find Statistics page
     user navigates to find statistics page on public frontend

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -56,7 +56,7 @@ Verify that the methodology is still not publicly accessible by URL without publ
 Approve the release
     user navigates to editable release summary from admin dashboard    ${PUBLICATION_NAME}
     ...    ${RELEASE_NAME} (not Live)
-    user approves release for immediate publication
+    user approves original release for immediate publication
 
 Verify that the methodology is visible on the public methodologies page with the expected URL
     user navigates to public methodologies page

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -174,7 +174,7 @@ Verify release is scheduled
     user checks summary list contains    Next release expected    December 3001
 
 Approve release for immediate publication
-    user approves release for immediate publication
+    user approves original release for immediate publication
 
 User goes to public Find Statistics page
     user navigates to find statistics page on public frontend
@@ -516,7 +516,7 @@ Update public prerelease access list for amendment
 
 Approve amendment for immediate release
     user clicks link    Sign off
-    user approves release for immediate publication
+    user approves amended release for immediate publication
 
 Go back to public find-statistics page
     user goes to url    %{PUBLIC_URL}/find-statistics

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -100,7 +100,7 @@ Add public prerelease access list
 
 Approve release
     user clicks link    Sign off
-    user approves release for immediate publication
+    user approves original release for immediate publication
 
 Go to public Table Tool page
     user navigates to data tables page on public frontend
@@ -292,7 +292,7 @@ Add release note to release amendment
 
 Go to "Sign off" page and approve release amendment
     user clicks link    Sign off
-    user approves release for immediate publication
+    user approves amended release for immediate publication
 
 Go to permalink page & check for error element to be present
     user goes to url    ${PERMA_LOCATION_URL}
@@ -410,9 +410,9 @@ Add release note for new release amendment
     user waits until element contains    css:#releaseNotes li:nth-of-type(1) time    ${date}
     user waits until element contains    css:#releaseNotes li:nth-of-type(1) p    Test release note two
 
-Go to "Sign off" to approve release for immediate publication
+Go to "Sign off" to approve amended release for immediate publication
     user clicks link    Sign off
-    user approves release for immediate publication
+    user approves amended release for immediate publication
 
 Go to public Table Tool page for amendment
     user goes to url    %{PUBLIC_URL}/data-tables

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -503,14 +503,25 @@ user deletes subject file
     user clicks element    ${button}
     user clicks button    Confirm
 
+user approves original release for immediate publication
+    user approves release for immediate publication    original
+
+user approves amended release for immediate publication
+    user approves release for immediate publication    amendment
+
 user approves release for immediate publication
+    [Arguments]    ${release_type}=original
     user clicks link    Sign off
     user waits until page does not contain loading spinner
     user waits until h2 is visible    Sign off
     user waits until page contains button    Edit release status
     user clicks button    Edit release status
     user waits until h2 is visible    Edit release status
+    user checks page does not contain    Notify subscribers by email
     user clicks radio    Approved for publication
+    IF    '${release_type}' == 'amendment'
+        user waits until page contains    Notify subscribers by email
+    END
     user enters text into element    id:releaseStatusForm-latestInternalReleaseNote    Approved by UI tests
     user clicks radio    Immediately
     user clicks button    Update status

--- a/tests/robot-tests/tests/libs/bootstrap_data/bootstrap_common.robot
+++ b/tests/robot-tests/tests/libs/bootstrap_data/bootstrap_common.robot
@@ -62,7 +62,7 @@ user creates a fully populated published release
     ...    ${RELEASE_TIME_PERIOD}
     ...    ${RELEASE_YEAR}
     ...    ${RELEASE_TYPE}
-    user approves release for immediate publication
+    user approves original release for immediate publication
 
 user creates a fully populated draft release
     [Arguments]


### PR DESCRIPTION
This PR adds a `Notify subscribers by email` checkbox when approving an amended release on the Admin Sign off page.

![image](https://user-images.githubusercontent.com/44812484/132324155-f12d4572-c441-4b98-a1d8-fe6b8745c525.png)

Previously, subscribers would be notified every time a release would be published. Now, analysts can choose whether subscribers are notified when publishing an amendment. Subscribers are still always notified when an original release is published.

Edit: 
We've additionally added a `NotifyOn` column to the Content DB ReleaseStatus table. This is to reduce the chance that we send a notification email twice.

It is possible for a ReleaseStatus to have `NotifySubscribers` set to true and the `NotifyOn` column to never get set. This happens if a user schedules a release for publication and then moves it back to draft. The ReleaseStatus associated with the scheduling of the release for publication will never have a notification sent with it.

The publisher always checks the most recent ReleaseStatus for a release when determining whether a notification should be sent. This means that if in the future the possibility of an additional ReleaseStatus being created between the scheduling of a release for publication and its actual publication, notification may be effected.