### PR TITLE
EES-2866 manage team access FE tidying

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/publication/PublicationManageTeamAccessPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/PublicationManageTeamAccessPage.tsx
@@ -20,29 +20,27 @@ const PublicationManageTeamAccessPage = ({
     [publicationId],
   );
 
-  if (isLoading) {
-    return <LoadingSpinner />;
-  }
-
   if (!publication) {
     return null;
   }
 
   return (
-    <Page
-      title="Manage team access"
-      caption={publication.title}
-      breadcrumbs={[{ name: 'Manage team access' }]}
-    >
-      <Tabs id="manageTeamAccessTabs">
-        <TabsSection id="manageTeamAccessTab" title="Manage team access">
-          <PublicationManageTeamAccessTab publication={publication} />
-        </TabsSection>
-        <TabsSection id="inviteNewUsersTab" title="Invite new users">
-          <PublicationInviteNewUsersTab publication={publication} />
-        </TabsSection>
-      </Tabs>
-    </Page>
+    <LoadingSpinner loading={isLoading}>
+      <Page
+        title="Manage team access"
+        caption={publication.title}
+        breadcrumbs={[{ name: 'Manage team access' }]}
+      >
+        <Tabs id="manageTeamAccessTabs">
+          <TabsSection id="manage-access" title="Manage team access">
+            <PublicationManageTeamAccessTab publication={publication} />
+          </TabsSection>
+          <TabsSection id="invite-users" title="Invite new users">
+            <PublicationInviteNewUsersTab publication={publication} />
+          </TabsSection>
+        </Tabs>
+      </Page>
+    </LoadingSpinner>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationManageTeamAccessTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationManageTeamAccessTab.tsx
@@ -1,51 +1,62 @@
 import { BasicPublicationDetails } from '@admin/services/publicationService';
-import React from 'react';
-import Details from '@common/components/Details';
-import orderBy from 'lodash/orderBy';
 import ReleaseContributorPermissions from '@admin/pages/publication/components/ReleaseContributorPermissions';
+import Details from '@common/components/Details';
+import WarningMessage from '@common/components/WarningMessage';
+import React, { useState } from 'react';
 
 export interface Props {
   publication: BasicPublicationDetails;
 }
 
 const PublicationManageTeamAccessTab = ({ publication }: Props) => {
-  if (
-    publication.releases === undefined ||
-    (publication.releases && publication.releases.length === 0)
-  ) {
-    return <p>No releases!</p>;
+  const [renderedReleases, setRenderedReleases] = useState<string[]>([]);
+
+  if (!publication.releases || !publication.releases.length) {
+    return (
+      <WarningMessage>
+        Create a release for this publication to manage team access.
+      </WarningMessage>
+    );
   }
 
-  const sortedReleases = orderBy(publication.releases, r =>
-    parseInt(r.releaseName, 10),
-  );
-  const newestRelease = sortedReleases.shift();
-
-  if (newestRelease === undefined) {
-    return <p>No releases!</p>;
-  }
+  const latestRelease = publication.releases[publication.releases.length - 1];
+  const previousReleases = publication.releases
+    .filter(release => release.id !== latestRelease.id)
+    .reverse();
 
   return (
     <>
-      <h2>Update access for latest release ({newestRelease?.title})</h2>
+      <h2>Update access for latest release ({latestRelease?.title})</h2>
       <p>
         Allow team members to be able to access and edit this release. You can
         also{' '}
         <a href="#previous-releases">control access to previous releases</a>.
       </p>
-      <ReleaseContributorPermissions releaseId={newestRelease.id} />
+      <ReleaseContributorPermissions release={latestRelease} />
 
-      {sortedReleases.length >= 0 && (
+      <h3 id="previous-releases">Previous releases</h3>
+
+      {previousReleases.length > 0 ? (
         <>
-          <h3 id="previous-releases">Previous releases</h3>
-          {sortedReleases.map(release => (
+          {previousReleases.map(release => (
             <div key={release.id}>
-              <Details summary={`${release.title}`}>
-                <ReleaseContributorPermissions releaseId={release.id} />
+              <Details
+                summary={`${release.title}`}
+                onToggle={isOpen => {
+                  if (isOpen && !renderedReleases.includes(release.id)) {
+                    setRenderedReleases([...renderedReleases, release.id]);
+                  }
+                }}
+              >
+                {renderedReleases.includes(release.id) && (
+                  <ReleaseContributorPermissions release={release} />
+                )}
               </Details>
             </div>
           ))}
         </>
+      ) : (
+        <p>No previous releases.</p>
       )}
     </>
   );

--- a/src/explore-education-statistics-admin/src/pages/publication/components/ReleaseContributorPermissions.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/ReleaseContributorPermissions.module.scss
@@ -1,0 +1,17 @@
+.control {
+  text-align: center;
+  vertical-align: middle;
+  width: 16.67%;
+
+  span {
+    display: block;
+  }
+  button {
+    text-align: center;
+    width: 100%;
+  }
+}
+
+.grantAllRow td {
+  border: 0;
+}

--- a/src/explore-education-statistics-admin/src/pages/publication/components/ReleaseContributorPermissions.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/ReleaseContributorPermissions.tsx
@@ -1,80 +1,184 @@
-import React from 'react';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
-import releasePermissionService from '@admin/services/releasePermissionService';
+import releasePermissionService, {
+  ReleaseContributor,
+} from '@admin/services/releasePermissionService';
+import ButtonText from '@common/components/ButtonText';
 import LoadingSpinner from '@common/components/LoadingSpinner';
-import classNames from 'classnames';
+import ModalConfirm from '@common/components/ModalConfirm';
+import Tag from '@common/components/Tag';
 import Button from '@common/components/Button';
+import WarningMessage from '@common/components/WarningMessage';
+import useToggle from '@common/hooks/useToggle';
+import styles from '@admin/pages/publication/components/ReleaseContributorPermissions.module.scss';
+import { Release } from '@admin/services/releaseService';
 import userService from '@admin/services/userService';
+import React, { useState } from 'react';
 
 export interface Props {
-  releaseId: string;
+  release: Release;
 }
 
-const ReleaseContributorPermissions = ({ releaseId }: Props) => {
-  const { value: releaseContributors, isLoading } = useAsyncRetry(
-    () => releasePermissionService.getReleaseContributors(releaseId),
-    [releaseId],
+const ReleaseContributorPermissions = ({ release }: Props) => {
+  const {
+    value: releaseContributors,
+    isLoading,
+    retry: reloadReleaseContributors,
+  } = useAsyncRetry(
+    () => releasePermissionService.getReleaseContributors(release.id),
+    [release.id],
   );
 
-  if (isLoading) {
-    return <LoadingSpinner />;
-  }
+  const [changeContributorAccess, setChangeContributerAccess] = useState<
+    ReleaseContributor
+  >();
 
-  if (releaseContributors && releaseContributors?.length === 0) {
-    return (
-      <p>
-        No users with contributor access. You can add people on{' '}
-        <a href="#inviteNewUsersTab">Invite users tab</a>.
-      </p>
+  const [
+    grantAllContributorAccess,
+    toggleGrantAllContributorAccess,
+  ] = useToggle(false);
+
+  const [removeUser, setRemoveUser] = useState<ReleaseContributor>();
+
+  const showGrantAllButton =
+    releaseContributors &&
+    releaseContributors?.length > 1 &&
+    releaseContributors?.some(
+      contributor => contributor.releaseRoleId === undefined,
     );
-  }
 
   return (
-    <table>
-      <tbody>
-        {releaseContributors!.map(contributor => (
-          <tr key={contributor.userId}>
-            <td>{contributor.userFullName}</td>
-            <td
-              className={classNames(
-                'govuk-!-margin-0',
-                'govuk-tag',
-                'dfe-align--centre',
-                contributor.releaseRoleId
-                  ? 'govuk-tag--grey'
-                  : 'govuk-tag--red',
+    <LoadingSpinner loading={isLoading}>
+      {!releaseContributors || releaseContributors.length === 0 ? (
+        <WarningMessage testId="releaseContributors-warning">
+          There are currently no team members associated to this publication.
+          <br />
+          Please <a href="#invite-users">invite new users</a> to join.
+        </WarningMessage>
+      ) : (
+        <>
+          <table>
+            <tbody>
+              {releaseContributors?.map(contributor => (
+                <tr key={contributor.userId}>
+                  <td className="govuk-!-width-one-half">
+                    {contributor.userFullName}
+                  </td>
+                  <td className={styles.control}>
+                    <Tag colour={contributor.releaseRoleId ? 'grey' : 'red'}>
+                      {contributor.releaseRoleId
+                        ? 'Access granted'
+                        : 'No access'}
+                    </Tag>
+                  </td>
+                  <td className={styles.control}>
+                    <Button
+                      className="govuk-!-margin-bottom-0"
+                      variant={
+                        contributor.releaseRoleId ? 'warning' : 'secondary'
+                      }
+                      onClick={() => setChangeContributerAccess(contributor)}
+                    >
+                      {contributor.releaseRoleId
+                        ? 'Remove access'
+                        : 'Grant access'}
+                    </Button>
+                  </td>
+                  <td className={styles.control}>
+                    <ButtonText onClick={() => setRemoveUser(contributor)}>
+                      Remove user
+                    </ButtonText>
+                  </td>
+                </tr>
+              ))}
+              {showGrantAllButton && (
+                <tr className={styles.grantAllRow}>
+                  <td colSpan={2} />
+                  <td className={styles.control}>
+                    <Button
+                      className="govuk-!-margin-bottom-0 govuk-!-margin-top-4"
+                      onClick={toggleGrantAllContributorAccess.on}
+                    >
+                      Grant access to all
+                    </Button>
+                  </td>
+                  <td />
+                </tr>
               )}
-            >
-              {contributor.releaseRoleId ? 'Access Granted' : 'No Access'}
-            </td>
-            <td>
-              {contributor.releaseRoleId ? (
-                <Button
-                  variant="warning"
-                  onClick={() =>
-                    userService.removeUserReleaseRole(contributor.releaseRoleId)
-                  }
-                >
-                  Remove access
-                </Button>
-              ) : (
-                <Button
-                  variant="secondary"
-                  onClick={() =>
-                    userService.addUserReleaseRole(contributor.userId, {
-                      releaseId: contributor.releaseId,
-                      releaseRole: 'Contributor',
-                    })
-                  }
-                >
-                  Grant access
-                </Button>
-              )}
-            </td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+            </tbody>
+          </table>
+
+          <ModalConfirm
+            title={`Change Access for ${changeContributorAccess?.userFullName}`}
+            open={!!changeContributorAccess}
+            onConfirm={async () => {
+              if (!changeContributorAccess) {
+                return;
+              }
+              if (changeContributorAccess?.releaseRoleId) {
+                await userService.removeUserReleaseRole(
+                  changeContributorAccess.releaseRoleId,
+                );
+                setChangeContributerAccess(undefined);
+                reloadReleaseContributors();
+                return;
+              }
+              await userService.addUserReleaseRole(
+                changeContributorAccess.userId,
+                {
+                  releaseId: changeContributorAccess.releaseId,
+                  releaseRole: 'Contributor',
+                },
+              );
+              setChangeContributerAccess(undefined);
+              reloadReleaseContributors();
+            }}
+            onCancel={() => setChangeContributerAccess(undefined)}
+            onExit={() => setChangeContributerAccess(undefined)}
+          >
+            <p>
+              Are you sure you want to{' '}
+              <strong>
+                {changeContributorAccess?.releaseRoleId ? 'remove' : 'grant'}{' '}
+                access
+              </strong>{' '}
+              for <strong>{release.title}</strong>?
+            </p>
+          </ModalConfirm>
+
+          <ModalConfirm
+            title="Grant access to all listed users"
+            open={grantAllContributorAccess}
+            onConfirm={async () => {
+              // await request here
+              toggleGrantAllContributorAccess.off();
+              reloadReleaseContributors();
+            }}
+            onCancel={toggleGrantAllContributorAccess.off}
+            onExit={toggleGrantAllContributorAccess.off}
+          >
+            <p>Are you sure you want to grant access to all listed users?</p>
+          </ModalConfirm>
+
+          <ModalConfirm
+            title="Confirm user removal"
+            open={!!removeUser}
+            onConfirm={async () => {
+              // await request here
+              setRemoveUser(undefined);
+              reloadReleaseContributors();
+            }}
+            onCancel={() => setRemoveUser(undefined)}
+            onExit={() => setRemoveUser(undefined)}
+          >
+            <p>
+              Are you sure you want to remove{' '}
+              <strong>{removeUser?.userFullName}</strong> from all releases in
+              this publication?
+            </p>
+          </ModalConfirm>
+        </>
+      )}
+    </LoadingSpinner>
   );
 };
 

--- a/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/ReleaseContributorPermissions.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/__tests__/ReleaseContributorPermissions.test.tsx
@@ -1,0 +1,261 @@
+import ReleaseContributorsPermissions from '@admin/pages/publication/components/ReleaseContributorPermissions';
+import { Release } from '@admin/services/releaseService';
+import _releasePermissionService, {
+  ReleaseContributor,
+} from '@admin/services/releasePermissionService';
+import _userService from '@admin/services/userService';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import React from 'react';
+
+jest.mock('@admin/services/releasePermissionService');
+jest.mock('@admin/services/userService');
+const releasePermissionService = _releasePermissionService as jest.Mocked<
+  typeof _releasePermissionService
+>;
+const userService = _userService as jest.Mocked<typeof _userService>;
+
+describe('ReleaseContributorPermissions', () => {
+  const testRelease = {
+    id: 'release-1',
+    title: 'Release 1',
+  } as Release;
+
+  const testReleaseContributors: ReleaseContributor[] = [
+    {
+      userId: 'user-1',
+      userFullName: 'User Name 1',
+      releaseId: 'release-1',
+      releaseRoleId: 'release-role-1',
+    },
+    {
+      userId: 'user-2',
+      userFullName: 'User Name 2',
+      releaseId: 'release-1',
+    },
+    {
+      userId: 'user-3',
+      userFullName: 'User Name 3',
+      releaseId: 'release-1',
+      releaseRoleId: 'release-role-3',
+    },
+  ];
+
+  test('renders a message when there are no release contributors', async () => {
+    releasePermissionService.getReleaseContributors.mockResolvedValue([]);
+
+    render(<ReleaseContributorsPermissions release={testRelease} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Warning')).toBeInTheDocument();
+
+      expect(
+        screen.getByTestId('releaseContributors-warning').textContent,
+      ).toContain(
+        'There are currently no team members associated to this publication.Please invite new users to join.',
+      );
+    });
+  });
+
+  test('renders the contributors table correctly', async () => {
+    releasePermissionService.getReleaseContributors.mockResolvedValue(
+      testReleaseContributors,
+    );
+
+    render(<ReleaseContributorsPermissions release={testRelease} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByRole('row');
+    expect(rows.length).toBe(4);
+
+    expect(within(rows[0]).getByText('User Name 1')).toBeInTheDocument();
+    expect(within(rows[0]).getByText('Access granted')).toBeInTheDocument();
+    expect(
+      within(rows[0]).getByRole('button', { name: 'Remove access' }),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[0]).getByRole('button', { name: 'Remove user' }),
+    ).toBeInTheDocument();
+
+    expect(within(rows[1]).getByText('User Name 2')).toBeInTheDocument();
+    expect(within(rows[1]).getByText('No access')).toBeInTheDocument();
+    expect(
+      within(rows[1]).getByRole('button', { name: 'Grant access' }),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[1]).getByRole('button', { name: 'Remove user' }),
+    ).toBeInTheDocument();
+
+    expect(within(rows[2]).getByText('User Name 3')).toBeInTheDocument();
+    expect(within(rows[2]).getByText('Access granted')).toBeInTheDocument();
+    expect(
+      within(rows[2]).getByRole('button', { name: 'Remove access' }),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[2]).getByRole('button', { name: 'Remove user' }),
+    ).toBeInTheDocument();
+
+    expect(
+      within(rows[3]).getByRole('button', { name: 'Grant access to all' }),
+    ).toBeInTheDocument();
+  });
+
+  test('granting user access', async () => {
+    releasePermissionService.getReleaseContributors.mockResolvedValue(
+      testReleaseContributors,
+    );
+
+    userService.addUserReleaseRole.mockResolvedValue(true);
+
+    render(<ReleaseContributorsPermissions release={testRelease} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+    const rows = screen.getAllByRole('row');
+
+    fireEvent.click(
+      within(rows[1]).getByRole('button', { name: 'Grant access' }),
+    );
+
+    const modal = screen.getByRole('dialog');
+
+    expect(
+      within(modal).getByRole('heading', {
+        name: 'Change Access for User Name 2',
+      }),
+    ).toBeInTheDocument();
+
+    expect(modal.textContent).toContain(
+      'Are you sure you want to grant access for Release 1?',
+    );
+
+    fireEvent.click(within(modal).getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(userService.addUserReleaseRole).toHaveBeenCalledWith('user-2', {
+        releaseId: 'release-1',
+        releaseRole: 'Contributor',
+      });
+    });
+  });
+
+  test('removing user access', async () => {
+    releasePermissionService.getReleaseContributors.mockResolvedValue(
+      testReleaseContributors,
+    );
+
+    userService.removeUserReleaseRole.mockResolvedValue(true);
+
+    render(<ReleaseContributorsPermissions release={testRelease} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+    const rows = screen.getAllByRole('row');
+
+    fireEvent.click(
+      within(rows[0]).getByRole('button', { name: 'Remove access' }),
+    );
+
+    const modal = screen.getByRole('dialog');
+
+    expect(
+      within(modal).getByRole('heading', {
+        name: 'Change Access for User Name 1',
+      }),
+    ).toBeInTheDocument();
+
+    expect(modal.textContent).toContain(
+      'Are you sure you want to remove access for Release 1?',
+    );
+
+    fireEvent.click(within(modal).getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => {
+      expect(userService.removeUserReleaseRole).toHaveBeenCalledWith(
+        'release-role-1',
+      );
+    });
+  });
+
+  test('remove user', async () => {
+    releasePermissionService.getReleaseContributors.mockResolvedValue(
+      testReleaseContributors,
+    );
+
+    render(<ReleaseContributorsPermissions release={testRelease} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+    const rows = screen.getAllByRole('row');
+
+    fireEvent.click(
+      within(rows[0]).getByRole('button', { name: 'Remove user' }),
+    );
+
+    const modal = screen.getByRole('dialog');
+
+    expect(
+      within(modal).getByRole('heading', {
+        name: 'Confirm user removal',
+      }),
+    ).toBeInTheDocument();
+
+    expect(modal.textContent).toContain(
+      'Are you sure you want to remove User Name 1 from all releases in this publication?',
+    );
+
+    fireEvent.click(within(modal).getByRole('button', { name: 'Confirm' }));
+
+    // TO DO:
+    // await waitFor(() => {
+    // Expect an endpoint to have been called
+    // });
+  });
+
+  test('grant all users access', async () => {
+    releasePermissionService.getReleaseContributors.mockResolvedValue(
+      testReleaseContributors,
+    );
+
+    render(<ReleaseContributorsPermissions release={testRelease} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('table')).toBeInTheDocument();
+    });
+    const rows = screen.getAllByRole('row');
+
+    fireEvent.click(
+      within(rows[3]).getByRole('button', { name: 'Grant access to all' }),
+    );
+
+    const modal = screen.getByRole('dialog');
+
+    expect(
+      within(modal).getByRole('heading', {
+        name: 'Grant access to all listed users',
+      }),
+    ).toBeInTheDocument();
+
+    expect(modal.textContent).toContain(
+      'Are you sure you want to grant access to all listed users?',
+    );
+
+    fireEvent.click(within(modal).getByRole('button', { name: 'Confirm' }));
+
+    // TO DO:
+    // await waitFor(() => {
+    // Expect an endpoint to have been called
+    // });
+  });
+});

--- a/src/explore-education-statistics-admin/src/services/releasePermissionService.ts
+++ b/src/explore-education-statistics-admin/src/services/releasePermissionService.ts
@@ -1,16 +1,14 @@
 import client from '@admin/services/utils/service';
 
-export interface ReleaseContributorViewModel {
+export interface ReleaseContributor {
   userId: string;
   userFullName: string;
   releaseId: string;
-  releaseRoleId: string;
+  releaseRoleId?: string;
 }
 
 const releasePermissionService = {
-  getReleaseContributors(
-    releaseId: string,
-  ): Promise<ReleaseContributorViewModel[]> {
+  getReleaseContributors(releaseId: string): Promise<ReleaseContributor[]> {
     return client.get(`/releases/${releaseId}/contributors`);
   },
 };

--- a/src/explore-education-statistics-common/src/components/WarningMessage.tsx
+++ b/src/explore-education-statistics-common/src/components/WarningMessage.tsx
@@ -7,14 +7,22 @@ interface Props {
   className?: string;
   error?: boolean;
   icon?: string;
+  testId?: string;
 }
 
-const WarningMessage = ({ children, className, error, icon = '!' }: Props) => {
+const WarningMessage = ({
+  children,
+  className,
+  error,
+  icon = '!',
+  testId,
+}: Props) => {
   return (
     <div
       className={classNames('govuk-warning-text', styles.warning, className, {
         [styles.error]: error,
       })}
+      data-testid={testId}
     >
       <span
         className={classNames('govuk-warning-text__icon', styles.icon)}


### PR DESCRIPTION
Tidies up the front end for the manage team access tab.

Adds buttons for granting access to all users and removing users, the click event for these will need to be updated.
  
<img width="1033" alt="manage-access" src="https://user-images.githubusercontent.com/81572860/140951245-443d418c-2c8d-48d8-a7e3-f076e7326604.PNG">
