### PR TITLE
EES-2759 GA tracking for external and glossary links

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/ContentBlockRenderer.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/ContentBlockRenderer.tsx
@@ -15,12 +15,16 @@ interface Props {
     attributes: Dictionary<string>,
   ) => Dictionary<string>;
   getGlossaryEntry?: (slug: string) => Promise<GlossaryEntry>;
+  trackContentLinks?: (url: string) => void;
+  trackGlossaryLinks?: (glossaryEntrySlug: string) => void;
 }
 
 const ContentBlockRenderer = ({
   block,
   transformImageAttributes,
   getGlossaryEntry,
+  trackContentLinks,
+  trackGlossaryLinks,
 }: Props) => {
   const { body = '', type } = block;
 
@@ -49,6 +53,8 @@ const ContentBlockRenderer = ({
           html={body}
           sanitizeOptions={sanitizeOptions}
           getGlossaryEntry={getGlossaryEntry}
+          trackContentLinks={trackContentLinks}
+          trackGlossaryLinks={trackGlossaryLinks}
         />
       );
     default:

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -24,7 +24,10 @@ import PageSearchFormWithAnalytics from '@frontend/components/PageSearchFormWith
 import PrintThisPage from '@frontend/components/PrintThisPage';
 import PublicationSectionBlocks from '@frontend/modules/find-statistics/components/PublicationSectionBlocks';
 import PublicationReleaseHelpAndSupportSection from '@frontend/modules/find-statistics/PublicationReleaseHelpAndSupportSection';
-import { logEvent } from '@frontend/services/googleAnalyticsService';
+import {
+  logEvent,
+  logOutboundLink,
+} from '@frontend/services/googleAnalyticsService';
 import glossaryService from '@frontend/services/glossaryService';
 import classNames from 'classnames';
 import orderBy from 'lodash/orderBy';
@@ -167,6 +170,16 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
               key={block.id}
               block={block}
               getGlossaryEntry={glossaryService.getEntry}
+              trackContentLinks={url =>
+                logOutboundLink(`Publication release summary link: ${url}`, url)
+              }
+              trackGlossaryLinks={glossaryEntrySlug =>
+                logEvent({
+                  category: `Publication Release Summary Glossary Link`,
+                  action: `Glossary link clicked`,
+                  label: glossaryEntrySlug,
+                })
+              }
             />
           ))}
 
@@ -310,7 +323,18 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                     {release.relatedInformation &&
                       release.relatedInformation.map(link => (
                         <li key={link.id}>
-                          <a href={link.url}>{link.description}</a>
+                          <a
+                            href={link.url}
+                            onClick={e => {
+                              e.preventDefault();
+                              logOutboundLink(
+                                `Publication release related page link: ${link.url}`,
+                                link.url,
+                              );
+                            }}
+                          >
+                            {link.description}
+                          </a>
                         </li>
                       ))}
                   </ul>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationReleaseHeadlinesSection.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationReleaseHeadlinesSection.tsx
@@ -7,6 +7,10 @@ import DataBlockTabs from '@common/modules/find-statistics/components/DataBlockT
 import KeyStat, {
   KeyStatContainer,
 } from '@common/modules/find-statistics/components/KeyStat';
+import {
+  logEvent,
+  logOutboundLink,
+} from '@frontend/services/googleAnalyticsService';
 import { Release } from '@common/services/publicationService';
 import orderBy from 'lodash/orderBy';
 import React from 'react';
@@ -49,6 +53,16 @@ const PublicationReleaseHeadlinesSection = ({
           key={block.id}
           block={block}
           getGlossaryEntry={glossaryService.getEntry}
+          trackContentLinks={url =>
+            logOutboundLink(`Publication release headlines link: ${url}`, url)
+          }
+          trackGlossaryLinks={glossaryEntrySlug =>
+            logEvent({
+              category: `Publication Release Headlines Glossary Link`,
+              action: `Glossary link clicked`,
+              label: glossaryEntrySlug,
+            })
+          }
         />
       ))}
     </TabsSection>

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
@@ -7,7 +7,10 @@ import { Release } from '@common/services/publicationService';
 import { Block } from '@common/services/types/blocks';
 import glossaryService from '@frontend/services/glossaryService';
 import ButtonLink from '@frontend/components/ButtonLink';
-import { logEvent } from '@frontend/services/googleAnalyticsService';
+import {
+  logEvent,
+  logOutboundLink,
+} from '@frontend/services/googleAnalyticsService';
 import React from 'react';
 
 export interface PublicationSectionBlocksProps {
@@ -76,6 +79,16 @@ const PublicationSectionBlocks = ({
             block={block}
             transformImageAttributes={transformImageAttributes}
             getGlossaryEntry={glossaryService.getEntry}
+            trackContentLinks={url =>
+              logOutboundLink(`Publication release content link: ${url}`, url)
+            }
+            trackGlossaryLinks={glossaryEntrySlug =>
+              logEvent({
+                category: `Publication Release Content Glossary Link`,
+                action: `Glossary link clicked`,
+                label: glossaryEntrySlug,
+              })
+            }
           />
         );
       })}

--- a/src/explore-education-statistics-frontend/src/modules/methodologies/components/MethodologySectionBlocks.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/methodologies/components/MethodologySectionBlocks.tsx
@@ -1,6 +1,10 @@
 import glossaryService from '@frontend/services/glossaryService';
 import InsetText from '@common/components/InsetText';
 import ContentBlockRenderer from '@common/modules/find-statistics/components/ContentBlockRenderer';
+import {
+  logEvent,
+  logOutboundLink,
+} from '@frontend/services/googleAnalyticsService';
 import { ContentBlock } from '@common/services/types/blocks';
 import React from 'react';
 import useMethodologyImageAttributeTransformer from '@common/modules/methodology/hooks/useMethodologyImageAttributeTransformer';
@@ -23,6 +27,16 @@ const MethodologySectionBlocks = ({ blocks, methodologyId }: Props) => {
           block={block}
           transformImageAttributes={transformImageAttributes}
           getGlossaryEntry={glossaryService.getEntry}
+          trackContentLinks={url =>
+            logOutboundLink(`Methodology page content link: ${url}`, url)
+          }
+          trackGlossaryLinks={glossaryEntrySlug =>
+            logEvent({
+              category: `Methodology Page Content Glossary Link`,
+              action: `Glossary link clicked`,
+              label: glossaryEntrySlug,
+            })
+          }
         />
       ))}
     </>

--- a/src/explore-education-statistics-frontend/src/services/googleAnalyticsService.ts
+++ b/src/explore-education-statistics-frontend/src/services/googleAnalyticsService.ts
@@ -55,6 +55,20 @@ export function logEvent({ category, action, label, value }: AnalyticsEvent) {
   });
 }
 
+export function logOutboundLink(label: string, url: string) {
+  if (!initialised) {
+    return;
+  }
+  ReactGA.outboundLink(
+    {
+      label,
+    },
+    function hitCallback() {
+      document.location.href = url;
+    },
+  );
+}
+
 export const logException = (description: string, fatal = false) => {
   if (initialised) {
     ReactGA.exception({ description, fatal });


### PR DESCRIPTION
Add Google Analytics tracking for:
- links in content blocks on releases and methodologies
- related pages links on releases
- glossary links  on releases and methodologies