### PR TITLE
EES-2128 Stop next-transpile-modules throwing on starting server in prod mode

### DIFF
--- a/src/explore-education-statistics-admin/config/webpackDevServer.config.js
+++ b/src/explore-education-statistics-admin/config/webpackDevServer.config.js
@@ -70,6 +70,10 @@ module.exports = (proxy, allowedHost) => {
       },
     },
     client: {
+      // EES - Disable default overlay as we're using the error-overlay-webpack-plugin
+      overlay: false,
+      // EES - Enables logging of compiler warnings to the browser console
+      logging: 'warn',
       webSocketURL: {
         // Enable custom sockjs pathname for websocket connection to hot reloading server.
         // Enable custom sockjs hostname, pathname and port for websocket connection

--- a/src/explore-education-statistics-frontend/next.config.js
+++ b/src/explore-education-statistics-frontend/next.config.js
@@ -82,12 +82,19 @@ const nextConfig = {
 // Plugins are applied to the
 // Next config from left to right
 module.exports = flowRight(
-  withTranspileModules([
-    'explore-education-statistics-common',
-    // Need to add explicit dependencies as they
-    // may be un-transpiled (ES6+) and cause
-    // IE11 to throw syntax errors.
-    'explore-education-statistics-common/node_modules/sanitize-html',
-    'explore-education-statistics-common/node_modules/nanoid',
-  ]),
+  withTranspileModules(
+    // Need to modify the following as next-transpile-modules
+    // throws when running server in a production environment
+    // because we remove the target modules as part
+    // of the build to reduce total artifact size.
+    process.env.NEXT_CONFIG_MODE !== 'server'
+      ? [
+          'explore-education-statistics-common',
+          // Need to add explicit dependencies as they may be un-transpiled
+          // (ES6+) and cause IE11 to throw syntax errors.
+          'explore-education-statistics-common/node_modules/sanitize-html',
+          'explore-education-statistics-common/node_modules/nanoid',
+        ]
+      : [],
+  ),
 )(nextConfig);

--- a/src/explore-education-statistics-frontend/package.json
+++ b/src/explore-education-statistics-frontend/package.json
@@ -89,7 +89,7 @@
   "scripts": {
     "start": "node server.js",
     "start:local": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 node server.js",
-    "start:prod": "cross-env NODE_ENV=production node server.js",
+    "start:prod": "cross-env NODE_ENV=production NEXT_CONFIG_MODE=server node server.js",
     "build": "next build ./src",
     "lint": "npm run lint:js && npm run lint:style",
     "lint:js": "eslint src/**/*.{ts,tsx}",


### PR DESCRIPTION
This PR:

- Fixes the public frontend server from crashing at startup in our non-local environments. This is due to `next-transpile-modules` searching for modules that are stripped out by our build and are not in the deployed artifacts.
- Fixes admin's Webpack dev server from still displaying the default error overlay.
- Enables logging of compile warnings (lints, etc) to the browser console for the admin development server.