### PR TITLE
EES-2306 Add Required attribute to DisplayDate field when adding/updating Methodology Notes

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MethodologyNoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MethodologyNoteService.cs
@@ -49,7 +49,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         methodologyVersionId: methodologyVersion.Id,
                         createdByUserId: _userService.GetUserId(),
                         content: request.Content,
-                        displayDate: request.DisplayDate);
+                        displayDate: request.DisplayDate ?? DateTime.Today.ToUniversalTime());
 
                     return BuildMethodologyNoteViewModel(addedNote);
                 });
@@ -92,7 +92,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         methodologyNoteId: methodologyNoteId,
                         updatedByUserId: _userService.GetUserId(),
                         content: request.Content,
-                        displayDate: request.DisplayDate
+                        displayDate: request.DisplayDate ?? DateTime.Today.ToUniversalTime()
                     );
 
                     return BuildMethodologyNoteViewModel(updatedNote);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteAddRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteAddRequest.cs
@@ -8,6 +8,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
     {
         [Required] public string Content { get; set; } = string.Empty;
 
-        public DateTime DisplayDate { get; set; }
+        [Required] public DateTime? DisplayDate { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteUpdateRequest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyNoteUpdateRequest.cs
@@ -8,6 +8,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
     {
         [Required] public string Content { get; set; } = string.Empty;
 
-        public DateTime DisplayDate { get; set; }
+        [Required] public DateTime? DisplayDate { get; set; }
     }
 }


### PR DESCRIPTION
This PR is a bugfix to prevent requests that accidently omit the `DisplayDate` field from setting the `DateTime` default value `0000-00-00T00:00:00` when adding or updating methodology notes.

Type `DateTime` has a default value of `0000-00-00T00:00:00`. Even when applying the `[Required]` attribute this default value would be assigned if the request field was missing rather than resulting in an invalid model state and a validation error.

This PR changes the fields to be of type `DateTime?` rather than `DateTime` and applies the `[Required]` attribute so that requests omitting the field now receive a validation error:

```
{
    "errors": {
        "DisplayDate": [
            "The DisplayDate field is required."
        ]
    },
    ...
}
```

At the service level we now default to using `DateTime.Today` if the field has no value to respect the optional type although this would only ever occur if the model validation is bypassed by calling the service directly.