### PR TITLE
EES-2698 Prevent deleting approved methodology amendments

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/CreateMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/CreateMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
@@ -75,7 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             {
                 await ForEachSecurityClaimAsync(async claim =>
                 {
-                    await using var context = InMemoryApplicationDbContext(Guid.NewGuid().ToString());
+                    await using var context = InMemoryApplicationDbContext();
                     context.Attach(publication);
 
                     var (handler, publicationRoleRepository) = CreateHandlerAndDependencies(context);
@@ -104,7 +104,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             {
                 await ForEachSecurityClaimAsync(async claim =>
                 {
-                    await using var context = InMemoryApplicationDbContext(Guid.NewGuid().ToString());
+                    await using var context = InMemoryApplicationDbContext();
                     await context.Publications.AddAsync(publication);
                     await context.SaveChangesAsync();
 
@@ -139,7 +139,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task UserCannotCreateMethodologyForPublicationWithoutPublicationOwnerRole()
             {
-                await using var context = InMemoryApplicationDbContext(Guid.NewGuid().ToString());
+                await using var context = InMemoryApplicationDbContext();
                 await context.Publications.AddAsync(Publication);
                 await context.SaveChangesAsync();
 
@@ -166,7 +166,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
             private static async Task AssertPublicationOwnerCanCreateMethodology(Publication publication)
             {
-                await using var context = InMemoryApplicationDbContext(Guid.NewGuid().ToString());
+                await using var context = InMemoryApplicationDbContext();
                 context.Attach(publication);
 
                 var (handler, publicationRoleRepository) = CreateHandlerAndDependencies(context);
@@ -186,7 +186,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
             private static async Task AssertPublicationOwnerCannotCreateMethodology(Publication publication)
             {
-                await using var context = InMemoryApplicationDbContext(Guid.NewGuid().ToString());
+                await using var context = InMemoryApplicationDbContext();
                 await context.Publications.AddAsync(publication);
                 await context.SaveChangesAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
@@ -28,18 +28,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
     {
         private static readonly Guid UserId = Guid.NewGuid();
 
-        private static readonly MethodologyVersion DraftMethodologyVersion = new()
+        private static readonly MethodologyVersion DraftFirstVersion = new()
         {
             Id = Guid.NewGuid(),
             MethodologyId = Guid.NewGuid(),
             Status = Draft
         };
 
-        private static readonly MethodologyVersion ApprovedMethodologyVersion = new()
+        private static readonly MethodologyVersion ApprovedFirstVersion = new()
         {
             Id = Guid.NewGuid(),
             MethodologyId = Guid.NewGuid(),
             Status = Approved
+        };
+
+        private static readonly MethodologyVersion DraftAmendmentVersion = new()
+        {
+            Id = Guid.NewGuid(),
+            MethodologyId = Guid.NewGuid(),
+            Status = Draft,
+            PreviousVersionId = new Guid(),
+            Version = 0
+        };
+
+        private static readonly MethodologyVersion ApprovedAmendmentVersion = new()
+        {
+            Id = Guid.NewGuid(),
+            MethodologyId = Guid.NewGuid(),
+            Status = Approved,
+            PreviousVersionId = new Guid(),
+            Version = 1
         };
 
         private static readonly Publication OwningPublication = new()
@@ -57,7 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     var expectClaimToSucceed = claim == DeleteAllMethodologies;
 
                     await using var context = InMemoryApplicationDbContext(Guid.NewGuid().ToString());
-                    context.Attach(DraftMethodologyVersion);
+                    context.Attach(DraftFirstVersion);
 
                     var (
                         handler,
@@ -67,7 +85,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository
-                        .Setup(s => s.IsPubliclyAccessible(DraftMethodologyVersion.Id))
+                        .Setup(s => s.IsPubliclyAccessible(DraftFirstVersion.Id))
                         .ReturnsAsync(false);
 
                     // If the Claim given to the handler isn't enough to make the handler succeed, it'll go on to check
@@ -75,7 +93,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     if (!expectClaimToSucceed)
                     {
                         methodologyRepository.Setup(s =>
-                                s.GetOwningPublication(DraftMethodologyVersion.MethodologyId))
+                                s.GetOwningPublication(DraftFirstVersion.MethodologyId))
                             .ReturnsAsync(OwningPublication);
 
                         publicationRoleRepository.SetupPublicationOwnerRoleExpectations(
@@ -83,7 +101,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     }
 
                     var user = CreateClaimsPrincipal(UserId, claim);
-                    var authContext = CreateAuthContext(user, DraftMethodologyVersion);
+                    var authContext = CreateAuthContext(user, DraftFirstVersion);
 
                     await handler.HandleAsync(authContext);
                     VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
@@ -107,17 +125,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository
-                        .Setup(s => s.IsPubliclyAccessible(DraftMethodologyVersion.Id))
+                        .Setup(s => s.IsPubliclyAccessible(DraftFirstVersion.Id))
                         .ReturnsAsync(true);
 
                     var user = CreateClaimsPrincipal(UserId, claim);
-                    var authContext = CreateAuthContext(user, DraftMethodologyVersion);
+                    var authContext = CreateAuthContext(user, DraftFirstVersion);
 
                     await handler.HandleAsync(authContext);
                     VerifyAllMocks(methodologyVersionRepository, publicationRoleRepository);
 
                     // Verify that the presence of the "DeleteAllMethodologies" Claim still doesn't allow the user to
-                    // do this with a Methodology in this state.
+                    // do this with a publicly accessible version.
                     Assert.False(authContext.HasSucceeded);
                 });
             }
@@ -135,17 +153,90 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository
-                        .Setup(s => s.IsPubliclyAccessible(ApprovedMethodologyVersion.Id))
+                        .Setup(s => s.IsPubliclyAccessible(ApprovedFirstVersion.Id))
                         .ReturnsAsync(false);
 
                     var user = CreateClaimsPrincipal(UserId, claim);
-                    var authContext = CreateAuthContext(user, ApprovedMethodologyVersion);
+                    var authContext = CreateAuthContext(user, ApprovedFirstVersion);
 
                     await handler.HandleAsync(authContext);
                     VerifyAllMocks(methodologyVersionRepository, publicationRoleRepository);
 
                     // Verify that the presence of the "DeleteAllMethodologies" Claim still doesn't allow the user to
-                    // do this with a Methodology in this state.
+                    // do this with an approved version.
+                    Assert.False(authContext.HasSucceeded);
+                });
+            }
+
+            [Fact]
+            public async Task UserWithCorrectClaimCanDeleteDraftMethodologyAmendment()
+            {
+                await ForEachSecurityClaimAsync(async claim =>
+                {
+                    var expectClaimToSucceed = claim == DeleteAllMethodologies;
+
+                    await using var context = InMemoryApplicationDbContext(Guid.NewGuid().ToString());
+                    context.Attach(DraftAmendmentVersion);
+
+                    var (
+                        handler,
+                        methodologyRepository,
+                        methodologyVersionRepository,
+                        publicationRoleRepository
+                        ) = CreateHandlerAndDependencies();
+
+                    methodologyVersionRepository
+                        .Setup(s => s.IsPubliclyAccessible(DraftAmendmentVersion.Id))
+                        .ReturnsAsync(false);
+
+                    // If the Claim given to the handler isn't enough to make the handler succeed, it'll go on to check
+                    // the user's Publication Roles.  
+                    if (!expectClaimToSucceed)
+                    {
+                        methodologyRepository.Setup(s =>
+                                s.GetOwningPublication(DraftAmendmentVersion.MethodologyId))
+                            .ReturnsAsync(OwningPublication);
+
+                        publicationRoleRepository.SetupPublicationOwnerRoleExpectations(
+                            UserId, OwningPublication, false);
+                    }
+
+                    var user = CreateClaimsPrincipal(UserId, claim);
+                    var authContext = CreateAuthContext(user, DraftAmendmentVersion);
+
+                    await handler.HandleAsync(authContext);
+                    VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
+                        publicationRoleRepository);
+
+                    // Verify that the presence of the "DeleteAllMethodologies" Claim and no other will pass the handler test
+                    Assert.Equal(expectClaimToSucceed, authContext.HasSucceeded);
+                });
+            }
+
+            [Fact]
+            public async Task UserWithCorrectClaimCannotDeleteApprovedMethodologyAmendment()
+            {
+                await ForEachSecurityClaimAsync(async claim =>
+                {
+                    var (
+                        handler,
+                        _,
+                        methodologyVersionRepository,
+                        publicationRoleRepository
+                        ) = CreateHandlerAndDependencies();
+
+                    methodologyVersionRepository
+                        .Setup(s => s.IsPubliclyAccessible(ApprovedAmendmentVersion.Id))
+                        .ReturnsAsync(false);
+
+                    var user = CreateClaimsPrincipal(UserId, claim);
+                    var authContext = CreateAuthContext(user, ApprovedAmendmentVersion);
+
+                    await handler.HandleAsync(authContext);
+                    VerifyAllMocks(methodologyVersionRepository, publicationRoleRepository);
+
+                    // Verify that the presence of the "DeleteAllMethodologies" Claim still doesn't allow the user to
+                    // do this with an approved version.
                     Assert.False(authContext.HasSucceeded);
                 });
             }
@@ -166,18 +257,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                         ) = CreateHandlerAndDependencies();
 
                     methodologyVersionRepository
-                        .Setup(s => s.IsPubliclyAccessible(DraftMethodologyVersion.Id))
+                        .Setup(s => s.IsPubliclyAccessible(DraftFirstVersion.Id))
                         .ReturnsAsync(false);
 
                     methodologyRepository.Setup(s =>
-                            s.GetOwningPublication(DraftMethodologyVersion.MethodologyId))
+                            s.GetOwningPublication(DraftFirstVersion.MethodologyId))
                         .ReturnsAsync(OwningPublication);
 
                     publicationRoleRepository.SetupPublicationOwnerRoleExpectations(UserId, OwningPublication,
                         role == Owner);
 
                     var user = CreateClaimsPrincipal(UserId);
-                    var authContext = CreateAuthContext(user, DraftMethodologyVersion);
+                    var authContext = CreateAuthContext(user, DraftFirstVersion);
 
                     await handler.HandleAsync(authContext);
                     VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
@@ -200,17 +291,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository
-                    .Setup(s => s.IsPubliclyAccessible(DraftMethodologyVersion.Id))
+                    .Setup(s => s.IsPubliclyAccessible(DraftFirstVersion.Id))
                     .ReturnsAsync(false);
 
                 methodologyRepository.Setup(s =>
-                        s.GetOwningPublication(DraftMethodologyVersion.MethodologyId))
+                        s.GetOwningPublication(DraftFirstVersion.MethodologyId))
                     .ReturnsAsync(OwningPublication);
 
                 publicationRoleRepository.SetupPublicationOwnerRoleExpectations(UserId, OwningPublication, false);
 
                 var user = CreateClaimsPrincipal(UserId);
-                var authContext = CreateAuthContext(user, DraftMethodologyVersion);
+                var authContext = CreateAuthContext(user, DraftFirstVersion);
 
                 await handler.HandleAsync(authContext);
                 VerifyAllMocks(methodologyRepository, methodologyVersionRepository, publicationRoleRepository);
@@ -230,15 +321,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository
-                    .Setup(s => s.IsPubliclyAccessible(ApprovedMethodologyVersion.Id))
+                    .Setup(s => s.IsPubliclyAccessible(DraftFirstVersion.Id))
                     .ReturnsAsync(true);
 
                 var user = CreateClaimsPrincipal(UserId);
-                var authContext = CreateAuthContext(user, ApprovedMethodologyVersion);
+                var authContext = CreateAuthContext(user, DraftFirstVersion);
 
                 await handler.HandleAsync(authContext);
 
-                // Verify that the fact that the Methodology is publicly accessible doesn't even need to check the
+                // Verify that the fact that the version is publicly accessible doesn't even need to check the
                 // users' Publication Roles to determine whether or not they can do this.
                 VerifyAllMocks(methodologyVersionRepository, publicationRoleRepository);
                 Assert.False(authContext.HasSucceeded);
@@ -255,15 +346,76 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                     ) = CreateHandlerAndDependencies();
 
                 methodologyVersionRepository
-                    .Setup(s => s.IsPubliclyAccessible(ApprovedMethodologyVersion.Id))
+                    .Setup(s => s.IsPubliclyAccessible(ApprovedFirstVersion.Id))
                     .ReturnsAsync(false);
 
                 var user = CreateClaimsPrincipal(UserId);
-                var authContext = CreateAuthContext(user, ApprovedMethodologyVersion);
+                var authContext = CreateAuthContext(user, ApprovedFirstVersion);
 
                 await handler.HandleAsync(authContext);
 
-                // Verify that the fact that the Methodology is Approved doesn't even need to check the
+                // Verify that the fact that the version is approved doesn't even need to check the
+                // users' Publication Roles to determine whether or not they can do this.
+                VerifyAllMocks(methodologyVersionRepository, publicationRoleRepository);
+                Assert.False(authContext.HasSucceeded);
+            }
+
+            [Fact]
+            public async Task UserWithPublicationOwnerRoleCanDeleteDraftMethodologyAmendment()
+            {
+                await GetEnumValues<PublicationRole>().ForEachAsync(async role =>
+                {
+                    var (
+                        handler,
+                        methodologyRepository,
+                        methodologyVersionRepository,
+                        publicationRoleRepository
+                        ) = CreateHandlerAndDependencies();
+
+                    methodologyVersionRepository
+                        .Setup(s => s.IsPubliclyAccessible(DraftAmendmentVersion.Id))
+                        .ReturnsAsync(false);
+
+                    methodologyRepository.Setup(s =>
+                            s.GetOwningPublication(DraftAmendmentVersion.MethodologyId))
+                        .ReturnsAsync(OwningPublication);
+
+                    publicationRoleRepository.SetupPublicationOwnerRoleExpectations(UserId, OwningPublication,
+                        role == Owner);
+
+                    var user = CreateClaimsPrincipal(UserId);
+                    var authContext = CreateAuthContext(user, DraftAmendmentVersion);
+
+                    await handler.HandleAsync(authContext);
+                    VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
+                        publicationRoleRepository);
+
+                    // Verify that the presence of a Publication Owner role for this user that is related to a
+                    // Publication that uses this Methodology will pass the handler test
+                    Assert.Equal(role == Owner, authContext.HasSucceeded);
+                });
+            }
+
+            [Fact]
+            public async Task UserWithPublicationOwnerRoleCannotDeleteApprovedMethodologyAmendment()
+            {
+                var (
+                    handler,
+                    _,
+                    methodologyVersionRepository,
+                    publicationRoleRepository
+                    ) = CreateHandlerAndDependencies();
+
+                methodologyVersionRepository
+                    .Setup(s => s.IsPubliclyAccessible(ApprovedAmendmentVersion.Id))
+                    .ReturnsAsync(false);
+
+                var user = CreateClaimsPrincipal(UserId);
+                var authContext = CreateAuthContext(user, ApprovedAmendmentVersion);
+
+                await handler.HandleAsync(authContext);
+
+                // Verify that the fact that the version is approved doesn't even need to check the
                 // users' Publication Roles to determine whether or not they can do this.
                 VerifyAllMocks(methodologyVersionRepository, publicationRoleRepository);
                 Assert.False(authContext.HasSucceeded);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
     AuthorizationHandlersTestUtil;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
@@ -73,9 +72,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 await ForEachSecurityClaimAsync(async claim =>
                 {
                     var expectClaimToSucceed = claim == DeleteAllMethodologies;
-
-                    await using var context = InMemoryApplicationDbContext(Guid.NewGuid().ToString());
-                    context.Attach(DraftFirstVersion);
 
                     var (
                         handler,
@@ -174,9 +170,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 await ForEachSecurityClaimAsync(async claim =>
                 {
                     var expectClaimToSucceed = claim == DeleteAllMethodologies;
-
-                    await using var context = InMemoryApplicationDbContext(Guid.NewGuid().ToString());
-                    context.Attach(DraftAmendmentVersion);
 
                     var (
                         handler,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ManageExternalMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ManageExternalMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
@@ -63,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task UserCanManageExternalMethodologyForPublicationWithPublicationOwnerRole()
             {
-                await using var context = InMemoryApplicationDbContext(Guid.NewGuid().ToString());
+                await using var context = InMemoryApplicationDbContext();
                 context.Attach(Publication);
 
                 var (handler, publicationRoleRepository) = CreateHandlerAndDependencies();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlers.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlers.cs
@@ -6,6 +6,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
+using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers
 {
@@ -41,9 +42,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security.Authorizatio
                 return;
             }
 
-            // If the Methodology is the first version added to a Publication and is still in Draft, or if it is a 
-            // subsequent version but is still an amendment, it can potentially be deleted.  Otherwise it cannot.
-            if (!methodologyVersion.Amendment && !methodologyVersion.DraftFirstVersion)
+            if (methodologyVersion.Status == Approved)
             {
                 return;
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model.Tests/MethodologyVersionTests.cs
@@ -498,41 +498,5 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Tests
 
             Assert.False(methodology.Amendment);
         }
-
-        [Fact]
-        public void DraftFirstVersionFlag()
-        {
-            var methodology = new MethodologyVersion
-            {
-                Status = Draft,
-                PreviousVersionId = null
-            };
-
-            Assert.True(methodology.DraftFirstVersion);
-        }
-
-        [Fact]
-        public void DraftFirstVersionFlag_NotDraft()
-        {
-            var methodology = new MethodologyVersion
-            {
-                Status = Approved,
-                PreviousVersionId = null
-            };
-
-            Assert.False(methodology.DraftFirstVersion);
-        }
-
-        [Fact]
-        public void DraftFirstVersionFlag_NotFirstVersion()
-        {
-            var methodology = new MethodologyVersion
-            {
-                Status = Draft,
-                PreviousVersionId = Guid.NewGuid()
-            };
-
-            Assert.False(methodology.DraftFirstVersion);
-        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyVersion.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/MethodologyVersion.cs
@@ -92,8 +92,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model
 
         public bool Amendment => PreviousVersionId != null && Published == null;
 
-        public bool DraftFirstVersion => PreviousVersionId == null && Status == Draft;
-
         public MethodologyVersion CreateMethodologyAmendment(DateTime createdDate, Guid createdByUserId)
         {
             var copy = (MethodologyVersion) MemberwiseClone();

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -114,7 +114,7 @@ Check publication owner can add data guidance to ${SUBJECT_NAME} on new release
     ...    data guidance content
     user clicks button    Save guidance
 
-Navigate to administration as bau1 and swap publication owner role for release approver
+Swap the publication owner role for release approver to test approving the methodology
     user changes to bau1
     user removes publication owner access from analyst    ${PUBLICATION_NAME}
     user gives release access to analyst    ${RELEASE_NAME}    Approver
@@ -124,7 +124,26 @@ Check release approver can approve methodology for publication
     user views methodology for publication    ${PUBLICATION_NAME}
     approve methodology from methodology view
 
+Swap the release approver role for publication owner to test removing the approved methodology
+    user changes to bau1
+    user removes release access from analyst    ${RELEASE_NAME}    Approver
+    user gives analyst publication owner access    ${PUBLICATION_NAME}
+
+Check publication owner cannot remove approved methodology
+    user changes to analyst1
+    ${accordion}    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
+    ${details}    user opens details dropdown    ${PUBLICATION_NAME}    ${accordion}
+    user cannot see the remove controls for methodology    ${details}
+
+Swap the publication owner role for release approver to test unapproving the methodology
+    user changes to bau1
+    user removes publication owner access from analyst    ${PUBLICATION_NAME}
+    user gives release access to analyst    ${RELEASE_NAME}    Approver
+
 Check release approver can unapprove methodology
+    user changes to analyst1
+    user views methodology for publication    ${PUBLICATION_NAME}
+    user clicks link    Sign off
     user changes methodology status to Draft
 
 Check release approver can approve methodology for publishing with the release
@@ -164,17 +183,18 @@ Check release approver can publish a release
     user clicks link    Sign off
     user approves original release for immediate publication
 
-Navigate to administration as bau1 and swap release approver role for publication owner now that the publication is live
+Swap the release approver role for publication owner now that the publication is live
     user changes to bau1
     user removes release access from analyst    ${RELEASE_NAME}    Approver
     user gives analyst publication owner access    ${PUBLICATION_NAME}
 
 Check publication owner can create and cancel methodology amendments on a live publication
+    user changes to analyst1
     user creates methodology amendment for publication    ${PUBLICATION_NAME}
     user cancels methodology amendment for publication    ${PUBLICATION_NAME}
     user creates methodology amendment for publication    ${PUBLICATION_NAME}
 
-Navigate to administration as bau1 and swap publication owner role for release approver
+Swap the publication owner role for release approver to test approving methodology amendments
     user changes to bau1
     user removes publication owner access from analyst    ${PUBLICATION_NAME}
     user gives release access to analyst    ${RELEASE_NAME}    Approver
@@ -182,3 +202,38 @@ Navigate to administration as bau1 and swap publication owner role for release a
 Check release approver can approve methodology amendments on a live publication
     user changes to analyst1
     user approves methodology amendment for publication    ${PUBLICATION_NAME}
+
+Swap the release approver role for publication owner to test creating a new release amendment
+    user changes to bau1
+    user removes release access from analyst    ${RELEASE_NAME}    Approver
+    user gives analyst publication owner access    ${PUBLICATION_NAME}
+
+Check publication owner can create a new release amendment
+    user changes to analyst1
+    user creates amendment for release    ${PUBLICATION_NAME}    ${RELEASE_TYPE}    (Live - Latest release)
+
+Create a new methodology amendment
+    user creates methodology amendment for publication    ${PUBLICATION_NAME}
+
+Swap the publication owner role for release approver to test approving the methodology amendment
+    user changes to bau1
+    user removes publication owner access from analyst    ${PUBLICATION_NAME}
+    user gives release access to analyst    ${RELEASE_NAME}    Approver
+
+Check release approver can approve the methodology amendment for publishing with the release amendment
+    user changes to analyst1
+    user approves methodology amendment for publication
+    ...    publication=${PUBLICATION_NAME}
+    ...    publishing_strategy=WithRelease
+    ...    with_release=${RELEASE_NAME}
+
+Swap the release approver role for publication owner to test that an approved methodology amendment cannot be cancelled
+    user changes to bau1
+    user removes release access from analyst    ${RELEASE_NAME}    Approver
+    user gives analyst publication owner access    ${PUBLICATION_NAME}
+
+Check publication owner cannot cancel approved methodology amendment
+    user changes to analyst1
+    ${accordion}    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
+    ${details}    user opens details dropdown    ${PUBLICATION_NAME}    ${accordion}
+    user cannot see the cancel amendment controls for methodology    ${details}

--- a/tests/robot-tests/tests/libs/admin/analyst/role_ui_permissions.robot
+++ b/tests/robot-tests/tests/libs/admin/analyst/role_ui_permissions.robot
@@ -57,3 +57,13 @@ user cannot see the edit status controls for methodology
     user clicks link    Sign off
     user waits until page does not contain loading spinner
     user checks page does not contain    Edit status
+
+user cannot see the remove controls for methodology
+    [Arguments]    ${DETAILS_SECTION}
+    user checks element contains link    ${DETAILS_SECTION}    View this methodology
+    user checks element does not contain button    ${DETAILS_SECTION}    Remove
+
+user cannot see the cancel amendment controls for methodology
+    [Arguments]    ${DETAILS_SECTION}
+    user checks element contains link    ${DETAILS_SECTION}    View this amendment
+    user checks element does not contain button    ${DETAILS_SECTION}    Cancel amendment


### PR DESCRIPTION
The 'Cancel amendment' button deletes a methodology version. To do so the user needs permission to delete the version.
However this also deletes image files in turn which are protected by a separate permission, checking that the user has permission to update the version. This secondary check fails when a version is approved and the user sees a 403 Forbidden error.

This PR makes a change to not show the 'Cancel amendment' button for an approved version, forcing the user to get the version changed to a draft before it can be deleted.

Prior to this change we allowed deleting the first version of a methodology so long as it was a draft, and we allowed deleting amendment versions.

Both of these operations are still allowed as we always allow deleting drafts. However this change prevents deleting amendment versions that are approved.

To delete an approved amendment a BAU user or Approver must first unapprove the version.

This also fixes a loophole where a publication owner could delete an approved version without the knowledge of an approver.