### PR TITLE
EES-2894 🐛 Allow LocationQuery fields to be optional

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/Data/Query/LocationQueryTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/Data/Query/LocationQueryTest.cs
@@ -8,36 +8,36 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model.Data.Que
     public class LocationQueryTest
     {
         [Fact]
-        public void CountItems_QueryIsEmpty()
+        public void CountItems_HandlesNullCollections()
         {
             var locationQuery = new LocationQuery();
             Assert.Equal(0, locationQuery.CountItems());
         }
 
         [Fact]
-        public void CountItems()
+        public void CountItems_CountsAllCollections()
         {
             var locationQuery = new LocationQuery
             {
-                Country = AsList("code"),
-                EnglishDevolvedArea = AsList("code"),
-                Institution = AsList("code"),
-                LocalAuthority = AsList("code"),
-                LocalAuthorityDistrict = AsList("code"),
-                LocalEnterprisePartnership = AsList("code"),
-                MultiAcademyTrust = AsList("code"),
-                MayoralCombinedAuthority = AsList("code"),
-                OpportunityArea = AsList("code"),
-                ParliamentaryConstituency = AsList("code"),
-                Provider = AsList("code"),
-                PlanningArea = AsList("code"),
-                Region = AsList("code"),
-                RscRegion = AsList("code"),
-                School = AsList("code"),
-                Sponsor = AsList("code"),
-                Ward = AsList("code")
+                Country = AsList("code1", "code2"),
+                EnglishDevolvedArea = AsList("code1", "code2"),
+                Institution = AsList("code1", "code2"),
+                LocalAuthority = AsList("code1", "code2"),
+                LocalAuthorityDistrict = AsList("code1", "code2"),
+                LocalEnterprisePartnership = AsList("code1", "code2"),
+                MultiAcademyTrust = AsList("code1", "code2"),
+                MayoralCombinedAuthority = AsList("code1", "code2"),
+                OpportunityArea = AsList("code1", "code2"),
+                ParliamentaryConstituency = AsList("code1", "code2"),
+                Provider = AsList("code1", "code2"),
+                PlanningArea = AsList("code1", "code2"),
+                Region = AsList("code1", "code2"),
+                RscRegion = AsList("code1", "code2"),
+                School = AsList("code1", "code2"),
+                Sponsor = AsList("code1", "code2"),
+                Ward = AsList("code1", "code2")
             };
-            Assert.Equal(17, locationQuery.CountItems());
+            Assert.Equal(34, locationQuery.CountItems());
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/Data/Query/LocationQueryTest.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Model/Data/Query/LocationQueryTest.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model.Data.Query
 {
@@ -16,24 +17,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Model.Data.Que
         [Fact]
         public void CountItems()
         {
-            var locationQuery = new LocationQuery();
-            locationQuery.Country.Add("1");
-            locationQuery.EnglishDevolvedArea.Add("2");
-            locationQuery.Institution.Add("3");
-            locationQuery.LocalAuthority.Add("4");
-            locationQuery.LocalAuthorityDistrict.Add("5");
-            locationQuery.LocalEnterprisePartnership.Add("6");
-            locationQuery.MultiAcademyTrust.Add("7");
-            locationQuery.MayoralCombinedAuthority.Add("8");
-            locationQuery.OpportunityArea.Add("9");
-            locationQuery.ParliamentaryConstituency.Add("10");
-            locationQuery.Provider.Add("11");
-            locationQuery.PlanningArea.Add("12");
-            locationQuery.Region.Add("13");
-            locationQuery.RscRegion.Add("14");
-            locationQuery.School.Add("15");
-            locationQuery.Sponsor.Add("16");
-            locationQuery.Ward.Add("17");
+            var locationQuery = new LocationQuery
+            {
+                Country = AsList("code"),
+                EnglishDevolvedArea = AsList("code"),
+                Institution = AsList("code"),
+                LocalAuthority = AsList("code"),
+                LocalAuthorityDistrict = AsList("code"),
+                LocalEnterprisePartnership = AsList("code"),
+                MultiAcademyTrust = AsList("code"),
+                MayoralCombinedAuthority = AsList("code"),
+                OpportunityArea = AsList("code"),
+                ParliamentaryConstituency = AsList("code"),
+                Provider = AsList("code"),
+                PlanningArea = AsList("code"),
+                Region = AsList("code"),
+                RscRegion = AsList("code"),
+                School = AsList("code"),
+                Sponsor = AsList("code"),
+                Ward = AsList("code")
+            };
             Assert.Equal(17, locationQuery.CountItems());
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/LocationQuery.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Data/Query/LocationQuery.cs
@@ -10,23 +10,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query
     {
         [JsonConverter(typeof(StringEnumConverter))]
         public GeographicLevel? GeographicLevel { get; set; }
-        public List<string> Country { get; set; } = new();
-        public List<string> EnglishDevolvedArea { get; set; } = new();
-        public List<string> Institution { get; set; } = new();
-        public List<string> LocalAuthority { get; set; } = new();
-        public List<string> LocalAuthorityDistrict { get; set; } = new();
-        public List<string> LocalEnterprisePartnership { get; set; } = new();
-        public List<string> MultiAcademyTrust { get; set; } = new();
-        public List<string> MayoralCombinedAuthority { get; set; } = new();
-        public List<string> OpportunityArea { get; set; } = new();
-        public List<string> ParliamentaryConstituency { get; set; } = new();
-        public List<string> Provider { get; set; } = new();
-        public List<string> PlanningArea { get; set; } = new();
-        public List<string> Region { get; set; } = new();
-        public List<string> RscRegion { get; set; } = new();
-        public List<string> School { get; set; } = new();
-        public List<string> Sponsor { get; set; } = new();
-        public List<string> Ward { get; set; } = new();
+        public List<string>? Country { get; set; }
+        public List<string>? EnglishDevolvedArea { get; set; }
+        public List<string>? Institution { get; set; }
+        public List<string>? LocalAuthority { get; set; }
+        public List<string>? LocalAuthorityDistrict { get; set; }
+        public List<string>? LocalEnterprisePartnership { get; set; }
+        public List<string>? MultiAcademyTrust { get; set; }
+        public List<string>? MayoralCombinedAuthority { get; set; }
+        public List<string>? OpportunityArea { get; set; }
+        public List<string>? ParliamentaryConstituency { get; set; }
+        public List<string>? Provider { get; set; }
+        public List<string>? PlanningArea { get; set; }
+        public List<string>? Region { get; set; }
+        public List<string>? RscRegion { get; set; }
+        public List<string>? School { get; set; }
+        public List<string>? Sponsor { get; set; }
+        public List<string>? Ward { get; set; }
 
         public int CountItems()
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationPredicateBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationPredicateBuilder.cs
@@ -1,7 +1,9 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
@@ -56,87 +58,87 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         {
             var predicate = PredicateBuilder.False<Observation>();
 
-            if (query.Country.Any())
+            if (query.Country != null)
             {
                 predicate = predicate.Or(CountryPredicate(query));
             }
 
-            if (query.EnglishDevolvedArea.Any())
+            if (query.EnglishDevolvedArea != null)
             {
                 predicate = predicate.Or(EnglishDevolvedAreaPredicate(query));
             }
 
-            if (query.Institution.Any())
+            if (query.Institution != null)
             {
                 predicate = predicate.Or(InstitutionPredicate(query));
             }
 
-            if (query.LocalAuthority.Any())
+            if (query.LocalAuthority != null)
             {
                 predicate = predicate.Or(LocalAuthorityPredicate(query));
             }
 
-            if (query.LocalAuthorityDistrict.Any())
+            if (query.LocalAuthorityDistrict != null)
             {
                 predicate = predicate.Or(LocalAuthorityDistrictPredicate(query));
             }
 
-            if (query.LocalEnterprisePartnership.Any())
+            if (query.LocalEnterprisePartnership != null)
             {
                 predicate = predicate.Or(LocalEnterprisePartnershipPredicate(query));
             }
 
-            if (query.MayoralCombinedAuthority.Any())
+            if (query.MayoralCombinedAuthority != null)
             {
                 predicate = predicate.Or(MayoralCombinedAuthorityPredicate(query));
             }
 
-            if (query.MultiAcademyTrust.Any())
+            if (query.MultiAcademyTrust != null)
             {
                 predicate = predicate.Or(MultiAcademyTrustPredicate(query));
             }
 
-            if (query.OpportunityArea.Any())
+            if (query.OpportunityArea != null)
             {
                 predicate = predicate.Or(OpportunityAreaPredicate(query));
             }
 
-            if (query.ParliamentaryConstituency.Any())
+            if (query.ParliamentaryConstituency != null)
             {
                 predicate = predicate.Or(ParliamentaryConstituencyPredicate(query));
             }
 
-            if (query.Provider.Any())
+            if (query.Provider != null)
             {
                 predicate = predicate.Or(ProviderPredicate(query));
             }
 
-            if (query.Region.Any())
+            if (query.Region != null)
             {
                 predicate = predicate.Or(RegionPredicate(query));
             }
 
-            if (query.RscRegion.Any())
+            if (query.RscRegion != null)
             {
                 predicate = predicate.Or(RscRegionPredicate(query));
             }
 
-            if (query.School.Any())
+            if (query.School != null)
             {
                 predicate = predicate.Or(SchoolPredicate(query));
             }
 
-            if (query.Sponsor.Any())
+            if (query.Sponsor != null)
             {
                 predicate = predicate.Or(SponsorPredicate(query));
             }
 
-            if (query.Ward.Any())
+            if (query.Ward != null)
             {
                 predicate = predicate.Or(WardPredicate(query));
             }
 
-            if (query.PlanningArea.Any())
+            if (query.PlanningArea != null)
             {
                 predicate = predicate.Or(PlanningAreaPredicate(query));
             }
@@ -146,48 +148,53 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
         private static bool ObservationalUnitExists(LocationQuery query)
         {
-            return query.Country.Any() ||
-                   query.EnglishDevolvedArea.Any() ||
-                   query.Institution.Any() ||
-                   query.LocalAuthority.Any() ||
-                   query.LocalAuthorityDistrict.Any() ||
-                   query.LocalEnterprisePartnership.Any() ||
-                   query.MultiAcademyTrust.Any() ||
-                   query.MayoralCombinedAuthority.Any() ||
-                   query.OpportunityArea.Any() ||
-                   query.ParliamentaryConstituency.Any() ||
-                   query.Region.Any() ||
-                   query.RscRegion.Any() ||
-                   query.Sponsor.Any() ||
-                   query.Ward.Any() ||
-                   query.PlanningArea.Any();
+            return !(query == null ||
+                     query.Country.IsNullOrEmpty() &&
+                     query.EnglishDevolvedArea.IsNullOrEmpty() &&
+                     query.Institution.IsNullOrEmpty() &&
+                     query.LocalAuthority.IsNullOrEmpty() &&
+                     query.LocalAuthorityDistrict.IsNullOrEmpty() &&
+                     query.LocalEnterprisePartnership.IsNullOrEmpty() &&
+                     query.MultiAcademyTrust.IsNullOrEmpty() &&
+                     query.MayoralCombinedAuthority.IsNullOrEmpty() &&
+                     query.OpportunityArea.IsNullOrEmpty() &&
+                     query.ParliamentaryConstituency.IsNullOrEmpty() &&
+                     query.Region.IsNullOrEmpty() &&
+                     query.RscRegion.IsNullOrEmpty() &&
+                     query.Sponsor.IsNullOrEmpty() &&
+                     query.Ward.IsNullOrEmpty() &&
+                     query.PlanningArea.IsNullOrEmpty());
         }
 
         private static Expression<Func<Observation, bool>> CountryPredicate(LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.Country,
-                observation => query.Country.Contains(observation.Location.Country_Code));
+                observation => query.Country != null &&
+                               query.Country.Contains(observation.Location.Country_Code));
         }
 
         private static Expression<Func<Observation, bool>> EnglishDevolvedAreaPredicate(LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.EnglishDevolvedArea,
-                observation => query.EnglishDevolvedArea.Contains(observation.Location.EnglishDevolvedArea_Code));
+                observation => query.EnglishDevolvedArea != null &&
+                               query.EnglishDevolvedArea.Contains(observation.Location.EnglishDevolvedArea_Code));
         }
 
         private static Expression<Func<Observation, bool>> InstitutionPredicate(LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.Institution,
-                observation => query.Institution.Contains(observation.Location.Institution_Code));
+                observation => query.Institution != null &&
+                               query.Institution.Contains(observation.Location.Institution_Code));
         }
 
         private static Expression<Func<Observation, bool>> LocalAuthorityPredicate(LocationQuery query)
         {
-            var localAuthorityOldCodes = query.LocalAuthority.Where(s => s.Length == 3).ToList();
-            var localAuthorityCodes = query.LocalAuthority.Except(localAuthorityOldCodes).ToList();
+            var allLocalAuthorityCodes = query.LocalAuthority ?? new List<string>();
+            var localAuthorityOldCodes = allLocalAuthorityCodes.Where(s => s.Length == 3).ToList();
+            var localAuthorityNewCodes = allLocalAuthorityCodes.Except(localAuthorityOldCodes).ToList();
 
             return ObservationalUnitPredicate(query, GeographicLevel.LocalAuthority,
-                observation => localAuthorityCodes.Contains(observation.Location.LocalAuthority_Code) ||
+                observation => localAuthorityNewCodes.Contains(observation.Location.LocalAuthority_Code) ||
                                localAuthorityOldCodes.Contains(observation.Location.LocalAuthority_OldCode));
         }
 
@@ -195,14 +202,15 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.LocalAuthorityDistrict,
-                observation => query.LocalAuthorityDistrict.Contains(observation.Location.LocalAuthorityDistrict_Code));
+                observation => query.LocalAuthorityDistrict != null &&
+                               query.LocalAuthorityDistrict.Contains(observation.Location.LocalAuthorityDistrict_Code));
         }
 
         private static Expression<Func<Observation, bool>> LocalEnterprisePartnershipPredicate(
             LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.LocalEnterprisePartnership,
-                observation =>
+                observation => query.LocalEnterprisePartnership != null &&
                     query.LocalEnterprisePartnership.Contains(observation.Location.LocalEnterprisePartnership_Code));
         }
 
@@ -210,27 +218,29 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.MayoralCombinedAuthority,
-                observation =>
+                observation => query.MayoralCombinedAuthority != null &&
                     query.MayoralCombinedAuthority.Contains(observation.Location.MayoralCombinedAuthority_Code));
         }
 
         private static Expression<Func<Observation, bool>> MultiAcademyTrustPredicate(LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.MultiAcademyTrust,
-                observation => query.MultiAcademyTrust.Contains(observation.Location.MultiAcademyTrust_Code));
+                observation => query.MultiAcademyTrust != null &&
+                    query.MultiAcademyTrust.Contains(observation.Location.MultiAcademyTrust_Code));
         }
 
         private static Expression<Func<Observation, bool>> OpportunityAreaPredicate(LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.OpportunityArea,
-                observation => query.OpportunityArea.Contains(observation.Location.OpportunityArea_Code));
+                observation => query.OpportunityArea != null &&
+                    query.OpportunityArea.Contains(observation.Location.OpportunityArea_Code));
         }
 
         private static Expression<Func<Observation, bool>> ParliamentaryConstituencyPredicate(
             LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.ParliamentaryConstituency,
-                observation =>
+                observation => query.ParliamentaryConstituency != null &&
                     query.ParliamentaryConstituency.Contains(observation.Location.ParliamentaryConstituency_Code));
         }
 
@@ -238,44 +248,50 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.Provider,
-                observation =>
+                observation => query.Provider != null &&
                     query.Provider.Contains(observation.Location.Provider_Code));
         }
 
         private static Expression<Func<Observation, bool>> RegionPredicate(LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.Region,
-                observation => query.Region.Contains(observation.Location.Region_Code));
+                observation => query.Region != null &&
+                    query.Region.Contains(observation.Location.Region_Code));
         }
 
         private static Expression<Func<Observation, bool>> RscRegionPredicate(LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.RscRegion,
-                observation => query.RscRegion.Contains(observation.Location.RscRegion_Code));
+                observation => query.RscRegion != null &&
+                               query.RscRegion.Contains(observation.Location.RscRegion_Code));
         }
 
         private static Expression<Func<Observation, bool>> SchoolPredicate(LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.School,
-                observation => query.School.Contains(observation.Location.School_Code));
+                observation => query.School != null &&
+                    query.School.Contains(observation.Location.School_Code));
         }
 
         private static Expression<Func<Observation, bool>> SponsorPredicate(LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.Sponsor,
-                observation => query.Sponsor.Contains(observation.Location.Sponsor_Code));
+                observation => query.Sponsor != null &&
+                               query.Sponsor.Contains(observation.Location.Sponsor_Code));
         }
 
         private static Expression<Func<Observation, bool>> WardPredicate(LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.Ward,
-                observation => query.Ward.Contains(observation.Location.Ward_Code));
+                observation => query.Ward != null &&
+                    query.Ward.Contains(observation.Location.Ward_Code));
         }
 
         private static Expression<Func<Observation, bool>> PlanningAreaPredicate(LocationQuery query)
         {
             return ObservationalUnitPredicate(query, GeographicLevel.PlanningArea,
-                observation => query.PlanningArea.Contains(observation.Location.PlanningArea_Code));
+                observation => query.PlanningArea != null &&
+                    query.PlanningArea.Contains(observation.Location.PlanningArea_Code));
         }
 
         private static Expression<Func<Observation, bool>> ObservationalUnitPredicate(LocationQuery query,

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatSelectForm.tsx
@@ -29,7 +29,9 @@ const KeyStatSelectForm = ({
     return availableDataBlocks.filter(dataBlock => {
       const { timePeriod, locations, indicators } = dataBlock.query;
 
-      const locationLevels = Object.values(locations);
+      const locationLevels = Object.values(locations).filter(
+        level => level?.length,
+      );
 
       const hasSingleLocation =
         locationLevels.length === 1 && locationLevels[0].length === 1;


### PR DESCRIPTION
This PR allows all of the LocationQuery attribute arrays to be optional again, reverting a change made by https://github.com/dfe-analytical-services/explore-education-statistics/pull/2960.

The previous change initialised them as new collections which was intended to make summing the count of all attributes easier by avoiding the possibility of `null` values. However this problem was easily solved by using `.Sum(collection => collection?.Count ?? 0)` which expects to encounter null values.

This PR fixes a problem where a DataBlock with a LocationQuery cannot be added as a Key Statistic since they now always fail a FE check which makes sure that candidate Key Statistic data blocks only have a single location attribute.

```
const locationLevels = Object.values(locations);
const hasSingleLocation = locationLevels.length === 1 ...`
