### PR TITLE
EES-2693 Add 'Select all' button to data catalogue's downloads step

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.module.scss
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStep.module.scss
@@ -22,6 +22,8 @@
 }
 
 .stepActive {
+  margin-top: govuk-spacing(4);
+
   &::before,
   &:last-child::after {
     border-color: govuk-colour('black');

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/WizardStepHeading.tsx
@@ -19,7 +19,7 @@ const WizardStepHeading = ({
   return (
     <h2
       className={classNames({
-        'govuk-heading-l dfe-flex dfe-align-items--center govuk-!-margin-top-6': isActive,
+        'govuk-heading-l dfe-flex dfe-align-items--center': isActive,
         'govuk-fieldset__heading': fieldsetHeading && isActive,
         [styles.stepEnabled]: stepEnabled && !isActive,
       })}

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DownloadStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/DownloadStep.tsx
@@ -137,6 +137,7 @@ const DownloadStep = ({
                   legend="Choose files from the list below"
                   legendHidden
                   disabled={form.isSubmitting}
+                  selectAll
                   options={checkboxOptions}
                 />
               )}


### PR DESCRIPTION
This PR adds the following 'Select/Unselect all' button to the data catalogue's downloads step (step 3):

![image](https://user-images.githubusercontent.com/9917868/133635485-695ef3fa-9142-4d8d-acf5-9d2747cec7fa.png)

## Other changes

- Adds minor adjustments to the margin between wizard steps to make things look nicer in error states (where an `ErrorSummary` component is rendered)