### PR TITLE
EES-2687 - added GA download files event to new Data Catalogue page

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Azure.Storage.Blobs;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
@@ -32,17 +33,33 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Utils.StartupUtils;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.PublisherQueues;
 using IReleaseService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IReleaseService;
 using IThemeService = GovUk.Education.ExploreEducationStatistics.Content.Services.Interfaces.IThemeService;
-using ThemeService = GovUk.Education.ExploreEducationStatistics.Content.Services.ThemeService;
+using ReleaseService = GovUk.Education.ExploreEducationStatistics.Content.Services.ReleaseService;
 
 namespace GovUk.Education.ExploreEducationStatistics.Content.Api
 {
     [ExcludeFromCodeCoverage]
     public class Startup
     {
+        private static readonly string[] LocalClientDomains =
+        {
+            "localhost",
+            "ees.local"
+        };        
+        
+        private static readonly string[] LocalClientPorts = { "3000", "3001" };
+        
+        private static readonly string[] LocalClientAddresses = 
+            AsArray("http", "https")
+            .SelectMany(scheme => LocalClientDomains
+            .SelectMany(domain => LocalClientPorts
+            .Select(port => $"{scheme}://{domain}:{port}")))
+            .ToArray();
+        
         private IConfiguration Configuration { get; }
         private IHostEnvironment HostEnvironment { get; }
 
@@ -120,7 +137,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
             services.AddTransient<IMethodologyRepository, MethodologyRepository>();
             services.AddTransient<IMethodologyVersionRepository, MethodologyVersionRepository>();
             services.AddTransient<IThemeService, ThemeService>();
-            services.AddTransient<IReleaseService, Services.ReleaseService>();
+            services.AddTransient<IReleaseService, ReleaseService>();
             services.AddTransient<IReleaseFileService, ReleaseFileService>();
             services.AddTransient<IReleaseDataFileRepository, ReleaseDataFileRepository>();
             services.AddTransient<IDataGuidanceFileWriter, DataGuidanceFileWriter>();
@@ -166,7 +183,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
                 app.UseHsts(hsts => hsts.MaxAge(365).IncludeSubdomains());
             }
 
-            if(Configuration.GetValue<bool>("enableSwagger"))
+            if (Configuration.GetValue<bool>("enableSwagger"))
             {
                 app.UseSwagger();
                 app.UseSwaggerUI(c =>
@@ -179,8 +196,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
                 option.AddRedirect("^$", "docs");
                 app.UseRewriter(option);
             }
-
-            app.UseCors(options => options.WithOrigins("http://localhost:3000", "http://localhost:3001","https://localhost:3000","https://localhost:3001").AllowAnyMethod().AllowAnyHeader());
+            
+            app
+                .UseCors(options => options
+                .WithOrigins(LocalClientAddresses)
+                .AllowAnyMethod()
+                .AllowAnyHeader());
+            
             app.UseMvc();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using AutoMapper;
 using Azure.Storage.Blobs;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
@@ -39,7 +38,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
-using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Utils.StartupUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api
@@ -47,21 +45,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
     [ExcludeFromCodeCoverage]
     public class Startup
     {
-        private static readonly string[] LocalClientDomains =
-        {
-            "localhost",
-            "ees.local"
-        };        
-        
-        private static readonly string[] LocalClientPorts = { "3000", "3001" };
-        
-        private static readonly string[] LocalClientAddresses = 
-            AsArray("http", "https")
-            .SelectMany(scheme => LocalClientDomains
-            .SelectMany(domain => LocalClientPorts
-            .Select(port => $"{scheme}://{domain}:{port}")))
-            .ToArray();
-        
         private IConfiguration Configuration { get; }
         private IHostEnvironment HostEnvironment { get; }
 
@@ -227,9 +210,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
             // Adds Brotli and Gzip compressing
             app.UseResponseCompression();
 
-            app
-                .UseCors(options => options
-                .WithOrigins(LocalClientAddresses)
+            app.UseCors(options => options
+                .WithOrigins(
+                    "http://localhost:3000",
+                    "http://localhost:3001",
+                    "https://localhost:3000",
+                    "https://localhost:3001")
                 .AllowAnyMethod()
                 .AllowAnyHeader());
             

--- a/src/explore-education-statistics-frontend/.env
+++ b/src/explore-education-statistics-frontend/.env
@@ -1,4 +1,4 @@
-CONTENT_API_BASE_URL=http://localhost:5010/api      # or http://ees.local:5010/api
-DATA_API_BASE_URL=http://localhost:5000/api         # or http://ees.local:5000/api
+CONTENT_API_BASE_URL=http://localhost:5010/api
+DATA_API_BASE_URL=http://localhost:5000/api
 NOTIFICATION_API_BASE_URL=http://localhost:7073/api
-GA_TRACKING_ID=                                     # Available from development GA account
+GA_TRACKING_ID=

--- a/src/explore-education-statistics-frontend/.env
+++ b/src/explore-education-statistics-frontend/.env
@@ -1,3 +1,4 @@
-CONTENT_API_BASE_URL=http://localhost:5010/api
-DATA_API_BASE_URL=http://localhost:5000/api
+CONTENT_API_BASE_URL=http://localhost:5010/api      # or http://ees.local:5010/api
+DATA_API_BASE_URL=http://localhost:5000/api         # or http://ees.local:5000/api
 NOTIFICATION_API_BASE_URL=http://localhost:7073/api
+GA_TRACKING_ID=                                     # Available from development GA account

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -341,7 +341,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                 logEvent({
                   category: 'Downloads',
                   action: 'Release page all files downloaded',
-                  label: `Publication: ${release.title}, File: All files`,
+                  label: `Publication: ${release.publication.title}, Release: ${release.title}, File: All files`,
                 });
               }}
             >
@@ -378,7 +378,7 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                   logEvent({
                     category: 'Downloads',
                     action: 'Release page file downloaded',
-                    label: `Publication: ${release.title}, File: ${file.fileName}`,
+                    label: `Publication: ${release.publication.title}, Release: ${release.title}, File: ${file.fileName}`,
                   });
                 }}
               >


### PR DESCRIPTION
This PR:
- adds a new file download GA event to the Data Catalogue page
- amends existing file download GA events to send Publication title and Release name separately, to bring in line with the format of the new event in the Data Catalogue page 