### PR TITLE
EES-2745 Delete Data catalogue page cache tree when publishing a release

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishStagedReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishStagedReleaseContentFunction.cs
@@ -99,6 +99,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                     await _blobCacheService.DeleteItem(new AllMethodologiesCacheKey());
                     await _blobCacheService.DeleteItem(new PublicationTreeCacheKey());
                     await _blobCacheService.DeleteItem(new PublicationTreeCacheKey(PublicationTreeFilter.LatestData));
+                    await _blobCacheService.DeleteItem(new PublicationTreeCacheKey(PublicationTreeFilter.AnyData));
 
                     await _contentService.DeletePreviousVersionsDownloadFiles(releaseIds);
                     await _contentService.DeletePreviousVersionsContent(releaseIds);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishStagedReleaseContentFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishStagedReleaseContentFunction.cs
@@ -2,10 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Cache;
-using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
-using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Utils;
@@ -18,21 +14,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
     // ReSharper disable once UnusedType.Global
     public class PublishStagedReleaseContentFunction
     {
-        private readonly IBlobCacheService _blobCacheService;
         private readonly IContentService _contentService;
         private readonly INotificationsService _notificationsService;
         private readonly IReleasePublishingStatusService _releasePublishingStatusService;
         private readonly IPublishingService _publishingService;
         private readonly IReleaseService _releaseService;
 
-        public PublishStagedReleaseContentFunction(IBlobCacheService blobCacheService,
-            IContentService contentService,
+        public PublishStagedReleaseContentFunction(IContentService contentService,
             INotificationsService notificationsService,
             IReleasePublishingStatusService releasePublishingStatusService,
             IPublishingService publishingService,
             IReleaseService releaseService)
         {
-            _blobCacheService = blobCacheService;
             _contentService = contentService;
             _notificationsService = notificationsService;
             _releasePublishingStatusService = releasePublishingStatusService;
@@ -96,10 +89,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
 
                     // Invalidate the cached trees in case any methodologies/publications
                     // are now accessible for the first time after publishing these releases
-                    await _blobCacheService.DeleteItem(new AllMethodologiesCacheKey());
-                    await _blobCacheService.DeleteItem(new PublicationTreeCacheKey());
-                    await _blobCacheService.DeleteItem(new PublicationTreeCacheKey(PublicationTreeFilter.LatestData));
-                    await _blobCacheService.DeleteItem(new PublicationTreeCacheKey(PublicationTreeFilter.AnyData));
+                    await _contentService.DeleteCachedTaxonomyBlobs();
 
                     await _contentService.DeletePreviousVersionsDownloadFiles(releaseIds);
                     await _contentService.DeletePreviousVersionsContent(releaseIds);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishTaxonomyFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Functions/PublishTaxonomyFunction.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
-using GovUk.Education.ExploreEducationStatistics.Publisher.Models;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfaces;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
@@ -31,9 +29,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Functions
                 executionContext.FunctionName,
                 message.ToString());
 
-            var context = new PublishContext(DateTime.UtcNow, false);
-
-            await _contentService.UpdateTaxonomy(context);
+            await _contentService.DeleteCachedTaxonomyBlobs();
 
             logger.LogInformation("{0} completed",
                 executionContext.FunctionName);

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -129,16 +129,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
             // Invalidate the various cached trees in case any
             // publications/methodologies are affected by the changes
-            await _blobCacheService.DeleteItem(new AllMethodologiesCacheKey());
-            await _blobCacheService.DeleteItem(new PublicationTreeCacheKey());
-            await _blobCacheService.DeleteItem(new PublicationTreeCacheKey(PublicationTreeFilter.AnyData));
-            await _blobCacheService.DeleteItem(new PublicationTreeCacheKey(PublicationTreeFilter.LatestData));
+            await DeleteCachedTaxonomyBlobs();
         }
 
-        public async Task UpdateTaxonomy(PublishContext context)
+        public async Task DeleteCachedTaxonomyBlobs()
         {
-            // Invalidate the cached trees in case any
-            // publications/methodologies are affected by the changes
             await _blobCacheService.DeleteItem(new AllMethodologiesCacheKey());
             await _blobCacheService.DeleteItem(new PublicationTreeCacheKey());
             await _blobCacheService.DeleteItem(new PublicationTreeCacheKey(PublicationTreeFilter.AnyData));

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/Interfaces/IContentService.cs
@@ -16,6 +16,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services.Interfac
 
         Task UpdatePublication(PublishContext context, Guid publicationId);
 
-        Task UpdateTaxonomy(PublishContext context);
+        Task DeleteCachedTaxonomyBlobs();
     }
 }


### PR DESCRIPTION
We also refactor the deleting of all cache tree json files in this PR to prevent the problem arising again.

It looks like due to this refactoring, the PublishTaxonomy function could now potentially be removed entirely. If that's right, I'll create a separate ticket for this work rather than address it here.