### PR TITLE
EES-2841 Improve importer failure messaging

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/Processor.cs
@@ -100,7 +100,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
                                      $"{message.Id} : {ex.Message}");
                 _logger.LogError(ex.StackTrace);
 
-                await _dataImportService.FailImport(message.Id, ex.Message);
+                await _dataImportService.FailImport(message.Id);
             }
         }
 
@@ -127,7 +127,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
                 _logger.LogError(ex, $"{GetType().Name} function FAILED for : Import: " +
                                      $"{message.Id} : {ex.Message}");
 
-                await _dataImportService.FailImport(message.Id, ex.Message);
+                await _dataImportService.FailImport(message.Id);
             }
         }
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ImporterStatus.tsx
@@ -7,6 +7,7 @@ import Details from '@common/components/Details';
 import LoadingSpinner from '@common/components/LoadingSpinner';
 import ProgressBar from '@common/components/ProgressBar';
 import Tag, { TagProps } from '@common/components/Tag';
+import WarningMessage from '@common/components/WarningMessage';
 import useInterval from '@common/hooks/useInterval';
 import useMounted from '@common/hooks/useMounted';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -161,17 +162,28 @@ const ImporterStatus = ({
         />
       )}
 
-      {currentStatus.errors && currentStatus.errors.length > 0 && (
-        <Details
-          className="govuk-!-margin-top-1 govuk-!-margin-bottom-0"
-          summary="See errors"
-        >
-          <ul className="govuk-!-margin-top-0">
-            {currentStatus.errors.map((error, index) => (
-              <li key={index.toString()}>{error}</li>
-            ))}
-          </ul>
-        </Details>
+      {currentStatus.status === 'FAILED' && (
+        <>
+          {currentStatus.errors && currentStatus.errors.length > 0 && (
+            <Details
+              className="govuk-!-margin-top-1 govuk-!-margin-bottom-0"
+              summary="See errors"
+            >
+              <ul className="govuk-!-margin-top-0">
+                {currentStatus.errors.map((error, index) => (
+                  <li key={index.toString()}>{error}</li>
+                ))}
+              </ul>
+            </Details>
+          )}
+          <WarningMessage>
+            Try running the file through the{' '}
+            <a href="https://rsconnect/rsc/dfe-published-data-qa/">
+              data screener
+            </a>{' '}
+            to check for potential causes of this failure before trying again.
+          </WarningMessage>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
This work improves the import messaging if a subject import fails.

![image](https://user-images.githubusercontent.com/44812484/144429314-aa8b55de-9d18-4100-b374-55fad8c680a6.png)

Firstly, we no longer add exception messages as errors, as they aren't
useful to users - for debugging these can still be found in AppInsights.

Secondly, we displays a generic message for all failed imports
suggesting analysts try running their data files through the data
screener.