### PR TITLE
EES-2721 Cleanup radio group markup across data catalogue

### DIFF
--- a/src/explore-education-statistics-common/src/components/form/FormFieldRadioGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldRadioGroup.tsx
@@ -15,7 +15,7 @@ function FormFieldRadioGroup<FormValues, Value extends string = string>(
   return (
     <FormField<Value> {...props}>
       {({ id, field }) => (
-        <FormRadioGroup
+        <FormRadioGroup<Value>
           {...props}
           {...field}
           id={id}

--- a/src/explore-education-statistics-common/src/components/form/FormFieldRadioSearchGroup.module.scss
+++ b/src/explore-education-statistics-common/src/components/form/FormFieldRadioSearchGroup.module.scss
@@ -1,7 +1,0 @@
-@import '~govuk-frontend/govuk/base';
-
-.optionsContainer {
-  margin: govuk-spacing(4) 0 govuk-spacing(1);
-  overflow-y: auto;
-  padding: govuk-spacing(2);
-}

--- a/src/explore-education-statistics-common/src/components/form/FormRadioGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormRadioGroup.tsx
@@ -18,8 +18,9 @@ export type RadioOption<Value extends string = string> = PartialBy<
   value: Value;
 };
 
-export type FormRadioGroupProps<Value extends string = string> = {
+export type BaseFormRadioGroupProps<Value extends string = string> = {
   disabled?: boolean;
+  id: string;
   inline?: boolean;
   name: string;
   onBlur?: FocusEventHandler<HTMLInputElement>;
@@ -29,27 +30,60 @@ export type FormRadioGroupProps<Value extends string = string> = {
   order?: OrderKeys<RadioOption<Value>>;
   orderDirection?: OrderDirection | OrderDirection[];
   value?: string;
-} & OmitStrict<FormFieldsetProps, 'useFormId' | 'onBlur' | 'onFocus'> & {
-    useFieldsetFormId?: boolean;
+};
+
+/**
+ * Base radio group without wrapping fieldset.
+ */
+export const BaseFormRadioGroup = <Value extends string = string>({
+  id,
+  inline = false,
+  small = false,
+  order = ['label'],
+  orderDirection = ['asc'],
+  options,
+  value = '',
+  ...props
+}: BaseFormRadioGroupProps<Value>) => {
+  return (
+    <div
+      className={classNames('govuk-radios', {
+        'govuk-radios--inline': inline,
+        'govuk-radios--small': small,
+      })}
+    >
+      {naturalOrderBy(options, order, orderDirection).map(option => (
+        <FormRadio
+          {...props}
+          {...option}
+          id={
+            option.id
+              ? `${id}-${option.id}`
+              : `${id}-${option.value.replace(/\s/g, '-')}`
+          }
+          checked={value === option.value}
+          key={option.value}
+        />
+      ))}
+    </div>
+  );
+};
+
+export type FormRadioGroupProps<
+  Value extends string = string
+> = BaseFormRadioGroupProps<Value> &
+  OmitStrict<FormFieldsetProps, 'useFormId' | 'onBlur' | 'onFocus'> & {
     onFieldsetBlur?: FocusEventHandler<HTMLFieldSetElement>;
     onFieldsetFocus?: FocusEventHandler<HTMLFieldSetElement>;
   };
 
 const FormRadioGroup = <Value extends string = string>({
   hint,
-  inline = false,
   legendSize = 'm',
-  small = false,
-  order = ['label'],
-  orderDirection = ['asc'],
-  options,
-  value = '',
   onFieldsetBlur,
   onFieldsetFocus,
   ...props
 }: FormRadioGroupProps<Value>) => {
-  const { id } = props;
-
   return (
     <FormFieldset
       {...props}
@@ -59,26 +93,7 @@ const FormRadioGroup = <Value extends string = string>({
       onBlur={onFieldsetBlur}
       onFocus={onFieldsetFocus}
     >
-      <div
-        className={classNames('govuk-radios', {
-          'govuk-radios--inline': inline,
-          'govuk-radios--small': small,
-        })}
-      >
-        {naturalOrderBy(options, order, orderDirection).map(option => (
-          <FormRadio
-            {...props}
-            {...option}
-            id={
-              option.id
-                ? `${id}-${option.id}`
-                : `${id}-${option.value.replace(/\s/g, '-')}`
-            }
-            checked={value === option.value}
-            key={option.value}
-          />
-        ))}
-      </div>
+      <BaseFormRadioGroup {...props} />
     </FormFieldset>
   );
 };

--- a/src/explore-education-statistics-common/src/components/form/FormRadioSearchGroup.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormRadioSearchGroup.tsx
@@ -1,9 +1,11 @@
+import { FormFieldsetProps } from '@common/components/form/FormFieldset';
 import FormTextSearchInput from '@common/components/form/FormTextSearchInput';
+import { FormFieldset } from '@common/components/form/index';
 import useMounted from '@common/hooks/useMounted';
 import FormRadioGroup, {
+  BaseFormRadioGroup,
   FormRadioGroupProps,
 } from '@common/components/form/FormRadioGroup';
-import styles from '@common/components/form/FormFieldRadioSearchGroup.module.scss';
 import React, { useState } from 'react';
 
 export interface FormRadioSearchGroupProps extends FormRadioGroupProps {
@@ -14,11 +16,35 @@ const FormRadioSearchGroup = ({
   searchLabel = 'Search',
   ...props
 }: FormRadioSearchGroupProps) => {
-  const { id, legend, name, options } = props;
   const { isMounted } = useMounted();
 
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedOption, setSelectedOption] = useState('');
+
+  const {
+    id,
+    hint,
+    legend,
+    legendHidden,
+    legendSize = 'm',
+    error,
+    name,
+    onFieldsetFocus,
+    onFieldsetBlur,
+    options = [],
+    ...groupProps
+  } = props;
+
+  const fieldsetProps: FormFieldsetProps = {
+    id,
+    legend,
+    legendHidden,
+    legendSize,
+    hint,
+    error,
+    onFocus: onFieldsetFocus,
+    onBlur: onFieldsetBlur,
+  };
 
   if (!isMounted) {
     return (
@@ -44,25 +70,28 @@ const FormRadioSearchGroup = ({
   }
 
   return (
-    <>
-      <FormTextSearchInput
-        id={`${id}-search`}
-        name={`${name}-search`}
-        label={searchLabel}
-        width={20}
-        onChange={event => setSearchTerm(event.target.value)}
-        onKeyPress={event => {
-          if (event.key === 'Enter') {
-            event.preventDefault();
-          }
-        }}
-      />
-      <div aria-live="assertive" className={styles.optionsContainer}>
+    <FormFieldset {...fieldsetProps} useFormId={false}>
+      {options.length > 1 && (
+        <FormTextSearchInput
+          id={`${id}-search`}
+          className="govuk-!-margin-bottom-4"
+          name={`${name}-search`}
+          label={searchLabel}
+          width={20}
+          onChange={event => setSearchTerm(event.target.value)}
+          onKeyPress={event => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+            }
+          }}
+        />
+      )}
+
+      <div aria-live="assertive">
         {filteredOptions.length > 0 ? (
-          <FormRadioGroup
-            {...props}
+          <BaseFormRadioGroup
+            {...groupProps}
             name={name}
-            legend={legend}
             id={id}
             options={filteredOptions}
             onChange={(event, option) => {
@@ -76,7 +105,7 @@ const FormRadioSearchGroup = ({
           <p>No results found</p>
         )}
       </div>
-    </>
+    </FormFieldset>
   );
 };
 

--- a/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormRadioSearchGroup.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/components/form/__tests__/__snapshots__/FormRadioSearchGroup.test.tsx.snap
@@ -1,27 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormRadioSearchGroup renders list of radio buttons in correct order 1`] = `
-<label class="govuk-label"
-       for="test-radios-search"
->
-  Search
-</label>
-<input name="testRadios-search"
-       class="govuk-input searchInput govuk-input--width-20"
-       id="test-radios-search"
-       type="text"
-       value
->
-<div aria-live="assertive"
-     class="optionsContainer"
->
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset"
-              id="test-radios"
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset"
+            id="test-radios"
+  >
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+      Choose options
+    </legend>
+    <label class="govuk-label"
+           for="test-radios-search"
     >
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-        Choose options
-      </legend>
+      Search
+    </label>
+    <input name="testRadios-search"
+           class="govuk-input govuk-!-margin-bottom-4 searchInput govuk-input--width-20"
+           id="test-radios-search"
+           type="text"
+           value
+    >
+    <div aria-live="assertive">
       <div class="govuk-radios">
         <div class="govuk-radios__item"
              data-testid="Radio item for Test radio 1"
@@ -69,7 +67,7 @@ exports[`FormRadioSearchGroup renders list of radio buttons in correct order 1`]
           </label>
         </div>
       </div>
-    </fieldset>
-  </div>
+    </div>
+  </fieldset>
 </div>
 `;

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/ReleaseForm.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/ReleaseForm.tsx
@@ -1,22 +1,16 @@
-import {
-  Form,
-  FormFieldRadioGroup,
-  FormGroup,
-  FormTextSearchInput,
-  FormFieldset,
-} from '@common/components/form';
+import { Form } from '@common/components/form';
+import FormFieldRadioSearchGroup from '@common/components/form/FormFieldRadioSearchGroup';
 import { FormFieldsetProps } from '@common/components/form/FormFieldset';
 import { RadioOption } from '@common/components/form/FormRadioGroup';
-import ResetFormOnPreviousStep from '@common/modules/table-tool/components/ResetFormOnPreviousStep';
-import Yup from '@common/validation/yup';
-import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
-import WizardStepFormActions from '@common/modules/table-tool/components/WizardStepFormActions';
-import createErrorHelper from '@common/validation/createErrorHelper';
-import { ReleaseSummary } from '@common/services/publicationService';
 import Tag from '@common/components/Tag';
 import useFormSubmit from '@common/hooks/useFormSubmit';
+import ResetFormOnPreviousStep from '@common/modules/table-tool/components/ResetFormOnPreviousStep';
+import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
+import WizardStepFormActions from '@common/modules/table-tool/components/WizardStepFormActions';
+import { ReleaseSummary } from '@common/services/publicationService';
+import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
-import React, { ReactNode, useMemo, useState } from 'react';
+import React, { ReactNode, useMemo } from 'react';
 
 export interface ReleaseFormValues {
   releaseId: string;
@@ -40,8 +34,6 @@ interface Props {
 const ReleaseForm = ({
   goToNextStep,
   legend,
-  legendSize = 'l',
-  legendHint,
   initialValues = {
     releaseId: '',
   },
@@ -49,32 +41,21 @@ const ReleaseForm = ({
   options,
   ...stepProps
 }: Props & InjectedWizardProps) => {
-  const [searchTerm, setSearchTerm] = useState('');
   const { isActive, currentStep, stepNumber } = stepProps;
 
   const radioOptions = useMemo<RadioOption[]>(
     () =>
-      options
-        .filter(option => {
-          if (!searchTerm) {
-            return option;
-          }
-          if (option.title.toLowerCase().includes(searchTerm.toLowerCase())) {
-            return option;
-          }
-          return null;
-        })
-        .map(option => {
-          return {
-            label: option.title,
-            hint: option.latestRelease ? (
-              <Tag strong>This is the latest data</Tag>
-            ) : undefined,
-            inlineHint: true,
-            value: option.id,
-          };
-        }),
-    [options, searchTerm],
+      options.map(option => {
+        return {
+          label: option.title,
+          hint: option.latestRelease ? (
+            <Tag strong>This is the latest data</Tag>
+          ) : undefined,
+          inlineHint: true,
+          value: option.id,
+        };
+      }),
+    [options],
   );
 
   const handleSubmit = useFormSubmit(
@@ -106,44 +87,15 @@ const ReleaseForm = ({
       onSubmit={handleSubmit}
     >
       {form => {
-        const { getError } = createErrorHelper(form);
         return isActive ? (
           <Form id={formId} showSubmitError>
-            <FormFieldset
-              error={getError('release')}
-              id="release"
+            <FormFieldRadioSearchGroup<ReleaseFormValues>
+              name="releaseId"
               legend={legend}
-              legendSize={legendSize}
-              hint={legendHint}
-            >
-              {options.length > 1 && (
-                <FormGroup>
-                  <FormTextSearchInput
-                    id={`${formId}-releaseIdSearch`}
-                    label="Search releases"
-                    name="releaseSearch"
-                    onChange={event => setSearchTerm(event.target.value)}
-                    onKeyPress={event => {
-                      if (event.key === 'Enter') {
-                        event.preventDefault();
-                      }
-                    }}
-                    width={20}
-                  />
-                </FormGroup>
-              )}
-              {options.length > 0 && (
-                <FormFieldRadioGroup<ReleaseFormValues>
-                  name="releaseId"
-                  legendSize={legendSize}
-                  legend="Choose a release from the list below"
-                  legendHidden
-                  disabled={form.isSubmitting}
-                  options={radioOptions}
-                  order={[]}
-                />
-              )}
-            </FormFieldset>
+              disabled={form.isSubmitting}
+              options={radioOptions}
+              order={[]}
+            />
 
             {options.length > 0 ? (
               <WizardStepFormActions {...stepProps} />

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/ReleaseStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/ReleaseStep.tsx
@@ -31,7 +31,9 @@ const ReleaseStep = ({
       Choose a release
     </WizardStepHeading>
   );
-  // isMounted check required as Formik context can be undefined if the step is active on page load.
+
+  // isMounted check required as Formik context can be
+  // undefined if the step is active on page load.
   if (isActive && isMounted) {
     return (
       <ReleaseForm

--- a/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/ReleaseStep.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/data-catalogue/components/__tests__/ReleaseStep.test.tsx
@@ -2,7 +2,7 @@ import { ReleaseFormSubmitHandler } from '@frontend/modules/data-catalogue/compo
 import ReleaseStep from '@frontend/modules/data-catalogue/components/ReleaseStep';
 import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
 import { ReleaseSummary } from '@common/services/publicationService';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import noop from 'lodash/noop';
@@ -47,22 +47,15 @@ describe('ReleaseStep', () => {
 
     expect(screen.getByText('Choose a release')).toBeInTheDocument();
 
-    expect(screen.getByLabelText('Search releases')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Search/)).toBeInTheDocument();
 
-    const releasesGroup = within(
-      screen.getByRole('group', {
-        name: 'Choose a release from the list below',
-      }),
-    );
-    const releases = releasesGroup.getAllByRole('radio');
+    const releases = screen.getAllByRole('radio');
 
     expect(releases.length).toBe(3);
     expect(releases[0]).toHaveAttribute('value', 'release-3');
     expect(releases[0]).toBeEnabled();
     expect(releases[0]).not.toBeChecked();
-    expect(releases[0]).toEqual(
-      releasesGroup.getByLabelText('Academic Year 2021/22'),
-    );
+    expect(releases[0]).toEqual(screen.getByLabelText('Academic Year 2021/22'));
     expect(
       screen.getByTestId('Radio item for Academic Year 2021/22'),
     ).toHaveTextContent('This is the latest data');
@@ -70,16 +63,12 @@ describe('ReleaseStep', () => {
     expect(releases[1]).toHaveAttribute('value', 'release-2');
     expect(releases[1]).toBeEnabled();
     expect(releases[1]).not.toBeChecked();
-    expect(releases[1]).toEqual(
-      releasesGroup.getByLabelText('Academic Year 2020/21'),
-    );
+    expect(releases[1]).toEqual(screen.getByLabelText('Academic Year 2020/21'));
 
     expect(releases[2]).toHaveAttribute('value', 'release-1');
     expect(releases[2]).toBeEnabled();
     expect(releases[2]).not.toBeChecked();
-    expect(releases[2]).toEqual(
-      releasesGroup.getByLabelText('Academic Year 2019/20'),
-    );
+    expect(releases[2]).toEqual(screen.getByLabelText('Academic Year 2019/20'));
 
     expect(
       screen.getByRole('button', { name: 'Next step' }),
@@ -93,7 +82,7 @@ describe('ReleaseStep', () => {
 
     expect(screen.getAllByRole('radio')).toHaveLength(3);
 
-    await userEvent.type(screen.getByLabelText('Search releases'), '2020/21');
+    await userEvent.type(screen.getByLabelText(/Search/), '2020/21');
 
     await waitFor(() => {
       expect(screen.getAllByRole('radio')).toHaveLength(1);
@@ -113,14 +102,9 @@ describe('ReleaseStep', () => {
       />,
     );
 
-    expect(screen.queryByLabelText('Search releases')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Search/)).not.toBeInTheDocument();
 
-    const releasesGroup = within(
-      screen.getByRole('group', {
-        name: 'Choose a release from the list below',
-      }),
-    );
-    const releases = releasesGroup.getAllByRole('radio');
+    const releases = screen.getAllByRole('radio');
 
     expect(releases.length).toBe(1);
     expect(releases[0]).toHaveAttribute('value', 'release-3');
@@ -131,7 +115,7 @@ describe('ReleaseStep', () => {
   test('renders a message when there are no releases', () => {
     render(<ReleaseStep {...wizardProps} releases={[]} onSubmit={noop} />);
 
-    expect(screen.queryByLabelText('Search releases')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Search/)).not.toBeInTheDocument();
 
     expect(
       screen.queryByRole('group', {


### PR DESCRIPTION
This removes unnecessarily nested `fieldset` elements across the data catalogue's release step. This kind of nesting is poor for
accessibility and breaks with the step patterns used in the table tool wizard.

We have mostly fixed this by refactoring `FormRadioGroup` (and its associated field/search groups) to be nearly identical to its checkbox group counterparts.