### PR TITLE
EES-152 Return validation error if table builder query can exceed maximum allowable table size

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -29,6 +29,9 @@
     "preReleaseMinutesBeforeEnd": {
       "value": 1
     },
+    "tableBuilderMaxTableCellsAllowed": {
+      "value": 25000
+    },
     "useSubnets": {
       "value": true
     },

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -493,6 +493,13 @@
       "type": "bool",
       "defaultValue": false
     },
+    "tableBuilderMaxTableCellsAllowed": {
+      "type": "int",
+      "defaultValue": 25000,
+      "metadata": {
+        "description": "Maximum number of table cells that a table builder query could potentially render for a request to be valid"
+      }
+    },
     "timeZone": {
       "type": "string",
       "defaultValue": "GMT Standard Time"
@@ -1196,7 +1203,8 @@
         "WEBSITE_NODE_DEFAULT_VERSION": "6.9.1",
         "WEBSITE_RUN_FROM_PACKAGE": "1",
         "PublicStorage": "[concat('@Microsoft.KeyVault(SecretUri=', reference(variables('ees-storage-public'), '2018-02-14').secretUriWithVersion, ')')]",
-        "enableSwagger": "[parameters('enableSwagger')]"
+        "enableSwagger": "[parameters('enableSwagger')]",
+        "TableBuilder:MaxTableCellsAllowed": "[parameters('tableBuilderMaxTableCellsAllowed')]"
       }
     },
     {
@@ -1659,7 +1667,8 @@
         "PreReleaseAccess:AccessWindow:MinutesBeforeReleaseTimeStart": "[parameters('preReleaseMinutesBeforeStart')]",
         "PreReleaseAccess:AccessWindow:MinutesBeforeReleaseTimeEnd": "[parameters('preReleaseMinutesBeforeEnd')]",
         "enableSwagger": "[parameters('enableSwagger')]",
-        "enableThemeDeletion": "[parameters('enableThemeDeletion')]"
+        "enableThemeDeletion": "[parameters('enableThemeDeletion')]",
+        "TableBuilder:MaxTableCellsAllowed": "[parameters('tableBuilderMaxTableCellsAllowed')]"
       }
     },
     {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReplacementServiceTests.cs
@@ -17,7 +17,6 @@ using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
@@ -25,6 +24,7 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbU
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.FileType;
 using static GovUk.Education.ExploreEducationStatistics.Common.Model.TimeIdentifier;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Data.Model.Database.StatisticsDbUtils;
 using IReleaseService = GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces.IReleaseService;
 using Release = GovUk.Education.ExploreEducationStatistics.Data.Model.Release;
@@ -574,7 +574,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Indicators = new[] {originalIndicator.Id},
                     Locations = new LocationQuery
                     {
-                        Country = new[] {CountryCodeEngland}
+                        Country = ListOf(CountryCodeEngland)
                     },
                     TimePeriod = timePeriod
                 },
@@ -1069,7 +1069,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Indicators = new[] {originalIndicator.Id},
                     Locations = new LocationQuery
                     {
-                        Country = new[] {CountryCodeEngland}
+                        Country = ListOf(CountryCodeEngland)
                     },
                     TimePeriod = timePeriod
                 },
@@ -1342,7 +1342,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Indicators = new[] {originalIndicator.Id},
                     Locations = new LocationQuery
                     {
-                        Country = new[] {CountryCodeEngland}
+                        Country = ListOf(CountryCodeEngland)
                     },
                     TimePeriod = timePeriod
                 },
@@ -1640,7 +1640,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Indicators = new[] {originalIndicator.Id},
                     Locations = new LocationQuery
                     {
-                        Country = new[] {CountryCodeEngland}
+                        Country = ListOf(CountryCodeEngland)
                     },
                     TimePeriod = timePeriod
                 },
@@ -2016,7 +2016,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Indicators = new[] {originalIndicator.Id},
                     Locations = new LocationQuery
                     {
-                        Country = new[] {CountryCodeEngland}
+                        Country = ListOf(CountryCodeEngland)
                     },
                     TimePeriod = timePeriod
                 },
@@ -2449,7 +2449,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Indicators = new Guid[] { },
                     Locations = new LocationQuery
                     {
-                        Country = new[] {CountryCodeEngland}
+                        Country = ListOf(CountryCodeEngland)
                     },
                     TimePeriod = timePeriod
                 },
@@ -2755,7 +2755,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     Indicators = new[] {originalIndicator.Id},
                     Locations = new LocationQuery
                     {
-                        Country = new[] {CountryCodeEngland}
+                        Country = ListOf(CountryCodeEngland)
                     },
                     TimePeriod = timePeriod
                 },

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataBlockQuerySizeController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataBlockQuerySizeController.cs
@@ -1,0 +1,116 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Content.Model;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Services;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.Utils;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
+{
+    /**
+     * Temporary controller for determining the maximum possible size of a table that could be generated
+     * by existing datablocks in the service.
+     *
+     * This figure will be used to establish the limit on the maximum table size of a datablock query that we allow
+     * during a validation check before a query is executed.
+     *
+     * The validation check assumes that all combinations of data have been provided and calculates the maximum
+     * possible table size from the query, rejecting the request if it's greater than the set limit.
+     * 
+     * Note that we *don't* execute all datablock queries here and count the results.
+     * A table result might be smaller than the possible table that could be generated since all combinations of time
+     * period, location and filters may not be provided in the data.
+     * 
+     * If we were to execute all the datablock queries and set a maximum based on the largest table result,
+     * several datablock requests may fail if they have a possible table size greater than the largest actual table.
+     */
+    [ApiController]
+    [Authorize]
+    public class DataBlockQuerySizeController : ControllerBase
+    {
+        private readonly ContentDbContext _contentDbContext;
+        private readonly IFilterItemRepository _filterItemRepository;
+
+        public DataBlockQuerySizeController(ContentDbContext contentDbContext,
+            IFilterItemRepository filterItemRepository)
+        {
+            _contentDbContext = contentDbContext;
+            _filterItemRepository = filterItemRepository;
+        }
+
+        [HttpGet("api/data-blocks/query-size-report")]
+        [Authorize(Roles = "BAU User")]
+        public async Task<ActionResult<List<DataBlockQuerySizeReport>>> QuerySizeReport()
+        {
+            var publishedReleaseIds = _contentDbContext.Releases
+                .Include(r => r.Publication)
+                .ToList()
+                .Where(r => r.Publication.IsLatestVersionOfRelease(r.Id))
+                .Select(r => r.Id)
+                .ToList();
+
+            var publishedDataBlocks = await _contentDbContext.ReleaseContentBlocks
+                .Include(rcb => rcb.ContentBlock)
+                .Where(rcb => publishedReleaseIds.Contains(rcb.ReleaseId))
+                .Select(rcb => rcb.ContentBlock)
+                .OfType<DataBlock>()
+                .ToListAsync();
+
+            return await publishedDataBlocks
+                .ToAsyncEnumerable()
+                .SelectAwait(async dataBlock =>
+                {
+                    var query = dataBlock.Query;
+
+                    var countsOfFilterItemsByFilter = await _filterItemRepository
+                        .CountFilterItemsByFilter(dataBlock.Query.Filters);
+
+                    var countOfIndicators = query.Indicators.Count();
+                    var countOfLocations = query.Locations.CountItems();
+                    var countOfTimePeriods = TimePeriodUtil.Range(query.TimePeriod).Count();
+
+                    var maxTableCellCount = TableBuilderUtils.MaximumTableCellCount(
+                        countOfIndicators: countOfIndicators,
+                        countOfLocations: countOfLocations,
+                        countOfTimePeriods: countOfTimePeriods,
+                        countsOfFilterItemsByFilter: countsOfFilterItemsByFilter
+                            .Select(pair =>
+                            {
+                                var (_, count) = pair;
+                                return count;
+                            }));
+
+                    return new DataBlockQuerySizeReport
+                    {
+                        DataBlockId = dataBlock.Id,
+                        DataBlockName = dataBlock.Name,
+                        Filters = countsOfFilterItemsByFilter,
+                        Indicators = countOfIndicators,
+                        Locations = countOfLocations,
+                        TimePeriods = countOfTimePeriods,
+                        MaxTableCells = maxTableCellCount
+                    };
+                })
+                .OrderByDescending(result => result.MaxTableCells)
+                .ToListAsync();
+        }
+    }
+
+    public class DataBlockQuerySizeReport
+    {
+        public Guid DataBlockId { get; set; }
+        public string DataBlockName { get; set; } = string.Empty;
+        public Dictionary<Guid, int> Filters { get; set; } = new Dictionary<Guid, int>();
+        public int Indicators { get; set; }
+        public int Locations { get; set; }
+        public int TimePeriods { get; set; }
+        public int MaxTableCells { get; set; }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/CommentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/CommentService.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Validators.ValidationUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageContent
 {
@@ -74,7 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
 
                     if (contentBlock == null)
                     {
-                        return ValidationActionResult<CommentViewModel>(ContentBlockNotFound);
+                        return ValidationResult<CommentViewModel>(ContentBlockNotFound);
                     }
 
                     var comment = new Comment

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -208,6 +208,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             });
 
             services.Configure<PreReleaseOptions>(Configuration);
+            services.Configure<TableBuilderOptions>(Configuration.GetSection(TableBuilderOptions.TableBuilder));
 
             // here we configure our security policies
             StartupSecurityConfiguration.ConfigureAuthorizationPolicies(services);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationErrorMessages.cs
@@ -1,0 +1,96 @@
+﻿#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
+{
+    public enum ValidationErrorMessages
+    {
+        // Slug
+        SlugNotUnique,
+
+        // Partial date
+        PartialDateNotValid,
+
+        // Content
+        EmptyContentSectionExists,
+        GenericSectionsContainEmptyHtmlBlock,
+        ContentBlockNotFound,
+        IncorrectContentBlockTypeForUpdate,
+        ContentBlockAlreadyAttachedToContentSection,
+        IncorrectContentBlockTypeForAttach,
+        ContentBlockAlreadyDetached,
+        ContentBlockNotAttachedToThisContentSection,
+
+        // User Management
+        UserAlreadyExists,
+        UserAlreadyHasResourceRole,
+
+        // Invite
+        InviteNotFound,
+        InvalidEmailAddress,
+        NoInvitableEmails,
+        InvalidUserRole,
+
+        // Methodology
+        MethodologyMustBeDraft,
+        MethodologyCannotDependOnPublishedRelease,
+        MethodologyCannotDependOnRelease,
+        CannotAdoptMethodologyAlreadyLinkedToPublication,
+
+        // Theme
+        ThemeDoesNotExist,
+
+        // Topic
+        TopicDoesNotExist,
+
+        // File
+        CannotOverwriteFile,
+        FileCannotBeEmpty,
+        FileTypeInvalid,
+
+        // Data file
+        SubjectTitleCannotContainSpecialCharacters,
+        SubjectTitleMustBeUnique,
+        CannotOverwriteDataFile,
+        DataAndMetadataFilesCannotHaveTheSameName,
+        DataFileCannotBeEmpty,
+        DataFileMustBeCsvFile,
+        DataFilenameCannotContainSpacesOrSpecialCharacters,
+        CannotRemoveDataFilesUntilImportComplete,
+        CannotRemoveDataFilesOnceReleaseApproved,
+        FileTypeMustBeData,
+
+        // Data zip file
+        DataFileMustBeZipFile,
+        DataZipFileCanOnlyContainTwoFiles,
+        DataZipFileDoesNotContainCsvFiles,
+
+        ReplacementFileTypesMustBeData,
+        ReplacementMustBeValid,
+
+        // Meta file
+        MetadataFileCannotBeEmpty,
+        MetaFileMustBeCsvFile,
+        UnableToFindMetadataFileToDelete,
+        MetaFilenameCannotContainSpacesOrSpecialCharacters,
+        MetaFileIsIncorrectlyNamed,
+
+        // Release
+        ReleaseNotApproved,
+        ApprovedReleaseMustHavePublishScheduledDate,
+        PublishedReleaseCannotBeUnapproved,
+
+        // Release checklist errors
+        DataFileImportsMustBeCompleted,
+        DataFileReplacementsMustBeCompleted,
+        ReleaseNoteRequired,
+        PublicDataGuidanceRequired,
+
+        // Release checklist warnings
+        NoMethodology,
+        NoNextReleaseDate,
+        NoDataFiles,
+        NoFootnotesOnSubjects,
+        NoTableHighlights,
+        NoPublicPreReleaseAccessList,
+        MethodologyNotApproved
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -1,6 +1,6 @@
+#nullable enable
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
@@ -10,23 +10,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
 {
     public static class ValidationUtils
     {
-        public static void AddErrors(ModelStateDictionary errors, ValidationResult result)
-        {
-            if (result.MemberNames?.Any() ?? false)
-            {
-                foreach (var memberName in result.MemberNames)
-                {
-                    errors.AddModelError(memberName, result.ErrorMessage);
-                }
-            }
-            else
-            {
-                // This appears to be the default MVC way of reporting generalised validation errors not associated
-                // with a single property.
-                errors.AddModelError(string.Empty, result.ErrorMessage);
-            }
-        }
-
         // TODO EES-919 - return ActionResults rather than ValidationResults
         public static ValidationResult ValidationResult(ValidationErrorMessages message)
         {
@@ -37,9 +20,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         // rename this to "ValidationResult"
         public static ActionResult ValidationActionResult(ValidationErrorMessages message)
         {
-            ModelStateDictionary errors = new ModelStateDictionary();
-            errors.AddModelError(string.Empty, message.ToString().ScreamingSnakeCase());
-            return new BadRequestObjectResult(new ValidationProblemDetails(errors));
+            return Common.Validators.ValidationUtils.ValidationResult(message);
         }
 
         public static ActionResult ValidationActionResult(IEnumerable<ValidationErrorMessages> messages)
@@ -54,110 +35,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
             return new BadRequestObjectResult(new ValidationProblemDetails(errors));
         }
 
-        // TODO EES-919 - return ActionResults rather than ValidationResults - as this work is done,
-        // rename this to "ValidationResult"
-        public static Either<ActionResult, T> ValidationActionResult<T>(ValidationErrorMessages message)
-        {
-            return ValidationActionResult(message);
-        }
-
         public static Either<ActionResult, T> NotFound<T>()
         {
             return new NotFoundResult();
         }
-    }
-
-    public enum ValidationErrorMessages
-    {
-        // Slug
-        SlugNotUnique,
-
-        // Partial date
-        PartialDateNotValid,
-
-        // Content
-        EmptyContentSectionExists,
-        GenericSectionsContainEmptyHtmlBlock,
-        ContentBlockNotFound,
-        IncorrectContentBlockTypeForUpdate,
-        ContentBlockAlreadyAttachedToContentSection,
-        IncorrectContentBlockTypeForAttach,
-        ContentBlockAlreadyDetached,
-        ContentBlockNotAttachedToThisContentSection,
-
-        // User Management
-        UserAlreadyExists,
-        UserAlreadyHasResourceRole,
-
-        // Invite
-        InviteNotFound,
-        InvalidEmailAddress,
-        NoInvitableEmails,
-        InvalidUserRole,
-
-        // Methodology
-        MethodologyMustBeDraft,
-        MethodologyCannotDependOnPublishedRelease,
-        MethodologyCannotDependOnRelease,
-        CannotAdoptMethodologyAlreadyLinkedToPublication,
-
-        // Theme
-        ThemeDoesNotExist,
-
-        // Topic
-        TopicDoesNotExist,
-
-        // File
-        CannotOverwriteFile,
-        FileCannotBeEmpty,
-        FileTypeInvalid,
-        FilenameCannotContainSpacesOrSpecialCharacters,
-
-        // Data file
-        SubjectTitleCannotContainSpecialCharacters,
-        SubjectTitleMustBeUnique,
-        CannotOverwriteDataFile,
-        DataAndMetadataFilesCannotHaveTheSameName,
-        DataFileCannotBeEmpty,
-        DataFileMustBeCsvFile,
-        DataFilenameCannotContainSpacesOrSpecialCharacters,
-        CannotRemoveDataFilesUntilImportComplete,
-        CannotRemoveDataFilesOnceReleaseApproved,
-        FileTypeMustBeData,
-
-        // Data zip file
-        DataFileMustBeZipFile,
-        DataZipFileCanOnlyContainTwoFiles,
-        DataZipFileDoesNotContainCsvFiles,
-
-        ReplacementFileTypesMustBeData,
-        ReplacementMustBeValid,
-
-        // Meta file
-        MetadataFileCannotBeEmpty,
-        MetaFileMustBeCsvFile,
-        UnableToFindMetadataFileToDelete,
-        MetaFilenameCannotContainSpacesOrSpecialCharacters,
-        MetaFileIsIncorrectlyNamed,
-
-        // Release
-        ReleaseNotApproved,
-        ApprovedReleaseMustHavePublishScheduledDate,
-        PublishedReleaseCannotBeUnapproved,
-
-        // Release checklist errors
-        DataFileImportsMustBeCompleted,
-        DataFileReplacementsMustBeCompleted,
-        ReleaseNoteRequired,
-        PublicDataGuidanceRequired,
-
-        // Release checklist warnings
-        NoMethodology,
-        NoNextReleaseDate,
-        NoDataFiles,
-        NoFootnotesOnSubjects,
-        NoTableHighlights,
-        NoPublicPreReleaseAccessList,
-        MethodologyNotApproved
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -36,5 +36,8 @@
       "MinutesBeforeReleaseTimeStart": 1440,
       "MinutesBeforeReleaseTimeEnd": 1
     }
+  },
+  "TableBuilder": {
+    "MaxTableCellsAllowed": 25000
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/Data/Query/LocationQueryTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/Data/Query/LocationQueryTest.cs
@@ -1,0 +1,40 @@
+﻿#nullable enable
+using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model.Data.Query
+{
+    public class LocationQueryTest
+    {
+        [Fact]
+        public void CountItems_QueryIsEmpty()
+        {
+            var locationQuery = new LocationQuery();
+            Assert.Equal(0, locationQuery.CountItems());
+        }
+
+        [Fact]
+        public void CountItems()
+        {
+            var locationQuery = new LocationQuery();
+            locationQuery.Country.Add("1");
+            locationQuery.EnglishDevolvedArea.Add("2");
+            locationQuery.Institution.Add("3");
+            locationQuery.LocalAuthority.Add("4");
+            locationQuery.LocalAuthorityDistrict.Add("5");
+            locationQuery.LocalEnterprisePartnership.Add("6");
+            locationQuery.MultiAcademyTrust.Add("7");
+            locationQuery.MayoralCombinedAuthority.Add("8");
+            locationQuery.OpportunityArea.Add("9");
+            locationQuery.ParliamentaryConstituency.Add("10");
+            locationQuery.Provider.Add("11");
+            locationQuery.PlanningArea.Add("12");
+            locationQuery.Region.Add("13");
+            locationQuery.RscRegion.Add("14");
+            locationQuery.School.Add("15");
+            locationQuery.Sponsor.Add("16");
+            locationQuery.Ward.Add("17");
+            Assert.Equal(17, locationQuery.CountItems());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/LocationQuery.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/LocationQuery.cs
@@ -1,29 +1,41 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query
 {
-    public class LocationQuery
+    public record LocationQuery
     {
         [JsonConverter(typeof(StringEnumConverter))]
         public GeographicLevel? GeographicLevel { get; set; }
-        public IEnumerable<string> Country { get; set; }
-        public IEnumerable<string> EnglishDevolvedArea { get; set; }
-        public IEnumerable<string> Institution { get; set; }
-        public IEnumerable<string> LocalAuthority { get; set; }
-        public IEnumerable<string> LocalAuthorityDistrict { get; set; }
-        public IEnumerable<string> LocalEnterprisePartnership { get; set; }
-        public IEnumerable<string> MultiAcademyTrust { get; set; }
-        public IEnumerable<string> MayoralCombinedAuthority { get; set; }
-        public IEnumerable<string> OpportunityArea { get; set; }
-        public IEnumerable<string> ParliamentaryConstituency { get; set; }
-        public IEnumerable<string> Provider { get; set; }
-        public IEnumerable<string> PlanningArea { get; set; }
-        public IEnumerable<string> Region { get; set; }
-        public IEnumerable<string> RscRegion { get; set; }
-        public IEnumerable<string> School { get; set; }
-        public IEnumerable<string> Sponsor { get; set; }
-        public IEnumerable<string> Ward { get; set; }
+        public List<string> Country { get; set; } = new();
+        public List<string> EnglishDevolvedArea { get; set; } = new();
+        public List<string> Institution { get; set; } = new();
+        public List<string> LocalAuthority { get; set; } = new();
+        public List<string> LocalAuthorityDistrict { get; set; } = new();
+        public List<string> LocalEnterprisePartnership { get; set; } = new();
+        public List<string> MultiAcademyTrust { get; set; } = new();
+        public List<string> MayoralCombinedAuthority { get; set; } = new();
+        public List<string> OpportunityArea { get; set; } = new();
+        public List<string> ParliamentaryConstituency { get; set; } = new();
+        public List<string> Provider { get; set; } = new();
+        public List<string> PlanningArea { get; set; } = new();
+        public List<string> Region { get; set; } = new();
+        public List<string> RscRegion { get; set; } = new();
+        public List<string> School { get; set; } = new();
+        public List<string> Sponsor { get; set; } = new();
+        public List<string> Ward { get; set; } = new();
+
+        public int CountItems()
+        {
+            return GetType()
+                .GetProperties()
+                .Where(property => property.PropertyType == typeof(List<string>))
+                .Select(property => property.GetValue(this))
+                .Cast<List<string>>()
+                .Sum(collection => collection?.Count ?? 0);
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ValidationUtils.cs
@@ -1,0 +1,32 @@
+﻿#nullable enable
+using System;
+using System.Linq;
+using System.Net;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Validators
+{
+    public static class ValidationUtils
+    {
+        public static ActionResult ValidationResult(params Enum[] errors)
+        {
+            var problemDetails = new ValidationProblemDetails(
+                errors.ToDictionary(
+                    _ => string.Empty,
+                    error => new[] {error.ToString().ScreamingSnakeCase()}))
+            {
+                Status = (int) HttpStatusCode.BadRequest,
+                Detail = "Please refer to the errors property for additional details"
+            };
+
+            return new BadRequestObjectResult(problemDetails);
+        }
+
+        public static Either<ActionResult, T> ValidationResult<T>(Enum error)
+        {
+            return ValidationResult(error);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -101,6 +101,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
                 c.SwaggerDoc("v1", new OpenApiInfo {Title = "Explore education statistics - Data API", Version = "v1"});
             });
 
+            services.Configure<TableBuilderOptions>(Configuration.GetSection(TableBuilderOptions.TableBuilder));
+
             services.AddTransient<IBlobCacheService, BlobCacheService>();
             services.AddTransient<IResultBuilder<Observation, ObservationViewModel>, ResultBuilder>();
             services.AddTransient<IBoundaryLevelRepository, BoundaryLevelRepository>();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.Development.json
@@ -12,5 +12,8 @@
       "Microsoft": "Warning",
       "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
     }
+  },
+  "TableBuilder": {
+    "MaxTableCellsAllowed": 25000
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/FilterItemRepositoryTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model.Tests/FilterItemRepositoryTests.cs
@@ -1,0 +1,178 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Database;
+using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Tests
+{
+    public class FilterItemRepositoryTests
+    {
+        [Fact]
+        public async Task CountFilterItemsByFilter()
+        {
+            var filterItemCharacteristicSchoolYear1 = new FilterItem();
+            var filterItemCharacteristicFsmEligible = new FilterItem();
+            var filterItemCharacteristicFsmNotEligible = new FilterItem();
+            var filterItemSchoolTypePrimary = new FilterItem();
+            var filterItemSchoolTypeSecondary = new FilterItem();
+
+            var filterCharacteristic = new Filter
+            {
+                FilterGroups = new List<FilterGroup>
+                {
+                    new()
+                    {
+                        FilterItems = new List<FilterItem>
+                        {
+                            filterItemCharacteristicSchoolYear1
+                        }
+                    },
+                    new()
+                    {
+                        FilterItems = new List<FilterItem>
+                        {
+                            filterItemCharacteristicFsmEligible,
+                            filterItemCharacteristicFsmNotEligible
+                        }
+                    }
+                }
+            };
+
+            var filterSchoolType = new Filter
+            {
+                FilterGroups = new List<FilterGroup>
+                {
+                    new()
+                    {
+                        FilterItems = new List<FilterItem>
+                        {
+                            filterItemSchoolTypePrimary,
+                            filterItemSchoolTypeSecondary
+                        }
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.Filter.AddRangeAsync(filterCharacteristic, filterSchoolType);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var repository = BuildFilterItemRepository(context);
+                var filterItemIds = new List<Guid>
+                {
+                    filterItemCharacteristicSchoolYear1.Id,
+                    filterItemCharacteristicFsmEligible.Id,
+                    filterItemCharacteristicFsmNotEligible.Id,
+                    filterItemSchoolTypePrimary.Id,
+                    filterItemSchoolTypeSecondary.Id
+                };
+                var result = await repository.CountFilterItemsByFilter(filterItemIds);
+
+                // Result should contain the counts of filter items in both filters
+                Assert.Equal(2, result.Count);
+
+                // 3 of the filter items belong to the Characteristic filter 
+                Assert.Equal(3, result[filterCharacteristic.Id]);
+
+                // 2 of the filter items belong to the School Type filter
+                Assert.Equal(2, result[filterSchoolType.Id]);
+            }
+        }
+
+        [Fact]
+        public async Task CountFilterItemsByFilter_EmptyFilterItemsIsEmpty()
+        {
+            var filter = new Filter
+            {
+                FilterGroups = new List<FilterGroup>
+                {
+                    new()
+                    {
+                        FilterItems = new List<FilterItem>
+                        {
+                            new()
+                        }
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.Filter.AddRangeAsync(filter);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var repository = BuildFilterItemRepository(context);
+                var result = await repository.CountFilterItemsByFilter(new List<Guid>());
+                Assert.Empty(result);
+            }
+        }
+
+        [Fact]
+        public async Task CountFilterItemsByFilter_FilterItemsNotFoundThrowsException()
+        {
+            var filterItem = new FilterItem();
+            var filter = new Filter
+            {
+                FilterGroups = new List<FilterGroup>
+                {
+                    new()
+                    {
+                        FilterItems = new List<FilterItem>
+                        {
+                            filterItem
+                        }
+                    }
+                }
+            };
+
+            var statisticsDbContextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                await statisticsDbContext.Filter.AddRangeAsync(filter);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var context = StatisticsDbUtils.InMemoryStatisticsDbContext(statisticsDbContextId))
+            {
+                var repository = BuildFilterItemRepository(context);
+
+                var filterItemNotFound1 = Guid.NewGuid();
+                var filterItemNotFound2 = Guid.NewGuid();
+
+                var exception = await Assert.ThrowsAsync<ArgumentException>(async () =>
+                {
+                    await repository.CountFilterItemsByFilter(
+                        ListOf(
+                            filterItem.Id,
+                            filterItemNotFound1,
+                            filterItemNotFound2
+                        ));
+                });
+
+                Assert.Equal($"Could not find filter items: {filterItemNotFound1}, {filterItemNotFound2}", exception.Message);
+            }
+        }
+
+        private static FilterItemRepository BuildFilterItemRepository(
+            StatisticsDbContext context)
+        {
+            return new(context);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IFilterItemRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/IFilterItemRepository.cs
@@ -1,15 +1,22 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces
 {
     public interface IFilterItemRepository : IRepository<FilterItem, Guid>
     {
-        IEnumerable<FilterItem> GetFilterItems(Guid subjectId, IQueryable<Observation> observations, bool listFilterItems);
+        Task<Dictionary<Guid, int>> CountFilterItemsByFilter(IEnumerable<Guid> filterItemIds);
 
-        FilterItem GetTotal(Filter filter);
+        IEnumerable<FilterItem> GetFilterItems(
+            Guid subjectId,
+            IQueryable<Observation> observations,
+            bool listFilterItems);
 
-        FilterItem GetTotal(IEnumerable<FilterItem> filterItems);
+        FilterItem? GetTotal(Filter filter);
+
+        FilterItem? GetTotal(IEnumerable<FilterItem> filterItems);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServicePermissionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServicePermissionTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
@@ -11,6 +12,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.PermissionTestUtils;
@@ -22,12 +24,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         private static readonly Guid SubjectId = Guid.NewGuid();
         private static readonly Guid ReleaseId = Guid.NewGuid();
 
-        private readonly Subject _subject = new Subject
+        private readonly Subject _subject = new()
         {
             Id = SubjectId,
         };
 
-        private readonly Release _release = new Release
+        private readonly Release _release = new()
         {
             Id = ReleaseId,
         };
@@ -123,22 +125,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
         }
 
         private TableBuilderService BuildTableBuilderService(
-            IObservationService observationService = null,
-            IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper = null,
-            IResultSubjectMetaService resultSubjectMetaService = null,
-            ISubjectRepository subjectRepository = null,
-            IUserService userService = null,
-            IResultBuilder<Observation, ObservationViewModel> resultBuilder = null,
-            IReleaseRepository releaseRepository = null)
+            IFilterItemRepository? filterItemRepository = null,
+            IObservationService? observationService = null,
+            IPersistenceHelper<StatisticsDbContext>? statisticsPersistenceHelper = null,
+            IResultSubjectMetaService? resultSubjectMetaService = null,
+            ISubjectRepository? subjectRepository = null,
+            IUserService? userService = null,
+            IResultBuilder<Observation, ObservationViewModel>? resultBuilder = null,
+            IReleaseRepository? releaseRepository = null,
+            IOptions<TableBuilderOptions>? options = null)
         {
-            return new TableBuilderService(
-                observationService ?? new Mock<IObservationService>().Object,
+            return new(
+                filterItemRepository ?? Mock.Of<IFilterItemRepository>(MockBehavior.Strict),
+                observationService ?? Mock.Of<IObservationService>(MockBehavior.Strict),
                 statisticsPersistenceHelper ?? StatisticsPersistenceHelperMock(_subject).Object,
-                resultSubjectMetaService ?? new Mock<IResultSubjectMetaService>().Object,
-                subjectRepository ?? new Mock<ISubjectRepository>().Object,
-                userService ?? new Mock<IUserService>().Object,
+                resultSubjectMetaService ?? Mock.Of<IResultSubjectMetaService>(MockBehavior.Strict),
+                subjectRepository ?? Mock.Of<ISubjectRepository>(MockBehavior.Strict),
+                userService ?? Mock.Of<IUserService>(MockBehavior.Strict),
                 resultBuilder ?? new ResultBuilder(DataServiceMapperUtils.DataServiceMapper()),
-                releaseRepository ?? new Mock<IReleaseRepository>().Object
+                releaseRepository ?? Mock.Of<IReleaseRepository>(MockBehavior.Strict),
+                options ?? Options.Create(new TableBuilderOptions())
             );
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
@@ -160,6 +160,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var result = await service.Query(query);
 
+                MockUtils.VerifyAllMocks(
+                    observationService,
+                    resultSubjectMetaService,
+                    subjectRepository,
+                    releaseRepository);
+
                 Assert.True(result.IsRight);
 
                 var observationResults = result.Right.Results.ToList();
@@ -176,12 +182,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal("789", observationResults[1].Measures[indicator1Id.ToString()]);
 
                 Assert.Equal(subjectMeta, result.Right.SubjectMeta);
-
-                MockUtils.VerifyAllMocks(
-                    observationService,
-                    resultSubjectMetaService,
-                    subjectRepository,
-                    releaseRepository);
             }
         }
 
@@ -219,8 +219,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var result = await service.Query(query);
 
-                result.AssertNotFound();
                 MockUtils.VerifyAllMocks(subjectRepository, releaseRepository);
+
+                result.AssertNotFound();
             }
         }
 
@@ -263,8 +264,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var result = await service.Query(query);
 
-                result.AssertNotFound();
                 MockUtils.VerifyAllMocks(subjectRepository, releaseRepository);
+
+                result.AssertNotFound();
             }
         }
 
@@ -371,9 +373,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var result = await service.Query(query);
 
-                result.AssertBadRequest(ValidationErrorMessages.QueryExceedsMaxAllowableTableSize);
-
                 MockUtils.VerifyAllMocks(filterItemRepository, subjectRepository, releaseRepository);
+
+                result.AssertBadRequest(ValidationErrorMessages.QueryExceedsMaxAllowableTableSize);
             }
         }
 
@@ -492,6 +494,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var result = await service.Query(releaseSubject.ReleaseId, query);
 
+                MockUtils.VerifyAllMocks(observationService, resultSubjectMetaService, subjectRepository);
+
                 Assert.True(result.IsRight);
 
                 var observationResults = result.Right.Results.ToList();
@@ -508,8 +512,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Equal("789", observationResults[1].Measures[indicator1Id.ToString()]);
 
                 Assert.Equal(subjectMeta, result.Right.SubjectMeta);
-
-                MockUtils.VerifyAllMocks(observationService, resultSubjectMetaService, subjectRepository);
             }
         }
 
@@ -661,9 +663,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var result = await service.Query(releaseSubject.ReleaseId, query);
 
-                result.AssertBadRequest(ValidationErrorMessages.QueryExceedsMaxAllowableTableSize);
-
                 MockUtils.VerifyAllMocks(filterItemRepository, subjectRepository);
+
+                result.AssertBadRequest(ValidationErrorMessages.QueryExceedsMaxAllowableTableSize);
             }
         }
 
@@ -688,7 +690,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             IOptions<TableBuilderOptions>? options = null)
         {
             return new(
-                
                 filterItemRepository ?? Mock.Of<IFilterItemRepository>(MockBehavior.Strict),
                 observationService ?? Mock.Of<IObservationService>(MockBehavior.Strict),
                 statisticsPersistenceHelper ?? new PersistenceHelper<StatisticsDbContext>(statisticsDbContext),

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/TableBuilderServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,7 +17,7 @@ using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
-using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 using Release = GovUk.Education.ExploreEducationStatistics.Data.Model.Release;
@@ -50,10 +51,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             var query = new ObservationQueryContext
             {
                 SubjectId = releaseSubject.Subject.Id,
-                Indicators = new[] { indicator1Id, indicator2Id, },
+                Indicators = new[] {indicator1Id, indicator2Id,},
                 Locations = new LocationQuery
                 {
-                    Country = new[] { "england" }
+                    Country = new List<string>
+                    {
+                        "england"
+                    }
                 },
                 TimePeriod = new TimePeriodQuery
                 {
@@ -76,18 +80,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 var observations = new List<Observation>
                 {
-                    new Observation
+                    new()
                     {
                         Measures = new Dictionary<Guid, string>
                         {
-                            { indicator1Id, "123" },
-                            { indicator2Id, "456" },
+                            {indicator1Id, "123"},
+                            {indicator2Id, "456"},
                         },
                         FilterItems = new List<ObservationFilterItem>(),
                         Year = 2019,
                         TimeIdentifier = TimeIdentifier.AcademicYear,
                     },
-                    new Observation
+                    new()
                     {
                         Measures = new Dictionary<Guid, string>
                         {
@@ -105,20 +109,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 {
                     Indicators = new List<IndicatorMetaViewModel>
                     {
-                        new IndicatorMetaViewModel
+                        new()
                         {
                             Label = "Test indicator"
                         }
                     },
                 };
 
-                var observationService = new Mock<IObservationService>();
+                var observationService = new Mock<IObservationService>(MockBehavior.Strict);
 
                 observationService
                     .Setup(s => s.FindObservations(query))
                     .Returns(observations);
 
-                var resultSubjectMetaService = new Mock<IResultSubjectMetaService>();
+                var resultSubjectMetaService = new Mock<IResultSubjectMetaService>(MockBehavior.Strict);
 
                 resultSubjectMetaService
                     .Setup(
@@ -130,7 +134,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     )
                     .ReturnsAsync(subjectMeta);
 
-                var subjectRepository = new Mock<ISubjectRepository>();
+                var subjectRepository = new Mock<ISubjectRepository>(MockBehavior.Strict);
 
                 subjectRepository
                     .Setup(s => s.GetPublicationIdForSubject(query.SubjectId))
@@ -140,7 +144,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     .Setup(s => s.IsSubjectForLatestPublishedRelease(query.SubjectId))
                     .ReturnsAsync(true);
 
-                var releaseRepository = new Mock<IReleaseRepository>();
+                var releaseRepository = new Mock<IReleaseRepository>(MockBehavior.Strict);
 
                 releaseRepository
                     .Setup(s => s.GetLatestPublishedRelease(publicationId))
@@ -173,7 +177,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 Assert.Equal(subjectMeta, result.Right.SubjectMeta);
 
-                MockUtils.VerifyAllMocks(observationService, resultSubjectMetaService, subjectRepository, releaseRepository);
+                MockUtils.VerifyAllMocks(
+                    observationService,
+                    resultSubjectMetaService,
+                    subjectRepository,
+                    releaseRepository);
             }
         }
 
@@ -191,16 +199,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
             {
-                var subjectRepository = new Mock<ISubjectRepository>();
+                var subjectRepository = new Mock<ISubjectRepository>(MockBehavior.Strict);
 
                 subjectRepository
                     .Setup(s => s.GetPublicationIdForSubject(query.SubjectId))
                     .ReturnsAsync(publicationId);
 
-                var releaseRepository = new Mock<IReleaseRepository>();
+                var releaseRepository = new Mock<IReleaseRepository>(MockBehavior.Strict);
 
                 releaseRepository
-                    .Setup(s => s.GetLatestPublishedRelease(publicationId));
+                    .Setup(s => s.GetLatestPublishedRelease(publicationId))
+                    .Returns((Release?) null);
 
                 var service = BuildTableBuilderService(
                     statisticsDbContext,
@@ -234,13 +243,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
             await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
             {
-                var subjectRepository = new Mock<ISubjectRepository>();
+                var subjectRepository = new Mock<ISubjectRepository>(MockBehavior.Strict);
 
                 subjectRepository
                     .Setup(s => s.GetPublicationIdForSubject(query.SubjectId))
                     .ReturnsAsync(publicationId);
 
-                var releaseRepository = new Mock<IReleaseRepository>();
+                var releaseRepository = new Mock<IReleaseRepository>(MockBehavior.Strict);
 
                 releaseRepository
                     .Setup(s => s.GetLatestPublishedRelease(publicationId))
@@ -256,6 +265,115 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 result.AssertNotFound();
                 MockUtils.VerifyAllMocks(subjectRepository, releaseRepository);
+            }
+        }
+
+        [Fact]
+        public async Task Query_LatestRelease_PredictedTableTooBig()
+        {
+            var publicationId = Guid.NewGuid();
+
+            var release = new Release
+            {
+                PublicationId = publicationId
+            };
+
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = release,
+                Subject = new Subject
+                {
+                    Id = Guid.NewGuid()
+                }
+            };
+
+            var filterItem1Id = Guid.NewGuid();
+            var filterItem2Id = Guid.NewGuid();
+            var indicator1Id = Guid.NewGuid();
+            var indicator2Id = Guid.NewGuid();
+
+            var query = new ObservationQueryContext
+            {
+                SubjectId = releaseSubject.Subject.Id,
+                Filters = new [] {filterItem1Id, filterItem2Id},
+                Indicators = new[] {indicator1Id, indicator2Id},
+                Locations = new LocationQuery
+                {
+                    Country = new List<string>
+                    {
+                        "england"
+                    }
+                },
+                TimePeriod = new TimePeriodQuery
+                {
+                    StartYear = 2019,
+                    StartCode = TimeIdentifier.AcademicYear,
+                    EndYear = 2020,
+                    EndCode = TimeIdentifier.AcademicYear
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var filterItemRepository = new Mock<IFilterItemRepository>(MockBehavior.Strict);
+
+                filterItemRepository
+                    .Setup(s => s.CountFilterItemsByFilter(
+                        query.Filters))
+                    .ReturnsAsync(new Dictionary<Guid, int>
+                    {
+                        {
+                            // For the purpose of calculating the potential table size,
+                            // treat all the Filter Items as belonging to the same Filter
+                            Guid.NewGuid(), query.Filters.Count()
+                        }
+                    });
+
+                var subjectRepository = new Mock<ISubjectRepository>(MockBehavior.Strict);
+
+                subjectRepository
+                    .Setup(s => s.GetPublicationIdForSubject(query.SubjectId))
+                    .ReturnsAsync(publicationId);
+
+                subjectRepository
+                    .Setup(s => s.IsSubjectForLatestPublishedRelease(query.SubjectId))
+                    .ReturnsAsync(true);
+
+                var releaseRepository = new Mock<IReleaseRepository>(MockBehavior.Strict);
+
+                releaseRepository
+                    .Setup(s => s.GetLatestPublishedRelease(publicationId))
+                    .Returns(release);
+
+                var options = Options.Create(new TableBuilderOptions
+                {
+                    // 2 Filter items (from 1 Filter), 1 Location, and 2 Time periods provide 4 different combinations,
+                    // assuming that all the data is provided. For 2 Indicators this would be 8 table cells rendered.
+                    // Configure a maximum table size limit lower than 8.
+                    MaxTableCellsAllowed = 7
+                });
+
+                var service = BuildTableBuilderService(
+                    statisticsDbContext,
+                    filterItemRepository: filterItemRepository.Object,
+                    subjectRepository: subjectRepository.Object,
+                    releaseRepository: releaseRepository.Object,
+                    options: options
+                );
+
+                var result = await service.Query(query);
+
+                result.AssertBadRequest(ValidationErrorMessages.QueryExceedsMaxAllowableTableSize);
+
+                MockUtils.VerifyAllMocks(filterItemRepository, subjectRepository, releaseRepository);
             }
         }
 
@@ -280,7 +398,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Indicators = new[] { indicator1Id, indicator2Id, },
                 Locations = new LocationQuery
                 {
-                    Country = new[] { "england" }
+                    Country = new List<string>
+                    {
+                        "england"
+                    }
                 },
                 TimePeriod = new TimePeriodQuery
                 {
@@ -303,7 +424,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             {
                 var observations = new List<Observation>
                 {
-                    new Observation
+                    new()
                     {
                         Measures = new Dictionary<Guid, string>
                         {
@@ -314,7 +435,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                         Year = 2019,
                         TimeIdentifier = TimeIdentifier.AcademicYear,
                     },
-                    new Observation
+                    new()
                     {
                         Measures = new Dictionary<Guid, string>
                         {
@@ -332,20 +453,20 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 {
                     Indicators = new List<IndicatorMetaViewModel>
                     {
-                        new IndicatorMetaViewModel
+                        new()
                         {
                             Label = "Test indicator"
                         }
                     },
                 };
 
-                var observationService = new Mock<IObservationService>();
+                var observationService = new Mock<IObservationService>(MockBehavior.Strict);
 
                 observationService
                     .Setup(s => s.FindObservations(query))
                     .Returns(observations);
 
-                var resultSubjectMetaService = new Mock<IResultSubjectMetaService>();
+                var resultSubjectMetaService = new Mock<IResultSubjectMetaService>(MockBehavior.Strict);
 
                 resultSubjectMetaService
                     .Setup(
@@ -357,10 +478,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                     )
                     .ReturnsAsync(subjectMeta);
 
+                var subjectRepository = new Mock<ISubjectRepository>(MockBehavior.Strict);
+                subjectRepository.Setup(s =>
+                        s.IsSubjectForLatestPublishedRelease(releaseSubject.Subject.Id))
+                    .ReturnsAsync(false);
+
                 var service = BuildTableBuilderService(
                     statisticsDbContext,
                     observationService: observationService.Object,
-                    resultSubjectMetaService: resultSubjectMetaService.Object
+                    resultSubjectMetaService: resultSubjectMetaService.Object,
+                    subjectRepository: subjectRepository.Object
                 );
 
                 var result = await service.Query(releaseSubject.ReleaseId, query);
@@ -382,7 +509,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 Assert.Equal(subjectMeta, result.Right.SubjectMeta);
 
-                MockUtils.VerifyAllMocks(observationService, resultSubjectMetaService);
+                MockUtils.VerifyAllMocks(observationService, resultSubjectMetaService, subjectRepository);
             }
         }
 
@@ -450,24 +577,127 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             }
         }
 
-        private TableBuilderService BuildTableBuilderService(
-            StatisticsDbContext statisticsDbContext,
-            IObservationService observationService = null,
-            IPersistenceHelper<StatisticsDbContext> statisticsPersistenceHelper = null,
-            IResultSubjectMetaService resultSubjectMetaService = null,
-            ISubjectRepository subjectRepository = null,
-            IUserService userService = null,
-            IResultBuilder<Observation, ObservationViewModel> resultBuilder = null,
-            IReleaseRepository releaseRepository = null)
+        [Fact]
+        public async Task Query_ReleaseId_PredictedTableTooBig()
         {
-            return new TableBuilderService(
-                observationService ?? new Mock<IObservationService>().Object,
+            var releaseSubject = new ReleaseSubject
+            {
+                Release = new Release(),
+                Subject = new Subject
+                {
+                    Id = Guid.NewGuid()
+                },
+            };
+
+            var filterItem1Id = Guid.NewGuid();
+            var filterItem2Id = Guid.NewGuid();
+            var indicator1Id = Guid.NewGuid();
+            var indicator2Id = Guid.NewGuid();
+
+            var query = new ObservationQueryContext
+            {
+                SubjectId = releaseSubject.Subject.Id,
+                Filters = new[] {filterItem1Id, filterItem2Id},
+                Indicators = new[] {indicator1Id, indicator2Id},
+                Locations = new LocationQuery
+                {
+                    Country = new List<string>
+                    {
+                        "england"
+                    }
+                },
+                TimePeriod = new TimePeriodQuery
+                {
+                    StartYear = 2019,
+                    StartCode = TimeIdentifier.AcademicYear,
+                    EndYear = 2020,
+                    EndCode = TimeIdentifier.AcademicYear
+                }
+            };
+
+            var contextId = Guid.NewGuid().ToString();
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                await statisticsDbContext.AddAsync(releaseSubject);
+                await statisticsDbContext.SaveChangesAsync();
+            }
+
+            await using (var statisticsDbContext = StatisticsDbUtils.InMemoryStatisticsDbContext(contextId))
+            {
+                var filterItemRepository = new Mock<IFilterItemRepository>(MockBehavior.Strict);
+
+                filterItemRepository
+                    .Setup(s => s.CountFilterItemsByFilter(
+                        query.Filters))
+                    .ReturnsAsync(new Dictionary<Guid, int>
+                    {
+                        {
+                            // For the purpose of calculating the potential table size,
+                            // treat all the Filter Items as belonging to the same Filter
+                            Guid.NewGuid(), query.Filters.Count()
+                        }
+                    });
+
+                var subjectRepository = new Mock<ISubjectRepository>(MockBehavior.Strict);
+                subjectRepository.Setup(s =>
+                        s.IsSubjectForLatestPublishedRelease(releaseSubject.Subject.Id))
+                    .ReturnsAsync(false);
+
+                var options = Options.Create(new TableBuilderOptions
+                {
+                    // 2 Filter items (from 1 Filter), 1 Location, and 2 Time periods provide 4 different combinations,
+                    // assuming that all the data is provided. For 2 Indicators this would be 8 table cells rendered.
+                    // Configure a maximum table size limit lower than 8.
+                    MaxTableCellsAllowed = 7
+                });
+
+                var service = BuildTableBuilderService(
+                    statisticsDbContext,
+                    filterItemRepository: filterItemRepository.Object,
+                    subjectRepository: subjectRepository.Object,
+                    options: options
+                );
+
+                var result = await service.Query(releaseSubject.ReleaseId, query);
+
+                result.AssertBadRequest(ValidationErrorMessages.QueryExceedsMaxAllowableTableSize);
+
+                MockUtils.VerifyAllMocks(filterItemRepository, subjectRepository);
+            }
+        }
+
+        private static IOptions<TableBuilderOptions> DefaultOptions()
+        {
+            return Options.Create(new TableBuilderOptions
+            {
+                MaxTableCellsAllowed = 25000
+            });
+        }
+
+        private static TableBuilderService BuildTableBuilderService(
+            StatisticsDbContext statisticsDbContext,
+            IFilterItemRepository? filterItemRepository = null,
+            IObservationService? observationService = null,
+            IPersistenceHelper<StatisticsDbContext>? statisticsPersistenceHelper = null,
+            IResultSubjectMetaService? resultSubjectMetaService = null,
+            ISubjectRepository? subjectRepository = null,
+            IUserService? userService = null,
+            IResultBuilder<Observation, ObservationViewModel>? resultBuilder = null,
+            IReleaseRepository? releaseRepository = null,
+            IOptions<TableBuilderOptions>? options = null)
+        {
+            return new(
+                
+                filterItemRepository ?? Mock.Of<IFilterItemRepository>(MockBehavior.Strict),
+                observationService ?? Mock.Of<IObservationService>(MockBehavior.Strict),
                 statisticsPersistenceHelper ?? new PersistenceHelper<StatisticsDbContext>(statisticsDbContext),
-                resultSubjectMetaService ?? new Mock<IResultSubjectMetaService>().Object,
-                subjectRepository ?? new Mock<ISubjectRepository>().Object,
+                resultSubjectMetaService ?? Mock.Of<IResultSubjectMetaService>(MockBehavior.Strict),
+                subjectRepository ?? Mock.Of<ISubjectRepository>(MockBehavior.Strict),
                 userService ?? MockUtils.AlwaysTrueUserService().Object,
                 resultBuilder ?? new ResultBuilder(DataServiceMapperUtils.DataServiceMapper()),
-                releaseRepository ?? new Mock<IReleaseRepository>().Object
+                releaseRepository ?? Mock.Of<IReleaseRepository>(MockBehavior.Strict),
+                options ?? DefaultOptions()
             );
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Utils/TableBuilderUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Utils/TableBuilderUtilsTests.cs
@@ -13,7 +13,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils
             /*
              * 2011  Bury  cell1
              */
-            Assert.Equal(1, MaximumTableCellCount(1, 1, 1));
+            Assert.Equal(
+                1,
+                MaximumTableCellCount(
+                    countOfIndicators: 1,
+                    countOfLocations: 1,
+                    countOfTimePeriods: 1));
         }
 
         [Fact]
@@ -22,7 +27,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils
             /*
              * 2011  Bury  cell1  cell2  cell 3
              */
-            Assert.Equal(3, MaximumTableCellCount(3, 1, 1));
+            Assert.Equal(
+                3,
+                MaximumTableCellCount(
+                    countOfIndicators: 3,
+                    countOfLocations: 1,
+                    countOfTimePeriods: 1));
         }
 
         [Fact]
@@ -33,7 +43,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils
              * 2011  Kent  cell2
              * 2011  York  cell3
              */
-            Assert.Equal(3, MaximumTableCellCount(1, 3, 1));
+            Assert.Equal(
+                3,
+                MaximumTableCellCount(
+                    countOfIndicators: 1,
+                    countOfLocations: 3,
+                    countOfTimePeriods: 1));
         }
 
         [Fact]
@@ -44,7 +59,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils
              * 2012  Bury  cell2
              * 2013  Bury  cell3
              */
-            Assert.Equal(3, MaximumTableCellCount(1, 1, 3));
+            Assert.Equal(
+                3,
+                MaximumTableCellCount(
+                    countOfIndicators: 1,
+                    countOfLocations: 1,
+                    countOfTimePeriods: 3));
         }
 
         [Fact]
@@ -58,7 +78,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils
              * 2013  Bury   cell9  cell10
              * 2013  York  cell11  cell12
              */
-            Assert.Equal(12, MaximumTableCellCount(2, 2, 3));
+            Assert.Equal(
+                12,
+                MaximumTableCellCount(
+                    countOfIndicators: 2,
+                    countOfLocations: 2,
+                    countOfTimePeriods: 3));
         }
 
         [Fact]
@@ -72,7 +97,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils
              * 2013  Bury  Year1   cell9  cell10
              * 2013  York  Year1  cell11  cell12
              */
-            Assert.Equal(12, MaximumTableCellCount(2, 2, 3, ListOf(1)));
+            Assert.Equal(
+                12,
+                MaximumTableCellCount(
+                    countOfIndicators: 2,
+                    countOfLocations: 2,
+                    countOfTimePeriods: 3,
+                    countsOfFilterItemsByFilter: ListOf(1)));
         }
 
         [Fact]
@@ -86,7 +117,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils
              * 2013  Bury  Year1  Male   cell9  cell10
              * 2013  York  Year1  Male  cell11  cell12
              */
-            Assert.Equal(12, MaximumTableCellCount(2, 2, 3, ListOf(1, 1)));
+            Assert.Equal(
+                12,
+                MaximumTableCellCount(
+                    countOfIndicators: 2,
+                    countOfLocations: 2,
+                    countOfTimePeriods: 3,
+                    countsOfFilterItemsByFilter: ListOf(1, 1)));
         }
 
         [Fact]
@@ -112,7 +149,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils
              * 2013  Bury  Year3  cell33  cell34
              * 2013  York  Year3  cell35  cell36
              */
-            Assert.Equal(36, MaximumTableCellCount(2, 2, 3, ListOf(3)));
+            Assert.Equal(
+                36,
+                MaximumTableCellCount(
+                    countOfIndicators: 2,
+                    countOfLocations: 2,
+                    countOfTimePeriods: 3,
+                    countsOfFilterItemsByFilter: ListOf(3)));
         }
 
         [Fact]
@@ -156,7 +199,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils
              * 2013  Bury  Year3  Female  cell69  cell70
              * 2013  York  Year3  Female  cell71  cell72
              */
-            Assert.Equal(72, MaximumTableCellCount(2, 2, 3, ListOf(3, 2)));
+            Assert.Equal(
+                72,
+                MaximumTableCellCount(
+                    countOfIndicators: 2,
+                    countOfLocations: 2,
+                    countOfTimePeriods: 3,
+                    countsOfFilterItemsByFilter: ListOf(3, 2)));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Utils/TableBuilderUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/Utils/TableBuilderUtilsTests.cs
@@ -1,0 +1,162 @@
+﻿#nullable enable
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Data.Services.Utils.TableBuilderUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests.Utils
+{
+    public class TableBuilderUtilsTests
+    {
+        [Fact]
+        public void MaximumTableCellCount_NoFilters_SingleIndicatorLocationAndTimePeriod()
+        {
+            /*
+             * 2011  Bury  cell1
+             */
+            Assert.Equal(1, MaximumTableCellCount(1, 1, 1));
+        }
+
+        [Fact]
+        public void MaximumTableCellCount_NoFilters_MultipleIndicators()
+        {
+            /*
+             * 2011  Bury  cell1  cell2  cell 3
+             */
+            Assert.Equal(3, MaximumTableCellCount(3, 1, 1));
+        }
+
+        [Fact]
+        public void MaximumTableCellCount_NoFilters_MultipleLocations()
+        {
+            /*
+             * 2011  Bury  cell1
+             * 2011  Kent  cell2
+             * 2011  York  cell3
+             */
+            Assert.Equal(3, MaximumTableCellCount(1, 3, 1));
+        }
+
+        [Fact]
+        public void MaximumTableCellCount_NoFilters_MultipleTimePeriods()
+        {
+            /*
+             * 2011  Bury  cell1
+             * 2012  Bury  cell2
+             * 2013  Bury  cell3
+             */
+            Assert.Equal(3, MaximumTableCellCount(1, 1, 3));
+        }
+
+        [Fact]
+        public void MaximumTableCellCount_NoFilters_MultipleIndicatorsLocationsAndTimePeriods()
+        {
+            /*
+             * 2011  Bury   cell1   cell2
+             * 2011  York   cell3   cell4
+             * 2012  Bury   cell5   cell6
+             * 2012  York   cell7   cell8
+             * 2013  Bury   cell9  cell10
+             * 2013  York  cell11  cell12
+             */
+            Assert.Equal(12, MaximumTableCellCount(2, 2, 3));
+        }
+
+        [Fact]
+        public void MaximumTableCellCount_SingleFilterWithSingleFilterItem()
+        {
+            /*
+             * 2011  Bury  Year1   cell1   cell2
+             * 2011  York  Year1   cell3   cell4
+             * 2012  Bury  Year1   cell5   cell6
+             * 2012  York  Year1   cell7   cell8
+             * 2013  Bury  Year1   cell9  cell10
+             * 2013  York  Year1  cell11  cell12
+             */
+            Assert.Equal(12, MaximumTableCellCount(2, 2, 3, ListOf(1)));
+        }
+
+        [Fact]
+        public void MaximumTableCellCount_MultipleFiltersWithSingleFilterItems()
+        {
+            /*
+             * 2011  Bury  Year1  Male   cell1   cell2
+             * 2011  York  Year1  Male   cell3   cell4
+             * 2012  Bury  Year1  Male   cell5   cell6
+             * 2012  York  Year1  Male   cell7   cell8
+             * 2013  Bury  Year1  Male   cell9  cell10
+             * 2013  York  Year1  Male  cell11  cell12
+             */
+            Assert.Equal(12, MaximumTableCellCount(2, 2, 3, ListOf(1, 1)));
+        }
+
+        [Fact]
+        public void MaximumTableCellCount_SingleFilterWithMultipleFilterItems()
+        {
+            /*
+             * 2011  Bury  Year1   cell1   cell2
+             * 2011  York  Year1   cell3   cell4
+             * 2012  Bury  Year1   cell5   cell6
+             * 2012  York  Year1   cell7   cell8
+             * 2013  Bury  Year1   cell9  cell10
+             * 2013  York  Year1  cell11  cell12
+             * 2011  Bury  Year2  cell13  cell14
+             * 2011  York  Year2  cell15  cell16
+             * 2012  Bury  Year2  cell17  cell18
+             * 2012  York  Year2  cell19  cell20
+             * 2013  Bury  Year2  cell21  cell22
+             * 2013  York  Year2  cell23  cell24
+             * 2011  Bury  Year3  cell25  cell26
+             * 2011  York  Year3  cell27  cell28
+             * 2012  Bury  Year3  cell29  cell30
+             * 2012  York  Year3  cell31  cell32
+             * 2013  Bury  Year3  cell33  cell34
+             * 2013  York  Year3  cell35  cell36
+             */
+            Assert.Equal(36, MaximumTableCellCount(2, 2, 3, ListOf(3)));
+        }
+
+        [Fact]
+        public void MaximumTableCellCount_MultipleFiltersWithMultipleFilterItems()
+        {
+            /*
+             * 2011  Bury  Year1    Male   cell1   cell2
+             * 2011  York  Year1    Male   cell3   cell4
+             * 2012  Bury  Year1    Male   cell5   cell6
+             * 2012  York  Year1    Male   cell7   cell8
+             * 2013  Bury  Year1    Male   cell9  cell10
+             * 2013  York  Year1    Male  cell11  cell12
+             * 2011  Bury  Year2    Male  cell13  cell14
+             * 2011  York  Year2    Male  cell15  cell16
+             * 2012  Bury  Year2    Male  cell17  cell18
+             * 2012  York  Year2    Male  cell19  cell20
+             * 2013  Bury  Year2    Male  cell21  cell22
+             * 2013  York  Year2    Male  cell23  cell24
+             * 2011  Bury  Year3    Male  cell25  cell26
+             * 2011  York  Year3    Male  cell27  cell28
+             * 2012  Bury  Year3    Male  cell29  cell30
+             * 2012  York  Year3    Male  cell31  cell32
+             * 2013  Bury  Year3    Male  cell33  cell34
+             * 2013  York  Year3    Male  cell35  cell36
+             * 2011  Bury  Year1  Female  cell37  cell38
+             * 2011  York  Year1  Female  cell39  cell40
+             * 2012  Bury  Year1  Female  cell41  cell42
+             * 2012  York  Year1  Female  cell43  cell44
+             * 2013  Bury  Year1  Female  cell45  cell46
+             * 2013  York  Year1  Female  cell47  cell48
+             * 2011  Bury  Year2  Female  cell49  cell50
+             * 2011  York  Year2  Female  cell51  cell52
+             * 2012  Bury  Year2  Female  cell53  cell54
+             * 2012  York  Year2  Female  cell55  cell56
+             * 2013  Bury  Year2  Female  cell57  cell58
+             * 2013  York  Year2  Female  cell59  cell60
+             * 2011  Bury  Year3  Female  cell61  cell62
+             * 2011  York  Year3  Female  cell63  cell64
+             * 2012  Bury  Year3  Female  cell65  cell66
+             * 2012  York  Year3  Female  cell67  cell68
+             * 2013  Bury  Year3  Female  cell69  cell70
+             * 2013  York  Year3  Female  cell71  cell72
+             */
+            Assert.Equal(72, MaximumTableCellCount(2, 2, 3, ListOf(3, 2)));
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ITableBuilderService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Interfaces/ITableBuilderService.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -11,6 +12,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces
     {
         Task<Either<ActionResult, TableBuilderResultViewModel>> Query(ObservationQueryContext queryContext);
 
-        Task<Either<ActionResult, TableBuilderResultViewModel>> Query(Guid releaseId, ObservationQueryContext queryContext);
+        Task<Either<ActionResult, TableBuilderResultViewModel>> Query(
+            Guid releaseId,
+            ObservationQueryContext queryContext);
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationPredicateBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationPredicateBuilder.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Linq;
 using System.Linq.Expressions;
@@ -34,15 +35,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 predicate = predicate.AndAlso(subPredicate);
             }
 
-            if (query.Locations?.GeographicLevel != null)
+            if (query.Locations != null)
             {
-                predicate = predicate.AndAlso(observation =>
-                    observation.GeographicLevel == query.Locations.GeographicLevel);
-            }
+                if (query.Locations.GeographicLevel != null)
+                {
+                    predicate = predicate.AndAlso(observation =>
+                        observation.GeographicLevel == query.Locations.GeographicLevel);
+                }
 
-            if (ObservationalUnitExists(query.Locations))
-            {
-                predicate = predicate.AndAlso(ObservationalUnitsPredicate(query.Locations));
+                if (ObservationalUnitExists(query.Locations))
+                {
+                    predicate = predicate.AndAlso(ObservationalUnitsPredicate(query.Locations));
+                }
             }
 
             return predicate;
@@ -52,87 +56,87 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         {
             var predicate = PredicateBuilder.False<Observation>();
 
-            if (query.Country != null)
+            if (query.Country.Any())
             {
                 predicate = predicate.Or(CountryPredicate(query));
             }
 
-            if (query.EnglishDevolvedArea != null)
+            if (query.EnglishDevolvedArea.Any())
             {
                 predicate = predicate.Or(EnglishDevolvedAreaPredicate(query));
             }
 
-            if (query.Institution != null)
+            if (query.Institution.Any())
             {
                 predicate = predicate.Or(InstitutionPredicate(query));
             }
 
-            if (query.LocalAuthority != null)
+            if (query.LocalAuthority.Any())
             {
                 predicate = predicate.Or(LocalAuthorityPredicate(query));
             }
 
-            if (query.LocalAuthorityDistrict != null)
+            if (query.LocalAuthorityDistrict.Any())
             {
                 predicate = predicate.Or(LocalAuthorityDistrictPredicate(query));
             }
 
-            if (query.LocalEnterprisePartnership != null)
+            if (query.LocalEnterprisePartnership.Any())
             {
                 predicate = predicate.Or(LocalEnterprisePartnershipPredicate(query));
             }
 
-            if (query.MayoralCombinedAuthority != null)
+            if (query.MayoralCombinedAuthority.Any())
             {
                 predicate = predicate.Or(MayoralCombinedAuthorityPredicate(query));
             }
 
-            if (query.MultiAcademyTrust != null)
+            if (query.MultiAcademyTrust.Any())
             {
                 predicate = predicate.Or(MultiAcademyTrustPredicate(query));
             }
 
-            if (query.OpportunityArea != null)
+            if (query.OpportunityArea.Any())
             {
                 predicate = predicate.Or(OpportunityAreaPredicate(query));
             }
 
-            if (query.ParliamentaryConstituency != null)
+            if (query.ParliamentaryConstituency.Any())
             {
                 predicate = predicate.Or(ParliamentaryConstituencyPredicate(query));
             }
 
-            if (query.Provider != null)
+            if (query.Provider.Any())
             {
                 predicate = predicate.Or(ProviderPredicate(query));
             }
 
-            if (query.Region != null)
+            if (query.Region.Any())
             {
                 predicate = predicate.Or(RegionPredicate(query));
             }
 
-            if (query.RscRegion != null)
+            if (query.RscRegion.Any())
             {
                 predicate = predicate.Or(RscRegionPredicate(query));
             }
 
-            if (query.School != null)
+            if (query.School.Any())
             {
                 predicate = predicate.Or(SchoolPredicate(query));
             }
 
-            if (query.Sponsor != null)
+            if (query.Sponsor.Any())
             {
                 predicate = predicate.Or(SponsorPredicate(query));
             }
 
-            if (query.Ward != null)
+            if (query.Ward.Any())
             {
                 predicate = predicate.Or(WardPredicate(query));
             }
 
-            if (query.PlanningArea != null)
+            if (query.PlanningArea.Any())
             {
                 predicate = predicate.Or(PlanningAreaPredicate(query));
             }
@@ -142,22 +146,21 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         private static bool ObservationalUnitExists(LocationQuery query)
         {
-            return !(query == null ||
-                     query.Country == null &&
-                     query.EnglishDevolvedArea == null &&
-                     query.Institution == null &&
-                     query.LocalAuthority == null &&
-                     query.LocalAuthorityDistrict == null &&
-                     query.LocalEnterprisePartnership == null &&
-                     query.MultiAcademyTrust == null &&
-                     query.MayoralCombinedAuthority == null &&
-                     query.OpportunityArea == null &&
-                     query.ParliamentaryConstituency == null &&
-                     query.Region == null &&
-                     query.RscRegion == null &&
-                     query.Sponsor == null &&
-                     query.Ward == null &&
-                     query.PlanningArea == null);
+            return query.Country.Any() ||
+                   query.EnglishDevolvedArea.Any() ||
+                   query.Institution.Any() ||
+                   query.LocalAuthority.Any() ||
+                   query.LocalAuthorityDistrict.Any() ||
+                   query.LocalEnterprisePartnership.Any() ||
+                   query.MultiAcademyTrust.Any() ||
+                   query.MayoralCombinedAuthority.Any() ||
+                   query.OpportunityArea.Any() ||
+                   query.ParliamentaryConstituency.Any() ||
+                   query.Region.Any() ||
+                   query.RscRegion.Any() ||
+                   query.Sponsor.Any() ||
+                   query.Ward.Any() ||
+                   query.PlanningArea.Any();
         }
 
         private static Expression<Func<Observation, bool>> CountryPredicate(LocationQuery query)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Utils/TableBuilderUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Utils/TableBuilderUtils.cs
@@ -1,0 +1,61 @@
+﻿#nullable enable
+using System.Collections.Generic;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Utils
+{
+    public static class TableBuilderUtils
+    {
+        /// <summary>
+        /// Calculates the maximum number of table cells that could be rendered for the result of a table query, based on
+        /// the indicator, location, time period, and any other filter parameters of the query.
+        /// </summary>
+        /// <remarks>
+        /// <p>
+        /// This works by making an assumption that data is provided for <i>all</i> combinations of location, time
+        /// period and any other filter values to calculate the maximum possible count of table cells.
+        /// </p>
+        /// <p>
+        /// The number of ways of observing each indicator is the product of the counts of the items in each of
+        /// the sets of locations, time periods, and filters. This is multiplied by the count of indicators 
+        /// to get the maximum possible count of table cells.
+        /// </p>
+        /// <p>
+        /// Note that filter items have to be counted by filter since each filter adds an independent set of possibilities.
+        /// </p>
+        /// <p>
+        /// Calculating based on attributes of the query criteria can be preferential to counting the actual result
+        /// to avoid wasted overhead of executing a query that won't be rendered due to exceeding the cell count limit.
+        /// </p>
+        /// <p>
+        /// The actual count of table cells that will be rendered is the product of the count of observation rows that
+        /// match the query when it's executed and the count of indicators requested.
+        /// </p>
+        /// <p>
+        /// There can be up to one observation for each combination of requested location, time period and other filter
+        /// values where such combinations of data have been provided. Every observation contains a measurement of the
+        /// requested indicators. 
+        /// </p>
+        /// </remarks>
+        /// <param name="countOfIndicators"></param>
+        /// <param name="countOfLocations"></param>
+        /// <param name="countOfTimePeriods"></param>
+        /// <param name="countsOfFilterItemsByFilter"></param>
+        /// <returns></returns>
+        public static int MaximumTableCellCount(
+            int countOfIndicators,
+            int countOfLocations,
+            int countOfTimePeriods,
+            IEnumerable<int>? countsOfFilterItemsByFilter = null)
+        {
+            var result = countOfIndicators * countOfLocations * countOfTimePeriods;
+            if (countsOfFilterItemsByFilter != null)
+            {
+                foreach (var countOfFilterItems in countsOfFilterItemsByFilter)
+                {
+                    result *= countOfFilterItems;
+                }
+            }
+            return result;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ValidationErrorMessages.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ValidationErrorMessages.cs
@@ -1,0 +1,8 @@
+﻿#nullable enable
+namespace GovUk.Education.ExploreEducationStatistics.Data.Services
+{
+    public enum ValidationErrorMessages
+    {
+        QueryExceedsMaxAllowableTableSize
+    }
+}

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -33,8 +33,71 @@ Select subject "Exclusions by geographic level"
     user waits until table tool wizard step is available    3    Choose locations
     user checks previous table tool step contains    2    Subject    Exclusions by geographic level
 
-Select Locations LA, Bury, Sheffield, York
+Select all LA Locations
     user opens details dropdown    Local Authority
+    user clicks button    Select all 156 options
+    user clicks element    id:locationFiltersForm-submit
+    user waits until table tool wizard step is available    4    Choose time period
+    user checks previous table tool step contains    3    Local Authority    Barking and Dagenham
+    user checks previous table tool step contains    3    Local Authority    Barnet
+    user checks previous table tool step contains    3    Local Authority    Barnsley
+    user checks previous table tool step contains    3    Local Authority    Bath and North East Somerset
+    user checks previous table tool step contains    3    Local Authority    Bedford
+    user checks previous table tool step contains    3    Local Authority    Show 151 more items
+
+Select all available Time periods
+    user chooses select option    id:timePeriodForm-start    2006/07
+    user chooses select option    id:timePeriodForm-end    2016/17
+    user clicks element    id:timePeriodForm-submit
+    user waits until table tool wizard step is available    5    Choose your filters
+    user waits until page contains element    id:filtersForm-indicators
+    user checks previous table tool step contains    4    Time period    2006/07 to 2016/17
+
+Select Indicator - Number of pupils
+    user clicks indicator checkbox    Number of pupils
+    user checks indicator checkbox is checked    Number of pupils
+
+Select Indicator - Number of permanent exclusions
+    user clicks indicator checkbox    Number of permanent exclusions
+    user checks indicator checkbox is checked    Number of permanent exclusions
+
+Select Indicator - Number of fixed period exclusions
+    user clicks indicator checkbox    Number of fixed period exclusions
+    user checks indicator checkbox is checked    Number of fixed period exclusions
+
+Select Indicator - Number of schools
+    user clicks indicator checkbox    Number of schools
+    user checks indicator checkbox is checked    Number of schools
+
+Select Indicator - Permanent exclusion rate
+    user clicks indicator checkbox    Permanent exclusion rate
+    user checks indicator checkbox is checked    Permanent exclusion rate
+
+Select Characteristic School types
+    user opens details dropdown    School type
+    user clicks category checkbox    School type    State-funded primary
+    user clicks category checkbox    School type    State-funded secondary
+    user clicks category checkbox    School type    Special
+
+User clicks Create table button
+    user clicks element    id:filtersForm-submit
+
+Validate the query could exceed the maximum allowable table size
+    user waits until element contains    id:filtersForm-indicators-error
+    ...    A table cannot be returned as the filters chosen can exceed the maximum allowable table size
+
+Go back to Locations step
+    user clicks element    xpath://button[contains(text(), "Edit locations")]
+    user waits until page contains element    xpath://h1[text()="Go back to previous step"]
+    user clicks element    xpath://button[text()="Confirm"]
+
+Unselect all LA Locations
+    user opens details dropdown    Local Authority
+    user clicks button    Unselect all 156 options
+    user checks page contains element
+    ...    xpath://*[@class="govuk-error-message" and text()="Select at least one location"]
+
+Select Locations LA, Bury, Sheffield, York
     user clicks checkbox    Bury
     user clicks checkbox    Sheffield
     user clicks checkbox    York
@@ -44,7 +107,7 @@ Select Locations LA, Bury, Sheffield, York
     user checks previous table tool step contains    3    Local Authority    Sheffield
     user checks previous table tool step contains    3    Local Authority    York
 
-Select Start date and End date
+Select new start and end date
     user chooses select option    id:timePeriodForm-start    2006/07
     user chooses select option    id:timePeriodForm-end    2008/09
     user clicks element    id:timePeriodForm-submit
@@ -64,14 +127,12 @@ Select Indicator - Number of fixed period exclusions
     user clicks indicator checkbox    Number of fixed period exclusions
     user checks indicator checkbox is checked    Number of fixed period exclusions
 
-Select Characteristics
+Select Characteristic School type State-funded secondary
     user opens details dropdown    School type
     user clicks category checkbox    School type    State-funded secondary
 
-User clicks Create table button
+Create table again
     user clicks element    id:filtersForm-submit
-
-User waits for table to appear
     # Extra timeout until EES-234
     user waits until results table appears    %{WAIT_LONG}
     user waits until page contains element

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -87,9 +87,9 @@ Validate the query could exceed the maximum allowable table size
     ...    A table cannot be returned as the filters chosen can exceed the maximum allowable table size
 
 Go back to Locations step
-    user clicks element    xpath://button[contains(text(), "Edit locations")]
+    user clicks button    Edit locations
     user waits until page contains element    xpath://h1[text()="Go back to previous step"]
-    user clicks element    xpath://button[text()="Confirm"]
+    user clicks button    Confirm
 
 Unselect all LA Locations
     user opens details dropdown    Local Authority


### PR DESCRIPTION
This PR returns a validation error if a table builder query exceeds the maximum number of allowed table cells.

This applies to both the admin site for analysts building data blocks and the public site for users using the table builder.

It calculates the maximum number of table cells that could be rendered for the result of a table query, based on
the indicator, location, time period, and any other filter parameters of the query.

Calculating based on attributes of the query criteria is preferential to counting the actual result
to avoid wasted overhead of executing a query that won't be rendered due to exceeding the cell count limit.

This works by making an assumption that data is provided for _all_ combinations of location, time
period and any other filter values to calculate the maximum possible count of table cells, agreed with @cjrace.

The number of ways of observing each indicator is the product of the counts of the items in each of
the sets of locations, time periods, and filters. This is multiplied by the count of indicators 
to get the maximum possible count of table cells.

Note that filter items have to be counted by filter since each filter adds an independent set of possibilities, so it's necessary to lookup the filters for the filter items in the query to count them by.

The limit is configurable in ARM template configuration and can be varied between environments as well as set differently for the local environment. Altering the limit requires an Infrastructure deploy and a restart of the Admin and Data API  app services.

![image](https://user-images.githubusercontent.com/4147126/139652624-4b1a9f0d-35fd-4844-874a-45b611244cf5.png)

### Determining size limit

Although the default limit has been specified at 25000 table cells it's intended that shortly after going live with this change the limit will be adjusted to a more suitable value. We must make sure that we don't block requests for any existing data block tables / charts / fast tracks.

A temporary controller has been written that returns a report for determining the maximum possible size of a table that could be generated by existing datablocks in the service.

`GET /api/data-blocks/query-size-report`

For each published data block this returns a result

```
    {
        "dataBlockId": "7eeb280f-6a37-4566-4645-08d93c022a16",
        "dataBlockName": "Test Data Block",
        "filters": {
            "da1843f5-5d52-4f91-9e81-f79f8fcca811": 7
        },
        "indicators": 3,
        "locations": 1,
        "timePeriods": 11,
        "maxTableCells": 231
    }
```

The greatest figure will be used to establish the lowest possible limit of the maximum table size that we can set so that we don't reject any requests for tables in existing data blocks or fast track entries.

Note that we *won't* execute all datablock queries here and count the results to get the data for this report.

A table result might be smaller than the possible table that could be generated since all combinations of time
period, location and filters may not be provided in the data.

If we were to execute all the datablock queries and set a maximum based on the largest table result,
several datablock requests may fail if they have a possible table size greater than the largest actual table.