### PR TITLE
EES-2302 add, edit and remove methodology notes

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/__tests__/MethodologyPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/__tests__/MethodologyPage.test.tsx
@@ -57,6 +57,7 @@ describe('MethodologyPage', () => {
     status: 'Draft',
     content: [],
     annexes: [],
+    notes: [],
   };
 
   test('renders the page with the summary tab', async () => {

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/MethodologyContentPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/MethodologyContentPage.tsx
@@ -11,11 +11,14 @@ import PageSearchForm from '@common/components/PageSearchForm';
 import WarningMessage from '@common/components/WarningMessage';
 import useAsyncHandledRetry from '@common/hooks/useAsyncHandledRetry';
 import MethodologyAccordion from '@admin/pages/methodology/edit-methodology/content/components/MethodologyAccordion';
+import MethodologyNotesSection from '@admin/pages/methodology/edit-methodology/content/components/MethodologyNotesSection';
 import {
   MethodologyContextState,
   MethodologyContentProvider,
   useMethodologyContentState,
 } from '@admin/pages/methodology/edit-methodology/content/context/MethodologyContentContext';
+import SummaryList from '@common/components/SummaryList';
+import SummaryListItem from '@common/components/SummaryListItem';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
 
@@ -55,32 +58,23 @@ const MethodologyContentPageInternal = () => {
                 {methodology.title}
               </h2>
 
-              <div className="govuk-grid-row">
-                <div className="govuk-grid-column-two-thirds">
-                  <dl className="dfe-meta-content govuk-!-margin-top-0">
-                    <div>
-                      <dt className="govuk-caption-m">Published: </dt>
-                      <dd data-testid="published-date">
-                        <strong>
-                          {methodology.published ? (
-                            <FormattedDate>
-                              {methodology.published}
-                            </FormattedDate>
-                          ) : (
-                            'Not yet published'
-                          )}
-                        </strong>
-                      </dd>
-                    </div>
-                  </dl>
-                  {editingMode !== 'edit' && (
-                    <>
-                      <PrintThisPage />
-                      <PageSearchForm inputLabel="Search in this methodology page." />
-                    </>
+              <SummaryList>
+                <SummaryListItem term="Publish date">
+                  {methodology.published ? (
+                    <FormattedDate>{methodology.published}</FormattedDate>
+                  ) : (
+                    'Not yet published'
                   )}
-                </div>
-              </div>
+                </SummaryListItem>
+                <MethodologyNotesSection methodology={methodology} />
+              </SummaryList>
+              {editingMode !== 'edit' && (
+                <>
+                  <PrintThisPage />
+                  <PageSearchForm inputLabel="Search in this methodology page." />
+                </>
+              )}
+
               <MethodologyAccordion
                 methodology={methodology}
                 sectionKey="content"

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesSection.tsx
@@ -242,7 +242,7 @@ const MethodologyNotesSection = ({ methodology }: Props) => {
       )}
 
       <ModalConfirm
-        open={deletedMethodologyNoteId.length > 0}
+        open={deletedMethodologyNoteId !== ''}
         title="Confirm deletion of methodology note"
         onExit={() => setDeletedMethodologyNoteId('')}
         onCancel={() => setDeletedMethodologyNoteId('')}

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesSection.tsx
@@ -1,0 +1,257 @@
+import { useEditingContext } from '@admin/contexts/EditingContext';
+import methodologyNoteService, {
+  MethodologyNote,
+} from '@admin/services/methodologyNoteService';
+import { MethodologyContent } from '@admin/services/methodologyContentService';
+import Button from '@common/components/Button';
+import ButtonGroup from '@common/components/ButtonGroup';
+import Details from '@common/components/Details';
+import { Form } from '@common/components/form';
+import FormFieldDateInput from '@common/components/form/FormFieldDateInput';
+import FormFieldTextArea from '@common/components/form/FormFieldTextArea';
+import FormattedDate from '@common/components/FormattedDate';
+import ModalConfirm from '@common/components/ModalConfirm';
+import SummaryListItem from '@common/components/SummaryListItem';
+import Yup from '@common/validation/yup';
+import orderBy from 'lodash/orderBy';
+import { Formik } from 'formik';
+import React, { useState } from 'react';
+
+interface Props {
+  methodology: MethodologyContent;
+}
+
+interface CreateFormValues {
+  content: string;
+}
+
+interface EditFormValues {
+  id: string;
+  content: string;
+  displayDate: Date;
+}
+
+const MethodologyNotesSection = ({ methodology }: Props) => {
+  const [addFormOpen, setAddFormOpen] = useState<boolean>(false);
+  const [editFormOpen, setEditFormOpen] = useState<boolean>(false);
+  const [deletedMethodologyNoteId, setDeletedMethodologyNoteId] = useState<
+    string
+  >('');
+  const [selectedMethodologyNote, setSelectedMethodologyNote] = useState<
+    MethodologyNote | undefined
+  >();
+  const [methodologyNotes, setMethodologyNotes] = useState<MethodologyNote[]>(
+    methodology.notes,
+  );
+  const { editingMode } = useEditingContext();
+
+  const addMethodologyNote = async (methodologyNote: CreateFormValues) => {
+    const newNote = await methodologyNoteService.create(methodology.id, {
+      content: methodologyNote.content,
+      displayDate: new Date(Date.now()),
+    });
+
+    setMethodologyNotes([...methodologyNotes, newNote]);
+    setAddFormOpen(false);
+  };
+
+  const editMethodologyNote = async (methodologyNote: EditFormValues) => {
+    const updatedNote = await methodologyNoteService.edit(
+      methodologyNote.id,
+      methodology.id,
+      {
+        content: methodologyNote.content,
+        displayDate: methodologyNote.displayDate,
+      },
+    );
+    const updatedNotes = methodologyNotes.map(note =>
+      note.id === updatedNote.id ? updatedNote : note,
+    );
+    setSelectedMethodologyNote(undefined);
+    setEditFormOpen(false);
+    setMethodologyNotes(updatedNotes);
+  };
+
+  const deleteMethodologyNote = async (id: string) => {
+    await methodologyNoteService.delete(id, methodology.id);
+    const updatedNotes = methodologyNotes.filter(note => note.id !== id);
+    setMethodologyNotes(updatedNotes);
+    setDeletedMethodologyNoteId('');
+  };
+
+  const openAddForm = () => {
+    setAddFormOpen(true);
+    setEditFormOpen(false);
+  };
+
+  const openEditForm = (selected: MethodologyNote) => {
+    setAddFormOpen(false);
+    setEditFormOpen(true);
+    setSelectedMethodologyNote(selected);
+  };
+
+  const renderAddForm = () => {
+    const formId = 'createMethodologyNoteForm';
+
+    return !addFormOpen ? (
+      <Button onClick={openAddForm}>Add note</Button>
+    ) : (
+      <Formik<CreateFormValues>
+        initialValues={{ content: '' }}
+        validationSchema={Yup.object<CreateFormValues>({
+          content: Yup.string().required('Methodology note must be provided'),
+        })}
+        onSubmit={methodologyNote => addMethodologyNote(methodologyNote)}
+      >
+        {form => {
+          return (
+            <Form id={formId}>
+              <FormFieldTextArea<CreateFormValues>
+                label="New methodology note"
+                name="content"
+                rows={3}
+              />
+
+              <ButtonGroup>
+                <Button type="submit">Save note</Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => {
+                    form.resetForm();
+                    setAddFormOpen(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+              </ButtonGroup>
+            </Form>
+          );
+        }}
+      </Formik>
+    );
+  };
+
+  const renderEditForm = () => {
+    const formId = 'editMethodologyNoteForm';
+
+    return (
+      <Formik<EditFormValues>
+        initialValues={
+          selectedMethodologyNote
+            ? {
+                id: selectedMethodologyNote.id,
+                displayDate: new Date(selectedMethodologyNote.displayDate),
+                content: selectedMethodologyNote.content,
+              }
+            : ({
+                content: '',
+              } as EditFormValues)
+        }
+        validationSchema={Yup.object<Omit<EditFormValues, 'id'>>({
+          displayDate: Yup.date().required('Enter a valid edit date'),
+          content: Yup.string().required('Methodology note must be provided'),
+        })}
+        onSubmit={methodologyNote => editMethodologyNote(methodologyNote)}
+      >
+        {form => {
+          return (
+            <Form id={formId}>
+              <FormFieldDateInput<EditFormValues>
+                name="displayDate"
+                legend="Edit date"
+                legendSize="s"
+              />
+              <FormFieldTextArea<EditFormValues>
+                label="Edit methodology note"
+                name="content"
+                rows={3}
+              />
+
+              <ButtonGroup>
+                <Button type="submit">Update note</Button>
+                <Button
+                  variant="secondary"
+                  onClick={() => {
+                    form.resetForm();
+                    setEditFormOpen(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+              </ButtonGroup>
+            </Form>
+          );
+        }}
+      </Formik>
+    );
+  };
+
+  return (
+    <SummaryListItem term="Last updated">
+      {methodologyNotes.length > 0 ? (
+        <>
+          <FormattedDate>{methodologyNotes[0].displayDate}</FormattedDate>
+          <Details
+            summary={`See all notes (${methodologyNotes.length})`}
+            id="methodologyNotes"
+            open={editingMode === 'edit'}
+          >
+            <ol className="govuk-list">
+              {orderBy(methodologyNotes, 'displayDate', 'desc').map(note => (
+                <li key={note.id}>
+                  {editingMode === 'edit' &&
+                  editFormOpen &&
+                  selectedMethodologyNote?.id === note.id ? (
+                    renderEditForm()
+                  ) : (
+                    <>
+                      <FormattedDate className="govuk-body govuk-!-font-weight-bold">
+                        {note.displayDate}
+                      </FormattedDate>
+                      <p>{note.content}</p>
+
+                      {editingMode === 'edit' && (
+                        <ButtonGroup>
+                          <Button
+                            variant="secondary"
+                            onClick={() => openEditForm(note)}
+                          >
+                            Edit note
+                          </Button>
+                          <Button
+                            variant="warning"
+                            onClick={() => setDeletedMethodologyNoteId(note.id)}
+                          >
+                            Remove note
+                          </Button>
+                        </ButtonGroup>
+                      )}
+                    </>
+                  )}
+                </li>
+              ))}
+            </ol>
+            {editingMode === 'edit' && renderAddForm()}
+          </Details>
+        </>
+      ) : (
+        <>
+          <p>TBA</p>
+          {editingMode === 'edit' && renderAddForm()}
+        </>
+      )}
+
+      <ModalConfirm
+        open={deletedMethodologyNoteId.length > 0}
+        title="Confirm deletion of methodology note"
+        onExit={() => setDeletedMethodologyNoteId('')}
+        onCancel={() => setDeletedMethodologyNoteId('')}
+        onConfirm={() => deleteMethodologyNote(deletedMethodologyNoteId)}
+      >
+        <p>This methodology note will be removed from this methodology</p>
+      </ModalConfirm>
+    </SummaryListItem>
+  );
+};
+
+export default MethodologyNotesSection;

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/__tests__/MethodologyNotesSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/__tests__/MethodologyNotesSection.test.tsx
@@ -1,0 +1,359 @@
+import MethodologyNotesSection from '@admin/pages/methodology/edit-methodology/content/components/MethodologyNotesSection';
+import { MethodologyContent } from '@admin/services/methodologyContentService';
+import { EditingContextProvider } from '@admin/contexts/EditingContext';
+import _methodologyNoteService from '@admin/services/methodologyNoteService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+jest.mock('@admin/services/methodologyNoteService');
+const methodologyNoteService = _methodologyNoteService as jest.Mocked<
+  typeof _methodologyNoteService
+>;
+
+describe('MethodologyNotesSection', () => {
+  const testMethodologyContentWithoutNotes: MethodologyContent = {
+    id: 'methodology-1',
+    title: 'Methodology title 1',
+    slug: 'methodology-title-1',
+    status: 'Draft',
+    annexes: [],
+    content: [],
+    notes: [],
+  };
+  const testMethodologyContentWithNotes: MethodologyContent = {
+    ...testMethodologyContentWithoutNotes,
+    notes: [
+      {
+        id: 'note-1',
+        content: 'Note 1',
+        displayDate: new Date('2021-09-10T00:00:00'),
+      },
+      {
+        id: 'note-2',
+        content: 'Note 2',
+        displayDate: new Date('2021-08-11T00:00:00'),
+      },
+      {
+        id: 'note-3',
+        content: 'Note 3',
+        displayDate: new Date('2021-08-10T00:00:00'),
+      },
+    ],
+  };
+
+  describe('displaying notes', () => {
+    test('renders correctly when there are no notes', () => {
+      render(
+        <EditingContextProvider initialEditingMode="edit">
+          <MethodologyNotesSection
+            methodology={testMethodologyContentWithoutNotes}
+          />
+        </EditingContextProvider>,
+      );
+      expect(screen.getByText('Last updated')).toBeInTheDocument();
+      expect(screen.getByTestId('Last updated-value')).toHaveTextContent('TBA');
+      expect(
+        screen.getByRole('button', { name: 'Add note' }),
+      ).toBeInTheDocument();
+    });
+
+    test('renders correctly with notes', () => {
+      render(
+        <EditingContextProvider initialEditingMode="edit">
+          <MethodologyNotesSection
+            methodology={testMethodologyContentWithNotes}
+          />
+        </EditingContextProvider>,
+      );
+      expect(screen.getByText('Last updated')).toBeInTheDocument();
+      expect(screen.getByTestId('Last updated-value')).toHaveTextContent(
+        '10 September 2021',
+      );
+
+      const notes = screen.getAllByRole('listitem');
+      expect(notes).toHaveLength(3);
+
+      expect(
+        within(notes[0]).getByText('10 September 2021'),
+      ).toBeInTheDocument();
+      expect(within(notes[0]).getByText('Note 1')).toBeInTheDocument();
+      expect(
+        within(notes[0]).getByRole('button', { name: 'Edit note' }),
+      ).toBeInTheDocument();
+      expect(
+        within(notes[0]).getByRole('button', { name: 'Remove note' }),
+      ).toBeInTheDocument();
+
+      expect(within(notes[1]).getByText('11 August 2021')).toBeInTheDocument();
+      expect(within(notes[1]).getByText('Note 2')).toBeInTheDocument();
+      expect(
+        within(notes[1]).getByRole('button', { name: 'Edit note' }),
+      ).toBeInTheDocument();
+      expect(
+        within(notes[1]).getByRole('button', { name: 'Remove note' }),
+      ).toBeInTheDocument();
+
+      expect(within(notes[2]).getByText('10 August 2021')).toBeInTheDocument();
+      expect(within(notes[2]).getByText('Note 3')).toBeInTheDocument();
+      expect(
+        within(notes[2]).getByRole('button', { name: 'Edit note' }),
+      ).toBeInTheDocument();
+      expect(
+        within(notes[2]).getByRole('button', { name: 'Remove note' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', { name: 'Add note' }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('adding a note', () => {
+    test('shows validation error if no note given and does not submit', async () => {
+      render(
+        <EditingContextProvider initialEditingMode="edit">
+          <MethodologyNotesSection
+            methodology={testMethodologyContentWithNotes}
+          />
+        </EditingContextProvider>,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Add note' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('New methodology note'),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.click(screen.getByLabelText('New methodology note'));
+      userEvent.tab();
+      await waitFor(() => {
+        expect(screen.getByText('There is a problem')).toBeInTheDocument();
+        expect(
+          screen.getByRole('link', {
+            name: 'Methodology note must be provided',
+          }),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.click(screen.getByRole('button', { name: 'Save note' }));
+      expect(methodologyNoteService.create).not.toHaveBeenCalled();
+    });
+
+    test('submits successfully with a note and displays the new note', async () => {
+      const realNow = Date.now;
+      global.Date.now = jest.fn(() => new Date('2031-09-20').getTime());
+
+      const newNote = {
+        content: 'New note',
+        displayDate: new Date('2031-09-20'),
+      };
+      methodologyNoteService.create.mockResolvedValue({
+        ...newNote,
+        id: 'note-4',
+      });
+      render(
+        <EditingContextProvider initialEditingMode="edit">
+          <MethodologyNotesSection
+            methodology={testMethodologyContentWithNotes}
+          />
+        </EditingContextProvider>,
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Add note' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('New methodology note'),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.type(screen.getByLabelText('New methodology note'), 'New note');
+      userEvent.click(screen.getByRole('button', { name: 'Save note' }));
+
+      await waitFor(() => {
+        expect(methodologyNoteService.create).toHaveBeenCalledWith(
+          'methodology-1',
+          newNote,
+        );
+      });
+      const notes = screen.getAllByRole('listitem');
+      expect(notes).toHaveLength(4);
+
+      expect(
+        within(notes[0]).getByText('20 September 2031'),
+      ).toBeInTheDocument();
+      expect(within(notes[0]).getByText('New note')).toBeInTheDocument();
+      expect(
+        within(notes[0]).getByRole('button', { name: 'Edit note' }),
+      ).toBeInTheDocument();
+      expect(
+        within(notes[0]).getByRole('button', { name: 'Remove note' }),
+      ).toBeInTheDocument();
+
+      // Reset Date.now
+      global.Date.now = realNow;
+    });
+  });
+
+  describe('editing a note', () => {
+    test('shows validation error if note or date removed and does not submit', async () => {
+      render(
+        <EditingContextProvider initialEditingMode="edit">
+          <MethodologyNotesSection
+            methodology={testMethodologyContentWithNotes}
+          />
+        </EditingContextProvider>,
+      );
+
+      const notes = screen.getAllByRole('listitem');
+      userEvent.click(
+        within(notes[0]).getByRole('button', { name: 'Edit note' }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('Edit methodology note'),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.clear(screen.getByLabelText('Edit methodology note'));
+      userEvent.tab();
+      await waitFor(() => {
+        expect(screen.getByText('There is a problem')).toBeInTheDocument();
+        expect(
+          screen.getByRole('link', {
+            name: 'Methodology note must be provided',
+          }),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.clear(screen.getByLabelText('Day'));
+      userEvent.clear(screen.getByLabelText('Month'));
+      userEvent.clear(screen.getByLabelText('Year'));
+
+      userEvent.tab();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', {
+            name: 'Enter a valid edit date',
+          }),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.click(screen.getByRole('button', { name: 'Update note' }));
+
+      expect(methodologyNoteService.edit).not.toHaveBeenCalled();
+    });
+
+    test('submits successfully the updated note and updates it in the list', async () => {
+      const updatedNote = {
+        content: 'Note 1 edited',
+        displayDate: new Date('2022-12-31'),
+      };
+      methodologyNoteService.edit.mockResolvedValue({
+        ...updatedNote,
+        id: 'note-1',
+      });
+      render(
+        <EditingContextProvider initialEditingMode="edit">
+          <MethodologyNotesSection
+            methodology={testMethodologyContentWithNotes}
+          />
+        </EditingContextProvider>,
+      );
+
+      const notes = screen.getAllByRole('listitem');
+      userEvent.click(
+        within(notes[0]).getByRole('button', { name: 'Edit note' }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('Edit methodology note'),
+        ).toBeInTheDocument();
+      });
+
+      userEvent.type(screen.getByLabelText('Edit methodology note'), ' edited');
+      userEvent.clear(screen.getByLabelText('Day'));
+      userEvent.type(screen.getByLabelText('Day'), '31');
+      userEvent.clear(screen.getByLabelText('Month'));
+      userEvent.type(screen.getByLabelText('Month'), '12');
+      userEvent.clear(screen.getByLabelText('Year'));
+      userEvent.type(screen.getByLabelText('Year'), '2022');
+
+      userEvent.click(screen.getByRole('button', { name: 'Update note' }));
+      await waitFor(() => {
+        expect(methodologyNoteService.edit).toHaveBeenCalledWith(
+          'note-1',
+          'methodology-1',
+          updatedNote,
+        );
+      });
+
+      expect(
+        within(notes[0]).getByText('31 December 2022'),
+      ).toBeInTheDocument();
+      expect(within(notes[0]).getByText('Note 1 edited')).toBeInTheDocument();
+    });
+  });
+
+  describe('removing notes', () => {
+    test('shows the confirm modal when clicking the Remove button', async () => {
+      render(
+        <EditingContextProvider initialEditingMode="edit">
+          <MethodologyNotesSection
+            methodology={testMethodologyContentWithNotes}
+          />
+        </EditingContextProvider>,
+      );
+
+      const notes = screen.getAllByRole('listitem');
+      userEvent.click(
+        within(notes[0]).getByRole('button', { name: 'Remove note' }),
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Confirm deletion of methodology note'),
+        ).toBeInTheDocument();
+
+        expect(
+          screen.getByText(
+            'This methodology note will be removed from this methodology',
+          ),
+        ).toBeInTheDocument();
+      });
+      expect(
+        screen.getByRole('button', { name: 'Confirm' }),
+      ).toBeInTheDocument();
+    });
+
+    test('successfully removes a note', async () => {
+      render(
+        <EditingContextProvider initialEditingMode="edit">
+          <MethodologyNotesSection
+            methodology={testMethodologyContentWithNotes}
+          />
+        </EditingContextProvider>,
+      );
+
+      const notes = screen.getAllByRole('listitem');
+      userEvent.click(
+        within(notes[0]).getByRole('button', { name: 'Remove note' }),
+      );
+
+      userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+      await waitFor(() => {
+        expect(methodologyNoteService.delete).toHaveBeenCalledWith(
+          'note-1',
+          'methodology-1',
+        );
+
+        expect(screen.getAllByRole('listitem')).toHaveLength(2);
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/context/__tests__/MethodologyContentContext.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/context/__tests__/MethodologyContentContext.test.tsx
@@ -67,6 +67,7 @@ const basicMethodology: MethodologyContent = {
       caption: '',
     },
   ],
+  notes: [],
 };
 
 const methodologyReducer = (

--- a/src/explore-education-statistics-admin/src/services/methodologyContentService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyContentService.ts
@@ -1,5 +1,6 @@
 import { ContentSectionKeys } from '@admin/pages/methodology/edit-methodology/content/context/MethodologyContentContextActionTypes';
 import { MethodologyStatus } from '@admin/services/methodologyService';
+import { MethodologyNote } from '@admin/services/methodologyNoteService';
 import {
   ContentBlockPostModel,
   ContentBlockPutModel,
@@ -19,6 +20,7 @@ export interface MethodologyContent {
   published?: string;
   content: ContentSection<EditableContentBlock>[];
   annexes: ContentSection<EditableContentBlock>[];
+  notes: MethodologyNote[];
 }
 
 const methodologyContentService = {

--- a/src/explore-education-statistics-admin/src/services/methodologyNoteService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyNoteService.ts
@@ -1,0 +1,30 @@
+import client from '@admin/services/utils/service';
+
+export interface MethodologyNote {
+  id: string;
+  content: string;
+  displayDate: Date;
+}
+
+const methodologyNoteService = {
+  create(methodologyId: string, methodologyNote: Omit<MethodologyNote, 'id'>): Promise<MethodologyNote> {
+    return client.post(`/methodologies/${methodologyId}/notes`, methodologyNote);
+  },
+
+  edit(
+    noteId: string,
+    methodologyId: string,
+    methodologyNote: Omit<MethodologyNote, 'id'>,
+  ): Promise<MethodologyNote> {
+    return client.put(`/methodologies/${methodologyId}/notes/${noteId}`, methodologyNote);
+  },
+
+  delete(
+    noteId: string,
+    methodologyId: string,
+  ): Promise<MethodologyNote[]> {
+    return client.delete(`/methodologies/${methodologyId}/notes/${noteId}`);
+  },
+};
+
+export default methodologyNoteService;

--- a/src/explore-education-statistics-admin/src/services/methodologyNoteService.ts
+++ b/src/explore-education-statistics-admin/src/services/methodologyNoteService.ts
@@ -7,8 +7,14 @@ export interface MethodologyNote {
 }
 
 const methodologyNoteService = {
-  create(methodologyId: string, methodologyNote: Omit<MethodologyNote, 'id'>): Promise<MethodologyNote> {
-    return client.post(`/methodologies/${methodologyId}/notes`, methodologyNote);
+  create(
+    methodologyId: string,
+    methodologyNote: Omit<MethodologyNote, 'id'>,
+  ): Promise<MethodologyNote> {
+    return client.post(
+      `/methodologies/${methodologyId}/notes`,
+      methodologyNote,
+    );
   },
 
   edit(
@@ -16,13 +22,13 @@ const methodologyNoteService = {
     methodologyId: string,
     methodologyNote: Omit<MethodologyNote, 'id'>,
   ): Promise<MethodologyNote> {
-    return client.put(`/methodologies/${methodologyId}/notes/${noteId}`, methodologyNote);
+    return client.put(
+      `/methodologies/${methodologyId}/notes/${noteId}`,
+      methodologyNote,
+    );
   },
 
-  delete(
-    noteId: string,
-    methodologyId: string,
-  ): Promise<MethodologyNote[]> {
+  delete(noteId: string, methodologyId: string): Promise<MethodologyNote[]> {
     return client.delete(`/methodologies/${methodologyId}/notes/${noteId}`);
   },
 };

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -125,11 +125,10 @@ Add and update another note describing the amendment
     user adds note to methodology
     ...    Note which should be updated
     user edits methodology note
-    ...    Earliest note
+    ...    Note which should be updated
     ...    01
     ...    03
     ...    2021
-    ...    css:#methodologyNotes li:nth-of-type(1)
 
 Approve the amendment for publishing immediately
     user approves methodology amendment for publication
@@ -170,7 +169,7 @@ Verify the list of notes
     user opens details dropdown    See all notes (2)
     user waits until page contains element    css:[data-testid="notes"] li    limit=2
     user checks methodology note    1    ${date}    Latest note
-    user checks methodology note    2    1 March 2021    Earliest note
+    user checks methodology note    2    1 March 2021    Note which should be updated - edited
     user closes details dropdown    See all notes (2)
 
 Schedule a methodology amendment to be published with a release amendment

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -111,35 +111,25 @@ Update the methodology amendment's content
     user changes accordion section title    1    New and Updated Title    ${METHODOLOGY_CONTENT_EDITABLE_ACCORDION}
 
 Add a note describing the amendment
-    # TODO EES-2302 / EES-2305 - Replace me when methodology notes can be created via content page
-    ${methodologyVersionId}=    get methodology version id from url
-    set suite variable    ${AMENDMENT_METHODOLOGY_VERSION_ID}    ${methodologyVersionId}
-    user creates methodology note via api
-    ...    ${AMENDMENT_METHODOLOGY_VERSION_ID}
+    user adds note to methodology
     ...    Latest note
-    ...    2021-09-16T23:00:00Z
 
 Add and remove another note describing the amendment
-    # TODO EES-2302 / EES-2305 - Replace me when methodology notes can be created via content page
-    ${noteIdToRemove}=    user creates methodology note via api
-    ...    ${AMENDMENT_METHODOLOGY_VERSION_ID}
+    user adds note to methodology
     ...    Note which should be deleted
-    ...    2021-09-16T23:00:00Z
-    user removes methodology note via api
-    ...    ${AMENDMENT_METHODOLOGY_VERSION_ID}
-    ...    ${noteIdToRemove}
+    user removes methodology note
+    ...    Note which should be deleted
+    ...    css:#methodologyNotes li:nth-of-type(1)
 
 Add and update another note describing the amendment
-    # TODO EES-2302 / EES-2305 - Replace me when methodology notes can be created via content page
-    ${noteIdToUpdate}=    user creates methodology note via api
-    ...    ${AMENDMENT_METHODOLOGY_VERSION_ID}
+    user adds note to methodology
     ...    Note which should be updated
-    ...    2021-09-16T23:00:00Z
-    user updates methodology note via api
-    ...    ${AMENDMENT_METHODOLOGY_VERSION_ID}
-    ...    ${noteIdToUpdate}
+    user edits methodology note
     ...    Earliest note
-    ...    2021-03-01T00:00:00Z
+    ...    01
+    ...    03
+    ...    2021
+    ...    css:#methodologyNotes li:nth-of-type(1)
 
 Approve the amendment for publishing immediately
     user approves methodology amendment for publication
@@ -168,7 +158,7 @@ Verify that the amended methodology is publicly accessible immediately
 Verify that the amended methodology content is correct
     ${date}=    get current datetime    %-d %B %Y
     user checks summary list contains    Published    ${date}
-    user checks summary list contains    Last updated    17 September 2021
+    user checks summary list contains    Last updated    ${date}
     user waits until page contains accordion section    New and Updated Title
     user opens accordion section    New and Updated Title
     ${content}=    user gets accordion section content element    New and Updated Title
@@ -176,9 +166,10 @@ Verify that the amended methodology content is correct
     user checks element contains    ${content}    New & Updated content
 
 Verify the list of notes
+    ${date}=    get current datetime    %-d %B %Y
     user opens details dropdown    See all notes (2)
     user waits until page contains element    css:[data-testid="notes"] li    limit=2
-    user checks methodology note    1    17 September 2021    Latest note
+    user checks methodology note    1    ${date}    Latest note
     user checks methodology note    2    1 March 2021    Earliest note
     user closes details dropdown    See all notes (2)
 

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -357,18 +357,17 @@ user removes methodology note
 
 user edits methodology note
     [Arguments]
-    ...    ${updated_note}
+    ...    ${note}
     ...    ${day}
     ...    ${month}
     ...    ${year}
-    ...    ${parent}
-    user clicks button     Edit note    ${parent}
+    user clicks button     Edit note    xpath://p[text()="${note}"]/ancestor::li
     user enters text into element    label:Day    ${day}
     user enters text into element    label:Month    ${month}
     user enters text into element    label:Year    ${year}
-    user enters text into element    label:Edit methodology note    ${updated_note}
+    user enters text into element    label:Edit methodology note    ${note} - edited
     user clicks button     Update note
-    user waits until page contains    ${updated_note}
+    user waits until page contains    ${note} - edited
 
 user links publication to external methodology
     [Arguments]

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -337,6 +337,39 @@ user cancels methodology amendment for publication
     user waits until modal is visible    Confirm you want to cancel this amended methodology
     user clicks button    Confirm
 
+user adds note to methodology
+    [Arguments]
+    ...    ${note}
+    user clicks button    Add note
+    user enters text into element    label:New methodology note    ${note}
+    user clicks button    Save note
+    ${date}=    get current datetime    %-d %B %Y
+    user waits until element contains    css:#methodologyNotes time    ${date}
+    user waits until element contains    css:#methodologyNotes p    ${note}
+
+user removes methodology note
+    [Arguments]
+    ...    ${note}
+    ...    ${parent}
+    user clicks button     Remove note    ${parent}
+    user clicks button     Confirm
+    user waits until page does not contain    ${note}
+
+user edits methodology note
+    [Arguments]
+    ...    ${updated_note}
+    ...    ${day}
+    ...    ${month}
+    ...    ${year}
+    ...    ${parent}
+    user clicks button     Edit note    ${parent}
+    user enters text into element    label:Day    ${day}
+    user enters text into element    label:Month    ${month}
+    user enters text into element    label:Year    ${year}
+    user enters text into element    label:Edit methodology note    ${updated_note}
+    user clicks button     Update note
+    user waits until page contains    ${updated_note}
+
 user links publication to external methodology
     [Arguments]
     ...    ${publication}

--- a/tests/robot-tests/tests/libs/admin-utilities.py
+++ b/tests/robot-tests/tests/libs/admin-utilities.py
@@ -35,14 +35,6 @@ def user_signs_in_as(user: str):
     except Exception as e:
         raise_assertion_error(e)
 
-# TODO EES-2302 / EES-2305 - Remove me when methodology notes can be added via content page
-def get_methodology_version_id_from_url():
-    url = sl.get_location()
-    assert '/methodology/' in url, 'URL does not contain /methodology'
-    result = url[len(os.getenv('ADMIN_URL')):].lstrip('/').split('/')
-    assert result[0] == 'methodology', 'String "methodology" should be 1st element in list'
-    return result[1]
-
 def get_theme_id_from_url():
     url = sl.get_location()
     assert '/themes/' in url, 'URL does not contain /themes'

--- a/tests/robot-tests/tests/libs/admin_api.py
+++ b/tests/robot-tests/tests/libs/admin_api.py
@@ -47,49 +47,6 @@ class AdminClient:
 
 admin_client = AdminClient()
 
-# TODO EES-2302 / EES-2305 - Remove me when methodology notes can be added via content page
-def user_creates_methodology_note_via_api(methodologyVersion_id: str, content: str, displayDate: str = '') -> str:
-    assert methodologyVersion_id
-    assert content
-    assert displayDate
-
-    resp = admin_client.post(f'/api/methodologies/{methodologyVersion_id}/notes', {
-        'content': content,
-        'displayDate': displayDate
-    })
-
-    assert resp.status_code == 201, \
-        f'Could not create methodology note! Responded with {resp.status_code} and {resp.text}'
-
-    return resp.json()['id']
-
-# TODO EES-2302 / EES-2305 - Remove me when methodology notes can be removed via content page
-def user_removes_methodology_note_via_api(methodologyVersion_id: str, methodologyNote_id: str = ''):
-    assert methodologyVersion_id
-    assert methodologyNote_id
-
-    resp = admin_client.delete(f'/api/methodologies/{methodologyVersion_id}/notes/{methodologyNote_id}')
-
-    assert resp.status_code == 204, \
-        f'Could not delete methodology note! Responded with {resp.status_code} and {resp.text}'
-
-# TODO EES-2302 / EES-2305 - Remove me when methodology notes can be updated via content page
-def user_updates_methodology_note_via_api(methodologyVersion_id: str, methodologyNote_id: str, content: str, displayDate: str = '') -> str:
-    assert methodologyVersion_id
-    assert methodologyNote_id
-    assert content
-    assert displayDate
-
-    resp = admin_client.put(f'/api/methodologies/{methodologyVersion_id}/notes/{methodologyNote_id}', {
-        'content': content,
-        'displayDate': displayDate
-    })
-
-    assert resp.status_code == 200, \
-        f'Could not update methodology note! Responded with {resp.status_code} and {resp.text}'
-
-    return resp.json()['id']
-
 def user_creates_theme_via_api(title: str, summary: str = '') -> str:
     assert title
 


### PR DESCRIPTION
![notes](https://user-images.githubusercontent.com/81572860/134041500-70b28f7d-084b-45df-85c6-f6d3e595c87b.PNG)

Add, edit and remove methodology notes from the methodology content tab.

Also updates the UI tests and removes the temporary api calls for notes added in https://github.com/dfe-analytical-services/explore-education-statistics/pull/2876/files 