### PR TITLE
EES-2304 EES-2306  Introduce support for methodology version notes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
@@ -54,7 +54,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 {
                     new()
                     {
-                        Content = "Original version"
+                        Content = "Note 1"
+                    },
+                    new()
+                    {
+                        Content = "Note 2"
                     }
                 }
             };
@@ -106,8 +110,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.NotNull(contentBlock);
                 Assert.Equal("Content!", contentBlock.Body);
 
-                var note = Assert.Single(amendment.Notes);
-                Assert.Equal("Original version", note.Content);
+                Assert.Equal(2, amendment.Notes.Count);
+                Assert.Equal("Note 1", amendment.Notes[0].Content);
+                Assert.Equal("Note 2", amendment.Notes[1].Content);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
@@ -216,7 +216,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             return new(
                 contentPersistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
                 userService ?? AlwaysTrueUserService().Object,
-                methodologyService ?? new Mock<IMethodologyService>(Strict).Object,
+                methodologyService ?? Mock.Of<IMethodologyService>(Strict),
                 contentDbContext
             );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
@@ -37,17 +37,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     Slug = "methodology-slug",
                     OwningPublicationTitle = "Owning Publication Title"
                 },
-                Content = AsList(new ContentSection
+                Content = new List<ContentSection>
                 {
-                    Content = AsList<ContentBlock>(new HtmlBlock
+                    new()
                     {
-                        Body = "Content!"
-                    })
-                })
+                        Content = new List<ContentBlock>
+                        {
+                            new HtmlBlock
+                            {
+                                Body = "Content!"
+                            }
+                        }
+                    }
+                },
+                Notes = new List<MethodologyNote>
+                {
+                    new()
+                    {
+                        Content = "Original version"
+                    }
+                }
             };
-            
+
             var contextId = Guid.NewGuid().ToString();
-            await using(var context = InMemoryApplicationDbContext(contextId))
+            await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 await context.MethodologyVersions.AddAsync(originalVersion);
                 await context.SaveChangesAsync();
@@ -56,21 +69,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             Guid amendmentId;
 
             // Call the method under test
-            await using(var context = InMemoryApplicationDbContext(contextId))
+            await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var methodologyService = new Mock<IMethodologyService>(Strict);
                 var service = BuildService(context, methodologyService: methodologyService.Object);
-                
+
                 var amendmentIdCapture = new List<Guid>();
                 var summaryViewModel = new MethodologySummaryViewModel();
-                
+
                 methodologyService
                     .Setup(s => s.GetSummary(Capture.In(amendmentIdCapture)))
                     .ReturnsAsync(summaryViewModel);
-                
+
                 var result = await service.CreateMethodologyAmendment(originalVersion.Id);
                 VerifyAllMocks(methodologyService);
-                
+
                 var resultingViewModel = result.AssertRight();
                 Assert.Same(summaryViewModel, resultingViewModel);
                 amendmentId = Assert.Single(amendmentIdCapture);
@@ -78,19 +91,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             // Check that the amendment was successfully saved.  More detailed field-by-field testing is available in
             // the MethodologyTests class.
-            await using(var context = InMemoryApplicationDbContext(contextId))
+            await using (var context = InMemoryApplicationDbContext(contextId))
             {
-                var amendment = await context.MethodologyVersions.SingleAsync(m => m.Id == amendmentId);
+                var amendment = await context.MethodologyVersions
+                    .Include(m => m.Notes)
+                    .SingleAsync(m => m.Id == amendmentId);
+
                 Assert.Equal(originalVersion.Id, amendment.PreviousVersionId);
 
                 var contentSection = Assert.Single(amendment.Content);
                 Assert.NotNull(contentSection);
+
                 var contentBlock = Assert.Single(contentSection.Content) as HtmlBlock;
                 Assert.NotNull(contentBlock);
                 Assert.Equal("Content!", contentBlock.Body);
+
+                var note = Assert.Single(amendment.Notes);
+                Assert.Equal("Original version", note.Content);
             }
         }
-        
+
         [Fact]
         public async Task CreateMethodologyAmendmentWithMethodologyFiles()
         {
@@ -132,9 +152,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     Id = Guid.NewGuid()
                 }
             };
-            
+
             var contextId = Guid.NewGuid().ToString();
-            await using(var context = InMemoryApplicationDbContext(contextId))
+            await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 await context.MethodologyVersions.AddAsync(originalVersion);
                 await context.MethodologyFiles.AddRangeAsync(originalMethodologyFile1, originalMethodologyFile2);
@@ -144,36 +164,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             Guid amendmentId;
 
             // Call the method under test
-            await using(var context = InMemoryApplicationDbContext(contextId))
+            await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var methodologyService = new Mock<IMethodologyService>(Strict);
                 var service = BuildService(context, methodologyService: methodologyService.Object);
-                
+
                 var amendmentIdCapture = new List<Guid>();
                 var summaryViewModel = new MethodologySummaryViewModel();
-                
+
                 methodologyService
                     .Setup(s => s.GetSummary(Capture.In(amendmentIdCapture)))
                     .ReturnsAsync(summaryViewModel);
-                
+
                 var result = await service.CreateMethodologyAmendment(originalVersion.Id);
                 VerifyAllMocks(methodologyService);
-                
+
                 var resultingViewModel = result.AssertRight();
                 Assert.Same(summaryViewModel, resultingViewModel);
                 amendmentId = Assert.Single(amendmentIdCapture);
             }
 
             // Check that the Methodology Files were successfully linked to the Amendment.
-            await using(var context = InMemoryApplicationDbContext(contextId))
+            await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var amendmentMethodologyFiles = await context
                     .MethodologyFiles
                     .Where(f => f.MethodologyVersionId == amendmentId)
                     .ToListAsync();
-                
+
                 Assert.Equal(2, amendmentMethodologyFiles.Count());
-                
+
                 var methodologyFile1ForAmendment =
                     Assert.Single(amendmentMethodologyFiles
                         .Where(f => f.FileId == originalMethodologyFile1.FileId));
@@ -196,7 +216,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             return new(
                 contentPersistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
                 userService ?? AlwaysTrueUserService().Object,
-                methodologyService ?? new Mock<IMethodologyService>().Object,
+                methodologyService ?? new Mock<IMethodologyService>(Strict).Object,
                 contentDbContext
             );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyNoteServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyNoteServicePermissionTests.cs
@@ -1,0 +1,125 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityPolicies;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies
+{
+    public class MethodologyNoteServicePermissionTests
+    {
+        [Fact]
+        public async Task AddNote()
+        {
+            var methodologyVersion = new MethodologyVersion
+            {
+                Id = Guid.NewGuid()
+            };
+
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(methodologyVersion, CanUpdateSpecificMethodology)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = SetupMethodologyNoteService(
+                            persistenceHelper: MockPersistenceHelper<ContentDbContext, MethodologyVersion>(
+                                methodologyVersion.Id, methodologyVersion).Object,
+                            userService: userService.Object);
+                        return service.AddNote(
+                            methodologyVersion.Id,
+                            new MethodologyNoteAddRequest());
+                    }
+                );
+        }
+
+        [Fact]
+        public async Task DeleteNote()
+        {
+            var methodologyVersion = new MethodologyVersion
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var methodologyNote = new MethodologyNote
+            {
+                Id = Guid.NewGuid(),
+                MethodologyVersion = methodologyVersion
+            };
+
+            var persistenceHelper = new Mock<IPersistenceHelper<ContentDbContext>>(Strict);
+            SetupCall(persistenceHelper, methodologyNote);
+
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(methodologyVersion, CanUpdateSpecificMethodology)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = SetupMethodologyNoteService(
+                            persistenceHelper: persistenceHelper.Object,
+                            userService: userService.Object);
+                        return service.DeleteNote(
+                            methodologyVersion.Id,
+                            methodologyNote.Id);
+                    }
+                );
+        }
+
+        [Fact]
+        public async Task UpdateNote()
+        {
+            var methodologyVersion = new MethodologyVersion
+            {
+                Id = Guid.NewGuid()
+            };
+
+            var methodologyNote = new MethodologyNote
+            {
+                Id = Guid.NewGuid(),
+                MethodologyVersion = methodologyVersion
+            };
+
+            var persistenceHelper = new Mock<IPersistenceHelper<ContentDbContext>>(Strict);
+            SetupCall(persistenceHelper, methodologyNote);
+
+            await PolicyCheckBuilder<SecurityPolicies>()
+                .SetupResourceCheckToFail(methodologyVersion, CanUpdateSpecificMethodology)
+                .AssertForbidden(
+                    userService =>
+                    {
+                        var service = SetupMethodologyNoteService(
+                            persistenceHelper: persistenceHelper.Object,
+                            userService: userService.Object);
+                        return service.UpdateNote(
+                            methodologyVersion.Id,
+                            methodologyNote.Id,
+                            new MethodologyNoteUpdateRequest());
+                    }
+                );
+        }
+
+        private static MethodologyNoteService SetupMethodologyNoteService(
+            IPersistenceHelper<ContentDbContext> persistenceHelper,
+            IMethodologyNoteRepository? methodologyNoteRepository = null,
+            IUserService? userService = null)
+        {
+            return new(
+                AdminMapper(),
+                persistenceHelper,
+                methodologyNoteRepository ?? Mock.Of<IMethodologyNoteRepository>(Strict),
+                userService ?? Mock.Of<IUserService>(Strict));
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyNoteServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyNoteServiceTests.cs
@@ -1,0 +1,339 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static Moq.MockBehavior;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Methodologies
+{
+    public class MethodologyNoteServiceTests
+    {
+        private static readonly Guid UserId = Guid.NewGuid();
+
+        [Fact]
+        public async Task AddNote()
+        {
+            var methodologyVersion = new MethodologyVersion();
+
+            var request = new MethodologyNoteAddRequest
+            {
+                Content = "Adding note",
+                DisplayDate = DateTime.Today.ToUniversalTime()
+            };
+
+            var expectedResult = new MethodologyNote
+            {
+                Id = Guid.NewGuid(),
+                Content = request.Content,
+                DisplayDate = request.DisplayDate
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyVersions.AddAsync(methodologyVersion);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var methodologyNoteRepository = new Mock<IMethodologyNoteRepository>(Strict);
+
+            methodologyNoteRepository.Setup(mock => mock.AddNote(
+                    methodologyVersion.Id,
+                    UserId,
+                    request.Content,
+                    request.DisplayDate
+                ))
+                .ReturnsAsync(expectedResult);
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyNoteService(contentDbContext: contentDbContext,
+                    methodologyNoteRepository: methodologyNoteRepository.Object);
+
+                var result = (await service.AddNote(
+                    methodologyVersion.Id,
+                    request)).AssertRight();
+
+                VerifyAllMocks(methodologyNoteRepository);
+
+                Assert.Equal(expectedResult.Id, result.Id);
+                Assert.Equal(expectedResult.Content, result.Content);
+                Assert.Equal(expectedResult.DisplayDate, result.DisplayDate);
+            }
+        }
+
+        [Fact]
+        public async Task AddNote_MethodologyVersionNotFound()
+        {
+            await using var contentDbContext = InMemoryApplicationDbContext();
+
+            var service = SetupMethodologyNoteService(contentDbContext: contentDbContext);
+
+            var result = await service.AddNote(
+                Guid.NewGuid(),
+                new MethodologyNoteAddRequest
+                {
+                    Content = "Adding note",
+                    DisplayDate = DateTime.Today.ToUniversalTime()
+                });
+
+            result.AssertNotFound();
+        }
+
+        [Fact]
+        public async Task DeleteNote()
+        {
+            var methodologyVersion = new MethodologyVersion();
+
+            var methodologyNote = new MethodologyNote
+            {
+                MethodologyVersion = methodologyVersion
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyVersions.AddAsync(methodologyVersion);
+                await contentDbContext.MethodologyNotes.AddAsync(methodologyNote);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var methodologyNoteRepository = new Mock<IMethodologyNoteRepository>(Strict);
+
+            methodologyNoteRepository.Setup(mock => mock.DeleteNote(
+                methodologyNote.Id
+            )).Returns(Task.CompletedTask);
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyNoteService(contentDbContext: contentDbContext,
+                    methodologyNoteRepository: methodologyNoteRepository.Object);
+
+                var result = await service.DeleteNote(
+                    methodologyVersion.Id,
+                    methodologyNote.Id);
+
+                VerifyAllMocks(methodologyNoteRepository);
+
+                result.AssertRight();
+            }
+        }
+
+        [Fact]
+        public async Task DeleteNote_DifferentMethodologyVersion()
+        {
+            var methodologyNote = new MethodologyNote
+            {
+                MethodologyVersion = new MethodologyVersion()
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyNotes.AddAsync(methodologyNote);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyNoteService(contentDbContext: contentDbContext);
+
+                // Attempt to delete the note using a different methodology version
+                var result = await service.DeleteNote(
+                    Guid.NewGuid(),
+                    methodologyNote.Id);
+
+                // No interaction with the repository is expected
+                // since a note matching the id and methodology version id won't be found
+
+                result.AssertNotFound();
+            }
+        }
+
+        [Fact]
+        public async Task DeleteNote_MethodologyNoteNotFound()
+        {
+            var methodologyVersion = new MethodologyVersion();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyVersions.AddAsync(methodologyVersion);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyNoteService(contentDbContext: contentDbContext);
+
+                var result = await service.DeleteNote(
+                    methodologyVersion.Id,
+                    Guid.NewGuid());
+
+                // No interaction with the repository is expected
+                // since a note matching the id and methodology version id won't be found
+
+                result.AssertNotFound();
+            }
+        }
+
+        [Fact]
+        public async Task UpdateNote()
+        {
+            var methodologyVersion = new MethodologyVersion();
+
+            var methodologyNote = new MethodologyNote
+            {
+                Id = Guid.NewGuid(),
+                MethodologyVersion = methodologyVersion
+            };
+
+            var request = new MethodologyNoteUpdateRequest
+            {
+                Content = "Updating note",
+                DisplayDate = DateTime.Today.ToUniversalTime()
+            };
+
+            var expectedResult = new MethodologyNote
+            {
+                Id = methodologyNote.Id,
+                Content = request.Content,
+                DisplayDate = request.DisplayDate
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyNotes.AddAsync(methodologyNote);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var methodologyNoteRepository = new Mock<IMethodologyNoteRepository>(Strict);
+
+            methodologyNoteRepository.Setup(mock => mock.UpdateNote(
+                    methodologyNote.Id,
+                    UserId,
+                    request.Content,
+                    request.DisplayDate
+                ))
+                .ReturnsAsync(expectedResult);
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyNoteService(contentDbContext: contentDbContext,
+                    methodologyNoteRepository: methodologyNoteRepository.Object);
+
+                var result = (await service.UpdateNote(
+                    methodologyVersion.Id,
+                    methodologyNote.Id,
+                    request)).AssertRight();
+
+                VerifyAllMocks(methodologyNoteRepository);
+
+                Assert.Equal(expectedResult.Id, result.Id);
+                Assert.Equal(expectedResult.Content, result.Content);
+                Assert.Equal(expectedResult.DisplayDate, result.DisplayDate);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateNote_DifferentMethodologyVersion()
+        {
+            var methodologyNote = new MethodologyNote
+            {
+                MethodologyVersion = new MethodologyVersion()
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyNotes.AddAsync(methodologyNote);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyNoteService(contentDbContext: contentDbContext);
+
+                // Attempt to update the note using a different methodology version
+                var result = await service.UpdateNote(
+                    Guid.NewGuid(),
+                    methodologyNote.Id,
+                    new MethodologyNoteUpdateRequest
+                    {
+                        Content = "Updating note",
+                        DisplayDate = DateTime.Today.ToUniversalTime()
+                    });
+
+                // No interaction with the repository is expected
+                // since a note matching the id and methodology version id won't be found
+
+                result.AssertNotFound();
+            }
+        }
+
+        [Fact]
+        public async Task UpdateNote_MethodologyNoteNotFound()
+        {
+            var methodologyVersion = new MethodologyVersion();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyVersions.AddAsync(methodologyVersion);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
+            {
+                var service = SetupMethodologyNoteService(contentDbContext: contentDbContext);
+
+                var result = await service.UpdateNote(
+                    methodologyVersion.Id,
+                    Guid.NewGuid(),
+                    new MethodologyNoteUpdateRequest
+                    {
+                        Content = "Updating note",
+                        DisplayDate = DateTime.Today.ToUniversalTime()
+                    });
+
+                // No interaction with the repository is expected
+                // since a note matching the id and methodology version id won't be found
+
+                result.AssertNotFound();
+            }
+        }
+
+        private static MethodologyNoteService SetupMethodologyNoteService(
+            ContentDbContext contentDbContext,
+            IPersistenceHelper<ContentDbContext>? persistenceHelper = null,
+            IMethodologyNoteRepository? methodologyNoteRepository = null,
+            IUserService? userService = null)
+        {
+            return new(
+                AdminMapper(),
+                persistenceHelper ?? new PersistenceHelper<ContentDbContext>(contentDbContext),
+                methodologyNoteRepository ?? Mock.Of<IMethodologyNoteRepository>(),
+                userService ?? AlwaysTrueUserService(UserId).Object);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyNoteController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyNoteController.cs
@@ -1,0 +1,53 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Methodologies
+{
+    [Route("api")]
+    [Authorize]
+    [ApiController]
+    public class MethodologyNoteController : ControllerBase
+    {
+        private readonly IMethodologyNoteService _methodologyNoteService;
+
+        public MethodologyNoteController(IMethodologyNoteService methodologyNoteService)
+        {
+            _methodologyNoteService = methodologyNoteService;
+        }
+
+        [HttpPost("methodologies/{methodologyVersionId:guid}/notes")]
+        public async Task<ActionResult<MethodologyNoteViewModel>> AddNote(
+            Guid methodologyVersionId,
+            MethodologyNoteAddRequest request)
+        {
+            return await _methodologyNoteService
+                .AddNote(methodologyVersionId, request)
+                .HandleFailuresOr(result => Created(HttpContext.Request.Path, result));
+        }
+
+        [HttpDelete("methodologies/{methodologyVersionId:guid}/notes/{methodologyNoteId:guid}")]
+        public async Task<ActionResult> DeleteNote(
+            Guid methodologyVersionId,
+            Guid methodologyNoteId)
+        {
+            return await _methodologyNoteService
+                .DeleteNote(methodologyVersionId, methodologyNoteId)
+                .HandleFailuresOrNoContent();
+        }
+
+        [HttpPut("methodologies/{methodologyVersionId:guid}/notes/{methodologyNoteId:guid}")]
+        public async Task<ActionResult<MethodologyNoteViewModel>> UpdateNote(
+            Guid methodologyVersionId, Guid methodologyNoteId, MethodologyNoteUpdateRequest request)
+        {
+            return await _methodologyNoteService
+                .UpdateNote(methodologyVersionId, methodologyNoteId, request)
+                .HandleFailuresOrOk();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -66,6 +66,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
             CreateMap<ReleaseStatus, ReleasePublishingStatusViewModel>()
                 .ForMember(model => model.LastUpdated, m => m.MapFrom(status => status.Timestamp));
 
+            CreateMap<MethodologyNote, MethodologyNoteViewModel>();
+
             CreateMap<MethodologyVersion, MethodologySummaryViewModel>()
                 .ForMember(dest => dest.LatestInternalReleaseNote,
                     m => m.MapFrom(model => model.InternalReleaseNote))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210913161056_EES-2171_AddMethodologyNotes.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210913161056_EES-2171_AddMethodologyNotes.Designer.cs
@@ -4,14 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    partial class ContentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210913161056_EES-2171_AddMethodologyNotes")]
+    partial class EES2171_AddMethodologyNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -268,37 +270,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasIndex("SourceId");
 
                     b.ToTable("Files");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.GlossaryEntry", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("Body")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime>("Created")
-                        .HasColumnType("datetime2");
-
-                    b.Property<Guid>("CreatedById")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("Slug")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("Title")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CreatedById");
-
-                    b.ToTable("GlossaryEntries");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.LegacyRelease", b =>
@@ -1064,15 +1035,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.File", "Source")
                         .WithMany()
                         .HasForeignKey("SourceId");
-                });
-
-            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.GlossaryEntry", b =>
-                {
-                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "CreatedBy")
-                        .WithMany()
-                        .HasForeignKey("CreatedById")
-                        .OnDelete(DeleteBehavior.NoAction)
-                        .IsRequired();
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.LegacyRelease", b =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210913161056_EES-2171_AddMethodologyNotes.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210913161056_EES-2171_AddMethodologyNotes.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
+{
+    public partial class EES2171_AddMethodologyNotes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MethodologyNotes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    Created = table.Column<DateTime>(nullable: false),
+                    CreatedById = table.Column<Guid>(nullable: false),
+                    Content = table.Column<string>(nullable: false),
+                    DisplayDate = table.Column<DateTime>(nullable: false),
+                    MethodologyVersionId = table.Column<Guid>(nullable: false),
+                    Updated = table.Column<DateTime>(nullable: true),
+                    UpdatedById = table.Column<Guid>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MethodologyNotes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MethodologyNotes_Users_CreatedById",
+                        column: x => x.CreatedById,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_MethodologyNotes_MethodologyVersions_MethodologyVersionId",
+                        column: x => x.MethodologyVersionId,
+                        principalTable: "MethodologyVersions",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_MethodologyNotes_Users_UpdatedById",
+                        column: x => x.UpdatedById,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MethodologyNotes_CreatedById",
+                table: "MethodologyNotes",
+                column: "CreatedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MethodologyNotes_MethodologyVersionId",
+                table: "MethodologyNotes",
+                column: "MethodologyVersionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MethodologyNotes_UpdatedById",
+                table: "MethodologyNotes",
+                column: "UpdatedById");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MethodologyNotes");
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210914150247_EES-2171_AddMethodologyNotes.Designer.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210914150247_EES-2171_AddMethodologyNotes.Designer.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMigrations
 {
     [DbContext(typeof(ContentDbContext))]
-    [Migration("20210913161056_EES-2171_AddMethodologyNotes")]
+    [Migration("20210914150247_EES-2171_AddMethodologyNotes")]
     partial class EES2171_AddMethodologyNotes
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -270,6 +270,37 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                     b.HasIndex("SourceId");
 
                     b.ToTable("Files");
+                });
+
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.GlossaryEntry", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Body")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTime>("Created")
+                        .HasColumnType("datetime2");
+
+                    b.Property<Guid>("CreatedById")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Slug")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Title")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CreatedById");
+
+                    b.ToTable("GlossaryEntries");
                 });
 
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.LegacyRelease", b =>
@@ -1037,6 +1068,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .HasForeignKey("SourceId");
                 });
 
+            modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.GlossaryEntry", b =>
+                {
+                    b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.User", "CreatedBy")
+                        .WithMany()
+                        .HasForeignKey("CreatedById")
+                        .OnDelete(DeleteBehavior.NoAction)
+                        .IsRequired();
+                });
+
             modelBuilder.Entity("GovUk.Education.ExploreEducationStatistics.Content.Model.LegacyRelease", b =>
                 {
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.Publication", "Publication")
@@ -1070,7 +1110,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .IsRequired();
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", "MethodologyVersion")
-                        .WithMany()
+                        .WithMany("Notes")
                         .HasForeignKey("MethodologyVersionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210914150247_EES-2171_AddMethodologyNotes.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/20210914150247_EES-2171_AddMethodologyNotes.cs
@@ -12,11 +12,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                 columns: table => new
                 {
                     Id = table.Column<Guid>(nullable: false),
-                    Created = table.Column<DateTime>(nullable: false),
-                    CreatedById = table.Column<Guid>(nullable: false),
                     Content = table.Column<string>(nullable: false),
                     DisplayDate = table.Column<DateTime>(nullable: false),
                     MethodologyVersionId = table.Column<Guid>(nullable: false),
+                    Created = table.Column<DateTime>(nullable: false),
+                    CreatedById = table.Column<Guid>(nullable: false),
                     Updated = table.Column<DateTime>(nullable: true),
                     UpdatedById = table.Column<Guid>(nullable: true)
                 },

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Migrations/ContentMigrations/ContentDbContextModelSnapshot.cs
@@ -1108,7 +1108,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Migrations.ContentMig
                         .IsRequired();
 
                     b.HasOne("GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyVersion", "MethodologyVersion")
-                        .WithMany()
+                        .WithMany("Notes")
                         .HasForeignKey("MethodologyVersionId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyNoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyNoteService.cs
@@ -1,0 +1,25 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies
+{
+    public interface IMethodologyNoteService
+    {
+        Task<Either<ActionResult, MethodologyNoteViewModel>> AddNote(
+            Guid methodologyVersionId,
+            MethodologyNoteAddRequest request);
+
+        Task<Either<ActionResult, Unit>> DeleteNote(
+            Guid methodologyVersionId,
+            Guid methodologyNoteId);
+
+        Task<Either<ActionResult, MethodologyNoteViewModel>> UpdateNote(
+            Guid methodologyVersionId,
+            Guid methodologyNoteId,
+            MethodologyNoteUpdateRequest request);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MethodologyNoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MethodologyNoteService.cs
@@ -1,0 +1,107 @@
+﻿#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Methodologies;
+using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
+{
+    public class MethodologyNoteService : IMethodologyNoteService
+    {
+        private readonly IMapper _mapper;
+        private readonly IPersistenceHelper<ContentDbContext> _persistenceHelper;
+        private readonly IMethodologyNoteRepository _methodologyNoteRepository;
+        private readonly IUserService _userService;
+
+        public MethodologyNoteService(
+            IMapper mapper,
+            IPersistenceHelper<ContentDbContext> persistenceHelper,
+            IMethodologyNoteRepository methodologyNoteRepository,
+            IUserService userService)
+        {
+            _mapper = mapper;
+            _persistenceHelper = persistenceHelper;
+            _methodologyNoteRepository = methodologyNoteRepository;
+            _userService = userService;
+        }
+
+        public Task<Either<ActionResult, MethodologyNoteViewModel>> AddNote(
+            Guid methodologyVersionId,
+            MethodologyNoteAddRequest request)
+        {
+            return _persistenceHelper
+                .CheckEntityExists<MethodologyVersion>(methodologyVersionId)
+                .OnSuccess(_userService.CheckCanUpdateMethodology)
+                .OnSuccess(async methodologyVersion =>
+                {
+                    var addedNote = await _methodologyNoteRepository.AddNote(
+                        methodologyVersion.Id,
+                        _userService.GetUserId(),
+                        request.Content,
+                        request.DisplayDate);
+
+                    return BuildMethodologyNoteViewModel(addedNote);
+                });
+        }
+
+        public async Task<Either<ActionResult, Unit>> DeleteNote(
+            Guid methodologyVersionId,
+            Guid methodologyNoteId)
+        {
+            return await _persistenceHelper
+                .CheckEntityExists<MethodologyNote>(q =>
+                    q.Include(n => n.MethodologyVersion)
+                        .Where(
+                            n => n.Id == methodologyNoteId
+                                 && n.MethodologyVersionId == methodologyVersionId))
+                .OnSuccessDo(methodologyNote =>
+                    _userService.CheckCanUpdateMethodology(methodologyNote.MethodologyVersion))
+                .OnSuccessVoid(async methodologyNote =>
+                {
+                    await _methodologyNoteRepository.DeleteNote(methodologyNoteId);
+                });
+        }
+
+        public async Task<Either<ActionResult, MethodologyNoteViewModel>> UpdateNote(
+            Guid methodologyVersionId,
+            Guid methodologyNoteId,
+            MethodologyNoteUpdateRequest request)
+        {
+            return await _persistenceHelper
+                .CheckEntityExists<MethodologyNote>(q =>
+                    q.Include(n => n.MethodologyVersion)
+                        .Where(
+                            n => n.Id == methodologyNoteId
+                                 && n.MethodologyVersionId == methodologyVersionId))
+                .OnSuccessDo(methodologyNote =>
+                    _userService.CheckCanUpdateMethodology(methodologyNote.MethodologyVersion))
+                .OnSuccess(async methodologyNote =>
+                {
+                    var updatedNote = await _methodologyNoteRepository.UpdateNote(
+                        methodologyNoteId,
+                        _userService.GetUserId(),
+                        request.Content,
+                        request.DisplayDate
+                    );
+
+                    return BuildMethodologyNoteViewModel(updatedNote);
+                });
+        }
+
+        private MethodologyNoteViewModel BuildMethodologyNoteViewModel(MethodologyNote methodologyNote)
+        {
+            return _mapper.Map<MethodologyNoteViewModel>(methodologyNote);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MethodologyNoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MethodologyNoteService.cs
@@ -46,10 +46,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(async methodologyVersion =>
                 {
                     var addedNote = await _methodologyNoteRepository.AddNote(
-                        methodologyVersion.Id,
-                        _userService.GetUserId(),
-                        request.Content,
-                        request.DisplayDate);
+                        methodologyVersionId: methodologyVersion.Id,
+                        createdByUserId: _userService.GetUserId(),
+                        content: request.Content,
+                        displayDate: request.DisplayDate);
 
                     return BuildMethodologyNoteViewModel(addedNote);
                 });
@@ -89,10 +89,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(async methodologyNote =>
                 {
                     var updatedNote = await _methodologyNoteRepository.UpdateNote(
-                        methodologyNoteId,
-                        _userService.GetUserId(),
-                        request.Content,
-                        request.DisplayDate
+                        methodologyNoteId: methodologyNoteId,
+                        updatedByUserId: _userService.GetUserId(),
+                        content: request.Content,
+                        displayDate: request.DisplayDate
                     );
 
                     return BuildMethodologyNoteViewModel(updatedNote);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -267,6 +267,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IReleaseChecklistService, ReleaseChecklistService>();
             services.AddTransient<IReleaseRepository, ReleaseRepository>();
             services.AddTransient<IMethodologyService, MethodologyService>();
+            services.AddTransient<IMethodologyNoteService, MethodologyNoteService>();
+            services.AddTransient<IMethodologyNoteRepository, MethodologyNoteRepository>();
             services.AddTransient<IMethodologyVersionRepository, MethodologyVersionRepository>();
             services.AddTransient<IMethodologyRepository, MethodologyRepository>();
             services.AddTransient<IMethodologyContentService, MethodologyContentService>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteAddRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteAddRequest.cs
@@ -1,0 +1,12 @@
+﻿#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology
+{
+    public class MethodologyNoteAddRequest
+    {
+        public string Content { get; set; } = null!;
+
+        public DateTime DisplayDate { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteAddRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteAddRequest.cs
@@ -1,11 +1,12 @@
 ﻿#nullable enable
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology
 {
     public class MethodologyNoteAddRequest
     {
-        public string Content { get; set; } = null!;
+        [Required] public string Content { get; set; } = string.Empty;
 
         public DateTime DisplayDate { get; set; }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteUpdateRequest.cs
@@ -1,0 +1,12 @@
+﻿#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology
+{
+    public class MethodologyNoteUpdateRequest
+    {
+        public string Content { get; set; } = null!;
+
+        public DateTime DisplayDate { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteUpdateRequest.cs
@@ -1,11 +1,12 @@
 ﻿#nullable enable
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology
 {
     public class MethodologyNoteUpdateRequest
     {
-        public string Content { get; set; } = null!;
+        [Required] public string Content { get; set; } = string.Empty;
 
         public DateTime DisplayDate { get; set; }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteViewModel.cs
@@ -1,0 +1,14 @@
+﻿#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology
+{
+    public class MethodologyNoteViewModel
+    {
+        public Guid Id { get; set; }
+
+        public string Content { get; set; } = null!;
+
+        public DateTime DisplayDate { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
@@ -138,7 +138,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                     OwningPublicationTitle = "Owning Publication Title"
                 }
             };
-            
+
             Assert.Equal(methodology.Methodology.OwningPublicationTitle, methodology.Title);
         }
 
@@ -153,7 +153,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 },
                 AlternativeTitle = "Alternative Title"
             };
-            
+
             Assert.Equal(methodology.AlternativeTitle, methodology.Title);
         }
 
@@ -167,12 +167,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                     Slug = "owning-publication-slug"
                 }
             };
-            
+
             Assert.Equal(methodology.Methodology.Slug, methodology.Slug);
         }
 
         [Fact]
-        public void CreateMethodologyAmendment()
+        public void CreateMethodologyAmendment_ClonesBasicFields()
         {
             var userId = Guid.NewGuid();
 
@@ -188,7 +188,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 CreatedBy = new User(),
                 CreatedById = Guid.NewGuid(),
                 Updated = DateTime.Today.AddDays(-10),
-                
+
                 // approval and publishing fields
                 Status = Approved,
                 Published = DateTime.Today.AddDays(-1),
@@ -200,87 +200,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 Version = 1,
                 PreviousVersion = new MethodologyVersion(),
                 PreviousVersionId = Guid.NewGuid(),
-                
+
                 // methodology field
                 Methodology = new Methodology(),
-                MethodologyId = Guid.NewGuid(),
-                
-                // annex field
-                Annexes = AsList(new ContentSection
-                {
-                    Id = Guid.NewGuid(),
-                    Caption = "Annex caption",
-                    Heading = "Annex heading",
-                    Order = 2,
-                    Type = ContentSectionType.Generic,
-                    Content = AsList<ContentBlock>(new HtmlBlock
-                    {
-                        Id = Guid.NewGuid(),
-                        Body = "Annex body",
-                        Created = DateTime.Today.AddDays(-13),
-                        Order = 5,
-                        ContentSection = new ContentSection(),
-                        ContentSectionId = Guid.NewGuid(),
-                        Comments = AsList(new Comment
-                        {
-                            Id = Guid.NewGuid(),
-                            Content = "Annex comment",
-                            Created = DateTime.Today.AddDays(-4),
-                            CreatedById = Guid.NewGuid(),
-                            Updated = DateTime.Today.AddDays(-3),
-                            CreatedBy = new User()
-                        })
-                    })
-                }),
-                
-                // content field
-                Content = AsList(new ContentSection
-                {
-                    Id = Guid.NewGuid(),
-                    Caption = "Content caption",
-                    Heading = "Content heading",
-                    Order = 2,
-                    Type = ContentSectionType.Generic,
-                    Content = AsList<ContentBlock>(new HtmlBlock
-                    {
-                        Id = Guid.NewGuid(),
-                        Body = "Content body",
-                        Comments = AsList(new Comment
-                        {
-                            Id = Guid.NewGuid(),
-                            Content = "Content comment",
-                            Created = DateTime.Today.AddDays(-4),
-                            CreatedById = Guid.NewGuid(),
-                            Updated = DateTime.Today.AddDays(-3),
-                            CreatedBy = new User()
-                        })
-                    }),
-                }),
-
-                // notes field
-                Notes = new List<MethodologyNote>
-                {
-                    new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Content = "Note content",
-                        Created = DateTime.Today.AddDays(-4),
-                        CreatedBy = new User(),
-                        CreatedById = Guid.NewGuid(),
-                        DisplayDate = DateTime.Today.ToUniversalTime(),
-                        Updated = DateTime.Today.AddDays(-3),
-                        UpdatedBy = new User(),
-                        UpdatedById = Guid.NewGuid()
-                    }
-                }
+                MethodologyId = Guid.NewGuid()
             };
-            
+
             Assert.False(originalVersion.Amendment);
 
             var creationTime = DateTime.Today.AddMinutes(-2);
-            
+
             var amendment = originalVersion.CreateMethodologyAmendment(creationTime, userId);
-            
+
             Assert.True(amendment.Amendment);
 
             // Check general fields.
@@ -310,21 +241,94 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
             // Check methodology field.
             Assert.Equal(originalVersion.MethodologyId, amendment.MethodologyId);
             Assert.Null(amendment.Methodology);
+        }
 
-            // Check Annex Content Sections.
-            var amendmentAnnexSection = Assert.Single(amendment.Annexes);
-            var originalAnnexSection = originalVersion.Annexes[0];
-            AssertContentSectionAmendedCorrectly(amendmentAnnexSection, originalAnnexSection, creationTime);
-            
-            // Check Content Content Sections.
-            var amendmentContentSection = Assert.Single(amendment.Content);
-            var originalContentSection = originalVersion.Content[0];
-            AssertContentSectionAmendedCorrectly(amendmentContentSection, originalContentSection, creationTime);
+        [Fact]
+        public void CreateMethodologyAmendment_ClonesAnnexContentSections()
+        {
+            var originalVersion = new MethodologyVersion
+            {
+                Id = Guid.NewGuid(),
+                Annexes = new List<ContentSection>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Caption = "Annex caption",
+                        Heading = "Annex heading",
+                        Order = 2,
+                        Type = ContentSectionType.Generic,
+                        Content = ListOf<ContentBlock>(new HtmlBlock
+                        {
+                            Id = Guid.NewGuid(),
+                            Body = "Annex body",
+                            Created = DateTime.Today.AddDays(-13),
+                            Order = 5,
+                            ContentSection = new ContentSection(),
+                            ContentSectionId = Guid.NewGuid(),
+                            Comments = new List<Comment>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Content = "Annex comment",
+                                    Created = DateTime.Today.AddDays(-4),
+                                    CreatedById = Guid.NewGuid(),
+                                    Updated = DateTime.Today.AddDays(-3),
+                                    CreatedBy = new User()
+                                }
+                            }
+                        })
+                    }
+                }
+            };
 
-            // Check notes
-            var amendmentNote = Assert.Single(amendment.Notes);
-            var originalNote = originalVersion.Notes[0];
-            AssertMethodologyNoteAmendedCorrectly(amendmentNote, originalNote, amendment);
+
+            var createdDate = DateTime.Today.AddMinutes(-2);
+            var amendment = originalVersion.CreateMethodologyAmendment(createdDate, Guid.NewGuid());
+            AssertContentSectionAmendedCorrectly(amendment.Annexes[0], originalVersion.Annexes[0], createdDate);
+        }
+
+        [Fact]
+        public void CreateMethodologyAmendment_ClonesContentSections()
+        {
+            var originalVersion = new MethodologyVersion
+            {
+                Id = Guid.NewGuid(),
+                Content = new List<ContentSection>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Caption = "Content caption",
+                        Heading = "Content heading",
+                        Order = 2,
+                        Type = ContentSectionType.Generic,
+                        Content = ListOf<ContentBlock>(new HtmlBlock
+                        {
+                            Id = Guid.NewGuid(),
+                            Body = "Content body",
+                            Comments = new List<Comment>
+                            {
+                                new()
+                                {
+                                    Id = Guid.NewGuid(),
+                                    Content = "Content comment",
+                                    Created = DateTime.Today.AddDays(-4),
+                                    CreatedById = Guid.NewGuid(),
+                                    Updated = DateTime.Today.AddDays(-3),
+                                    CreatedBy = new User()
+                                }
+                            }
+                        })
+                    }
+                }
+            };
+
+
+            var createdDate = DateTime.Today.AddMinutes(-2);
+            var amendment = originalVersion.CreateMethodologyAmendment(createdDate, Guid.NewGuid());
+            AssertContentSectionAmendedCorrectly(amendment.Content[0], originalVersion.Content[0], createdDate);
         }
 
         private static void AssertContentSectionAmendedCorrectly(ContentSection amendmentContentSection,
@@ -346,7 +350,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
             // Check the Content Block has a new id.
             Assert.NotEqual(Guid.Empty, amendmentContentBlock.Id);
             Assert.NotEqual(originalContentBlock.Id, amendmentContentBlock.Id);
-            
+
             // Check the other Content Block basic fields.
             Assert.Equal(originalContentBlock.Body, amendmentContentBlock.Body);
             Assert.Equal(creationTime, amendmentContentBlock.Created);
@@ -358,6 +362,69 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
 
             // Check the amendment's Content Block Comments are empty as we are starting with a clean slate.
             Assert.Empty(amendmentContentBlock.Comments);
+        }
+
+        [Fact]
+        public void CreateMethodologyAmendment_ClonesNotes()
+        {
+            var originalVersion = new MethodologyVersion
+            {
+                Id = Guid.NewGuid()
+            };
+
+            originalVersion.Notes = new List<MethodologyNote>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Content = "Note 1",
+                    DisplayDate = DateTime.Today.ToUniversalTime(),
+                    MethodologyVersion = originalVersion,
+                    MethodologyVersionId = originalVersion.Id,
+                    Created = DateTime.Today.AddDays(-6).ToUniversalTime(),
+                    CreatedBy = new User(),
+                    CreatedById = Guid.NewGuid(),
+                    Updated = DateTime.Today.AddDays(-5).ToUniversalTime(),
+                    UpdatedBy = new User(),
+                    UpdatedById = Guid.NewGuid()
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Content = "Note 2",
+                    DisplayDate = DateTime.Today.ToUniversalTime(),
+                    MethodologyVersion = originalVersion,
+                    MethodologyVersionId = originalVersion.Id,
+                    Created = DateTime.Today.AddDays(-4).ToUniversalTime(),
+                    CreatedBy = new User(),
+                    CreatedById = Guid.NewGuid(),
+                    Updated = DateTime.Today.AddDays(-3).ToUniversalTime(),
+                    UpdatedBy = new User(),
+                    UpdatedById = Guid.NewGuid()
+                },
+                new()
+                {
+                    Id = Guid.NewGuid(),
+                    Content = "Note 3",
+                    DisplayDate = DateTime.Today.ToUniversalTime(),
+                    MethodologyVersion = originalVersion,
+                    MethodologyVersionId = originalVersion.Id,
+                    Created = DateTime.Today.AddDays(-2).ToUniversalTime(),
+                    CreatedBy = new User(),
+                    CreatedById = Guid.NewGuid(),
+                    Updated = DateTime.Today.AddDays(-1).ToUniversalTime(),
+                    UpdatedBy = new User(),
+                    UpdatedById = Guid.NewGuid()
+                }
+            };
+
+            var createdDate = DateTime.Today.AddMinutes(-2);
+            var amendment = originalVersion.CreateMethodologyAmendment(createdDate, Guid.NewGuid());
+            Assert.Equal(3, amendment.Notes.Count);
+
+            AssertMethodologyNoteAmendedCorrectly(amendment.Notes[0], originalVersion.Notes[0], amendment);
+            AssertMethodologyNoteAmendedCorrectly(amendment.Notes[1], originalVersion.Notes[1], amendment);
+            AssertMethodologyNoteAmendedCorrectly(amendment.Notes[2], originalVersion.Notes[2], amendment);
         }
 
         private static void AssertMethodologyNoteAmendedCorrectly(
@@ -392,7 +459,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 PreviousVersionId = null,
                 Published = null
             };
-            
+
             Assert.False(methodology.Amendment);
         }
 
@@ -404,7 +471,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 PreviousVersionId = null,
                 Published = DateTime.Now
             };
-            
+
             Assert.False(methodology.Amendment);
         }
 
@@ -416,7 +483,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 PreviousVersionId = Guid.NewGuid(),
                 Published = null
             };
-            
+
             Assert.True(methodology.Amendment);
         }
 
@@ -428,7 +495,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 PreviousVersionId = Guid.NewGuid(),
                 Published = DateTime.Now
             };
-            
+
             Assert.False(methodology.Amendment);
         }
 
@@ -440,7 +507,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 Status = Draft,
                 PreviousVersionId = null
             };
-            
+
             Assert.True(methodology.DraftFirstVersion);
         }
 
@@ -452,10 +519,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 Status = Approved,
                 PreviousVersionId = null
             };
-            
+
             Assert.False(methodology.DraftFirstVersion);
         }
-        
+
         [Fact]
         public void DraftFirstVersionFlag_NotFirstVersion()
         {
@@ -464,7 +531,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                 Status = Draft,
                 PreviousVersionId = Guid.NewGuid()
             };
-            
+
             Assert.False(methodology.DraftFirstVersion);
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;
@@ -254,7 +255,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
                             CreatedBy = new User()
                         })
                     }),
-                })
+                }),
+
+                // notes field
+                Notes = new List<MethodologyNote>
+                {
+                    new()
+                    {
+                        Id = Guid.NewGuid(),
+                        Content = "Note content",
+                        Created = DateTime.Today.AddDays(-4),
+                        CreatedBy = new User(),
+                        CreatedById = Guid.NewGuid(),
+                        DisplayDate = DateTime.Today.ToUniversalTime(),
+                        Updated = DateTime.Today.AddDays(-3),
+                        UpdatedBy = new User(),
+                        UpdatedById = Guid.NewGuid()
+                    }
+                }
             };
             
             Assert.False(originalVersion.Amendment);
@@ -302,6 +320,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
             var amendmentContentSection = Assert.Single(amendment.Content);
             var originalContentSection = originalVersion.Content[0];
             AssertContentSectionAmendedCorrectly(amendmentContentSection, originalContentSection, creationTime);
+
+            // Check notes
+            var amendmentNote = Assert.Single(amendment.Notes);
+            var originalNote = originalVersion.Notes[0];
+            AssertMethodologyNoteAmendedCorrectly(amendmentNote, originalNote, amendment);
         }
 
         private static void AssertContentSectionAmendedCorrectly(ContentSection amendmentContentSection,
@@ -335,6 +358,30 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
 
             // Check the amendment's Content Block Comments are empty as we are starting with a clean slate.
             Assert.Empty(amendmentContentBlock.Comments);
+        }
+
+        private static void AssertMethodologyNoteAmendedCorrectly(
+            MethodologyNote amendmentNote,
+            MethodologyNote originalNote,
+            MethodologyVersion amendment)
+        {
+            // Check the note has a new id.
+            Assert.NotEqual(Guid.Empty, amendmentNote.Id);
+            Assert.NotEqual(originalNote.Id, amendmentNote.Id);
+
+            // Check the note has the amended methodology version
+            Assert.Equal(amendment, amendmentNote.MethodologyVersion);
+            Assert.Equal(amendment.Id, amendmentNote.MethodologyVersionId);
+
+            // Check the other fields are the same
+            Assert.Equal(originalNote.Content, amendmentNote.Content);
+            Assert.Equal(originalNote.Created, amendmentNote.Created);
+            Assert.Equal(originalNote.CreatedBy, amendmentNote.CreatedBy);
+            Assert.Equal(originalNote.CreatedById, amendmentNote.CreatedById);
+            Assert.Equal(originalNote.DisplayDate, amendmentNote.DisplayDate);
+            Assert.Equal(originalNote.Updated, amendmentNote.Updated);
+            Assert.Equal(originalNote.UpdatedBy, amendmentNote.UpdatedBy);
+            Assert.Equal(originalNote.UpdatedById, amendmentNote.UpdatedById);
         }
 
         [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyNoteRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyNoteRepositoryTests.cs
@@ -32,10 +32,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyNoteRepository(contentDbContext);
 
-                var result = await service.AddNote(methodologyVersion.Id,
-                    createdById,
-                    content,
-                    displayDate);
+                var result = await service.AddNote(
+                    methodologyVersionId: methodologyVersion.Id,
+                    createdByUserId: createdById,
+                    content: content,
+                    displayDate: displayDate);
 
                 Assert.NotNull(result);
             }
@@ -48,6 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
                     await contentDbContext.MethodologyNotes.SingleAsync(n =>
                         n.MethodologyVersionId == methodologyVersion.Id);
 
+                Assert.NotEqual(Guid.Empty, addedNote.Id);
                 Assert.Equal(content, addedNote.Content);
                 Assert.InRange(DateTime.UtcNow.Subtract(addedNote.Created).Milliseconds, 0, 1500);
                 Assert.Equal(createdById, addedNote.CreatedById);
@@ -114,10 +116,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Reposit
             {
                 var service = BuildMethodologyNoteRepository(contentDbContext);
 
-                var result = await service.UpdateNote(methodologyNote.Id,
-                    updatedById,
-                    content,
-                    displayDate);
+                var result = await service.UpdateNote(
+                    methodologyNoteId: methodologyNote.Id,
+                    updatedByUserId: updatedById,
+                    content: content,
+                    displayDate: displayDate);
 
                 Assert.NotNull(result);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyNoteRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/Repository/MethodologyNoteRepositoryTests.cs
@@ -1,0 +1,147 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.Database.ContentDbUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests.Repository
+{
+    public class MethodologyNoteRepositoryTests
+    {
+        [Fact]
+        public async Task AddNote()
+        {
+            var methodologyVersion = new MethodologyVersion();
+
+            const string content = "Adding note";
+            var createdById = Guid.NewGuid();
+            var displayDate = DateTime.Today.ToUniversalTime();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyVersions.AddAsync(methodologyVersion);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = BuildMethodologyNoteRepository(contentDbContext);
+
+                var result = await service.AddNote(methodologyVersion.Id,
+                    createdById,
+                    content,
+                    displayDate);
+
+                Assert.NotNull(result);
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                Assert.Single(contentDbContext.MethodologyNotes);
+
+                var addedNote =
+                    await contentDbContext.MethodologyNotes.SingleAsync(n =>
+                        n.MethodologyVersionId == methodologyVersion.Id);
+
+                Assert.Equal(content, addedNote.Content);
+                Assert.InRange(DateTime.UtcNow.Subtract(addedNote.Created).Milliseconds, 0, 1500);
+                Assert.Equal(createdById, addedNote.CreatedById);
+                Assert.Equal(displayDate, addedNote.DisplayDate);
+                Assert.Equal(methodologyVersion.Id, addedNote.MethodologyVersionId);
+                Assert.Null(addedNote.Updated);
+                Assert.Null(addedNote.UpdatedById);
+            }
+        }
+
+        [Fact]
+        public async Task DeleteNote()
+        {
+            var methodologyNote = new MethodologyNote
+            {
+                MethodologyVersion = new MethodologyVersion()
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyNotes.AddAsync(methodologyNote);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = BuildMethodologyNoteRepository(contentDbContext);
+                await service.DeleteNote(methodologyNote.Id);
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                Assert.Empty(contentDbContext.MethodologyNotes);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateNote()
+        {
+            var methodologyNote = new MethodologyNote
+            {
+                Content = "Original note",
+                Created = DateTime.UtcNow,
+                CreatedById = Guid.NewGuid(),
+                DisplayDate = DateTime.Today.ToUniversalTime(),
+                MethodologyVersion = new MethodologyVersion()
+            };
+
+            const string content = "Updating note";
+            var updatedById = Guid.NewGuid();
+            var displayDate = DateTime.Today.AddDays(-7).ToUniversalTime();
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.MethodologyNotes.AddAsync(methodologyNote);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                var service = BuildMethodologyNoteRepository(contentDbContext);
+
+                var result = await service.UpdateNote(methodologyNote.Id,
+                    updatedById,
+                    content,
+                    displayDate);
+
+                Assert.NotNull(result);
+            }
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                Assert.Single(contentDbContext.MethodologyNotes);
+
+                var updatedNote = await contentDbContext.MethodologyNotes.FindAsync(methodologyNote.Id);
+
+                Assert.Equal(content, updatedNote.Content);
+                Assert.Equal(methodologyNote.Created, updatedNote.Created);
+                Assert.Equal(methodologyNote.CreatedById, updatedNote.CreatedById);
+                Assert.Equal(displayDate, updatedNote.DisplayDate);
+                Assert.Equal(methodologyNote.MethodologyVersion.Id, updatedNote.MethodologyVersionId);
+                Assert.NotNull(updatedNote.Updated);
+                Assert.InRange(DateTime.UtcNow.Subtract(updatedNote.Updated.Value).Milliseconds, 0, 1500);
+                Assert.Equal(updatedById, updatedNote.UpdatedById);
+            }
+        }
+
+        private static MethodologyNoteRepository BuildMethodologyNoteRepository(ContentDbContext contentDbContext)
+        {
+            return new(contentDbContext);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Database/ContentDbContext.cs
@@ -42,6 +42,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
         public DbSet<DataImportError> DataImportErrors { get; set; }
         public DbSet<HtmlBlock> HtmlBlocks { get; set; }
         public DbSet<MarkDownBlock> MarkDownBlocks { get; set; }
+        public DbSet<MethodologyNote> MethodologyNotes { get; set; }
         public DbSet<ReleaseType> ReleaseTypes { get; set; }
         public DbSet<Contact> Contacts { get; set; }
         public DbSet<ReleaseContentSection> ReleaseContentSections { get; set; }
@@ -138,6 +139,34 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Database
 
             modelBuilder.Entity<MethodologyFile>()
                 .HasOne(mf => mf.File)
+                .WithMany()
+                .OnDelete(DeleteBehavior.NoAction);
+
+            modelBuilder.Entity<MethodologyNote>()
+                .Property(n => n.Created)
+                .HasConversion(
+                    v => v,
+                    v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+
+            modelBuilder.Entity<MethodologyNote>()
+                .HasOne(m => m.CreatedBy)
+                .WithMany()
+                .OnDelete(DeleteBehavior.NoAction);
+
+            modelBuilder.Entity<MethodologyNote>()
+                .Property(n => n.DisplayDate)
+                .HasConversion(
+                    v => v,
+                    v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+
+            modelBuilder.Entity<MethodologyNote>()
+                .Property(n => n.Updated)
+                .HasConversion(
+                    v => v, 
+                    v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : (DateTime?) null);
+
+            modelBuilder.Entity<MethodologyNote>()
+                .HasOne(m => m.UpdatedBy)
                 .WithMany()
                 .OnDelete(DeleteBehavior.NoAction);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyNote.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyNote.cs
@@ -1,0 +1,30 @@
+﻿#nullable enable
+using System;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model
+{
+    public class MethodologyNote
+    {
+        public Guid Id { get; set; }
+
+        public DateTime Created { get; set; }
+
+        public User CreatedBy { get; set; } = null!;
+
+        public Guid CreatedById { get; set; }
+
+        public string Content { get; set; } = null!;
+
+        public DateTime DisplayDate { get; set; }
+
+        public Guid MethodologyVersionId { get; set; }
+
+        public MethodologyVersion MethodologyVersion { get; set; } = null!;
+
+        public DateTime? Updated { get; set; }
+
+        public Guid? UpdatedById { get; set; }
+
+        public User UpdatedBy { get; set; } = null!;
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyNote.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyNote.cs
@@ -7,12 +7,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
     {
         public Guid Id { get; set; }
 
-        public DateTime Created { get; set; }
-
-        public User CreatedBy { get; set; } = null!;
-
-        public Guid CreatedById { get; set; }
-
         public string Content { get; set; } = null!;
 
         public DateTime DisplayDate { get; set; }
@@ -20,6 +14,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public Guid MethodologyVersionId { get; set; }
 
         public MethodologyVersion MethodologyVersion { get; set; } = null!;
+
+        public DateTime Created { get; set; }
+
+        public User CreatedBy { get; set; } = null!;
+
+        public Guid CreatedById { get; set; }
 
         public DateTime? Updated { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyNote.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyNote.cs
@@ -26,5 +26,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public Guid? UpdatedById { get; set; }
 
         public User UpdatedBy { get; set; } = null!;
+
+        public MethodologyNote Clone(MethodologyVersion newVersion)
+        {
+            var copy = (MethodologyNote) MemberwiseClone();
+
+            copy.Id = Guid.NewGuid();
+            copy.MethodologyVersion = newVersion;
+            copy.MethodologyVersionId = newVersion.Id;
+
+            return copy;
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyVersion.cs
@@ -40,6 +40,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public List<ContentSection> Annexes { get; set; } = new();
 
+        public List<MethodologyNote> Notes { get; set; } = new();
+
         public string? InternalReleaseNote { get; set; }
 
         public Methodology Methodology { get; set; } = null!;
@@ -94,7 +96,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public MethodologyVersion CreateMethodologyAmendment(DateTime createdDate, Guid createdByUserId)
         {
-            var copy = MemberwiseClone() as MethodologyVersion;
+            var copy = (MethodologyVersion) MemberwiseClone();
+
             copy.Id = Guid.NewGuid();
             copy.Status = Draft;
             copy.Published = null;
@@ -117,6 +120,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
             copy.Content = Content
                 .Select(c => c.Clone(createdDate))
+                .ToList();
+
+            copy.Notes = copy
+                .Notes
+                .Select(n => n.Clone(copy))
                 .ToList();
 
             return copy;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyNoteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/Interfaces/IMethodologyNoteRepository.cs
@@ -1,0 +1,23 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces
+{
+    public interface IMethodologyNoteRepository
+    {
+        Task<MethodologyNote> AddNote(
+            Guid methodologyVersionId,
+            Guid createdByUserId,
+            string content,
+            DateTime displayDate);
+
+        Task DeleteNote(Guid methodologyNoteId);
+
+        Task<MethodologyNote> UpdateNote(
+            Guid methodologyNoteId,
+            Guid updatedByUserId,
+            string content,
+            DateTime displayDate);
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyNoteRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyNoteRepository.cs
@@ -1,0 +1,63 @@
+﻿#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
+
+namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
+{
+    public class MethodologyNoteRepository : IMethodologyNoteRepository
+    {
+        private readonly ContentDbContext _contentDbContext;
+
+        public MethodologyNoteRepository(ContentDbContext contentDbContext)
+        {
+            _contentDbContext = contentDbContext;
+        }
+
+        public async Task<MethodologyNote> AddNote(
+            Guid methodologyVersionId,
+            Guid createdByUserId,
+            string content,
+            DateTime displayDate)
+        {
+            var added = (await _contentDbContext.MethodologyNotes.AddAsync(new MethodologyNote
+            {
+                Content = content,
+                Created = DateTime.UtcNow,
+                CreatedById = createdByUserId,
+                DisplayDate = displayDate,
+                MethodologyVersionId = methodologyVersionId
+            })).Entity;
+            await _contentDbContext.SaveChangesAsync();
+
+            return added;
+        }
+
+        public async Task DeleteNote(Guid methodologyNoteId)
+        {
+            var methodologyNote = await _contentDbContext.MethodologyNotes.FindAsync(methodologyNoteId);
+            _contentDbContext.Remove(methodologyNote);
+            await _contentDbContext.SaveChangesAsync();
+        }
+
+        public async Task<MethodologyNote> UpdateNote(
+            Guid methodologyNoteId,
+            Guid updatedByUserId,
+            string content,
+            DateTime displayDate)
+        {
+            var methodologyNote = await _contentDbContext.MethodologyNotes.FindAsync(methodologyNoteId);
+            _contentDbContext.Update(methodologyNote);
+
+            methodologyNote.Content = content;
+            methodologyNote.DisplayDate = displayDate;
+            methodologyNote.Updated = DateTime.UtcNow;
+            methodologyNote.UpdatedById = updatedByUserId;
+
+            await _contentDbContext.SaveChangesAsync();
+
+            return methodologyNote;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Update.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Update.cs
@@ -15,6 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
         public DateTime? Created { get; set; }
 
         public User? CreatedBy { get; set; }
+
         public Guid? CreatedById { get; set; }
 
         [Required] public DateTime On { get; set; }


### PR DESCRIPTION
This PR introduces support for methodology version notes along with a new API to create, update and delete them.

* `POST /api/methodologies/{versionId}/notes`
  * Returns the created note view model resource.
* `PUT /api/methodologies/{versionId}/notes/{id}`
  * Returns the updated note view model resource.
* `DELETE /api/methodologies/{versionId}/notes/{id}`
  * Deletes the note and returns no content.

### Other changes

- Clone notes when creating a new methodology version.
  - Notes are cloned for the new version and are assigned a new Id but retain all other values, i.e. the original content, display date, created and last updated dates, created by and last updated by users id's.