### PR TITLE
EES-2896 - setup slack notifications for UI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ src/explore-education-statistics-frontend/*.xml
 /tests/robot-tests/backup-data
 /tests/robot-tests/webdriver
 /tests/robot-tests/.env.*
+/tests/robot-tests/UI-test-report.zip
 !/tests/robot-tests/.env.example
 /tests/robot-tests/IDENTITY_*
 /tests/robot-tests/.pabotsuitenames

--- a/README.md
+++ b/README.md
@@ -523,12 +523,10 @@ docker exec -it ees-idp /opt/jboss/keycloak/bin/standalone.sh -Djboss.socket.bin
 Then simply copy the file from the `/tmp/new-ees-realm.json` file in the `ees-idp` container to `src/keycloak-ees-realm.json` in order for future restarts of the IdP to use this new 
 realm configuration.
 
-Aside from unit tests for each project, we maintain suites of Robot Framework and Postman/Newman 
-tests that can be found in `tests`.
+Aside from unit tests for each project, we maintain suites of Robot Framework tests that can be found in `tests`.
 
-See the relevant READMEs:
+See the relevant README:
 
-- [Postman/Newman tests](./tests/newman/README.md)
 - [Robot Framework tests](./tests/robot-tests/README.md)
 
 ## Contributing

--- a/tests/robot-tests/scripts/pipeline-run-rf-tests.sh
+++ b/tests/robot-tests/scripts/pipeline-run-rf-tests.sh
@@ -47,4 +47,4 @@ google-chrome-stable --version
 python -m pip install --upgrade pip
 pip install pipenv
 pipenv install
-pipenv run python run_tests.py --admin-pass $admin_pass --analyst-pass $analyst_pass --slack-webhook-url "$slack_webhook_url" -e $env --ci --file $file --processes 4
+pipenv run python run_tests.py --admin-pass $admin_pass --analyst-pass $analyst_pass --slack-webhook-url "$slack_webhook_url" -e $env --ci --file $file --processes 4 --enable-slack

--- a/tests/robot-tests/tests/libs/admin-utilities.py
+++ b/tests/robot-tests/tests/libs/admin-utilities.py
@@ -35,6 +35,7 @@ def user_signs_in_as(user: str):
     except Exception as e:
         raise_assertion_error(e)
 
+
 def get_theme_id_from_url():
     url = sl.get_location()
     assert '/themes/' in url, 'URL does not contain /themes'

--- a/tests/robot-tests/tests/libs/admin_api.py
+++ b/tests/robot-tests/tests/libs/admin_api.py
@@ -16,9 +16,9 @@ class AdminClient:
         assert os.getenv('ADMIN_URL') is not None
 
         requests.sessions.HTTPAdapter(
-        pool_connections=50,
-        pool_maxsize=50,
-        max_retries=3
+            pool_connections=50,
+            pool_maxsize=50,
+            max_retries=3
         )
         session = requests.Session()
 
@@ -54,6 +54,7 @@ class AdminClient:
 
 
 admin_client = AdminClient()
+
 
 def user_creates_theme_via_api(title: str, summary: str = '') -> str:
     assert title

--- a/tests/robot-tests/tests/libs/file_operations.py
+++ b/tests/robot-tests/tests/libs/file_operations.py
@@ -1,16 +1,18 @@
 from robot.libraries.BuiltIn import BuiltIn
-
-sl = BuiltIn().get_library_instance('SeleniumLibrary')
 import os
 import requests
 import zipfile
 
+sl = BuiltIn().get_library_instance('SeleniumLibrary')
+
+
 requests.sessions.HTTPAdapter(
-        pool_connections=50,
-        pool_maxsize=50,
-        max_retries=3
-    )
+    pool_connections=50,
+    pool_maxsize=50,
+    max_retries=3
+)
 session = requests.Session()
+
 
 def download_file(link_locator, file_name):
     if not os.path.exists('test-results/downloads'):
@@ -32,7 +34,8 @@ def downloaded_file_should_have_first_line(filename, expected_first_line):
 def zip_should_contains_x_files(zipfilename, num_files):
     zip = zipfile.ZipFile(f'test-results/downloads/{zipfilename}')
     files_in_zip = zip.namelist()
-    assert len(files_in_zip) == int(num_files), f'Number of files in zip {zipfilename} was {len(files_in_zip)}. The test expected {num_files}!)'
+    assert len(files_in_zip) == int(
+        num_files), f'Number of files in zip {zipfilename} was {len(files_in_zip)}. The test expected {num_files}!)'
 
 
 def zip_should_contain_file(zipfilename, filename):

--- a/tests/robot-tests/tests/libs/no_javascript.py
+++ b/tests/robot-tests/tests/libs/no_javascript.py
@@ -4,15 +4,17 @@ from bs4 import BeautifulSoup
 from robot.libraries.BuiltIn import BuiltIn
 
 requests.sessions.HTTPAdapter(
-        pool_connections=50,
-        pool_maxsize=50,
-        max_retries=3
-    )
+    pool_connections=50,
+    pool_maxsize=50,
+    max_retries=3
+)
 session = requests.Session()
 httpBasicAuth = requests.auth.HTTPBasicAuth
 
+
 def user_gets_parsed_html_from_page(url):
-    response = session.get(url, stream=False, auth=httpBasicAuth(os.getenv('PUBLIC_AUTH_USER'), os.getenv('PUBLIC_AUTH_PASSWORD')))
+    response = session.get(url, stream=False,
+                           auth=httpBasicAuth(os.getenv('PUBLIC_AUTH_USER'), os.getenv('PUBLIC_AUTH_PASSWORD')))
     return BeautifulSoup(response.text, "html.parser")
 
 

--- a/tests/robot-tests/tests/libs/public-utilities.py
+++ b/tests/robot-tests/tests/libs/public-utilities.py
@@ -93,6 +93,7 @@ def get_methodology_link(topic, publication, methodology):
         raise_assertion_error(
             f'Could not find methodology link with title "{methodology}""!')
 
+
 # Table tool
 def user_checks_generated_permalink_is_valid():
     elem = sl.driver.find_element_by_css_selector('[data-testid="permalink-generated-url"]')

--- a/tests/robot-tests/tests/libs/slack.py
+++ b/tests/robot-tests/tests/libs/slack.py
@@ -1,0 +1,85 @@
+import os
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+import shutil
+import json
+import requests
+from bs4 import BeautifulSoup
+
+PATH = f'{os.getcwd()}{os.sep}test-results'
+
+
+def _generate_slack_attachments():
+    failed_tests = dict()
+    passed_tests = dict()
+
+    report = open(f'{PATH}{os.sep}output.xml', 'rb')
+    contents = report.read()
+
+    soup = BeautifulSoup(contents, 'xml')
+    test = soup.find('total').find('stat')
+
+    failed_tests = int(test['fail'])
+    passed_tests = int(test['pass'])
+
+    return [
+        {
+            "pretext": "All results",
+            "color": "danger" if failed_tests else "good",
+            "mrkdwn_in": [
+                "pretext"
+            ],
+            "fields": [
+                {
+                    "title": "Total test cases",
+                    "value": passed_tests + failed_tests
+                },
+                {
+                    "title": "Passed tests",
+                    "value": passed_tests
+                },
+                {
+                    "title": "Failed tests",
+                    "value": failed_tests if failed_tests else "0"
+                },
+                {
+                    "title": "Results",
+                    "value": "Failed" if failed_tests else "Passed"
+                },
+
+            ]
+        }
+    ]
+
+
+def send_slack_report():
+    attachments = _generate_slack_attachments()
+    data = {"attachments": attachments}
+
+    webhook_url = os.getenv('SLACK_TEST_REPORT_WEBHOOK_URL')
+    slack_bot_token = os.getenv('SLACK_BOT_TOKEN')
+
+    assert webhook_url, print("SLACK_TEST_REPORT_WEBHOOK_URL env variable needs to bet set")
+    assert slack_bot_token, print("SLACK_BOT_TOKEN env variable needs to bet set")
+
+    response = requests.post(
+        url=webhook_url,
+        data=json.dumps(data), headers={'Content-Type': 'application/json'}
+    )
+    assert response.status_code == 200, print(f"Response wasn't 200, it was {response}")
+
+    print("Sent UI test statistics to #build")
+
+    client = WebClient(token=slack_bot_token)
+    print('Sending UI test report to #build')
+
+    shutil.make_archive('UI-test-report', 'zip', PATH)
+    try:
+        client.files_upload(
+            channels='#build',
+            file='UI-test-report.zip',
+            title='test-report.zip',
+        )
+    except SlackApiError as e:
+        print(f'Error uploading test report: {e}')
+    os.remove('UI-test-report.zip')

--- a/tests/robot-tests/tests/libs/utilities.py
+++ b/tests/robot-tests/tests/libs/utilities.py
@@ -27,6 +27,7 @@ if not utilities_init.initialised:
 
         return parent_locator
 
+
     def _find_by_label(parent_locator: object, criteria: str, tag: str, constraints: dict) -> list:
         parent_locator = _normalize_parent_locator(parent_locator)
 
@@ -43,6 +44,7 @@ if not utilities_init.initialised:
         parent_locator = _normalize_parent_locator(parent_locator)
 
         return get_child_elements(parent_locator, f'css:[data-testid="{criteria}"]')
+
 
     # Register locator strategies
 
@@ -127,7 +129,7 @@ def user_waits_until_parent_does_not_contain_element(parent_locator: object, chi
             return waiting._wait_until(
                 parent_does_not_contain_matching_element,
                 "Parent '%s' should not have contained '%s' in <TIMEOUT>." % (
-                parent_locator, child_locator),
+                    parent_locator, child_locator),
                 timeout, error
             )
 
@@ -264,7 +266,7 @@ def capture_large_screenshot():
 
 def capture_html():
     html = sl.get_source()
-    current_time_millis=round(datetime.datetime.timestamp(datetime.datetime.now()) * 1000)
+    current_time_millis = round(datetime.datetime.timestamp(datetime.datetime.now()) * 1000)
     html_file = open(f"test-results/captured-html-{current_time_millis}.html", "w")
     html_file.write(html)
     html_file.close()
@@ -367,4 +369,3 @@ def _get_parent_webelement_from_locator(parent_locator: object, timeout: int = N
         return parent_locator
     else:
         raise_assertion_error(f"Parent locator was neither a str or a WebElement - {parent_locator}")
-


### PR DESCRIPTION
This PR: 
- enables test reports to be sent via slack to the #build channel 
- formats various python files to PEP8 standards