### PR TITLE
EES-2678 Rename MethodologyVersion view models to include 'version' in name

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
@@ -48,7 +48,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             methodologyService
                 .Setup(s => s.CreateMethodology(_id))
-                .ReturnsAsync(new MethodologySummaryViewModel());
+                .ReturnsAsync(new MethodologyVersionSummaryViewModel());
 
             var controller = SetupMethodologyController(methodologyService.Object);
 
@@ -87,7 +87,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             methodologyService
                 .Setup(s => s.GetAdoptableMethodologies(_id))
-                .ReturnsAsync(AsList(new MethodologySummaryViewModel()));
+                .ReturnsAsync(AsList(new MethodologyVersionSummaryViewModel()));
 
             var controller = SetupMethodologyController(methodologyService.Object);
 
@@ -105,7 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             methodologyService
                 .Setup(s => s.GetSummary(_id))
-                .ReturnsAsync(new MethodologySummaryViewModel());
+                .ReturnsAsync(new MethodologyVersionSummaryViewModel());
 
             var controller = SetupMethodologyController(methodologyService.Object);
 
@@ -179,7 +179,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             methodologyService
                 .Setup(s => s.UpdateMethodology(_id, request))
-                .ReturnsAsync(new MethodologySummaryViewModel());
+                .ReturnsAsync(new MethodologyVersionSummaryViewModel());
 
             var controller = SetupMethodologyController(methodologyService.Object);
 
@@ -197,7 +197,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             methodologyAmendmentService
                 .Setup(s => s.CreateMethodologyAmendment(_id))
-                .ReturnsAsync(new MethodologySummaryViewModel());
+                .ReturnsAsync(new MethodologyVersionSummaryViewModel());
 
             var controller =
                 SetupMethodologyController(methodologyAmendmentService: methodologyAmendmentService.Object);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyMethodologyVersionPermissionsResolverTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyMethodologyVersionPermissionsResolverTest.cs
@@ -10,7 +10,7 @@ using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
 {
-    public class MyMethodologyPermissionSetPropertyResolverTest
+    public class MyMethodologyVersionPermissionsResolverTest
     {
         [Fact]
         public void ResolvePermissions()
@@ -18,7 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
             var methodologyVersion = new MethodologyVersion();
 
             var userService = new Mock<IUserService>(Strict);
-            var resolver = new MyMethodologyPermissionSetPropertyResolver(userService.Object);
+            var resolver = new MyMethodologyVersionPermissionsResolver(userService.Object);
 
             userService.Setup(s => s.MatchesPolicy(methodologyVersion, CanApproveSpecificMethodology))
                 .ReturnsAsync(true);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyPublicationMethodologyPermissionsResolverTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyPublicationMethodologyPermissionsResolverTest.cs
@@ -10,7 +10,7 @@ using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
 {
-    public class MyPublicationMethodologyPermissionsPropertyResolverTest
+    public class MyPublicationMethodologyPermissionsResolverTest
     {
         [Fact]
         public void ResolvePermissions()
@@ -18,7 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
             var publicationMethodology = new PublicationMethodology();
 
             var userService = new Mock<IUserService>(Strict);
-            var resolver = new MyPublicationMethodologyPermissionsPropertyResolver(userService.Object);
+            var resolver = new MyPublicationMethodologyVersionPermissionsResolver(userService.Object);
 
             userService.Setup(s =>
                     s.MatchesPolicy(publicationMethodology, CanDropMethodologyLink))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyPublicationPermissionsResolverTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyPublicationPermissionsResolverTest.cs
@@ -10,7 +10,7 @@ using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
 {
-    public class MyPublicationPermissionsPropertyResolverTest
+    public class MyPublicationPermissionsResolverTest
     {
         [Fact]
         public void ResolvePermissions()
@@ -18,7 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
             var publication = new Publication();
 
             var userService = new Mock<IUserService>(Strict);
-            var resolver = new MyPublicationPermissionSetPropertyResolver(userService.Object);
+            var resolver = new MyPublicationPermissionsResolver(userService.Object);
 
             userService.Setup(s => s.MatchesPolicy(publication, CanUpdateSpecificPublication))
                 .ReturnsAsync(true);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyReleasePermissionsResolverTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Mappings/MyReleasePermissionsResolverTest.cs
@@ -9,16 +9,16 @@ using static Moq.MockBehavior;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
 {
-    public class MyReleasePermissionsPropertyResolverTest
+    public class MyReleasePermissionsResolverTest
     {
         [Fact]
         public void ResolvePermissions()
         {
             var release = new Release();
-            
+
             var userService = new Mock<IUserService>(Strict);
-            var resolver = new MyReleasePermissionSetPropertyResolver(userService.Object);
-            
+            var resolver = new MyReleasePermissionsResolver(userService.Object);
+
             userService.Setup(s => s.MatchesPolicy(release, SecurityPolicies.CanUpdateSpecificRelease)).ReturnsAsync(true);
             userService.Setup(s => s.MatchesPolicy(release, SecurityPolicies.CanDeleteSpecificRelease)).ReturnsAsync(true);
             userService.Setup(s => s.MatchesPolicy(release, SecurityPolicies.CanAssignPrereleaseContactsToSpecificRelease)).ReturnsAsync(false);
@@ -26,7 +26,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Mappings
 
             var permissionsSet = resolver.Resolve(release, null, null, null);
             VerifyAllMocks(userService);
-            
+
             Assert.True(permissionsSet.CanUpdateRelease);
             Assert.True(permissionsSet.CanDeleteRelease);
             Assert.False(permissionsSet.CanAddPrereleaseUsers);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MapperUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/MapperUtils.cs
@@ -15,20 +15,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
             var serviceLookupByType = new Dictionary<Type, object>
             {
                 {
-                    typeof(IMyPublicationPermissionSetPropertyResolver),
-                    new Mock<IMyPublicationPermissionSetPropertyResolver>().Object
+                    typeof(IMyPublicationPermissionsResolver),
+                    new Mock<IMyPublicationPermissionsResolver>().Object
                 },
                 {
-                    typeof(IMyReleasePermissionSetPropertyResolver),
-                    new Mock<IMyReleasePermissionSetPropertyResolver>().Object
+                    typeof(IMyReleasePermissionsResolver),
+                    new Mock<IMyReleasePermissionsResolver>().Object
                 },
                 {
-                    typeof(IMyPublicationMethodologyPermissionsPropertyResolver),
-                    new Mock<IMyPublicationMethodologyPermissionsPropertyResolver>().Object
+                    typeof(IMyPublicationMethodologyVersionPermissionsResolver),
+                    new Mock<IMyPublicationMethodologyVersionPermissionsResolver>().Object
                 },
                 {
-                    typeof(IMyMethodologyPermissionSetPropertyResolver),
-                    new Mock<IMyMethodologyPermissionSetPropertyResolver>().Object
+                    typeof(IMyMethodologyVersionPermissionsResolver),
+                    new Mock<IMyMethodologyVersionPermissionsResolver>().Object
                 }
             };
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/Methodologies/MethodologyAmendmentServiceTests.cs
@@ -79,7 +79,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var service = BuildService(context, methodologyService: methodologyService.Object);
 
                 var amendmentIdCapture = new List<Guid>();
-                var summaryViewModel = new MethodologySummaryViewModel();
+                var summaryViewModel = new MethodologyVersionSummaryViewModel();
 
                 methodologyService
                     .Setup(s => s.GetSummary(Capture.In(amendmentIdCapture)))
@@ -175,7 +175,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Method
                 var service = BuildService(context, methodologyService: methodologyService.Object);
 
                 var amendmentIdCapture = new List<Guid>();
-                var summaryViewModel = new MethodologySummaryViewModel();
+                var summaryViewModel = new MethodologyVersionSummaryViewModel();
 
                 methodologyService
                     .Setup(s => s.GetSummary(Capture.In(amendmentIdCapture)))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Methodologies/MethodologyController.cs
@@ -37,7 +37,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
         }
 
         [HttpPost("publication/{publicationId}/methodology")]
-        public Task<ActionResult<MethodologySummaryViewModel>> CreateMethodology(Guid publicationId)
+        public Task<ActionResult<MethodologyVersionSummaryViewModel>> CreateMethodology(Guid publicationId)
         {
             return _methodologyService
                 .CreateMethodology(publicationId)
@@ -53,7 +53,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
         }
 
         [HttpGet("publication/{publicationId}/adoptable-methodologies")]
-        public async Task<ActionResult<List<MethodologySummaryViewModel>>> GetAdoptableMethodologies(Guid publicationId)
+        public async Task<ActionResult<List<MethodologyVersionSummaryViewModel>>> GetAdoptableMethodologies(Guid publicationId)
         {
             return await _methodologyService
                 .GetAdoptableMethodologies(publicationId)
@@ -61,7 +61,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
         }
 
         [HttpGet("methodology/{methodologyVersionId}/summary")]
-        public async Task<ActionResult<MethodologySummaryViewModel>> GetMethodologySummary(Guid methodologyVersionId)
+        public async Task<ActionResult<MethodologyVersionSummaryViewModel>> GetMethodologySummary(Guid methodologyVersionId)
         {
             return await _methodologyService
                 .GetSummary(methodologyVersionId)
@@ -78,7 +78,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
         }
 
         [HttpPut("methodology/{methodologyVersionId}")]
-        public async Task<ActionResult<MethodologySummaryViewModel>> UpdateMethodology(
+        public async Task<ActionResult<MethodologyVersionSummaryViewModel>> UpdateMethodology(
             Guid methodologyVersionId,
             MethodologyUpdateRequest request)
         {
@@ -88,7 +88,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Metho
         }
 
         [HttpPost("methodology/{originalMethodologyVersionId}/amendment")]
-        public Task<ActionResult<MethodologySummaryViewModel>> CreateMethodologyAmendment(
+        public Task<ActionResult<MethodologyVersionSummaryViewModel>> CreateMethodologyAmendment(
             Guid originalMethodologyVersionId)
         {
             return _methodologyAmendmentService

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/Interfaces/IMyMethodoloyPermissionSetPropertyResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/Interfaces/IMyMethodoloyPermissionSetPropertyResolver.cs
@@ -1,12 +1,14 @@
+#nullable enable
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces
 {
-    public interface IMyMethodologyPermissionSetPropertyResolver
-        : IValueResolver<MethodologyVersion, MyMethodologyViewModel, MyMethodologyViewModel.PermissionsSet> 
+    public interface IMyMethodologyVersionPermissionsResolver : IValueResolver<
+        MethodologyVersion,
+        MyMethodologyVersionViewModel,
+        MyMethodologyVersionViewModel.PermissionsSet>
     {
-        
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/Interfaces/IMyPublicationMethodologyVersionPermissionsResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/Interfaces/IMyPublicationMethodologyVersionPermissionsResolver.cs
@@ -5,9 +5,10 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces
 {
-    public interface IMyPublicationMethodologyPermissionsPropertyResolver :
-        IValueResolver<PublicationMethodology, MyPublicationMethodologyViewModel,
-            MyPublicationMethodologyViewModel.PermissionsSet>
+    public interface IMyPublicationMethodologyVersionPermissionsResolver : IValueResolver<
+        PublicationMethodology,
+        MyPublicationMethodologyVersionViewModel,
+        MyPublicationMethodologyVersionViewModel.PermissionsSet>
     {
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/Interfaces/IMyPublicationPermissionsResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/Interfaces/IMyPublicationPermissionsResolver.cs
@@ -1,12 +1,14 @@
+#nullable enable
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces
 {
-    public interface IMyReleasePermissionSetPropertyResolver
-        : IValueResolver<Release, MyReleaseViewModel, MyReleaseViewModel.PermissionsSet> 
+    public interface IMyPublicationPermissionsResolver : IValueResolver<
+        Publication,
+        MyPublicationViewModel,
+        MyPublicationViewModel.PermissionsSet>
     {
-        
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/Interfaces/IMyReleasePermissionsResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/Interfaces/IMyReleasePermissionsResolver.cs
@@ -1,12 +1,14 @@
+#nullable enable
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces
 {
-    public interface IMyPublicationPermissionSetPropertyResolver
-        : IValueResolver<Publication, MyPublicationViewModel, MyPublicationViewModel.PermissionsSet> 
+    public interface IMyReleasePermissionsResolver : IValueResolver<
+        Release,
+        MyReleaseViewModel,
+        MyReleaseViewModel.PermissionsSet>
     {
-        
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MappingProfiles.cs
@@ -57,7 +57,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                         model.PublishScheduled.HasValue
                             ? model.PublishScheduled.Value.ConvertUtcToUkTimeZone()
                             : (DateTime?) null))
-                .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyReleasePermissionSetPropertyResolver>());
+                .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyReleasePermissionsResolver>());
 
             CreateMap<ReleaseCreateViewModel, Release>()
                 .ForMember(dest => dest.PublishScheduled, m => m.MapFrom(model =>
@@ -68,7 +68,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
 
             CreateMap<MethodologyNote, MethodologyNoteViewModel>();
 
-            CreateMap<MethodologyVersion, MethodologySummaryViewModel>()
+            CreateMap<MethodologyVersion, MethodologyVersionSummaryViewModel>()
                 .ForMember(dest => dest.LatestInternalReleaseNote,
                     m => m.MapFrom(model => model.InternalReleaseNote))
                 .ForMember(dest => dest.ScheduledWithRelease,
@@ -92,15 +92,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                     dest => dest.ThemeId,
                     m => m.MapFrom(p => p.Topic.ThemeId));
 
-            CreateMap<MethodologyVersion, MyMethodologyViewModel>()
+            CreateMap<MethodologyVersion, MyMethodologyVersionViewModel>()
                 .ForMember(dest => dest.LatestInternalReleaseNote,
                     m => m.MapFrom(model => model.InternalReleaseNote))
-                .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyMethodologyPermissionSetPropertyResolver>());
+                .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyMethodologyVersionPermissionsResolver>());
 
-            CreateMap<PublicationMethodology, MyPublicationMethodologyViewModel>()
+            CreateMap<PublicationMethodology, MyPublicationMethodologyVersionViewModel>()
                 .ForMember(dest => dest.Methodology,
                     m => m.MapFrom(pm => pm.Methodology.LatestVersion()))
-                .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyPublicationMethodologyPermissionsPropertyResolver>());
+                .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyPublicationMethodologyVersionPermissionsResolver>());
 
             CreateMap<Publication, MyPublicationViewModel>()
                 .ForMember(
@@ -111,7 +111,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
                         .FindAll(r => IsLatestVersionOfRelease(p.Releases, r.Id))
                         .OrderByDescending(r => r.Year)
                         .ThenByDescending(r => r.TimePeriodCoverage)))
-                .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyPublicationPermissionSetPropertyResolver>())
+                .ForMember(dest => dest.Permissions, exp => exp.MapFrom<IMyPublicationPermissionsResolver>())
                 .AfterMap((publication, model) => model.Methodologies = model.Methodologies.OrderBy(m => m.Methodology.Title).ToList());
 
             CreateMap<Contact, ContactViewModel>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyMethodologyVersionPermissionsResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyMethodologyVersionPermissionsResolver.cs
@@ -8,33 +8,33 @@ using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Mvc;
-using static GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.MyMethodologyViewModel;
+using static GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.MyMethodologyVersionViewModel;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
 {
-    public class MyMethodologyPermissionSetPropertyResolver : IMyMethodologyPermissionSetPropertyResolver
+    public class MyMethodologyVersionPermissionsResolver : IMyMethodologyVersionPermissionsResolver
     {
         private readonly IUserService _userService;
 
-        public MyMethodologyPermissionSetPropertyResolver(IUserService userService)
+        public MyMethodologyVersionPermissionsResolver(IUserService userService)
         {
             _userService = userService;
         }
 
         public PermissionsSet Resolve(
-            MethodologyVersion methodologyVersion,
-            MyMethodologyViewModel destination,
+            MethodologyVersion source,
+            MyMethodologyVersionViewModel destination,
             PermissionsSet destMember,
             ResolutionContext context)
         {
             return new PermissionsSet
             {
-                CanApproveMethodology = CheckResult(_userService.CheckCanApproveMethodology(methodologyVersion)),
-                CanUpdateMethodology = CheckResult(_userService.CheckCanUpdateMethodology(methodologyVersion)),
-                CanDeleteMethodology = CheckResult(_userService.CheckCanDeleteMethodology(methodologyVersion)),
+                CanApproveMethodology = CheckResult(_userService.CheckCanApproveMethodology(source)),
+                CanUpdateMethodology = CheckResult(_userService.CheckCanUpdateMethodology(source)),
+                CanDeleteMethodology = CheckResult(_userService.CheckCanDeleteMethodology(source)),
                 CanMakeAmendmentOfMethodology =
-                    CheckResult(_userService.CheckCanMakeAmendmentOfMethodology(methodologyVersion)),
-                CanMarkMethodologyAsDraft = CheckResult(_userService.CheckCanMarkMethodologyAsDraft(methodologyVersion))
+                    CheckResult(_userService.CheckCanMakeAmendmentOfMethodology(source)),
+                CanMarkMethodologyAsDraft = CheckResult(_userService.CheckCanMarkMethodologyAsDraft(source))
             };
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyPublicationMethodologyVersionPermissionsResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyPublicationMethodologyVersionPermissionsResolver.cs
@@ -5,23 +5,23 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.Secur
 using GovUk.Education.ExploreEducationStatistics.Admin.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
-using static GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.MyPublicationMethodologyViewModel;
+using static GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.MyPublicationMethodologyVersionViewModel;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
 {
-    public class MyPublicationMethodologyPermissionsPropertyResolver
-        : IMyPublicationMethodologyPermissionsPropertyResolver
+    public class MyPublicationMethodologyVersionPermissionsResolver
+        : IMyPublicationMethodologyVersionPermissionsResolver
     {
         private readonly IUserService _userService;
 
-        public MyPublicationMethodologyPermissionsPropertyResolver(IUserService userService)
+        public MyPublicationMethodologyVersionPermissionsResolver(IUserService userService)
         {
             _userService = userService;
         }
 
         public PermissionsSet Resolve(
             PublicationMethodology source,
-            MyPublicationMethodologyViewModel destination,
+            MyPublicationMethodologyVersionViewModel destination,
             PermissionsSet destMember,
             ResolutionContext context)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyPublicationPermissionsResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyPublicationPermissionsResolver.cs
@@ -7,11 +7,11 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
 {
-    public class MyPublicationPermissionSetPropertyResolver : IMyPublicationPermissionSetPropertyResolver
+    public class MyPublicationPermissionsResolver : IMyPublicationPermissionsResolver
     {
         private readonly IUserService _userService;
  
-        public MyPublicationPermissionSetPropertyResolver(IUserService userService)
+        public MyPublicationPermissionsResolver(IUserService userService)
         {
             _userService = userService;
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyReleasePermissionsResolver.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Mappings/MyReleasePermissionsResolver.cs
@@ -10,19 +10,19 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Mappings
 {
-    public class MyReleasePermissionSetPropertyResolver : IMyReleasePermissionSetPropertyResolver
+    public class MyReleasePermissionsResolver : IMyReleasePermissionsResolver
     {
         private readonly IUserService _userService;
- 
-        public MyReleasePermissionSetPropertyResolver(IUserService userService)
+
+        public MyReleasePermissionsResolver(IUserService userService)
         {
             _userService = userService;
         }
- 
+
         public MyReleaseViewModel.PermissionsSet Resolve(
-            Release release, 
-            MyReleaseViewModel destination, 
-            MyReleaseViewModel.PermissionsSet destMember, 
+            Release release,
+            MyReleaseViewModel destination,
+            MyReleaseViewModel.PermissionsSet destMember,
             ResolutionContext context)
         {
             return new MyReleaseViewModel.PermissionsSet

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyAmendmentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyAmendmentService.cs
@@ -8,7 +8,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 {
     public interface IMethodologyAmendmentService
     {
-        Task<Either<ActionResult, MethodologySummaryViewModel>> CreateMethodologyAmendment(
+        Task<Either<ActionResult, MethodologyVersionSummaryViewModel>> CreateMethodologyAmendment(
             Guid originalMethodologyVersionId);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Interfaces/Methodologies/IMethodologyService.cs
@@ -13,7 +13,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
     {
         Task<Either<ActionResult, Unit>> AdoptMethodology(Guid publicationId, Guid methodologyId);
 
-        Task<Either<ActionResult, MethodologySummaryViewModel>> CreateMethodology(Guid publicationId);
+        Task<Either<ActionResult, MethodologyVersionSummaryViewModel>> CreateMethodology(Guid publicationId);
 
         Task<Either<ActionResult, Unit>> DeleteMethodology(Guid methodologyId, bool forceDelete = false);
 
@@ -21,14 +21,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.M
 
         Task<Either<ActionResult, Unit>> DropMethodology(Guid publicationId, Guid methodologyId);
 
-        Task<Either<ActionResult, List<MethodologySummaryViewModel>>> GetAdoptableMethodologies(Guid publicationId);
+        Task<Either<ActionResult, List<MethodologyVersionSummaryViewModel>>> GetAdoptableMethodologies(
+            Guid publicationId);
 
-        Task<Either<ActionResult, MethodologySummaryViewModel>> GetSummary(Guid methodologyVersionId);
+        Task<Either<ActionResult, MethodologyVersionSummaryViewModel>> GetSummary(Guid methodologyVersionId);
 
         Task<Either<ActionResult, List<TitleAndIdViewModel>>> GetUnpublishedReleasesUsingMethodology(
             Guid methodologyVersionId);
 
-        Task<Either<ActionResult, MethodologySummaryViewModel>> UpdateMethodology(Guid methodologyVersionId,
+        Task<Either<ActionResult, MethodologyVersionSummaryViewModel>> UpdateMethodology(
+            Guid methodologyVersionId,
             MethodologyUpdateRequest request);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyAmendmentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyAmendmentService.cs
@@ -34,7 +34,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
             _context = context;
         }
 
-        public async Task<Either<ActionResult, MethodologySummaryViewModel>> CreateMethodologyAmendment(
+        public async Task<Either<ActionResult, MethodologyVersionSummaryViewModel>> CreateMethodologyAmendment(
             Guid originalMethodologyVersionId)
         {
             return await _persistenceHelper.CheckEntityExists<MethodologyVersion>(originalMethodologyVersionId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/Methodologies/MethodologyService.cs
@@ -81,7 +81,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 });
         }
 
-        public Task<Either<ActionResult, MethodologySummaryViewModel>> CreateMethodology(Guid publicationId)
+        public Task<Either<ActionResult, MethodologyVersionSummaryViewModel>> CreateMethodology(Guid publicationId)
         {
             return _persistenceHelper
                 .CheckEntityExists<Publication>(publicationId)
@@ -106,7 +106,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 });
         }
 
-        public async Task<Either<ActionResult, List<MethodologySummaryViewModel>>> GetAdoptableMethodologies(
+        public async Task<Either<ActionResult, List<MethodologyVersionSummaryViewModel>>> GetAdoptableMethodologies(
             Guid publicationId)
         {
             return await _persistenceHelper
@@ -121,7 +121,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 });
         }
 
-        public async Task<Either<ActionResult, MethodologySummaryViewModel>> GetSummary(Guid id)
+        public async Task<Either<ActionResult, MethodologyVersionSummaryViewModel>> GetSummary(Guid id)
         {
             return await _persistenceHelper
                 .CheckEntityExists<MethodologyVersion>(id)
@@ -159,7 +159,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 });
         }
 
-        public async Task<Either<ActionResult, MethodologySummaryViewModel>> UpdateMethodology(Guid id,
+        public async Task<Either<ActionResult, MethodologyVersionSummaryViewModel>> UpdateMethodology(Guid id,
             MethodologyUpdateRequest request)
         {
             return await _persistenceHelper
@@ -170,7 +170,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 .OnSuccess(_ => GetSummary(id));
         }
 
-        private async Task<MethodologySummaryViewModel> BuildMethodologySummaryViewModel(
+        private async Task<MethodologyVersionSummaryViewModel> BuildMethodologySummaryViewModel(
             MethodologyVersion methodologyVersion)
         {
             var loadedMethodology = _context.AssertEntityLoaded(methodologyVersion);
@@ -188,7 +188,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologie
                 .OrderBy(model => model.Title)
                 .ToList();
 
-            var viewModel = _mapper.Map<MethodologySummaryViewModel>(loadedMethodology);
+            var viewModel = _mapper.Map<MethodologyVersionSummaryViewModel>(loadedMethodology);
 
             viewModel.OwningPublication = owningPublication;
             viewModel.OtherPublications = otherPublications;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -215,14 +215,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.Configure<RouteOptions>(options => options.LowercaseUrls = true);
 
             services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
-            services.AddTransient<IMyReleasePermissionSetPropertyResolver,
-                MyReleasePermissionSetPropertyResolver>();
-            services.AddTransient<IMyPublicationPermissionSetPropertyResolver,
-                MyPublicationPermissionSetPropertyResolver>();
-            services.AddTransient<IMyPublicationMethodologyPermissionsPropertyResolver,
-                MyPublicationMethodologyPermissionsPropertyResolver>();
-            services.AddTransient<IMyMethodologyPermissionSetPropertyResolver,
-                MyMethodologyPermissionSetPropertyResolver>();
+            services.AddTransient<IMyReleasePermissionsResolver,
+                MyReleasePermissionsResolver>();
+            services.AddTransient<IMyPublicationPermissionsResolver,
+                MyPublicationPermissionsResolver>();
+            services.AddTransient<IMyPublicationMethodologyVersionPermissionsResolver,
+                MyPublicationMethodologyVersionPermissionsResolver>();
+            services.AddTransient<IMyMethodologyVersionPermissionsResolver,
+                MyMethodologyVersionPermissionsResolver>();
 
             services.AddMvc(options =>
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyVersionSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/Methodology/MethodologyVersionSummaryViewModel.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels.Methodology
 {
-    public class MethodologySummaryViewModel
+    public class MethodologyVersionSummaryViewModel
     {
         public Guid Id { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyMethodologyVersionViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyMethodologyVersionViewModel.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
-    public class MyMethodologyViewModel
+    public class MyMethodologyVersionViewModel
     {
         public Guid Id { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationMethodologyVersionViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationMethodologyVersionViewModel.cs
@@ -1,11 +1,11 @@
 ﻿#nullable enable
 namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
 {
-    public class MyPublicationMethodologyViewModel
+    public class MyPublicationMethodologyVersionViewModel
     {
         public bool Owner { get; set; }
 
-        public MyMethodologyViewModel Methodology { get; set; } = null!;
+        public MyMethodologyVersionViewModel Methodology { get; set; } = null!;
 
         public PermissionsSet Permissions { get; set; } = new PermissionsSet();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/ViewModels/MyPublicationViewModel.cs
@@ -7,21 +7,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.ViewModels
     public class MyPublicationViewModel
     {
         public Guid Id { get; set; }
-        
+
         public string Title { get; set; }
 
         public DateTime? NextUpdate { get; set; }
 
         public List<MyReleaseViewModel> Releases { get; set; }
 
-        public List<MyPublicationMethodologyViewModel> Methodologies { get; set; }
+        public List<MyPublicationMethodologyVersionViewModel> Methodologies { get; set; }
 
         public ExternalMethodology ExternalMethodology { get; set; }
-        
+
         public Guid TopicId { get; set; }
-        
+
         public Guid ThemeId { get; set; }
-        
+
         public Contact Contact { get; set; }
 
         public PermissionsSet Permissions { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/MethodologyControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/MethodologyControllerTests.cs
@@ -20,7 +20,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
             var methodologyService = new Mock<IMethodologyService>(MockBehavior.Strict);
 
             methodologyService.Setup(mock => mock.GetLatestMethodologyBySlug("test-slug"))
-                .ReturnsAsync(new MethodologyViewModel
+                .ReturnsAsync(new MethodologyVersionViewModel
                 {
                     Id = methodologyId
                 });

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api.Tests/Controllers/ThemeControllerTests.cs
@@ -75,7 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Tests.Controlle
                                     Id = Guid.NewGuid(),
                                     Title = "Publication title",
                                     Methodologies = AsList(
-                                        new MethodologySummaryViewModel
+                                        new MethodologyVersionSummaryViewModel
                                         {
                                             Id = Guid.NewGuid(),
                                             Slug = "methodology-slug",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/MethodologyController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Controllers/MethodologyController.cs
@@ -19,7 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api.Controllers
         }
 
         [HttpGet("methodologies/{slug}")]
-        public async Task<ActionResult<MethodologyViewModel>> GetLatestMethodologyBySlug(string slug)
+        public async Task<ActionResult<MethodologyVersionViewModel>> GetLatestMethodologyBySlug(string slug)
         {
             return await _methodologyService.GetLatestMethodologyBySlug(slug)
                 .HandleFailuresOrOk();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ReleaseServiceTests.cs
@@ -32,7 +32,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests
             const string publicationPath = "publications/publication-a/publication.json";
             const string releasePath = "publications/publication-a/releases/2016.json";
 
-            var methodology = new MethodologySummaryViewModel
+            var methodology = new MethodologyVersionSummaryViewModel
             {
                     Id = Guid.NewGuid(),
                     Slug = "methodology-slug",

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ViewModels/AllMethodologiesThemeViewModelTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ViewModels/AllMethodologiesThemeViewModelTests.cs
@@ -28,7 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.View
                             new AllMethodologiesPublicationViewModel
                             {
                                 Title = "PublicationWithNoMethodologies",
-                                Methodologies = new List<MethodologySummaryViewModel>()
+                                Methodologies = new List<MethodologyVersionSummaryViewModel>()
                             }
                         )
                     },
@@ -40,13 +40,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.View
                             {
                                 Title = "PublicationWithMethodologies",
                                 Methodologies = AsList(
-                                    new MethodologySummaryViewModel()
+                                    new MethodologyVersionSummaryViewModel()
                                 )
                             },
                             new AllMethodologiesPublicationViewModel
                             {
                                 Title = "PublicationWithoutMethodologies",
-                                Methodologies = new List<MethodologySummaryViewModel>()
+                                Methodologies = new List<MethodologyVersionSummaryViewModel>()
                             }
                         )
                     }
@@ -76,21 +76,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.View
                             {
                                 Title = "Topic C Publication C",
                                 Methodologies = AsList(
-                                    new MethodologySummaryViewModel()
+                                    new MethodologyVersionSummaryViewModel()
                                 )
                             },
                             new AllMethodologiesPublicationViewModel
                             {
                                 Title = "Topic C Publication A",
                                 Methodologies = AsList(
-                                    new MethodologySummaryViewModel()
+                                    new MethodologyVersionSummaryViewModel()
                                 )
                             },
                             new AllMethodologiesPublicationViewModel
                             {
                                 Title = "Topic C Publication B",
                                 Methodologies = AsList(
-                                    new MethodologySummaryViewModel()
+                                    new MethodologyVersionSummaryViewModel()
                                 )
                             }
                         )
@@ -103,21 +103,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.View
                             {
                                 Title = "Topic A Publication C",
                                 Methodologies = AsList(
-                                    new MethodologySummaryViewModel()
+                                    new MethodologyVersionSummaryViewModel()
                                 )
                             },
                             new AllMethodologiesPublicationViewModel
                             {
                                 Title = "Topic A Publication A",
                                 Methodologies = AsList(
-                                    new MethodologySummaryViewModel()
+                                    new MethodologyVersionSummaryViewModel()
                                 )
                             },
                             new AllMethodologiesPublicationViewModel
                             {
                                 Title = "Topic A Publication B",
                                 Methodologies = AsList(
-                                    new MethodologySummaryViewModel()
+                                    new MethodologyVersionSummaryViewModel()
                                 )
                             }
                         )
@@ -130,21 +130,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.View
                             {
                                 Title = "Topic B Publication C",
                                 Methodologies = AsList(
-                                    new MethodologySummaryViewModel()
+                                    new MethodologyVersionSummaryViewModel()
                                 )
                             },
                             new AllMethodologiesPublicationViewModel
                             {
                                 Title = "Topic B Publication A",
                                 Methodologies = AsList(
-                                    new MethodologySummaryViewModel()
+                                    new MethodologyVersionSummaryViewModel()
                                 )
                             },
                             new AllMethodologiesPublicationViewModel
                             {
                                 Title = "Topic B Publication B",
                                 Methodologies = AsList(
-                                    new MethodologySummaryViewModel()
+                                    new MethodologyVersionSummaryViewModel()
                                 )
                             }
                         )

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ViewModels/AllMethodologiesTopicViewModelTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services.Tests/ViewModels/AllMethodologiesTopicViewModelTests.cs
@@ -19,13 +19,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.View
                     new AllMethodologiesPublicationViewModel
                     {
                         Title = "PublicationWithoutMethodology",
-                        Methodologies = new List<MethodologySummaryViewModel>()
+                        Methodologies = new List<MethodologyVersionSummaryViewModel>()
                     },
                     new AllMethodologiesPublicationViewModel
                     {
                         Title = "PublicationWithMethodology",
                         Methodologies = AsList(
-                            new MethodologySummaryViewModel()
+                            new MethodologyVersionSummaryViewModel()
                         )
                     }
                 )
@@ -48,21 +48,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Tests.View
                     {
                         Title = "Publication C",
                         Methodologies = AsList(
-                            new MethodologySummaryViewModel()
+                            new MethodologyVersionSummaryViewModel()
                         )
                     },
                     new AllMethodologiesPublicationViewModel
                     {
                         Title = "Publication A",
                         Methodologies = AsList(
-                            new MethodologySummaryViewModel()
+                            new MethodologyVersionSummaryViewModel()
                         )
                     },
                     new AllMethodologiesPublicationViewModel
                     {
                         Title = "Publication B",
                         Methodologies = AsList(
-                            new MethodologySummaryViewModel()
+                            new MethodologyVersionSummaryViewModel()
                         )
                     }
                 )

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IMethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Interfaces/IMethodologyService.cs
@@ -11,9 +11,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces
 {
     public interface IMethodologyService
     {
-        public Task<Either<ActionResult, MethodologyViewModel>> GetLatestMethodologyBySlug(string slug);
+        public Task<Either<ActionResult, MethodologyVersionViewModel>> GetLatestMethodologyBySlug(string slug);
 
-        public Task<Either<ActionResult, List<MethodologySummaryViewModel>>> GetSummariesByPublication(Guid publicationId);
+        public Task<Either<ActionResult, List<MethodologyVersionSummaryViewModel>>> GetSummariesByPublication(Guid publicationId);
 
         public Task<Either<ActionResult, List<AllMethodologiesThemeViewModel>>> GetTree();
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Mappings/MappingProfiles.cs
@@ -23,9 +23,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Mappings
 
             CreateMap<MethodologyNote, MethodologyNoteViewModel>();
 
-            CreateMap<MethodologyVersion, MethodologySummaryViewModel>();
+            CreateMap<MethodologyVersion, MethodologyVersionSummaryViewModel>();
 
-            CreateMap<MethodologyVersion, MethodologyViewModel>()
+            CreateMap<MethodologyVersion, MethodologyVersionViewModel>()
                 .ForMember(dest => dest.Annexes,
                     m => m.MapFrom(methodologyVersion =>
                         methodologyVersion.Annexes.OrderBy(annexSection => annexSection.Order)))

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
@@ -37,13 +37,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             _methodologyVersionRepository = methodologyVersionRepository;
         }
 
-        public async Task<Either<ActionResult, MethodologyViewModel>> GetLatestMethodologyBySlug(string slug)
+        public async Task<Either<ActionResult, MethodologyVersionViewModel>> GetLatestMethodologyBySlug(string slug)
         {
             return await _persistenceHelper
                 .CheckEntityExists<Methodology>(
                     query => query
                         .Where(mp => mp.Slug == slug))
-                .OnSuccess<ActionResult, Methodology, MethodologyViewModel>(async methodology =>
+                .OnSuccess<ActionResult, Methodology, MethodologyVersionViewModel>(async methodology =>
                 {
                     var latestPublishedVersion =
                         await _methodologyVersionRepository.GetLatestPublishedVersion(methodology.Id);
@@ -56,7 +56,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                         .Collection(m => m.Notes)
                         .LoadAsync();
 
-                    var viewModel = _mapper.Map<MethodologyViewModel>(latestPublishedVersion);
+                    var viewModel = _mapper.Map<MethodologyVersionViewModel>(latestPublishedVersion);
                     viewModel.Publications =
                         await GetPublishedPublicationsForMethodology(latestPublishedVersion.MethodologyId);
 
@@ -64,7 +64,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                 });
         }
 
-        public async Task<Either<ActionResult, List<MethodologySummaryViewModel>>> GetSummariesByPublication(
+        public async Task<Either<ActionResult, List<MethodologyVersionSummaryViewModel>>> GetSummariesByPublication(
             Guid publicationId)
         {
             return await _persistenceHelper
@@ -126,11 +126,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
             return _mapper.Map<List<PublicationSummaryViewModel>>(publicationsWithPublishedReleases);
         }
 
-        private async Task<List<MethodologySummaryViewModel>> BuildMethodologiesForPublication(Guid publicationId)
+        private async Task<List<MethodologyVersionSummaryViewModel>> BuildMethodologiesForPublication(Guid publicationId)
         {
             var latestPublishedMethodologies =
                 await _methodologyVersionRepository.GetLatestPublishedVersionByPublication(publicationId);
-            return _mapper.Map<List<MethodologySummaryViewModel>>(latestPublishedMethodologies);
+            return _mapper.Map<List<MethodologyVersionSummaryViewModel>>(latestPublishedMethodologies);
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/AllMethodologiesViewModels.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/AllMethodologiesViewModels.cs
@@ -40,8 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 
         public string Title { get; set; } = string.Empty;
 
-        public List<AllMethodologiesPublicationViewModel> Publications { get; set; } =
-            new List<AllMethodologiesPublicationViewModel>();
+        public List<AllMethodologiesPublicationViewModel> Publications { get; set; } = new();
 
         public void RemovePublicationNodesWithoutMethodologiesAndSort()
         {
@@ -67,7 +66,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 
         public string Title { get; set; } = string.Empty;
 
-        public List<MethodologySummaryViewModel> Methodologies { get; set; } = new();
+        public List<MethodologyVersionSummaryViewModel> Methodologies { get; set; } = new();
 
 
         public int CompareTo(AllMethodologiesPublicationViewModel? other)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/MethodologyVersionSummaryViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/MethodologyVersionSummaryViewModel.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 {
-    public record MethodologySummaryViewModel
+    public record MethodologyVersionSummaryViewModel
     {
         public Guid Id { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/MethodologyVersionViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/MethodologyVersionViewModel.cs
@@ -5,7 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Publisher.Model.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 {
-    public record MethodologyViewModel
+    public record MethodologyVersionViewModel
     {
         public Guid Id { get; set; }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PublicationViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/ViewModels/PublicationViewModel.cs
@@ -58,6 +58,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.ViewModels
 
         public ExternalMethodologyViewModel ExternalMethodology { get; }
 
-        public List<MethodologySummaryViewModel> Methodologies { get; set; }
+        public List<MethodologyVersionSummaryViewModel> Methodologies { get; set; }
     }
 }


### PR DESCRIPTION
This PR renames view models representing a `MethodologyVerison` to include 'version' in their names.

### Admin.ViewModels

```
MethodologySummaryViewModel -> MethodologyVersionSummaryViewModel
MyMethodologyViewModel -> MyMethodologyVersionViewModel
MyPublicationMethodologyViewModel -> MyPublicationMethodologyVersionViewModel
```

### Content.Services.ViewModels

```
MethodologySummaryViewModel -> MethodologySummaryViewModel
MethodologyViewModel -> MethodologyVersionViewModel
```

### Admin.Mappings

Rename permission set property value resolvers (including interfaces):
```
MyMethodologyPermissionSetPropertyResolver -> MyMethodologyVersionPermissionsResolver
MyPublicationMethodologyPermissionsPropertyResolver -> MyPublicationMethodologyVersionPermissionsResolver
````

### Other changes

Standardise and shorten naming for other permision set property value resolves. Renames (including interfaces):

```
MyPublicationPermissionSetPropertyResolver -> MyPublicationPermissionsResolver
MyReleasePermissionSetPropertyResolver -> MyReleasePermissionsResolver
```