### PR TITLE
EES-2893 Fix UI tests failing due to basic auth credentials in URL

### DIFF
--- a/src/explore-education-statistics-frontend/next.config.js
+++ b/src/explore-education-statistics-frontend/next.config.js
@@ -14,7 +14,6 @@ const nextConfig = {
     HOTJAR_ID: process.env.HOTJAR_ID,
     PUBLIC_URL: process.env.PUBLIC_URL,
   },
-  productionBrowserSourceMaps: true,
   async redirects() {
     return [
       {

--- a/tests/robot-tests/.env.example
+++ b/tests/robot-tests/.env.example
@@ -1,6 +1,8 @@
-PUBLIC_URL=http://localhost:3000  # (string) URL of the public frontend (protected by basic auth in non-prod environments)
+PUBLIC_URL=http://localhost:3000  # (string) URL of the public frontend
 DATA_API_URL=http://localhost:5000/api  # (string) URL for the Data API
 CONTENT_API_URL=http://localhost:5010/api  # (string) URL for the Content API
+PUBLIC_AUTH_USER= # (string) the basic auth user for the public frontend (leave empty if none)
+PUBLIC_AUTH_PASSWORD= # (string) the basic auth password for the public frontend (leave empty if none)
 ADMIN_URL=https://localhost:5021  # (string) URL for the Admin frontend
 ADMIN_EMAIL=ADMIN_EMAIL  # (string) BAU1 user email
 ADMIN_PASSWORD=ADMIN_PASSWORD  # (string) BAU1 user password

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -93,6 +93,7 @@ user opens chrome headless
     Call Method    ${c_opts}    add_argument    disable-logging
 
     Create Webdriver    Chrome    crm_alias    chrome_options=${c_opts}
+    setup chromedriver
 
 user opens chrome with xvfb
     start virtual display    1920    1080
@@ -104,6 +105,7 @@ user opens chrome with xvfb
     END
 
     create webdriver    Chrome    chrome_options=${options}
+    setup chromedriver
     set window size    1920    1080
 
 user opens chrome without xvfb
@@ -114,6 +116,7 @@ user opens chrome without xvfb
     Call Method    ${c_opts}    add_argument    window-size\=1920,1080
     Call Method    ${c_opts}    add_argument    ignore-certificate-errors
     Create Webdriver    Chrome    crm_alias    chrome_options=${c_opts}
+    setup chromedriver
     maximize browser window
 
 user opens firefox headless


### PR DESCRIPTION
This changes how the UI tests perform basic authentication against the public frontend. Previously, we were putting these into the `PUBLIC_URL` variable, but unfortunately this seems to now be incompatible with Next.js now that we've upgrade to v11.

To get around this, we now add the basic auth credentials into the request headers using the Chrome DevTools prototocol. This necessitates the use of two new environment variables: `PUBLIC_AUTH_USER` and `PUBLIC_AUTH_PASSWORD`.