### PR TITLE
EES-2680 Refresh permissions after methodology status update

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -42,7 +42,7 @@ const MethodologyStatusPage = () => {
 
   const {
     value: permissions,
-    setState: setPermissions,
+    retry: refreshPermissions,
     isLoading,
   } = useAsyncRetry(async () => {
     const [canApprove, canMarkAsDraft] = await Promise.all([
@@ -80,14 +80,7 @@ const MethodologyStatusPage = () => {
 
     onMethodologyChange(nextSummary);
 
-    const [nextCanApprove, nextCanMarkAsDraft] = await Promise.all([
-      permissionService.canApproveMethodology(methodologyId),
-      permissionService.canMarkMethodologyAsDraft(methodologyId),
-    ]);
-
-    setPermissions({
-      value: { canApprove: nextCanApprove, canMarkAsDraft: nextCanMarkAsDraft },
-    });
+    refreshPermissions();
 
     toggleForm.off();
   };

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/status/MethodologyStatusPage.tsx
@@ -40,7 +40,11 @@ const MethodologyStatusPage = () => {
 
   const [isEditing, toggleForm] = useToggle(false);
 
-  const { value: permissions, isLoading } = useAsyncRetry(async () => {
+  const {
+    value: permissions,
+    setState: setPermissions,
+    isLoading,
+  } = useAsyncRetry(async () => {
     const [canApprove, canMarkAsDraft] = await Promise.all([
       permissionService.canApproveMethodology(methodologyId),
       permissionService.canMarkMethodologyAsDraft(methodologyId),
@@ -75,6 +79,15 @@ const MethodologyStatusPage = () => {
     );
 
     onMethodologyChange(nextSummary);
+
+    const [nextCanApprove, nextCanMarkAsDraft] = await Promise.all([
+      permissionService.canApproveMethodology(methodologyId),
+      permissionService.canMarkMethodologyAsDraft(methodologyId),
+    ]);
+
+    setPermissions({
+      value: { canApprove: nextCanApprove, canMarkAsDraft: nextCanMarkAsDraft },
+    });
 
     toggleForm.off();
   };

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -65,6 +65,15 @@ Approve the release
     ...    ${RELEASE_NAME} (not Live)
     user approves original release for immediate publication
 
+Verify that the user cannot edit the status of the methodology
+    user views methodology for publication
+    ...    ${PUBLICATION_NAME}
+    ...    ${PUBLICATION_NAME}
+    ...    View this methodology
+    user clicks link    Sign off
+    user waits until h2 is visible    Sign off
+    user checks page does not contain    Edit status
+
 Verify that the methodology is visible on the public methodologies page with the expected URL
     user navigates to public methodologies page
     user waits until page contains accordion section    %{TEST_THEME_NAME}
@@ -145,6 +154,11 @@ Approve the amendment for publishing immediately
     user approves methodology amendment for publication
     ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME} - Amended methodology
+
+Verify that the user cannot edit the status of the amended methodology
+    user clicks link    Sign off
+    user waits until h2 is visible    Sign off
+    user checks page does not contain    Edit status
 
 Verify that the amended methodology is visible on the public methodologies page immediately
     user navigates to public methodologies page


### PR DESCRIPTION
This PR makes a change to the methodology Sign off view to refresh the permissions after the form is submitted.

Depending on the new status and the status of releases that are using this methodology, the permissions can change which affect whether the 'Edit status' button should still be shown or not.

Example:

* If a user approves a methodology for publishing immediately and it's already used by a published release, then its publicly accessible immediately. The ‘Edit status’ button should not be visible since it’s publicly accessible and can't be modified except by creating an amendment.

* If a user approves a methodology for publishing immediately and it's _not_ used by any published release, then it's not yet made publicly accessible. We continue to show the 'Edit status' button so that it can still be unapproved, or the publishing strategy can be changed.

I was unsure how to test this change but a couple of additional steps are added in to the UI tests to at least make sure that users just arriving at the Sign off view can't edit the status if the methodology is already publicly accessible.