### PR TITLE
Upgrade Function Storage Extensions from 4.0.2 to 4.0.5. 

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/GovUk.Education.ExploreEducationStatistics.Data.Processor.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/GovUk.Education.ExploreEducationStatistics.Data.Processor.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.7" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.18" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/GovUk.Education.ExploreEducationStatistics.Notifier.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
     <PackageReference Include="JWT" Version="7.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.5" />
     <!-- EES-1205 Temporarily downgrading dependency Microsoft.NET.Sdk.Functions to 3.0.3
     Prevents error when subscribing to Publications
     'Could not load file or assembly 'Microsoft.IdentityModel.Tokens, Version=6.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified'

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/GovUk.Education.ExploreEducationStatistics.Publisher.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="3.0.0-preview" />
     <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="1.3.0" />
     <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.7" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.18" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.6" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />


### PR DESCRIPTION
This PR fixes a problem starting any of the Azure Function applications if you have upgraded Azure Core Tools from v3 to v4.

As soon as the Azure Functions Host is v4 it enforces a minimum version of supported extensions including `Microsoft.Azure.WebJobs.Extensions.Storage` at version 4.0.4 or later.

See https://aka.ms/func-min-extension-versions for more information.

Without this, starting any of the function projects will fail startup with the error

```
ExtensionStartupType AzureStorageWebJobsStartup from assembly 'Microsoft.Azure.WebJobs.Extensions.Storage, Version=4.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' does not meet the required minimum versi
on of 4.0.4.0. Update your NuGet package reference for Microsoft.Azure.WebJobs.Extensions.Storage to 4.0.4 or later.
```



