### PR TITLE
EES-2853 & EES-2854 table size custom error and ga event

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -142,6 +142,7 @@ const DataBlockSourceWizard = ({
         themeMeta={[]}
         hidePublicationSelectionStage
         initialState={tableToolState}
+        tableSizeErrorDownloadAvailable={false}
         finalStep={({ response, query }) => (
           <WizardStep size="l">
             {wizardStepProps => (

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/DataBlockSourceWizard.tsx
@@ -142,7 +142,7 @@ const DataBlockSourceWizard = ({
         themeMeta={[]}
         hidePublicationSelectionStage
         initialState={tableToolState}
-        tableSizeErrorDownloadAvailable={false}
+        showTableSizeErrorDownload={false}
         finalStep={({ response, query }) => (
           <WizardStep size="l">
             {wizardStepProps => (

--- a/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
+++ b/src/explore-education-statistics-common/src/components/ErrorSummary.tsx
@@ -1,4 +1,10 @@
-import React, { MouseEventHandler, useEffect, useRef } from 'react';
+import React, {
+  forwardRef,
+  MouseEventHandler,
+  ReactNode,
+  useEffect,
+  useRef,
+} from 'react';
 import ErrorPrefixPageTitle from './ErrorPrefixPageTitle';
 
 export interface ErrorSummaryMessage {
@@ -6,7 +12,40 @@ export interface ErrorSummaryMessage {
   message: string;
 }
 
-interface Props {
+interface BaseErrorSummaryProps {
+  id: string;
+  children: ReactNode;
+  title: string;
+}
+
+export const BaseErrorSummary = forwardRef<
+  HTMLDivElement,
+  BaseErrorSummaryProps
+>((props, ref) => {
+  const { id, children, title } = props;
+  const idTitle = `${id}-title`;
+
+  return (
+    <div
+      aria-labelledby={idTitle}
+      className="govuk-error-summary"
+      ref={ref}
+      role="alert"
+      tabIndex={-1}
+    >
+      <h2 className="govuk-error-summary__title" id={idTitle}>
+        {title}
+      </h2>
+
+      <ErrorPrefixPageTitle />
+
+      <div className="govuk-error-summary__body">{children}</div>
+    </div>
+  );
+});
+BaseErrorSummary.displayName = 'BaseErrorSummary';
+
+interface ErrorSummaryProps {
   errors: ErrorSummaryMessage[];
   id: string;
   focusOnError?: boolean;
@@ -22,7 +61,7 @@ const ErrorSummary = ({
   title = 'There is a problem',
   onFocus,
   onErrorClick,
-}: Props) => {
+}: ErrorSummaryProps) => {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -51,34 +90,18 @@ const ErrorSummary = ({
     }
   }, [errors, focusOnError, onFocus]);
 
-  const idTitle = `${id}-title`;
-
   return errors.length > 0 ? (
-    <div
-      aria-labelledby={idTitle}
-      className="govuk-error-summary"
-      ref={ref}
-      role="alert"
-      tabIndex={-1}
-    >
-      <h2 className="govuk-error-summary__title" id={idTitle}>
-        {title}
-      </h2>
-
-      <ErrorPrefixPageTitle />
-
-      <div className="govuk-error-summary__body">
-        <ul className="govuk-list govuk-error-summary__list">
-          {errors.map(error => (
-            <li key={error.id}>
-              <a href={`#${error.id}`} onClick={onErrorClick}>
-                {error.message}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </div>
+    <BaseErrorSummary id={id} title={title} ref={ref}>
+      <ul className="govuk-list govuk-error-summary__list">
+        {errors.map(error => (
+          <li key={error.id}>
+            <a href={`#${error.id}`} onClick={onErrorClick}>
+              {error.message}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </BaseErrorSummary>
   ) : null;
 };
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -119,17 +119,16 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
       toggleTableSizeError.off();
       goToNextStep();
     } catch (error) {
-      if (isServerValidationError(error) && error.response?.data) {
-        const errors = Object.values(error.response?.data.errors);
-        if (errors.flat().includes('QUERY_EXCEEDS_MAX_ALLOWABLE_TABLE_SIZE')) {
-          if (onTableSizeError) {
-            onTableSizeError(
-              selectedPublication?.title || '',
-              subject?.name || '',
-            );
-          }
-          toggleTableSizeError.on();
+      if (
+        isServerValidationError(error, 'QUERY_EXCEEDS_MAX_ALLOWABLE_TABLE_SIZE')
+      ) {
+        if (onTableSizeError) {
+          onTableSizeError(
+            selectedPublication?.title || '',
+            subject?.name || '',
+          );
         }
+        toggleTableSizeError.on();
       }
     }
   };

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -45,11 +45,8 @@ interface Props {
   selectedPublication?: SelectedPublication;
   subject: Subject;
   subjectMeta: SubjectMeta;
-  tableSizeErrorDownloadAvailable?: boolean;
-  tableSizeErrorLogEvent?: (
-    publicationTitle: string,
-    subjectName: string,
-  ) => void;
+  showTableSizeErrorDownload?: boolean;
+  onTableSizeError?: (publicationTitle: string, subjectName: string) => void;
   onSubmit: FilterFormSubmitHandler;
 }
 
@@ -66,8 +63,8 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
     stepNumber,
     initialValues,
     isActive,
-    tableSizeErrorDownloadAvailable = true,
-    tableSizeErrorLogEvent,
+    showTableSizeErrorDownload = true,
+    onTableSizeError,
   } = props;
 
   const [hasTableSizeError, toggleTableSizeError] = useToggle(false);
@@ -123,16 +120,10 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
       goToNextStep();
     } catch (error) {
       if (isServerValidationError(error) && error.response?.data) {
-        const errorMessages = Object.entries(error.response.data.errors).reduce(
-          (acc, [, messages]) => {
-            messages.forEach(message => acc.push(message));
-            return acc;
-          },
-          [] as string[],
-        );
-        if (errorMessages.includes('QUERY_EXCEEDS_MAX_ALLOWABLE_TABLE_SIZE')) {
-          if (tableSizeErrorLogEvent) {
-            tableSizeErrorLogEvent(
+        const errors = Object.values(error.response?.data.errors);
+        if (errors.flat().includes('QUERY_EXCEEDS_MAX_ALLOWABLE_TABLE_SIZE')) {
+          if (onTableSizeError) {
+            onTableSizeError(
               selectedPublication?.title || '',
               subject?.name || '',
             );
@@ -175,10 +166,10 @@ const FiltersForm = (props: Props & InjectedWizardProps) => {
                 form.submitCount > 0 &&
                 isEqual(form.values, previousValues) && (
                   <TableSizeError
-                    focus
+                    id={`${formId}-tableSizeError`}
                     releaseId={selectedPublication?.selectedRelease.id}
                     subject={subject}
-                    showDownloadOption={tableSizeErrorDownloadAvailable}
+                    showDownloadOption={showTableSizeErrorDownload}
                   />
                 )}
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableSizeError.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableSizeError.tsx
@@ -1,76 +1,57 @@
 import Button from '@common/components/Button';
-import ErrorPrefixPageTitle from '@common/components//ErrorPrefixPageTitle';
+import { BaseErrorSummary } from '@common/components/ErrorSummary';
 import downloadService from '@common/services/downloadService';
 import { Subject } from '@common/services/tableBuilderService';
 import React, { useEffect, useRef } from 'react';
 
 interface Props {
-  focus: boolean;
+  id: string;
   releaseId?: string;
   showDownloadOption?: boolean;
   subject: Subject;
 }
 
 const TableSizeError = ({
-  focus = false,
+  id,
   releaseId,
   showDownloadOption = true,
   subject,
 }: Props) => {
-  const handleDownloadFile = async (fileId: string) => {
-    if (releaseId) {
-      await downloadService.downloadFiles(releaseId, [fileId]);
-    }
-  };
-
   const ref = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
-    if (focus && ref.current) {
+    if (ref.current) {
       ref.current.focus();
     }
-  }, [focus]);
+  }, []);
 
   return (
-    <div
-      aria-labelledby="tableSizeError"
-      className="govuk-error-summary"
-      id="filtersForm-tableSizeError"
-      ref={ref}
-      role="alert"
-      tabIndex={-1}
-    >
-      <h2 className="govuk-error-summary__title" id="tableSizeError">
-        There is a problem
-      </h2>
-
-      <ErrorPrefixPageTitle />
-      <div className="govuk-error-summary__body">
-        <p>
-          A table cannot be returned as the filters chosen can exceed the
-          maximum allowable table size.
-        </p>
-        {showDownloadOption ? (
-          <>
-            <p>Select different filters or download the subject data.</p>
-            {releaseId ? (
-              <Button
-                className="govuk-!-margin-bottom-0"
-                onClick={() => handleDownloadFile(subject.file.id)}
-              >
-                {`Download ${subject.name} (${subject.file.extension}, ${subject.file.size})`}
-              </Button>
-            ) : (
-              <Button className="govuk-!-margin-bottom-0" disabled>
-                Download subject file (available when the release is published)
-              </Button>
-            )}
-          </>
-        ) : (
-          <p>Select different filters and try again.</p>
-        )}
-      </div>
-    </div>
+    <BaseErrorSummary id={id} ref={ref} title="There is a problem">
+      <p>
+        Could not create table as the filters chosen may exceed the maximum
+        allowed table size.
+      </p>
+      {showDownloadOption ? (
+        <>
+          <p>Select different filters or download the subject data.</p>
+          <Button
+            className="govuk-!-margin-bottom-0"
+            disabled={!releaseId}
+            onClick={async () => {
+              if (releaseId) {
+                await downloadService.downloadFiles(releaseId, [
+                  subject.file.id,
+                ]);
+              }
+            }}
+          >
+            {`Download ${subject.name} (${subject.file.extension}, ${subject.file.size})`}
+            {!releaseId && ` (available when the release is published)`}
+          </Button>
+        </>
+      ) : (
+        <p>Select different filters and try again.</p>
+      )}
+    </BaseErrorSummary>
   );
 };
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableSizeError.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableSizeError.tsx
@@ -1,0 +1,77 @@
+import Button from '@common/components/Button';
+import ErrorPrefixPageTitle from '@common/components//ErrorPrefixPageTitle';
+import downloadService from '@common/services/downloadService';
+import { Subject } from '@common/services/tableBuilderService';
+import React, { useEffect, useRef } from 'react';
+
+interface Props {
+  focus: boolean;
+  releaseId?: string;
+  showDownloadOption?: boolean;
+  subject: Subject;
+}
+
+const TableSizeError = ({
+  focus = false,
+  releaseId,
+  showDownloadOption = true,
+  subject,
+}: Props) => {
+  const handleDownloadFile = async (fileId: string) => {
+    if (releaseId) {
+      await downloadService.downloadFiles(releaseId, [fileId]);
+    }
+  };
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (focus && ref.current) {
+      ref.current.focus();
+    }
+  }, [focus]);
+
+  return (
+    <div
+      aria-labelledby="tableSizeError"
+      className="govuk-error-summary"
+      id="filtersForm-tableSizeError"
+      ref={ref}
+      role="alert"
+      tabIndex={-1}
+    >
+      <h2 className="govuk-error-summary__title" id="tableSizeError">
+        There is a problem
+      </h2>
+
+      <ErrorPrefixPageTitle />
+      <div className="govuk-error-summary__body">
+        <p>
+          A table cannot be returned as the filters chosen can exceed the
+          maximum allowable table size.
+        </p>
+        {showDownloadOption ? (
+          <>
+            <p>Select different filters or download the subject data.</p>
+            {releaseId ? (
+              <Button
+                className="govuk-!-margin-bottom-0"
+                onClick={() => handleDownloadFile(subject.file.id)}
+              >
+                {`Download ${subject.name} (${subject.file.extension}, ${subject.file.size})`}
+              </Button>
+            ) : (
+              <Button className="govuk-!-margin-bottom-0" disabled>
+                Download subject file (available when the release is published)
+              </Button>
+            )}
+          </>
+        ) : (
+          <p>Select different filters and try again.</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TableSizeError;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -71,11 +71,8 @@ export interface TableToolWizardProps {
   loadingFastTrack?: boolean;
   renderFeaturedTable?: (featuredTable: FeaturedTable) => ReactNode;
   scrollOnMount?: boolean;
-  tableSizeErrorDownloadAvailable?: boolean;
-  tableSizeErrorLogEvent?: (
-    publicationTitle: string,
-    subjectName: string,
-  ) => void;
+  showTableSizeErrorDownload?: boolean;
+  onTableSizeError?: (publicationTitle: string, subjectName: string) => void;
   onSubmit?: (table: FullTable) => void;
   onSubjectStepBack?: () => void;
 }
@@ -87,8 +84,8 @@ const TableToolWizard = ({
   hidePublicationSelectionStage,
   renderFeaturedTable,
   finalStep,
-  tableSizeErrorDownloadAvailable = true,
-  tableSizeErrorLogEvent,
+  showTableSizeErrorDownload = true,
+  onTableSizeError,
   onSubmit,
   onSubjectStepBack,
   loadingFastTrack = false,
@@ -375,10 +372,8 @@ const TableToolWizard = ({
                     )[0]
                   }
                   subjectMeta={state.subjectMeta}
-                  tableSizeErrorDownloadAvailable={
-                    tableSizeErrorDownloadAvailable
-                  }
-                  tableSizeErrorLogEvent={tableSizeErrorLogEvent}
+                  showTableSizeErrorDownload={showTableSizeErrorDownload}
+                  onTableSizeError={onTableSizeError}
                   onSubmit={handleFiltersFormSubmit}
                 />
               )}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -68,11 +68,15 @@ export interface TableToolWizardProps {
   initialState?: Partial<InitialTableToolState>;
   hidePublicationSelectionStage?: boolean;
   finalStep?: (props: FinalStepRenderProps) => ReactElement;
+  loadingFastTrack?: boolean;
   renderFeaturedTable?: (featuredTable: FeaturedTable) => ReactNode;
   scrollOnMount?: boolean;
+  tableSizeErrorLogEvent?: (
+    publicationTitle: string,
+    subjectName: string,
+  ) => void;
   onSubmit?: (table: FullTable) => void;
   onSubjectStepBack?: () => void;
-  loadingFastTrack?: boolean;
 }
 
 const TableToolWizard = ({
@@ -82,6 +86,7 @@ const TableToolWizard = ({
   hidePublicationSelectionStage,
   renderFeaturedTable,
   finalStep,
+  tableSizeErrorLogEvent,
   onSubmit,
   onSubjectStepBack,
   loadingFastTrack = false,
@@ -361,7 +366,14 @@ const TableToolWizard = ({
                     indicators: state.query.indicators,
                     filters: state.query.filters,
                   }}
+                  selectedPublication={state.selectedPublication}
+                  subject={
+                    state.subjects.filter(
+                      subject => subject.id === state.query.subjectId,
+                    )[0]
+                  }
                   subjectMeta={state.subjectMeta}
+                  tableSizeErrorLogEvent={tableSizeErrorLogEvent}
                   onSubmit={handleFiltersFormSubmit}
                 />
               )}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -71,6 +71,7 @@ export interface TableToolWizardProps {
   loadingFastTrack?: boolean;
   renderFeaturedTable?: (featuredTable: FeaturedTable) => ReactNode;
   scrollOnMount?: boolean;
+  tableSizeErrorDownloadAvailable?: boolean;
   tableSizeErrorLogEvent?: (
     publicationTitle: string,
     subjectName: string,
@@ -86,6 +87,7 @@ const TableToolWizard = ({
   hidePublicationSelectionStage,
   renderFeaturedTable,
   finalStep,
+  tableSizeErrorDownloadAvailable = true,
   tableSizeErrorLogEvent,
   onSubmit,
   onSubjectStepBack,
@@ -373,6 +375,9 @@ const TableToolWizard = ({
                     )[0]
                   }
                   subjectMeta={state.subjectMeta}
+                  tableSizeErrorDownloadAvailable={
+                    tableSizeErrorDownloadAvailable
+                  }
                   tableSizeErrorLogEvent={tableSizeErrorLogEvent}
                   onSubmit={handleFiltersFormSubmit}
                 />

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FiltersForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FiltersForm.test.tsx
@@ -1,6 +1,6 @@
 import FiltersForm from '@common/modules/table-tool/components/FiltersForm';
 import { InjectedWizardProps } from '@common/modules/table-tool/components/Wizard';
-import { SubjectMeta } from '@common/services/tableBuilderService';
+import { Subject, SubjectMeta } from '@common/services/tableBuilderService';
 import { waitFor } from '@testing-library/dom';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -227,10 +227,24 @@ describe('FiltersForm', () => {
     shouldScroll: false,
   };
 
+  const testSubject = {
+    id: 'subject-1',
+    name: 'Subject 1',
+    file: {
+      id: 'file-1',
+      fileName: 'File 1',
+      extension: 'csv',
+      name: 'File 1',
+      size: '100mb',
+      type: 'Data',
+    },
+  } as Subject;
+
   test('renders indicators and filter group options correctly', () => {
     render(
       <FiltersForm
         {...testWizardStepProps}
+        subject={testSubject}
         subjectMeta={testSubjectMeta}
         onSubmit={noop}
       />,
@@ -301,6 +315,7 @@ describe('FiltersForm', () => {
     render(
       <FiltersForm
         {...testWizardStepProps}
+        subject={testSubject}
         subjectMeta={testSubjectMetaSingleFilters}
         onSubmit={noop}
       />,
@@ -341,6 +356,7 @@ describe('FiltersForm', () => {
     render(
       <FiltersForm
         {...testWizardStepProps}
+        subject={testSubject}
         subjectMeta={testSubjectMetaSingleFilters}
         onSubmit={noop}
       />,
@@ -386,6 +402,7 @@ describe('FiltersForm', () => {
     render(
       <FiltersForm
         {...testWizardStepProps}
+        subject={testSubject}
         subjectMeta={testSubjectMeta}
         onSubmit={noop}
       />,
@@ -423,6 +440,7 @@ describe('FiltersForm', () => {
     render(
       <FiltersForm
         {...testWizardStepProps}
+        subject={testSubject}
         subjectMeta={testSubjectMeta}
         onSubmit={noop}
       />,
@@ -463,6 +481,7 @@ describe('FiltersForm', () => {
           filters: ['state-funded-secondary', 'ethnicity-major-asian-total'],
           indicators: ['unauthorised-absence-rate'],
         }}
+        subject={testSubject}
         subjectMeta={testSubjectMeta}
         onSubmit={noop}
       />,
@@ -481,6 +500,7 @@ describe('FiltersForm', () => {
           filters: ['state-funded-secondary', 'ethnicity-major-asian-total'],
           indicators: ['unauthorised-absence-rate'],
         }}
+        subject={testSubject}
         subjectMeta={testSubjectMeta}
         onSubmit={noop}
       />,
@@ -499,6 +519,7 @@ describe('FiltersForm', () => {
     render(
       <FiltersForm
         {...testWizardStepProps}
+        subject={testSubject}
         subjectMeta={testSubjectMetaOneIndicator}
         onSubmit={noop}
       />,
@@ -519,6 +540,7 @@ describe('FiltersForm', () => {
     render(
       <FiltersForm
         {...testWizardStepProps}
+        subject={testSubject}
         subjectMeta={{
           ...testSubjectMeta,
           filters: {
@@ -557,6 +579,7 @@ describe('FiltersForm', () => {
     const { container, rerender } = render(
       <FiltersForm
         {...testWizardStepProps}
+        subject={testSubject}
         subjectMeta={testSubjectMeta}
         onSubmit={noop}
       />,
@@ -570,6 +593,7 @@ describe('FiltersForm', () => {
       <FiltersForm
         {...testWizardStepProps}
         isActive={false}
+        subject={testSubject}
         subjectMeta={testSubjectMeta}
         onSubmit={noop}
       />,

--- a/src/explore-education-statistics-common/src/validation/serverValidations.ts
+++ b/src/explore-education-statistics-common/src/validation/serverValidations.ts
@@ -134,6 +134,7 @@ export function convertServerFieldErrors<FormValues>(
 
 export function isServerValidationError(
   error: Error,
+  errorMessage?: string,
 ): error is AxiosError<ServerValidationErrorResponse> {
   if (!isAxiosError(error) || !error.response?.data) {
     return false;
@@ -142,9 +143,33 @@ export function isServerValidationError(
   const errorDataAsValidationError = error.response
     .data as ServerValidationErrorResponse;
 
-  return (
+  const isServerError =
     errorDataAsValidationError.errors !== undefined &&
     errorDataAsValidationError.status !== undefined &&
-    errorDataAsValidationError.title !== undefined
-  );
+    errorDataAsValidationError.title !== undefined;
+
+  if (!errorMessage) {
+    return isServerError;
+  }
+
+  if (isServerError && error.response?.data) {
+    const errors = Object.values(error.response?.data.errors);
+    if (errors.flat().includes(errorMessage)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function hasServerValidationError(
+  error: Error,
+  errorMessage: string,
+): boolean {
+  if (isServerValidationError(error) && error.response?.data) {
+    const errors = Object.values(error.response?.data.errors);
+    if (errors.flat().includes(errorMessage)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -131,6 +131,16 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
             {highlight.name}
           </Link>
         )}
+        tableSizeErrorLogEvent={(
+          publicationTitle: string,
+          subjectName: string,
+        ) => {
+          logEvent({
+            category: 'Table tool size error',
+            action: 'Table exceeeded maximum size',
+            label: `${publicationTitle}/${subjectName}`,
+          });
+        }}
         finalStep={({
           query,
           response,

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -131,10 +131,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
             {highlight.name}
           </Link>
         )}
-        tableSizeErrorLogEvent={(
-          publicationTitle: string,
-          subjectName: string,
-        ) => {
+        onTableSizeError={(publicationTitle: string, subjectName: string) => {
           logEvent({
             category: 'Table tool size error',
             action: 'Table exceeeded maximum size',

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -83,7 +83,7 @@ User clicks Create table button
     user clicks element    id:filtersForm-submit
 
 Validate the query could exceed the maximum allowable table size
-    user waits until element contains    id:filtersForm-indicators-error
+    user waits until element contains    id:filtersForm-tableSizeError
     ...    A table cannot be returned as the filters chosen can exceed the maximum allowable table size
 
 Go back to Locations step

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -83,8 +83,8 @@ User clicks Create table button
     user clicks element    id:filtersForm-submit
 
 Validate the query could exceed the maximum allowable table size
-    user waits until element contains    id:filtersForm-tableSizeError
-    ...    A table cannot be returned as the filters chosen can exceed the maximum allowable table size
+    user waits until page contains element    id:filtersForm-tableSizeError-title
+    user checks page contains    Could not create table as the filters chosen may exceed the maximum allowed table size
     user clicks button    Download Exclusions by geographic level (csv, 0.00 B)
 
 Go back to Locations step

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -85,6 +85,7 @@ User clicks Create table button
 Validate the query could exceed the maximum allowable table size
     user waits until element contains    id:filtersForm-tableSizeError
     ...    A table cannot be returned as the filters chosen can exceed the maximum allowable table size
+    user clicks button    Download Exclusions by geographic level (csv, 0.00 B)
 
 Go back to Locations step
     user clicks button    Edit locations


### PR DESCRIPTION
Adds custom error handling for the table size error to:
- show a button to download the subject file in the error message (in the admin this button is disabled / not shown as appropriate)
- log a GA event

**Public:**
![tablesizeerror-public](https://user-images.githubusercontent.com/81572860/140058071-bc9dd7a8-be93-4d8f-a644-fc5179c2c683.PNG)

**Admin - table tool preview and pre-release:**
![admin](https://user-images.githubusercontent.com/81572860/140743217-8f5e85eb-baeb-4b2b-802a-2f6fee43eae4.PNG)

**Admin - data blocks**
![tablesizeerror-datablock](https://user-images.githubusercontent.com/81572860/140317427-329ff7d2-fbeb-40bd-9d1c-4efa356d7505.PNG)
