### PR TITLE
EES-2768 - one-line performance fix

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/LocationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/LocationRepository.cs
@@ -27,6 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
             var list = observations
                 // NOTE: Not including Location to avoid join for performance
                 .Select(o => new {o.GeographicLevel, o.LocationId})
+                .Distinct()
                 .AsNoTracking()
                 .ToList();
 


### PR DESCRIPTION
This PR:
- fixes up a slow call to retrieve unique sets of Location parameters.

A larger PR can follow this up, with additional caching of 2 reasonably expensive database calls, at https://github.com/dfe-analytical-services/explore-education-statistics/pull/2944.