### PR TITLE
EES-2697 - prevent prod UI tests from throwing false failures

### DIFF
--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -429,7 +429,7 @@ Check latest release is correct
     user checks page contains    See other releases (1)
 
     user opens details dropdown    See other releases (1)
-    user checks page contains other release    ${RELEASE_1_NAME}
+    user waits until page contains other release    ${RELEASE_1_NAME}
     user checks page does not contain other release    ${RELEASE_2_NAME}
 
     user clicks link    ${RELEASE_1_NAME}
@@ -439,7 +439,7 @@ Check other release is correct
 
     user waits until page contains link    View latest data: ${RELEASE_2_NAME}
     user checks page contains    See other releases (1)
-    user checks page contains other release    ${RELEASE_2_NAME}
+    user waits until page contains other release    ${RELEASE_2_NAME}
     user checks page does not contain other release    ${RELEASE_1_NAME}
 
 Go to Table Tool page

--- a/tests/robot-tests/tests/general_public/prod_table_tool.robot
+++ b/tests/robot-tests/tests/general_public/prod_table_tool.robot
@@ -40,7 +40,7 @@ check publications have correct number of releases
     user checks element count is x    //*[@name="publicationId"]    56
 
 check 'Children's social care' contains correct topics
-    user expands details section    Children's social care
+    user opens details dropdown    Children's social care
     user checks page for details dropdown    Children in need and child protection
     user checks page for details dropdown    Children looked after
     user checks page for details dropdown    Children's social work workforce
@@ -49,40 +49,40 @@ check 'Children's social care' contains correct topics
     user checks page for details dropdown    Serious incident notifications
 
 check 'COVID-19' contains correct topics
-    user expands details section    COVID-19
+    user opens details dropdown    COVID-19
     user checks page for details dropdown    Attendance
     user checks page for details dropdown    Confirmed cases reported by Higher Education providers
     user checks page for details dropdown    Devices
     user checks page for details dropdown    Testing
 
 check 'Destination of pupils and students' contains correct topics
-    user expands details section    Destination of pupils and students
+    user opens details dropdown    Destination of pupils and students
     user checks page for details dropdown    Destinations of key stage 4 and 16-18 pupils
     user checks page for details dropdown    NEET and participation
 
 check 'Early years' contains correct topics
-    user expands details section    Early years
+    user opens details dropdown    Early years
     user checks page for details dropdown    Childcare and early years
     user checks page for details dropdown    Early years foundation stage profile
 
 check 'Finance and funding' contains correct topics
-    user expands details section    Finance and funding
+    user opens details dropdown    Finance and funding
     user checks page for details dropdown    Local authority and school finance
     user checks page for details dropdown    Student loan forecasts
 
 check 'Further education' contains correct topics
-    user expands details section    Further education
+    user opens details dropdown    Further education
     user checks page for details dropdown    Further education and skills
     user checks page for details dropdown    Further education: outcome-based success measures
 
 check 'Higher education' contains correct topics
-    user expands details section    Higher education
+    user opens details dropdown    Higher education
     user checks page for details dropdown    Higher education graduate employment and earnings
     user checks page for details dropdown    Participation measures in higher education
     user checks page for details dropdown    Widening participation in higher education
 
 check 'Pupils and schools' contains correct topics
-    user expands details section    Pupils and schools
+    user opens details dropdown    Pupils and schools
     user checks page for details dropdown    Academy transfers
     user checks page for details dropdown    Admission appeals
     user checks page for details dropdown    Exclusions
@@ -95,16 +95,16 @@ check 'Pupils and schools' contains correct topics
     user checks page for details dropdown    Special educational needs (SEN)
 
 check 'School and college outcomes and performance' contains correct topics
-    user expands details section    School and college outcomes and performance
+    user opens details dropdown    School and college outcomes and performance
     user checks page for details dropdown    16 to 19 attainment
     user checks page for details dropdown    GCSEs (key stage 4)
     user checks page for details dropdown    Key stage 2
 
 check 'Teachers and school workforce' contains correct topics
-    user expands details section    Teachers and school workforce
+    user opens details dropdown    Teachers and school workforce
     user checks page for details dropdown    Initial teacher training (ITT)
     user checks page for details dropdown    School workforce
 
 check 'UK education and training statistics' contains correct topics
-    user expands details section    UK education and training statistics
+    user opens details dropdown    UK education and training statistics
     user checks page for details dropdown    UK education and training statistics

--- a/tests/robot-tests/tests/general_public/prod_table_tool.robot
+++ b/tests/robot-tests/tests/general_public/prod_table_tool.robot
@@ -11,27 +11,27 @@ Go to 'data-tables' page
     user navigates to data tables page on public frontend
 
 Check page contains correct themes
-    user checks page for details section    Children's social care
+    user waits until page contains details section    Children's social care
 
-    user checks page for details section    COVID-19
+    user waits until page contains details section    COVID-19
 
-    user checks page for details section    Destination of pupils and students
+    user waits until page contains details section    Destination of pupils and students
 
-    user checks page for details section    Early years
+    user waits until page contains details section    Early years
 
-    user checks page for details section    Finance and funding
+    user waits until page contains details section    Finance and funding
 
-    user checks page for details section    Further education
+    user waits until page contains details section    Further education
 
-    user checks page for details section    Higher education
+    user waits until page contains details section    Higher education
 
-    user checks page for details section    Pupils and schools
+    user waits until page contains details section    Pupils and schools
 
-    user checks page for details section    School and college outcomes and performance
+    user waits until page contains details section    School and college outcomes and performance
 
-    user checks page for details section    Teachers and school workforce
+    user waits until page contains details section    Teachers and school workforce
 
-    user checks page for details section    UK education and training statistics
+    user waits until page contains details section    UK education and training statistics
 
 check publications have correct number of releases
     # There are 56 publications that have a live release with a subject on prod
@@ -41,70 +41,70 @@ check publications have correct number of releases
 
 check 'Children's social care' contains correct topics
     user opens details dropdown    Children's social care
-    user checks page for details dropdown    Children in need and child protection
-    user checks page for details dropdown    Children looked after
-    user checks page for details dropdown    Children's social work workforce
-    user checks page for details dropdown    Outcomes for children in social care
-    user checks page for details dropdown    Secure children's homes
-    user checks page for details dropdown    Serious incident notifications
+    user waits until page contains details dropdown    Children in need and child protection
+    user waits until page contains details dropdown    Children looked after
+    user waits until page contains details dropdown    Children's social work workforce
+    user waits until page contains details dropdown    Outcomes for children in social care
+    user waits until page contains details dropdown    Secure children's homes
+    user waits until page contains details dropdown    Serious incident notifications
 
 check 'COVID-19' contains correct topics
     user opens details dropdown    COVID-19
-    user checks page for details dropdown    Attendance
-    user checks page for details dropdown    Confirmed cases reported by Higher Education providers
-    user checks page for details dropdown    Devices
-    user checks page for details dropdown    Testing
+    user waits until page contains details dropdown    Attendance
+    user waits until page contains details dropdown    Confirmed cases reported by Higher Education providers
+    user waits until page contains details dropdown    Devices
+    user waits until page contains details dropdown    Testing
 
 check 'Destination of pupils and students' contains correct topics
     user opens details dropdown    Destination of pupils and students
-    user checks page for details dropdown    Destinations of key stage 4 and 16-18 pupils
-    user checks page for details dropdown    NEET and participation
+    user waits until page contains details dropdown    Destinations of key stage 4 and 16-18 pupils
+    user waits until page contains details dropdown    NEET and participation
 
 check 'Early years' contains correct topics
     user opens details dropdown    Early years
-    user checks page for details dropdown    Childcare and early years
-    user checks page for details dropdown    Early years foundation stage profile
+    user waits until page contains details dropdown    Childcare and early years
+    user waits until page contains details dropdown    Early years foundation stage profile
 
 check 'Finance and funding' contains correct topics
     user opens details dropdown    Finance and funding
-    user checks page for details dropdown    Local authority and school finance
-    user checks page for details dropdown    Student loan forecasts
+    user waits until page contains details dropdown    Local authority and school finance
+    user waits until page contains details dropdown    Student loan forecasts
 
 check 'Further education' contains correct topics
     user opens details dropdown    Further education
-    user checks page for details dropdown    Further education and skills
-    user checks page for details dropdown    Further education: outcome-based success measures
+    user waits until page contains details dropdown    Further education and skills
+    user waits until page contains details dropdown    Further education: outcome-based success measures
 
 check 'Higher education' contains correct topics
     user opens details dropdown    Higher education
-    user checks page for details dropdown    Higher education graduate employment and earnings
-    user checks page for details dropdown    Participation measures in higher education
-    user checks page for details dropdown    Widening participation in higher education
+    user waits until page contains details dropdown    Higher education graduate employment and earnings
+    user waits until page contains details dropdown    Participation measures in higher education
+    user waits until page contains details dropdown    Widening participation in higher education
 
 check 'Pupils and schools' contains correct topics
     user opens details dropdown    Pupils and schools
-    user checks page for details dropdown    Academy transfers
-    user checks page for details dropdown    Admission appeals
-    user checks page for details dropdown    Exclusions
-    user checks page for details dropdown    Parental responsibility measures
-    user checks page for details dropdown    Pupil absence
-    user checks page for details dropdown    Pupil projections
-    user checks page for details dropdown    School and pupil numbers
-    user checks page for details dropdown    School applications
-    user checks page for details dropdown    School capacity
-    user checks page for details dropdown    Special educational needs (SEN)
+    user waits until page contains details dropdown    Academy transfers
+    user waits until page contains details dropdown    Admission appeals
+    user waits until page contains details dropdown    Exclusions
+    user waits until page contains details dropdown    Parental responsibility measures
+    user waits until page contains details dropdown    Pupil absence
+    user waits until page contains details dropdown    Pupil projections
+    user waits until page contains details dropdown    School and pupil numbers
+    user waits until page contains details dropdown    School applications
+    user waits until page contains details dropdown    School capacity
+    user waits until page contains details dropdown    Special educational needs (SEN)
 
 check 'School and college outcomes and performance' contains correct topics
     user opens details dropdown    School and college outcomes and performance
-    user checks page for details dropdown    16 to 19 attainment
-    user checks page for details dropdown    GCSEs (key stage 4)
-    user checks page for details dropdown    Key stage 2
+    user waits until page contains details dropdown    16 to 19 attainment
+    user waits until page contains details dropdown    GCSEs (key stage 4)
+    user waits until page contains details dropdown    Key stage 2
 
 check 'Teachers and school workforce' contains correct topics
     user opens details dropdown    Teachers and school workforce
-    user checks page for details dropdown    Initial teacher training (ITT)
-    user checks page for details dropdown    School workforce
+    user waits until page contains details dropdown    Initial teacher training (ITT)
+    user waits until page contains details dropdown    School workforce
 
 check 'UK education and training statistics' contains correct topics
     user opens details dropdown    UK education and training statistics
-    user checks page for details dropdown    UK education and training statistics
+    user waits until page contains details dropdown    UK education and training statistics

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -719,10 +719,10 @@ user checks nth breadcrumb contains
     [Arguments]    ${num}    ${text}
     user checks element should contain    css:[data-testid="breadcrumbs--list"] li:nth-child(${num})    ${text}
 
-user checks page contains other release
-    [Arguments]    ${other_release_title}
-    user checks page contains element
-    ...    xpath://li[@data-testid="other-release-item"]/a[text()="${other_release_title}"]
+user waits until page contains other release
+    [Arguments]    ${other_release_title}    ${wait}=${timeout}
+    user waits until page contains element
+    ...    xpath://li[@data-testid="other-release-item"]/a[text()="${other_release_title}"]    ${wait}
 
 user checks page does not contain other release
     [Arguments]    ${other_release_title}
@@ -773,13 +773,9 @@ user closes Set Page View box
     user waits until element is not visible    id:editingMode
 
 user checks page for details section
-    [Arguments]    ${heading}
-    user checks page contains element    testid:Expand Details Section ${heading}
-
-user expands details section
-    [Arguments]    ${heading}
-    user clicks element    testid:Expand Details Section ${heading}
+    [Arguments]    ${heading}    ${wait}=${timeout}
+    user waits until page contains element    testid:Expand Details Section ${heading}    ${wait}
 
 user checks page for details dropdown
-    [Arguments]    ${text}
-    user checks page contains element    xpath:.//details/summary[contains(., "${text}")]
+    [Arguments]    ${text}    ${wait}=${timeout}
+    user waits until page contains element    xpath:.//details/summary[contains(., "${text}")]    ${wait}

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -772,10 +772,10 @@ user closes Set Page View box
     user clicks element    id:pageViewToggleButton
     user waits until element is not visible    id:editingMode
 
-user checks page for details section
+user waits until page contains details section
     [Arguments]    ${heading}    ${wait}=${timeout}
     user waits until page contains element    testid:Expand Details Section ${heading}    ${wait}
 
-user checks page for details dropdown
+user waits until page contains details dropdown
     [Arguments]    ${text}    ${wait}=${timeout}
     user waits until page contains element    xpath:.//details/summary[contains(., "${text}")]    ${wait}


### PR DESCRIPTION
This PR: 
- prevents the prod UI tests from throwing errors due to not finding an element in x amount of seconds. This is caused by the UI tests being run in a slow CI environment. Once the UI tests are able to run in a VMSS this issue should go away 