### PR TITLE
EES-2674 Return failure results when deleting topics and forcefully delete methodology images

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Models/VersionedEntityDeletionOrderComparerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Models/VersionedEntityDeletionOrderComparerTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Models
+{
+    public class VersionedEntityDeletionOrderComparerTests
+    {
+        [Fact]
+        public void VersionedEntityDeletionOrderComparer()
+        {
+            var version1Id = Guid.NewGuid();
+            var version2Id = Guid.NewGuid();
+            var version3Id = Guid.NewGuid();
+
+            var version1 = new IdAndPreviousVersionIdPair(version1Id, null);
+            var version2 = new IdAndPreviousVersionIdPair(version2Id, version1Id);
+            var version3 = new IdAndPreviousVersionIdPair(version3Id, version2Id);
+
+            var comparer = new VersionedEntityDeletionOrderComparer();
+
+            Assert.Equal(-1, comparer.Compare(version2, version1));
+            Assert.Equal(-1, comparer.Compare(version3, version2));
+
+            Assert.Equal(1, comparer.Compare(version1, version2));
+            Assert.Equal(1, comparer.Compare(version2, version3));
+
+            Assert.Equal(1, comparer.Compare(version1, version3));
+            Assert.Equal(-1, comparer.Compare(version3, version1));
+        }
+
+        [Fact]
+        public void VersionedEntityDeletionOrderComparer_WithSequence()
+        {
+            var version1Id = Guid.NewGuid();
+            var version4Id = Guid.NewGuid();
+            var version3Id = Guid.NewGuid();
+            var version2Id = Guid.NewGuid();
+            var version5Id = Guid.NewGuid();
+
+            var versions = new List<IdAndPreviousVersionIdPair>
+            {
+                new(version2Id, version1Id),
+                new(version1Id, null),
+                new(version5Id, version4Id),
+                new(version4Id, version3Id),
+                new(version3Id, version2Id)
+            };
+
+            var orderedByLatestVersionsFirst = versions
+                .OrderBy(version => version, new VersionedEntityDeletionOrderComparer())
+                .Select(version => version.Id)
+                .ToList();
+
+            var expectedVersionOrder = ListOf(version5Id, version4Id, version3Id, version2Id, version1Id);
+            Assert.Equal(expectedVersionOrder, orderedByLatestVersionsFirst);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyImageServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyImageServicePermissionTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
-using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
@@ -15,16 +14,46 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Http;
 using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
+using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies
 {
     public class MethodologyImageServicePermissionTests
     {
-        private readonly MethodologyVersion _methodologyVersion = new MethodologyVersion
+        private readonly MethodologyVersion _methodologyVersion = new()
         {
             Id = Guid.NewGuid()
         };
+
+        [Fact]
+        public async Task DeleteAll()
+        {
+            var methodologyFileRepository = new Mock<IMethodologyFileRepository>(Strict);
+
+            methodologyFileRepository.Setup(mock => mock.GetByFileType(_methodologyVersion.Id, Image))
+                .ReturnsAsync(new List<MethodologyFile>
+                {
+                    new ()
+                    {
+                        Id = Guid.NewGuid(),
+                        FileId = Guid.NewGuid()
+                    }
+                });
+
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_methodologyVersion, SecurityPolicies.CanUpdateSpecificMethodology)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = SetupMethodologyImageService(
+                            methodologyFileRepository: methodologyFileRepository.Object,
+                            userService: userService.Object);
+                        return service.DeleteAll(_methodologyVersion.Id);
+                    }
+                );
+        }
 
         [Fact]
         public async Task Delete()
@@ -35,7 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     userService =>
                     {
                         var service = SetupMethodologyImageService(userService: userService.Object);
-                        return service.Delete(methodologyId: _methodologyVersion.Id,
+                        return service.Delete(methodologyVersionId: _methodologyVersion.Id,
                             fileIds: new List<Guid>());
                     }
                 );
@@ -65,20 +94,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             IMethodologyFileRepository methodologyFileRepository = null,
             IUserService userService = null)
         {
-            return new MethodologyImageService(
-                contentDbContext ?? new Mock<ContentDbContext>().Object,
+            return new(
+                contentDbContext ?? Mock.Of<ContentDbContext>(),
                 contentPersistenceHelper ?? DefaultPersistenceHelperMock().Object,
-                blobStorageService ?? new Mock<IBlobStorageService>().Object,
-                fileUploadsValidatorService ?? new Mock<IFileUploadsValidatorService>().Object,
-                fileRepository ?? new FileRepository(contentDbContext),
-                methodologyFileRepository ?? new MethodologyFileRepository(contentDbContext),
-                userService ?? new Mock<IUserService>().Object
+                blobStorageService ?? Mock.Of<IBlobStorageService>(),
+                fileUploadsValidatorService ?? Mock.Of<IFileUploadsValidatorService>(),
+                fileRepository ?? Mock.Of<IFileRepository>(),
+                methodologyFileRepository ?? Mock.Of<IMethodologyFileRepository>(),
+                userService ?? Mock.Of<IUserService>()
             );
         }
 
         private Mock<IPersistenceHelper<ContentDbContext>> DefaultPersistenceHelperMock()
         {
-            return MockUtils.MockPersistenceHelper<ContentDbContext, MethodologyVersion>(_methodologyVersion.Id, _methodologyVersion);
+            return MockUtils.MockPersistenceHelper<ContentDbContext, MethodologyVersion>(
+                _methodologyVersion.Id, _methodologyVersion);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyImageServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyImageServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -31,7 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 {
     public class MethodologyImageServiceTests
     {
-        private readonly User _user = new User
+        private readonly User _user = new()
         {
             Id = Guid.NewGuid(),
             Email = "test@test.com"
@@ -86,13 +87,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
 
-            blobStorageService.Setup(mock =>
-                    mock.DeleteBlob(PrivateMethodologyFiles, imageFile1.Path()))
-                .Returns(Task.CompletedTask);
-
-            blobStorageService.Setup(mock =>
-                    mock.DeleteBlob(PrivateMethodologyFiles, imageFile2.Path()))
-                .Returns(Task.CompletedTask);
+            blobStorageService.SetupDeleteBlob(PrivateMethodologyFiles, imageFile1.Path());
+            blobStorageService.SetupDeleteBlob(PrivateMethodologyFiles, imageFile2.Path());
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -104,11 +100,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 result.AssertRight();
 
-                blobStorageService.Verify(mock =>
-                    mock.DeleteBlob(PrivateMethodologyFiles, imageFile1.Path()), Times.Once);
-
-                blobStorageService.Verify(mock =>
-                    mock.DeleteBlob(PrivateMethodologyFiles, imageFile2.Path()), Times.Once);
+                MockUtils.VerifyAllMocks(blobStorageService);
             }
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -122,8 +114,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.NotNull(await contentDbContext.MethodologyFiles.FindAsync(imageFile3.Id));
                 Assert.NotNull(await contentDbContext.Files.FindAsync(imageFile3.File.Id));
             }
-
-            MockUtils.VerifyAllMocks(blobStorageService);
         }
 
         [Fact]
@@ -172,9 +162,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
 
-            blobStorageService.Setup(mock =>
-                    mock.DeleteBlob(PrivateMethodologyFiles, imageFile1.Path()))
-                .Returns(Task.CompletedTask);
+            blobStorageService.SetupDeleteBlob(PrivateMethodologyFiles, imageFile1.Path());
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
@@ -186,8 +174,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
                 result.AssertRight();
 
-                blobStorageService.Verify(mock =>
-                    mock.DeleteBlob(PrivateMethodologyFiles, imageFile1.Path()), Times.Once);
+                MockUtils.VerifyAllMocks(blobStorageService);
             }
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
@@ -213,8 +200,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 // MethodologyFile link that was deleted.
                 Assert.Equal(filesForFileLinkedToDeletingMethodology, filesForFileLinkedToAnotherMethodology);
             }
-
-            MockUtils.VerifyAllMocks(blobStorageService);
         }
 
         [Fact]
@@ -253,12 +238,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 await contentDbContext.SaveChangesAsync();
             }
 
-            var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
-
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var service = SetupMethodologyImageService(contentDbContext: contentDbContext,
-                    blobStorageService: blobStorageService.Object);
+                var service = SetupMethodologyImageService(contentDbContext: contentDbContext);
 
                 var result = await service.Delete(methodologyVersion.Id,
                     AsList(ancillaryFile.File.Id, imageFile.File.Id));
@@ -275,12 +257,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.NotNull(await contentDbContext.MethodologyFiles.FindAsync(imageFile.Id));
                 Assert.NotNull(await contentDbContext.Files.FindAsync(imageFile.File.Id));
             }
-
-            MockUtils.VerifyAllMocks(blobStorageService);
         }
 
         [Fact]
-        public async Task Delete_MethodologyNotFound()
+        public async Task Delete_MethodologyVersionNotFound()
         {
             var methodologyVersion = new MethodologyVersion();
 
@@ -304,12 +284,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 await contentDbContext.SaveChangesAsync();
             }
 
-            var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
-
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var service = SetupMethodologyImageService(contentDbContext: contentDbContext,
-                    blobStorageService: blobStorageService.Object);
+                var service = SetupMethodologyImageService(contentDbContext: contentDbContext);
 
                 var result = await service.Delete(Guid.NewGuid(),
                     AsList(imageFile.File.Id));
@@ -323,8 +300,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.NotNull(await contentDbContext.MethodologyFiles.FindAsync(imageFile.Id));
                 Assert.NotNull(await contentDbContext.Files.FindAsync(imageFile.File.Id));
             }
-
-            MockUtils.VerifyAllMocks(blobStorageService);
         }
 
         [Fact]
@@ -352,12 +327,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 await contentDbContext.SaveChangesAsync();
             }
 
-            var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
-
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var service = SetupMethodologyImageService(contentDbContext: contentDbContext,
-                    blobStorageService: blobStorageService.Object);
+                var service = SetupMethodologyImageService(contentDbContext: contentDbContext);
 
                 var result = await service.Delete(methodologyVersion.Id,
                     AsList(imageFile.File.Id, Guid.NewGuid()));
@@ -371,8 +343,206 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.NotNull(await contentDbContext.MethodologyFiles.FindAsync(imageFile.Id));
                 Assert.NotNull(await contentDbContext.Files.FindAsync(imageFile.File.Id));
             }
+        }
 
-            MockUtils.VerifyAllMocks(blobStorageService);
+        [Fact]
+        public async Task DeleteAll()
+        {
+            var methodologyVersion = new MethodologyVersion();
+            var anotherVersion = new MethodologyVersion();
+
+            var imageFile1 = new MethodologyFile
+            {
+                MethodologyVersion = methodologyVersion,
+                File = new File
+                {
+                    RootPath = Guid.NewGuid(),
+                    Filename = "image1.png",
+                    Type = Image
+                }
+            };
+
+            var imageFile2 = new MethodologyFile
+            {
+                MethodologyVersion = methodologyVersion,
+                File = new File
+                {
+                    RootPath = Guid.NewGuid(),
+                    Filename = "image2.png",
+                    Type = Image
+                }
+            };
+
+            var imageFile3 = new MethodologyFile
+            {
+                MethodologyVersion = anotherVersion,
+                File = new File
+                {
+                    RootPath = Guid.NewGuid(),
+                    Filename = "image3.png",
+                    Type = Image
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyVersions.AddRangeAsync(methodologyVersion, anotherVersion);
+                await contentDbContext.MethodologyFiles.AddRangeAsync(imageFile1, imageFile2, imageFile3);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+
+            blobStorageService.SetupDeleteBlob(PrivateMethodologyFiles, imageFile1.Path());
+            blobStorageService.SetupDeleteBlob(PrivateMethodologyFiles, imageFile2.Path());
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyImageService(contentDbContext: contentDbContext,
+                    blobStorageService: blobStorageService.Object);
+
+                var result = await service.DeleteAll(methodologyVersion.Id);
+
+                MockUtils.VerifyAllMocks(blobStorageService);
+                
+                result.AssertRight();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                Assert.Null(await contentDbContext.MethodologyFiles.FindAsync(imageFile1.Id));
+                Assert.Null(await contentDbContext.Files.FindAsync(imageFile1.File.Id));
+
+                Assert.Null(await contentDbContext.MethodologyFiles.FindAsync(imageFile2.Id));
+                Assert.Null(await contentDbContext.Files.FindAsync(imageFile2.File.Id));
+
+                // Check that other file remains untouched since it is unrelated to this version
+                Assert.NotNull(await contentDbContext.MethodologyFiles.FindAsync(imageFile3.Id));
+                Assert.NotNull(await contentDbContext.Files.FindAsync(imageFile3.File.Id));
+            }
+        }
+
+        [Fact]
+        public async Task DeleteAll_MethodologyVersionNotFound()
+        {
+            await using (var contentDbContext = InMemoryApplicationDbContext())
+            {
+                var service = SetupMethodologyImageService(contentDbContext: contentDbContext);
+
+                var result = await service.DeleteAll(Guid.NewGuid());
+
+                result.AssertNotFound();
+            }
+        }
+
+        [Fact]
+        public async Task DeleteAll_NoFiles()
+        {
+            var methodologyVersion = new MethodologyVersion();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyVersions.AddAsync(methodologyVersion);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyImageService(contentDbContext: contentDbContext);
+
+                var result = await service.DeleteAll(methodologyVersion.Id);
+
+                Assert.True(result.IsRight);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteAll_FilesLinkedToOtherMethodologyVersions()
+        {
+            var methodologyVersion = new MethodologyVersion();
+            var anotherVersion = new MethodologyVersion();
+
+            var imageFile1 = new MethodologyFile
+            {
+                MethodologyVersion = methodologyVersion,
+                File = new File
+                {
+                    RootPath = Guid.NewGuid(),
+                    Filename = "image1.png",
+                    Type = Image
+                }
+            };
+
+            var imageFile2 = new MethodologyFile
+            {
+                MethodologyVersion = methodologyVersion,
+                File = new File
+                {
+                    RootPath = Guid.NewGuid(),
+                    Filename = "image2.png",
+                    Type = Image
+                }
+            };
+
+            var imageFile2UsedByAnotherMethodology = new MethodologyFile
+            {
+                MethodologyVersion = anotherVersion,
+                File = imageFile2.File
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyVersions.AddAsync(methodologyVersion);
+                await contentDbContext.MethodologyFiles.AddRangeAsync(imageFile1, imageFile2,
+                    imageFile2UsedByAnotherMethodology);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
+
+            blobStorageService.SetupDeleteBlob(PrivateMethodologyFiles, imageFile1.Path());
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyImageService(contentDbContext: contentDbContext,
+                    blobStorageService: blobStorageService.Object);
+
+                var result = await service.DeleteAll(methodologyVersion.Id);
+
+                result.AssertRight();
+
+                MockUtils.VerifyAllMocks(blobStorageService);
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                // All of the MethodologyFiles links for the methodology having the images removed from it are removed.
+                Assert.Null(await contentDbContext.MethodologyFiles.FindAsync(imageFile1.Id));
+                Assert.Null(await contentDbContext.Files.FindAsync(imageFile1.File.Id));
+                Assert.Null(await contentDbContext.MethodologyFiles.FindAsync(imageFile2.Id));
+
+                // However, the file that is still linked to anotherMethodology remains in the File table, as does
+                // its link to anotherMethodology.
+                Assert.NotNull(await contentDbContext.MethodologyFiles.FindAsync(imageFile2UsedByAnotherMethodology.Id));
+
+                var filesForFileLinkedToDeletingMethodology =
+                    await contentDbContext.Files.FindAsync(imageFile2.File.Id);
+
+                var filesForFileLinkedToAnotherMethodology =
+                    await contentDbContext.Files.FindAsync(imageFile2UsedByAnotherMethodology.File.Id);
+
+                Assert.NotNull(filesForFileLinkedToAnotherMethodology);
+
+                // Sanity check that the File entry that remains is the same File as was referenced by the
+                // MethodologyFile link that was deleted.
+                Assert.Equal(filesForFileLinkedToDeletingMethodology, filesForFileLinkedToAnotherMethodology);
+            }
         }
 
         [Fact]
@@ -403,8 +573,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
 
             var blob = new BlobInfo(
-                path: null,
-                size: null,
+                path: methodologyFile.Path(),
+                size: "1 Mb",
                 contentType: "image/png",
                 contentLength: 0L,
                 meta: null,
@@ -447,7 +617,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         }
 
         [Fact]
-        public async Task Stream_MethodologyNotFound()
+        public async Task Stream_MethodologyVersionNotFound()
         {
             var methodologyFile = new MethodologyFile
             {
@@ -604,7 +774,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         }
 
         [Fact]
-        public async Task Upload_MethodologyNotFound()
+        public async Task Upload_MethodologyVersionNotFound()
         {
             const string filename = "image.png";
 
@@ -628,12 +798,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
         private MethodologyImageService SetupMethodologyImageService(
             ContentDbContext contentDbContext,
-            IPersistenceHelper<ContentDbContext> contentPersistenceHelper = null,
-            IBlobStorageService blobStorageService = null,
-            IFileUploadsValidatorService fileUploadsValidatorService = null,
-            IFileRepository fileRepository = null,
-            IMethodologyFileRepository methodologyFileRepository = null,
-            IUserService userService = null)
+            IPersistenceHelper<ContentDbContext>? contentPersistenceHelper = null,
+            IBlobStorageService? blobStorageService = null,
+            IFileUploadsValidatorService? fileUploadsValidatorService = null,
+            IFileRepository? fileRepository = null,
+            IMethodologyFileRepository? methodologyFileRepository = null,
+            IUserService? userService = null)
         {
             contentDbContext.Users.Add(_user);
             contentDbContext.SaveChanges();
@@ -641,8 +811,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             return new MethodologyImageService(
                 contentDbContext,
                 contentPersistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
-                blobStorageService ?? new Mock<IBlobStorageService>().Object,
-                fileUploadsValidatorService ?? new Mock<IFileUploadsValidatorService>().Object,
+                blobStorageService ?? Mock.Of<IBlobStorageService>(MockBehavior.Strict),
+                fileUploadsValidatorService ?? Mock.Of<IFileUploadsValidatorService>(MockBehavior.Strict),
                 fileRepository ?? new FileRepository(contentDbContext),
                 methodologyFileRepository ?? new MethodologyFileRepository(contentDbContext),
                 userService ?? MockUtils.AlwaysTrueUserService(_user.Id).Object

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServicePermissionTests.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
@@ -28,6 +29,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         private readonly Publication _publication = new()
         {
             Id = Guid.NewGuid()
+        };
+
+        private readonly Methodology _methodology = new()
+        {
+            Id = Guid.NewGuid(),
+            Versions = new List<MethodologyVersion>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid()
+                }
+            }
         };
 
         private readonly MethodologyVersion _methodologyVersion = new()
@@ -217,6 +230,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
         [Fact]
         public async Task DeleteMethodology()
+        {
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(_methodology.Versions[0], CanDeleteSpecificMethodology)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = SetupMethodologyService(
+                            contentPersistenceHelper: MockPersistenceHelper<ContentDbContext, Methodology>(
+                                _methodology.Id, _methodology).Object,
+                            userService: userService.Object);
+                        return service.DeleteMethodology(_methodology.Id);
+                    }
+                );
+        }
+
+        [Fact]
+        public async Task DeleteMethodologyVersion()
         {
             await PolicyCheckBuilder<SecurityPolicies>()
                 .SetupResourceCheckToFail(_methodologyVersion, CanDeleteSpecificMethodology)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -49,9 +50,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
+            var publishingService = new Mock<IPublishingService>(Strict);
+
+            publishingService.Setup(s => s.TaxonomyChanged())
+                .ReturnsAsync(Unit.Instance);
+
             await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
             {
-                var service = SetupTopicService(context);
+                var service = SetupTopicService(contentContext: context,
+                    publishingService: publishingService.Object);
 
                 var result = await service.CreateTopic(
                     new TopicSaveViewModel
@@ -60,6 +67,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         ThemeId = theme.Id
                     }
                 );
+
+                VerifyAllMocks(publishingService);
 
                 Assert.True(result.IsRight);
                 Assert.Equal("Test topic", result.Right.Title);
@@ -161,9 +170,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 await context.SaveChangesAsync();
             }
 
+            var publishingService = new Mock<IPublishingService>(Strict);
+
+            publishingService.Setup(s => s.TaxonomyChanged())
+                .ReturnsAsync(Unit.Instance);
+
             await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
             {
-                var service = SetupTopicService(context);
+                var service = SetupTopicService(contentContext: context,
+                    publishingService: publishingService.Object);
 
                 var result = await service.UpdateTopic(
                     topic.Id,
@@ -173,6 +188,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         ThemeId = theme.Id
                     }
                 );
+
+                VerifyAllMocks(publishingService);
 
                 Assert.True(result.IsRight);
                 Assert.Equal(topic.Id, result.Right.Id);
@@ -315,22 +332,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var topicId = Guid.NewGuid();
             var releaseId = Guid.NewGuid();
             var publicationId = Guid.NewGuid();
-            var methodologyVersionId = Guid.NewGuid();
 
-            var publicationMethodology = new PublicationMethodology
-            {
-                PublicationId = publicationId,
-                Methodology = new Methodology
-                {
-                    Versions = new List<MethodologyVersion>
-                    {
-                        new()
-                        {
-                            Id = methodologyVersionId
-                        }
-                    }
-                }
-            };
+            var methodology = new Methodology();
 
             var topic = new Topic
             {
@@ -342,10 +345,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Id = publicationId,
                 Topic = topic,
-                Releases = AsList(new ContentRelease
+                Methodologies = new List<PublicationMethodology>
                 {
-                    Id = releaseId
-                })
+                    new()
+                    {
+                        PublicationId = publicationId,
+                        Methodology = methodology,
+                        Owner = true
+                    }
+                },
+                Releases = new List<ContentRelease>
+                {
+                    new()
+                    {
+                        Id = releaseId
+                    }
+                }
             };
 
             var statsRelease = new Release
@@ -359,9 +374,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
             await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
             {
+                await contentContext.Methodologies.AddAsync(methodology);
                 await contentContext.Publications.AddAsync(publication);
                 await contentContext.Topics.AddAsync(topic);
-                await contentContext.PublicationMethodologies.AddAsync(publicationMethodology);
                 await statisticsContext.Release.AddAsync(statsRelease);
 
                 await contentContext.SaveChangesAsync();
@@ -369,7 +384,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(1, contentContext.Publications.Count());
                 Assert.Equal(1, contentContext.Topics.Count());
-                Assert.Equal(1, contentContext.MethodologyVersions.Count());
                 Assert.Equal(1, contentContext.PublicationMethodologies.Count());
                 Assert.Equal(1, contentContext.Releases.Count());
                 Assert.Equal(1, statisticsContext.Release.Count());
@@ -379,6 +393,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var releaseFileService = new Mock<IReleaseFileService>(Strict);
             var releaseSubjectRepository = new Mock<IReleaseSubjectRepository>(Strict);
             var methodologyService = new Mock<IMethodologyService>(Strict);
+            var publishingService = new Mock<IPublishingService>(Strict);
 
             await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
             await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
@@ -389,7 +404,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseDataFileService: releaseDataFileService.Object,
                     releaseFileService: releaseFileService.Object,
                     releaseSubjectRepository: releaseSubjectRepository.Object,
-                    methodologyService: methodologyService.Object);
+                    methodologyService: methodologyService.Object,
+                    publishingService: publishingService.Object);
 
                 releaseDataFileService
                     .Setup(s => s.DeleteAll(releaseId, true))
@@ -404,12 +420,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .Returns(Task.CompletedTask);
 
                 methodologyService
-                    .Setup(s => s.DeleteMethodologyVersion(methodologyVersionId, true))
+                    .Setup(s => s.DeleteMethodology(methodology.Id, true))
+                    .ReturnsAsync(Unit.Instance);
+
+                publishingService.Setup(s => s.TaxonomyChanged())
                     .ReturnsAsync(Unit.Instance);
 
                 var result = await service.DeleteTopic(topicId);
-                VerifyAllMocks(releaseDataFileService, releaseFileService, releaseSubjectRepository,
-                    methodologyService);
+                VerifyAllMocks(releaseDataFileService,
+                    releaseFileService,
+                    releaseSubjectRepository,
+                    methodologyService,
+                    publishingService);
+
                 result.AssertRight();
 
                 Assert.Equal(0, contentContext.Publications.Count());
@@ -420,7 +443,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         [Fact]
-        public async Task DeleteTopic_ReleaseAndMethodologyVersionsDeletedInCorrectOrder()
+        public async Task DeleteTopic_ReleaseVersionsDeletedInCorrectOrder()
         {
             var topicId = Guid.NewGuid();
             var publicationId = Guid.NewGuid();
@@ -429,41 +452,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var releaseVersion2Id = Guid.NewGuid();
             var releaseVersion3Id = Guid.NewGuid();
             var releaseVersion4Id = Guid.NewGuid();
-
-            var methodologyVersion1Id = Guid.NewGuid();
-            var methodologyVersion2Id = Guid.NewGuid();
-            var methodologyVersion3Id = Guid.NewGuid();
-            var methodologyVersion4Id = Guid.NewGuid();
-
-            var publicationMethodology = new PublicationMethodology
-            {
-                PublicationId = publicationId,
-                Methodology = new Methodology
-                {
-                    Versions = new List<MethodologyVersion>
-                    {
-                        new()
-                        {
-                            Id = methodologyVersion2Id,
-                            PreviousVersionId = methodologyVersion1Id
-                        },
-                        new()
-                        {
-                            Id = methodologyVersion1Id
-                        },
-                        new()
-                        {
-                            Id = methodologyVersion4Id,
-                            PreviousVersionId = methodologyVersion3Id
-                        },
-                        new()
-                        {
-                            Id = methodologyVersion3Id,
-                            PreviousVersionId = methodologyVersion2Id,
-                        }
-                    }
-                }
-            };
 
             var topic = new Topic
             {
@@ -525,7 +513,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 await contentContext.Publications.AddAsync(publication);
                 await contentContext.Topics.AddAsync(topic);
-                await contentContext.PublicationMethodologies.AddAsync(publicationMethodology);
                 await statisticsContext.Release.AddRangeAsync(statsReleases);
 
                 await contentContext.SaveChangesAsync();
@@ -533,8 +520,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(1, contentContext.Publications.Count());
                 Assert.Equal(1, contentContext.Topics.Count());
-                Assert.Equal(4, contentContext.MethodologyVersions.Count());
-                Assert.Equal(1, contentContext.PublicationMethodologies.Count());
                 Assert.Equal(4, contentContext.Releases.Count());
                 Assert.Equal(4, statisticsContext.Release.Count());
             }
@@ -542,7 +527,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var releaseDataFileService = new Mock<IReleaseDataFileService>(Strict);
             var releaseFileService = new Mock<IReleaseFileService>(Strict);
             var releaseSubjectRepository = new Mock<IReleaseSubjectRepository>(Strict);
-            var methodologyService = new Mock<IMethodologyService>(Strict);
+            var publishingService = new Mock<IPublishingService>(Strict);
 
             await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
             await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
@@ -553,7 +538,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseDataFileService: releaseDataFileService.Object,
                     releaseFileService: releaseFileService.Object,
                     releaseSubjectRepository: releaseSubjectRepository.Object,
-                    methodologyService: methodologyService.Object);
+                    publishingService: publishingService.Object);
 
                 var releaseDataFileDeleteSequence = new MockSequence();
 
@@ -621,30 +606,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .Setup(s => s.DeleteAllReleaseSubjects(releaseVersion1Id, false))
                     .Returns(Task.CompletedTask);
 
-                var methodologyDeleteSequence = new MockSequence();
-
-                methodologyService
-                    .InSequence(methodologyDeleteSequence)
-                    .Setup(s => s.DeleteMethodologyVersion(methodologyVersion4Id, true))
-                    .ReturnsAsync(Unit.Instance);
-
-                methodologyService
-                    .InSequence(methodologyDeleteSequence)
-                    .Setup(s => s.DeleteMethodologyVersion(methodologyVersion3Id, true))
-                    .ReturnsAsync(Unit.Instance);
-
-                methodologyService
-                    .InSequence(methodologyDeleteSequence)
-                    .Setup(s => s.DeleteMethodologyVersion(methodologyVersion2Id, true))
-                    .ReturnsAsync(Unit.Instance);
-
-                methodologyService
-                    .InSequence(methodologyDeleteSequence)
-                    .Setup(s => s.DeleteMethodologyVersion(methodologyVersion1Id, true))
+                publishingService.Setup(s => s.TaxonomyChanged())
                     .ReturnsAsync(Unit.Instance);
 
                 var result = await service.DeleteTopic(topicId);
-                VerifyAllMocks(releaseDataFileService, releaseFileService, releaseSubjectRepository, methodologyService);
+                VerifyAllMocks(releaseDataFileService, releaseFileService, releaseSubjectRepository, publishingService);
                 result.AssertRight();
 
                 Assert.Equal(0, contentContext.Publications.Count());
@@ -787,27 +753,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var topicId = Guid.NewGuid();
             var releaseId = Guid.NewGuid();
             var publicationId = Guid.NewGuid();
-            var methodologyId = Guid.NewGuid();
 
             var otherTopicId = Guid.NewGuid();
             var otherReleaseId = Guid.NewGuid();
             var otherPublicationId = Guid.NewGuid();
-            var otherMethodologyId = Guid.NewGuid();
 
-            var publicationMethodology = new PublicationMethodology
-            {
-                PublicationId = publicationId,
-                Methodology = new Methodology
-                {
-                    Versions = new List<MethodologyVersion>
-                    {
-                        new()
-                        {
-                            Id = methodologyId
-                        }
-                    }
-                }
-            };
+            var methodology = new Methodology();
 
             var topic = new Topic
             {
@@ -819,6 +770,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Id = publicationId,
                 Topic = topic,
+                Methodologies = new List<PublicationMethodology>
+                {
+                    new()
+                    {
+                        PublicationId = publicationId,
+                        Methodology = methodology,
+                        Owner = true
+                    }
+                },
                 Releases = AsList(new ContentRelease
                 {
                     Id = releaseId
@@ -831,21 +791,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 PublicationId = publicationId
             };
 
-            var otherPublicationMethodology = new PublicationMethodology
-            {
-                PublicationId = otherPublicationId,
-                Methodology = new Methodology
-                {
-                    Versions = new List<MethodologyVersion>
-                    {
-                        new()
-                        {
-                            Id = otherMethodologyId
-                        }
-                    }
-                }
-            };
-
             var otherTopic = new Topic
             {
                 Id = otherTopicId,
@@ -856,6 +801,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 Id = otherPublicationId,
                 Topic = otherTopic,
+                Methodologies = new List<PublicationMethodology>
+                {
+                    new()
+                    {
+                        PublicationId = otherPublicationId,
+                        Methodology = new Methodology(),
+                        Owner = true
+                    }
+                },
                 Releases = AsList(new ContentRelease
                 {
                     Id = otherReleaseId
@@ -873,9 +827,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
             await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
             {
+                await contentContext.Methodologies.AddAsync(methodology);
                 await contentContext.Publications.AddRangeAsync(publication, otherPublication);
                 await contentContext.Topics.AddRangeAsync(topic, otherTopic);
-                await contentContext.PublicationMethodologies.AddRangeAsync(publicationMethodology, otherPublicationMethodology);
                 await statisticsContext.Release.AddRangeAsync(statsRelease, otherStatsRelease);
 
                 await contentContext.SaveChangesAsync();
@@ -883,7 +837,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 Assert.Equal(2, contentContext.Publications.Count());
                 Assert.Equal(2, contentContext.Topics.Count());
-                Assert.Equal(2, contentContext.MethodologyVersions.Count());
+                Assert.Equal(2, contentContext.Methodologies.Count());
                 Assert.Equal(2, contentContext.PublicationMethodologies.Count());
                 Assert.Equal(2, contentContext.Releases.Count());
                 Assert.Equal(2, statisticsContext.Release.Count());
@@ -893,6 +847,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var releaseFileService = new Mock<IReleaseFileService>(Strict);
             var releaseSubjectRepository = new Mock<IReleaseSubjectRepository>(Strict);
             var methodologyService = new Mock<IMethodologyService>(Strict);
+            var publishingService = new Mock<IPublishingService>(Strict);
 
             await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
             await using (var statisticsContext = InMemoryStatisticsDbContext(contextId))
@@ -903,7 +858,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     releaseDataFileService: releaseDataFileService.Object,
                     releaseFileService: releaseFileService.Object,
                     releaseSubjectRepository: releaseSubjectRepository.Object,
-                    methodologyService: methodologyService.Object);
+                    methodologyService: methodologyService.Object,
+                    publishingService: publishingService.Object);
 
                 releaseDataFileService
                     .Setup(s => s.DeleteAll(releaseId, true))
@@ -918,11 +874,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     .Returns(Task.CompletedTask);
 
                 methodologyService
-                    .Setup(s => s.DeleteMethodologyVersion(methodologyId, true))
+                    .Setup(s => s.DeleteMethodology(methodology.Id, true))
+                    .ReturnsAsync(Unit.Instance);
+
+                publishingService.Setup(s => s.TaxonomyChanged())
                     .ReturnsAsync(Unit.Instance);
 
                 var result = await service.DeleteTopic(topicId);
-                VerifyAllMocks(releaseDataFileService, releaseFileService, releaseSubjectRepository, methodologyService);
+                VerifyAllMocks(releaseDataFileService,
+                    releaseFileService,
+                    releaseSubjectRepository,
+                    methodologyService,
+                    publishingService);
+
                 result.AssertRight();
 
                 Assert.Equal(otherPublicationId, contentContext.Publications.Select(p => p.Id).Single());
@@ -932,65 +896,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             }
         }
 
-        [Fact]
-        public void VersionedEntityDeletionOrderComparer()
-        {
-            var version1Id = Guid.NewGuid();
-            var version2Id = Guid.NewGuid();
-            var version3Id = Guid.NewGuid();
-
-            var version1 = new TopicService.IdAndPreviousVersionIdPair(version1Id, null);
-            var version2 = new TopicService.IdAndPreviousVersionIdPair(version2Id, version1Id);
-            var version3 = new TopicService.IdAndPreviousVersionIdPair(version3Id, version2Id);
-
-            var comparer = new TopicService.VersionedEntityDeletionOrderComparer();
-
-            Assert.Equal(-1, comparer.Compare(version2, version1));
-            Assert.Equal(-1, comparer.Compare(version3, version2));
-
-            Assert.Equal(1, comparer.Compare(version1, version2));
-            Assert.Equal(1, comparer.Compare(version2, version3));
-
-            Assert.Equal(1, comparer.Compare(version1, version3));
-            Assert.Equal(-1, comparer.Compare(version3, version1));
-        }
-
-        [Fact]
-        public void VersionedEntityDeletionOrderComparer_WithSequence()
-        {
-            var version1Id = Guid.NewGuid();
-            var version4Id = Guid.NewGuid();
-            var version3Id = Guid.NewGuid();
-            var version2Id = Guid.NewGuid();
-            var version5Id = Guid.NewGuid();
-
-            var versions = AsList(
-                new TopicService.IdAndPreviousVersionIdPair(version2Id, version1Id),
-                new TopicService.IdAndPreviousVersionIdPair(version1Id, null),
-                new TopicService.IdAndPreviousVersionIdPair(version5Id, version4Id),
-                new TopicService.IdAndPreviousVersionIdPair(version4Id, version3Id),
-                new TopicService.IdAndPreviousVersionIdPair(version3Id, version2Id));
-
-            var orderedByLatestVersionsFirst = versions
-                .OrderBy(version => version, new TopicService.VersionedEntityDeletionOrderComparer())
-                .Select(version => version.Id)
-                .ToList();
-
-            var expectedVersionOrder = AsList(version5Id, version4Id, version3Id, version2Id, version1Id);
-            Assert.Equal(expectedVersionOrder, orderedByLatestVersionsFirst);
-        }
-
-        private TopicService SetupTopicService(
+        private static TopicService SetupTopicService(
             ContentDbContext contentContext,
-            StatisticsDbContext statisticsContext = null,
-            IPersistenceHelper<ContentDbContext> persistenceHelper = null,
-            IMapper mapper = null,
-            IUserService userService = null,
-            IReleaseSubjectRepository releaseSubjectRepository = null,
-            IReleaseDataFileService releaseDataFileService = null,
-            IReleaseFileService releaseFileService = null,
-            IPublishingService publishingService = null,
-            IMethodologyService methodologyService = null,
+            StatisticsDbContext? statisticsContext = null,
+            IPersistenceHelper<ContentDbContext>? persistenceHelper = null,
+            IMapper? mapper = null,
+            IUserService? userService = null,
+            IReleaseSubjectRepository? releaseSubjectRepository = null,
+            IReleaseDataFileService? releaseDataFileService = null,
+            IReleaseFileService? releaseFileService = null,
+            IPublishingService? publishingService = null,
+            IMethodologyService? methodologyService = null,
             bool enableThemeDeletion = true)
         {
             var configuration =
@@ -999,15 +915,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             return new TopicService(
                 configuration.Object,
                 contentContext,
-                statisticsContext ?? Mock.Of<StatisticsDbContext>(),
+                statisticsContext ?? Mock.Of<StatisticsDbContext>(Strict),
                 persistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentContext),
                 mapper ?? AdminMapper(),
                 userService ?? AlwaysTrueUserService().Object,
-                releaseSubjectRepository ?? Mock.Of<IReleaseSubjectRepository>(),
-                releaseDataFileService ?? Mock.Of<IReleaseDataFileService>(),
-                releaseFileService ?? Mock.Of<IReleaseFileService>(),
-                publishingService ?? Mock.Of<IPublishingService>(),
-                methodologyService ?? Mock.Of<IMethodologyService>()
+                releaseSubjectRepository ?? Mock.Of<IReleaseSubjectRepository>(Strict),
+                releaseDataFileService ?? Mock.Of<IReleaseDataFileService>(Strict),
+                releaseFileService ?? Mock.Of<IReleaseFileService>(Strict),
+                publishingService ?? Mock.Of<IPublishingService>(Strict),
+                methodologyService ?? Mock.Of<IMethodologyService>(Strict)
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/ViewModels/PublicationSaveViewModelTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/ViewModels/PublicationSaveViewModelTests.cs
@@ -1,9 +1,10 @@
+#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using Xunit;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Model.Api
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.ViewModels
 {
-    public class CreatePublicationViewModelTests
+    public class PublicationSaveViewModelTests
     {
         [Fact]
         public void ManualSlugOverride()

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/IdAndPreviousVersionIdPair.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/IdAndPreviousVersionIdPair.cs
@@ -1,0 +1,56 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
+{
+    public class IdAndPreviousVersionIdPair
+    {
+        public readonly Guid Id;
+        public readonly Guid? PreviousVersionId;
+
+        public IdAndPreviousVersionIdPair(Guid id, Guid? previousVersionId)
+        {
+            Id = id;
+            PreviousVersionId = previousVersionId;
+        }
+    }
+
+    /// <summary>
+    /// An IComparer implementation that orders entities based upon having previous versions.  This IComparer will
+    /// order the entities so that entities that have no previous versions will appear at the end of the list,
+    /// entities that have that set of entities as previous versions will appear before them etc. 
+    /// </summary>
+    public class VersionedEntityDeletionOrderComparer : IComparer<IdAndPreviousVersionIdPair>
+    {
+        public int Compare(IdAndPreviousVersionIdPair? entity1Ids, IdAndPreviousVersionIdPair? entity2Ids)
+        {
+            if (entity1Ids == null)
+            {
+                return 1;
+            }
+
+            if (entity2Ids == null)
+            {
+                return -1;
+            }
+
+            if (entity1Ids.PreviousVersionId == null)
+            {
+                return 1;
+            }
+
+            if (entity2Ids.PreviousVersionId == null)
+            {
+                return -1;
+            }
+
+            if (entity1Ids.PreviousVersionId == entity2Ids.Id)
+            {
+                return -1;
+            }
+
+            return entity2Ids.PreviousVersionId == entity1Ids.Id ? 1 : -1;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyImageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyImageService.cs
@@ -11,9 +11,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 {
     public interface IMethodologyImageService
     {
+        Task<Either<ActionResult, Unit>> DeleteAll(Guid methodologyVersionId, bool forceDelete = false);
+
         Task<Either<ActionResult, Unit>> Delete(
-            Guid methodologyId,
-            IEnumerable<Guid> fileIds);
+            Guid methodologyVersionId,
+            IEnumerable<Guid> fileIds,
+            bool forceDelete = false);
 
         Task<Either<ActionResult, FileStreamResult>> Stream(Guid methodologyVersionId, Guid fileId);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
@@ -15,6 +15,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 
         Task<Either<ActionResult, MethodologySummaryViewModel>> CreateMethodology(Guid publicationId);
 
+        Task<Either<ActionResult, Unit>> DeleteMethodology(Guid methodologyId, bool forceDelete = false);
+
+        Task<Either<ActionResult, Unit>> DeleteMethodologyVersion(Guid methodologyVersionId, bool forceDelete = false);
+
         Task<Either<ActionResult, Unit>> DropMethodology(Guid publicationId, Guid methodologyId);
 
         Task<Either<ActionResult, List<MethodologySummaryViewModel>>> GetAdoptableMethodologies(Guid publicationId);
@@ -26,7 +30,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 
         Task<Either<ActionResult, MethodologySummaryViewModel>> UpdateMethodology(Guid methodologyVersionId,
             MethodologyUpdateRequest request);
-
-        Task<Either<ActionResult, Unit>> DeleteMethodologyVersion(Guid methodologyVersionId, bool forceDelete = false);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Security/UserServiceExtensions.cs
@@ -61,43 +61,49 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
         }
 
         public static Task<Either<ActionResult, MethodologyVersion>> CheckCanViewMethodology(
-            this IUserService userService, MethodologyVersion methodology)
+            this IUserService userService, MethodologyVersion methodologyVersion)
         {
-            return userService.CheckPolicy(methodology, SecurityPolicies.CanViewSpecificMethodology);
+            return userService.CheckPolicy(methodologyVersion, SecurityPolicies.CanViewSpecificMethodology);
         }
 
         public static Task<Either<ActionResult, MethodologyVersion>> CheckCanUpdateMethodology(
-            this IUserService userService, MethodologyVersion methodology)
+            this IUserService userService, MethodologyVersion methodologyVersion)
         {
-            return userService.CheckPolicy(methodology, SecurityPolicies.CanUpdateSpecificMethodology);
+            return userService.CheckPolicy(methodologyVersion, SecurityPolicies.CanUpdateSpecificMethodology);
+        }
+
+        public static Task<Either<ActionResult, MethodologyVersion>> CheckCanUpdateMethodology(
+            this IUserService userService, MethodologyVersion methodologyVersion, bool ignoreCheck)
+        {
+            return ignoreCheck
+                ? Task.FromResult(new Either<ActionResult, MethodologyVersion>(methodologyVersion))
+                : userService.CheckCanUpdateMethodology(methodologyVersion);
         }
 
         public static Task<Either<ActionResult, MethodologyVersion>> CheckCanMarkMethodologyAsDraft(
-            this IUserService userService, MethodologyVersion methodology)
+            this IUserService userService, MethodologyVersion methodologyVersion)
         {
-            return userService.CheckPolicy(methodology, SecurityPolicies.CanMarkSpecificMethodologyAsDraft);
+            return userService.CheckPolicy(methodologyVersion, SecurityPolicies.CanMarkSpecificMethodologyAsDraft);
         }
 
         public static Task<Either<ActionResult, MethodologyVersion>> CheckCanApproveMethodology(
-            this IUserService userService, MethodologyVersion methodology)
+            this IUserService userService, MethodologyVersion methodologyVersion)
         {
-            return userService.CheckPolicy(methodology, SecurityPolicies.CanApproveSpecificMethodology);
+            return userService.CheckPolicy(methodologyVersion, SecurityPolicies.CanApproveSpecificMethodology);
         }
 
         public static Task<Either<ActionResult, MethodologyVersion>> CheckCanMakeAmendmentOfMethodology(
-            this IUserService userService, MethodologyVersion methodology)
+            this IUserService userService, MethodologyVersion methodologyVersion)
         {
-            return userService.CheckPolicy(methodology, SecurityPolicies.CanMakeAmendmentOfSpecificMethodology);
+            return userService.CheckPolicy(methodologyVersion, SecurityPolicies.CanMakeAmendmentOfSpecificMethodology);
         }
 
         public static Task<Either<ActionResult, MethodologyVersion>> CheckCanDeleteMethodology(
-            this IUserService userService, MethodologyVersion methodology, bool ignoreCheck = false)
+            this IUserService userService, MethodologyVersion methodologyVersion, bool ignoreCheck = false)
         {
-            if (ignoreCheck)
-            {
-                return Task.FromResult(new Either<ActionResult, MethodologyVersion>(methodology));
-            }
-            return userService.CheckPolicy(methodology, SecurityPolicies.CanDeleteSpecificMethodology);
+            return ignoreCheck
+                ? Task.FromResult(new Either<ActionResult, MethodologyVersion>(methodologyVersion))
+                : userService.CheckPolicy(methodologyVersion, SecurityPolicies.CanDeleteSpecificMethodology);
         }
 
         public static Task<Either<ActionResult, Unit>> CheckCanViewAllReleases(this IUserService userService)
@@ -151,11 +157,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.S
         public static Task<Either<ActionResult, Release>> CheckCanUpdateRelease(
             this IUserService userService, Release release, bool ignoreCheck)
         {
-            if (ignoreCheck)
-            {
-                return Task.FromResult(new Either<ActionResult, Release>(release));
-            }
-            return userService.CheckCanUpdateRelease(release);
+            return ignoreCheck
+                ? Task.FromResult(new Either<ActionResult, Release>(release))
+                : userService.CheckCanUpdateRelease(release);
         }
 
         public static Task<Either<ActionResult, Release>> CheckCanDeleteRelease(

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobStorageServiceExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/MockBlobStorageServiceExtensions.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -29,6 +30,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
         {
             return service.Setup(s => s.CheckBlobExists(container, path))
                 .ReturnsAsync(exists);
+        }
+
+        public static IReturnsResult<IBlobStorageService> SetupDeleteBlob(
+            this Mock<IBlobStorageService> service,
+            IBlobContainer container,
+            string path)
+        {
+            return service.Setup(s => s.DeleteBlob(container, path))
+                .Returns(Task.CompletedTask);
         }
 
         public static IReturnsResult<IBlobStorageService> SetupDownloadToStream(


### PR DESCRIPTION
When the UI tests complete they delete the Topic resource using `DELETE /api/topics/{topicId}`.

The service method being called depends on several other service calls to forcefully delete Methodologies and Releases.

The results of some of these calls were being ignored making it appear as though the Topic has been deleted successfully (returning 204 No Content), when in some cases an error should have occurred.

_Example Failure_

If a Topic contains any approved Methodologies with images, there should have been a 403 Forbidden as the user does not have permission to update an approved Methodology.

This PR also prevents this failure by adding in a `DeleteAll` method to forcefully delete Methodology images.

### Other changes

- Delete Releases that are soft deleted. Failures caused by attempting to delete a Release that is the previous version of a soft deleted Release were being ignored. We now attempt to hard delete these Releases in sequence with the rest of the Releases.
- Previously we were deleting all methodologies linked to Publications of the Topic being deleted. This is changed to only delete Methodologies owned by the Publications so we we don't inadvertently delete a Methodology of a Publication from a different Topic. 