### PR TITLE
EES-2810 - fix transient failure in `create_methodology_amendment.robot`

### DIFF
--- a/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
@@ -138,6 +138,7 @@ Remove a Content Section from the Amendment
     user deletes editable accordion section    Methodology annex section 1    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
 
 Remove an image from a Content Block
+    user closes Set Page View box
     user opens accordion section    Methodology annex section 2    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}
     user removes image from accordion section text block    Methodology annex section 2    2
     ...    Alt text for the uploaded annex image 3    ${METHODOLOGY_ANNEXES_EDITABLE_ACCORDION}

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -216,6 +216,7 @@ user deletes editable accordion section
     user clicks button    Remove this section    ${section}
     user waits until modal is visible    Are you sure?
     user clicks button    Confirm
+    user waits until page does not contain button    Confirm
 
 get accordion section text block
     [Arguments]


### PR DESCRIPTION
This PR: 
- fixes a transient failure in the 'remove an image from content block' test case in the `create_methodology_amendment.robot` test. This was due to a click being intercepted because the modal for deleting a content section wasn't fully closed. 