### PR TITLE
EES-2715 Rename TimePeriodRangeLabels back to TimePeriodLabels

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/FootnoteControllerTests.cs
@@ -97,7 +97,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                                 id: id,
                                 name: $"Subject {id}",
                                 content: "Test content",
-                                timePeriodRange: new TimePeriodRangeLabels(),
+                                timePeriods: new TimePeriodLabels(),
                                 geographicLevels: new List<string>(),
                                 file: new FileInfo
                                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -43,7 +43,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     {
                         "National", "Local Authority", "Local Authority District"
                     },
-                    TimePeriodsRange = new TimePeriodRangeLabels("2020/21 Q3", "2021/22 Q1"),
+                    TimePeriods = new TimePeriodLabels("2020/21 Q3", "2021/22 Q1"),
                     Variables = new List<LabelValue>
                     {
                         new LabelValue("Filter label", "test_filter"),

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataGuidanceFileWriterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/DataGuidanceFileWriterTests.cs
@@ -141,7 +141,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                         "National",
                         "Regional"
                     },
-                    TimePeriodsRange = new TimePeriodRangeLabels("2018", "2020"),
+                    TimePeriods = new TimePeriodLabels("2018", "2020"),
                     Variables = new List<LabelValue>
                     {
                         new("Accommodation type", "accommodation_type"),
@@ -168,7 +168,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     {
                         "National",
                     },
-                    TimePeriodsRange = new TimePeriodRangeLabels("2018", "2018"),
+                    TimePeriods = new TimePeriodLabels("2018", "2018"),
                     Variables = new List<LabelValue>
                     {
                         new("Academic age", "age"),
@@ -250,7 +250,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                         "National",
                         "Regional"
                     },
-                    TimePeriodsRange = new TimePeriodRangeLabels("2018", "2020"),
+                    TimePeriods = new TimePeriodLabels("2018", "2020"),
                     Variables = new List<LabelValue>
                     {
                         new("Accommodation type", "accommodation_type"),
@@ -330,7 +330,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                         "National",
                         "Regional"
                     },
-                    TimePeriodsRange = new TimePeriodRangeLabels("2018", "2020"),
+                    TimePeriods = new TimePeriodLabels("2018", "2020"),
                     Variables = new List<LabelValue>
                     {
                         new("Accommodation type", "accommodation_type"),
@@ -447,7 +447,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     {
                         "Local Authority",
                     },
-                    TimePeriodsRange = new TimePeriodRangeLabels("2018", "2018"),
+                    TimePeriods = new TimePeriodLabels("2018", "2018"),
                     Variables = new List<LabelValue>
                     {
                         new("Accommodation type", "accommodation_type"),
@@ -570,7 +570,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     Name = "Test data 1",
                     Content = "",
                     GeographicLevels = new List<string>(),
-                    TimePeriodsRange = new TimePeriodRangeLabels("", "2019"),
+                    TimePeriods = new TimePeriodLabels("", "2019"),
                     Variables = new List<LabelValue>()
                 }
             };
@@ -628,7 +628,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 {
                     Filename = "test-1.csv",
                     Name = "Test data 1",
-                    TimePeriodsRange = new TimePeriodRangeLabels("2018", ""),
+                    TimePeriods = new TimePeriodLabels("2018", ""),
                 }
             };
 
@@ -685,7 +685,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 {
                     Filename = "test-1.csv",
                     Name = "Test data 1",
-                    TimePeriodsRange = new TimePeriodRangeLabels("2018", ""),
+                    TimePeriods = new TimePeriodLabels("2018", ""),
                     Variables = new List<LabelValue>
                     {
                         new("", "")
@@ -748,7 +748,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     Name = "Test data 1",
                     Content = "",
                     GeographicLevels = new List<string>(),
-                    TimePeriodsRange = new TimePeriodRangeLabels("2018", ""),
+                    TimePeriods = new TimePeriodLabels("2018", ""),
                     Variables = new List<LabelValue>
                     {
                         new("Accommodation type", "accommodation_type"),
@@ -831,7 +831,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     Name = "Test data 1",
                     Content = "",
                     GeographicLevels = new List<string>(),
-                    TimePeriodsRange = new TimePeriodRangeLabels("2018", ""),
+                    TimePeriods = new TimePeriodLabels("2018", ""),
                     Variables = new List<LabelValue>
                     {
                         new("Accommodation type", "accommodation_type"),

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MetaGuidanceServiceTests.cs
@@ -28,7 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                     {
                         "National", "Local Authority", "Local Authority District"
                     },
-                    TimePeriodsRange = new TimePeriodRangeLabels("2020_AYQ3", "2021_AYQ1"),
+                    TimePeriods = new TimePeriodLabels("2020_AYQ3", "2021_AYQ1"),
                     Variables = new List<LabelValue>
                     {
                         new LabelValue("Filter label", "test_filter"),

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
@@ -121,7 +121,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                         await file.WriteLineAsync("Geographic levels: " + string.Join("; ", subject.GeographicLevels));
                     }
 
-                    var timePeriodsLabel = subject.TimePeriodsRange.ToLabel();
+                    var timePeriodsLabel = subject.TimePeriods.ToLabel();
 
                     if (!timePeriodsLabel.IsNullOrWhitespace())
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/MetaGuidanceSubjectServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/MetaGuidanceSubjectServiceTests.cs
@@ -293,8 +293,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal("file1.csv", result[0].Filename);
                 Assert.Equal("Subject 1", result[0].Name);
 
-                Assert.Equal("2020/21 Q3", result[0].TimePeriodsRange.From);
-                Assert.Equal("2021/22 Q1", result[0].TimePeriodsRange.To);
+                Assert.Equal("2020/21 Q3", result[0].TimePeriods.From);
+                Assert.Equal("2021/22 Q1", result[0].TimePeriods.To);
                 Assert.Equal(new List<string>
                 {
                     "National",
@@ -321,8 +321,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal("file2.csv", result[1].Filename);
                 Assert.Equal("Subject 2", result[1].Name);
 
-                Assert.Equal("2020/21 Summer Term", result[1].TimePeriodsRange.From);
-                Assert.Equal("2021/22 Spring Term", result[1].TimePeriodsRange.To);
+                Assert.Equal("2020/21 Summer Term", result[1].TimePeriods.From);
+                Assert.Equal("2021/22 Spring Term", result[1].TimePeriods.To);
                 Assert.Equal(new List<string>
                 {
                     "National",
@@ -549,8 +549,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal("Subject 1 Meta Guidance", result.Right[0].Content);
                 Assert.Equal("file1.csv", result.Right[0].Filename);
                 Assert.Equal("Subject 1", result.Right[0].Name);
-                Assert.Empty(result.Right[0].TimePeriodsRange.From);
-                Assert.Empty(result.Right[0].TimePeriodsRange.To);
+                Assert.Empty(result.Right[0].TimePeriods.From);
+                Assert.Empty(result.Right[0].TimePeriods.To);
                 Assert.Empty(result.Right[0].GeographicLevels);
                 Assert.Empty(result.Right[0].Variables);
 
@@ -558,8 +558,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal("Subject 3 Meta Guidance", result.Right[1].Content);
                 Assert.Equal("file3.csv", result.Right[1].Filename);
                 Assert.Equal("Subject 3", result.Right[1].Name);
-                Assert.Empty(result.Right[1].TimePeriodsRange.From);
-                Assert.Empty(result.Right[1].TimePeriodsRange.To);
+                Assert.Empty(result.Right[1].TimePeriods.From);
+                Assert.Empty(result.Right[1].TimePeriods.To);
                 Assert.Empty(result.Right[1].GeographicLevels);
                 Assert.Empty(result.Right[1].Variables);
             }
@@ -732,8 +732,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal("Version 1 Subject 1 Meta Guidance", version1Result.Right[0].Content);
                 Assert.Equal("file1.csv", version1Result.Right[0].Filename);
                 Assert.Equal("Subject 1", version1Result.Right[0].Name);
-                Assert.Empty(version1Result.Right[0].TimePeriodsRange.From);
-                Assert.Empty(version1Result.Right[0].TimePeriodsRange.To);
+                Assert.Empty(version1Result.Right[0].TimePeriods.From);
+                Assert.Empty(version1Result.Right[0].TimePeriods.To);
                 Assert.Empty(version1Result.Right[0].GeographicLevels);
                 Assert.Empty(version1Result.Right[0].Variables);
 
@@ -748,16 +748,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal("Version 2 Subject 1 Meta Guidance", version2Result.Right[0].Content);
                 Assert.Equal("file1.csv", version2Result.Right[0].Filename);
                 Assert.Equal("Subject 1", version2Result.Right[0].Name);
-                Assert.Empty(version2Result.Right[0].TimePeriodsRange.From);
-                Assert.Empty(version2Result.Right[0].TimePeriodsRange.To);
+                Assert.Empty(version2Result.Right[0].TimePeriods.From);
+                Assert.Empty(version2Result.Right[0].TimePeriods.To);
                 Assert.Empty(version2Result.Right[0].GeographicLevels);
 
                 Assert.Equal(subject2.Id, version2Result.Right[1].Id);
                 Assert.Equal("Version 2 Subject 2 Meta Guidance", version2Result.Right[1].Content);
                 Assert.Equal("file2.csv", version2Result.Right[1].Filename);
                 Assert.Equal("Subject 2", version2Result.Right[1].Name);
-                Assert.Empty(version2Result.Right[1].TimePeriodsRange.From);
-                Assert.Empty(version2Result.Right[1].TimePeriodsRange.To);
+                Assert.Empty(version2Result.Right[1].TimePeriods.From);
+                Assert.Empty(version2Result.Right[1].TimePeriods.To);
                 Assert.Empty(version2Result.Right[1].GeographicLevels);
                 Assert.Empty(version2Result.Right[1].Variables);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/PublicationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/PublicationServiceTests.cs
@@ -54,7 +54,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     id: Guid.NewGuid(),
                     name: "Subject 1",
                     content: "Subject 1 content",
-                    timePeriodRange: new TimePeriodRangeLabels("2018", "2021"),
+                    timePeriods: new TimePeriodLabels("2018", "2021"),
                     geographicLevels: ListOf("National", "Local Authority"),
                     file: new FileInfo
                     {
@@ -67,7 +67,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     id: Guid.NewGuid(),
                     name: "Subject 2",
                     content: "Subject 2 content",
-                    timePeriodRange: new TimePeriodRangeLabels("2015", "2020"),
+                    timePeriods: new TimePeriodLabels("2015", "2020"),
                     geographicLevels: ListOf("Local Authority District"),
                     file: new FileInfo
                     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ReleaseServiceTests.cs
@@ -108,12 +108,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 var timePeriodService = new Mock<ITimePeriodService>();
 
                 timePeriodService
-                    .Setup(s => s.GetTimePeriodRangeLabels(releaseSubject1.SubjectId))
-                    .Returns(new TimePeriodRangeLabels("2020/21", "2021/22"));
+                    .Setup(s => s.GetTimePeriodLabels(releaseSubject1.SubjectId))
+                    .Returns(new TimePeriodLabels("2020/21", "2021/22"));
 
                 timePeriodService
-                    .Setup(s => s.GetTimePeriodRangeLabels(releaseSubject2.SubjectId))
-                    .Returns(new TimePeriodRangeLabels("2030", "2031"));
+                    .Setup(s => s.GetTimePeriodLabels(releaseSubject2.SubjectId))
+                    .Returns(new TimePeriodLabels("2030", "2031"));
 
                 metaGuidanceSubjectService
                     .Setup(s => s.GetGeographicLevels(releaseSubject1.SubjectId))
@@ -180,8 +180,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 Assert.Equal(releaseSubject1.MetaGuidance, subjects[0].Content);
 
-                Assert.Equal("2020/21", subjects[0].TimePeriodRange.From);
-                Assert.Equal("2021/22", subjects[0].TimePeriodRange.To);
+                Assert.Equal("2020/21", subjects[0].TimePeriods.From);
+                Assert.Equal("2021/22", subjects[0].TimePeriods.To);
 
                 Assert.Equal(2, subjects[0].GeographicLevels.Count);
                 Assert.Equal("Local Authority", subjects[0].GeographicLevels[0]);
@@ -195,8 +195,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal(releaseSubject2.MetaGuidance, subjects[1].Content);
                 Assert.Equal("csv", subjects[1].File.Extension);
 
-                Assert.Equal("2030", subjects[1].TimePeriodRange.From);
-                Assert.Equal("2031", subjects[1].TimePeriodRange.To);
+                Assert.Equal("2030", subjects[1].TimePeriods.From);
+                Assert.Equal("2031", subjects[1].TimePeriods.To);
 
                 Assert.Single(subjects[1].GeographicLevels);
                 Assert.Equal("National", subjects[1].GeographicLevels[0]);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TimePeriodServiceTests.cs
@@ -117,7 +117,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         }
 
         [Fact]
-        public async Task GetTimePeriodRangeLabels()
+        public async Task GetTimePeriodLabels()
         {
             var release = new Release();
 
@@ -172,7 +172,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 var service = new TimePeriodService(statisticsDbContext);
 
-                var result = service.GetTimePeriodRangeLabels(subject.Id);
+                var result = service.GetTimePeriodLabels(subject.Id);
 
                 Assert.Equal("2020/21 Q4", result.From);
                 Assert.Equal("2030/31 Q3", result.To);
@@ -180,7 +180,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         }
 
         [Fact]
-        public async Task GetTimePeriodRangeLabels_CorrectlyOrderWeeks()
+        public async Task GetTimePeriodLabels_CorrectlyOrderWeeks()
         {
             var release = new Release();
 
@@ -234,7 +234,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 var service = new TimePeriodService(statisticsDbContext);
 
-                var result = service.GetTimePeriodRangeLabels(subject.Id);
+                var result = service.GetTimePeriodLabels(subject.Id);
 
                 Assert.Equal("2020 Week 8", result.From);
                 Assert.Equal("2020 Week 37", result.To);
@@ -242,7 +242,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         }
 
         [Fact]
-        public async Task GetTimePeriodRangeLabels_NoObservations()
+        public async Task GetTimePeriodLabels_NoObservations()
         {
             var release = new Release();
 
@@ -269,7 +269,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 var service = new TimePeriodService(statisticsDbContext);
 
-                var result = service.GetTimePeriodRangeLabels(subject.Id);
+                var result = service.GetTimePeriodLabels(subject.Id);
 
                 Assert.Empty(result.From);
                 Assert.Empty(result.To);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ITimePeriodService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ITimePeriodService.cs
@@ -15,6 +15,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
 
         IEnumerable<(int Year, TimeIdentifier TimeIdentifier)> GetTimePeriodRange(IQueryable<Observation> observations);
 
-        TimePeriodRangeLabels GetTimePeriodRangeLabels(Guid subjectId);
+        TimePeriodLabels GetTimePeriodLabels(Guid subjectId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/MetaGuidanceSubjectService.cs
@@ -136,7 +136,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     releaseSubject.SubjectId);
 
             var geographicLevels = await GetGeographicLevels(subject.Id);
-            var timePeriods = _timePeriodService.GetTimePeriodRangeLabels(subject.Id);
+            var timePeriods = _timePeriodService.GetTimePeriodLabels(subject.Id);
             var variables = GetVariables(subject.Id);
             var footnotes = GetFootnotes(releaseSubject.ReleaseId, subject.Id);
 
@@ -147,7 +147,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 Filename = releaseFile.File.Filename,
                 Name = releaseFile.Name ?? "",
                 GeographicLevels = geographicLevels,
-                TimePeriodsRange = timePeriods,
+                TimePeriods = timePeriods,
                 Variables = variables,
                 Footnotes = footnotes
             };

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
@@ -90,7 +90,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                             id: rs.SubjectId,
                             name: await GetSubjectName(releaseId, rs.SubjectId),
                             content: rs.MetaGuidance,
-                            timePeriodRange: _timePeriodService.GetTimePeriodRangeLabels(rs.SubjectId),
+                            timePeriods: _timePeriodService.GetTimePeriodLabels(rs.SubjectId),
                             geographicLevels: await _metaGuidanceSubjectService.GetGeographicLevels(rs.SubjectId),
                             file: blobInfo is null
                                 ? releaseFile.ToPublicFileInfoNotFound()

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TimePeriodService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TimePeriodService.cs
@@ -50,7 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             return TimePeriodUtil.GetTimePeriodRange(start, end);
         }
 
-        public TimePeriodRangeLabels GetTimePeriodRangeLabels(Guid subjectId)
+        public TimePeriodLabels GetTimePeriodLabels(Guid subjectId)
         {
             var observationsQuery = _context
                 .Observation
@@ -59,13 +59,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
             if (!orderedTimePeriods.Any())
             {
-                return new TimePeriodRangeLabels();
+                return new TimePeriodLabels();
             }
 
             var first = orderedTimePeriods.First();
             var last = orderedTimePeriods.Last();
 
-            return new TimePeriodRangeLabels(
+            return new TimePeriodLabels(
                 TimePeriodLabelFormatter.Format(first.Year, first.TimeIdentifier),
                 TimePeriodLabelFormatter.Format(last.Year, last.TimeIdentifier));
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/MetaGuidanceSubjectViewModel.cs
@@ -15,7 +15,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
 
         public string Content { get; set; } = string.Empty;
 
-        public TimePeriodRangeLabels TimePeriodsRange { get; set; } = new TimePeriodRangeLabels();
+        public TimePeriodLabels TimePeriods { get; set; } = new TimePeriodLabels();
 
         public List<string> GeographicLevels { get; set; } = new List<string>();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/SubjectViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/SubjectViewModel.cs
@@ -13,7 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
 
         public string Content { get; }
 
-        public TimePeriodRangeLabels TimePeriodRange { get; }
+        public TimePeriodLabels TimePeriods { get; }
 
         public List<string> GeographicLevels { get; }
 
@@ -23,14 +23,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
             Guid id,
             string name,
             string content,
-            TimePeriodRangeLabels timePeriodRange,
+            TimePeriodLabels timePeriods,
             List<string> geographicLevels,
             FileInfo file)
         {
             Id = id;
             Name = name;
             Content = content;
-            TimePeriodRange = timePeriodRange;
+            TimePeriods = timePeriods;
             GeographicLevels = geographicLevels;
             File = file;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/TimePeriodLabels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/TimePeriodLabels.cs
@@ -4,16 +4,16 @@ using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels
 {
-    public class TimePeriodRangeLabels
+    public class TimePeriodLabels
     {
         public string From { get; } = string.Empty;
         public string To { get; } = string.Empty;
 
-        public TimePeriodRangeLabels()
+        public TimePeriodLabels()
         {
         }
 
-        public TimePeriodRangeLabels(string from, string to)
+        public TimePeriodLabels(string from, string to)
         {
             From = from;
             To = to;


### PR DESCRIPTION
After changing TimePeriods to TimePeriodRange, this broke the app as the frontend was expecting `timePeriods` not `timePeriodRange`. So I've changed everything back to what it was originally named rather than changing the frontend, just in case this is cached somewhere.