### PR TITLE
EES-2831 Move data API's table tool timeout into appsettings.json

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.Development.json
@@ -39,8 +39,5 @@
   },
   "FeatureManagement": {
     "LocationHierarchies" : false
-  },
-  "TableBuilder": {
-    "MaxTableCellsAllowed": 25000
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
@@ -28,8 +28,10 @@
     "TokenValidationParameters.NameClaimType": "name",
     "TokenValidationParameters.RoleClaimType": "role"
   },
-  "Locations":
-  {
+  "TableBuilder": {
+    "MaxTableCellsAllowed": 25000
+  },
+  "Locations": {
     "Hierarchies": {
       "LocalAuthority": [
         "Country",

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.Development.json
@@ -15,8 +15,5 @@
   },
   "FeatureManagement": {
     "LocationHierarchies" : false
-  },
-  "TableBuilder": {
-    "MaxTableCellsAllowed": 25000
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.Development.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.Development.json
@@ -18,8 +18,5 @@
   },
   "TableBuilder": {
     "MaxTableCellsAllowed": 25000
-  },
-  "RequestTimeouts": {
-    "TableBuilderQuery": 300000
   }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
@@ -6,8 +6,10 @@
     }
   },
   "AllowedHosts": "*",
-  "Locations":
-  {
+  "RequestTimeouts": {
+    "TableBuilderQuery": 300000
+  },
+  "Locations": {
     "Hierarchies": {
       "LocalAuthority": [
         "Country",

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
@@ -9,6 +9,9 @@
   "RequestTimeouts": {
     "TableBuilderQuery": 300000
   },
+  "TableBuilder": {
+    "MaxTableCellsAllowed": 25000
+  },
   "Locations": {
     "Hierarchies": {
       "LocalAuthority": [


### PR DESCRIPTION
This sets a sensible default timeout of 5 minutes for all environments (not just for local development).