### PR TITLE
EES-2711 Add publicly accessible methodology URL to the Sign off tab

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -301,6 +301,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                     Methodology = new Methodology
                     {
                         Id = Guid.NewGuid(),
+                        Slug = "test-publication",
                         OwningPublicationTitle = publication.Title,
                         Publications = new List<PublicationMethodology>
                         {
@@ -324,6 +325,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 VerifyAllMocks(repository);
 
                 Assert.Equal(createdMethodology.Id, viewModel.Id);
+                Assert.Equal("test-publication", viewModel.Slug);
                 Assert.False(viewModel.Amendment);
                 Assert.Null(viewModel.LatestInternalReleaseNote);
                 Assert.Equal(createdMethodology.Methodology.Id, viewModel.MethodologyId);
@@ -524,7 +526,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         [Fact]
         public async Task GetAdoptableMethodologies()
         {
-            var methodology = new Methodology();
+            var methodology = new Methodology
+            {
+                Slug = "test-publication"
+            };
 
             var publication = new Publication
             {
@@ -587,6 +592,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var viewModel = result[0];
 
                 Assert.Equal(methodologyVersion.Id, viewModel.Id);
+                Assert.Equal("test-publication", viewModel.Slug);
                 Assert.False(viewModel.Amendment);
                 Assert.Equal("Test approval", viewModel.LatestInternalReleaseNote);
                 Assert.Equal(methodologyVersion.MethodologyId, viewModel.MethodologyId);
@@ -637,7 +643,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
         [Fact]
         public async Task GetSummary()
         {
-            var methodology = new Methodology();
+            var methodology = new Methodology
+            {
+                Slug = "test-publication"
+            };
 
             var owningPublication = new Publication
             {
@@ -709,6 +718,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var viewModel = (await service.GetSummary(methodologyVersion.Id)).AssertRight();
 
                 Assert.Equal(methodologyVersion.Id, viewModel.Id);
+                Assert.Equal("test-publication", viewModel.Slug);
                 Assert.False(viewModel.Amendment);
                 Assert.Equal("Test approval", viewModel.LatestInternalReleaseNote);
                 Assert.Equal(methodologyVersion.MethodologyId, viewModel.MethodologyId);
@@ -1047,6 +1057,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var viewModel = (await service.UpdateMethodology(methodologyVersion.Id, request)).AssertRight();
 
                 Assert.Equal(methodologyVersion.Id, viewModel.Id);
+                Assert.Equal("updated-methodology-title", viewModel.Slug);
                 Assert.Null(viewModel.LatestInternalReleaseNote);
                 Assert.Null(viewModel.Published);
                 Assert.Equal(Immediately, viewModel.PublishingStrategy);
@@ -1126,6 +1137,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var viewModel = (await service.UpdateMethodology(methodologyVersion.Id, request)).AssertRight();
 
                 Assert.Equal(methodologyVersion.Id, viewModel.Id);
+                Assert.Equal("test-publication", viewModel.Slug);
                 Assert.Null(viewModel.LatestInternalReleaseNote);
                 Assert.Null(viewModel.Published);
                 Assert.Equal(Immediately, viewModel.PublishingStrategy);
@@ -1205,6 +1217,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var viewModel = (await service.UpdateMethodology(methodologyVersion.Id, request)).AssertRight();
 
                 Assert.Equal(methodologyVersion.Id, viewModel.Id);
+                Assert.Equal("test-publication", viewModel.Slug);
                 Assert.Null(viewModel.LatestInternalReleaseNote);
                 Assert.Null(viewModel.Published);
                 Assert.Equal(Immediately, viewModel.PublishingStrategy);
@@ -1288,6 +1301,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var viewModel = (await service.UpdateMethodology(methodologyVersion.Id, request)).AssertRight();
 
                 Assert.Equal(methodologyVersion.Id, viewModel.Id);
+                Assert.Equal("alternative-methodology-title", viewModel.Slug);
                 Assert.Null(viewModel.LatestInternalReleaseNote);
                 Assert.Null(viewModel.Published);
                 Assert.Equal(Immediately, viewModel.PublishingStrategy);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologySummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologySummaryViewModel.cs
@@ -26,6 +26,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodolog
 
         public TitleAndIdViewModel? ScheduledWithRelease { get; set; }
 
+        public string Slug { get; set; } = string.Empty;
+
         [JsonConverter(typeof(StringEnumConverter))]
         public MethodologyStatus Status { get; set; }
 

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/__tests__/MethodologyPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/__tests__/MethodologyPage.test.tsx
@@ -16,6 +16,7 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Route } from 'react-router-dom';
+import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
 
 jest.mock('@admin/services/methodologyService');
 jest.mock('@admin/services/methodologyContentService');
@@ -177,7 +178,9 @@ describe('MethodologyPage', () => {
 
     render(
       <MemoryRouter initialEntries={[path]}>
-        <Route component={MethodologyPage} path={methodologyRoute.path} />
+        <TestConfigContextProvider>
+          <Route component={MethodologyPage} path={methodologyRoute.path} />
+        </TestConfigContextProvider>
       </MemoryRouter>,
     );
   }

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -1,4 +1,5 @@
 import StatusBlock from '@admin/components/StatusBlock';
+import { useConfig } from '@admin/contexts/ConfigContext';
 import methodologyService, {
   MethodologyStatus,
 } from '@admin/services/methodologyService';
@@ -14,6 +15,7 @@ import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import MethodologyStatusEditPage from '@admin/pages/methodology/edit-methodology/status/MethodologyStatusEditPage';
 import React from 'react';
+import UrlContainer from '@common/components/UrlContainer';
 
 interface FormValues {
   status: MethodologyStatus;
@@ -33,6 +35,8 @@ const MethodologyStatusPage = () => {
     methodology: currentMethodology,
     onMethodologyChange,
   } = useMethodologyContext();
+
+  const config = useConfig();
 
   const [isEditing, toggleForm] = useToggle(false);
 
@@ -85,6 +89,17 @@ const MethodologyStatusPage = () => {
             {!isEditing ? (
               <>
                 <h2>Sign off</h2>
+
+                <p>
+                  The <strong>public methodology</strong> will be accessible at:
+                </p>
+
+                <p>
+                  <UrlContainer
+                    data-testid="public-methodology-url"
+                    url={`${config.PublicAppUrl}/methodologies/${currentMethodology.slug}`}
+                  />
+                </p>
 
                 <SummaryList>
                   <SummaryListItem term="Status">

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -36,7 +36,7 @@ const MethodologyStatusPage = () => {
     onMethodologyChange,
   } = useMethodologyContext();
 
-  const config = useConfig();
+  const { PublicAppUrl } = useConfig();
 
   const [isEditing, toggleForm] = useToggle(false);
 
@@ -97,7 +97,7 @@ const MethodologyStatusPage = () => {
                 <p>
                   <UrlContainer
                     data-testid="public-methodology-url"
-                    url={`${config.PublicAppUrl}/methodology/${currentMethodology.slug}`}
+                    url={`${PublicAppUrl}/methodology/${currentMethodology.slug}`}
                   />
                 </p>
 

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -97,7 +97,7 @@ const MethodologyStatusPage = () => {
                 <p>
                   <UrlContainer
                     data-testid="public-methodology-url"
-                    url={`${config.PublicAppUrl}/methodologies/${currentMethodology.slug}`}
+                    url={`${config.PublicAppUrl}/methodology/${currentMethodology.slug}`}
                   />
                 </p>
 

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/__tests__/MethodologyStatusPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/__tests__/MethodologyStatusPage.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '@admin/routes/methodologyRoutes';
 import userEvent from '@testing-library/user-event';
 import { Route } from 'react-router-dom';
+import { TestConfigContextProvider } from '@admin/contexts/ConfigContext';
 
 jest.mock('@admin/services/methodologyService');
 jest.mock('@admin/services/permissionService');
@@ -259,6 +260,16 @@ describe('MethodologyStatusPage', () => {
     });
   });
 
+  test('renders the publicly accessible url of the methodology', async () => {
+    renderPage(testMethodology);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('public-methodology-url')).toHaveValue(
+        'http://localhost/methodology/test-methodology',
+      );
+    });
+  });
+
   function renderPage(methodology: BasicMethodology) {
     render(
       <MemoryRouter
@@ -268,12 +279,14 @@ describe('MethodologyStatusPage', () => {
           }),
         ]}
       >
-        <MethodologyContextProvider methodology={methodology}>
-          <Route
-            path={methodologyStatusRoute.path}
-            component={MethodologyStatusPage}
-          />
-        </MethodologyContextProvider>
+        <TestConfigContextProvider>
+          <MethodologyContextProvider methodology={methodology}>
+            <Route
+              path={methodologyStatusRoute.path}
+              component={MethodologyStatusPage}
+            />
+          </MethodologyContextProvider>
+        </TestConfigContextProvider>
       </MemoryRouter>,
     );
   }

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -31,6 +31,13 @@ Approve a methodology for publishing immediately
 
     user approves methodology for publication    ${PUBLICATION_NAME}
 
+Verify the expected public URL of the methodology on the Sign off tab
+    user views methodology for publication    ${PUBLICATION_NAME}
+    user clicks link    Sign off
+    user waits until page contains testid    public-methodology-url
+    ${ACCESSIBLE_METHODOLOGY_URL}=    Get Value    xpath://*[@data-testid="public-methodology-url"]
+    should be equal    ${PUBLIC_METHODOLOGY_URL}    ${ACCESSIBLE_METHODOLOGY_URL}
+
 Verify that the publication is not visible on the public methodologies page without a published release
     user navigates to public methodologies page
     user checks page does not contain    ${PUBLICATION_NAME}


### PR DESCRIPTION
This PR adds the expected publicly accessible methodology URL to the admin Sign off tab.

This is done in the same way that we show the release URL from the admin release Sign Off tab.

![image](https://user-images.githubusercontent.com/4147126/133979509-20578fce-ad04-4ad1-9377-4cbd096a49e2.png)
