### PR TITLE
EES-2858 - Refactor requests to use connection pooling

### DIFF
--- a/tests/robot-tests/scripts/create_snapshots.py
+++ b/tests/robot-tests/scripts/create_snapshots.py
@@ -6,7 +6,13 @@ from bs4 import BeautifulSoup
 
 
 def _gets_parsed_html_from_page(url):
-    response = requests.get(url)
+    requests.sessions.HTTPAdapter(
+        pool_connections=50,
+        pool_maxsize=50,
+        max_retries=3
+    )
+    session = requests.Session()
+    response = session.get(url, stream=True)
     assert response.status_code == 200, f"Requests response wasn\'t 200!\nResponse: {response}"
     return BeautifulSoup(response.text, "html.parser")
 

--- a/tests/robot-tests/tests/libs/admin_api.py
+++ b/tests/robot-tests/tests/libs/admin_api.py
@@ -15,16 +15,24 @@ class AdminClient:
         assert os.getenv('IDENTITY_LOCAL_STORAGE_ADMIN') is not None
         assert os.getenv('ADMIN_URL') is not None
 
+        requests.sessions.HTTPAdapter(
+        pool_connections=50,
+        pool_maxsize=50,
+        max_retries=3
+        )
+        session = requests.Session()
+
         jwt_token = json.loads(os.getenv('IDENTITY_LOCAL_STORAGE_ADMIN'))['access_token']
         headers = {
             'Content-Type': 'application/json',
             'Authorization': f'Bearer {jwt_token}',
         }
 
-        return requests.request(
+        return session.request(
             method,
             url=f'{os.getenv("ADMIN_URL")}{url}',
             headers=headers,
+            stream=True,
             json=body,
             verify=False
         )

--- a/tests/robot-tests/tests/libs/file_operations.py
+++ b/tests/robot-tests/tests/libs/file_operations.py
@@ -5,12 +5,18 @@ import os
 import requests
 import zipfile
 
+requests.sessions.HTTPAdapter(
+        pool_connections=50,
+        pool_maxsize=50,
+        max_retries=3
+    )
+session = requests.Session()
 
 def download_file(link_locator, file_name):
     if not os.path.exists('test-results/downloads'):
         os.makedirs('test-results/downloads')
     link_url = sl.get_element_attribute(link_locator, 'href')
-    r = requests.get(link_url, allow_redirects=True)
+    r = session.get(link_url, allow_redirects=True, stream=True)
     with open(f'test-results/downloads/{file_name}', 'wb') as f:
         f.write(r.content)
 

--- a/tests/robot-tests/tests/libs/no_javascript.py
+++ b/tests/robot-tests/tests/libs/no_javascript.py
@@ -1,8 +1,15 @@
 import requests
 from bs4 import BeautifulSoup
 
+requests.sessions.HTTPAdapter(
+        pool_connections=50,
+        pool_maxsize=50,
+        max_retries=3
+    )
+session = requests.Session()
+
 def user_gets_parsed_html_from_page(url):
-    response = requests.get(url)
+    response = session.get(url, stream=True)
     return BeautifulSoup(response.text, "html.parser")
 
 

--- a/tests/robot-tests/tests/libs/setup_auth_variables.py
+++ b/tests/robot-tests/tests/libs/setup_auth_variables.py
@@ -32,18 +32,25 @@ def setup_auth_variables(user, email, password, clear_existing=False, driver=Non
         os.environ[local_storage_name] = local_storage_file.read_text()
         os.environ[cookie_name] = cookie_file.read_text()
 
+        requests.sessions.HTTPAdapter(
+            pool_connections=50,
+            pool_maxsize=50,
+            max_retries=3
+        )
+        session = requests.Session()
         requests.packages.urllib3.disable_warnings()
 
         # Checks that the stored authentication information is actually valid.
         # If not, we want to be able to try and authenticate again.
         jwt_token = json.loads(os.environ[local_storage_name])['access_token']
-        response = requests.request(
+        response = session.request(
             'GET',
             url=f'{os.getenv("ADMIN_URL")}/api/permissions/access',
             headers={
                 'Content-Type': 'application/json',
                 'Authorization': f'Bearer {jwt_token}',
             },
+            stream=True,
             verify=False
         )
 


### PR DESCRIPTION
### This PR 

Refactors our current implementation of the requests library to use connection pooling. This offers several performance improvements to using the standard `requests.<verb>` method  (lower CPU + memory usage, reduced latency in multiple requests, etc.)

We do this via creating a new session in requests: 

```python 
requests.sessions.HTTPAdapter(
    pool_connections=50,
    pool_maxsize=50,
    max_retries=3
)
session = requests.Session()

# Example: 
def my_request:
    myData = session.get("https://www.google.com", flush=True)
    # the response we get here is identical to the response we would get from `requests.get`


```

Sessions allow us to reuse an already opened connection. Each connection is stored in a pool of connections. Reusing the connection to send out multiple requests offers multiple performance improvements

In addition to connection pooling, I've added `flush=True` to all requests. The flush parameter provides a way to **not** load the full content of a given response into memory as soon as the request is executed. This is important as we don't have to read the entire body of the HTTP response (which will increase memory usage) and can instead read it in chunks.

![image](https://user-images.githubusercontent.com/55030296/139691904-a5848c91-36b5-49d3-81e3-59d1ae9504bc.png)

[snapshots.zip](https://github.com/dfe-analytical-services/explore-education-statistics/files/7454224/snapshots.zip)


