### PR TITLE
EES-2698 Fix failing UI tests caused by removing incorrect analyst Release roles

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/users/components/PublicationAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/PublicationAccessForm.tsx
@@ -83,7 +83,7 @@ const PublicationAccessForm = ({
                 </div>
               </div>
             </FormFieldset>
-            <table className="govuk-table">
+            <table className="govuk-table" data-testid="publicationAccessTable">
               <thead className="govuk-table__head">
                 <tr className="govuk-table__row">
                   <th scope="col" className="govuk-table__header">
@@ -114,7 +114,6 @@ const PublicationAccessForm = ({
                       <td className="govuk-table__cell">
                         <ButtonText
                           onClick={() => onRemove(userPublicationRole)}
-                          testId={`remove-publication-role-${userPublicationRole.publication}`}
                         >
                           Remove
                         </ButtonText>

--- a/src/explore-education-statistics-admin/src/pages/users/components/ReleaseAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/components/ReleaseAccessForm.tsx
@@ -112,10 +112,7 @@ const ReleaseAccessForm = ({
                       {userReleaseRole.role}
                     </td>
                     <td className="govuk-table__cell">
-                      <ButtonText
-                        onClick={() => onRemove(userReleaseRole)}
-                        testId={`remove-release-role-${userReleaseRole.role}`}
-                      >
+                      <ButtonText onClick={() => onRemove(userReleaseRole)}>
                         Remove
                       </ButtonText>
                     </td>

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -126,7 +126,7 @@ Check release approver can approve methodology for publication
 
 Swap the release approver role for publication owner to test removing the approved methodology
     user changes to bau1
-    user removes release access from analyst    ${RELEASE_NAME}    Approver
+    user removes release access from analyst    ${PUBLICATION_NAME}    ${RELEASE_TYPE}    Approver
     user gives analyst publication owner access    ${PUBLICATION_NAME}
 
 Check publication owner cannot remove approved methodology
@@ -185,7 +185,7 @@ Check release approver can publish a release
 
 Swap the release approver role for publication owner now that the publication is live
     user changes to bau1
-    user removes release access from analyst    ${RELEASE_NAME}    Approver
+    user removes release access from analyst    ${PUBLICATION_NAME}    ${RELEASE_TYPE}    Approver
     user gives analyst publication owner access    ${PUBLICATION_NAME}
 
 Check publication owner can create and cancel methodology amendments on a live publication
@@ -205,7 +205,7 @@ Check release approver can approve methodology amendments on a live publication
 
 Swap the release approver role for publication owner to test creating a new release amendment
     user changes to bau1
-    user removes release access from analyst    ${RELEASE_NAME}    Approver
+    user removes release access from analyst    ${PUBLICATION_NAME}    ${RELEASE_TYPE}    Approver
     user gives analyst publication owner access    ${PUBLICATION_NAME}
 
 Check publication owner can create a new release amendment
@@ -229,7 +229,7 @@ Check release approver can approve the methodology amendment for publishing with
 
 Swap the release approver role for publication owner to test that an approved methodology amendment cannot be cancelled
     user changes to bau1
-    user removes release access from analyst    ${RELEASE_NAME}    Approver
+    user removes release access from analyst    ${PUBLICATION_NAME}    ${RELEASE_TYPE}    Approver
     user gives analyst publication owner access    ${PUBLICATION_NAME}
 
 Check publication owner cannot cancel approved methodology amendment

--- a/tests/robot-tests/tests/admin/bau/themes_and_topics.robot
+++ b/tests/robot-tests/tests/admin/bau/themes_and_topics.robot
@@ -1,5 +1,4 @@
 *** Settings ***
-Library             ../../libs/admin_utilities.py
 Library             ../../libs/admin_api.py
 Resource            ../../libs/admin-common.robot
 

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -660,21 +660,19 @@ user gives release access to analyst
 user removes publication owner access from analyst
     [Arguments]    ${PUBLICATION_NAME}    ${ANALYST_EMAIL}=ees-analyst1@education.gov.uk
     user goes to manage user    ${ANALYST_EMAIL}
-    user scrolls to element    css:[name="selectedPublicationId"]
-    # NOTE: The below wait is to prevent a transient failure that occurs on the UI test pipeline due to the DOM not being fully rendered which
-    # causes issues with getting the 'selectedPublicationId' selector (staleElementException)
-    Sleep    1
-    user clicks element    testid:remove-publication-role-${PUBLICATION_NAME}
+    ${table}=    user gets testid element    publicationAccessTable
+    ${row}=    get child element    ${table}
+    ...    xpath://tbody/tr[td[//th[text()="Publication"] and text()="${PUBLICATION_NAME}"] and td[//th[text()="Role"] and text()="Owner"]]
+    user clicks button    Remove    ${row}
     user waits until page does not contain loading spinner
 
 user removes release access from analyst
-    [Arguments]    ${RELEASE_NAME}    ${ROLE}    ${ANALYST_EMAIL}=ees-analyst1@education.gov.uk
+    [Arguments]    ${PUBLICATION_NAME}    ${RELEASE_NAME}    ${ROLE}    ${ANALYST_EMAIL}=ees-analyst1@education.gov.uk
     user goes to manage user    ${ANALYST_EMAIL}
-    user scrolls to element    css:[name="selectedReleaseId"]
-    # NOTE: The below wait is to prevent a transient failure that occurs on the UI test pipeline due to the DOM not being fully rendered which
-    # causes issues with getting the 'selectedPublicationId' selector (staleElementException)
-    Sleep    1
-    user clicks element    testid:remove-release-role-${ROLE}
+    ${table}=    user gets testid element    releaseAccessTable
+    ${row}=    get child element    ${table}
+    ...    xpath://tbody/tr[td[//th[text()="Publication"] and text()="${PUBLICATION_NAME}"] and td[//th[text()="Release"] and text()="${RELEASE_NAME}"] and td[//th[text()="Role"] and text()="${ROLE}"]]
+    user clicks button    Remove    ${row}
     user waits until page does not contain loading spinner
 
 user goes to manage user


### PR DESCRIPTION
This PR fixes failing UI tests caused by removing incorrect analyst Release roles.

`user removes release access from analyst` was ignoring the Release name, and even then would not be able to accurately identify the correct Release without also having a Publication name parameter.

The test now clicks the correct 'Remove' link to remove the desired permission for the correct Publication/Release/Role combination.

This will also fix an intermittent failing in the test `Navigate to Release where analyst has Release Approver role` which was being caused by the previous suite sometimes removing the incorrect Release role from the analyst.

