### PR TITLE
Ees 2151 warning when cancelling release amendment with scheduled methodologies

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServicePermissionTests.cs
@@ -205,6 +205,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
+        public async Task GetDeleteReleasePlan()
+        {
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_release, CanDeleteSpecificRelease)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = BuildReleaseService(userService: userService.Object);
+                        return service.GetDeleteReleasePlan(_release.Id);
+                    }
+                );
+        }
+
+        [Fact]
         public async Task DeleteRelease()
         {
             await PolicyCheckBuilder<SecurityPolicies>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceTests.cs
@@ -1886,9 +1886,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 // Assert that only the 2 Methodologies that were scheduled with the Release being deleted are flagged
                 // up in the Plan.
-                Assert.Equal(2, plan.MethodologiesScheduledWithRelease.Count);
-                var methodology1 = plan.MethodologiesScheduledWithRelease.Single(m => m.Id == methodology1ScheduledWithRelease1.Id);
-                var methodology2 = plan.MethodologiesScheduledWithRelease.Single(m => m.Id == methodology2ScheduledWithRelease1.Id);
+                Assert.Equal(2, plan.ScheduledMethodologies.Count);
+                var methodology1 = plan.ScheduledMethodologies.Single(m => m.Id == methodology1ScheduledWithRelease1.Id);
+                var methodology2 = plan.ScheduledMethodologies.Single(m => m.Id == methodology2ScheduledWithRelease1.Id);
                 
                 Assert.Equal("Methodology 1 with alternative title", methodology1.Title);
                 Assert.Equal("Methodology 2 with owned Publication title", methodology2.Title);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -215,11 +216,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
-        [HttpGet("release/{releaseId}/data/{fileId}/delete-plan")]
-        public async Task<ActionResult<DeleteDataFilePlan>> GetDeleteDataFilePlan(Guid releaseId, Guid fileId)
+        [HttpGet("release/{releaseId}/delete-plan")]
+        public async Task<ActionResult<DeleteReleasePlan>> GetDeleteReleasePlan(Guid releaseId)
         {
             return await _releaseService
-                .GetDeleteDataFilePlan(releaseId, fileId)
+                .GetDeleteReleasePlan(releaseId)
                 .HandleFailuresOrOk();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -184,7 +183,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpGet("publications/{publicationId}/releases/template")]
-        public async Task<ActionResult<TitleAndIdViewModel?>> GetTemplateRelease(
+        public async Task<ActionResult<TitleAndIdViewModel>> GetTemplateRelease(
             [Required] Guid publicationId)
         {
             return await _releaseService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/ReleasesController.cs
@@ -224,6 +224,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
                 .HandleFailuresOrOk();
         }
 
+        [HttpGet("release/{releaseId}/data/{fileId}/delete-plan")]
+        public async Task<ActionResult<DeleteDataFilePlan>> GetDeleteDataFilePlan(Guid releaseId, Guid fileId)
+        {
+            return await _releaseService
+                .GetDeleteDataFilePlan(releaseId, fileId)
+                .HandleFailuresOrOk();
+        }
+
         [HttpDelete("release/{releaseId}/data/{fileId}")]
         public async Task<ActionResult> DeleteDataFiles(Guid releaseId, Guid fileId)
         {
@@ -233,7 +241,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpPost("release/{releaseId}/data/{fileId}/import/cancel")]
-        public async Task<IActionResult> CancelFileImport(Guid releaseId, Guid fileId)
+        public async Task<ActionResult> CancelFileImport(Guid releaseId, Guid fileId)
         {
             return await _dataImportService
                 .CancelImport(releaseId, fileId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/IReleaseService.cs
@@ -13,6 +13,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces
     {
         Task<Either<ActionResult, ReleaseViewModel>> CreateRelease(ReleaseCreateViewModel release);
 
+        Task<Either<ActionResult, DeleteReleasePlan>> GetDeleteReleasePlan(Guid releaseId);
+
         Task<Either<ActionResult, Unit>> DeleteRelease(Guid releaseId);
 
         Task<Either<ActionResult, ReleaseViewModel>> CreateReleaseAmendment(Guid releaseId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -190,7 +190,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     return new DeleteReleasePlan
                     {
-                        MethodologiesScheduledWithRelease = methodologiesScheduledWithRelease
+                        ScheduledMethodologies = methodologiesScheduledWithRelease
                     };
                 });
         }
@@ -724,7 +724,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
     public class DeleteReleasePlan
     {
-        public List<TitleAndIdViewModel> MethodologiesScheduledWithRelease { get; set; } =
-            new List<TitleAndIdViewModel>();
+        public List<TitleAndIdViewModel> ScheduledMethodologies { get; set; } = new List<TitleAndIdViewModel>();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -108,6 +108,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(release => _mapper.Map<ReleaseViewModel>(release));
         }
 
+        // TODO EES-2687 - extract Release Status methods into separate Service  
         public async Task<Either<ActionResult, List<ReleaseStatusViewModel>>> GetReleaseStatuses(
             Guid releaseId)
         {
@@ -222,7 +223,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                     var methodologiesScheduledWithRelease = 
                         GetMethodologiesScheduledWithRelease(releaseId);
-                    
+
+                    // TODO EES-2687 - as part of a ReleaseService refactor to extract Release Status update logic into
+                    // its own Service, this should be looked at to see how best to reuse similar "set to draft" logic
+                    // in MethodologyService.
                     methodologiesScheduledWithRelease.ForEach(m =>
                     {
                         m.PublishingStrategy = Immediately;
@@ -322,6 +326,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(_mapper.Map<ReleasePublicationStatusViewModel>);
         }
 
+        // TODO EES-2687 - extract Release Status methods into separate Service  
         public async Task<Either<ActionResult, ReleaseViewModel>> UpdateRelease(
             Guid releaseId, ReleaseUpdateViewModel request)
         {
@@ -343,6 +348,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
+        // TODO EES-2687 - extract Release Status methods into separate Service  
         public async Task<Either<ActionResult, ReleaseViewModel>> CreateReleaseStatus(
             Guid releaseId, ReleaseStatusCreateViewModel request)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -173,6 +173,28 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 });
         }
 
+        public Task<Either<ActionResult, DeleteReleasePlan>> GetDeleteReleasePlan(Guid releaseId)
+        {
+            return _persistenceHelper
+                .CheckEntityExists<Release>(releaseId)
+                .OnSuccess(_userService.CheckCanDeleteRelease)
+                .OnSuccess(release =>
+                {
+                    var methodologiesScheduledWithRelease = _context
+                        .Methodologies
+                        .Include(m => m.MethodologyParent)
+                        .Where(m => releaseId == m.ScheduledWithReleaseId)
+                        .Select(m => new TitleAndIdViewModel(m.Id, m.Title))
+                        .ToList();
+
+                    return new DeleteReleasePlan
+                    {
+                        MethodologiesScheduledWithRelease = methodologiesScheduledWithRelease
+                    };
+                });
+
+        }
+
         public Task<Either<ActionResult, Unit>> DeleteRelease(Guid releaseId)
         {
             return _persistenceHelper
@@ -671,5 +693,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public DeleteDataBlockPlan DeleteDataBlockPlan { get; set; } = null!;
 
         public List<Guid> FootnoteIds { get; set; } = null!;
+    }
+
+    public class DeleteReleasePlan
+    {
+        public List<TitleAndIdViewModel> MethodologiesScheduledWithRelease { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ActionResultTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ActionResultTestExtensions.cs
@@ -24,7 +24,32 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             Assert.IsAssignableFrom<NoContentResult>(result);
         }
         
+        public static void AssertForbidden(this ActionResult result)
+        {
+            Assert.IsAssignableFrom<ForbidResult>(result);
+        }
+        
+        public static void AssertForbidden<T>(this ActionResult<T> result)
+        {
+            Assert.IsAssignableFrom<ForbidResult>(result);
+        }
+        
+        public static void AssertAccepted(this ActionResult result)
+        {
+            Assert.IsAssignableFrom<AcceptedResult>(result);
+        }
+        
+        public static void AssertBadRequest<T>(this ActionResult<T> result, params Enum[] expectedValidationErrors)
+        {
+            AssertBadRequestWithValidationErrors(result.Result, expectedValidationErrors);
+        }
+        
         public static void AssertBadRequest(this ActionResult result, params Enum[] expectedValidationErrors)
+        {
+            AssertBadRequestWithValidationErrors(result, expectedValidationErrors);
+        }
+        
+        private static void AssertBadRequestWithValidationErrors(this object result, params Enum[] expectedValidationErrors)
         {
             var badRequest = Assert.IsAssignableFrom<BadRequestObjectResult>(result);
             var validationProblem = Assert.IsAssignableFrom<ValidationProblemDetails>(badRequest?.Value);

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/CancelAmendmentModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/CancelAmendmentModal.tsx
@@ -1,12 +1,24 @@
 import ModalConfirm from '@common/components/ModalConfirm';
 import React from 'react';
+import { IdTitlePair } from '@admin/services/types/common';
+import Link from '@admin/components/Link';
+import { generatePath } from 'react-router';
+import {
+  MethodologyRouteParams,
+  methodologyStatusRoute,
+} from '@admin/routes/methodologyRoutes';
 
 interface Props {
   onConfirm: () => void;
   onCancel: () => void;
+  methodologiesScheduledWithRelease: IdTitlePair[];
 }
 
-const CancelAmendmentModal = ({ onConfirm, onCancel }: Props) => {
+const CancelAmendmentModal = ({
+  onConfirm,
+  onCancel,
+  methodologiesScheduledWithRelease,
+}: Props) => {
   return (
     <ModalConfirm
       title="Confirm you want to cancel this amended release"
@@ -19,6 +31,19 @@ const CancelAmendmentModal = ({ onConfirm, onCancel }: Props) => {
         By cancelling the amendments you will lose any changes made, and the
         original release will remain unchanged.
       </p>
+      {methodologiesScheduledWithRelease.length > 0 && (
+        <>
+          <p>
+            The following methodologies are scheduled to be published with this
+            amended release:
+          </p>
+          <ul>
+            {methodologiesScheduledWithRelease.map(m => (
+              <li key={m.id}>{m.title}</li>
+            ))}
+          </ul>
+        </>
+      )}
     </ModalConfirm>
   );
 };

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/CancelAmendmentModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/CancelAmendmentModal.tsx
@@ -3,37 +3,37 @@ import React from 'react';
 import { IdTitlePair } from '@admin/services/types/common';
 
 interface Props {
-  onConfirm: () => void;
+  scheduledMethodologies: IdTitlePair[];
   onCancel: () => void;
-  methodologiesScheduledWithRelease: IdTitlePair[];
+  onConfirm: () => void;
 }
 
 const CancelAmendmentModal = ({
-  onConfirm,
+  scheduledMethodologies,
   onCancel,
-  methodologiesScheduledWithRelease,
+  onConfirm,
 }: Props) => {
   return (
     <ModalConfirm
+      open
       title="Confirm you want to cancel this amended release"
+      onCancel={onCancel}
       onConfirm={onConfirm}
       onExit={onCancel}
-      onCancel={onCancel}
-      open
     >
       <p>
         By cancelling the amendments you will lose any changes made, and the
         original release will remain unchanged.
       </p>
-      {methodologiesScheduledWithRelease.length > 0 && (
+      {scheduledMethodologies.length > 0 && (
         <>
           <p>
             The following methodologies are scheduled to be published with this
             amended release:
           </p>
           <ul>
-            {methodologiesScheduledWithRelease.map(m => (
-              <li key={m.id}>{m.title}</li>
+            {scheduledMethodologies.map(methodology => (
+              <li key={methodology.id}>{methodology.title}</li>
             ))}
           </ul>
         </>

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/CancelAmendmentModal.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/CancelAmendmentModal.tsx
@@ -1,12 +1,6 @@
 import ModalConfirm from '@common/components/ModalConfirm';
 import React from 'react';
 import { IdTitlePair } from '@admin/services/types/common';
-import Link from '@admin/components/Link';
-import { generatePath } from 'react-router';
-import {
-  MethodologyRouteParams,
-  methodologyStatusRoute,
-} from '@admin/routes/methodologyRoutes';
 
 interface Props {
   onConfirm: () => void;

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTab.tsx
@@ -1,11 +1,7 @@
-import CancelAmendmentModal from '@admin/pages/admin-dashboard/components/CancelAmendmentModal';
 import NonScheduledReleaseSummary from '@admin/pages/admin-dashboard/components/NonScheduledReleaseSummary';
 import ReleasesTab from '@admin/pages/admin-dashboard/components/ReleasesByStatusTab';
-import releaseService, {
-  DeleteReleasePlan,
-  MyRelease,
-} from '@admin/services/releaseService';
-import React, { useState } from 'react';
+import { MyRelease } from '@admin/services/releaseService';
+import React from 'react';
 
 interface Props {
   releases: MyRelease[];
@@ -13,42 +9,18 @@ interface Props {
 }
 
 const DraftReleasesTab = ({ releases, onChangeRelease }: Props) => {
-  const [deleteReleasePlan, setDeleteReleasePlan] = useState<
-    DeleteReleasePlan
-  >();
-
   return (
-    <>
-      <ReleasesTab
-        releases={releases}
-        noReleasesMessage="There are currently no draft releases"
-        releaseSummaryRenderer={release => (
-          <NonScheduledReleaseSummary
-            key={release.id}
-            onClickCancelAmendment={async releaseId => {
-              setDeleteReleasePlan(
-                await releaseService.getDeleteReleasePlan(releaseId),
-              );
-            }}
-            release={release}
-          />
-        )}
-      />
-
-      {deleteReleasePlan && (
-        <CancelAmendmentModal
-          methodologiesScheduledWithRelease={
-            deleteReleasePlan.methodologiesScheduledWithRelease
-          }
-          onConfirm={async () => {
-            await releaseService.deleteRelease(deleteReleasePlan.releaseId);
-            setDeleteReleasePlan(undefined);
-            onChangeRelease();
-          }}
-          onCancel={() => setDeleteReleasePlan(undefined)}
+    <ReleasesTab
+      releases={releases}
+      noReleasesMessage="There are currently no draft releases"
+      releaseSummaryRenderer={release => (
+        <NonScheduledReleaseSummary
+          key={release.id}
+          release={release}
+          onAmendmentCancelled={onChangeRelease}
         />
       )}
-    </>
+    />
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/DraftReleasesTab.tsx
@@ -1,7 +1,10 @@
 import CancelAmendmentModal from '@admin/pages/admin-dashboard/components/CancelAmendmentModal';
 import NonScheduledReleaseSummary from '@admin/pages/admin-dashboard/components/NonScheduledReleaseSummary';
 import ReleasesTab from '@admin/pages/admin-dashboard/components/ReleasesByStatusTab';
-import releaseService, { MyRelease } from '@admin/services/releaseService';
+import releaseService, {
+  DeleteReleasePlan,
+  MyRelease,
+} from '@admin/services/releaseService';
 import React, { useState } from 'react';
 
 interface Props {
@@ -10,8 +13,8 @@ interface Props {
 }
 
 const DraftReleasesTab = ({ releases, onChangeRelease }: Props) => {
-  const [cancelAmendmentReleaseId, setCancelAmendmentReleaseId] = useState<
-    string
+  const [deleteReleasePlan, setDeleteReleasePlan] = useState<
+    DeleteReleasePlan
   >();
 
   return (
@@ -22,20 +25,27 @@ const DraftReleasesTab = ({ releases, onChangeRelease }: Props) => {
         releaseSummaryRenderer={release => (
           <NonScheduledReleaseSummary
             key={release.id}
-            onClickCancelAmendment={setCancelAmendmentReleaseId}
+            onClickCancelAmendment={async releaseId => {
+              setDeleteReleasePlan(
+                await releaseService.getDeleteReleasePlan(releaseId),
+              );
+            }}
             release={release}
           />
         )}
       />
 
-      {cancelAmendmentReleaseId && (
+      {deleteReleasePlan && (
         <CancelAmendmentModal
+          methodologiesScheduledWithRelease={
+            deleteReleasePlan.methodologiesScheduledWithRelease
+          }
           onConfirm={async () => {
-            await releaseService.deleteRelease(cancelAmendmentReleaseId);
-            setCancelAmendmentReleaseId(undefined);
+            await releaseService.deleteRelease(deleteReleasePlan.releaseId);
+            setDeleteReleasePlan(undefined);
             onChangeRelease();
           }}
-          onCancel={() => setCancelAmendmentReleaseId(undefined)}
+          onCancel={() => setDeleteReleasePlan(undefined)}
         />
       )}
     </>

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/NonScheduledReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/NonScheduledReleaseSummary.tsx
@@ -5,96 +5,164 @@ import {
   ReleaseRouteParams,
   releaseSummaryRoute,
 } from '@admin/routes/releaseRoutes';
-import { MyRelease } from '@admin/services/releaseService';
+import releaseService, {
+  DeleteReleasePlan,
+  MyRelease,
+} from '@admin/services/releaseService';
 import Button from '@common/components/Button';
-import React from 'react';
-import { generatePath } from 'react-router';
+import React, { useState } from 'react';
+import { generatePath, useHistory } from 'react-router';
+import CancelAmendmentModal from '@admin/pages/admin-dashboard/components/CancelAmendmentModal';
+import ModalConfirm from '@common/components/ModalConfirm';
 
 interface Props {
   release: MyRelease;
-  onClickAmendRelease?: (releaseId: string) => void;
-  onClickCancelAmendment: (releaseId: string) => void;
+  includeCreateAmendmentControls?: boolean;
+  onAmendmentCancelled: (releaseId: string) => void;
 }
 
 const NonScheduledReleaseSummary = ({
   release,
-  onClickAmendRelease,
-  onClickCancelAmendment,
+  includeCreateAmendmentControls = false,
+  onAmendmentCancelled,
 }: Props) => {
+  const history = useHistory();
+
+  const [deleteReleasePlan, setDeleteReleasePlan] = useState<
+    DeleteReleasePlan
+  >();
+
+  const [amendReleaseId, setAmendReleaseId] = useState<string>();
+
   return (
-    <ReleaseSummary
-      release={release}
-      open={release.live && release.latestRelease}
-      actions={
-        <>
-          {release.amendment ? (
-            <>
-              <ButtonLink
-                to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
-                  publicationId: release.publicationId,
-                  releaseId: release.id,
-                })}
-                data-testid={`Edit release amendment link for ${
-                  release.publicationTitle
-                }, ${getReleaseSummaryLabel(release)}`}
-              >
-                {release.permissions.canUpdateRelease
-                  ? 'Edit this release amendment'
-                  : 'View this release amendment'}
-              </ButtonLink>
-              <ButtonLink
-                to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
-                  publicationId: release.publicationId,
-                  releaseId: release.previousVersionId,
-                })}
-                className="govuk-button--secondary govuk-!-margin-left-4"
-                data-testid={`View original release link for ${
-                  release.publicationTitle
-                }, ${getReleaseSummaryLabel(release)}`}
-              >
-                View original release
-              </ButtonLink>
-            </>
-          ) : (
-            <>
-              <ButtonLink
-                to={generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
-                  publicationId: release.publicationId,
-                  releaseId: release.id,
-                })}
-                data-testid={`Edit release link for ${
-                  release.publicationTitle
-                }, ${getReleaseSummaryLabel(release)}`}
-              >
-                {release.permissions.canUpdateRelease
-                  ? 'Edit this release'
-                  : 'View this release'}
-              </ButtonLink>
-              {onClickAmendRelease &&
-                release.permissions.canMakeAmendmentOfRelease && (
-                  <Button
-                    className="govuk-button--secondary govuk-!-margin-left-4"
-                    onClick={() => onClickAmendRelease(release.id)}
-                  >
-                    Amend this release
-                  </Button>
-                )}
-            </>
-          )}
-        </>
-      }
-      secondaryActions={
-        release.permissions.canDeleteRelease &&
-        release.amendment && (
-          <Button
-            onClick={() => onClickCancelAmendment(release.id)}
-            className="govuk-button--warning"
-          >
-            Cancel amendment
-          </Button>
-        )
-      }
-    />
+    <>
+      <ReleaseSummary
+        release={release}
+        open={release.live && release.latestRelease}
+        actions={
+          <>
+            {release.amendment ? (
+              <>
+                <ButtonLink
+                  to={generatePath<ReleaseRouteParams>(
+                    releaseSummaryRoute.path,
+                    {
+                      publicationId: release.publicationId,
+                      releaseId: release.id,
+                    },
+                  )}
+                  data-testid={`Edit release amendment link for ${
+                    release.publicationTitle
+                  }, ${getReleaseSummaryLabel(release)}`}
+                >
+                  {release.permissions.canUpdateRelease
+                    ? 'Edit this release amendment'
+                    : 'View this release amendment'}
+                </ButtonLink>
+                <ButtonLink
+                  to={generatePath<ReleaseRouteParams>(
+                    releaseSummaryRoute.path,
+                    {
+                      publicationId: release.publicationId,
+                      releaseId: release.previousVersionId,
+                    },
+                  )}
+                  className="govuk-button--secondary govuk-!-margin-left-4"
+                  data-testid={`View original release link for ${
+                    release.publicationTitle
+                  }, ${getReleaseSummaryLabel(release)}`}
+                >
+                  View original release
+                </ButtonLink>
+              </>
+            ) : (
+              <>
+                <ButtonLink
+                  to={generatePath<ReleaseRouteParams>(
+                    releaseSummaryRoute.path,
+                    {
+                      publicationId: release.publicationId,
+                      releaseId: release.id,
+                    },
+                  )}
+                  data-testid={`Edit release link for ${
+                    release.publicationTitle
+                  }, ${getReleaseSummaryLabel(release)}`}
+                >
+                  {release.permissions.canUpdateRelease
+                    ? 'Edit this release'
+                    : 'View this release'}
+                </ButtonLink>
+                {includeCreateAmendmentControls &&
+                  release.permissions.canMakeAmendmentOfRelease && (
+                    <Button
+                      className="govuk-button--secondary govuk-!-margin-left-4"
+                      onClick={() => setAmendReleaseId(release.id)}
+                    >
+                      Amend this release
+                    </Button>
+                  )}
+              </>
+            )}
+          </>
+        }
+        secondaryActions={
+          release.permissions.canDeleteRelease &&
+          release.amendment && (
+            <Button
+              onClick={async () => {
+                setDeleteReleasePlan(
+                  await releaseService.getDeleteReleasePlan(release.id),
+                );
+              }}
+              className="govuk-button--warning"
+            >
+              Cancel amendment
+            </Button>
+          )
+        }
+      />
+
+      {deleteReleasePlan && (
+        <CancelAmendmentModal
+          methodologiesScheduledWithRelease={
+            deleteReleasePlan.methodologiesScheduledWithRelease
+          }
+          onConfirm={async () => {
+            await releaseService.deleteRelease(deleteReleasePlan.releaseId);
+            setDeleteReleasePlan(undefined);
+            onAmendmentCancelled(deleteReleasePlan.releaseId);
+          }}
+          onCancel={() => setDeleteReleasePlan(undefined)}
+        />
+      )}
+
+      {amendReleaseId && (
+        <ModalConfirm
+          title="Confirm you want to amend this live release"
+          onConfirm={async () => {
+            const amendment = await releaseService.createReleaseAmendment(
+              amendReleaseId,
+            );
+
+            history.push(
+              generatePath<ReleaseRouteParams>(releaseSummaryRoute.path, {
+                publicationId: release.publicationId,
+                releaseId: amendment.id,
+              }),
+            );
+          }}
+          onExit={() => setAmendReleaseId(undefined)}
+          onCancel={() => setAmendReleaseId(undefined)}
+          open
+        >
+          <p>
+            Please note, any changes made to this live release must be approved
+            before updates can be published.
+          </p>
+        </ModalConfirm>
+      )}
+    </>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/NonScheduledReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/NonScheduledReleaseSummary.tsx
@@ -29,7 +29,9 @@ const NonScheduledReleaseSummary = ({
   const history = useHistory();
 
   const [deleteReleasePlan, setDeleteReleasePlan] = useState<
-    DeleteReleasePlan
+    DeleteReleasePlan & {
+      releaseId: string;
+    }
   >();
 
   const [amendReleaseId, setAmendReleaseId] = useState<string>();
@@ -111,9 +113,10 @@ const NonScheduledReleaseSummary = ({
           release.amendment && (
             <Button
               onClick={async () => {
-                setDeleteReleasePlan(
-                  await releaseService.getDeleteReleasePlan(release.id),
-                );
+                setDeleteReleasePlan({
+                  ...(await releaseService.getDeleteReleasePlan(release.id)),
+                  releaseId: release.id,
+                });
               }}
               className="govuk-button--warning"
             >
@@ -125,9 +128,7 @@ const NonScheduledReleaseSummary = ({
 
       {deleteReleasePlan && (
         <CancelAmendmentModal
-          methodologiesScheduledWithRelease={
-            deleteReleasePlan.methodologiesScheduledWithRelease
-          }
+          scheduledMethodologies={deleteReleasePlan.scheduledMethodologies}
           onConfirm={async () => {
             await releaseService.deleteRelease(deleteReleasePlan.releaseId);
             setDeleteReleasePlan(undefined);
@@ -139,7 +140,9 @@ const NonScheduledReleaseSummary = ({
 
       {amendReleaseId && (
         <ModalConfirm
+          open
           title="Confirm you want to amend this live release"
+          onCancel={() => setAmendReleaseId(undefined)}
           onConfirm={async () => {
             const amendment = await releaseService.createReleaseAmendment(
               amendReleaseId,
@@ -153,8 +156,6 @@ const NonScheduledReleaseSummary = ({
             );
           }}
           onExit={() => setAmendReleaseId(undefined)}
-          onCancel={() => setAmendReleaseId(undefined)}
-          open
         >
           <p>
             Please note, any changes made to this live release must be approved

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
@@ -9,7 +9,10 @@ import {
   releaseCreateRoute,
 } from '@admin/routes/routes';
 import { MyPublication } from '@admin/services/publicationService';
-import releaseService, { Release } from '@admin/services/releaseService';
+import releaseService, {
+  DeleteReleasePlan,
+  Release,
+} from '@admin/services/releaseService';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ModalConfirm from '@common/components/ModalConfirm';
 import React, { useState } from 'react';
@@ -32,11 +35,11 @@ const PublicationSummary = ({
   const history = useHistory();
 
   const [amendReleaseId, setAmendReleaseId] = useState<string>();
-  const [cancelAmendmentReleaseId, setCancelAmendmentReleaseId] = useState<
-    string
-  >();
-
   const { contact, permissions, releases, id, title } = publication;
+
+  const [deleteReleasePlan, setDeleteReleasePlan] = useState<
+    DeleteReleasePlan
+  >();
 
   const noAmendmentInProgressFilter = (release: Release) =>
     !releases.some(r => r.amendment && r.previousVersionId === release.id);
@@ -139,7 +142,13 @@ const PublicationSummary = ({
                     <li key={release.id}>
                       <NonScheduledReleaseSummary
                         onClickAmendRelease={setAmendReleaseId}
-                        onClickCancelAmendment={setCancelAmendmentReleaseId}
+                        onClickCancelAmendment={async releaseId => {
+                          setDeleteReleasePlan(
+                            await releaseService.getDeleteReleasePlan(
+                              releaseId,
+                            ),
+                          );
+                        }}
                         release={release}
                       />
                     </li>
@@ -179,14 +188,17 @@ const PublicationSummary = ({
         </ModalConfirm>
       )}
 
-      {cancelAmendmentReleaseId && (
+      {deleteReleasePlan && (
         <CancelAmendmentModal
+          methodologiesScheduledWithRelease={
+            deleteReleasePlan.methodologiesScheduledWithRelease
+          }
           onConfirm={async () => {
-            await releaseService.deleteRelease(cancelAmendmentReleaseId);
-            setCancelAmendmentReleaseId(undefined);
+            await releaseService.deleteRelease(deleteReleasePlan.releaseId);
+            setDeleteReleasePlan(undefined);
             onChangePublication();
           }}
-          onCancel={() => setCancelAmendmentReleaseId(undefined)}
+          onCancel={() => setDeleteReleasePlan(undefined)}
         />
       )}
     </>

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
@@ -41,7 +41,10 @@ const ReleaseSummary = ({
       summaryAfter={
         <TagGroup className="govuk-!-margin-left-2">
           {release.approvalStatus !== 'Approved' && (
-            <Tag>{getReleaseApprovalStatusLabel(release.approvalStatus)}</Tag>
+            <>
+              {' '}
+              <Tag>{getReleaseApprovalStatusLabel(release.approvalStatus)}</Tag>
+            </>
           )}
           {release.approvalStatus === 'Approved' && (
             <LazyLoad
@@ -50,14 +53,22 @@ const ReleaseSummary = ({
                 <LoadingSpinner className="govuk-!-margin-0" inline size="sm" />
               }
             >
-              <ReleaseServiceStatus
-                exclude="details"
-                releaseId={release.id}
-                isApproved
-              />
+              <>
+                {' '}
+                <ReleaseServiceStatus
+                  exclude="details"
+                  releaseId={release.id}
+                  isApproved
+                />
+              </>
             </LazyLoad>
           )}
-          {release.amendment && <Tag>Amendment</Tag>}
+          {release.amendment && (
+            <>
+              {' '}
+              <Tag>Amendment</Tag>
+            </>
+          )}
         </TagGroup>
       }
     >

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/CancelAmendmentModal.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/CancelAmendmentModal.test.tsx
@@ -9,9 +9,9 @@ describe('CancelAmendmentModal', () => {
   test('renders with no methodologies supplied', async () => {
     render(
       <CancelAmendmentModal
-        methodologiesScheduledWithRelease={[]}
-        onConfirm={noop}
+        scheduledMethodologies={[]}
         onCancel={noop}
+        onConfirm={noop}
       />,
     );
 
@@ -27,7 +27,7 @@ describe('CancelAmendmentModal', () => {
   test('renders with methodologies supplied', async () => {
     render(
       <CancelAmendmentModal
-        methodologiesScheduledWithRelease={[
+        scheduledMethodologies={[
           {
             id: 'methodology-1',
             title: 'Methodology 1',
@@ -37,8 +37,8 @@ describe('CancelAmendmentModal', () => {
             title: 'Methodology 2',
           },
         ]}
-        onConfirm={noop}
         onCancel={noop}
+        onConfirm={noop}
       />,
     );
 
@@ -56,14 +56,14 @@ describe('CancelAmendmentModal', () => {
   });
 
   test('clicking confirm and cancel call the correct callbacks', async () => {
-    const confirmCallback = jest.fn();
-    const cancelCallback = jest.fn();
+    const onCancel = jest.fn();
+    const onConfirm = jest.fn();
 
     render(
       <CancelAmendmentModal
-        methodologiesScheduledWithRelease={[]}
-        onConfirm={confirmCallback}
-        onCancel={cancelCallback}
+        scheduledMethodologies={[]}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
       />,
     );
 
@@ -74,11 +74,11 @@ describe('CancelAmendmentModal', () => {
     );
 
     await waitFor(() => {
-      expect(confirmCallback).toHaveBeenCalled();
-      expect(cancelCallback).not.toHaveBeenCalled();
+      expect(onConfirm).toHaveBeenCalled();
+      expect(onCancel).not.toHaveBeenCalled();
     });
 
-    confirmCallback.mockClear();
+    onConfirm.mockClear();
 
     userEvent.click(
       screen.getByRole('button', {
@@ -87,8 +87,8 @@ describe('CancelAmendmentModal', () => {
     );
 
     await waitFor(() => {
-      expect(confirmCallback).not.toHaveBeenCalled();
-      expect(cancelCallback).toHaveBeenCalled();
+      expect(onConfirm).not.toHaveBeenCalled();
+      expect(onCancel).toHaveBeenCalled();
     });
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/CancelAmendmentModal.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/CancelAmendmentModal.test.tsx
@@ -1,0 +1,94 @@
+import { waitFor } from '@testing-library/dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import CancelAmendmentModal from '@admin/pages/admin-dashboard/components/CancelAmendmentModal';
+import { noop } from 'lodash';
+import userEvent from '@testing-library/user-event';
+
+describe('CancelAmendmentModal', () => {
+  test('renders with no methodologies supplied', async () => {
+    render(
+      <CancelAmendmentModal
+        methodologiesScheduledWithRelease={[]}
+        onConfirm={noop}
+        onCancel={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          'The following methodologies are scheduled to be published with this amended release:',
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('renders with methodologies supplied', async () => {
+    render(
+      <CancelAmendmentModal
+        methodologiesScheduledWithRelease={[
+          {
+            id: 'methodology-1',
+            title: 'Methodology 1',
+          },
+          {
+            id: 'methodology-2',
+            title: 'Methodology 2',
+          },
+        ]}
+        onConfirm={noop}
+        onCancel={noop}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'The following methodologies are scheduled to be published with this amended release:',
+        ),
+      ).toBeInTheDocument();
+
+      expect(screen.getByText('Methodology 1')).toBeInTheDocument();
+
+      expect(screen.getByText('Methodology 2')).toBeInTheDocument();
+    });
+  });
+
+  test('clicking confirm and cancel call the correct callbacks', async () => {
+    const confirmCallback = jest.fn();
+    const cancelCallback = jest.fn();
+
+    render(
+      <CancelAmendmentModal
+        methodologiesScheduledWithRelease={[]}
+        onConfirm={confirmCallback}
+        onCancel={cancelCallback}
+      />,
+    );
+
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Confirm',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(confirmCallback).toHaveBeenCalled();
+      expect(cancelCallback).not.toHaveBeenCalled();
+    });
+
+    confirmCallback.mockClear();
+
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Cancel',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(confirmCallback).not.toHaveBeenCalled();
+      expect(cancelCallback).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -13,7 +13,7 @@ import noop from 'lodash/noop';
 import React from 'react';
 import { MemoryRouter, Router } from 'react-router';
 import userEvent from '@testing-library/user-event';
-import createMemoryHistoryWithMockedPush from '@admin-test/createMemoryHistoryWithMockedPush';
+import { createMemoryHistory } from 'history';
 
 jest.mock('@admin/services/methodologyService');
 
@@ -176,7 +176,7 @@ describe('MethodologySummary', () => {
     test('clicking Create Methodology creates the Methodology and takes the user to the Methodology summary', async () => {
       methodologyService.createMethodology.mockResolvedValue(testMethodology);
 
-      const history = createMemoryHistoryWithMockedPush();
+      const history = createMemoryHistory();
 
       render(
         <Router history={history}>
@@ -196,7 +196,7 @@ describe('MethodologySummary', () => {
         expect(methodologyService.createMethodology).toHaveBeenCalledWith(
           testPublicationNoMethodology.id,
         );
-        expect(history.push).toBeCalledWith(
+        expect(history.location.pathname).toBe(
           `/methodology/${testMethodology.id}/summary`,
         );
       });
@@ -921,7 +921,8 @@ describe('MethodologySummary', () => {
     });
 
     test('calls the service to amend the methodology when the confirm button is clicked', async () => {
-      const history = createMemoryHistoryWithMockedPush();
+      const history = createMemoryHistory();
+
       const mockMethodology: BasicMethodology = {
         amendment: true,
         id: '12345',
@@ -971,7 +972,7 @@ describe('MethodologySummary', () => {
           testPublicationWithMethodologyCanAmend.methodologies[0].methodology
             .id,
         );
-        expect(history.push).toBeCalledWith(
+        expect(history.location.pathname).toBe(
           `/methodology/${mockMethodology.id}/summary`,
         );
       });

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/NonScheduledReleaseSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/NonScheduledReleaseSummary.test.tsx
@@ -1,0 +1,418 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { noop } from 'lodash';
+import { MemoryRouter, Router } from 'react-router-dom';
+import _releaseService, {
+  MyRelease,
+  ReleaseSummary,
+} from '@admin/services/releaseService';
+import userEvent from '@testing-library/user-event';
+import NonScheduledReleaseSummary from '@admin/pages/admin-dashboard/components/NonScheduledReleaseSummary';
+import produce from 'immer';
+import createMemoryHistoryWithMockedPush from '@admin-test/createMemoryHistoryWithMockedPush';
+
+jest.mock('@admin/services/releaseService');
+
+const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
+
+describe('NonScheduledReleaseSummary', () => {
+  const testRelease: MyRelease = {
+    id: 'rel-3',
+    latestRelease: false,
+    published: '2021-01-01T11:21:17.7585345',
+    slug: 'rel-3-slug',
+    title: 'The Release',
+    previousVersionId: 'rel-2',
+    publicationId: 'publication-id',
+    permissions: {
+      canUpdateRelease: false,
+      canDeleteRelease: false,
+      canMakeAmendmentOfRelease: false,
+    },
+    approvalStatus: 'Draft',
+  } as MyRelease;
+
+  test('renders correctly with a release and no permissions', async () => {
+    render(
+      <MemoryRouter>
+        <NonScheduledReleaseSummary
+          release={testRelease}
+          includeCreateAmendmentControls
+          onAmendmentCancelled={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    // Expand the Release to see its details.
+    userEvent.click(
+      screen.getByRole('button', {
+        name: `${testRelease.title} (not Live) Draft`,
+      }),
+    );
+
+    expect(
+      screen.getByText('View this release', {
+        selector: 'a',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText('Edit this release', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Amend this release',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Cancel amendment',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText('View this release amendment', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText('Edit this release amendment', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText('View original release', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correctly with a release and edit / create amendment permissions', async () => {
+    render(
+      <MemoryRouter>
+        <NonScheduledReleaseSummary
+          release={produce(testRelease, draft => {
+            draft.permissions.canUpdateRelease = true;
+            draft.permissions.canMakeAmendmentOfRelease = true;
+          })}
+          includeCreateAmendmentControls
+          onAmendmentCancelled={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    // Expand the Release to see its details.
+    userEvent.click(
+      screen.getByRole('button', {
+        name: `${testRelease.title} (not Live) Draft`,
+      }),
+    );
+
+    expect(
+      screen.queryByText('View this release', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText('Edit this release', {
+        selector: 'a',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Amend this release',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Cancel amendment',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText('View this release amendment', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText('Edit this release amendment', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText('View original release', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correctly with a release amendment and no permissions', async () => {
+    render(
+      <MemoryRouter>
+        <NonScheduledReleaseSummary
+          release={produce(testRelease, draft => {
+            draft.amendment = true;
+            draft.previousVersionId = 'rel-2';
+          })}
+          includeCreateAmendmentControls
+          onAmendmentCancelled={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    // Expand the Release to see its details.
+    userEvent.click(
+      screen.getByRole('button', {
+        name: `${testRelease.title} (not Live) Draft Amendment`,
+      }),
+    );
+
+    expect(
+      screen.queryByText('View this release', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText('Edit this release', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Amend this release',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Cancel amendment',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText('View this release amendment', {
+        selector: 'a',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText('Edit this release amendment', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText('View original release', {
+        selector: 'a',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders correctly with a release amendment and full permissions', async () => {
+    render(
+      <MemoryRouter>
+        <NonScheduledReleaseSummary
+          release={produce(testRelease, draft => {
+            draft.amendment = true;
+            draft.previousVersionId = 'rel-2';
+            draft.permissions.canUpdateRelease = true;
+            draft.permissions.canDeleteRelease = true;
+          })}
+          includeCreateAmendmentControls
+          onAmendmentCancelled={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    // Expand the Release to see its details.
+    userEvent.click(
+      screen.getByRole('button', {
+        name: `${testRelease.title} (not Live) Draft Amendment`,
+      }),
+    );
+
+    expect(
+      screen.queryByText('View this release', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText('Edit this release', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Amend this release',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Cancel amendment',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText('View this release amendment', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText('Edit this release amendment', {
+        selector: 'a',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('View original release', {
+        selector: 'a',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('handles creating amendments ok', async () => {
+    const history = createMemoryHistoryWithMockedPush();
+
+    render(
+      <Router history={history}>
+        <NonScheduledReleaseSummary
+          release={produce(testRelease, draft => {
+            draft.permissions.canMakeAmendmentOfRelease = true;
+          })}
+          includeCreateAmendmentControls
+          onAmendmentCancelled={noop}
+        />
+      </Router>,
+    );
+
+    // Expand the Release to see the controls within it.
+    userEvent.click(
+      screen.getByRole('button', {
+        name: `${testRelease.title} (not Live) Draft`,
+      }),
+    );
+
+    // Now click the "Amend this release" button and check that the warning modal appears.
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Amend this release',
+      }),
+    );
+
+    expect(
+      screen.getByText('Confirm you want to amend this live release'),
+    ).toBeInTheDocument();
+
+    // Confirm the amending of the Release.
+    releaseService.createReleaseAmendment.mockResolvedValue({
+      id: 'release-amendment-id',
+    } as ReleaseSummary);
+
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Confirm',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(releaseService.createReleaseAmendment).toHaveBeenCalledWith(
+        testRelease.id,
+      );
+    });
+
+    expect(history.push).toBeCalledWith(
+      `/publication/${testRelease.publicationId}/release/release-amendment-id/summary`,
+    );
+  });
+
+  test('handles cancelling amendments ok', async () => {
+    const amendmentCancelledCallback = jest.fn();
+
+    render(
+      <MemoryRouter>
+        <NonScheduledReleaseSummary
+          release={produce(testRelease, draft => {
+            draft.permissions.canDeleteRelease = true;
+            draft.amendment = true;
+            draft.previousVersionId = 'rel-2';
+          })}
+          includeCreateAmendmentControls
+          onAmendmentCancelled={amendmentCancelledCallback}
+        />
+      </MemoryRouter>,
+    );
+
+    // Expand the Release Amendment to see the controls within it.
+    userEvent.click(
+      screen.getByRole('button', {
+        name: `${testRelease.title} (not Live) Draft Amendment`,
+      }),
+    );
+
+    // Now click the "Cancel amendment" button and check that the warning modal appears.
+    releaseService.getDeleteReleasePlan.mockResolvedValue({
+      releaseId: testRelease.id,
+      methodologiesScheduledWithRelease: [
+        {
+          id: 'methodology-1',
+          title: 'Methodology 1',
+        },
+        {
+          id: 'methodology-2',
+          title: 'Methodology 2',
+        },
+      ],
+    });
+
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Cancel amendment',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(releaseService.getDeleteReleasePlan).toHaveBeenCalledWith(
+        testRelease.id,
+      );
+    });
+
+    expect(
+      screen.getByText('Confirm you want to cancel this amended release'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Methodology 1')).toBeInTheDocument();
+    expect(screen.getByText('Methodology 2')).toBeInTheDocument();
+
+    // Confirm the cancelling of the Release Amendment.
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Confirm',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(releaseService.deleteRelease).toHaveBeenCalledWith(testRelease.id);
+      expect(amendmentCancelledCallback).toHaveBeenCalled();
+    });
+
+    expect(
+      screen.queryByText('Confirm you want to cancel this amended release'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/NonScheduledReleaseSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/NonScheduledReleaseSummary.test.tsx
@@ -9,7 +9,7 @@ import _releaseService, {
 import userEvent from '@testing-library/user-event';
 import NonScheduledReleaseSummary from '@admin/pages/admin-dashboard/components/NonScheduledReleaseSummary';
 import produce from 'immer';
-import createMemoryHistoryWithMockedPush from '@admin-test/createMemoryHistoryWithMockedPush';
+import { createMemoryHistory } from 'history';
 
 jest.mock('@admin/services/releaseService');
 
@@ -19,7 +19,7 @@ describe('NonScheduledReleaseSummary', () => {
   const testRelease: MyRelease = {
     id: 'rel-3',
     latestRelease: false,
-    published: '2021-01-01T11:21:17.7585345',
+    published: '2021-01-01T11:21:17',
     slug: 'rel-3-slug',
     title: 'The Release',
     previousVersionId: 'rel-2',
@@ -36,8 +36,8 @@ describe('NonScheduledReleaseSummary', () => {
     render(
       <MemoryRouter>
         <NonScheduledReleaseSummary
-          release={testRelease}
           includeCreateAmendmentControls
+          release={testRelease}
           onAmendmentCancelled={noop}
         />
       </MemoryRouter>,
@@ -51,14 +51,14 @@ describe('NonScheduledReleaseSummary', () => {
     );
 
     expect(
-      screen.getByText('View this release', {
-        selector: 'a',
+      screen.getByRole('link', {
+        name: 'View this release',
       }),
     ).toBeInTheDocument();
 
     expect(
-      screen.queryByText('Edit this release', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'Edit this release',
       }),
     ).not.toBeInTheDocument();
 
@@ -75,20 +75,20 @@ describe('NonScheduledReleaseSummary', () => {
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByText('View this release amendment', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'View this release amendment',
       }),
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByText('Edit this release amendment', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'Edit this release amendment',
       }),
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByText('View original release', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'View original release',
       }),
     ).not.toBeInTheDocument();
   });
@@ -97,11 +97,11 @@ describe('NonScheduledReleaseSummary', () => {
     render(
       <MemoryRouter>
         <NonScheduledReleaseSummary
+          includeCreateAmendmentControls
           release={produce(testRelease, draft => {
             draft.permissions.canUpdateRelease = true;
             draft.permissions.canMakeAmendmentOfRelease = true;
           })}
-          includeCreateAmendmentControls
           onAmendmentCancelled={noop}
         />
       </MemoryRouter>,
@@ -115,14 +115,14 @@ describe('NonScheduledReleaseSummary', () => {
     );
 
     expect(
-      screen.queryByText('View this release', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'View this release',
       }),
     ).not.toBeInTheDocument();
 
     expect(
-      screen.getByText('Edit this release', {
-        selector: 'a',
+      screen.getByRole('link', {
+        name: 'Edit this release',
       }),
     ).toBeInTheDocument();
 
@@ -139,20 +139,20 @@ describe('NonScheduledReleaseSummary', () => {
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByText('View this release amendment', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'View this release amendment',
       }),
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByText('Edit this release amendment', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'Edit this release amendment',
       }),
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByText('View original release', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'View original release',
       }),
     ).not.toBeInTheDocument();
   });
@@ -161,11 +161,11 @@ describe('NonScheduledReleaseSummary', () => {
     render(
       <MemoryRouter>
         <NonScheduledReleaseSummary
+          includeCreateAmendmentControls
           release={produce(testRelease, draft => {
             draft.amendment = true;
             draft.previousVersionId = 'rel-2';
           })}
-          includeCreateAmendmentControls
           onAmendmentCancelled={noop}
         />
       </MemoryRouter>,
@@ -179,14 +179,14 @@ describe('NonScheduledReleaseSummary', () => {
     );
 
     expect(
-      screen.queryByText('View this release', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'View this release',
       }),
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByText('Edit this release', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'Edit this release',
       }),
     ).not.toBeInTheDocument();
 
@@ -203,20 +203,20 @@ describe('NonScheduledReleaseSummary', () => {
     ).not.toBeInTheDocument();
 
     expect(
-      screen.getByText('View this release amendment', {
-        selector: 'a',
+      screen.getByRole('link', {
+        name: 'View this release amendment',
       }),
     ).toBeInTheDocument();
 
     expect(
-      screen.queryByText('Edit this release amendment', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'Edit this release amendment',
       }),
     ).not.toBeInTheDocument();
 
     expect(
-      screen.getByText('View original release', {
-        selector: 'a',
+      screen.getByRole('link', {
+        name: 'View original release',
       }),
     ).toBeInTheDocument();
   });
@@ -225,13 +225,13 @@ describe('NonScheduledReleaseSummary', () => {
     render(
       <MemoryRouter>
         <NonScheduledReleaseSummary
+          includeCreateAmendmentControls
           release={produce(testRelease, draft => {
             draft.amendment = true;
             draft.previousVersionId = 'rel-2';
             draft.permissions.canUpdateRelease = true;
             draft.permissions.canDeleteRelease = true;
           })}
-          includeCreateAmendmentControls
           onAmendmentCancelled={noop}
         />
       </MemoryRouter>,
@@ -245,14 +245,14 @@ describe('NonScheduledReleaseSummary', () => {
     );
 
     expect(
-      screen.queryByText('View this release', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'View this release',
       }),
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByText('Edit this release', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'Edit this release',
       }),
     ).not.toBeInTheDocument();
 
@@ -269,34 +269,34 @@ describe('NonScheduledReleaseSummary', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.queryByText('View this release amendment', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'View this release amendment',
       }),
     ).not.toBeInTheDocument();
 
     expect(
-      screen.getByText('Edit this release amendment', {
-        selector: 'a',
+      screen.getByRole('link', {
+        name: 'Edit this release amendment',
       }),
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText('View original release', {
-        selector: 'a',
+      screen.getByRole('link', {
+        name: 'View original release',
       }),
     ).toBeInTheDocument();
   });
 
   test('handles creating amendments ok', async () => {
-    const history = createMemoryHistoryWithMockedPush();
+    const history = createMemoryHistory();
 
     render(
       <Router history={history}>
         <NonScheduledReleaseSummary
+          includeCreateAmendmentControls
           release={produce(testRelease, draft => {
             draft.permissions.canMakeAmendmentOfRelease = true;
           })}
-          includeCreateAmendmentControls
           onAmendmentCancelled={noop}
         />
       </Router>,
@@ -337,24 +337,24 @@ describe('NonScheduledReleaseSummary', () => {
       );
     });
 
-    expect(history.push).toBeCalledWith(
+    expect(history.location.pathname).toBe(
       `/publication/${testRelease.publicationId}/release/release-amendment-id/summary`,
     );
   });
 
   test('handles cancelling amendments ok', async () => {
-    const amendmentCancelledCallback = jest.fn();
+    const onAmendmentCancelled = jest.fn();
 
     render(
       <MemoryRouter>
         <NonScheduledReleaseSummary
+          includeCreateAmendmentControls
           release={produce(testRelease, draft => {
             draft.permissions.canDeleteRelease = true;
             draft.amendment = true;
             draft.previousVersionId = 'rel-2';
           })}
-          includeCreateAmendmentControls
-          onAmendmentCancelled={amendmentCancelledCallback}
+          onAmendmentCancelled={onAmendmentCancelled}
         />
       </MemoryRouter>,
     );
@@ -368,8 +368,7 @@ describe('NonScheduledReleaseSummary', () => {
 
     // Now click the "Cancel amendment" button and check that the warning modal appears.
     releaseService.getDeleteReleasePlan.mockResolvedValue({
-      releaseId: testRelease.id,
-      methodologiesScheduledWithRelease: [
+      scheduledMethodologies: [
         {
           id: 'methodology-1',
           title: 'Methodology 1',
@@ -408,11 +407,39 @@ describe('NonScheduledReleaseSummary', () => {
 
     await waitFor(() => {
       expect(releaseService.deleteRelease).toHaveBeenCalledWith(testRelease.id);
-      expect(amendmentCancelledCallback).toHaveBeenCalled();
+      expect(onAmendmentCancelled).toHaveBeenCalled();
     });
 
     expect(
       screen.queryByText('Confirm you want to cancel this amended release'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('false "includeCreateAmendmentControls" flag hides Create Amendment controls', async () => {
+    render(
+      <MemoryRouter>
+        <NonScheduledReleaseSummary
+          release={produce(testRelease, draft => {
+            draft.permissions.canMakeAmendmentOfRelease = true;
+          })}
+          onAmendmentCancelled={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    // Expand the Release to see the controls within it.
+    userEvent.click(
+      screen.getByRole('button', {
+        name: `${testRelease.title} (not Live) Draft`,
+      }),
+    );
+
+    // Assert that the Amend release controls are not displayed as per our usage if the "includeCreateAmendmentControls"
+    // flag.
+    expect(
+      screen.queryByRole('button', {
+        name: 'Amend this release',
+      }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
@@ -4,11 +4,11 @@ import { noop } from 'lodash';
 import PublicationSummary from '@admin/pages/admin-dashboard/components/PublicationSummary';
 import {
   MyPublication,
+  MyPublicationMethodology,
   PublicationContactDetails,
 } from '@admin/services/publicationService';
 import { MemoryRouter } from 'react-router-dom';
 import { MyRelease } from '@admin/services/releaseService';
-import { MyMethodology } from '@admin/services/methodologyService';
 
 describe('PublicationSummary', () => {
   const testTopicId = 'test-topic';
@@ -84,26 +84,32 @@ describe('PublicationSummary', () => {
     } as MyRelease,
   ];
 
-  const testMethodologies: MyMethodology[] = [
+  const testMethodologies: MyPublicationMethodology[] = [
     {
-      amendment: false,
-      id: '1234',
-      latestInternalReleaseNote: 'this is the release note',
-      previousVersionId: 'lfkjdlfj',
-      published: '2021-06-08T09:04:17.9805585',
-      slug: 'meth-1',
-      status: 'Approved',
-      title: 'I am a methodology',
-      owningPublication: {
-        id: 'p1',
-        title: 'Publication title',
+      owner: true,
+      methodology: {
+        amendment: false,
+        id: '1234',
+        latestInternalReleaseNote: 'this is the release note',
+        previousVersionId: 'lfkjdlfj',
+        published: '2021-06-08T09:04:17.9805585',
+        slug: 'meth-1',
+        status: 'Approved',
+        title: 'I am a methodology',
+        owningPublication: {
+          id: 'p1',
+          title: 'Publication title',
+        },
+        permissions: {
+          canApproveMethodology: false,
+          canUpdateMethodology: false,
+          canDeleteMethodology: false,
+          canMakeAmendmentOfMethodology: false,
+          canMarkMethodologyAsDraft: false,
+        },
       },
       permissions: {
-        canApproveMethodology: false,
-        canUpdateMethodology: false,
-        canDeleteMethodology: false,
-        canMakeAmendmentOfMethodology: false,
-        canMarkMethodologyAsDraft: false,
+        canDropMethodology: false,
       },
     },
   ];
@@ -307,7 +313,7 @@ describe('PublicationSummary', () => {
     // PublicationSummary.
     expect(
       screen.getByRole('button', {
-        name: `${testMethodologies[0].title} Approved`,
+        name: `${testMethodologies[0].methodology.title} Approved`,
       }),
     ).toBeInTheDocument();
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
@@ -1,0 +1,415 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { noop } from 'lodash';
+import PublicationSummary from '@admin/pages/admin-dashboard/components/PublicationSummary';
+import {
+  MyPublication,
+  PublicationContactDetails,
+} from '@admin/services/publicationService';
+import { MemoryRouter } from 'react-router-dom';
+import _releaseService, { MyRelease } from '@admin/services/releaseService';
+import { MyMethodology } from '@admin/services/methodologyService';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@admin/services/releaseService');
+
+const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
+
+describe('PublicationSummary', () => {
+  const testTopicId = 'test-topic';
+
+  const testContact: PublicationContactDetails = {
+    id: 'contact-1',
+    contactName: 'John Smith',
+    contactTelNo: '0777777777',
+    teamEmail: 'john.smith@test.com',
+    teamName: 'Team Smith',
+  };
+
+  const fullPermissions: MyPublication['permissions'] = {
+    canCreateReleases: true,
+    canUpdatePublication: true,
+    canCreateMethodologies: true,
+    canManageExternalMethodology: true,
+  };
+
+  const testPublication: MyPublication = {
+    id: 'publication-1',
+    title: 'Publication 1',
+    contact: undefined,
+    releases: [],
+    methodologies: [],
+    permissions: {
+      canCreateReleases: false,
+      canUpdatePublication: false,
+      canCreateMethodologies: false,
+      canManageExternalMethodology: false,
+    },
+  };
+
+  const testReleases: MyRelease[] = [
+    {
+      id: 'rel-1',
+      latestRelease: true,
+      published: '2021-06-30T11:21:17.7585345',
+      slug: 'rel-1-slug',
+      title: 'Release 1',
+      publicationId: testPublication.id,
+      permissions: {
+        canUpdateRelease: false,
+      },
+      approvalStatus: 'Draft',
+    } as MyRelease,
+    {
+      id: 'rel-3',
+      latestRelease: false,
+      published: '2021-01-01T11:21:17.7585345',
+      slug: 'rel-3-slug',
+      title: 'Amendment Release',
+      amendment: true,
+      previousVersionId: 'rel-2',
+      publicationId: testPublication.id,
+      permissions: {
+        canUpdateRelease: false,
+        canDeleteRelease: true,
+      },
+      approvalStatus: 'Draft',
+    } as MyRelease,
+    {
+      id: 'rel-2',
+      latestRelease: true,
+      published: '2021-05-30T11:21:17.7585345',
+      slug: 'rel-2-slug',
+      title: 'Release 2',
+      publicationId: testPublication.id,
+      permissions: {
+        canUpdateRelease: false,
+      },
+      approvalStatus: 'Approved',
+    } as MyRelease,
+  ];
+
+  const testMethodologies: MyMethodology[] = [
+    {
+      amendment: false,
+      id: '1234',
+      latestInternalReleaseNote: 'this is the release note',
+      previousVersionId: 'lfkjdlfj',
+      published: '2021-06-08T09:04:17.9805585',
+      slug: 'meth-1',
+      status: 'Approved',
+      title: 'I am a methodology',
+      owningPublication: {
+        id: 'p1',
+        title: 'Publication title',
+      },
+      permissions: {
+        canApproveMethodology: false,
+        canUpdateMethodology: false,
+        canDeleteMethodology: false,
+        canMakeAmendmentOfMethodology: false,
+        canMarkMethodologyAsDraft: false,
+      },
+    },
+  ];
+
+  const testExternalMethodology: MyPublication['externalMethodology'] = {
+    title: 'External methodology',
+    url: 'https://example.com',
+  };
+
+  test('renders correctly with a publication with no releases, methodologies, contact details or permissions', async () => {
+    render(
+      <MemoryRouter>
+        <PublicationSummary
+          publication={testPublication}
+          topicId={testTopicId}
+          onChangePublication={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('No team name')).toBeInTheDocument();
+    expect(screen.getByText('No contact name')).toBeInTheDocument();
+
+    expect(screen.getByText('No releases created')).toBeInTheDocument();
+
+    expect(screen.getByText('Methodologies')).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Create methodology',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'Link to an externally hosted methodology',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText('Manage this publication', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText('Create new release', {
+        selector: 'a',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders correctly with team and contact details', async () => {
+    render(
+      <MemoryRouter>
+        <PublicationSummary
+          publication={{
+            ...testPublication,
+            contact: testContact,
+          }}
+          topicId={testTopicId}
+          onChangePublication={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('No team name')).not.toBeInTheDocument();
+    expect(screen.queryByText('No contact name')).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText(testContact.teamName as string),
+    ).toBeInTheDocument();
+
+    const teamEmailLink = screen.getByText(testContact.teamEmail as string, {
+      selector: 'a',
+    });
+    expect(teamEmailLink).toBeInTheDocument();
+    expect(teamEmailLink).toHaveAttribute(
+      'href',
+      `mailto:${testContact.teamEmail}`,
+    );
+
+    expect(
+      screen.getByText(testContact.contactName as string),
+    ).toBeInTheDocument();
+
+    const contactTelNoLink = screen.getByText(
+      testContact.contactTelNo as string,
+      {
+        selector: 'a',
+      },
+    );
+    expect(contactTelNoLink).toBeInTheDocument();
+    expect(contactTelNoLink).toHaveAttribute(
+      'href',
+      `tel:${testContact.contactTelNo}`,
+    );
+  });
+
+  test('renders correct controls with full permissions', async () => {
+    render(
+      <MemoryRouter>
+        <PublicationSummary
+          publication={{
+            ...testPublication,
+            permissions: fullPermissions,
+          }}
+          topicId={testTopicId}
+          onChangePublication={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('No releases created')).toBeInTheDocument();
+
+    expect(screen.getByText('Methodologies')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Create methodology',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Link to an externally hosted methodology',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('Manage this publication', {
+        selector: 'a',
+      }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('Create new release', {
+        selector: 'a',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders correctly with releases', async () => {
+    render(
+      <MemoryRouter>
+        <PublicationSummary
+          publication={{
+            ...testPublication,
+            releases: testReleases,
+          }}
+          topicId={testTopicId}
+          onChangePublication={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('No releases created')).not.toBeInTheDocument();
+
+    const releaseList = screen.getByTestId(
+      `Releases for ${testPublication.title}`,
+    );
+    expect(releaseList).toBeInTheDocument();
+
+    const releaseExpandButtons = within(releaseList)
+      .getAllByRole('button')
+      .filter(b => b.hasAttribute('aria-expanded'));
+
+    // We expect only 2 Releases to be visible here, as the "rel-3" Amendment is hiding the "rel-2" Release that
+    // it's an Amendment of.
+    expect(releaseExpandButtons).toHaveLength(2);
+
+    // Not exhaustively testing the contents of each Release, as this is handled in a separate component used by
+    // PublicationSummary.
+    const release1 = releaseExpandButtons[0];
+    expect(release1.textContent).toEqual(
+      `${testReleases[0].title} (not Live)Draft`,
+    );
+
+    const release2 = releaseExpandButtons[1];
+    expect(release2.textContent).toEqual(
+      `${testReleases[1].title} (not Live)DraftAmendment`,
+    );
+  });
+
+  test('renders correctly with methodologies', async () => {
+    render(
+      <MemoryRouter>
+        <PublicationSummary
+          publication={{
+            ...testPublication,
+            methodologies: testMethodologies,
+            externalMethodology: testExternalMethodology,
+          }}
+          topicId={testTopicId}
+          onChangePublication={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    // Not exhaustively testing the Methodology details, as this is handled in a separate component used by
+    // PublicationSummary.
+    expect(
+      screen.getByRole('button', {
+        name: `${testMethodologies[0].title} Approved`,
+      }),
+    ).toBeInTheDocument();
+
+    const externalMethodologyLink = screen.getByText(
+      `${testExternalMethodology.title} (external methodology)`,
+      {
+        selector: 'a',
+      },
+    );
+    expect(externalMethodologyLink).toBeInTheDocument();
+    expect(externalMethodologyLink).toHaveAttribute(
+      'href',
+      testExternalMethodology.url,
+    );
+  });
+
+  test('handles the cancelling of Release Amendments successfully', async () => {
+    const onChangePublicationCallback = jest.fn();
+
+    render(
+      <MemoryRouter>
+        <PublicationSummary
+          publication={{
+            ...testPublication,
+            releases: testReleases,
+            permissions: fullPermissions,
+          }}
+          topicId={testTopicId}
+          onChangePublication={onChangePublicationCallback}
+        />
+      </MemoryRouter>,
+    );
+
+    // Expand the Release Amendment to see the controls within it.
+    userEvent.click(
+      screen.getByRole('button', {
+        name: `${testReleases[1].title} (not Live) Draft Amendment`,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {
+          name: 'Cancel amendment',
+        }),
+      ).toBeInTheDocument();
+    });
+
+    // Now click the "Cancel amendment" button and check that the warning modal appears.
+    releaseService.getDeleteReleasePlan.mockResolvedValue({
+      releaseId: testReleases[1].id,
+      methodologiesScheduledWithRelease: [
+        {
+          id: 'methodology-1',
+          title: 'Methodology 1',
+        },
+        {
+          id: 'methodology-2',
+          title: 'Methodology 2',
+        },
+      ],
+    });
+
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Cancel amendment',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(releaseService.getDeleteReleasePlan).toHaveBeenCalledWith(
+        testReleases[1].id,
+      );
+    });
+
+    expect(
+      screen.getByText('Confirm you want to cancel this amended release'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Methodology 1')).toBeInTheDocument();
+    expect(screen.getByText('Methodology 2')).toBeInTheDocument();
+
+    // Confirm the cancelling of the Release Amendment.
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Confirm',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(releaseService.deleteRelease).toHaveBeenCalledWith(
+        testReleases[1].id,
+      );
+      expect(onChangePublicationCallback).toHaveBeenCalled();
+    });
+
+    expect(
+      screen.queryByText('Confirm you want to cancel this amended release'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
@@ -46,7 +46,7 @@ describe('PublicationSummary', () => {
     {
       id: 'rel-1',
       latestRelease: true,
-      published: '2021-06-30T11:21:17.7585345',
+      published: '2021-06-30T11:21:17',
       slug: 'rel-1-slug',
       title: 'Release 1',
       publicationId: testPublication.id,
@@ -58,7 +58,7 @@ describe('PublicationSummary', () => {
     {
       id: 'rel-3',
       latestRelease: false,
-      published: '2021-01-01T11:21:17.7585345',
+      published: '2021-01-01T11:21:17',
       slug: 'rel-3-slug',
       title: 'Amendment Release',
       amendment: true,
@@ -73,7 +73,7 @@ describe('PublicationSummary', () => {
     {
       id: 'rel-2',
       latestRelease: true,
-      published: '2021-05-30T11:21:17.7585345',
+      published: '2021-05-30T11:21:17',
       slug: 'rel-2-slug',
       title: 'Release 2',
       publicationId: testPublication.id,
@@ -150,14 +150,14 @@ describe('PublicationSummary', () => {
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByText('Manage this publication', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'Manage this publication',
       }),
     ).not.toBeInTheDocument();
 
     expect(
-      screen.queryByText('Create new release', {
-        selector: 'a',
+      screen.queryByRole('link', {
+        name: 'Create new release',
       }),
     ).not.toBeInTheDocument();
   });
@@ -179,29 +179,21 @@ describe('PublicationSummary', () => {
     expect(screen.queryByText('No team name')).not.toBeInTheDocument();
     expect(screen.queryByText('No contact name')).not.toBeInTheDocument();
 
-    expect(
-      screen.getByText(testContact.teamName as string),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Team Smith')).toBeInTheDocument();
 
-    const teamEmailLink = screen.getByText(testContact.teamEmail as string, {
-      selector: 'a',
+    const teamEmailLink = screen.getByRole('link', {
+      name: 'john.smith@test.com',
     });
     expect(teamEmailLink).toBeInTheDocument();
-    expect(teamEmailLink).toHaveAttribute(
-      'href',
-      `mailto:${testContact.teamEmail}`,
-    );
+    expect(teamEmailLink).toHaveAttribute('href', 'mailto:john.smith@test.com');
 
     expect(
       screen.getByText(testContact.contactName as string),
     ).toBeInTheDocument();
 
-    const contactTelNoLink = screen.getByText(
-      testContact.contactTelNo as string,
-      {
-        selector: 'a',
-      },
-    );
+    const contactTelNoLink = screen.getByRole('link', {
+      name: '0777777777',
+    });
     expect(contactTelNoLink).toBeInTheDocument();
     expect(contactTelNoLink).toHaveAttribute(
       'href',
@@ -240,14 +232,14 @@ describe('PublicationSummary', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText('Manage this publication', {
-        selector: 'a',
+      screen.getByRole('link', {
+        name: 'Manage this publication',
       }),
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText('Create new release', {
-        selector: 'a',
+      screen.getByRole('link', {
+        name: 'Create new release',
       }),
     ).toBeInTheDocument();
   });
@@ -285,12 +277,12 @@ describe('PublicationSummary', () => {
     // PublicationSummary.
     const release1 = releaseExpandButtons[0];
     expect(release1.textContent).toEqual(
-      `${testReleases[0].title} (not Live)Draft`,
+      `${testReleases[0].title} (not Live) Draft`,
     );
 
     const release2 = releaseExpandButtons[1];
     expect(release2.textContent).toEqual(
-      `${testReleases[1].title} (not Live)DraftAmendment`,
+      `${testReleases[1].title} (not Live) Draft Amendment`,
     );
   });
 
@@ -317,12 +309,9 @@ describe('PublicationSummary', () => {
       }),
     ).toBeInTheDocument();
 
-    const externalMethodologyLink = screen.getByText(
-      `${testExternalMethodology.title} (external methodology)`,
-      {
-        selector: 'a',
-      },
-    );
+    const externalMethodologyLink = screen.getByRole('link', {
+      name: `${testExternalMethodology.title} (external methodology)`,
+    });
     expect(externalMethodologyLink).toBeInTheDocument();
     expect(externalMethodologyLink).toHaveAttribute(
       'href',

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -169,6 +169,11 @@ export interface ReleaseStatus {
   createdByEmail: string;
 }
 
+export interface DeleteReleasePlan {
+  releaseId: string;
+  methodologiesScheduledWithRelease: IdTitlePair[];
+}
+
 const releaseService = {
   createRelease(createRequest: CreateReleaseRequest): Promise<ReleaseSummary> {
     return client.post(
@@ -199,9 +204,20 @@ const releaseService = {
     return client.post(`/releases/${releaseId}/status`, createRequest);
   },
 
+  async getDeleteReleasePlan(releaseId: string): Promise<DeleteReleasePlan> {
+    const deletePlan = await client.get<Omit<DeleteReleasePlan, 'releaseId'>>(
+      `/release/${releaseId}/delete-plan`,
+    );
+    return {
+      ...deletePlan,
+      releaseId,
+    };
+  },
+
   deleteRelease(releaseId: string): Promise<void> {
     return client.delete(`/release/${releaseId}`);
   },
+
   getDraftReleases(): Promise<MyRelease[]> {
     return client.get('/releases/draft');
   },

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -170,8 +170,7 @@ export interface ReleaseStatus {
 }
 
 export interface DeleteReleasePlan {
-  releaseId: string;
-  methodologiesScheduledWithRelease: IdTitlePair[];
+  scheduledMethodologies: IdTitlePair[];
 }
 
 const releaseService = {
@@ -204,14 +203,8 @@ const releaseService = {
     return client.post(`/releases/${releaseId}/status`, createRequest);
   },
 
-  async getDeleteReleasePlan(releaseId: string): Promise<DeleteReleasePlan> {
-    const deletePlan = await client.get<Omit<DeleteReleasePlan, 'releaseId'>>(
-      `/release/${releaseId}/delete-plan`,
-    );
-    return {
-      ...deletePlan,
-      releaseId,
-    };
+  getDeleteReleasePlan(releaseId: string): Promise<DeleteReleasePlan> {
+    return client.get<DeleteReleasePlan>(`/release/${releaseId}/delete-plan`);
   },
 
   deleteRelease(releaseId: string): Promise<void> {

--- a/src/explore-education-statistics-admin/test/createMemoryHistoryWithMockedPush.ts
+++ b/src/explore-education-statistics-admin/test/createMemoryHistoryWithMockedPush.ts
@@ -1,9 +1,0 @@
-import { createMemoryHistory } from 'history';
-
-export default function createMemoryHistoryWithMockedPush() {
-  const history = createMemoryHistory();
-  return {
-    ...history,
-    push: jest.fn(),
-  };
-}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -148,11 +148,12 @@ Schedule a methodology amendment to be published with a release amendment
     user waits until element contains    ${modal}    ${PUBLICATION_NAME} - Amended methodology
     user clicks button    Confirm
     user waits until page does not contain    Confirm you want to cancel this amended release
-    user views methodology amendment for publication    ${PUBLICATION_NAME}    ${PUBLICATION_NAME} - Amended methodology
+    user views methodology amendment for publication    ${PUBLICATION_NAME}
+    ...    ${PUBLICATION_NAME} - Amended methodology
     user clicks link    Sign off
     user waits until h2 is visible    Sign off
     user clicks button    Edit status
     user waits until h2 is visible    Edit methodology status
-    user checks radio is checked    Draft
+    user checks radio is checked    In draft
     user clicks radio    Approved for publication
     user checks radio is checked    Immediately

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -12,6 +12,7 @@ Force Tags          Admin    Local    Dev    AltersData
 *** Variables ***
 ${PUBLICATION_NAME}=            UI tests - publish methodology %{RUN_IDENTIFIER}
 ${PUBLIC_METHODOLOGY_URL}=      %{PUBLIC_URL}/methodology/ui-tests-publish-methodology-%{RUN_IDENTIFIER}
+${RELEASE_NAME}=                Academic Year 2021/22
 
 *** Test Cases ***
 Create a draft release
@@ -42,7 +43,7 @@ Alter the approval to publish the methodology with the release
     user approves methodology for publication
     ...    publication=${PUBLICATION_NAME}
     ...    publishing_strategy=WithRelease
-    ...    with_release=${PUBLICATION_NAME} - Academic Year 2021/22
+    ...    with_release=${PUBLICATION_NAME} - ${RELEASE_NAME}
 
 Verify that the publication is still not visible on the public methodologies page without publishing the release
     user navigates to public methodologies page
@@ -54,7 +55,7 @@ Verify that the methodology is still not publicly accessible by URL without publ
 
 Approve the release
     user navigates to editable release summary from admin dashboard    ${PUBLICATION_NAME}
-    ...    Academic Year 2021/22 (not Live)
+    ...    ${RELEASE_NAME} (not Live)
     user approves release for immediate publication
 
 Verify that the methodology is visible on the public methodologies page with the expected URL
@@ -130,3 +131,28 @@ Verify that the amended methodology content is correct
     ${content}=    user gets accordion section content element    New and Updated Title
     user checks element contains    ${content}    Adding Methodology content
     user checks element contains    ${content}    New & Updated content
+
+Schedule a methodology amendment to be published with a release amendment
+    user navigates to admin dashboard
+    user creates amendment for release    ${PUBLICATION_NAME}    ${RELEASE_NAME}    (Live - Latest release)
+    user creates methodology amendment for publication    ${PUBLICATION_NAME}
+    user approves methodology amendment for publication
+    ...    publication=${PUBLICATION_NAME}
+    ...    publishing_strategy=WithRelease
+    ...    with_release=${PUBLICATION_NAME} - ${RELEASE_NAME}
+    ${details}=    user opens release summary on the admin dashboard    ${PUBLICATION_NAME}    ${RELEASE_NAME}
+    user clicks button    Cancel amendment    ${details}
+    ${modal}=    user waits until modal is visible    Confirm you want to cancel this amended release
+    user waits until element contains    ${modal}
+    ...    The following methodologies are scheduled to be published with this amended release
+    user waits until element contains    ${modal}    ${PUBLICATION_NAME} - Amended methodology
+    user clicks button    Confirm
+    user waits until page does not contain    Confirm you want to cancel this amended release
+    user views methodology amendment for publication    ${PUBLICATION_NAME}    ${PUBLICATION_NAME} - Amended methodology
+    user clicks link    Sign off
+    user waits until h2 is visible    Sign off
+    user clicks button    Edit status
+    user waits until h2 is visible    Edit methodology status
+    user checks radio is checked    Draft
+    user clicks radio    Approved for publication
+    user checks radio is checked    Immediately

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -140,6 +140,8 @@ Schedule a methodology amendment to be published with a release amendment
     ...    publication=${PUBLICATION_NAME}
     ...    publishing_strategy=WithRelease
     ...    with_release=${PUBLICATION_NAME} - ${RELEASE_NAME}
+
+Cancel the release amendment and validate that the appropriate warning modal is shown
     ${details}=    user opens release summary on the admin dashboard    ${PUBLICATION_NAME}    ${RELEASE_NAME}
     user clicks button    Cancel amendment    ${details}
     ${modal}=    user waits until modal is visible    Confirm you want to cancel this amended release
@@ -148,6 +150,8 @@ Schedule a methodology amendment to be published with a release amendment
     user waits until element contains    ${modal}    ${PUBLICATION_NAME} - Amended methodology
     user clicks button    Confirm
     user waits until page does not contain    Confirm you want to cancel this amended release
+
+Verify that the methodology that was scheduled with the cancelled release amendment is set back to Draft / Immediately
     user views methodology amendment for publication    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME} - Amended methodology
     user clicks link    Sign off

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -70,6 +70,19 @@ user navigates to editable release summary from admin dashboard
     ...    ${TOPIC_NAME}
     ...    Edit this release
 
+user navigates to editable release amendment summary from admin dashboard
+    [Arguments]
+    ...    ${PUBLICATION_NAME}
+    ...    ${DETAILS_HEADING}
+    ...    ${THEME_NAME}=%{TEST_THEME_NAME}
+    ...    ${TOPIC_NAME}=%{TEST_TOPIC_NAME}
+    user navigates to release summary from admin dashboard
+    ...    ${PUBLICATION_NAME}
+    ...    ${DETAILS_HEADING}
+    ...    ${THEME_NAME}
+    ...    ${TOPIC_NAME}
+    ...    Edit this release amendment
+
 user navigates to readonly release summary from admin dashboard
     [Arguments]
     ...    ${PUBLICATION_NAME}
@@ -90,17 +103,29 @@ user navigates to release summary from admin dashboard
     ...    ${THEME_NAME}=%{TEST_THEME_NAME}
     ...    ${TOPIC_NAME}=%{TEST_TOPIC_NAME}
     ...    ${RELEASE_SUMMARY_LINK_TEXT}=Edit this release
+    ${details}=    user opens release summary on the admin dashboard
+    ...    ${PUBLICATION_NAME}
+    ...    ${DETAILS_HEADING}
+    ...    ${THEME_NAME}
+    ...    ${TOPIC_NAME}
+
+    ${summary_button}=    user waits until element contains link    ${details}    ${RELEASE_SUMMARY_LINK_TEXT}    60
+    user clicks element    ${summary_button}
+    user waits until h2 is visible    Release summary    60
+    user checks summary list contains    Publication title    ${PUBLICATION_NAME}
+
+user opens release summary on the admin dashboard
+    [Arguments]
+    ...    ${PUBLICATION_NAME}
+    ...    ${DETAILS_HEADING}
+    ...    ${THEME_NAME}=%{TEST_THEME_NAME}
+    ...    ${TOPIC_NAME}=%{TEST_TOPIC_NAME}
     user opens publication on the admin dashboard    ${PUBLICATION_NAME}    ${THEME_NAME}    ${TOPIC_NAME}
 
     ${accordion}=    user gets accordion section content element    ${PUBLICATION_NAME}
     user opens details dropdown    ${DETAILS_HEADING}    ${accordion}
     ${details}=    user gets details content element    ${DETAILS_HEADING}    ${accordion}
-
-    ${summary_button}=    user waits until element contains link    ${details}    ${RELEASE_SUMMARY_LINK_TEXT}    60
-    user clicks element    ${summary_button}
-
-    user waits until h2 is visible    Release summary    60
-    user checks summary list contains    Publication title    ${PUBLICATION_NAME}
+    [Return]    ${details}
 
 user creates publication
     [Arguments]    ${title}
@@ -228,10 +253,14 @@ user approves methodology for publication
     ...    ${publishing_strategy}=Immediately
     ...    ${with_release}=
 
-    ${accordion}=    user opens publication on the admin dashboard    ${publication}    ${theme}    ${topic}
-    user opens details dropdown    ${methodology_title}    ${accordion}
-    user clicks link    Edit this methodology    ${accordion}
-    approve methodology from methodology view    ${publishing_strategy}    ${with_release}
+    approve methodology for publication
+    ...    ${publication}
+    ...    ${methodology_title}
+    ...    ${theme}
+    ...    ${topic}
+    ...    ${publishing_strategy}
+    ...    ${with_release}
+    ...    Edit this methodology
 
 user approves methodology amendment for publication
     [Arguments]
@@ -242,9 +271,28 @@ user approves methodology amendment for publication
     ...    ${publishing_strategy}=Immediately
     ...    ${with_release}=
 
+    approve methodology for publication
+    ...    ${publication}
+    ...    ${methodology_title}
+    ...    ${theme}
+    ...    ${topic}
+    ...    ${publishing_strategy}
+    ...    ${with_release}
+    ...    Edit this amendment
+
+approve methodology for publication
+    [Arguments]
+    ...    ${publication}
+    ...    ${methodology_title}
+    ...    ${theme}
+    ...    ${topic}
+    ...    ${publishing_strategy}
+    ...    ${with_release}
+    ...    ${edit_button_text}
+
     ${accordion}=    user opens publication on the admin dashboard    ${publication}    ${theme}    ${topic}
     user opens details dropdown    ${methodology_title}    ${accordion}
-    user clicks link    Edit this amendment    ${accordion}
+    user clicks link    ${edit_button_text}    ${accordion}
     approve methodology from methodology view    ${publishing_strategy}    ${with_release}
 
 approve methodology from methodology view
@@ -636,6 +684,8 @@ user waits until modal is visible
     IF    "${MODAL_TEXT}" != "${EMPTY}"
         user waits until parent contains element    css:.ReactModal__Content    xpath://*[.="${MODAL_TEXT}"]
     END
+    ${modal_element}=    get webelement    css:.ReactModal__Content
+    [Return]    ${modal_element}
 
 user gets comment
     [Arguments]    ${comment_text}

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -157,6 +157,7 @@ user opens publication on the admin dashboard
     ...    ${publication}
     ...    ${theme}=%{TEST_THEME_NAME}
     ...    ${topic}=%{TEST_TOPIC_NAME}
+    user navigates to admin dashboard
     user waits until page contains link    Explore education statistics    10
     user waits until page does not contain loading spinner
     user waits for page to finish loading


### PR DESCRIPTION
This PR:
- adds a list of Methodologies to the warning modal when deleting a Release Amendment if they are scheduled to be published alongside the Release Amendment.
- unsets any Methodology scheduling details after the Amendment is deleted.
- resets the Methodologies to Draft, otherwise they would be left as "Approved" / "Immediately".

Also in this PR, I noticed we didn't have any coverage of `PublicationSummary.tsx`, so I've added various test cases around this component, including the deleting of Amendments, which is the last test case.

Also, I've moved the Cancel modal functionality into `NonScheduledReleaseSummary.tsx` and out of its parent components, to reduce the duplication of code.  I've added Jest tests for `NonScheduledReleaseSummary.tsx` as well as we didn't have any before.