### PR TITLE
EES-2709 Add publication links to public methodology page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
@@ -36,12 +36,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 {
                     new()
                     {
-                        Id = Guid.NewGuid(),
-                        PreviousVersionId = null,
                         PublishingStrategy = Immediately,
+                        Published = DateTime.UtcNow,
                         Status = Approved,
                         AlternativeTitle = "Alternative title",
-                        Version = 0
+                    }
+                }
+            };
+
+            var publication = new Publication
+            {
+                Slug = "publication-slug",
+                Title = "Publication title",
+                Methodologies = new List<PublicationMethodology>
+                {
+                    new()
+                    {
+                        Methodology = methodology,
+                        Owner = true
+                    }
+                },
+                Releases = new List<Release>
+                {
+                    new()
+                    {
+                        Published = new DateTime(2021, 1, 1)
                     }
                 }
             };
@@ -51,6 +70,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
             {
                 await contentDbContext.Methodologies.AddAsync(methodology);
+                await contentDbContext.Publications.AddAsync(publication);
                 await contentDbContext.SaveChangesAsync();
             }
 
@@ -71,10 +91,150 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
                 VerifyAllMocks(methodologyVersionRepository);
 
                 Assert.Equal(methodology.Versions[0].Id, result.Id);
+                Assert.Equal(methodology.Versions[0].Published, result.Published);
+                Assert.Equal(methodology.Slug, result.Slug);
                 Assert.Equal("Alternative title", result.Title);
                 Assert.Empty(result.Annexes);
                 Assert.Empty(result.Content);
                 Assert.Empty(result.Notes);
+
+                Assert.Single(result.Publications);
+                Assert.Equal(publication.Id, result.Publications[0].Id);
+                Assert.Equal(publication.Slug, result.Publications[0].Slug);
+                Assert.Equal(publication.Title, result.Publications[0].Title);
+            }
+        }
+
+        [Fact]
+        public async Task GetLatestMethodologyBySlug_FiltersPublicationsWithNoVisibleReleases()
+        {
+            var methodology = new Methodology
+            {
+                Versions = new List<MethodologyVersion>
+                {
+                    new()
+                    {
+                        PublishingStrategy = Immediately,
+                        Published = DateTime.UtcNow,
+                        Status = Approved
+                    }
+                }
+            };
+
+            // Publication has a published release and is visible
+            var publicationA = new Publication
+            {
+                Slug = "publication-a",
+                Title = "Publication A",
+                Methodologies = new List<PublicationMethodology>
+                {
+                    new()
+                    {
+                        Methodology = methodology,
+                        Owner = true
+                    }
+                },
+                Releases = new List<Release>
+                {
+                    new()
+                    {
+                        Published = new DateTime(2021, 1, 1)
+                    }
+                }
+            };
+
+            // Publication has published and unpublished releases and is visible
+            var publicationB = new Publication
+            {
+                Slug = "publication-b",
+                Title = "Publication B",
+                Methodologies = new List<PublicationMethodology>
+                {
+                    new()
+                    {
+                        Methodology = methodology,
+                        Owner = false
+                    }
+                },
+                Releases = new List<Release>
+                {
+                    new()
+                    {
+                        Published = new DateTime(2021, 1, 1)
+                    },
+                    new()
+                }
+            };
+
+            // Publication has no releases and is not visible
+            var publicationC = new Publication
+            {
+                Slug = "publication-c",
+                Title = "Publication C",
+                Methodologies = new List<PublicationMethodology>
+                {
+                    new()
+                    {
+                        Methodology = methodology,
+                        Owner = false
+                    }
+                },
+                Releases = new List<Release>()
+            };
+
+            // Publication has no published releases and is not visible
+            var publicationD = new Publication
+            {
+                Slug = "publication-d",
+                Title = "Publication D",
+                Methodologies = new List<PublicationMethodology>
+                {
+                    new()
+                    {
+                        Methodology = methodology,
+                        Owner = false
+                    }
+                },
+                Releases = new List<Release>
+                {
+                    // Release is not published
+                    new()
+                }
+            };
+
+            var contentDbContextId = Guid.NewGuid().ToString();
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                await contentDbContext.Methodologies.AddAsync(methodology);
+                await contentDbContext.Publications.AddRangeAsync(publicationA, publicationB, publicationC,
+                    publicationD);
+                await contentDbContext.SaveChangesAsync();
+            }
+
+            var methodologyVersionRepository = new Mock<IMethodologyVersionRepository>(MockBehavior.Strict);
+
+            methodologyVersionRepository.Setup(mock => mock.GetLatestPublishedVersion(methodology.Id))
+                .ReturnsAsync(methodology.Versions[0]);
+
+            await using (var contentDbContext = InMemoryContentDbContext(contentDbContextId))
+            {
+                contentDbContext.Attach(methodology.Versions[0]);
+
+                var service = SetupMethodologyService(contentDbContext: contentDbContext,
+                    methodologyVersionRepository: methodologyVersionRepository.Object);
+
+                var result = (await service.GetLatestMethodologyBySlug(methodology.Slug)).AssertRight();
+
+                VerifyAllMocks(methodologyVersionRepository);
+
+                Assert.Equal(2, result.Publications.Count);
+                Assert.Equal(publicationA.Id, result.Publications[0].Id);
+                Assert.Equal(publicationA.Slug, result.Publications[0].Slug);
+                Assert.Equal(publicationA.Title, result.Publications[0].Title);
+                Assert.Equal(publicationB.Id, result.Publications[1].Id);
+                Assert.Equal(publicationB.Slug, result.Publications[1].Slug);
+                Assert.Equal(publicationB.Title, result.Publications[1].Title);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/MethodologyServiceTests.cs
@@ -106,7 +106,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
         }
 
         [Fact]
-        public async Task GetLatestMethodologyBySlug_FiltersPublicationsWithNoVisibleReleases()
+        public async Task GetLatestMethodologyBySlug_FiltersPublicationsWithNoPublishedReleases()
         {
             var methodology = new Methodology
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Mappings/MappingProfiles.cs
@@ -35,6 +35,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Mappings
                 .ForMember(dest => dest.Notes,
                     m => m.MapFrom(methodologyVersion =>
                         methodologyVersion.Notes.OrderByDescending(note => note.DisplayDate)));
+
+            CreateMap<Publication, PublicationSummaryViewModel>();
         }
 
         private void CreateContentBlockMap()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels;
@@ -55,7 +56,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                         .Collection(m => m.Notes)
                         .LoadAsync();
 
-                    return _mapper.Map<MethodologyViewModel>(latestPublishedVersion);
+                    var viewModel = _mapper.Map<MethodologyViewModel>(latestPublishedVersion);
+                    viewModel.Publications =
+                        await GetVisiblePublicationsForMethodology(latestPublishedVersion.MethodologyId);
+
+                    return viewModel;
                 });
         }
 
@@ -102,6 +107,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             return themes.Where(theme => theme.Topics.Any())
                 .OrderBy(theme => theme.Title)
                 .ToList();
+        }
+
+        private async Task<List<PublicationSummaryViewModel>> GetVisiblePublicationsForMethodology(Guid methodologyId)
+        {
+            var publications = await _contentDbContext.PublicationMethodologies
+                .Include(pm => pm.Publication)
+                .ThenInclude(p => p.Releases)
+                .Where(pm => pm.MethodologyId == methodologyId)
+                .Select(pm => pm.Publication)
+                .ToListAsync();
+
+            var publicationsWithPublishedReleases = publications
+                .Where(p => p.Releases.Any(r => r.IsLatestPublishedVersionOfRelease()))
+                .OrderBy(p => p.Title)
+                .ToList();
+
+            return _mapper.Map<List<PublicationSummaryViewModel>>(publicationsWithPublishedReleases);
         }
 
         private async Task<List<MethodologySummaryViewModel>> BuildMethodologiesForPublication(Guid publicationId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
@@ -58,7 +58,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
 
                     var viewModel = _mapper.Map<MethodologyViewModel>(latestPublishedVersion);
                     viewModel.Publications =
-                        await GetVisiblePublicationsForMethodology(latestPublishedVersion.MethodologyId);
+                        await GetPublishedPublicationsForMethodology(latestPublishedVersion.MethodologyId);
 
                     return viewModel;
                 });
@@ -109,7 +109,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                 .ToList();
         }
 
-        private async Task<List<PublicationSummaryViewModel>> GetVisiblePublicationsForMethodology(Guid methodologyId)
+        private async Task<List<PublicationSummaryViewModel>> GetPublishedPublicationsForMethodology(Guid methodologyId)
         {
             var publications = await _contentDbContext.PublicationMethodologies
                 .Include(pm => pm.Publication)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/MethodologyViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/MethodologyViewModel.cs
@@ -20,5 +20,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
         public List<ContentSectionViewModel> Annexes { get; set; } = new();
 
         public List<MethodologyNoteViewModel> Notes { get; set; } = new();
+
+        public List<PublicationSummaryViewModel> Publications { get; set; } = new();
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PublicationSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PublicationSummaryViewModel.cs
@@ -1,21 +1,26 @@
+#nullable enable
 using System;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 {
-    public class PublicationSummaryViewModel
+    public record PublicationSummaryViewModel
     {
-        public Guid Id { get; }
+        public Guid Id { get; set; }
 
-        public string Title { get; }
+        public string Title { get; set; } = string.Empty;
 
-        public string Slug { get;  }
+        public string Slug { get; set; } = string.Empty;
 
-        public string Description { get; }
+        public string Description { get; set; } = string.Empty;
 
-        public string DataSource { get; }
+        public string DataSource { get; set; } = string.Empty;
 
-        public string Summary { get; }
+        public string Summary { get; set; } = string.Empty;
+
+        public PublicationSummaryViewModel()
+        {
+        }
 
         public PublicationSummaryViewModel(CachedPublicationViewModel publication)
         {

--- a/src/explore-education-statistics-common/src/services/methodologyService.ts
+++ b/src/explore-education-statistics-common/src/services/methodologyService.ts
@@ -1,3 +1,4 @@
+import { PublicationSummary } from '@common/services/publicationService';
 import { ContentBlock } from '@common/services/types/blocks';
 import { contentApi } from './api';
 
@@ -6,6 +7,7 @@ export interface Methodology {
   title: string;
   published: string;
   slug: string;
+  publications: PublicationSummary[];
   content: {
     order: number;
     heading: string;

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
@@ -30,7 +30,7 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
       breadcrumbs={[{ name: 'Methodologies', link: '/methodology' }]}
       caption="Methodology"
     >
-      <div className="govuk-grid-row">
+      <div className="govuk-grid-row govuk-!-margin-bottom-3">
         <div className="govuk-grid-column-two-thirds">
           <SummaryList>
             <SummaryListItem term="Published">
@@ -89,6 +89,34 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
         </div>
         <div className="govuk-grid-column-one-third">
           <RelatedInformation>
+            {data.publications && data.publications.length > 0 && (
+              <>
+                <h3
+                  className="govuk-heading-s govuk-!-margin-top-6"
+                  id="publications"
+                >
+                  Publications
+                </h3>
+
+                <ul className="govuk-list govuk-list--spaced">
+                  {data.publications.map(publication => (
+                    <li key={publication.id}>
+                      <Link
+                        to="/find-statistics/[publication]"
+                        as={`/find-statistics/${publication.slug}`}
+                      >
+                        {publication.title}
+                      </Link>{' '}
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+
+            <h3 className="govuk-heading-s" id="related-pages">
+              Related pages
+            </h3>
+
             <ul className="govuk-list">
               <li>
                 <Link to="/find-statistics">Find statistics and data</Link>

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/MethodologyPage.tsx
@@ -37,7 +37,7 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
               <FormattedDate>{data.published}</FormattedDate>
             </SummaryListItem>
 
-            {data.notes.length > 0 && (
+            {data.notes?.length > 0 && (
               <SummaryListItem term="Last updated">
                 <FormattedDate>{data.notes[0].displayDate}</FormattedDate>
 
@@ -89,7 +89,7 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
         </div>
         <div className="govuk-grid-column-one-third">
           <RelatedInformation>
-            {data.publications && data.publications.length > 0 && (
+            {data.publications?.length > 0 && (
               <>
                 <h3
                   className="govuk-heading-s govuk-!-margin-top-6"
@@ -162,7 +162,7 @@ const MethodologyPage: NextPage<Props> = ({ data }) => {
         </Accordion>
       )}
 
-      {data.annexes && data.annexes.length > 0 && (
+      {data.annexes?.length > 0 && (
         <>
           <h2 className="govuk-heading-l govuk-!-margin-top-9">Annexes</h2>
 

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/__tests__/MethodologyPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/__tests__/MethodologyPage.test.tsx
@@ -31,6 +31,33 @@ describe('MethodologyPage', () => {
     ).toHaveLength(2);
   });
 
+  test('renders related information links', async () => {
+    render(<MethodologyPage data={testMethodology} />);
+
+    expect(
+      screen.getByRole('navigation', { name: 'Related information' }),
+    ).toBeInTheDocument();
+
+    const relatedInformationNav = screen.getByRole('navigation', {
+      name: 'Related information',
+    });
+
+    const relatedInformationLinks = within(relatedInformationNav).getAllByRole(
+      'link',
+    );
+
+    expect(relatedInformationLinks).toHaveLength(4);
+
+    expect(relatedInformationLinks[0]).toHaveTextContent('Publication 1');
+    expect(relatedInformationLinks[1]).toHaveTextContent('Publication 2');
+    expect(relatedInformationLinks[2]).toHaveTextContent(
+      'Find statistics and data',
+    );
+    expect(relatedInformationLinks[3]).toHaveTextContent(
+      'Education statistics: glossary',
+    );
+  });
+
   test('renders the methodology content', () => {
     render(<MethodologyPage data={testMethodology} />);
     const contentAccordion = screen.getAllByTestId('accordion')[0];

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/__tests__/__data__/testMethodologyData.ts
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/__tests__/__data__/testMethodologyData.ts
@@ -1,4 +1,5 @@
 import { Methodology } from '@common/services/methodologyService';
+import { PublicationSummary } from '@common/services/publicationService';
 
 export const testMethodology: Methodology = {
   id: 'methodology-1',
@@ -91,6 +92,18 @@ export const testMethodology: Methodology = {
       content: 'Earliest note',
     },
   ],
+  publications: [
+    {
+      id: 'publication-1',
+      title: 'Publication 1',
+      slug: 'publication-1-slug',
+    },
+    {
+      id: 'publication-2',
+      title: 'Publication 2',
+      slug: 'publication-2-slug',
+    },
+  ] as PublicationSummary[],
 };
 
 export default testMethodology;

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -93,6 +93,14 @@ Verify that the methodology is publicly accessible
     user waits until h1 is visible    ${PUBLICATION_NAME}
     user waits until page contains title caption    Methodology
 
+Verify that the methodology displays a link to the publication
+    ${relatedInformation}=    get webelement    css:[aria-labelledby="related-information"]
+    user checks element contains child element    ${relatedInformation}    xpath://h3[text()="Publications"]
+    user checks page contains link with text and url
+    ...    ${PUBLICATION_NAME}
+    ...    /find-statistics/ui-tests-publish-methodology-%{RUN_IDENTIFIER}
+    ...    ${relatedInformation}
+
 Verify that the methodology content is correct
     ${date}=    get current datetime    %-d %B %Y
     user checks summary list contains    Published    ${date}
@@ -167,6 +175,14 @@ Verify that the amended methodology is publicly accessible immediately
     ...    ${PUBLICATION_NAME} - Amended methodology
     user waits until h1 is visible    ${PUBLICATION_NAME} - Amended methodology
     user waits until page contains title caption    Methodology
+
+Verify that the amended methodology displays a link to the publication
+    ${relatedInformation}=    get webelement    css:[aria-labelledby="related-information"]
+    user checks element contains child element    ${relatedInformation}    xpath://h3[text()="Publications"]
+    user checks page contains link with text and url
+    ...    ${PUBLICATION_NAME}
+    ...    /find-statistics/ui-tests-publish-methodology-%{RUN_IDENTIFIER}
+    ...    ${relatedInformation}
 
 Verify that the amended methodology content is correct
     ${date}=    get current datetime    %-d %B %Y

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -94,12 +94,13 @@ Verify that the methodology is publicly accessible
     user waits until page contains title caption    Methodology
 
 Verify that the methodology displays a link to the publication
-    ${relatedInformation}=    get webelement    css:[aria-labelledby="related-information"]
-    user checks element contains child element    ${relatedInformation}    xpath://h3[text()="Publications"]
+    user checks element contains child element
+    ...    css:[aria-labelledby="related-information"]
+    ...    xpath://h3[text()="Publications"]
     user checks page contains link with text and url
     ...    ${PUBLICATION_NAME}
     ...    /find-statistics/ui-tests-publish-methodology-%{RUN_IDENTIFIER}
-    ...    ${relatedInformation}
+    ...    css:[aria-labelledby="related-information"]
 
 Verify that the methodology content is correct
     ${date}=    get current datetime    %-d %B %Y
@@ -177,12 +178,13 @@ Verify that the amended methodology is publicly accessible immediately
     user waits until page contains title caption    Methodology
 
 Verify that the amended methodology displays a link to the publication
-    ${relatedInformation}=    get webelement    css:[aria-labelledby="related-information"]
-    user checks element contains child element    ${relatedInformation}    xpath://h3[text()="Publications"]
+    user checks element contains child element
+    ...    css:[aria-labelledby="related-information"]
+    ...    xpath://h3[text()="Publications"]
     user checks page contains link with text and url
     ...    ${PUBLICATION_NAME}
     ...    /find-statistics/ui-tests-publish-methodology-%{RUN_IDENTIFIER}
-    ...    ${relatedInformation}
+    ...    css:[aria-labelledby="related-information"]
 
 Verify that the amended methodology content is correct
     ${date}=    get current datetime    %-d %B %Y

--- a/tests/robot-tests/tests/general_public/methodology_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/methodology_page_absence.robot
@@ -49,15 +49,25 @@ Validate accordion sections order
     user checks accordion is in position    Annex F - Absence rates over time    6    id:annexes
 
 Validate Related information section and links exist
-    user checks page contains element    xpath://h2[text()="Related information"]
+    ${relatedInformation}=    get webelement    css:[aria-labelledby="related-information"]
 
+    user checks element contains child element    ${relatedInformation}    xpath://h2[text()="Related information"]
+
+    user checks element contains child element    ${relatedInformation}    xpath://h3[text()="Publications"]
+    user checks page contains link with text and url
+    ...    Pupil absence in schools in England
+    ...    /find-statistics/pupil-absence-in-schools-in-england
+    ...    ${relatedInformation}
+
+    user checks element contains child element    ${relatedInformation}    xpath://h3[text()="Related pages"]
     user checks page contains link with text and url
     ...    Find statistics and data
     ...    /find-statistics
-
+    ...    ${relatedInformation}
     user checks page contains link with text and url
     ...    Education statistics: glossary
     ...    /glossary
+    ...    ${relatedInformation}
 
 Validate page has Print this page link
     user waits until page contains button    Print this page


### PR DESCRIPTION
This PR adds publications links to the general public methodology page for publications that are using the methodology.

This will always include the owning publication of a methodology but can also include other publications which have adopted it.
Since this is a change to the general public site, only visible publications _with published releases_ can be shown.

A recent change has already added in a 'Related information' section to the page which can be seen here on the live site:
![image](https://user-images.githubusercontent.com/4147126/134902654-9ccab116-7782-402d-add5-57e9c4b81547.png)

This change now adds links to the publications within this section.

Here is the same example but running locally where another publication with a published release has adopted the methodology:

![image](https://user-images.githubusercontent.com/4147126/134903371-89bcdfb0-9776-4256-a96d-7c26e00469c4.png)
