### PR TITLE
EES-2900 Fix UI tests

### DIFF
--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -372,7 +372,7 @@ Validate line chart embeds correctly
     user checks chart tooltip item contains    ${datablock}    1    Admission Numbers (Nailsea Youngwood): 4,198
 
 Configure basic vertical bar chart
-    user goes to url    ${DATABLOCK_URL}
+    user navigates to admin frontend    ${DATABLOCK_URL}
 
     user waits until h2 is visible    ${DATABLOCK_NAME}    %{WAIT_MEDIUM}
     user waits until page does not contain loading spinner
@@ -470,7 +470,7 @@ Save and validate vertical bar chart embeds correctly
     user checks chart tooltip item contains    ${datablock}    1    Admissions: 4,198
 
 Configure basic horizontal bar chart
-    user goes to url    ${DATABLOCK_URL}
+    user navigates to admin frontend    ${DATABLOCK_URL}
     user waits until h2 is visible    ${DATABLOCK_NAME}    60
     user waits until page does not contain loading spinner
 
@@ -552,7 +552,7 @@ Save and validate horizontal bar chart embeds correctly
     user checks chart tooltip item contains    ${datablock}    1    Admissions: 4,198
 
 Configure basic geographic chart
-    user goes to url    ${DATABLOCK_URL}
+    user navigates to admin frontend    ${DATABLOCK_URL}
     user waits until h2 is visible    ${DATABLOCK_NAME}    60
     user waits until page does not contain loading spinner
 
@@ -636,7 +636,7 @@ Save and validate geographic chart embeds correctly
     user checks map chart indicator tile contains    ${datablock}    5    Admissions in 2016    4,198
 
 Configure basic infographic chart
-    user goes to url    ${DATABLOCK_URL}
+    user navigates to admin frontend    ${DATABLOCK_URL}
 
     user waits until h2 is visible    ${DATABLOCK_NAME}
     user waits until page does not contain loading spinner
@@ -668,7 +668,7 @@ Delete embedded data block
     user clicks button    Confirm
 
 Delete chart from data block
-    user goes to url    ${DATABLOCK_URL}
+    user navigates to admin frontend    ${DATABLOCK_URL}
     user waits until h2 is visible    ${DATABLOCK_NAME}
     user waits until page does not contain loading spinner
     user clicks link    Chart

--- a/tests/robot-tests/tests/admin/bau/manage_users_page.robot
+++ b/tests/robot-tests/tests/admin/bau/manage_users_page.robot
@@ -12,7 +12,7 @@ Test Setup          fail test fast if required
 
 *** Test Cases ***
 Navigate to manage users page as bau1
-    user goes to url    %{ADMIN_URL}/administration/users
+    user navigates to admin frontend    %{ADMIN_URL}/administration/users
     user checks table column heading contains    1    1    Name
     user checks table column heading contains    1    2    Email
     user checks table column heading contains    1    3    Role

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -17,7 +17,6 @@ ${PUBLICATION_NAME}=                        UI tests - prerelease %{RUN_IDENTIFI
 ${DATABLOCK_NAME}=                          UI test table
 ${DATABLOCK_FEATURED_NAME}=                 UI test featured table name
 ${DATABLOCK_FEATURED_TABLE_DESCRIPTION}=    UI test featured table description
-${RELEASE_URL}=
 
 *** Test Cases ***
 Create test publication and release via API
@@ -136,7 +135,7 @@ Navigate to prerelease page
     ${current_url}=    get location
     ${RELEASE_URL}=    remove substring from right of string    ${current_url}    /status
     set suite variable    ${RELEASE_URL}
-    user goes to url    ${RELEASE_URL}/prerelease/content
+    user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
 
 Validate prerelease has not started
     user waits until h1 is visible    Pre-release access is not yet available    60
@@ -152,7 +151,7 @@ Validate prerelease has not started
     user checks page contains    Pre-release access will be available from ${time_start} until ${time_end}.
 
 Go to prerelease access page
-    user goes to url    ${RELEASE_URL}/prerelease-access
+    user navigates to admin frontend    ${RELEASE_URL}/prerelease-access
     user waits until h2 is visible    Manage pre-release user access
 
 Validate the invite emails field is required
@@ -229,7 +228,7 @@ Invite a further list of new users but mixed with existing invitees and accepted
 
 Validate prerelease has not started for Analyst user
     user changes to analyst1
-    user goes to url    ${RELEASE_URL}/prerelease/content
+    user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
 
     user waits until h1 is visible    Pre-release access is not yet available    60
     user checks breadcrumb count should be    2
@@ -249,7 +248,7 @@ Start prerelease
     ${month}=    get current datetime    %-m    1
     ${month_word}=    get current datetime    %B    1
     ${year}=    get current datetime    %Y    1
-    user goes to url    ${RELEASE_URL}/status
+    user navigates to admin frontend    ${RELEASE_URL}/status
     user clicks button    Edit release status
     user enters text into element    id:releaseStatusForm-publishScheduled-day    ${day}
     user enters text into element    id:releaseStatusForm-publishScheduled-month    ${month}
@@ -266,7 +265,7 @@ Validate prerelease has started
     ${current_url}=    get location
     ${RELEASE_URL}=    remove substring from right of string    ${current_url}    /status
     set suite variable    ${RELEASE_URL}
-    user goes to url    ${RELEASE_URL}/prerelease/content
+    user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
 
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
@@ -364,7 +363,7 @@ Create and validate custom table
 
 Validate prerelease has started for Analyst user
     user changes to analyst1
-    user goes to url    ${RELEASE_URL}/prerelease/content
+    user navigates to admin frontend    ${RELEASE_URL}/prerelease/content
 
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home
@@ -470,7 +469,7 @@ Unschedule release
     # EES-2826 Cancel scheduled publishing because ReleaseStatus row in table storage isn't removed
     # by test topic teardown. Unscheduling prevents an error when the scheduled publishing begins.
     user changes to bau1
-    user goes to url    ${RELEASE_URL}/status
+    user navigates to admin frontend    ${RELEASE_URL}/status
     user clicks button    Edit release status
     user clicks radio    In draft
     user clicks button    Update status

--- a/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
@@ -105,7 +105,7 @@ Verify newly published release is on Find Statistics page
     user checks publication bullet does not contain link    ${PUBLICATION_NAME}    Statistics at DfE
 
 User navigates to /data-catalogue page
-    user goes to url    %{PUBLIC_URL}/data-catalogue
+    user navigates to public frontend    %{PUBLIC_URL}/data-catalogue
     user waits until page contains title caption    Data catalogue
     user waits until h1 is visible    Browse our open data
     user waits until page contains    View all of the open data available and choose files to download.

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -36,10 +36,7 @@ Go to 'Sign Off' page
     Set Suite Variable    ${PUBLIC_RELEASE_LINK}
 
 Go to Public Release Link
-    # To get around basic auth on public frontend
-    user goes to url    %{PUBLIC_URL}
-    user waits until h1 is visible    Explore our statistics and data
-    user goes to url    ${PUBLIC_RELEASE_LINK}
+    user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
     user waits until page contains    Page not found
     user checks page does not contain    ${RELEASE_NAME}
 
@@ -112,7 +109,7 @@ Check scheduled release isn't visible on public Table Tool
     user checks page does not contain    ${PUBLICATION_NAME}
 
 Go to public release URL and check release isn't visible
-    user goes to url    ${PUBLIC_RELEASE_LINK}
+    user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
     user waits until page does not contain    ${PUBLICATION_NAME}
 
 Check "Page not found" appears
@@ -137,5 +134,5 @@ Approve release for immediate publication but don't wait to finish
     user checks summary list contains    Current status    Approved
 
 Go to public release URL again and check release isn't visible
-    user goes to url    ${PUBLIC_RELEASE_LINK}
+    user navigates to public frontend    ${PUBLIC_RELEASE_LINK}
     user waits until page contains    Page not found

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -45,7 +45,7 @@ Verify that the publication is not visible on the public methodologies page with
     user checks page does not contain    ${PUBLICATION_NAME}
 
 Verify that the methodology is not publicly accessible by URL without a published release
-    user goes to url    ${ACCESSIBLE_METHODOLOGY_URL}
+    user navigates to public frontend    ${ACCESSIBLE_METHODOLOGY_URL}
     user waits until h1 is visible    Page not found    %{WAIT_MEDIUM}
 
 Alter the approval to publish the methodology with the release
@@ -59,7 +59,7 @@ Verify that the publication is still not visible on the public methodologies pag
     user checks page does not contain    ${PUBLICATION_NAME}
 
 Verify that the methodology is still not publicly accessible by URL without publishing the release
-    user goes to url    ${ACCESSIBLE_METHODOLOGY_URL}
+    user navigates to public frontend    ${ACCESSIBLE_METHODOLOGY_URL}
     user waits until page contains    Page not found
 
 Approve the release
@@ -162,7 +162,7 @@ Verify that the user cannot edit the status of the amended methodology
 
 Go to methodology amendment's public page
     ${METHODOLOGY_URL}=    get element attribute    css:#public-methodology-url    value
-    user goes to url    ${METHODOLOGY_URL}
+    user navigates to public frontend    ${METHODOLOGY_URL}
     user waits until page contains title    ${PUBLICATION_NAME} - Amended methodology
     user waits until page contains title caption    Methodology
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -521,7 +521,7 @@ Approve amendment for immediate release
     user approves amended release for immediate publication
 
 Go back to public find-statistics page
-    user goes to url    %{PUBLIC_URL}/find-statistics
+    user navigates to public frontend    %{PUBLIC_URL}/find-statistics
     user waits until h1 is visible    Find statistics and data
     user waits for page to finish loading
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -235,7 +235,7 @@ Generate the permalink
     Set Suite Variable    ${PERMA_LOCATION_URL}
 
 Go to permalink
-    user goes to url    ${PERMA_LOCATION_URL}
+    user navigates to public frontend    ${PERMA_LOCATION_URL}
     user waits until h1 is visible    '${SUBJECT_NAME}' from '${PUBLICATION_NAME}'
     user checks page does not contain    WARNING - The data used in this permalink may be out-of-date.
     user checks page contains    Footnote 1 ${SUBJECT_NAME}
@@ -311,7 +311,7 @@ Approve release amendment
     user approves amended release for immediate publication
 
 Go to permalink page & check for error element to be present
-    user goes to url    ${PERMA_LOCATION_URL}
+    user navigates to public frontend    ${PERMA_LOCATION_URL}
     user waits until page contains    WARNING - The data used in this permalink may be out-of-date.
 
 Check the table has the same results as original table
@@ -371,7 +371,7 @@ Check the table has the same results as original table
     user checks results table cell contains    7    5    1
 
 Check amended release doesn't contain deleted subject
-    user goes to url    %{PUBLIC_URL}/data-tables
+    user navigates to public frontend    %{PUBLIC_URL}/data-tables
     user waits until h1 is visible    Create your own tables
     user opens details dropdown    %{TEST_THEME_NAME}
     user opens details dropdown    %{TEST_TOPIC_NAME}
@@ -431,7 +431,7 @@ Go to "Sign off" to approve amended release for immediate publication
     user approves amended release for immediate publication
 
 Go to public Table Tool page for amendment
-    user goes to url    %{PUBLIC_URL}/data-tables
+    user navigates to public frontend    %{PUBLIC_URL}/data-tables
     user waits until h1 is visible    Create your own tables
 
 Select publication
@@ -503,7 +503,7 @@ Generate the new permalink
     Set Suite Variable    ${PERMA_LOCATION_URL_TWO}
 
 Go to new permalink
-    user goes to url    ${PERMA_LOCATION_URL_TWO}
+    user navigates to public frontend    ${PERMA_LOCATION_URL_TWO}
     user waits until h1 is visible    '${SUBJECT_NAME}' from '${PUBLICATION_NAME}'
     user checks page does not contain    WARNING - The data used in this permalink may be out-of-date.
     user checks page contains    Updating ${SUBJECT_NAME} footnote

--- a/tests/robot-tests/tests/general_public/fast_track.robot
+++ b/tests/robot-tests/tests/general_public/fast_track.robot
@@ -10,7 +10,7 @@ Test Setup          fail test fast if required
 *** Test Cases ***
 Navigate to publication release page
     environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}/find-statistics/pupil-absence-in-schools-in-england
+    user navigates to public frontend    %{PUBLIC_URL}/find-statistics/pupil-absence-in-schools-in-england
 
 Click fast track link for 'Pupil absence rates' data block
     user waits until h1 is visible    Pupil absence in schools in England

--- a/tests/robot-tests/tests/general_public/glossary_page.robot
+++ b/tests/robot-tests/tests/general_public/glossary_page.robot
@@ -9,8 +9,7 @@ Force Tags          GeneralPublic    Local    Dev    Test    Preprod    Prod
 
 *** Test Cases ***
 Navigate to glossary page
-    environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}
+    user navigates to public frontend
     user waits until h1 is visible    Explore our statistics and data
 
     user clicks link    Glossary

--- a/tests/robot-tests/tests/general_public/miscellaneous.robot
+++ b/tests/robot-tests/tests/general_public/miscellaneous.robot
@@ -9,8 +9,7 @@ Force Tags          GeneralPublic    Local    Dev    Test    Preprod    Prod
 
 *** Test Cases ***
 Verify public page loads
-    environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}
+    user navigates to public frontend
     user waits until page contains    Explore education statistics
 
 Verify can accept cookie banner
@@ -53,9 +52,9 @@ Validate homepage
 
 Validate Cookies page
     user clicks link    Cookies
-    user checks url contains    %{PUBLIC_URL}/cookies
-
     user waits until h1 is visible    Cookies on Explore education statistics    %{WAIT_MEDIUM}
+
+    user checks url contains    %{PUBLIC_URL}/cookies
 
     user checks breadcrumb count should be    2
     user checks nth breadcrumb contains    1    Home

--- a/tests/robot-tests/tests/general_public/notifications_absence.robot
+++ b/tests/robot-tests/tests/general_public/notifications_absence.robot
@@ -10,8 +10,7 @@ Test Setup          fail test fast if required
 *** Test Cases ***
 Navigate to Absence publication
     [Tags]    Local
-    environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}
+    user navigates to public frontend
     user waits until page contains    Explore our statistics and data
 
     user clicks link    Explore

--- a/tests/robot-tests/tests/general_public/permalink_prod_1.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_1.robot
@@ -12,7 +12,7 @@ Go to Table Tool page
     user navigates to data tables page on public frontend
 
 Go to permalink
-    user goes to url    %{PUBLIC_URL}/data-tables/permalink/30999037-fcd4-409f-9ff4-d3680da7402d
+    user navigates to public frontend    %{PUBLIC_URL}/data-tables/permalink/30999037-fcd4-409f-9ff4-d3680da7402d
     user waits until h1 is visible
     ...    'Total days missed due to fixed period exclusions' from 'Permanent and fixed-period exclusions in England'
 

--- a/tests/robot-tests/tests/general_public/permalink_prod_2.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_2.robot
@@ -12,7 +12,7 @@ Go to Table Tool page
     user navigates to data tables page on public frontend
 
 Go to permalink
-    user goes to url    %{PUBLIC_URL}/data-tables/permalink/edfe9f83-d1f0-40fc-8dce-9467a250c61b
+    user navigates to public frontend    %{PUBLIC_URL}/data-tables/permalink/edfe9f83-d1f0-40fc-8dce-9467a250c61b
     user waits until h1 is visible
     ...    'Exclusions by characteristic' from 'Permanent and fixed-period exclusions in England'
 

--- a/tests/robot-tests/tests/general_public/permalink_prod_3.robot
+++ b/tests/robot-tests/tests/general_public/permalink_prod_3.robot
@@ -12,7 +12,7 @@ Go to Table Tool page
     user navigates to data tables page on public frontend
 
 Go to permalink
-    user goes to url    %{PUBLIC_URL}/data-tables/permalink/c5688b39-2630-4de0-a143-725df9e48690
+    user navigates to public frontend    %{PUBLIC_URL}/data-tables/permalink/c5688b39-2630-4de0-a143-725df9e48690
     user waits until h1 is visible
     ...    'Exclusions by geographic level' from 'Permanent and fixed-period exclusions in England'
 

--- a/tests/robot-tests/tests/general_public/release_page_absence.robot
+++ b/tests/robot-tests/tests/general_public/release_page_absence.robot
@@ -10,9 +10,9 @@ Force Tags          GeneralPublic    Local    Dev    Preprod
 
 *** Test Cases ***
 Navigate to Absence publication
-    environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}
+    user navigates to public frontend
     user waits until page contains    Explore our statistics and data
+
     user clicks link    Explore
     user waits until page contains
     ...    Browse to find the statistics and data you’re looking for and open the section to get links to:

--- a/tests/robot-tests/tests/general_public/statistics_page.robot
+++ b/tests/robot-tests/tests/general_public/statistics_page.robot
@@ -11,9 +11,7 @@ Force Tags          GeneralPublic    Prod
 Navigate to Find Statistics page
     [Tags]    Local    Dev
     environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}/find-statistics
-    user waits until h1 is visible    Find statistics and data
-    user waits for page to finish loading
+    user navigates to find statistics page on public frontend
 
 check bootstrapped data
     [Tags]    Local    Dev    NotAgainstProd
@@ -28,10 +26,7 @@ check bootstrapped data
     user waits until page contains accordion section    UK education and training statistics
 
 Navigate to Find Statistics page
-    environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}/find-statistics
-    user waits until h1 is visible    Find statistics and data
-    user waits for page to finish loading
+    user navigates to find statistics page on public frontend
 
 Validate accordion sections exist
     user waits until page contains accordion section    Children's social care

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -8,8 +8,7 @@ user signs in as bau1
     IF    ${open_browser}
         user opens the browser
     END
-    environment variable should be set    ADMIN_URL
-    user goes to url    %{ADMIN_URL}
+    user navigates to admin frontend
     user waits until h1 is visible    Sign in    %{WAIT_MEDIUM}
     user signs in as    ADMIN
     user navigates to admin dashboard    Bau1
@@ -22,8 +21,7 @@ user signs in as analyst1
     IF    ${open_browser}
         user opens the browser
     END
-    environment variable should be set    ADMIN_URL
-    user goes to url    %{ADMIN_URL}
+    user navigates to admin frontend
     user waits until h1 is visible    Sign in
     user signs in as    ANALYST
     user navigates to admin dashboard    Analyst1
@@ -721,7 +719,7 @@ user removes release access from analyst
 
 user goes to manage user
     [Arguments]    ${EMAIL_ADDRESS}
-    user goes to url    %{ADMIN_URL}/administration/users
+    user navigates to admin frontend    %{ADMIN_URL}/administration/users
     user clicks link    Manage    xpath://td[text()="${EMAIL_ADDRESS}"]/..
     user waits until page does not contain loading spinner
     # stale element exception if you don't wait until it's enabled

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -93,7 +93,7 @@ user opens chrome headless
     Call Method    ${c_opts}    add_argument    disable-logging
 
     Create Webdriver    Chrome    crm_alias    chrome_options=${c_opts}
-    setup chromedriver
+    enable basic auth headers
 
 user opens chrome with xvfb
     start virtual display    1920    1080
@@ -105,7 +105,7 @@ user opens chrome with xvfb
     END
 
     create webdriver    Chrome    chrome_options=${options}
-    setup chromedriver
+    enable basic auth headers
     set window size    1920    1080
 
 user opens chrome without xvfb
@@ -116,7 +116,7 @@ user opens chrome without xvfb
     Call Method    ${c_opts}    add_argument    window-size\=1920,1080
     Call Method    ${c_opts}    add_argument    ignore-certificate-errors
     Create Webdriver    Chrome    crm_alias    chrome_options=${c_opts}
-    setup chromedriver
+    enable basic auth headers
     maximize browser window
 
 user opens firefox headless
@@ -138,7 +138,9 @@ user closes the browser
 
 user goes to url
     [Arguments]    ${destination}
-    go to    ${destination}
+    # Due to the need to set and unset basic auth for public and admin respectively, we now want to coerce any switches
+    # in test suites through "user navigates to public frontend" or "user navigates to admin frontend"
+    fail    Use 'user navigates to public frontend' or 'user navigates to admin frontend'
 
 user gets url
     ${url}=    get location
@@ -768,19 +770,24 @@ user checks page does not contain other release
     user checks page does not contain element
     ...    xpath://li[@data-testid="other-release-item"]/a[text()="${other_release_title}"]
 
+user navigates to admin frontend
+    [Arguments]    ${URL}=%{ADMIN_URL}
+    disable basic auth headers
+    go to    ${URL}
+
 user navigates to public frontend
-    environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}
-    user waits until h1 is visible    Explore our statistics and data
+    [Arguments]    ${URL}=%{PUBLIC_URL}
+    enable basic auth headers
+    go to    ${URL}
 
 user navigates to find statistics page on public frontend
     environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}/find-statistics
+    user navigates to public frontend    %{PUBLIC_URL}/find-statistics
     user waits until h1 is visible    Find statistics and data
 
 user navigates to data tables page on public frontend
     environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}/data-tables
+    user navigates to public frontend    %{PUBLIC_URL}/data-tables
     user waits until h1 is visible    Create your own tables
 
 check that variable is not empty

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -93,7 +93,6 @@ user opens chrome headless
     Call Method    ${c_opts}    add_argument    disable-logging
 
     Create Webdriver    Chrome    crm_alias    chrome_options=${c_opts}
-    enable basic auth headers
 
 user opens chrome with xvfb
     start virtual display    1920    1080
@@ -105,7 +104,6 @@ user opens chrome with xvfb
     END
 
     create webdriver    Chrome    chrome_options=${options}
-    enable basic auth headers
     set window size    1920    1080
 
 user opens chrome without xvfb
@@ -116,7 +114,6 @@ user opens chrome without xvfb
     Call Method    ${c_opts}    add_argument    window-size\=1920,1080
     Call Method    ${c_opts}    add_argument    ignore-certificate-errors
     Create Webdriver    Chrome    crm_alias    chrome_options=${c_opts}
-    enable basic auth headers
     maximize browser window
 
 user opens firefox headless
@@ -135,12 +132,6 @@ user opens firefox without xvfb
 
 user closes the browser
     close browser
-
-user goes to url
-    [Arguments]    ${destination}
-    # Due to the need to set and unset basic auth for public and admin respectively, we now want to coerce any switches
-    # in test suites through "user navigates to public frontend" or "user navigates to admin frontend"
-    fail    Use 'user navigates to public frontend' or 'user navigates to admin frontend'
 
 user gets url
     ${url}=    get location

--- a/tests/robot-tests/tests/libs/no_javascript.py
+++ b/tests/robot-tests/tests/libs/no_javascript.py
@@ -1,5 +1,7 @@
+import os
 import requests
 from bs4 import BeautifulSoup
+from robot.libraries.BuiltIn import BuiltIn
 
 requests.sessions.HTTPAdapter(
         pool_connections=50,
@@ -7,9 +9,10 @@ requests.sessions.HTTPAdapter(
         max_retries=3
     )
 session = requests.Session()
+httpBasicAuth = requests.auth.HTTPBasicAuth
 
 def user_gets_parsed_html_from_page(url):
-    response = session.get(url, stream=True)
+    response = session.get(url, stream=False, auth=httpBasicAuth(os.getenv('PUBLIC_AUTH_USER'), os.getenv('PUBLIC_AUTH_PASSWORD')))
     return BeautifulSoup(response.text, "html.parser")
 
 

--- a/tests/robot-tests/tests/libs/public-common.robot
+++ b/tests/robot-tests/tests/libs/public-common.robot
@@ -36,7 +36,7 @@ user goes to release page via breadcrumb
 
 user navigates to public methodologies page
     environment variable should be set    PUBLIC_URL
-    user goes to url    %{PUBLIC_URL}/methodology
+    user navigates to public frontend    %{PUBLIC_URL}/methodology
     user waits until h1 is visible    Methodologies
 
 user checks methodology note

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -52,7 +52,7 @@ if not utilities_init.initialised:
     utilities_init.initialised = True
 
 
-def setup_chromedriver():
+def enable_basic_auth_headers():
     # Setup basic auth headers for public frontend
     public_auth_user = os.getenv('PUBLIC_AUTH_USER')
     public_auth_password = os.getenv('PUBLIC_AUTH_PASSWORD')
@@ -66,6 +66,11 @@ def setup_chromedriver():
                 'Authorization': f'Basic {token.decode()}'
             }
         })
+
+
+def disable_basic_auth_headers():
+    # Must be disabled to visit admin frontend
+    sl.driver.execute_cdp_cmd('Network.disable', {})
 
 
 def raise_assertion_error(err_msg):
@@ -331,6 +336,7 @@ def user_is_on_admin_dashboard_with_theme_and_topic_selected(admin_url: str, the
 
 
 def user_navigates_to_admin_dashboard_if_needed(admin_url: str):
+    disable_basic_auth_headers()
     if user_is_on_admin_dashboard(admin_url):
         return
 


### PR DESCRIPTION
Apart from a couple of small fixes, this PR makes a larger change to make sure basic auth headers aree enabled / disabled for public / admin respectively, as if they're set when you try to visit the admin frontend, you get a blank screen.

To solve this issue, we've created keywords `user navigates to public frontend` and `user navigates to admin frontend` and tried to coerce switches from public to admin or vice versa through those keywords. We've also made `user goes to url` throw an error so it's clear that the new keywords should be used in future.