### PR TITLE
EES-1790 release type tag on release page

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/BasicReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/BasicReleaseSummary.tsx
@@ -20,7 +20,7 @@ interface ReleaseTypeIcon {
 }
 
 const nationalStatisticsLogo: ReleaseTypeIcon = {
-  url: '/assets/images/UKSA-quality-mark.jpg',
+  url: '/assets/images/UKSA-quality-mark2.jpg',
   altText: 'UK statistics authority quality mark',
 };
 
@@ -55,19 +55,20 @@ const BasicReleaseSummary = ({ release }: Props) => {
     <>
       {releaseTypeIdsToIcons && (
         <>
-          <div className="dfe-flex dfe-align-items--center dfe-justify-content--space-between">
-            <div className="dfe-flex govuk-!-margin-bottom-3">
-              <Tag>{getReleaseApprovalStatusLabel(release.approvalStatus)}</Tag>
+          <div className="dfe-flex dfe-align-items--center dfe-justify-content--space-between govuk-!-margin-bottom-3">
+            <div>
+              <Tag className="govuk-!-margin-right-3 govuk-!-margin-bottom-3">
+                {getReleaseApprovalStatusLabel(release.approvalStatus)}
+              </Tag>
+              <Tag>{release.type.title}</Tag>
             </div>
             {releaseTypeIdsToIcons[release.type.id] && (
-              <div className="dfe-flex">
-                <img
-                  src={releaseTypeIdsToIcons[release.type.id].url}
-                  alt={releaseTypeIdsToIcons[release.type.id].altText}
-                  height="120"
-                  width="120"
-                />
-              </div>
+              <img
+                src={releaseTypeIdsToIcons[release.type.id].url}
+                alt={releaseTypeIdsToIcons[release.type.id].altText}
+                height="60"
+                width="60"
+              />
             )}
           </div>
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -138,9 +138,7 @@ const ReleaseContent = () => {
     <>
       <div className="govuk-grid-row">
         <div className="govuk-grid-column-two-thirds">
-          <div className="govuk-grid-row">
-            <BasicReleaseSummary release={release} />
-          </div>
+          <BasicReleaseSummary release={release} />
 
           <div id="releaseSummary">
             {release.summarySection && (

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -72,37 +72,38 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
     >
       <div className={classNames('govuk-grid-row', styles.releaseIntro)}>
         <div className="govuk-grid-column-two-thirds">
-          <div className="dfe-flex dfe-align-items--center dfe-justify-content--space-between">
-            <div className="dfe-flex govuk-!-margin-bottom-3">
+          <div className="dfe-flex dfe-align-items--center dfe-justify-content--space-between govuk-!-margin-bottom-3">
+            <div>
               {release.latestRelease ? (
-                <Tag strong className="govuk-!-margin-right-6">
+                <Tag className="govuk-!-margin-right-3 govuk-!-margin-bottom-3">
                   This is the latest data
                 </Tag>
               ) : (
-                <Link
-                  className="dfe-print-hidden"
-                  unvisited
-                  to="/find-statistics/[publication]"
-                  as={`/find-statistics/${release.publication.slug}`}
-                >
-                  View latest data:{' '}
-                  <span className="govuk-!-font-weight-bold">
-                    {release.publication.otherReleases[0].title}
-                  </span>
-                </Link>
+                <div className="govuk-!-margin-bottom-3">
+                  <Link
+                    className="dfe-print-hidden "
+                    unvisited
+                    to="/find-statistics/[publication]"
+                    as={`/find-statistics/${release.publication.slug}`}
+                  >
+                    View latest data:{' '}
+                    <span className="govuk-!-font-weight-bold">
+                      {release.publication.otherReleases[0].title}
+                    </span>
+                  </Link>
+                </div>
               )}
+              {release.type && <Tag>{release.type.title}</Tag>}
             </div>
-            <div className="dfe-flex">
-              {release.type &&
-                release.type.title === ReleaseType.NationalStatistics && (
-                  <img
-                    src="/assets/images/UKSA-quality-mark2.jpg"
-                    alt="UK statistics authority quality mark"
-                    height="60"
-                    width="60"
-                  />
-                )}
-            </div>
+            {release.type &&
+              release.type.title === ReleaseType.NationalStatistics && (
+                <img
+                  src="/assets/images/UKSA-quality-mark2.jpg"
+                  alt="UK statistics authority quality mark"
+                  height="60"
+                  width="60"
+                />
+              )}
           </div>
 
           <SummaryList>


### PR DESCRIPTION
Adds the release type in a Tag on the public release page and admin equivalents. Also:
- makes the national statistics the same size in the admin as on the public site
-  fixes a small layout problem in the admin when editing a release (it was bugging me that the publication title didn't line up with the content below).