### PR TITLE
EES-2739 Add `Content.Services` as dependency of `Admin`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/LegacyReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/LegacyReleaseServiceTests.cs
@@ -21,15 +21,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var id = Guid.NewGuid();
             var publicationId = Guid.NewGuid();
-            
+
             using (var context = InMemoryApplicationDbContext())
             {
-                context.Add(new Publication 
+                context.Add(new Publication
                 {
                     Id = publicationId,
                     LegacyReleases = new List<LegacyRelease>
                         {
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Id = id,
                                 Description = "Test description",
@@ -47,7 +47,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     MockUtils.AlwaysTrueUserService().Object,
                     new PersistenceHelper<ContentDbContext>(context)
                 );
-                
+
                 // Service method under test
                 var result = await legacyReleaseService.GetLegacyRelease(id);
 
@@ -62,10 +62,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         public async Task CreateLegacyRelease()
         {
             var publicationId = Guid.NewGuid();
-            
+
             using (var context = InMemoryApplicationDbContext())
             {
-                context.Add(new Publication 
+                context.Add(new Publication
                 {
                     Id = publicationId,
                 });
@@ -78,7 +78,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     MockUtils.AlwaysTrueUserService().Object,
                     new PersistenceHelper<ContentDbContext>(context)
                 );
-                
+
                 // Service method under test
                 var result = await legacyReleaseService.CreateLegacyRelease(
                     new LegacyReleaseCreateViewModel()
@@ -109,12 +109,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext())
             {
-                context.Add(new Publication 
+                context.Add(new Publication
                 {
                     Id = publicationId,
                     LegacyReleases = new List<LegacyRelease>
                         {
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Id = Guid.NewGuid(),
                                 Description = "Test description 1",
@@ -133,7 +133,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     MockUtils.AlwaysTrueUserService().Object,
                     new PersistenceHelper<ContentDbContext>(context)
                 );
-                
+
                 // Service method under test
                 var result = await legacyReleaseService.CreateLegacyRelease(
                     new LegacyReleaseCreateViewModel()
@@ -160,12 +160,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext())
             {
-                context.Add(new Publication 
+                context.Add(new Publication
                 {
                     Id = publicationId,
                     LegacyReleases = new List<LegacyRelease>
                         {
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Id = id,
                                 Description = "Test description",
@@ -183,7 +183,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     MockUtils.AlwaysTrueUserService().Object,
                     new PersistenceHelper<ContentDbContext>(context)
                 );
-                
+
                 // Service method under test
                 var result = await legacyReleaseService.UpdateLegacyRelease(
                     id,
@@ -217,24 +217,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext())
             {
-                context.Add(new Publication 
+                context.Add(new Publication
                 {
                     Id = publicationId,
                     LegacyReleases = new List<LegacyRelease>
                         {
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Description = "Test description 1",
                                 Url = "http://test1.com",
                                 Order = 1,
                             },
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Description = "Test description 2",
                                 Url = "http://test2.com",
                                 Order = 2,
                             },
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Id = id,
                                 Description = "Test description 3",
@@ -252,7 +252,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     MockUtils.AlwaysTrueUserService().Object,
                     new PersistenceHelper<ContentDbContext>(context)
                 );
-                
+
                 // Service method under test
                 await legacyReleaseService.UpdateLegacyRelease(
                     id,
@@ -265,6 +265,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     });
 
                 var legacyReleases = context.LegacyReleases
+                    .AsQueryable()
                     .OrderBy(release => release.Order)
                     .ToList();
 
@@ -280,7 +281,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         }
 
         /// Test that we do not leave gaps in the order values when
-        /// updating a legacy release with an `Order` larger than 
+        /// updating a legacy release with an `Order` larger than
         /// the number of legacy releases.
         [Fact]
         public async Task UpdateLegacyRelease_ReordersWithoutGaps()
@@ -290,25 +291,25 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext())
             {
-                context.Add(new Publication 
+                context.Add(new Publication
                 {
                     Id = publicationId,
                     LegacyReleases = new List<LegacyRelease>
                         {
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Id = id,
                                 Description = "Test description 1",
                                 Url = "http://test1.com",
                                 Order = 1,
                             },
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Description = "Test description 2",
                                 Url = "http://test2.com",
                                 Order = 2,
                             },
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Description = "Test description 3",
                                 Url = "http://test3.com",
@@ -325,7 +326,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     MockUtils.AlwaysTrueUserService().Object,
                     new PersistenceHelper<ContentDbContext>(context)
                 );
-                
+
                 // Service method under test
                 await legacyReleaseService.UpdateLegacyRelease(
                     id,
@@ -338,6 +339,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     });
 
                 var legacyReleases = context.LegacyReleases
+                    .AsQueryable()
                     .OrderBy(release => release.Order)
                     .ToList();
 
@@ -360,12 +362,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext())
             {
-                context.Add(new Publication 
+                context.Add(new Publication
                 {
                     Id = publicationId,
                     LegacyReleases = new List<LegacyRelease>
                         {
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Id = id,
                                 Description = "Test description",
@@ -383,7 +385,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     MockUtils.AlwaysTrueUserService().Object,
                     new PersistenceHelper<ContentDbContext>(context)
                 );
-                
+
                 // Service method under test
                 await legacyReleaseService.DeleteLegacyRelease(id);
 
@@ -404,26 +406,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             using (var context = InMemoryApplicationDbContext())
             {
-                context.Add(new Publication 
+                context.Add(new Publication
                 {
                     Id = publicationId,
                     LegacyReleases = new List<LegacyRelease>
                         {
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Id = id,
                                 Description = "Test description 1",
                                 Url = "http://test1.com",
                                 Order = 1,
                             },
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Id = Guid.NewGuid(),
                                 Description = "Test description 2",
                                 Url = "http://test2.com",
                                 Order = 2,
                             },
-                            new LegacyRelease 
+                            new LegacyRelease
                             {
                                 Id = Guid.NewGuid(),
                                 Description = "Test description 3",
@@ -441,11 +443,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     MockUtils.AlwaysTrueUserService().Object,
                     new PersistenceHelper<ContentDbContext>(context)
                 );
-                
+
                 // Service method under test
                 await legacyReleaseService.DeleteLegacyRelease(id);
 
                 var legacyReleases = context.LegacyReleases
+                    .AsQueryable()
                     .OrderBy(release => release.Order)
                     .ToList();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MetaGuidanceServiceTests.cs
@@ -17,7 +17,6 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
@@ -487,12 +486,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 // Assert only one Subject has been updated
                 Assert.Equal("Subject 1 Meta Guidance Updated",
                     (await statisticsDbContext.ReleaseSubject
+                        .AsQueryable()
                         .Where(rs => rs.ReleaseId == statsRelease.Id
                                      && rs.SubjectId == releaseSubject1.Subject.Id)
                         .FirstAsync()).MetaGuidance);
 
                 Assert.Equal("Subject 2 Meta Guidance",
                     (await statisticsDbContext.ReleaseSubject
+                        .AsQueryable()
                         .Where(rs => rs.ReleaseId == statsRelease.Id
                                      && rs.SubjectId == releaseSubject2.Subject.Id)
                         .FirstAsync()).MetaGuidance);
@@ -673,17 +674,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 // Assert the same Subject on version 1 hasn't been affected
                 Assert.Equal("Version 1 Subject 1 Meta Guidance",
                     (await statisticsDbContext.ReleaseSubject
+                        .AsQueryable()
                         .Where(rs => rs.ReleaseId == statsReleaseVersion1.Id && rs.SubjectId == subject1.Id)
                         .FirstAsync()).MetaGuidance);
 
                 // Assert only one Subject on version 2 has been updated
                 Assert.Equal("Version 2 Subject 1 Meta Guidance Updated",
                     (await statisticsDbContext.ReleaseSubject
+                        .AsQueryable()
                         .Where(rs => rs.ReleaseId == statsReleaseVersion2.Id && rs.SubjectId == subject1.Id)
                         .FirstAsync()).MetaGuidance);
 
                 Assert.Equal("Version 2 Subject 2 Meta Guidance",
                     (await statisticsDbContext.ReleaseSubject
+                        .AsQueryable()
                         .Where(rs => rs.ReleaseId == statsReleaseVersion2.Id && rs.SubjectId == subject2.Id)
                         .FirstAsync()).MetaGuidance);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
@@ -194,6 +194,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var amendmentMethodologyFiles = await context
                     .MethodologyFiles
+                    .AsQueryable()
                     .Where(f => f.MethodologyVersionId == amendmentId)
                     .ToListAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyServiceTests.cs
@@ -75,7 +75,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var publicationMethodologies = await context.PublicationMethodologies.ToListAsync();
+                var publicationMethodologies = await context.PublicationMethodologies
+                    .AsQueryable()
+                    .ToListAsync();
 
                 // Check the existing and new relationships between publications and methodologies
                 Assert.Equal(2, publicationMethodologies.Count);
@@ -136,7 +138,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var publicationMethodologies = await context.PublicationMethodologies.ToListAsync();
+                var publicationMethodologies = await context.PublicationMethodologies
+                    .AsQueryable()
+                    .ToListAsync();
 
                 // Check the relationships between publications and methodologies are not altered
                 Assert.Equal(2, publicationMethodologies.Count);
@@ -192,7 +196,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var publicationMethodologies = await context.PublicationMethodologies.ToListAsync();
+                var publicationMethodologies = await context.PublicationMethodologies
+                    .AsQueryable()
+                    .ToListAsync();
 
                 // Check the relationships between publications and methodologies are not altered
                 Assert.Single(publicationMethodologies);
@@ -385,7 +391,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var publicationMethodologies = await context.PublicationMethodologies.ToListAsync();
+                var publicationMethodologies = await context.PublicationMethodologies
+                    .AsQueryable()
+                    .ToListAsync();
 
                 // Check the adopting relationship is removed
                 Assert.Single(publicationMethodologies);
@@ -441,7 +449,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var publicationMethodologies = await context.PublicationMethodologies.ToListAsync();
+                var publicationMethodologies = await context.PublicationMethodologies
+                    .AsQueryable()
+                    .ToListAsync();
 
                 // Check the relationships between publications and methodologies are not altered
                 Assert.Equal(2, publicationMethodologies.Count);
@@ -1416,7 +1426,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.False(notUpdatedMethodology.Updated.HasValue);
             }
         }
-        
+
         [Fact]
         public async Task UpdateMethodology_StatusUpdate()
         {
@@ -1463,17 +1473,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
                 var methodologyApprovalService = new Mock<IMethodologyApprovalService>();
-                
+
                 methodologyApprovalService
                     .Setup(s => s.UpdateApprovalStatus(methodologyVersion.Id, request))
                     .ReturnsAsync(methodologyVersion);
-                    
+
                 var service = SetupMethodologyService(
                     context,
                     methodologyApprovalService: methodologyApprovalService.Object);
 
                 await service.UpdateMethodology(methodologyVersion.Id, request);
-                
+
                 // Verify that the call to update the approval status happened.
                 VerifyAllMocks(methodologyApprovalService);
             }
@@ -1482,6 +1492,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 var updatedMethodology = await context
                     .MethodologyVersions
+                    .AsQueryable()
                     .Include(m => m.Methodology)
                     .SingleAsync(m => m.Id == methodologyVersion.Id);
 
@@ -1548,7 +1559,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
 
             // Since the MethodologyVersions should be deleted in sequence, expect a call to delete images for each of the
             // versions in the same sequence
-            
+
             var deleteSequence = new MockSequence();
 
             methodologyImageService
@@ -1625,10 +1636,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             {
                 // Sanity check that a Methodology, a MethodologyVersion and a PublicationMethodology row were
                 // created.
-                Assert.NotNull(await context.Methodologies.SingleAsync(m => m.Id == methodologyId));
-                Assert.NotNull(await context.MethodologyVersions.SingleAsync(m => m.Id == methodologyVersion.Id));
-                Assert.NotNull(await context.PublicationMethodologies.SingleAsync(
-                    m => m.MethodologyId == methodologyId));
+                Assert.NotNull(await context.Methodologies.AsQueryable()
+                    .SingleAsync(m => m.Id == methodologyId));
+                Assert.NotNull(await context.MethodologyVersions.AsQueryable()
+                    .SingleAsync(m => m.Id == methodologyVersion.Id));
+                Assert.NotNull(await context.PublicationMethodologies.AsQueryable()
+                    .SingleAsync(m => m.MethodologyId == methodologyId));
             }
 
             var methodologyImageService = new Mock<IMethodologyImageService>(Strict);
@@ -1697,9 +1710,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
             await using (var context = InMemoryApplicationDbContext(contentDbContextId))
             {
                 // Sanity check that there is a methodology with two versions.
-                Assert.NotNull(await context.Methodologies.SingleAsync(m => m.Id == methodologyId));
-                Assert.NotNull(await context.MethodologyVersions.SingleAsync(m => m.Id == methodology.Versions[0].Id));
-                Assert.NotNull(await context.MethodologyVersions.SingleAsync(m => m.Id == methodology.Versions[1].Id));
+                Assert.NotNull(await context.Methodologies.AsQueryable()
+                    .SingleAsync(m => m.Id == methodologyId));
+                Assert.NotNull(await context.MethodologyVersions.AsQueryable()
+                    .SingleAsync(m => m.Id == methodology.Versions[0].Id));
+                Assert.NotNull(await context.MethodologyVersions.AsQueryable()
+                    .SingleAsync(m => m.Id == methodology.Versions[1].Id));
             }
 
             var methodologyImageService = new Mock<IMethodologyImageService>(Strict);
@@ -1726,8 +1742,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 // Assert that the version has successfully been deleted and as there was another version attached
                 // to the methodology, the methodology itself is not deleted, or the other version.
                 Assert.False(context.MethodologyVersions.Any(m => m.Id == methodology.Versions[1].Id));
-                Assert.NotNull(await context.MethodologyVersions.SingleAsync(m => m.Id == methodology.Versions[0].Id));
-                Assert.NotNull(await context.Methodologies.SingleAsync(m => m.Id == methodologyId));
+                Assert.NotNull(await context.MethodologyVersions.AsQueryable()
+                    .SingleAsync(m => m.Id == methodology.Versions[0].Id));
+                Assert.NotNull(await context.Methodologies.AsQueryable()
+                    .SingleAsync(m => m.Id == methodologyId));
             }
         }
 
@@ -1797,8 +1815,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 Assert.False(context.Methodologies.Any(m => m.Id == methodologyId));
 
                 Assert.NotNull(
-                    await context.MethodologyVersions.SingleAsync(m => m.Id == unrelatedMethodology.Versions[0].Id));
-                Assert.NotNull(await context.Methodologies.SingleAsync(m => m.Id == unrelatedMethodologyId));
+                    await context.MethodologyVersions.AsQueryable()
+                        .SingleAsync(m => m.Id == unrelatedMethodology.Versions[0].Id));
+                Assert.NotNull(
+                    await context.Methodologies.AsQueryable()
+                        .SingleAsync(m => m.Id == unrelatedMethodologyId));
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/PreReleaseUserServiceTests.cs
@@ -395,6 +395,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
             {
                 var savedUserReleaseRole = await context.UserReleaseRoles
+                    .AsQueryable()
                     .Where(userReleaseRole => userReleaseRole.ReleaseId == release.Id)
                     .SingleAsync();
 
@@ -403,6 +404,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(user.Id, savedUserReleaseRole.UserId);
 
                 var releaseInvite = await context.UserReleaseInvites
+                    .AsQueryable()
                     .Where(userReleaseInvite => userReleaseInvite.ReleaseId == release.Id)
                     .SingleAsync();
 
@@ -415,6 +417,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var userAndRolesDbContext = DbUtils.InMemoryUserAndRolesDbContext(contextId))
             {
                 var systemInvite = await userAndRolesDbContext.UserInvites
+                    .AsQueryable()
                     .Where(userInvite => userInvite.Email == "test@test.com")
                     .SingleAsync();
 
@@ -492,6 +495,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
             {
                 var savedUserReleaseRole = await context.UserReleaseRoles
+                    .AsQueryable()
                     .Where(userReleaseRole => userReleaseRole.ReleaseId == release.Id)
                     .SingleAsync();
 
@@ -500,6 +504,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(user.Id, savedUserReleaseRole.UserId);
 
                 var releaseInvite = await context.UserReleaseInvites
+                    .AsQueryable()
                     .Where(userReleaseInvite => userReleaseInvite.ReleaseId == release.Id)
                     .SingleAsync();
 
@@ -512,6 +517,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var userAndRolesDbContext = DbUtils.InMemoryUserAndRolesDbContext(contextId))
             {
                 var systemInvite = await userAndRolesDbContext.UserInvites
+                    .AsQueryable()
                     .Where(userInvite => userInvite.Email == "test@test.com")
                     .SingleAsync();
 
@@ -615,6 +621,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
             {
                 var releaseInvite = await context.UserReleaseInvites
+                    .AsQueryable()
                     .Where(userReleaseInvite => userReleaseInvite.ReleaseId == release.Id)
                     .SingleAsync();
 
@@ -627,6 +634,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var userAndRolesDbContext = DbUtils.InMemoryUserAndRolesDbContext(contextId))
             {
                 var systemInvite = await userAndRolesDbContext.UserInvites
+                    .AsQueryable()
                     .Where(userInvite => userInvite.Email == "test@test.com")
                     .SingleAsync();
 
@@ -695,6 +703,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
             {
                 var releaseInvite = await context.UserReleaseInvites
+                    .AsQueryable()
                     .Where(userReleaseInvite => userReleaseInvite.ReleaseId == release.Id)
                     .SingleAsync();
 
@@ -707,6 +716,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var userAndRolesDbContext = DbUtils.InMemoryUserAndRolesDbContext(contextId))
             {
                 var systemInvite = await userAndRolesDbContext.UserInvites
+                    .AsQueryable()
                     .Where(userInvite => userInvite.Email == "test@test.com")
                     .SingleAsync();
 
@@ -797,6 +807,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
             {
                 var savedUserReleaseRoles = await context.UserReleaseRoles
+                    .AsQueryable()
                     .ToListAsync();
 
                 Assert.Empty(savedUserReleaseRoles);
@@ -884,6 +895,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = DbUtils.InMemoryApplicationDbContext(contextId))
             {
                 var savedUserReleaseRoles = await context.UserReleaseRoles
+                    .AsQueryable()
                     .ToListAsync();
 
                 Assert.Equal(2, savedUserReleaseRoles.Count);
@@ -953,12 +965,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var userAndRolesDbContext = DbUtils.InMemoryUserAndRolesDbContext(contextId))
             {
                 var savedUserReleaseInvites = await context.UserReleaseInvites
+                    .AsQueryable()
                     .ToListAsync();
 
                 Assert.Empty(savedUserReleaseInvites);
 
                 // Removes system invite as there are no release invites left
                 var savedUserInvites = await userAndRolesDbContext.UserInvites
+                    .AsQueryable()
                     .ToListAsync();
 
                 Assert.Empty(savedUserInvites);
@@ -1037,6 +1051,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var userAndRolesDbContext = DbUtils.InMemoryUserAndRolesDbContext(contextId))
             {
                 var savedUserReleaseInvites = await context.UserReleaseInvites
+                    .AsQueryable()
                     .ToListAsync();
 
                 Assert.Equal(2, savedUserReleaseInvites.Count);
@@ -1049,6 +1064,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal("test@test.com", savedUserReleaseInvites[1].Email);
 
                 var savedUserInvite = await userAndRolesDbContext.UserInvites
+                    .AsQueryable()
                     .SingleAsync();
 
                 Assert.Equal("test@test.com", savedUserInvite.Email);
@@ -1112,11 +1128,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var userAndRolesDbContext = DbUtils.InMemoryUserAndRolesDbContext(contextId))
             {
                 var savedUserReleaseInvites = await context.UserReleaseInvites
+                    .AsQueryable()
                     .ToListAsync();
 
                 Assert.Empty(savedUserReleaseInvites);
 
                 var savedUserInvite = await userAndRolesDbContext.UserInvites
+                    .AsQueryable()
                     .SingleAsync();
 
                 Assert.Equal("test@test.com", savedUserInvite.Email);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseFileServiceTests.cs
@@ -1829,9 +1829,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contextId))
             {
-                var updatedReleaseFile = await contentDbContext.ReleaseFiles.FirstAsync(rf =>
-                    rf.ReleaseId == releaseFile.ReleaseId
-                    && rf.FileId == releaseFile.FileId);
+                var updatedReleaseFile = await contentDbContext.ReleaseFiles
+                    .AsQueryable()
+                    .FirstAsync(rf =>
+                        rf.ReleaseId == releaseFile.ReleaseId
+                        && rf.FileId == releaseFile.FileId);
 
                 Assert.Equal("New file title", updatedReleaseFile.Name);
                 Assert.Equal("New file summary", updatedReleaseFile.Summary);
@@ -1885,9 +1887,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contextId))
             {
-                var updatedReleaseFile = await contentDbContext.ReleaseFiles.FirstAsync(rf =>
-                    rf.ReleaseId == releaseFile.ReleaseId
-                    && rf.FileId == releaseFile.FileId);
+                var updatedReleaseFile = await contentDbContext.ReleaseFiles
+                    .AsQueryable()
+                    .FirstAsync(rf =>
+                        rf.ReleaseId == releaseFile.ReleaseId
+                        && rf.FileId == releaseFile.FileId);
 
                 Assert.Equal("New file title", updatedReleaseFile.Name);
                 Assert.Equal("Old file summary", updatedReleaseFile.Summary);
@@ -1941,9 +1945,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contextId))
             {
-                var updatedReleaseFile = await contentDbContext.ReleaseFiles.FirstAsync(rf =>
-                    rf.ReleaseId == releaseFile.ReleaseId
-                    && rf.FileId == releaseFile.FileId);
+                var updatedReleaseFile = await contentDbContext.ReleaseFiles
+                    .AsQueryable()
+                    .FirstAsync(rf =>
+                        rf.ReleaseId == releaseFile.ReleaseId
+                        && rf.FileId == releaseFile.FileId);
 
                 Assert.Equal("Old file title", updatedReleaseFile.Name);
                 Assert.Equal("New file summary", updatedReleaseFile.Summary);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseServiceAmendmentTests.cs
@@ -494,6 +494,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 var amendmentReleaseRoles = contentDbContext
                     .UserReleaseRoles
+                    .AsQueryable()
                     .Where(r => r.ReleaseId == amendment.Id)
                     .ToList();
 
@@ -530,6 +531,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var releaseSubjectLinks = statisticsDbContext
                     .ReleaseSubject
+                    .AsQueryable()
                     .Where(r => r.ReleaseId == newReleaseId)
                     .ToList();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -3094,6 +3094,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 // Check the original Meta Guidance has been retained on the replacement
                 var replacedReleaseSubject = await statisticsDbContext.ReleaseSubject
+                    .AsQueryable()
                     .Where(rs => rs.ReleaseId == statsReleaseVersion2.Id
                                  && rs.SubjectId == replacementSubject.Id)
                     .FirstAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ThemeServiceTests.cs
@@ -291,7 +291,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 context.Add(theme);
                 await context.SaveChangesAsync();
-                
+
                 Assert.Equal(1, context.Themes.Count());
                 Assert.Equal(2, context.Topics.Count());
             }
@@ -303,7 +303,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 topicService
                     .Setup(s => s.DeleteTopic(theme.Topics[0].Id))
                     .ReturnsAsync(Unit.Instance);
-                
+
                 topicService
                     .Setup(s => s.DeleteTopic(theme.Topics[1].Id))
                     .ReturnsAsync(Unit.Instance);
@@ -311,7 +311,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var service = SetupThemeService(context, topicService: topicService.Object);
                 var result = await service.DeleteTheme(theme.Id);
                 VerifyAllMocks(topicService);
-                
+
                 result.AssertRight();
                 Assert.Equal(0, context.Themes.Count());
             }
@@ -345,15 +345,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 var topicService = new Mock<ITopicService>(Strict);
                 var service = SetupThemeService(context, topicService: topicService.Object);
-                
+
                 var result = await service.DeleteTheme(theme.Id);
                 VerifyAllMocks(topicService);
                 result.AssertForbidden();
 
                 Assert.Equal(1, context.Themes.Count());
             }
-        }        
-        
+        }
+
         [Fact]
         public async Task DeleteTheme_DisallowedByConfiguration()
         {
@@ -381,12 +381,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             await using (var context = InMemoryApplicationDbContext(contextId))
             {
                 var topicService = new Mock<ITopicService>(Strict);
-                
+
                 var service = SetupThemeService(
-                    context, 
-                    topicService: topicService.Object, 
+                    context,
+                    topicService: topicService.Object,
                     enableThemeDeletion: false);
-                
+
                 var result = await service.DeleteTheme(theme.Id);
                 VerifyAllMocks(topicService);
                 result.AssertForbidden();
@@ -394,7 +394,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Assert.Equal(1, context.Themes.Count());
             }
         }
-        
+
         [Fact]
         public async Task DeleteTheme_OtherThemesUnaffected()
         {
@@ -412,7 +412,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                         Title = "UI test topic 2"
                     })
             };
-            
+
             var otherTheme = new Theme
             {
                 Title = "UI test theme",
@@ -434,7 +434,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             {
                 await context.AddRangeAsync(theme, otherTheme);
                 await context.SaveChangesAsync();
-                
+
                 Assert.Equal(2, context.Themes.Count());
                 Assert.Equal(4, context.Topics.Count());
             }
@@ -446,7 +446,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 topicService
                     .Setup(s => s.DeleteTopic(theme.Topics[0].Id))
                     .ReturnsAsync(Unit.Instance);
-                
+
                 topicService
                     .Setup(s => s.DeleteTopic(theme.Topics[1].Id))
                     .ReturnsAsync(Unit.Instance);
@@ -454,9 +454,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var service = SetupThemeService(context, topicService: topicService.Object);
                 var result = await service.DeleteTheme(theme.Id);
                 VerifyAllMocks(topicService);
-                
+
                 result.AssertRight();
-                Assert.Equal(otherTheme.Id, context.Themes.Select(t => t.Id).Single());
+                Assert.Equal(otherTheme.Id, context.Themes.AsQueryable().Select(t => t.Id).Single());
             }
         }
 
@@ -471,7 +471,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var configuration =
                 CreateMockConfiguration(new Tuple<string, string>("enableThemeDeletion", enableThemeDeletion.ToString()));
-            
+
             return new ThemeService(
                 configuration.Object,
                 context,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/TopicServiceTests.cs
@@ -505,7 +505,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 PreviousVersionId = releaseVersion3Id,
                 PublicationId = publicationId
             });
-            
+
             var contextId = Guid.NewGuid().ToString();
 
             await using (var contentContext = DbUtils.InMemoryApplicationDbContext(contextId))
@@ -889,10 +889,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
                 result.AssertRight();
 
-                Assert.Equal(otherPublicationId, contentContext.Publications.Select(p => p.Id).Single());
-                Assert.Equal(otherTopicId, contentContext.Topics.Select(t => t.Id).Single());
-                Assert.Equal(otherReleaseId, contentContext.Releases.Select(r => r.Id).Single());
-                Assert.Equal(otherReleaseId, statisticsContext.Release.Select(r => r.Id).Single());
+                Assert.Equal(otherPublicationId, contentContext.Publications.AsQueryable().Select(p => p.Id).Single());
+                Assert.Equal(otherTopicId, contentContext.Topics.AsQueryable().Select(t => t.Id).Single());
+                Assert.Equal(otherReleaseId, contentContext.Releases.AsQueryable().Select(r => r.Id).Single());
+                Assert.Equal(otherReleaseId, statisticsContext.Release.AsQueryable().Select(r => r.Id).Single());
             }
         }
 
@@ -911,7 +911,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
         {
             var configuration =
                 CreateMockConfiguration(new Tuple<string, string>("enableThemeDeletion", enableThemeDeletion.ToString()));
-            
+
             return new TopicService(
                 configuration.Object,
                 contentContext,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseRoleRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserReleaseRoleRepositoryTests.cs
@@ -49,7 +49,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var userReleaseRoles = await contentDbContext.UserReleaseRoles.ToListAsync();
+                var userReleaseRoles = await contentDbContext.UserReleaseRoles
+                    .AsQueryable()
+                    .ToListAsync();
                 Assert.Single(userReleaseRoles);
 
                 Assert.NotEqual(Guid.Empty, userReleaseRoles[0].Id);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserRoleServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/UserRoleServiceTests.cs
@@ -201,7 +201,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var userPublicationRoles = await contentDbContext.UserPublicationRoles.ToListAsync();
+                var userPublicationRoles = await contentDbContext.UserPublicationRoles
+                    .AsQueryable()
+                    .ToListAsync();
                 Assert.Single(userPublicationRoles);
 
                 Assert.NotEqual(Guid.Empty, userPublicationRoles[0].Id);
@@ -264,7 +266,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var userPublicationRoles = await contentDbContext.UserPublicationRoles.ToListAsync();
+                var userPublicationRoles = await contentDbContext.UserPublicationRoles
+                    .AsQueryable()
+                    .ToListAsync();
                 Assert.Single(userPublicationRoles);
 
                 Assert.Equal(userPublicationRole.Id, userPublicationRoles[0].Id);
@@ -303,7 +307,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var userPublicationRoles = await contentDbContext.UserPublicationRoles.ToListAsync();
+                var userPublicationRoles = await contentDbContext.UserPublicationRoles
+                    .AsQueryable()
+                    .ToListAsync();
                 Assert.Empty(userPublicationRoles);
             }
 
@@ -345,7 +351,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var userPublicationRoles = await contentDbContext.UserPublicationRoles.ToListAsync();
+                var userPublicationRoles = await contentDbContext.UserPublicationRoles
+                    .AsQueryable()
+                    .ToListAsync();
                 Assert.Empty(userPublicationRoles);
             }
 
@@ -407,7 +415,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var userReleaseRoles = await contentDbContext.UserReleaseRoles.ToListAsync();
+                var userReleaseRoles = await contentDbContext.UserReleaseRoles
+                    .AsQueryable()
+                    .ToListAsync();
                 Assert.Single(userReleaseRoles);
 
                 Assert.NotEqual(Guid.Empty, userReleaseRoles[0].Id);
@@ -471,7 +481,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var userReleaseRoles = await contentDbContext.UserReleaseRoles.ToListAsync();
+                var userReleaseRoles = await contentDbContext.UserReleaseRoles
+                    .AsQueryable()
+                    .ToListAsync();
                 Assert.Single(userReleaseRoles);
 
                 Assert.Equal(userReleaseRole.Id, userReleaseRoles[0].Id);
@@ -513,7 +525,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var userReleaseRoles = await contentDbContext.UserReleaseRoles.ToListAsync();
+                var userReleaseRoles = await contentDbContext.UserReleaseRoles
+                    .AsQueryable()
+                    .ToListAsync();
                 Assert.Empty(userReleaseRoles);
             }
 
@@ -555,7 +569,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var userReleaseRoles = await contentDbContext.UserReleaseRoles.ToListAsync();
+                var userReleaseRoles = await contentDbContext.UserReleaseRoles
+                    .AsQueryable()
+                    .ToListAsync();
                 Assert.Empty(userReleaseRoles);
             }
 
@@ -827,7 +843,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 Role = Approver
             };
 
-            // Role assignment for a different user 
+            // Role assignment for a different user
             var userReleaseRole3 = new UserReleaseRole
             {
                 User = new User(),
@@ -1032,7 +1048,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var userPublicationRoles = await contentDbContext.UserPublicationRoles.ToListAsync();
+                var userPublicationRoles = await contentDbContext.UserPublicationRoles
+                    .AsQueryable()
+                    .ToListAsync();
                 Assert.Empty(userPublicationRoles);
             }
         }
@@ -1079,7 +1097,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             await using (var contentDbContext = InMemoryApplicationDbContext(contentDbContextId))
             {
-                var userReleaseRoles = await contentDbContext.UserReleaseRoles.ToListAsync();
+                var userReleaseRoles = await contentDbContext.UserReleaseRoles
+                    .AsQueryable()
+                    .ToListAsync();
                 Assert.Empty(userReleaseRoles);
             }
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="AutoMapper" Version="9.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="GovukNotify" Version="4.0.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.31" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -7,7 +7,7 @@
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
     <AspNetCoreModuleName>AspNetCoreModule</AspNetCoreModuleName>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Content Include="Migrations\ContentMigrations\*.sql">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -19,27 +19,27 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  
+
   <ItemGroup>
     <Content Include="Migrations\ContentMigrations\Html\Pupil_Absence_Statistics\*.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  
+
   <ItemGroup>
     <Content Include="Migrations\ContentMigrations\Html\Pupil_Exclusion_Statistics\*.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  
+
   <ItemGroup>
     <Content Include="Migrations\ContentMigrations\Html\Secondary_And_Primary_School_Applications_And_Offers\*.html">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  
+
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="9.0.0" />
+    <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="GovukNotify" Version="4.0.0" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.31" />
@@ -61,9 +61,10 @@
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.18" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <_ContentIncludedByDefault Remove="wwwroot\css\site.css" />
     <_ContentIncludedByDefault Remove="wwwroot\lib\bootstrap\dist\css\bootstrap-grid.css" />
@@ -184,14 +185,15 @@
     <_ContentIncludedByDefault Remove="Areas\Tools\Views\Notifications\NotifySubscribers.cshtml" />
     <_ContentIncludedByDefault Remove="Areas\Tools\Views\Home\Index.cshtml" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Model\GovUk.Education.ExploreEducationStatistics.Content.Model.csproj" />
+    <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Content.Services\GovUk.Education.ExploreEducationStatistics.Content.Services.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Processor.Model\GovUk.Education.ExploreEducationStatistics.Data.Processor.Model.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Data.Services\GovUk.Education.ExploreEducationStatistics.Data.Services.csproj" />
     <ProjectReference Include="..\GovUk.Education.ExploreEducationStatistics.Publisher.Model\GovUk.Education.ExploreEducationStatistics.Publisher.Model.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Folder Include="Migrations\ContentMigrations" />
     <Folder Include="Migrations\UsersAndRolesMigrations" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/BootstrapUsersService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/BootstrapUsersService.cs
@@ -24,7 +24,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         }
 
         /**
-         * Add any bootstrapping BAU users that we have specified on startup. 
+         * Add any bootstrapping BAU users that we have specified on startup.
          */
         public void AddBootstrapUsers()
         {
@@ -42,11 +42,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             var existingEmailInvites = _usersAndRolesDbContext
                 .UserInvites
+                .AsQueryable()
                 .Select(i => i.Email.ToLower())
                 .ToList();
 
             var existingUserEmails = _contentDbContext
                 .Users
+                .AsQueryable()
                 .Select(u => u.Email.ToLower())
                 .ToList();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataBlockService.cs
@@ -197,6 +197,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .ToList();
 
             var files = await _context.Files
+                .AsQueryable()
                 .Where(f => fileIds.Contains(f.Id))
                 .ToListAsync();
 
@@ -271,6 +272,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             var dependentDataBlocks = _context
                 .DataBlocks
+                .AsQueryable()
                 .Where(block => blockIdsToDelete.Contains(block.Id));
 
             _context.ContentBlocks.RemoveRange(dependentDataBlocks);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataImportService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/DataImportService.cs
@@ -65,6 +65,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<bool> HasIncompleteImports(Guid releaseId)
         {
             return await _contentDbContext.ReleaseFiles
+                .AsQueryable()
                 .Where(rf => rf.ReleaseId == releaseId)
                 .Join(_contentDbContext.DataImports,
                     rf => rf.FileId,

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
@@ -86,6 +86,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
         private async Task<Release> HydrateReleaseForReleaseViewModel(Release release)
         {
             release.Updates = await _contentDbContext.Update
+                .AsQueryable()
                 .Where(u => u.ReleaseId == release.Id)
                 .ToListAsync();
 
@@ -105,6 +106,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                 .LoadAsync();
 
             var content = await _contentDbContext.ReleaseContentSections
+                .AsQueryable()
                 .Where(rcs => rcs.ReleaseId == release.Id)
                 .Include(rcs => rcs.ContentSection)
                 .ThenInclude(cs => cs.Content)
@@ -116,6 +118,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                 await rcs.ContentSection.Content.ForEachAsync(async cb =>
                 {
                     cb.Comments = await _contentDbContext.Comment
+                        .AsQueryable()
                         .Where(c => c.ContentBlockId == cb.Id)
                         .Include(c => c.CreatedBy)
                         .Include(c => c.ResolvedBy)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ReleaseNoteService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ReleaseNoteService.cs
@@ -26,9 +26,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
         private readonly IUserService _userService;
 
         public ReleaseNoteService(
-            IMapper mapper, 
-            ContentDbContext context, 
-            IPersistenceHelper<ContentDbContext> persistenceHelper, 
+            IMapper mapper,
+            ContentDbContext context,
+            IPersistenceHelper<ContentDbContext> persistenceHelper,
             IUserService userService)
         {
             _mapper = mapper;
@@ -101,7 +101,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                     {
                         return NotFound<List<ReleaseNoteViewModel>>();
                     }
-                    
+
                     _context.Update.Remove(releaseNote);
                     await _context.SaveChangesAsync();
                     return GetReleaseNoteViewModels(release.Id);
@@ -111,11 +111,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
         private List<ReleaseNoteViewModel> GetReleaseNoteViewModels(Guid releaseId)
         {
             var releaseNotes = _context.Update
+                .AsQueryable()
                 .Where(update => update.ReleaseId == releaseId)
                 .OrderByDescending(update => update.On);
             return _mapper.Map<List<ReleaseNoteViewModel>>(releaseNotes);
         }
-        
+
         private static IQueryable<Release> HydrateReleaseForUpdates(IQueryable<Release> values)
         {
             return values.Include(r => r.Updates);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/MetaGuidanceService.cs
@@ -107,6 +107,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             var subjectIds = subjects.Select(s => s.Id);
 
             var matchingSubjects = await _statisticsDbContext.ReleaseSubject
+                .AsQueryable()
                 .Where(
                     releaseSubject => releaseSubject.ReleaseId == releaseId
                                       && subjectIds.Contains(releaseSubject.SubjectId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyAmendmentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyAmendmentService.cs
@@ -59,6 +59,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         {
             var originalFiles = await _context
                 .MethodologyFiles
+                .AsQueryable()
                 .Where(f => f.MethodologyVersionId == methodologyVersion.PreviousVersionId)
                 .ToListAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyFileRepository.cs
@@ -109,6 +109,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         {
             return _contentDbContext
                 .MethodologyFiles
+                .AsQueryable()
                 .Where(f => f.FileId == fileId)
                 .ToListAsync();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -247,7 +247,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 // Check that the Methodology will have a unique slug.  It is possible to have a clash in the case where
                 // another Methodology has previously set its AlternativeTitle (and Slug) to something specific and then
                 // this Methodology attempts to set its AlternativeTitle (and Slug) to the same value.  Whilst an
-                // unlikely scenario, it's entirely possible. 
+                // unlikely scenario, it's entirely possible.
                 .OnSuccessDo(methodologyVersion =>
                     ValidateMethodologySlugUniqueForUpdate(methodologyVersion.Id, request.Slug))
                 .OnSuccess(async methodologyVersion =>
@@ -347,12 +347,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
         {
             var methodologyId = await _context
                 .MethodologyVersions
+                .AsQueryable()
                 .Where(m => m.Id == methodologyVersionId)
                 .Select(m => m.MethodologyId)
                 .SingleAsync();
 
             if (await _context
                 .Methodologies
+                .AsQueryable()
                 .AnyAsync(p => p.Slug == slug && p.Id != methodologyId))
             {
                 return ValidationActionResult(SlugNotUnique);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseUserService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PreReleaseUserService.cs
@@ -80,6 +80,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                         var invitedPrereleaseContacts = await _context
                             .UserReleaseInvites
+                            .AsQueryable()
                             .Where(
                                 r => r.Role == ReleaseRole.PrereleaseViewer && !r.Accepted && r.ReleaseId == releaseId
                             )
@@ -123,6 +124,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     {
                         var existingUser = await _context
                             .Users
+                            .AsQueryable()
                             .Where(u => u.Email.ToLower() == email.ToLower())
                             .FirstOrDefaultAsync();
                         var isExistingUser = existingUser != null;
@@ -185,6 +187,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         _context.RemoveRange(
                             _context
                                 .UserReleaseInvites
+                                .AsQueryable()
                                 .Where(
                                     i =>
                                         i.ReleaseId == releaseId
@@ -199,6 +202,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         // UserInvites if they no longer have any PrereleaseView roles.
                         var remainingReleaseInvites = await _context
                             .UserReleaseInvites
+                            .AsQueryable()
                             .Where(
                                 i =>
                                     i.Email.ToLower() == email.ToLower()
@@ -212,6 +216,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
                             _usersAndRolesDbContext.UserInvites.RemoveRange(
                                 _usersAndRolesDbContext.UserInvites
+                                    .AsQueryable()
                                     .Where(
                                         i =>
                                             i.Email.ToLower() == email.ToLower()
@@ -229,6 +234,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<Either<ActionResult, Unit>> SendPreReleaseUserInviteEmails(Release release)
         {
             var userReleaseInvites = await _context.UserReleaseInvites
+                .AsQueryable()
                 .Where(i =>
                     i.ReleaseId == release.Id
                     && i.Role == ReleaseRole.PrereleaseViewer
@@ -238,6 +244,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             await userReleaseInvites.ForEachAsync(async invite =>
             {
                 var user = await _context.Users
+                    .AsQueryable()
                     .SingleOrDefaultAsync(u => u.Email.ToLower() == invite.Email.ToLower());
                 var isNewUser = user == null;
                 SendPreReleaseInviteEmail(release, invite.Email.ToLower(), isNewUser);
@@ -269,6 +276,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             var hasExistingReleaseInvite = await _context
                 .UserReleaseInvites
+                .AsQueryable()
                 .Where(
                     i =>
                         i.ReleaseId == releaseId
@@ -289,6 +297,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             var hasExistingInvite = await _context
                 .UserReleaseInvites
+                .AsQueryable()
                 .Where(
                     i =>
                         i.ReleaseId == releaseId
@@ -318,6 +327,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             var hasExistingSystemInvite = await _usersAndRolesDbContext
                 .UserInvites
+                .AsQueryable()
                 .Where(i => i.Email.ToLower() == email.ToLower())
                 .AnyAsync();
 
@@ -384,6 +394,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             // TODO represent Roles with an Enum
             return await _usersAndRolesDbContext
                 .Roles
+                .AsQueryable()
                 .Where(r => r.Name == "Prerelease User")
                 .FirstAsync();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationRepository.cs
@@ -40,6 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             Guid userId)
         {
             var publicationsGrantedByPublicationOwnerRole = await _context.UserPublicationRoles
+                .AsQueryable()
                 .Where(userPublicationRole => userPublicationRole.UserId == userId &&
                                               userPublicationRole.Publication.TopicId == topicId &&
                                               userPublicationRole.Role == PublicationRole.Owner)
@@ -71,7 +72,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .GroupBy(release => release.Publication)
                 .Where(publicationWithReleases =>
                 {
-                    // Don't include a publication that's already been included by Publication Owner role 
+                    // Don't include a publication that's already been included by Publication Owner role
                     var publication = publicationWithReleases.Key;
                     return !publicationIdsGrantedByPublicationOwnerRole.Contains(publication.Id);
                 })

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/PublicationService.cs
@@ -125,19 +125,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 {
                     var originalTitle = publication.Title;
                     var originalSlug = publication.Slug;
-                    
+
                     if (!publication.Live) {
-                        
+
                         var slugValidation = await ValidatePublicationSlugUniqueForUpdate(publication.Id, updatedPublication.Slug);
-                        
+
                         if (slugValidation.IsLeft)
                         {
                             return new Either<ActionResult, PublicationViewModel>(slugValidation.Left);
-                        }    
-                            
+                        }
+
                         publication.Slug = updatedPublication.Slug;
                     }
-                    
+
                     publication.Title = updatedPublication.Title;
                     publication.TopicId = updatedPublication.TopicId;
                     publication.ExternalMethodology = updatedPublication.ExternalMethodology;
@@ -161,7 +161,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     _context.Publications.Update(publication);
 
                     await _context.SaveChangesAsync();
-                    
+
                     if (originalTitle != publication.Title)
                     {
                         await _methodologyVersionRepository.PublicationTitleChanged(publicationId, originalSlug, publication.Title, publication.Slug);
@@ -242,7 +242,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         private async Task<Either<ActionResult, Unit>> ValidatePublicationSlugUniqueForUpdate(Guid id, string slug)
         {
-            if (await _context.Publications.AnyAsync(publication => publication.Slug == slug && publication.Id != id))
+            if (await _context.Publications.AsQueryable().AnyAsync(publication => publication.Slug == slug && publication.Id != id))
             {
                 return ValidationActionResult(SlugNotUnique);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseFileRepository.cs
@@ -120,6 +120,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<bool> FileIsLinkedToOtherReleases(Guid releaseId, Guid fileId)
         {
             return await _contentDbContext.ReleaseFiles
+                .AsQueryable()
                 .AnyAsync(releaseFile =>
                     releaseFile.ReleaseId != releaseId
                     && releaseFile.FileId == fileId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseRepository.cs
@@ -22,7 +22,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         private readonly IMapper _mapper;
 
         public ReleaseRepository(
-            ContentDbContext contentDbContext, 
+            ContentDbContext contentDbContext,
             StatisticsDbContext statisticsDbContext,
             IMapper mapper)
         {
@@ -34,11 +34,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<List<MyReleaseViewModel>> ListReleases(
             params ReleaseApprovalStatus[] releaseApprovalStatuses)
         {
-            var releases = await 
+            var releases = await
                 HydrateReleaseForReleaseViewModel(_contentDbContext.Releases)
                 .Where(r => releaseApprovalStatuses.Contains(r.ApprovalStatus))
                 .ToListAsync();
-            
+
             return _mapper.Map<List<MyReleaseViewModel>>(releases);
         }
 
@@ -47,24 +47,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             var userReleaseIds = await _contentDbContext
                 .UserReleaseRoles
+                .AsQueryable()
                 .Where(r => r.UserId == userId && r.Role != ReleaseRole.PrereleaseViewer)
                 .Select(r => r.ReleaseId)
                 .ToListAsync();
 
             var userPublicationIds = await _contentDbContext
                 .UserPublicationRoles
+                .AsQueryable()
                 .Where(r => r.UserId == userId && r.Role == PublicationRole.Owner)
                 .Select(r => r.PublicationId)
                 .ToListAsync();
             var userPublicationRoleReleaseIds = await _contentDbContext
                 .Releases
+                .AsQueryable()
                 .Where(r => userPublicationIds.Contains(r.PublicationId))
                 .Select(r => r.Id)
                 .ToListAsync();
             userReleaseIds.AddRange(userPublicationRoleReleaseIds);
             userReleaseIds = userReleaseIds.Distinct().ToList();
 
-            var releases = await 
+            var releases = await
                 HydrateReleaseForReleaseViewModel(_contentDbContext.Releases)
                 .Where(r => userReleaseIds.Contains(r.Id) && releaseApprovalStatuses.Contains(r.ApprovalStatus))
                 .ToListAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReplacementService.cs
@@ -313,12 +313,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
             var existingFilterNames = _statisticsDbContext
                 .FilterItem
+                .AsQueryable()
                 .Where(fi => existingFilterItemIds.Contains(fi.Id))
                 .Select(fi => fi.FilterGroup.Filter)
                 .Select(f => f.Name)
                 .Distinct()
                 .ToList();
-            
+
             return replacementSubjectMeta
                 .Filters
                 .Select(d => d.Value)
@@ -337,7 +338,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     .Select(fi => new FilterItemReplacementViewModel(fi.Id, fi.Label, null)))
                 )
                 .ToDictionary(f => f.Id);
-            
+
             return new FilterReplacementViewModel(filter.Id, filter.Label, filter.Name, filterGroupReplacementViewModels);
         }
 
@@ -346,6 +347,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             ReplacementSubjectMeta replacementSubjectMeta)
         {
             return _statisticsDbContext.FilterItem
+                .AsQueryable()
                 .Where(filterItem => dataBlock.Query.Filters.Contains(filterItem.Id))
                 .Include(filterItem => filterItem.FilterGroup)
                 .ThenInclude(filterGroup => filterGroup.Filter)
@@ -567,6 +569,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             Guid replacementSubjectId)
         {
             var dataBlock = await _contentDbContext.ContentBlocks
+                .AsQueryable()
                 .OfType<DataBlock>()
                 .SingleAsync(block => block.Id == replacementPlan.Id);
 
@@ -803,8 +806,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         private async Task ReplaceFootnoteSubject(Guid footnoteId, Guid originalSubjectId, Guid replacementSubjectId)
         {
-            var subjectFootnote = await _statisticsDbContext.SubjectFootnote.Where(f =>
-                f.FootnoteId == footnoteId && f.SubjectId == originalSubjectId).SingleOrDefaultAsync();
+            var subjectFootnote = await _statisticsDbContext.SubjectFootnote
+                .AsQueryable()
+                .Where(f =>
+                    f.FootnoteId == footnoteId && f.SubjectId == originalSubjectId).SingleOrDefaultAsync();
 
             if (subjectFootnote != null)
             {
@@ -819,9 +824,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         private async Task ReplaceFootnoteFilter(Guid footnoteId, TargetableReplacementViewModel plan)
         {
-            var filterFootnote = await _statisticsDbContext.FilterFootnote.SingleAsync(f =>
-                f.FootnoteId == footnoteId && f.FilterId == plan.Id
-            );
+            var filterFootnote = await _statisticsDbContext.FilterFootnote
+                .AsQueryable()
+                .SingleAsync(f =>
+                    f.FootnoteId == footnoteId && f.FilterId == plan.Id
+                );
 
             _statisticsDbContext.Remove(filterFootnote);
             await _statisticsDbContext.FilterFootnote.AddAsync(new FilterFootnote
@@ -833,9 +840,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         private async Task ReplaceFootnoteFilterGroup(Guid footnoteId, TargetableReplacementViewModel plan)
         {
-            var filterGroupFootnote = await _statisticsDbContext.FilterGroupFootnote.SingleAsync(f =>
-                f.FootnoteId == footnoteId && f.FilterGroupId == plan.Id
-            );
+            var filterGroupFootnote = await _statisticsDbContext.FilterGroupFootnote
+                .AsQueryable()
+                .SingleAsync(f =>
+                    f.FootnoteId == footnoteId && f.FilterGroupId == plan.Id
+                );
 
             _statisticsDbContext.Remove(filterGroupFootnote);
             await _statisticsDbContext.FilterGroupFootnote.AddAsync(new FilterGroupFootnote
@@ -847,9 +856,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         private async Task ReplaceFootnoteFilterItem(Guid footnoteId, TargetableReplacementViewModel plan)
         {
-            var filterItemFootnote = await _statisticsDbContext.FilterItemFootnote.SingleAsync(f =>
-                f.FootnoteId == footnoteId && f.FilterItemId == plan.Id
-            );
+            var filterItemFootnote = await _statisticsDbContext.FilterItemFootnote
+                .AsQueryable()
+                .SingleAsync(f =>
+                    f.FootnoteId == footnoteId && f.FilterItemId == plan.Id
+                );
 
             _statisticsDbContext.Remove(filterItemFootnote);
             await _statisticsDbContext.FilterItemFootnote.AddAsync(new FilterItemFootnote
@@ -861,9 +872,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         private async Task ReplaceIndicatorFootnote(Guid footnoteId, TargetableReplacementViewModel plan)
         {
-            var indicatorFootnote = await _statisticsDbContext.IndicatorFootnote.SingleAsync(f =>
-                f.FootnoteId == footnoteId && f.IndicatorId == plan.Id
-            );
+            var indicatorFootnote = await _statisticsDbContext.IndicatorFootnote
+                .AsQueryable()
+                .SingleAsync(f =>
+                    f.FootnoteId == footnoteId && f.IndicatorId == plan.Id
+                );
 
             _statisticsDbContext.Remove(indicatorFootnote);
             await _statisticsDbContext.IndicatorFootnote.AddAsync(new IndicatorFootnote
@@ -879,11 +892,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             Guid replacementSubject)
         {
             var originalReleaseSubject = await _statisticsDbContext.ReleaseSubject
+                .AsQueryable()
                 .Where(rs => rs.ReleaseId == releaseId &&
                              rs.SubjectId == originalSubject)
                 .FirstAsync();
 
             var replacementReleaseSubject = await _statisticsDbContext.ReleaseSubject
+                .AsQueryable()
                 .Where(rs => rs.ReleaseId == releaseId &&
                              rs.SubjectId == replacementSubject)
                 .FirstAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ThemeService.cs
@@ -163,7 +163,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             {
                 return new ForbidResult();
             }
-                        
+
             // For now we only want to delete test themes as we
             // don't really have a mechanism to clean things up
             // properly across the entire application.
@@ -181,17 +181,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             var userId = _userService.GetUserId();
 
             var topics = await (
-                    from userReleaseRole in _context.UserReleaseRoles
-                    where userReleaseRole.UserId == userId 
+                    from userReleaseRole in _context.UserReleaseRoles.AsQueryable()
+                    where userReleaseRole.UserId == userId
                           && userReleaseRole.Role != ReleaseRole.PrereleaseViewer
                     select userReleaseRole.Release.Publication
                 ).Concat(
-                    from userPublicationRole in _context.UserPublicationRoles
-                    where userPublicationRole.UserId == userId 
+                    from userPublicationRole in _context.UserPublicationRoles.AsQueryable()
+                    where userPublicationRole.UserId == userId
                           && userPublicationRole.Role == Owner
                     select userPublicationRole.Publication
                 ).Include(publication => publication.Topic)
-                .ThenInclude(topic => topic.Theme).Select(publication => publication.Topic)
+                .ThenInclude(topic => topic.Theme)
+                .Select(publication => publication.Topic)
                 .Distinct()
                 .ToListAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/TopicService.cs
@@ -188,6 +188,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             var methodologyIdsToDelete = await _contentContext
                 .PublicationMethodologies
+                .AsQueryable()
                 .Where(pm => pm.Owner && publicationIds.Contains(pm.PublicationId))
                 .Select(pm => pm.MethodologyId)
                 .ToListAsync();
@@ -220,8 +221,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             var contentRelease = await _contentContext
                 .Releases
+                .AsQueryable()
                 .SingleOrDefaultAsync(r => r.Id == releaseId);
-            
+
             if (contentRelease == null)
             {
                 // The Content Db Release may already be soft-deleted and therefore not visible.
@@ -259,6 +261,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         {
             var statsRelease = await _statisticsContext
                 .Release
+                .AsQueryable()
                 .SingleOrDefaultAsync(r => r.Id == releaseId);
 
             if (statsRelease != null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserManagementService.cs
@@ -50,6 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(() =>
                 {
                     return _usersAndRolesDbContext.Users
+                        .AsQueryable()
                         .Join(
                             _usersAndRolesDbContext.UserRoles,
                             user => user.Id,
@@ -85,6 +86,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(_ =>
                 {
                     return _contentDbContext.Publications
+                        .AsQueryable()
                         .Select(p => new TitleAndIdViewModel
                         {
                             Id = p.Id,
@@ -119,7 +121,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .CheckCanManageAllUsers()
                 .OnSuccess(async () =>
                 {
-                    return await _usersAndRolesDbContext.Roles.Select(r => new RoleViewModel
+                    return await _usersAndRolesDbContext.Roles
+                        .AsQueryable()
+                        .Select(r => new RoleViewModel
                         {
                             Id = r.Id,
                             Name = r.Name,
@@ -133,6 +137,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
         public async Task<List<UserViewModel>> ListPreReleaseUsersAsync()
         {
             return await _usersAndRolesDbContext.Users
+                .AsQueryable()
                 .Join(
                     _usersAndRolesDbContext.UserRoles,
                     user => user.Id,
@@ -200,6 +205,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .CheckCanManageAllUsers()
                 .OnSuccess(async () =>
                     await _usersAndRolesDbContext.UserInvites
+                        .AsQueryable()
                         .Where(ui => !ui.Accepted)
                         .OrderBy(ui => ui.Email)
                         .Include(ui => ui.Role)
@@ -228,7 +234,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         return ValidationActionResult(UserAlreadyExists);
                     }
 
-                    var role = await _usersAndRolesDbContext.Roles.FirstOrDefaultAsync(r => r.Id == roleId);
+                    var role = await _usersAndRolesDbContext.Roles
+                        .AsQueryable()
+                        .FirstOrDefaultAsync(r => r.Id == roleId);
+
                     if (role == null)
                     {
                         return ValidationActionResult(InvalidUserRole);
@@ -254,7 +263,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .CheckCanManageAllUsers()
                 .OnSuccess<ActionResult, Unit, Unit>(async () =>
                 {
-                    var invite = await _usersAndRolesDbContext.UserInvites.FirstOrDefaultAsync(i => i.Email == email);
+                    var invite = await _usersAndRolesDbContext.UserInvites
+                        .AsQueryable()
+                        .FirstOrDefaultAsync(i => i.Email == email);
+
                     if (invite == null)
                     {
                         return ValidationActionResult(InviteNotFound);
@@ -275,8 +287,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 {
                     // Currently we only allow a user to have a maximum of one global role
                     var existingRole =
-                        await _usersAndRolesDbContext.UserRoles.FirstOrDefaultAsync(userRole =>
-                            userRole.UserId == userId);
+                        await _usersAndRolesDbContext.UserRoles
+                            .AsQueryable()
+                            .FirstOrDefaultAsync(userRole => userRole.UserId == userId);
+
                     if (existingRole == null)
                     {
                         return await _userRoleService.AddGlobalRole(userId, roleId);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserPublicationRoleRepository.cs
@@ -41,7 +41,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<List<PublicationRole>> GetAllRolesByUser(Guid userId, Guid publicationId)
         {
-            return await _contentDbContext.UserPublicationRoles.Where(r =>
+            return await _contentDbContext.UserPublicationRoles
+                .AsQueryable()
+                .Where(r =>
                     r.UserId == userId &&
                     r.PublicationId == publicationId)
                 .Select(role => role.Role)
@@ -55,10 +57,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<bool> UserHasRoleOnPublication(Guid userId, Guid publicationId, PublicationRole role)
         {
-            return await _contentDbContext.UserPublicationRoles.AnyAsync(r =>
-                r.UserId == userId &&
-                r.PublicationId == publicationId &&
-                r.Role == role);
+            return await _contentDbContext.UserPublicationRoles
+                .AsQueryable()
+                .AnyAsync(r =>
+                    r.UserId == userId &&
+                    r.PublicationId == publicationId &&
+                    r.Role == role);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseRoleRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserReleaseRoleRepository.cs
@@ -36,7 +36,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<List<ReleaseRole>> GetAllRolesByUser(Guid userId, Guid releaseId)
         {
-            return await _contentDbContext.UserReleaseRoles.Where(r =>
+            return await _contentDbContext.UserReleaseRoles
+                .AsQueryable()
+                .Where(r =>
                     r.UserId == userId &&
                     r.ReleaseId == releaseId)
                 .Select(r => r.Role)
@@ -61,10 +63,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
 
         public async Task<bool> UserHasRoleOnRelease(Guid userId, Guid releaseId, ReleaseRole role)
         {
-            return await _contentDbContext.UserReleaseRoles.AnyAsync(r =>
-                r.UserId == userId &&
-                r.ReleaseId == releaseId &&
-                r.Role == role);
+            return await _contentDbContext.UserReleaseRoles
+                .AsQueryable()
+                .AnyAsync(r =>
+                    r.UserId == userId &&
+                    r.ReleaseId == releaseId &&
+                    r.Role == role);
         }
 
         public async Task<bool> UserHasAnyOfRolesOnLatestRelease(Guid userId,
@@ -84,6 +88,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             }
 
             return await _contentDbContext.UserReleaseRoles
+                .AsQueryable()
                 .AnyAsync(r =>
                     r.UserId == userId &&
                     r.ReleaseId == latestRelease.Id &&

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserRoleService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/UserRoleService.cs
@@ -64,7 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .CheckEntityExists<ApplicationUser, string>(userId)
                         .OnSuccessCombineWith(user =>_usersAndRolesPersistenceHelper
                             .CheckEntityExists<IdentityRole, string>(roleId))
-                        .OnSuccessVoid(async tuple => 
+                        .OnSuccessVoid(async tuple =>
                         {
                             var (user, role) = tuple;
                             await _userManager.AddToRoleAsync(user, role.Name);
@@ -124,7 +124,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .CheckCanManageAllUsers()
                 .OnSuccess(async () =>
                 {
-                    return await _usersAndRolesDbContext.Roles.Select(r => new RoleViewModel
+                    return await _usersAndRolesDbContext.Roles
+                        .AsQueryable()
+                        .Select(r => new RoleViewModel
                         {
                             Id = r.Id,
                             Name = r.Name,
@@ -167,11 +169,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 .OnSuccess(async () =>
                 {
                     var roleIds = await _usersAndRolesDbContext.UserRoles
+                        .AsQueryable()
                         .Where(r => r.UserId == userId)
                         .Select(r => r.RoleId)
                         .ToListAsync();
 
                     return await _usersAndRolesDbContext.Roles
+                        .AsQueryable()
                         .Where(r => roleIds.Contains(r.Id))
                         .OrderBy(r => r.Name)
                         .Select(r => new RoleViewModel
@@ -225,8 +229,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .ThenBy(userReleaseRole => userReleaseRole.Release.Year)
                         .ThenBy(userReleaseRole => userReleaseRole.Release.TimePeriodCoverage)
                         .ToList();
-                        
-                    return latestReleaseRoles.Select(userReleaseRole => new UserReleaseRoleViewModel 
+
+                    return latestReleaseRoles.Select(userReleaseRole => new UserReleaseRoleViewModel
                         {
                             Id = userReleaseRole.Id,
                             Publication = userReleaseRole.Release.Publication.Title,
@@ -247,7 +251,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                         .CheckEntityExists<ApplicationUser, string>(userId)
                         .OnSuccessCombineWith(user =>_usersAndRolesPersistenceHelper
                             .CheckEntityExists<IdentityRole, string>(roleId))
-                        .OnSuccessVoid(async tuple => 
+                        .OnSuccessVoid(async tuple =>
                         {
                             var (user, role) = tuple;
                             await _userManager.RemoveFromRoleAsync(user, role.Name);
@@ -278,7 +282,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                     await _contentDbContext.SaveChangesAsync();
                 });
         }
-        
+
         private async Task<Either<ActionResult, Unit>> ValidatePublicationRoleCanBeAdded(Guid userId,
             Guid publicationId,
             PublicationRole role)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/GovUk.Education.ExploreEducationStatistics.Content.Api.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="10.1.1" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+        <PackageReference Include="AutoMapper" Version="9.0.0" />
+        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
         <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.7" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using AutoMapper;
 using Azure.Storage.Blobs;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GovUk.Education.ExploreEducationStatistics.Content.Services.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GovUk.Education.ExploreEducationStatistics.Content.Services.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="10.1.1" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+        <PackageReference Include="AutoMapper" Version="9.0.0" />
+        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="System.Linq.Async" Version="5.0.0" />
         <PackageReference Include="System.Linq.Async.Queryable" Version="5.0.0" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.0-alpha-844" />
-    <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+    <PackageReference Include="AutoMapper" Version="9.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.DataFactory" Version="4.7.0" />


### PR DESCRIPTION
This PR adds the `Content.Services` project as a dependency of `Admin`. This is required as a prerequisite to EES-369.

Due to `Content.Services` having a dependency on the `System.Linq.Async` package, we need to add `AsQueryable` calls across the admin to avoid ambiguity over which extension methods should be chosen by the compiler.

Additionally, we also have needed to downgrade `AutoMapper` in various parts of the project that had previously upgraded it to 10.1.1. Trying to bring in `Content.Services` created a dependency conflict meaning that `AutoMapper` needed to be upgraded or downgraded to be consistent across the project. 

Unfortunately, `AutoMapper` 10.1.1 appears to have a conflict with the `IdentityServer` dependency used in the admin. This meant that we have needed to settle for downgrading everything back to 9.0.0 instead.

This issue could potentially be resolved when we are able to upgrade all of the packages to their latest and greatest in November as part of the .NET 6 release.