### PR TITLE
EES-2748 - added fail fast mechanism

### DIFF
--- a/tests/robot-tests/.env.example
+++ b/tests/robot-tests/.env.example
@@ -9,3 +9,4 @@ ANALYST_PASSWORD=ANALYST_PASSWORD
 RELEASE_COMPLETE_WAIT=120
 WAIT_MEDIUM=120
 WAIT_LONG=180
+FAIL_TEST_SUITES_FAST=1   # or "0" if wanting to allow test suites to continue even after one of their child tests fails

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -355,6 +355,9 @@ else:
 if os.getenv('RELEASE_COMPLETE_WAIT'):
     robotArgs += ["-v", f"release_complete_wait:{os.getenv('RELEASE_COMPLETE_WAIT')}"]
 
+if os.getenv('FAIL_TEST_SUITES_FAST'):
+    robotArgs += ["-v", f"FAIL_TEST_SUITES_FAST:{os.getenv('FAIL_TEST_SUITES_FAST')}"]
+
 if args.prompt_to_continue:
     robotArgs += ["-v", "prompt_to_continue_on_failure:1"]
 

--- a/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/analyst_absence_permissions.robot
@@ -3,6 +3,7 @@ Resource            ../../libs/admin-common.robot
 
 Suite Setup         user signs in as analyst1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev
 

--- a/tests/robot-tests/tests/admin/analyst/create_methodology_as_publication_owner.robot
+++ b/tests/robot-tests/tests/admin/analyst/create_methodology_as_publication_owner.robot
@@ -5,6 +5,7 @@ Resource            ../../libs/admin/manage-content-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_owner_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_owner_permissions.robot
@@ -6,6 +6,7 @@ Resource            ../../../libs/admin/analyst/role_ui_permissions.robot
 
 Suite Setup         user signs in as analyst1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev
 

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -6,6 +6,7 @@ Resource            ../../../libs/admin/analyst/role_ui_permissions.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData    Footnotes
 

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_approver_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_approver_ui_permissions.robot
@@ -6,6 +6,7 @@ Resource            ../../../libs/admin/analyst/role_ui_permissions.robot
 
 Suite Setup         user signs in as analyst1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev
 

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_contributor_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_contributor_ui_permissions.robot
@@ -6,6 +6,7 @@ Resource            ../../../libs/admin/analyst/role_ui_permissions.robot
 
 Suite Setup         user signs in as analyst1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev
 

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_viewer_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_viewer_ui_permissions.robot
@@ -6,6 +6,7 @@ Resource            ../../../libs/admin/analyst/role_ui_permissions.robot
 
 Suite Setup         user signs in as analyst1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev
 

--- a/tests/robot-tests/tests/admin/bau/admin_dashboard_page.robot
+++ b/tests/robot-tests/tests/admin/bau/admin_dashboard_page.robot
@@ -5,6 +5,7 @@ Force Tags          Admin    Local    Dev
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Variables ***
 ${TOPIC_NAME}       %{TEST_TOPIC_NAME}

--- a/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
+++ b/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
@@ -7,9 +7,10 @@ Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Variables ***
-${OWNING_PUBLICATION_NAME}=        UI tests - methodology owning publication %{RUN_IDENTIFIER}
+${OWNING_PUBLICATION_NAME}=         UI tests - methodology owning publication %{RUN_IDENTIFIER}
 ${ADOPTING_PUBLICATION_NAME}=       UI tests - adopting methodology publication %{RUN_IDENTIFIER}
 
 *** Test Cases ***
@@ -25,7 +26,8 @@ Adopt a Methodology
     user waits until page contains title    Adopt a methodology
     user clicks radio    ${OWNING_PUBLICATION_NAME}
     user opens details dropdown    More details    css:[data-testid="Radio item for ${OWNING_PUBLICATION_NAME}"]
-    ${selected_methodology_details}=    user gets details content element    More details    css:[data-testid="Radio item for ${OWNING_PUBLICATION_NAME}"]
+    ${selected_methodology_details}=    user gets details content element    More details
+    ...    css:[data-testid="Radio item for ${OWNING_PUBLICATION_NAME}"]
     user checks element should contain    ${selected_methodology_details}    ${OWNING_PUBLICATION_NAME}
     user checks element should contain    ${selected_methodology_details}    DRAFT
     user checks element should contain    ${selected_methodology_details}    Not yet published

--- a/tests/robot-tests/tests/admin/bau/comments.robot
+++ b/tests/robot-tests/tests/admin/bau/comments.robot
@@ -6,6 +6,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Variables ***
 ${RELEASE_NAME}=                Academic Year Q1 2020/21

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -7,6 +7,7 @@ Resource            ../../libs/charts.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 

--- a/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
@@ -8,6 +8,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Variables ***
 ${PUBLICATION_NAME}=    UI tests - create methodology amendment publication %{RUN_IDENTIFIER}

--- a/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
@@ -7,6 +7,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Variables ***
 ${PUBLICATION_NAME}=    UI tests - create methodology publication %{RUN_IDENTIFIER}

--- a/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
+++ b/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
@@ -4,6 +4,7 @@ Resource            ../../libs/admin-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      teardown suite
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 

--- a/tests/robot-tests/tests/admin/bau/delete_subject.robot
+++ b/tests/robot-tests/tests/admin/bau/delete_subject.robot
@@ -6,6 +6,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Variables ***
 ${TOPIC_NAME}           %{TEST_TOPIC_NAME}

--- a/tests/robot-tests/tests/admin/bau/legacy_releases.robot
+++ b/tests/robot-tests/tests/admin/bau/legacy_releases.robot
@@ -6,6 +6,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Variables ***
 ${PUBLICATION_NAME}     UI tests - legacy releases %{RUN_IDENTIFIER}

--- a/tests/robot-tests/tests/admin/bau/link_publication_to_external_methodology.robot
+++ b/tests/robot-tests/tests/admin/bau/link_publication_to_external_methodology.robot
@@ -4,6 +4,7 @@ Resource            ../../libs/admin-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 

--- a/tests/robot-tests/tests/admin/bau/manage_users_page.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_users_page.robot
@@ -8,6 +8,7 @@ Force Tags          Admin    Local    Dev
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Test Cases ***
 Navigate to manage users page as bau1

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -7,6 +7,7 @@ Resource            ../../libs/tables-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -6,6 +6,7 @@ Resource            ../../libs/admin/manage-content-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -5,6 +5,7 @@ Resource            ../../libs/admin-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 

--- a/tests/robot-tests/tests/admin/bau/themes_and_topics.robot
+++ b/tests/robot-tests/tests/admin/bau/themes_and_topics.robot
@@ -4,6 +4,7 @@ Resource            ../../libs/admin-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      teardown suite
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -5,6 +5,7 @@ Resource            ../../libs/admin-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 

--- a/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
@@ -8,6 +8,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Variables ***
 ${TOPIC_NAME}=          %{TEST_TOPIC_NAME}

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -6,6 +6,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Variables ***
 ${RELEASE_NAME}=        Calendar Year 2000

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -5,6 +5,7 @@ Resource            ../../libs/public-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -6,6 +6,7 @@ Resource            ../../libs/public-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -7,6 +7,7 @@ Resource            ../../libs/public-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          Admin    Local    Dev    AltersData
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -7,6 +7,7 @@ Force Tags          Admin    Local    Dev    AltersData
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Variables ***
 ${RELEASE_NAME}         Academic Year Q1 2020/21

--- a/tests/robot-tests/tests/bootstrap_data/release_and_publication_role_permissions_data.robot
+++ b/tests/robot-tests/tests/bootstrap_data/release_and_publication_role_permissions_data.robot
@@ -15,6 +15,7 @@ Resource            ../libs/admin-common.robot
 
 Suite Setup         user signs in as bau1
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          BootstrapData    Local    Dev
 

--- a/tests/robot-tests/tests/general_public/fast_track.robot
+++ b/tests/robot-tests/tests/general_public/fast_track.robot
@@ -5,6 +5,7 @@ Force Tags          GeneralPublic    Local    Dev    Test    Preprod
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Test Cases ***
 Navigate to publication release page

--- a/tests/robot-tests/tests/general_public/glossary_page.robot
+++ b/tests/robot-tests/tests/general_public/glossary_page.robot
@@ -3,6 +3,7 @@ Resource            ../libs/common.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Local    Dev    Test    Preprod    Prod
 

--- a/tests/robot-tests/tests/general_public/methodologies_page.robot
+++ b/tests/robot-tests/tests/general_public/methodologies_page.robot
@@ -4,6 +4,7 @@ Force Tags          GeneralPublic    Prod
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Test Cases ***
 Navigate to /methodology page

--- a/tests/robot-tests/tests/general_public/methodology_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/methodology_page_absence.robot
@@ -3,6 +3,7 @@ Resource            ../libs/public-common.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Local    Test
 

--- a/tests/robot-tests/tests/general_public/miscellaneous.robot
+++ b/tests/robot-tests/tests/general_public/miscellaneous.robot
@@ -3,6 +3,7 @@ Resource            ../libs/public-common.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Local    Dev    Test    Preprod    Prod
 

--- a/tests/robot-tests/tests/general_public/no_javascript.robot
+++ b/tests/robot-tests/tests/general_public/no_javascript.robot
@@ -2,6 +2,8 @@
 Resource        ../libs/public-common.robot
 Library         ../libs/no_javascript.py
 
+Test Setup      fail test fast if required
+
 Force Tags      GeneralPublic    Local    Dev    Test    Preprod    Prod
 
 *** Test Cases ***

--- a/tests/robot-tests/tests/general_public/notifications_absence.robot
+++ b/tests/robot-tests/tests/general_public/notifications_absence.robot
@@ -5,6 +5,7 @@ Force Tags          GeneralPublic    Dev    Test    Preprod    Prod
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 *** Test Cases ***
 Navigate to Absence publication

--- a/tests/robot-tests/tests/general_public/permalink_prod_1.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_1.robot
@@ -3,6 +3,7 @@ Resource            ../libs/public-common.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Prod
 

--- a/tests/robot-tests/tests/general_public/permalink_prod_2.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_2.robot
@@ -3,6 +3,7 @@ Resource            ../libs/public-common.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Prod
 

--- a/tests/robot-tests/tests/general_public/permalink_prod_3.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_3.robot
@@ -3,6 +3,7 @@ Resource            ../libs/public-common.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Prod
 

--- a/tests/robot-tests/tests/general_public/prod_table_tool.robot
+++ b/tests/robot-tests/tests/general_public/prod_table_tool.robot
@@ -3,6 +3,7 @@ Resource            ../libs/public-common.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Prod
 

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -4,6 +4,7 @@ Resource            ../libs/charts.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Local    Dev    Test    Preprod
 

--- a/tests/robot-tests/tests/general_public/statistics_page.robot
+++ b/tests/robot-tests/tests/general_public/statistics_page.robot
@@ -3,6 +3,7 @@ Resource            ../libs/public-common.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Prod
 

--- a/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_by_characteristic.robot
@@ -3,6 +3,7 @@ Resource            ../libs/public-common.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Local    Dev    Preprod
 

--- a/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
@@ -3,6 +3,7 @@ Resource            ../libs/public-common.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Local    Dev    Preprod
 

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -3,6 +3,7 @@ Resource            ../libs/public-common.robot
 
 Suite Setup         user opens the browser
 Suite Teardown      user closes the browser
+Test Setup          fail test fast if required
 
 Force Tags          GeneralPublic    Local    Dev
 

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -5,6 +5,7 @@ Library     Collections
 #Library    XvfbRobot    # sudo apt install xvfb + pip install robotframework-xvfb
 Library     file_operations.py
 Library     utilities.py
+Library     fail_fast.py
 Resource    ./tables-common.robot
 Resource    ./table_tool.robot
 
@@ -17,10 +18,26 @@ ${timeout}=                             30
 ${implicit_wait}=                       15
 ${RELEASE_COMPLETE_WAIT}=               900
 ${prompt_to_continue_on_failure}=       0
+${FAIL_TEST_SUITES_FAST}=               1
 
 *** Keywords ***
 do this on failure
-    capture large screenshot and html
+    # See if the currently executing Test Suite is failing fast and if not, take a screenshot and HTML grab of the
+    # failing page.
+    ${currently_failing_fast}=    current test suite failing fast
+
+    IF    "${currently_failing_fast}" == "${FALSE}"
+
+        capture large screenshot and html
+
+        # Additionally, mark the current Test Suite as failing if the "FAIL_TEST_SUITES_FAST" option is enabled, and
+        # this will cause subsequent tests within this same Test Suite to fail immediately (by virtue of their "Test
+        # Setup" steps checking to see if their owning Test Suite is currently failing fast).
+        IF    ${FAIL_TEST_SUITES_FAST} == 1
+            record failing test suite
+        END
+    END
+
     IF    ${prompt_to_continue_on_failure} == 1
         prompt to continue
     END

--- a/tests/robot-tests/tests/libs/fail_fast.py
+++ b/tests/robot-tests/tests/libs/fail_fast.py
@@ -1,0 +1,37 @@
+"""
+This utility class is responsible for allowing us to control the fail-fast behaviour of Robot Test Suites if one of 
+their Tests fails.  If the "fail tests suites fast" option is enabled, this file's methods are called from Robot 
+scripts, firstly to record that a test suite is failing, and then again on subsequent Tests starting to see if they
+should continue to run or if they should fail immediately and therefore fail the test suite immediately.
+"""
+from logging import warning
+from robot.libraries.BuiltIn import BuiltIn
+
+
+sl = BuiltIn().get_library_instance('SeleniumLibrary')
+FAILING_SUITES = set()
+
+
+def current_test_suite_failing_fast() -> bool:
+    test_suite = _get_current_test_suite()
+    return test_suite in FAILING_SUITES
+
+
+def record_failing_test_suite():
+    test_suite = _get_current_test_suite()
+    warning(f"Recording test suite '{test_suite}' as failing - subsequent tests will automatically fail in this suite")
+    FAILING_SUITES.add(test_suite)
+
+
+def fail_test_fast_if_required():
+    if current_test_suite_failing_fast():
+        _raise_assertion_error(f"Test suite {_get_current_test_suite()} is already failing.  Failing this test fast.")
+
+
+def _get_current_test_suite() -> str:
+    return BuiltIn().get_variable_value("${SUITE SOURCE}")
+
+
+def _raise_assertion_error(err_msg):
+    sl.failure_occurred()
+    raise AssertionError(err_msg)        


### PR DESCRIPTION
This PR:
- adds in a mechanism to fail the rest of a Test Suite immediately if any of its child Tests fail

So in the "do this on failure" step, we record which test suite is failing, and then on a Test Setup that runs before every test, we check to see if that Test's suite is already marked as failing and, if so, fail the Test immediately.

Tests all passing below with the exception of one that's failing on dev right now as well.

![image](https://user-images.githubusercontent.com/12444316/135617303-6c0dc276-2ffc-4e49-94ac-873cf1124fa6.png)
