### PR TITLE
EES-2741 fix methodology last updated

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/MethodologyNotesSection.tsx
@@ -186,18 +186,22 @@ const MethodologyNotesSection = ({ methodology }: Props) => {
     );
   };
 
+  const orderedNotes = orderBy(methodologyNotes, 'displayDate', 'desc');
+
   return (
     <SummaryListItem term="Last updated">
       {methodologyNotes.length > 0 ? (
         <>
-          <FormattedDate>{methodologyNotes[0].displayDate}</FormattedDate>
+          <FormattedDate testId="Last updated date">
+            {orderedNotes[0].displayDate}
+          </FormattedDate>
           <Details
             summary={`See all notes (${methodologyNotes.length})`}
             id="methodologyNotes"
             open={editingMode === 'edit'}
           >
             <ol className="govuk-list">
-              {orderBy(methodologyNotes, 'displayDate', 'desc').map(note => (
+              {orderedNotes.map(note => (
                 <li key={note.id}>
                   {editingMode === 'edit' &&
                   editFormOpen &&

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/__tests__/MethodologyNotesSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/__tests__/MethodologyNotesSection.test.tsx
@@ -67,7 +67,7 @@ describe('MethodologyNotesSection', () => {
         </EditingContextProvider>,
       );
       expect(screen.getByText('Last updated')).toBeInTheDocument();
-      expect(screen.getByTestId('Last updated-value')).toHaveTextContent(
+      expect(screen.getByTestId('Last updated date')).toHaveTextContent(
         '10 September 2021',
       );
 
@@ -106,6 +106,44 @@ describe('MethodologyNotesSection', () => {
       expect(
         screen.getByRole('button', { name: 'Add note' }),
       ).toBeInTheDocument();
+    });
+
+    test('renders correctly when there are no notes', () => {
+      render(
+        <EditingContextProvider initialEditingMode="edit">
+          <MethodologyNotesSection
+            methodology={testMethodologyContentWithoutNotes}
+          />
+        </EditingContextProvider>,
+      );
+      expect(screen.getByText('Last updated')).toBeInTheDocument();
+      expect(screen.getByTestId('Last updated-value')).toHaveTextContent('TBA');
+      expect(
+        screen.getByRole('button', { name: 'Add note' }),
+      ).toBeInTheDocument();
+    });
+
+    test('shows the most recent date for Last Updated', () => {
+      const oldNote = {
+        id: 'note-old',
+        content: 'Note Old',
+        displayDate: new Date('2020-01-01T00:00:00'),
+      };
+      const testMethodologyContentWithOldNote = {
+        ...testMethodologyContentWithNotes,
+        notes: [oldNote, ...testMethodologyContentWithNotes.notes],
+      };
+      render(
+        <EditingContextProvider initialEditingMode="edit">
+          <MethodologyNotesSection
+            methodology={testMethodologyContentWithOldNote}
+          />
+        </EditingContextProvider>,
+      );
+      expect(screen.getByText('Last updated')).toBeInTheDocument();
+      expect(screen.getByTestId('Last updated date')).toHaveTextContent(
+        '10 September 2021',
+      );
     });
   });
 

--- a/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/__tests__/MethodologyNotesSection.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/edit-methodology/content/components/__tests__/MethodologyNotesSection.test.tsx
@@ -1,7 +1,9 @@
 import MethodologyNotesSection from '@admin/pages/methodology/edit-methodology/content/components/MethodologyNotesSection';
 import { MethodologyContent } from '@admin/services/methodologyContentService';
 import { EditingContextProvider } from '@admin/contexts/EditingContext';
-import _methodologyNoteService from '@admin/services/methodologyNoteService';
+import _methodologyNoteService, {
+  MethodologyNote,
+} from '@admin/services/methodologyNoteService';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -124,12 +126,12 @@ describe('MethodologyNotesSection', () => {
     });
 
     test('shows the most recent date for Last Updated', () => {
-      const oldNote = {
+      const oldNote: MethodologyNote = {
         id: 'note-old',
         content: 'Note Old',
         displayDate: new Date('2020-01-01T00:00:00'),
       };
-      const testMethodologyContentWithOldNote = {
+      const testMethodologyContentWithOldNote: MethodologyContent = {
         ...testMethodologyContentWithNotes,
         notes: [oldNote, ...testMethodologyContentWithNotes.notes],
       };

--- a/tests/robot-tests/tests/admin/bau/link_publication_to_external_methodology.robot
+++ b/tests/robot-tests/tests/admin/bau/link_publication_to_external_methodology.robot
@@ -29,6 +29,7 @@ Link Publication to External Methodology
 
 Edit the External Methodology of the Publication
     user edits an external methodology    ${PUBLICATION_NAME}
+    user waits until page contains title    Dashboard
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     ${details}=    user opens details dropdown    External methodology updated (External)    ${accordion}
     user checks page contains link with text and url    https://example.com/updated


### PR DESCRIPTION
Fixes the bug where editing the dates on methodology notes could result in the wrong 'Last updated' date being shown.

Also, fixes the external methodology robot test as noticed it was failing.