### PR TITLE
EES-152 Override tableBuilderMaxTableCellsAllowed with an over generous value in Prod environment

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -29,9 +29,6 @@
     "preReleaseMinutesBeforeEnd": {
       "value": 1
     },
-    "tableBuilderMaxTableCellsAllowed": {
-      "value": 25000
-    },
     "useSubnets": {
       "value": true
     },

--- a/infrastructure/parameters/prod.parameters.json
+++ b/infrastructure/parameters/prod.parameters.json
@@ -67,6 +67,9 @@
     },
     "enableAlerts": {
       "value": true
+    },
+    "tableBuilderMaxTableCellsAllowed": {
+      "value": 1000000
     }
   }
 }

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -115,19 +115,19 @@ Select new start and end date
     user waits until page contains element    id:filtersForm-indicators
     user checks previous table tool step contains    4    Time period    2006/07 to 2008/09
 
-Select Indicator - Number of pupils
+Select Indicator again - Number of pupils
     user clicks indicator checkbox    Number of pupils
     user checks indicator checkbox is checked    Number of pupils
 
-Select Indicator - Number of permanent exclusions
+Select Indicator again - Number of permanent exclusions
     user clicks indicator checkbox    Number of permanent exclusions
     user checks indicator checkbox is checked    Number of permanent exclusions
 
-Select Indicator - Number of fixed period exclusions
+Select Indicator again - Number of fixed period exclusions
     user clicks indicator checkbox    Number of fixed period exclusions
     user checks indicator checkbox is checked    Number of fixed period exclusions
 
-Select Characteristic School type State-funded secondary
+Select Characteristic School type - State-funded secondary
     user opens details dropdown    School type
     user clicks category checkbox    School type    State-funded secondary
 


### PR DESCRIPTION
This PR overrides `tableBuilderMaxTableCellsAllowed` configuration parameter with an over generous value in the Prod environment so that no existing data blocks fail to load because their table queries exceed the maximum allowed table size when the changes for EES-152 are first deployed.

Default in all environments unless overridden: 25,000.
Override in Prod: 1,000,000.

After the deploy is complete we can run the report `GET /api/data-blocks/query-size-report` which contains the size of the existing data blocks and use this to establish a more suitable value for the Prod environment.

### 
Other changes

- Remove the same override for the Dev environment which was setting the same value as the default.
- Remove some warninge in UI Test 'Table Tool Exclusions By Geographic Level' caused by multiple cases using the same names.
![image](https://user-images.githubusercontent.com/4147126/140377473-b7dacfe8-8adb-4802-876b-2c5d6df36057.png)
