### PR TITLE
EES-2844 Fix table headers alignments for row/col headers with large cross spans

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/MultiHeaderTable.tsx
@@ -1,16 +1,15 @@
 import Header from '@common/modules/table-tool/components/utils/Header';
 import classNames from 'classnames';
 import last from 'lodash/last';
-import React, { forwardRef } from 'react';
+import sumBy from 'lodash/sumBy';
+import React, { forwardRef, useMemo } from 'react';
 import styles from './MultiHeaderTable.module.scss';
 
 interface ExpandedHeader {
   id: string;
   text: string;
-  start: number;
   span: number;
   crossSpan: number;
-  isHidden: boolean;
   isGroup: boolean;
 }
 
@@ -24,109 +23,134 @@ export interface MultiHeaderTableProps {
 
 const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
   ({ ariaLabelledBy, className, columnHeaders, rowHeaders, rows }, ref) => {
-    const createExpandedHeaders = (headers: Header[]): ExpandedHeader[][] => {
-      const createExpandedHeader = (
-        header: Header,
-        expandedHeaders: ExpandedHeader[][],
-      ): ExpandedHeader => {
-        const { depth } = header;
-        const previousSibling = last(expandedHeaders[depth]);
+    // We 'expand' our headers so that we create the real table
+    // cells we need to render in array format (instead of a tree).
+    const expandedColumnHeaders = useMemo(() => {
+      const acc: ExpandedHeader[][] = [];
 
-        const newExpandedHeader = {
-          id: header.id,
-          text: header.text,
-          start: previousSibling
-            ? previousSibling.start + previousSibling.span
-            : 0,
-          span: header.span,
-          crossSpan: 1,
-          isHidden: false,
-          isGroup: header.hasChildren(),
-        };
+      // To construct these headers, we use a breadth-first
+      // search algorithm, consequently, we need a 'queue' to
+      // track the correct order of header nodes as we process
+      // them (queues have first in, first out ordering).
+      const queue = [...columnHeaders];
 
-        // Header and its parents appear identical
-        // so we can merge them together.
-        if (
-          header.text === header.parent?.text &&
-          header.span === header.parent?.span
-        ) {
-          const parent = expandedHeaders[depth - 1]?.find(
-            expandedHeader => expandedHeader.start === newExpandedHeader.start,
-          );
+      let currentDepth = 0;
+      let row: ExpandedHeader[] = [];
 
-          if (parent) {
-            newExpandedHeader.isHidden = true;
+      while (queue.length > 0) {
+        const current = queue.shift();
 
-            // Need to modify parent so that it can take
-            // up the position of the child header.
-            parent.crossSpan += 1;
-            parent.isGroup = newExpandedHeader.isGroup;
+        if (!current) {
+          break;
+        }
+
+        // We're moving to the next level of the tree, so
+        // we are now finished on the last row and should push it.
+        if (currentDepth !== current.depth) {
+          acc.push(row);
+
+          row = [];
+          currentDepth = current.depth;
+        }
+
+        const { parent } = current;
+
+        // If the current header's parent appears identical to it,
+        // the parent will have a cross span higher than 1.
+        // In this case, we shouldn't add the current header to the row
+        // as the parent will have already been added to the row above
+        // and is supposed to be merged with the current header.
+        if (!parent || parent?.crossSpan === 1) {
+          row.push({
+            id: current.id,
+            text: current.text,
+            span: current.span,
+            isGroup: current.hasChildren(),
+            crossSpan: current.crossSpan,
+          });
+        }
+
+        if (current.hasChildren()) {
+          queue.push(...current.children);
+        }
+
+        // There are no more children to iterate
+        // through so push the final row.
+        if (queue.length === 0) {
+          acc.push(row);
+          row = [];
+        }
+      }
+
+      return acc;
+    }, [columnHeaders]);
+
+    const expandedRowHeaders = useMemo(() => {
+      return rowHeaders.reduce<ExpandedHeader[][]>((acc, header) => {
+        // To construct these headers, we use a depth-first
+        // search algorithm. This requires a 'stack' to
+        // track the correct order of header nodes as we process
+        // them (stacks have last in, first out ordering).
+        const stack = [header];
+
+        let row: ExpandedHeader[] = [];
+
+        while (stack.length > 0) {
+          const current = stack.shift();
+
+          if (!current) {
+            break;
+          }
+
+          const prev = last(row);
+
+          // We only add the current header to the row if we know
+          // that the previous header doesn't match it.
+          // Otherwise, we want the previous header to span
+          // across where the current header would be in the row.
+          if (prev?.text !== current?.text || prev?.crossSpan === 1) {
+            row.push({
+              id: current.id,
+              text: current.text,
+              span: current.span,
+              isGroup: current.hasChildren(),
+              crossSpan: current.crossSpan,
+            });
+          } else if (!current.hasChildren() && prev.crossSpan > 1) {
+            // This one is a bit weird, but we have to directly update
+            // the previous header's `isGroup` to allow the header
+            // to have `scope="row"` in the table i.e. it's the
+            // header cell directly adjacent to non-header cells.
+            prev.isGroup = false;
+          }
+
+          if (current.hasChildren()) {
+            stack.unshift(...current.children);
+          } else {
+            // The following is a bit of an edge case, but it's worth handling.
+            // We get the previous row's final header span so that we can
+            // determine if the previous row is going to span more than
+            // one row across all of its headers.
+            // This means that these following row positions should be
+            // completely empty and we want to avoid placing our current
+            // row into any of these positions.
+            const prevSpan = last(last(acc))?.span ?? 0;
+            const index = acc.length > 0 ? acc.length - 1 + prevSpan : 0;
+
+            acc[index] = row;
+
+            row = [];
           }
         }
 
-        return newExpandedHeader;
-      };
-
-      const addExpandedChildren = (
-        acc: ExpandedHeader[][],
-        children: Header[],
-      ): ExpandedHeader[][] => {
-        children.forEach(child => {
-          const { depth } = child;
-
-          if (!acc[depth]) {
-            acc[depth] = [createExpandedHeader(child, acc)];
-          } else {
-            acc[depth].push(createExpandedHeader(child, acc));
-          }
-
-          if (child.hasChildren()) {
-            addExpandedChildren(acc, child.children);
-          }
-        });
-
-        return acc;
-      };
-
-      return headers.reduce<ExpandedHeader[][]>((acc, header) => {
-        const { depth } = header;
-
-        if (!acc[depth]) {
-          acc[depth] = [createExpandedHeader(header, acc)];
-        } else {
-          acc[depth].push(createExpandedHeader(header, acc));
-        }
-
-        return addExpandedChildren(acc, header.children);
-      }, []);
-    };
-
-    const expandedRowHeaders = createExpandedHeaders(rowHeaders);
-    const expandedColumnHeaders = createExpandedHeaders(columnHeaders);
-
-    const firstRowHeaderLength = expandedRowHeaders[0].length;
-
-    // Expanded headers need to be transposed so that
-    // they are compatible with HTML table rows.
-    const transposeToRows = (
-      headerGroups: ExpandedHeader[][],
-    ): ExpandedHeader[][] => {
-      return headerGroups.reduce<ExpandedHeader[][]>((acc, headerGroup) => {
-        headerGroup.forEach(header => {
-          if (acc[header.start]) {
-            acc[header.start].push(header);
-          } else {
-            acc[header.start] = [header];
-          }
-        });
-
         return acc;
       }, []);
-    };
+    }, [rowHeaders]);
 
-    const transposedRowHeaders = transposeToRows(
-      expandedRowHeaders,
-    ) as ExpandedHeader[][];
+    const rowHeaderColumnLength = sumBy(
+      expandedRowHeaders[0],
+      header => header.crossSpan,
+    );
 
     return (
       <table
@@ -142,28 +166,31 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
               <tr key={rowIndex}>
                 {rowIndex === 0 && (
                   <td
-                    colSpan={expandedRowHeaders.length}
+                    colSpan={rowHeaderColumnLength}
                     rowSpan={expandedColumnHeaders.length}
                     className={styles.borderBottom}
                   />
                 )}
 
-                {columns
-                  .filter(column => !column.isHidden)
-                  .map((column, columnIndex) => {
-                    const key = `${column.text}_${columnIndex}`;
+                {columns.map((column, columnIndex) => {
+                  const key = `${column.text}_${columnIndex}`;
 
-                    return (
-                      <th
-                        colSpan={column.span}
-                        rowSpan={column.crossSpan}
-                        scope={column.isGroup ? 'colgroup' : 'col'}
-                        key={key}
-                      >
-                        {column.text}
-                      </th>
-                    );
-                  })}
+                  return (
+                    <th
+                      colSpan={column.span}
+                      rowSpan={column.crossSpan}
+                      scope={
+                        rowIndex + column.crossSpan !==
+                        expandedColumnHeaders.length
+                          ? 'colgroup'
+                          : 'col'
+                      }
+                      key={key}
+                    >
+                      {column.text}
+                    </th>
+                  );
+                })}
               </tr>
             );
           })}
@@ -173,9 +200,8 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
           {rows.map((row, rowIndex) => (
             // eslint-disable-next-line react/no-array-index-key
             <tr key={rowIndex}>
-              {transposedRowHeaders[rowIndex]
-                ?.filter(header => !header.isHidden)
-                ?.map((header, headerIndex) => (
+              {expandedRowHeaders[rowIndex]?.map((header, headerIndex) => {
+                return (
                   <th
                     // eslint-disable-next-line react/no-array-index-key
                     key={headerIndex}
@@ -188,7 +214,8 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
                   >
                     {header.text}
                   </th>
-                ))}
+                );
+              })}
 
               {row.map((cell, cellIndex) => (
                 <td
@@ -196,7 +223,7 @@ const MultiHeaderTable = forwardRef<HTMLTableElement, MultiHeaderTableProps>(
                   key={cellIndex}
                   className={classNames('govuk-table__cell--numeric', {
                     [styles.borderBottom]:
-                      (rowIndex + 1) % firstRowHeaderLength === 0,
+                      (rowIndex + 1) % rowHeaders.length === 0,
                   })}
                 >
                   {cell}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/MultiHeaderTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/MultiHeaderTable.test.tsx
@@ -807,6 +807,44 @@ describe('MultiHeaderTable', () => {
     expect(container.innerHTML).toMatchSnapshot();
   });
 
+  test('renders table with `rowgroup` header merged with multiple identical parents', () => {
+    const { container } = render(
+      <MultiHeaderTable
+        columnHeaders={[new Header('1', '1'), new Header('2', '2')]}
+        rowHeaders={[
+          new Header('A', 'A').addChild(
+            new Header('B', 'B').addChild(new Header('C', 'C')),
+          ),
+          new Header('D', 'D').addChild(
+            new Header('D', 'D').addChild(new Header('D', 'D')),
+          ),
+          new Header('F', 'F').addChild(
+            new Header('G', 'G').addChild(new Header('H', 'H')),
+          ),
+        ]}
+        rows={[
+          ['ABC1', 'ABC2'],
+          ['DDD1', 'DDD2'],
+          ['FGH1', 'FGH2'],
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(3);
+    expect(container.querySelectorAll('tbody td')).toHaveLength(6);
+
+    // Row 2
+    const row2Headers = container.querySelectorAll('tbody tr:nth-child(2) th');
+    expect(row2Headers).toHaveLength(1);
+
+    expect(row2Headers[0]).toHaveTextContent('D');
+    expect(row2Headers[0]).toHaveAttribute('scope', 'row');
+    expect(row2Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row2Headers[0]).toHaveAttribute('colspan', '3');
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
   test('renders table with `rowgroup` header merged with identical parent on first row', () => {
     const { container } = render(
       <MultiHeaderTable
@@ -1191,6 +1229,83 @@ describe('MultiHeaderTable', () => {
     expect(row2Headers[1]).toHaveAttribute('scope', 'colgroup');
     expect(row2Headers[1]).toHaveAttribute('rowspan', '1');
     expect(row2Headers[1]).toHaveAttribute('colspan', '1');
+
+    expect(container.innerHTML).toMatchSnapshot();
+  });
+
+  test('renders table with `colgroup` header merged with multiple identical parents', () => {
+    const { container } = render(
+      <MultiHeaderTable
+        columnHeaders={[
+          new Header('B', 'B').addChild(
+            new Header('A', 'A').addChild(new Header('F', 'F')),
+          ),
+          new Header('C', 'C').addChild(
+            new Header('C', 'C').addChild(new Header('C', 'C')),
+          ),
+          new Header('D', 'D').addChild(
+            new Header('E', 'E').addChild(new Header('F', 'F')),
+          ),
+        ]}
+        rowHeaders={[new Header('1', '1'), new Header('2', '2')]}
+        rows={[
+          ['BAF1', 'CCC1', 'DEF1'],
+          ['BAF2', 'CCC2', 'DEF2'],
+        ]}
+      />,
+    );
+
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2);
+    expect(container.querySelectorAll('tbody td')).toHaveLength(6);
+
+    expect(container.querySelectorAll('thead tr')).toHaveLength(3);
+
+    // Row 1
+    const row1Headers = container.querySelectorAll('thead tr:nth-child(1) th');
+    expect(row1Headers).toHaveLength(3);
+
+    expect(row1Headers[0]).toHaveTextContent('B');
+    expect(row1Headers[0]).toHaveAttribute('scope', 'colgroup');
+    expect(row1Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row1Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row1Headers[1]).toHaveTextContent('C');
+    expect(row1Headers[1]).toHaveAttribute('scope', 'col');
+    expect(row1Headers[1]).toHaveAttribute('rowspan', '3');
+    expect(row1Headers[1]).toHaveAttribute('colspan', '1');
+
+    expect(row1Headers[2]).toHaveTextContent('D');
+    expect(row1Headers[2]).toHaveAttribute('scope', 'colgroup');
+    expect(row1Headers[2]).toHaveAttribute('rowspan', '1');
+    expect(row1Headers[2]).toHaveAttribute('colspan', '1');
+
+    // Row 2
+    const row2Headers = container.querySelectorAll('thead tr:nth-child(2) th');
+    expect(row2Headers).toHaveLength(2);
+
+    expect(row2Headers[0]).toHaveTextContent('A');
+    expect(row2Headers[0]).toHaveAttribute('scope', 'colgroup');
+    expect(row2Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row2Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row2Headers[1]).toHaveTextContent('E');
+    expect(row2Headers[1]).toHaveAttribute('scope', 'colgroup');
+    expect(row2Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row2Headers[1]).toHaveAttribute('colspan', '1');
+
+    // Row 3
+    const row3Headers = container.querySelectorAll('thead tr:nth-child(3) th');
+    expect(row3Headers).toHaveLength(2);
+
+    expect(row3Headers[0]).toHaveTextContent('F');
+    expect(row3Headers[0]).toHaveAttribute('scope', 'col');
+    expect(row3Headers[0]).toHaveAttribute('rowspan', '1');
+    expect(row3Headers[0]).toHaveAttribute('colspan', '1');
+
+    expect(row3Headers[1]).toHaveTextContent('F');
+    expect(row3Headers[1]).toHaveAttribute('scope', 'col');
+    expect(row3Headers[1]).toHaveAttribute('rowspan', '1');
+    expect(row3Headers[1]).toHaveAttribute('colspan', '1');
 
     expect(container.innerHTML).toMatchSnapshot();
   });

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/MultiHeaderTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/MultiHeaderTable.test.tsx.snap
@@ -1204,6 +1204,104 @@ exports[`MultiHeaderTable renders table with \`colgroup\` header merged with ide
 </table>
 `;
 
+exports[`MultiHeaderTable renders table with \`colgroup\` header merged with multiple identical parents 1`] = `
+<table class="govuk-table table">
+  <thead class="tableHead">
+    <tr>
+      <td colspan="1"
+          rowspan="3"
+          class="borderBottom"
+      >
+      </td>
+      <th colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        B
+      </th>
+      <th colspan="1"
+          rowspan="3"
+          scope="col"
+      >
+        C
+      </th>
+      <th colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        D
+      </th>
+    </tr>
+    <tr>
+      <th colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        A
+      </th>
+      <th colspan="1"
+          rowspan="1"
+          scope="colgroup"
+      >
+        E
+      </th>
+    </tr>
+    <tr>
+      <th colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        F
+      </th>
+      <th colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        F
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        1
+      </th>
+      <td class="govuk-table__cell--numeric">
+        BAF1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        CCC1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        DEF1
+      </td>
+    </tr>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        2
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        BAF2
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        CCC2
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        DEF2
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
 exports[`MultiHeaderTable renders table with \`row\` header merged with identical parent 1`] = `
 <table class="govuk-table table">
   <thead class="tableHead">
@@ -1710,6 +1808,107 @@ exports[`MultiHeaderTable renders table with \`rowgroup\` header merged with ide
       </td>
       <td class="govuk-table__cell--numeric borderBottom">
         DEF2
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`MultiHeaderTable renders table with \`rowgroup\` header merged with multiple identical parents 1`] = `
+<table class="govuk-table table">
+  <thead class="tableHead">
+    <tr>
+      <td colspan="3"
+          rowspan="1"
+          class="borderBottom"
+      >
+      </td>
+      <th colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        1
+      </th>
+      <th colspan="1"
+          rowspan="1"
+          scope="col"
+      >
+        2
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        A
+      </th>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        B
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        C
+      </th>
+      <td class="govuk-table__cell--numeric">
+        ABC1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        ABC2
+      </td>
+    </tr>
+    <tr>
+      <th class
+          rowspan="1"
+          colspan="3"
+          scope="row"
+      >
+        D
+      </th>
+      <td class="govuk-table__cell--numeric">
+        DDD1
+      </td>
+      <td class="govuk-table__cell--numeric">
+        DDD2
+      </td>
+    </tr>
+    <tr>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        F
+      </th>
+      <th class="borderBottom"
+          rowspan="1"
+          colspan="1"
+          scope="rowgroup"
+      >
+        G
+      </th>
+      <th class
+          rowspan="1"
+          colspan="1"
+          scope="row"
+      >
+        H
+      </th>
+      <td class="govuk-table__cell--numeric borderBottom">
+        FGH1
+      </td>
+      <td class="govuk-table__cell--numeric borderBottom">
+        FGH2
       </td>
     </tr>
   </tbody>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/Header.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/Header.ts
@@ -13,7 +13,7 @@ export default class Header {
 
   public span = 1;
 
-  public children: Header[] = [];
+  public readonly children: Header[] = [];
 
   public parent?: Header;
 
@@ -22,16 +22,39 @@ export default class Header {
     this.text = text;
   }
 
-  private updateSpan(): void {
-    this.span = sum(this.children.map(child => child.span));
-
-    if (this.parent) {
-      this.parent.updateSpan();
+  public get depth(): number {
+    if (!this.parent) {
+      return 0;
     }
+
+    return this.parent?.depth + 1;
+  }
+
+  public get crossSpan(): number {
+    if (this.children.length > 1) {
+      return 1;
+    }
+
+    let crossSpan = 1;
+    let child = this.getFirstChild();
+
+    while (child) {
+      if (child.text === this.text && child.span === this.span) {
+        crossSpan += 1;
+      }
+
+      if (child.children.length === 1) {
+        child = child.getFirstChild();
+      } else {
+        child = undefined;
+      }
+    }
+
+    return crossSpan;
   }
 
   public addChild(child: Header): this {
-    const lastChild = last(this.children);
+    const lastChild = this.getLastChild();
 
     if (lastChild?.id === child.id) {
       lastChild.span += child.span;
@@ -41,9 +64,20 @@ export default class Header {
       this.children.push(child);
     }
 
-    this.updateSpan();
+    this.span = sum(this.children.map(c => c.span));
+
+    this.updateParent();
 
     return this;
+  }
+
+  private updateParent(): void {
+    let { parent } = this;
+
+    while (parent) {
+      parent.span = sum(parent.children.map(child => child.span));
+      parent = parent.parent;
+    }
   }
 
   public addChildToLastParent(child: Header, depth: number) {
@@ -58,20 +92,36 @@ export default class Header {
     return parent.addChild(child);
   }
 
-  public get depth(): number {
-    if (!this.parent) {
-      return 0;
-    }
-
-    return this.parent?.depth + 1;
-  }
-
   public hasChildren(): boolean {
     return this.children.length > 0;
   }
 
+  public getFirstChild(): Header | undefined {
+    return this.children[0];
+  }
+
   public getLastChild(): Header | undefined {
     return last(this.children);
+  }
+
+  public getPrevSibling(): Header | undefined {
+    if (!this.parent) {
+      return undefined;
+    }
+
+    const index = this.parent.children.indexOf(this);
+
+    return this.parent.children[index - 1];
+  }
+
+  public getNextSibling(): Header | undefined {
+    if (!this.parent) {
+      return undefined;
+    }
+
+    const index = this.parent.children.indexOf(this);
+
+    return this.parent.children[index + 1];
   }
 
   public getLastParent(depth = 0): Header | undefined {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/Header.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/Header.test.ts
@@ -16,7 +16,99 @@ describe('Header', () => {
     );
   });
 
+  describe('crossSpan', () => {
+    test('returns 2 if has identical child', () => {
+      const header = new Header('1', '1').addChild(new Header('1', '1'));
+
+      expect(header.crossSpan).toBe(2);
+    });
+
+    test('returns 1 if has identical and non-identical children', () => {
+      const header = new Header('1', '1')
+        .addChild(new Header('1', '1'))
+        .addChild(new Header('2', '2'));
+
+      expect(header.crossSpan).toBe(1);
+    });
+
+    test('returns 1 if has identical and non-identical children (in reverse order)', () => {
+      const header = new Header('1', '1')
+        .addChild(new Header('2', '2'))
+        .addChild(new Header('1', '1'));
+
+      expect(header.crossSpan).toBe(1);
+    });
+
+    test('returns 3 if has identical child and grandchild', () => {
+      const header = new Header('1', '1').addChild(
+        new Header('1', '1').addChild(new Header('1', '1')),
+      );
+
+      expect(header.crossSpan).toBe(3);
+    });
+
+    test('returns 2 if has identical child, and identical and non-identical grandchildren', () => {
+      const header = new Header('1', '1').addChild(
+        new Header('1', '1')
+          .addChild(new Header('1', '1'))
+          .addChild(new Header('2', '2')),
+      );
+
+      expect(header.crossSpan).toBe(2);
+    });
+
+    test('returns 2 if has identical child, and identical and non-identical grandchildren (in reverse order)', () => {
+      const header = new Header('1', '1').addChild(
+        new Header('1', '1')
+          .addChild(new Header('2', '2'))
+          .addChild(new Header('1', '1')),
+      );
+
+      expect(header.crossSpan).toBe(2);
+    });
+  });
+
   describe('addChild', () => {
+    const testTreeWithSymmetricAdjacentBranches = () =>
+      new Header('0', 'Header 0')
+        .addChild(
+          new Header('0a', 'Header 0a')
+            .addChild(
+              new Header('0a-1a', 'Header 0a-1a')
+                .addChild(new Header('0a-1a-2a', 'Header 0a-1a-2a'))
+                .addChild(new Header('0a-1a-2b', 'Header 0a-1a-2b')),
+            )
+            .addChild(
+              new Header('0a-1b', 'Header 0a-1b')
+                .addChild(new Header('0a-1b-2a', 'Header 0a-1b-2a'))
+                .addChild(new Header('0a-1b-2b', 'Header 0a-1b-2b')),
+            )
+            .addChild(
+              new Header('0a-1c', 'Header 0a-1c')
+                .addChild(new Header('0a-1c-2a', 'Header 0a-1c-2a'))
+                .addChild(new Header('0a-1c-2b', 'Header 0a-1c-2b')),
+            ),
+        )
+        .addChild(new Header('0b', 'Header 0b'));
+
+    const testTreeWithAsymmetricAdjacentBranches = () =>
+      new Header('0', 'Header 0')
+        .addChild(
+          new Header('0a', 'Header 0a')
+            .addChild(
+              new Header('0a-1a', 'Header 0a-1a')
+                .addChild(new Header('0a-1a-2a', 'Header 0a-1a-2a'))
+                .addChild(new Header('0a-1a-2b', 'Header 0a-1a-2b')),
+            )
+            .addChild(new Header('0a-1b', 'Header 0a-1b'))
+            .addChild(
+              new Header('0a-1c', 'Header 0a-1c')
+                .addChild(new Header('0a-1c-2a', 'Header 0a-1c-2a'))
+                .addChild(new Header('0a-1c-2b', 'Header 0a-1c-2b')),
+            ),
+        )
+        .addChild(new Header('0b', 'Header 0b'));
+
     test('increases `span` of the last child if the `id` matches', () => {
       const header = new Header('0', 'Header 0').addChild(
         new Header('0a', 'Header 0a'),
@@ -65,26 +157,12 @@ describe('Header', () => {
       expect(header.span).toBe(2);
     });
 
-    test('increases `span` correctly when there are nested children', () => {
-      const header = new Header('0', 'Header 0')
-        .addChild(
-          new Header('0a', 'Header 0a')
-            .addChild(
-              new Header('0a-1a', 'Header 0a-1a')
-                .addChild(new Header('0a-1a-2a', 'Header 0a-1a-2a'))
-                .addChild(new Header('0a-1a-2b', 'Header 0a-1a-2b')),
-            )
-            .addChild(
-              new Header('0a-1b', 'Header 0a-1b')
-                .addChild(new Header('0a-1b-2a', 'Header 0a-1b-2a'))
-                .addChild(new Header('0a-1b-2b', 'Header 0a-1b-2b')),
-            ),
-        )
-        .addChild(new Header('0b', 'Header 0b'));
+    test('updates `span` recursively for tree with symmetric adjacent branches', () => {
+      const header = testTreeWithSymmetricAdjacentBranches();
 
-      expect(header.span).toBe(5);
+      expect(header.span).toBe(7);
 
-      expect(header.children[0].span).toBe(4);
+      expect(header.children[0].span).toBe(6);
 
       expect(header.children[0].children[0].span).toBe(2);
       expect(header.children[0].children[0].children[0].span).toBe(1);
@@ -93,6 +171,30 @@ describe('Header', () => {
       expect(header.children[0].children[1].span).toBe(2);
       expect(header.children[0].children[1].children[0].span).toBe(1);
       expect(header.children[0].children[1].children[1].span).toBe(1);
+
+      expect(header.children[0].children[2].span).toBe(2);
+      expect(header.children[0].children[2].children[0].span).toBe(1);
+      expect(header.children[0].children[2].children[1].span).toBe(1);
+
+      expect(header.children[1].span).toBe(1);
+    });
+
+    test('updates `span` recursively for tree with asymmetric adjacent branches', () => {
+      const header = testTreeWithAsymmetricAdjacentBranches();
+
+      expect(header.span).toBe(6);
+
+      expect(header.children[0].span).toBe(5);
+
+      expect(header.children[0].children[0].span).toBe(2);
+      expect(header.children[0].children[0].children[0].span).toBe(1);
+      expect(header.children[0].children[0].children[1].span).toBe(1);
+
+      expect(header.children[0].children[1].span).toBe(1);
+
+      expect(header.children[0].children[2].span).toBe(2);
+      expect(header.children[0].children[2].children[0].span).toBe(1);
+      expect(header.children[0].children[2].children[1].span).toBe(1);
 
       expect(header.children[1].span).toBe(1);
     });
@@ -163,46 +265,150 @@ describe('Header', () => {
   });
 
   describe('getLastParent', () => {
-    const header = new Header('0', 'Header 0')
-      .addChild(new Header('0a', 'Header 0a'))
-      .addChild(
-        new Header('0b', 'Header 0b')
-          .addChild(
-            new Header('0b-1a', 'Header 0b-1a')
-              .addChild(new Header('0b-1a-2a', 'Header 0b-1a-2a'))
-              .addChild(new Header('0b-1a-2b', 'Header 0b-1a-2b')),
-          )
-          .addChild(
-            new Header('0b-1b', 'Header 0b-1b')
-              .addChild(new Header('0b-1b-2a', 'Header 0b-1b-2a'))
-              .addChild(new Header('0b-1b-2b', 'Header 0b-1b-2b')),
-          ),
-      );
+    const testHeader = () =>
+      new Header('0', 'Header 0')
+        .addChild(new Header('0a', 'Header 0a'))
+        .addChild(
+          new Header('0b', 'Header 0b')
+            .addChild(
+              new Header('0b-1a', 'Header 0b-1a')
+                .addChild(new Header('0b-1a-2a', 'Header 0b-1a-2a'))
+                .addChild(new Header('0b-1a-2b', 'Header 0b-1a-2b')),
+            )
+            .addChild(
+              new Header('0b-1b', 'Header 0b-1b')
+                .addChild(new Header('0b-1b-2a', 'Header 0b-1b-2a'))
+                .addChild(new Header('0b-1b-2b', 'Header 0b-1b-2b')),
+            ),
+        );
 
     test('returns root for depth = 0', () => {
-      expect(header.getLastParent(0)?.id).toBe('0');
+      expect(testHeader().getLastParent(0)?.id).toBe('0');
     });
 
     test('returns root when depth < 0', () => {
-      expect(header.getLastParent(-1)?.id).toBe('0');
-      expect(header.getLastParent(-2)?.id).toBe('0');
+      expect(testHeader().getLastParent(-1)?.id).toBe('0');
+      expect(testHeader().getLastParent(-2)?.id).toBe('0');
     });
 
     test('returns last parent for depth = 1', () => {
-      expect(header.getLastParent(1)?.id).toBe('0b');
+      expect(testHeader().getLastParent(1)?.id).toBe('0b');
     });
 
     test('returns last parent for depth = 2', () => {
-      expect(header.getLastParent(2)?.id).toBe('0b-1b');
+      expect(testHeader().getLastParent(2)?.id).toBe('0b-1b');
     });
 
     test('returns last parent for depth = 3', () => {
-      expect(header.getLastParent(3)?.id).toBe('0b-1b-2b');
+      expect(testHeader().getLastParent(3)?.id).toBe('0b-1b-2b');
     });
 
     test('returns undefined if depth is too high', () => {
-      expect(header.getLastParent(4)).toBeUndefined();
-      expect(header.getLastParent(5)).toBeUndefined();
+      expect(testHeader().getLastParent(4)).toBeUndefined();
+      expect(testHeader().getLastParent(5)).toBeUndefined();
+    });
+  });
+
+  describe('getPrevSibling', () => {
+    test('returns previous sibling', () => {
+      const header = new Header('0b', 'Header 0b');
+
+      new Header('0', 'Header 0')
+        .addChild(new Header('0a', 'Header 0a'))
+        .addChild(header)
+        .addChild(new Header('0c', 'Header 0c'));
+
+      expect(header.getPrevSibling()?.id).toEqual('0a');
+    });
+
+    test('returns previous sibling for nested child', () => {
+      const header = new Header('0a-1b', 'Header 0a-1b');
+
+      new Header('0', 'Header 0').addChild(
+        new Header('0a', 'Header 0a')
+          .addChild(new Header('0a-1a', 'Header 0a-1a'))
+          .addChild(header)
+          .addChild(new Header('0a-1c', 'Header 0a-1c')),
+      );
+
+      expect(header.getPrevSibling()?.id).toEqual('0a-1a');
+    });
+
+    test('returns undefined when there is previous sibling', () => {
+      const header = new Header('0b', 'Header 0a');
+
+      new Header('0', 'Header 0')
+        .addChild(header)
+        .addChild(new Header('0b', 'Header 0b'))
+        .addChild(new Header('0c', 'Header 0c'));
+
+      expect(header.getPrevSibling()).toBeUndefined();
+    });
+
+    test('returns undefined when there is no previous sibling to nested child', () => {
+      const header = new Header('0a-1a', 'Header 0a-1a');
+
+      new Header('0', 'Header 0').addChild(
+        new Header('0a', 'Header 0a')
+          .addChild(header)
+          .addChild(new Header('0a-1b', 'Header 0a-1b'))
+          .addChild(new Header('0a-1c', 'Header 0a-1c')),
+      );
+
+      expect(header.getPrevSibling()).toBeUndefined();
+    });
+
+    test('returns undefined when there are no siblings', () => {
+      const header = new Header('0a', 'Header 0a');
+
+      new Header('0', 'Header 0').addChild(header);
+
+      expect(header.getPrevSibling()?.id).toBeUndefined();
+    });
+  });
+
+  describe('getNextSibling', () => {
+    test('returns next sibling', () => {
+      const header = new Header('0b', 'Header 0b');
+
+      new Header('0', 'Header 0')
+        .addChild(new Header('0a', 'Header 0a'))
+        .addChild(header)
+        .addChild(new Header('0c', 'Header 0c'));
+
+      expect(header.getNextSibling()?.id).toEqual('0c');
+    });
+
+    test('returns undefined when there is no next sibling', () => {
+      const header = new Header('0b', 'Header 0a');
+
+      new Header('0', 'Header 0')
+        .addChild(new Header('0a', 'Header 0a'))
+        .addChild(new Header('0b', 'Header 0b'))
+        .addChild(header);
+
+      expect(header.getNextSibling()).toBeUndefined();
+    });
+
+    test('returns undefined when there is no next sibling to nested child', () => {
+      const header = new Header('0a-1c', 'Header 0a-1c');
+
+      new Header('0', 'Header 0').addChild(
+        new Header('0a', 'Header 0a')
+          .addChild(new Header('0a-1a', 'Header 0a-1a'))
+          .addChild(new Header('0a-1b', 'Header 0a-1b'))
+          .addChild(header),
+      );
+
+      expect(header.getNextSibling()).toBeUndefined();
+    });
+
+    test('returns undefined when there are no siblings', () => {
+      const header = new Header('0b', 'Header 0a');
+
+      new Header('0', 'Header 0').addChild(header);
+
+      expect(header.getNextSibling()?.id).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
This PR fixes table cell misalignment that was being caused by row/col headers not taking up the correct cross span. This was caused by a bug meaning that headers only had a max cross span of 2. We have now fixed this so that headers take up the correct cross spans and fill the table cells correctly.

Ironically, due to recent changes limiting the table tool's maximum number of filters, it's not really possible to generate the table that demonstrates the issue in the ticket anymore.

## Relevant changes

- Refactored most of `MultiHeaderTable` to construct it's expanded headers in a more imperative way. This is hopefully a little simpler to understand as there's less going on. It also allows us to take advantage of breadth/depth first search algorithms to try improve performance.

## Screenshots

![image](https://user-images.githubusercontent.com/9917868/142331621-9cdb4cac-f3e1-47ea-84c4-a45aca73eaf6.png)
