### PR TITLE
EES-2754 show external methodology on release

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -286,7 +286,8 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                 )}
               </ul>
             </nav>
-            {release.publication.methodologies.length > 0 && (
+            {(release.publication.methodologies.length > 0 ||
+              release.publication.externalMethodology) && (
               <>
                 <h3
                   className="govuk-heading-s govuk-!-margin-top-6"

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/__tests__/PublicationReleasePage.test.tsx
@@ -161,4 +161,88 @@ describe('PublicationReleasePage', () => {
       'First update',
     );
   });
+
+  test('renders link to a methodology', () => {
+    render(<PublicationReleasePage release={testRelease} />);
+    const usefulInfo = screen.getByRole('complementary');
+
+    expect(
+      within(usefulInfo).getByRole('heading', { name: 'Methodologies' }),
+    ).toBeInTheDocument();
+
+    expect(
+      within(usefulInfo).getByRole('link', {
+        name: 'Pupil absence statistics: methodology',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/methodology/pupil-absence-in-schools-in-england',
+    );
+  });
+
+  test('renders link to an external methodology', () => {
+    const testReleaseWithExternalMethodology = {
+      ...testRelease,
+      publication: {
+        ...testRelease.publication,
+        methodologies: [],
+        externalMethodology: {
+          title: 'External methodology title',
+          url: 'http://gov.uk',
+        },
+      },
+    };
+    render(
+      <PublicationReleasePage release={testReleaseWithExternalMethodology} />,
+    );
+    const usefulInfo = screen.getByRole('complementary');
+
+    expect(
+      within(usefulInfo).getByRole('heading', { name: 'Methodologies' }),
+    ).toBeInTheDocument();
+
+    expect(
+      within(usefulInfo).getByRole('link', {
+        name: 'External methodology title',
+      }),
+    ).toHaveAttribute('href', 'http://gov.uk');
+  });
+
+  test('renders links to internal and external methodologies', () => {
+    const testReleaseWithInternalAndExternalMethodologies = {
+      ...testRelease,
+      publication: {
+        ...testRelease.publication,
+        externalMethodology: {
+          title: 'External methodology title',
+          url: 'http://gov.uk',
+        },
+      },
+    };
+    render(
+      <PublicationReleasePage
+        release={testReleaseWithInternalAndExternalMethodologies}
+      />,
+    );
+    const usefulInfo = screen.getByRole('complementary');
+
+    expect(
+      within(usefulInfo).getByRole('heading', { name: 'Methodologies' }),
+    ).toBeInTheDocument();
+
+    expect(
+      within(usefulInfo).getByRole('link', {
+        name: 'Pupil absence statistics: methodology',
+      }),
+    ).toHaveAttribute(
+      'href',
+      '/methodology/pupil-absence-in-schools-in-england',
+    );
+
+    expect(
+      within(usefulInfo).getByRole('link', {
+        name: 'External methodology title',
+      }),
+    ).toHaveAttribute('href', 'http://gov.uk');
+  });
 });


### PR DESCRIPTION
Fixes the bug where on public release pages external methodologies didn't show under useful information unless there was also an internal methodology.