### PR TITLE
Ees 2898 key and secondary stats UI tests

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/AddSecondaryStats.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/AddSecondaryStats.tsx
@@ -44,7 +44,7 @@ const AddSecondaryStats = ({ release, updating = false }: Props) => {
               setShowConfirmation(true);
             }}
           >
-            Remove Secondary Stats
+            Remove secondary stats
           </Button>
         )}
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatSelectForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatSelectForm.tsx
@@ -71,8 +71,8 @@ const KeyStatSelectForm = ({
     <>
       <FormSelect
         className="govuk-!-margin-right-1"
-        id="id"
-        name="key_indicator_select"
+        id="keyIndicatorSelect"
+        name="selectedDataBlock"
         label={label}
         value={selectedDataBlockId}
         onChange={e => setSelectedDataBlockId(e.target.value)}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/KeyStatistics.tsx
@@ -223,8 +223,8 @@ const AddKeyStatistics = ({ release }: KeyStatisticsProps) => {
           }}
         >
           {`Add ${
-            keyStatisticsSection.content.length > 0 ? ' another ' : ''
-          } key statistic`}
+            keyStatisticsSection.content.length > 0 ? 'another ' : ''
+          }key statistic`}
         </Button>
       )}
     </>

--- a/tests/robot-tests/run_tests.py
+++ b/tests/robot-tests/run_tests.py
@@ -167,7 +167,6 @@ output_file="rerun.xml" if args.rerun_failed_tests or args.rerun_failed_suites e
 # Set robotArgs
 robotArgs = ["--outputdir", "test-results/",
              "--output", output_file,
-             # "--exitonfailure",
              "--exclude", "Failing",
              "--exclude", "UnderConstruction",
              "--exclude", "BootstrapData"]

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_and_publication_role_end_to_end_permissions.robot
@@ -43,8 +43,6 @@ Check publication owner cannot approve methodology for publication
 Check publication owner can upload subject file
     user navigates to editable release summary from admin dashboard    ${PUBLICATION_NAME}
     ...    ${RELEASE_TYPE} (not Live)
-    user clicks link    Data and files
-    user waits until page does not contain loading spinner
     user uploads subject    ${SUBJECT_NAME}    seven_filters.csv    seven_filters.meta.csv
 
 Check publication owner can add data guidance to ${SUBJECT_NAME}
@@ -133,7 +131,6 @@ Check that a publication owner can make a new release
     user creates release for publication    ${PUBLICATION_NAME}    Academic Year Q1    2020
 
 Check publication owner can upload subject file on new release
-    user clicks link    Data and files
     user uploads subject    ${SUBJECT_NAME}    seven_filters.csv    seven_filters.meta.csv
 
 Check publication owner can add data guidance to ${SUBJECT_NAME} on new release

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -25,7 +25,6 @@ Create test publication and release via API
 Upload subject
     user navigates to editable release summary from admin dashboard    ${PUBLICATION_NAME}
     ...    Academic Year 2025/26 (not Live)
-    user clicks link    Data and files
     user uploads subject    UI test subject    upload-file-test.csv    upload-file-test.meta.csv
 
 Start creating a data block
@@ -174,11 +173,7 @@ Embed data block into release content
 
     user creates new content section    1    ${CONTENT_SECTION_NAME}
     user clicks button    Add data block
-    user chooses select option    css:select[name="selectedDataBlock"]    ${DATABLOCK_NAME}
-    user waits until element is visible    css:table
-    user clicks button    Embed
-    user waits until page does not contain button    Embed
-    user waits until page does not contain loading spinner
+    user chooses and embeds data block    ${DATABLOCK_NAME}
 
 Validate embedded table rows
     ${table}=    set variable    css:[data-testid="Data block - ${DATABLOCK_NAME}"] table

--- a/tests/robot-tests/tests/admin/bau/delete_subject.robot
+++ b/tests/robot-tests/tests/admin/bau/delete_subject.robot
@@ -24,7 +24,6 @@ Verify Release summary
     ...    National Statistics
 
 Upload subject
-    user clicks link    Data and files
     user uploads subject    UI test subject    upload-file-test-with-filter.csv
     ...    upload-file-test-with-filter.meta.csv
 

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -31,7 +31,6 @@ Verify release summary
     user checks summary list contains    Publication title    ${PUBLICATION_NAME}
 
 Upload subject
-    user clicks link    Data and files
     user uploads subject    UI test subject    upload-file-test.csv    upload-file-test.meta.csv
 
 Add metadata guidance

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -18,6 +18,17 @@ ${PUBLICATION_NAME}     UI tests - release content %{RUN_IDENTIFIER}
 Create test publication and release via API
     ${PUBLICATION_ID}    user creates test publication via api    ${PUBLICATION_NAME}
     user create test release via api    ${PUBLICATION_ID}    AY    2025
+    user navigates to editable release summary from admin dashboard    ${PUBLICATION_NAME}
+    ...    Academic Year 2025/26 (not Live)
+
+Upload a subject
+    user uploads subject    Dates test subject    dates.csv    dates.meta.csv
+
+Create 3 data blocks
+    user creates data block for dates csv    Dates test subject    Data Block 1
+    user creates data block for dates csv    Dates test subject    Data Block 2
+    user creates key stats data block for dates csv    Dates test subject    Key Stats Data Block 1
+    user creates key stats data block for dates csv    Dates test subject    Key Stats Data Block 2
 
 Navigate to 'Content' page
     user navigates to editable release summary from admin dashboard    ${PUBLICATION_NAME}
@@ -50,11 +61,33 @@ Add Useful information related page link to release
     user enters text into element    id:relatedPageForm-url    http://test1.example.com/test1
     user clicks button    Create link
 
-# TODO: Add Secondary Stats
+Add Secondary Stats
+    user checks page does not contain link with text and url    Table    ${'#releaseHeadlines-dataBlock-tables'}
+    user clicks button    Add secondary stats
+    user chooses and embeds data block    Data Block 1
+    user checks page contains link with text and url    Table    ${'#releaseHeadlines-dataBlock-tables'}
+    user waits until page contains button    Change secondary stats
+    user waits until page contains button    Remove secondary stats
+    user checks page does not contain button    Add secondary stats
+
+Check Secondary Stats are included correctly
+    user clicks link    Table
+    user checks page contains    'nd01' in England for 2013/14
+
+Change Secondary Stats
+    user clicks link    Change secondary stats
+    user chooses and embeds data block    Data Block 2
+    user clicks link    Table
+    user checks page contains    'nd01' in England for 2013/14
+
+Remove Secondary Stats
+    user clicks link    Remove secondary stats
+    user checks page does not contain link with text and url    Table    ${'#releaseHeadlines-dataBlock-tables'}
+
 # TODO: Add key statistics
 
 Add key statistics summary content to release
-    user clicks button    Add a headlines text block    id:releaseHeadlines
+    user clicks button    Add a headlines text bl2ock    id:releaseHeadlines
     user waits until element contains    id:releaseHeadlines    This section is empty
     user clicks button    Edit block    id:releaseHeadlines
     user presses keys    Test key statistics summary text for ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -24,11 +24,27 @@ Create test publication and release via API
 Upload a subject
     user uploads subject    Dates test subject    dates.csv    dates.meta.csv
 
-Create 3 data blocks
-    user creates data block for dates csv    Dates test subject    Data Block 1
-    user creates data block for dates csv    Dates test subject    Data Block 2
-    user creates key stats data block for dates csv    Dates test subject    Key Stats Data Block 1
-    user creates key stats data block for dates csv    Dates test subject    Key Stats Data Block 2
+Create 4 data blocks
+    user creates data block for dates csv
+    ...    Dates test subject
+    ...    Data Block 1
+    ...    Data Block 1 title
+    user creates data block for dates csv
+    ...    Dates test subject
+    ...    Data Block 2
+    ...    Data Block 2 title
+    user creates key stats data block for dates csv
+    ...    Dates test subject
+    ...    Key Stats Data Block 1
+    ...    Key Stats Data Block 1 title
+    ...    Proportion of settings open
+    ...    1%
+    user creates key stats data block for dates csv
+    ...    Dates test subject
+    ...    Key Stats Data Block 2
+    ...    Key Stats Data Block 2 title
+    ...    Number of open settings
+    ...    22,900
 
 Navigate to 'Content' page
     user navigates to editable release summary from admin dashboard    ${PUBLICATION_NAME}
@@ -61,33 +77,94 @@ Add Useful information related page link to release
     user enters text into element    id:relatedPageForm-url    http://test1.example.com/test1
     user clicks button    Create link
 
-Add Secondary Stats
-    user checks page does not contain link with text and url    Table    ${'#releaseHeadlines-dataBlock-tables'}
+Add secondary statistics
+    user waits until the page does not contain the secondary statistics table tab
     user clicks button    Add secondary stats
+    user checks select contains x options    css:select[name="selectedDataBlock"]    5
+    user checks select contains option    css:select[name="selectedDataBlock"]    Select a data block
+    user checks select contains option    css:select[name="selectedDataBlock"]    Data Block 1
+    user checks select contains option    css:select[name="selectedDataBlock"]    Data Block 2
+    user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 1
+    user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 2
     user chooses and embeds data block    Data Block 1
-    user checks page contains link with text and url    Table    ${'#releaseHeadlines-dataBlock-tables'}
+    user waits until the page contains the secondary statistics table tab
+
+Check secondary statistics are included correctly
+    user clicks the secondary statistics table tab
+    user checks page contains    Data Block 1 title
+    user checks page contains element    css:table
     user waits until page contains button    Change secondary stats
     user waits until page contains button    Remove secondary stats
-    user checks page does not contain button    Add secondary stats
 
-Check Secondary Stats are included correctly
-    user clicks link    Table
-    user checks page contains    'nd01' in England for 2013/14
-
-Change Secondary Stats
-    user clicks link    Change secondary stats
+Change secondary statistics
+    user clicks button    Change secondary stats
+    user checks select contains x options    css:select[name="selectedDataBlock"]    4
+    user checks select contains option    css:select[name="selectedDataBlock"]    Select a data block
+    user checks select contains option    css:select[name="selectedDataBlock"]    Data Block 2
+    user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 1
+    user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 2
     user chooses and embeds data block    Data Block 2
-    user clicks link    Table
-    user checks page contains    'nd01' in England for 2013/14
+    user waits until the page contains the secondary statistics table tab
+    user checks page contains    Data Block 2 title
+    user waits until page contains button    Change secondary stats
+    user waits until page contains button    Remove secondary stats
 
-Remove Secondary Stats
-    user clicks link    Remove secondary stats
-    user checks page does not contain link with text and url    Table    ${'#releaseHeadlines-dataBlock-tables'}
+Remove secondary statistics
+    user clicks button    Remove secondary stats
+    user waits until modal is visible    Remove secondary statistics section
+    user clicks button    Confirm
+    user waits until modal is not visible    Remove secondary statistics section
+    user waits until the page does not contain the secondary statistics table tab
+    user waits until page does not contain button    Change secondary stats
+    user waits until page does not contain button    Remove secondary stats
+    user waits until page contains button    Add secondary stats
 
-# TODO: Add key statistics
+Add a key statistics tile
+    user clicks button    Add key statistic
+    user checks select contains x options    css:select[name="selectedDataBlock"]    3
+    user checks select contains option    css:select[name="selectedDataBlock"]    Select a data block
+    user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 1
+    user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 2
+    user chooses and embeds data block    Key Stats Data Block 1
+    user waits until page contains    Proportion of settings open
+    user waits until page contains    1%
+
+Edit the guidance information for the key statistics tile
+    user clicks element    //*[@data-testid="keyStat"][1]//button[.="Edit"]
+    user enters text into element    css:input[name="dataSummary"]    Down from last year
+    user enters text into element    label:Guidance title    Learn more about open settings
+    # Tab into the CK Editor guidance text editor
+    user presses keys    TAB
+    user presses keys    Some information about about open settings
+    user clicks element    //*[@data-testid="keyStat"][1]//button[.="Save"]
+    user waits until page does not contain element    css:input[name="dataSummary"]
+
+Check the guidance information for the key statistics tile
+    user waits until page contains    Down from last year
+    user waits until page contains    Some information about about open settings
+    user checks page for details dropdown    Learn more about open settings
+    user opens details dropdown    Learn more about open settings
+    user checks page contains    Some information about about open settings
+
+Add another key statistics tile
+    user clicks button    Add another key statistic
+    user checks select contains x options    css:select[name="selectedDataBlock"]    2
+    user checks select contains option    css:select[name="selectedDataBlock"]    Select a data block
+    user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 2
+    user chooses and embeds data block    Key Stats Data Block 2
+    user waits until page contains    Number of open settings
+    user waits until page contains    22,900
+
+Remove a key statistics tile
+    # Remove the second tile
+    user clicks element    //*[@data-testid="keyStat"][2]//button[.="Remove"]
+    user waits until page does not contain    Number of open settings
+    user waits until page does not contain    22,900
+    # Make sure the first key stat tile is still there
+    user checks page contains    Proportion of settings open
 
 Add key statistics summary content to release
-    user clicks button    Add a headlines text bl2ock    id:releaseHeadlines
+    user clicks button    Add a headlines text block    id:releaseHeadlines
     user waits until element contains    id:releaseHeadlines    This section is empty
     user clicks button    Edit block    id:releaseHeadlines
     user presses keys    Test key statistics summary text for ${PUBLICATION_NAME}
@@ -125,3 +202,13 @@ Validate two remaining content blocks
     ...    id:releaseMainContent
     user checks accordion section text block contains    Test section one    2    block three test text
     ...    id:releaseMainContent
+
+*** Keywords ***
+user waits until the page contains the secondary statistics table tab
+    user waits until page contains link    Table
+
+user waits until the page does not contain the secondary statistics table tab
+    user waits until page does not contain element    id:releaseHeadlines-dataBlock-tables-tab
+
+user clicks the secondary statistics table tab
+    user clicks element    id:releaseHeadlines-dataBlock-tables-tab

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -11,8 +11,9 @@ Test Setup          fail test fast if required
 Force Tags          Admin    Local    Dev    AltersData
 
 *** Variables ***
-${TOPIC_NAME}           %{TEST_TOPIC_NAME}
-${PUBLICATION_NAME}     UI tests - release content %{RUN_IDENTIFIER}
+${TOPIC_NAME}                               %{TEST_TOPIC_NAME}
+${PUBLICATION_NAME}                         UI tests - release content %{RUN_IDENTIFIER}
+${SECONDARY_STATS_TABLE_TAB_SELECTOR}       releaseHeadlines-dataBlock-tables-tab
 
 *** Test Cases ***
 Create test publication and release via API
@@ -78,7 +79,7 @@ Add Useful information related page link to release
     user clicks button    Create link
 
 Add secondary statistics
-    user waits until the page does not contain the secondary statistics table tab
+    user waits until page does not contain element    ${SECONDARY_STATS_TABLE_TAB_SELECTOR}
     user clicks button    Add secondary stats
     user checks select contains x options    css:select[name="selectedDataBlock"]    5
     user checks select contains option    css:select[name="selectedDataBlock"]    Select a data block
@@ -87,10 +88,10 @@ Add secondary statistics
     user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 1
     user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 2
     user chooses and embeds data block    Data Block 1
-    user waits until the page contains the secondary statistics table tab
+    user waits until page contains element    ${SECONDARY_STATS_TABLE_TAB_SELECTOR}
 
 Check secondary statistics are included correctly
-    user clicks the secondary statistics table tab
+    user clicks element    ${SECONDARY_STATS_TABLE_TAB_SELECTOR}
     user checks page contains    Data Block 1 title
     user checks page contains element    css:table
     user waits until page contains button    Change secondary stats
@@ -104,7 +105,7 @@ Change secondary statistics
     user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 1
     user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 2
     user chooses and embeds data block    Data Block 2
-    user waits until the page contains the secondary statistics table tab
+    user waits until page contains element    ${SECONDARY_STATS_TABLE_TAB_SELECTOR}
     user checks page contains    Data Block 2 title
     user waits until page contains button    Change secondary stats
     user waits until page contains button    Remove secondary stats
@@ -114,7 +115,7 @@ Remove secondary statistics
     user waits until modal is visible    Remove secondary statistics section
     user clicks button    Confirm
     user waits until modal is not visible    Remove secondary statistics section
-    user waits until the page does not contain the secondary statistics table tab
+    user waits until page does not contain element    ${SECONDARY_STATS_TABLE_TAB_SELECTOR}
     user waits until page does not contain button    Change secondary stats
     user waits until page does not contain button    Remove secondary stats
     user waits until page contains button    Add secondary stats
@@ -204,15 +205,6 @@ Validate two remaining content blocks
     ...    id:releaseMainContent
 
 *** Keywords ***
-user waits until the page contains the secondary statistics table tab
-    user waits until page contains element    id:releaseHeadlines-dataBlock-tables-tab
-
-user waits until the page does not contain the secondary statistics table tab
-    user waits until page does not contain element    id:releaseHeadlines-dataBlock-tables-tab
-
-user clicks the secondary statistics table tab
-    user clicks element    id:releaseHeadlines-dataBlock-tables-tab
-
 user clicks the nth key stats tile button
     [Arguments]
     ...    ${tile_number}

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -130,13 +130,13 @@ Add a key statistics tile
     user waits until page contains    1%
 
 Edit the guidance information for the key statistics tile
-    user clicks element    //*[@data-testid="keyStat"][1]//button[.="Edit"]
+    user clicks the nth key stats tile button    1    Edit
     user enters text into element    css:input[name="dataSummary"]    Down from last year
     user enters text into element    label:Guidance title    Learn more about open settings
     # Tab into the CK Editor guidance text editor
     user presses keys    TAB
     user presses keys    Some information about about open settings
-    user clicks element    //*[@data-testid="keyStat"][1]//button[.="Save"]
+    user clicks the nth key stats tile button    1    Save
     user waits until page does not contain element    css:input[name="dataSummary"]
 
 Check the guidance information for the key statistics tile
@@ -157,7 +157,7 @@ Add another key statistics tile
 
 Remove a key statistics tile
     # Remove the second tile
-    user clicks element    //*[@data-testid="keyStat"][2]//button[.="Remove"]
+    user clicks the nth key stats tile button    2    Remove
     user waits until page does not contain    Number of open settings
     user waits until page does not contain    22,900
     # Make sure the first key stat tile is still there
@@ -212,3 +212,9 @@ user waits until the page does not contain the secondary statistics table tab
 
 user clicks the secondary statistics table tab
     user clicks element    id:releaseHeadlines-dataBlock-tables-tab
+
+user clicks the nth key stats tile button
+    [Arguments]
+    ...    ${tile_number}
+    ...    ${button_text}
+    user clicks element    //*[@data-testid="keyStat"][${tile_number}]//button[.="${button_text}"]

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -81,6 +81,7 @@ Add Useful information related page link to release
 Add secondary statistics
     user waits until page does not contain element    ${SECONDARY_STATS_TABLE_TAB_SELECTOR}
     user clicks button    Add secondary stats
+    user waits until page contains element    css:select[name="selectedDataBlock"]    %{WAIT_MEDIUM}
     user checks select contains x options    css:select[name="selectedDataBlock"]    5
     user checks select contains option    css:select[name="selectedDataBlock"]    Select a data block
     user checks select contains option    css:select[name="selectedDataBlock"]    Data Block 1
@@ -94,11 +95,12 @@ Check secondary statistics are included correctly
     user clicks element    ${SECONDARY_STATS_TABLE_TAB_SELECTOR}
     user checks page contains    Data Block 1 title
     user checks page contains element    css:table
-    user waits until page contains button    Change secondary stats
-    user waits until page contains button    Remove secondary stats
+    user checks page contains button    Change secondary stats
+    user checks page contains button    Remove secondary stats
 
 Change secondary statistics
     user clicks button    Change secondary stats
+    user waits until page contains element    css:select[name="selectedDataBlock"]    %{WAIT_MEDIUM}
     user checks select contains x options    css:select[name="selectedDataBlock"]    4
     user checks select contains option    css:select[name="selectedDataBlock"]    Select a data block
     user checks select contains option    css:select[name="selectedDataBlock"]    Data Block 2
@@ -107,28 +109,29 @@ Change secondary statistics
     user chooses and embeds data block    Data Block 2
     user waits until page contains element    ${SECONDARY_STATS_TABLE_TAB_SELECTOR}
     user checks page contains    Data Block 2 title
-    user waits until page contains button    Change secondary stats
-    user waits until page contains button    Remove secondary stats
+    user checks page contains button    Change secondary stats
+    user checks page contains button    Remove secondary stats
 
 Remove secondary statistics
     user clicks button    Remove secondary stats
     user waits until modal is visible    Remove secondary statistics section
     user clicks button    Confirm
-    user waits until modal is not visible    Remove secondary statistics section
+    user waits until modal is not visible    Remove secondary statistics section    %{WAIT_MEDIUM}
     user waits until page does not contain element    ${SECONDARY_STATS_TABLE_TAB_SELECTOR}
-    user waits until page does not contain button    Change secondary stats
-    user waits until page does not contain button    Remove secondary stats
-    user waits until page contains button    Add secondary stats
+    user checks page does not contain button    Change secondary stats
+    user checks page does not contain button    Remove secondary stats
+    user checks page contains button    Add secondary stats
 
 Add a key statistics tile
     user clicks button    Add key statistic
+    user waits until page contains element    css:select[name="selectedDataBlock"]    %{WAIT_MEDIUM}
     user checks select contains x options    css:select[name="selectedDataBlock"]    3
     user checks select contains option    css:select[name="selectedDataBlock"]    Select a data block
     user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 1
     user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 2
     user chooses and embeds data block    Key Stats Data Block 1
-    user waits until page contains    Proportion of settings open
-    user waits until page contains    1%
+    user waits until page contains    Proportion of settings open    %{WAIT_MEDIUM}
+    user checks page contains    1%
 
 Edit the guidance information for the key statistics tile
     user clicks the nth key stats tile button    1    Edit
@@ -138,29 +141,30 @@ Edit the guidance information for the key statistics tile
     user presses keys    TAB
     user presses keys    Some information about about open settings
     user clicks the nth key stats tile button    1    Save
-    user waits until page does not contain element    css:input[name="dataSummary"]
+    user waits until page does not contain element    css:input[name="dataSummary"]    %{WAIT_MEDIUM}
 
 Check the guidance information for the key statistics tile
-    user waits until page contains    Down from last year
-    user waits until page contains    Some information about about open settings
+    user waits until page contains    Down from last year    %{WAIT_MEDIUM}
+    user checks page contains    Some information about about open settings
     user checks page for details dropdown    Learn more about open settings
     user opens details dropdown    Learn more about open settings
     user checks page contains    Some information about about open settings
 
 Add another key statistics tile
     user clicks button    Add another key statistic
+    user waits until page contains element    css:select[name="selectedDataBlock"]    %{WAIT_MEDIUM}
     user checks select contains x options    css:select[name="selectedDataBlock"]    2
     user checks select contains option    css:select[name="selectedDataBlock"]    Select a data block
     user checks select contains option    css:select[name="selectedDataBlock"]    Key Stats Data Block 2
     user chooses and embeds data block    Key Stats Data Block 2
-    user waits until page contains    Number of open settings
-    user waits until page contains    22,900
+    user checks page contains    Number of open settings
+    user checks page contains    22,900
 
 Remove a key statistics tile
     # Remove the second tile
     user clicks the nth key stats tile button    2    Remove
-    user waits until page does not contain    Number of open settings
-    user waits until page does not contain    22,900
+    user waits until page does not contain    Number of open settings    %{WAIT_MEDIUM}
+    user checks page does not contain    22,900
     # Make sure the first key stat tile is still there
     user checks page contains    Proportion of settings open
 

--- a/tests/robot-tests/tests/admin/bau/release_content.robot
+++ b/tests/robot-tests/tests/admin/bau/release_content.robot
@@ -205,7 +205,7 @@ Validate two remaining content blocks
 
 *** Keywords ***
 user waits until the page contains the secondary statistics table tab
-    user waits until page contains link    Table
+    user waits until page contains element    id:releaseHeadlines-dataBlock-tables-tab
 
 user waits until the page does not contain the secondary statistics table tab
     user waits until page does not contain element    id:releaseHeadlines-dataBlock-tables-tab

--- a/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/data_catalogue.robot
@@ -30,10 +30,7 @@ Create new release with data files
     user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     user clicks link    Create new release
     user creates release for publication    ${PUBLICATION_NAME}    ${RELEASE_NAME}    2020
-    user clicks link    Data and files
-
     user uploads subject    ${SUBJECT_NAME_1}    seven_filters.csv    seven_filters.meta.csv
-
     user uploads subject    ${SUBJECT_NAME_2}    tiny-two-filters.csv    tiny-two-filters.meta.csv
 
 Add data guidance to subjects
@@ -63,7 +60,6 @@ User creates second release
     user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     user clicks link    Create new release
     user creates release for publication    ${PUBLICATION_NAME}    ${RELEASE_NAME}    2021
-    user clicks link    Data and files
     user uploads subject    ${SUBJECT_NAME_3}    dates.csv    dates.meta.csv
     user uploads subject    ${SUBJECT_NAME_4}    upload-file-test-with-filter.csv
     ...    upload-file-test-with-filter.meta.csv

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -24,7 +24,6 @@ Verify release summary
     ...    National Statistics
 
 Upload subject
-    user clicks link    Data and files
     user uploads subject    UI test subject    upload-file-test.csv    upload-file-test.meta.csv
 
 Go to 'Sign Off' page

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -66,7 +66,6 @@ Verify new release summary
     user checks summary list contains    Publication title    ${PUBLICATION_NAME}
 
 Upload subjects to release
-    user clicks link    Data and files
     user uploads subject    ${SUBJECT_1_NAME}    tiny-two-filters.csv    tiny-two-filters.meta.csv
     user uploads subject    ${SUBJECT_2_NAME}    upload-file-test.csv    upload-file-test-with-filter.meta.csv
 

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -31,7 +31,6 @@ Verify release summary
     user checks summary list contains    Publication title    ${PUBLICATION_NAME}
 
 Upload subject
-    user clicks link    Data and files
     user uploads subject    Dates test subject    dates.csv    dates.meta.csv
 
 Add data guidance
@@ -72,54 +71,7 @@ Add ancillary file
     user checks there are x accordion sections    1    id:file-uploads
 
 Create data block table
-    user clicks link    Data blocks
-    user waits until h2 is visible    Data blocks
-
-    user clicks link    Create data block
-    user waits until h2 is visible    Create data block
-
-    user waits until table tool wizard step is available    1    Choose a subject
-    user waits until page contains    Dates test subject
-    user clicks radio    Dates test subject
-    user clicks element    id:publicationSubjectForm-submit
-
-    user waits until table tool wizard step is available    2    Choose locations
-    user opens details dropdown    National
-    user checks location checkbox is checked    England
-
-    user clicks element    id:locationFiltersForm-submit
-
-    user waits until table tool wizard step is available    3    Choose time period
-    user chooses select option    id:timePeriodForm-start    2020 Week 13
-    user chooses select option    id:timePeriodForm-end    2020 Week 16
-    user clicks element    id:timePeriodForm-submit
-
-    user waits until table tool wizard step is available    4    Choose your filters
-    user clicks subheaded indicator checkbox    Open settings    Number of open settings
-    user checks subheaded indicator checkbox is checked    Open settings    Number of open settings
-    user clicks subheaded indicator checkbox    Open settings    Proportion of settings open
-    user checks subheaded indicator checkbox is checked    Open settings    Proportion of settings open
-
-    user opens details dropdown    Date
-    user clicks category checkbox    Date    23/03/2020
-    user checks category checkbox is checked    Date    23/03/2020
-
-    user clicks element    id:filtersForm-submit
-    user waits until results table appears    %{WAIT_LONG}
-
-    user checks table column heading contains    1    1    2020 Week 13
-    user checks headed table body row cell contains    Number of open settings    1    22,900
-    user checks headed table body row cell contains    Proportion of settings open    1    1%
-
-Save data block
-    user enters text into element    id:dataBlockDetailsForm-name    ${DATABLOCK_NAME}
-    user enters text into element    id:dataBlockDetailsForm-heading    Dates table title
-    user enters text into element    id:dataBlockDetailsForm-source    Dates source
-
-    user clicks button    Save data block
-
-    user waits until h2 is visible    Edit data block
-    user waits until page contains button    Delete this data block
+    user creates data block for dates csv    Dates test subject    ${DATABLOCK_NAME}
 
 Create chart for data block
     user waits until page contains link    Chart

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -71,7 +71,7 @@ Add ancillary file
     user checks there are x accordion sections    1    id:file-uploads
 
 Create data block table
-    user creates data block for dates csv    Dates test subject    ${DATABLOCK_NAME}
+    user creates data block for dates csv    Dates test subject    ${DATABLOCK_NAME}    Dates table title
 
 Create chart for data block
     user waits until page contains link    Chart

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend_2.robot
@@ -27,7 +27,6 @@ Create new release
     user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     user clicks link    Create new release
     user creates release for publication    ${PUBLICATION_NAME}    Academic Year Q1    2020
-    user clicks link    Data and files
     user uploads subject    ${SUBJECT_NAME}    seven_filters.csv    seven_filters.meta.csv
 
 Upload another subject (for deletion later)
@@ -386,7 +385,6 @@ Create amendment to modify release
     user creates amendment for release    ${PUBLICATION_NAME}    ${RELEASE_NAME}    (Live - Latest release)
 
 Add subject to release
-    user clicks link    Data and files
     user uploads subject    ${THIRD_SUBJECT}    upload-file-test-with-filter.csv
     ...    upload-file-test-with-filter.meta.csv
 

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -586,6 +586,7 @@ user navigates to admin dashboard
 
 user uploads subject
     [Arguments]    ${SUBJECT_NAME}    ${SUBJECT_FILE}    ${META_FILE}
+    user clicks link    Data and files
     user waits until page contains element    id:dataFileUploadForm-subjectTitle    60
     user enters text into element    id:dataFileUploadForm-subjectTitle    ${SUBJECT_NAME}
     user chooses file    id:dataFileUploadForm-dataFile    ${FILES_DIR}${SUBJECT_FILE}

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -740,9 +740,9 @@ user waits until modal is visible
     [Return]    ${modal_element}
 
 user waits until modal is not visible
-    [Arguments]    ${MODAL_TITLE}
-    user waits until page does not contain element    css:.ReactModal__Content
-    user waits until h1 is not visible    ${MODAL_TITLE}
+    [Arguments]    ${modal_title}    ${wait}=${timeout}
+    user waits until page does not contain element    css:.ReactModal__Content    ${wait}
+    user waits until h1 is not visible    ${modal_title}
 
 user gets comment
     [Arguments]    ${comment_text}

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -135,7 +135,7 @@ user chooses and embeds data block
     ...    ${datablock_name}
     user chooses select option    css:select[name="selectedDataBlock"]    ${datablock_name}
     user clicks button    Embed
-    user waits until page does not contain button    Embed
+    user waits until page does not contain button    Embed    %{WAIT_MEDIUM}
     user waits until page does not contain loading spinner
 
 user opens nth editable accordion section

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -27,6 +27,7 @@ user creates data block for dates csv
     [Arguments]
     ...    ${subject_name}
     ...    ${datablock_name}
+    ...    ${datablock_title}
 
     user clicks link    Data blocks
     user waits until h2 is visible    Data blocks
@@ -68,7 +69,7 @@ user creates data block for dates csv
     user checks headed table body row cell contains    Proportion of settings open    1    1%
 
     user enters text into element    id:dataBlockDetailsForm-name    ${datablock_name}
-    user enters text into element    id:dataBlockDetailsForm-heading    Dates table title
+    user enters text into element    id:dataBlockDetailsForm-heading    ${datablock_title}
     user enters text into element    id:dataBlockDetailsForm-source    Dates source
 
     user clicks button    Save data block
@@ -80,6 +81,9 @@ user creates key stats data block for dates csv
     [Arguments]
     ...    ${subject_name}
     ...    ${datablock_name}
+    ...    ${datablock_title}
+    ...    ${indicator_name}
+    ...    ${expected_indicator_value}
 
     user clicks link    Data blocks
     user waits until h2 is visible    Data blocks
@@ -104,8 +108,8 @@ user creates key stats data block for dates csv
     user clicks element    id:timePeriodForm-submit
 
     user waits until table tool wizard step is available    4    Choose your filters
-    user clicks subheaded indicator checkbox    Open settings    Proportion of settings open
-    user checks subheaded indicator checkbox is checked    Open settings    Proportion of settings open
+    user clicks subheaded indicator checkbox    Open settings    ${indicator_name}
+    user checks subheaded indicator checkbox is checked    Open settings    ${indicator_name}
 
     user opens details dropdown    Date
     user clicks category checkbox    Date    23/03/2020
@@ -115,10 +119,10 @@ user creates key stats data block for dates csv
     user waits until results table appears    %{WAIT_LONG}
 
     user checks table column heading contains    1    1    2020 Week 13
-    user checks headed table body row cell contains    Proportion of settings open    1%
+    user checks headed table body row cell contains    ${indicator_name}    1    ${expected_indicator_value}
 
     user enters text into element    id:dataBlockDetailsForm-name    ${datablock_name}
-    user enters text into element    id:dataBlockDetailsForm-heading    Dates table title
+    user enters text into element    id:dataBlockDetailsForm-heading    ${datablock_title}
     user enters text into element    id:dataBlockDetailsForm-source    Dates source
 
     user clicks button    Save data block
@@ -130,7 +134,6 @@ user chooses and embeds data block
     [Arguments]
     ...    ${datablock_name}
     user chooses select option    css:select[name="selectedDataBlock"]    ${datablock_name}
-    user waits until element is visible    css:table
     user clicks button    Embed
     user waits until page does not contain button    Embed
     user waits until page does not contain loading spinner

--- a/tests/robot-tests/tests/libs/admin/manage-content-common.robot
+++ b/tests/robot-tests/tests/libs/admin/manage-content-common.robot
@@ -23,6 +23,118 @@ user creates new content section
     user clicks element    xpath://button[.="Add new section"]    ${parent}
     user changes accordion section title    ${section_number}    ${content_section_name}    ${parent}
 
+user creates data block for dates csv
+    [Arguments]
+    ...    ${subject_name}
+    ...    ${datablock_name}
+
+    user clicks link    Data blocks
+    user waits until h2 is visible    Data blocks
+
+    user clicks link    Create data block
+    user waits until h2 is visible    Create data block
+
+    user waits until table tool wizard step is available    1    Choose a subject
+    user waits until page contains    ${subject_name}
+    user clicks radio    ${subject_name}
+    user clicks element    id:publicationSubjectForm-submit
+
+    user waits until table tool wizard step is available    2    Choose locations
+    user opens details dropdown    National
+    user checks location checkbox is checked    England
+
+    user clicks element    id:locationFiltersForm-submit
+
+    user waits until table tool wizard step is available    3    Choose time period
+    user chooses select option    id:timePeriodForm-start    2020 Week 13
+    user chooses select option    id:timePeriodForm-end    2020 Week 16
+    user clicks element    id:timePeriodForm-submit
+
+    user waits until table tool wizard step is available    4    Choose your filters
+    user clicks subheaded indicator checkbox    Open settings    Number of open settings
+    user checks subheaded indicator checkbox is checked    Open settings    Number of open settings
+    user clicks subheaded indicator checkbox    Open settings    Proportion of settings open
+    user checks subheaded indicator checkbox is checked    Open settings    Proportion of settings open
+
+    user opens details dropdown    Date
+    user clicks category checkbox    Date    23/03/2020
+    user checks category checkbox is checked    Date    23/03/2020
+
+    user clicks element    id:filtersForm-submit
+    user waits until results table appears    %{WAIT_LONG}
+
+    user checks table column heading contains    1    1    2020 Week 13
+    user checks headed table body row cell contains    Number of open settings    1    22,900
+    user checks headed table body row cell contains    Proportion of settings open    1    1%
+
+    user enters text into element    id:dataBlockDetailsForm-name    ${datablock_name}
+    user enters text into element    id:dataBlockDetailsForm-heading    Dates table title
+    user enters text into element    id:dataBlockDetailsForm-source    Dates source
+
+    user clicks button    Save data block
+
+    user waits until h2 is visible    Edit data block
+    user waits until page contains button    Delete this data block
+
+user creates key stats data block for dates csv
+    [Arguments]
+    ...    ${subject_name}
+    ...    ${datablock_name}
+
+    user clicks link    Data blocks
+    user waits until h2 is visible    Data blocks
+
+    user clicks link    Create data block
+    user waits until h2 is visible    Create data block
+
+    user waits until table tool wizard step is available    1    Choose a subject
+    user waits until page contains    ${subject_name}
+    user clicks radio    ${subject_name}
+    user clicks element    id:publicationSubjectForm-submit
+
+    user waits until table tool wizard step is available    2    Choose locations
+    user opens details dropdown    National
+    user checks location checkbox is checked    England
+
+    user clicks element    id:locationFiltersForm-submit
+
+    user waits until table tool wizard step is available    3    Choose time period
+    user chooses select option    id:timePeriodForm-start    2020 Week 13
+    user chooses select option    id:timePeriodForm-end    2020 Week 13
+    user clicks element    id:timePeriodForm-submit
+
+    user waits until table tool wizard step is available    4    Choose your filters
+    user clicks subheaded indicator checkbox    Open settings    Proportion of settings open
+    user checks subheaded indicator checkbox is checked    Open settings    Proportion of settings open
+
+    user opens details dropdown    Date
+    user clicks category checkbox    Date    23/03/2020
+    user checks category checkbox is checked    Date    23/03/2020
+
+    user clicks element    id:filtersForm-submit
+    user waits until results table appears    %{WAIT_LONG}
+
+    user checks table column heading contains    1    1    2020 Week 13
+    user checks headed table body row cell contains    Proportion of settings open    1%
+
+    user enters text into element    id:dataBlockDetailsForm-name    ${datablock_name}
+    user enters text into element    id:dataBlockDetailsForm-heading    Dates table title
+    user enters text into element    id:dataBlockDetailsForm-source    Dates source
+
+    user clicks button    Save data block
+
+    user waits until h2 is visible    Edit data block
+    user waits until page contains button    Delete this data block
+
+user chooses and embeds data block
+    [Arguments]
+    ...    ${datablock_name}
+    user chooses select option    css:select[name="selectedDataBlock"]    ${datablock_name}
+    user waits until element is visible    css:table
+    user clicks button    Embed
+    user waits until page does not contain button    Embed
+    user waits until page does not contain loading spinner
+
 user opens nth editable accordion section
     [Arguments]
     ...    ${section_num}

--- a/tests/robot-tests/tests/libs/bootstrap_data/bootstrap_common.robot
+++ b/tests/robot-tests/tests/libs/bootstrap_data/bootstrap_common.robot
@@ -81,9 +81,7 @@ user creates a fully populated draft release
     ...    ${TOPIC_NAME}
 
     # add data files
-    user clicks link    Data and files
-    user waits until page does not contain loading spinner
-    user uploads subject    ${SUBJECT_NAME}    seven_filters.csv    seven_filters.meta.csv
+    user uploads subjec t    ${SUBJECT_NAME}    seven_filters.csv    seven_filters.meta.csv
 
     # add data guidance
     user clicks link    Data guidance

--- a/tests/robot-tests/tests/libs/bootstrap_data/bootstrap_common.robot
+++ b/tests/robot-tests/tests/libs/bootstrap_data/bootstrap_common.robot
@@ -81,7 +81,7 @@ user creates a fully populated draft release
     ...    ${TOPIC_NAME}
 
     # add data files
-    user uploads subjec t    ${SUBJECT_NAME}    seven_filters.csv    seven_filters.meta.csv
+    user uploads subject    ${SUBJECT_NAME}    seven_filters.csv    seven_filters.meta.csv
 
     # add data guidance
     user clicks link    Data guidance

--- a/tests/robot-tests/tests/libs/common.robot
+++ b/tests/robot-tests/tests/libs/common.robot
@@ -392,8 +392,8 @@ user checks element is not visible
     element should not be visible    ${element}    ${wait}
 
 user waits until element is enabled
-    [Arguments]    ${element}
-    wait until element is enabled    ${element}
+    [Arguments]    ${element}    ${wait}=${timeout}
+    wait until element is enabled    ${element}    ${wait}
 
 user checks element is enabled
     [Arguments]    ${element}
@@ -454,17 +454,21 @@ user waits until page contains button
     [Arguments]    ${text}    ${wait}=${timeout}
     user waits until page contains element    xpath://button[text()="${text}"]    ${wait}
 
+user checks page contains button
+    [Arguments]    ${text}
+    user checks page contains element    xpath://button[text()="${text}"]
+
 user checks page does not contain button
     [Arguments]    ${text}
     user checks page does not contain element    xpath://button[text()="${text}"]
 
 user waits until page does not contain button
-    [Arguments]    ${text}
-    user waits until page does not contain element    xpath://button[text()="${text}"]
+    [Arguments]    ${text}    ${wait}=${timeout}
+    user waits until page does not contain element    xpath://button[text()="${text}"]    ${wait}
 
 user waits until button is enabled
-    [Arguments]    ${text}
-    user waits until element is enabled    xpath://button[text()="${text}"]
+    [Arguments]    ${text}    ${wait}=${timeout}
+    user waits until element is enabled    xpath://button[text()="${text}"]    ${wait}
 
 user gets button element
     [Arguments]    ${text}    ${parent}=css:body


### PR DESCRIPTION
This PR:
- adds UI tests around the management of Key Stats tiles and the Secondary stats section when editing Release Content.
![image](https://user-images.githubusercontent.com/12444316/142852615-3b828eec-f9dd-4592-81fb-d27608674309.png)


UPDATE:
- Added medium waits into various points of the new test code
![image](https://user-images.githubusercontent.com/12444316/143257396-013ffec7-a9c8-470f-9f01-687da92eed5e.png)
