### PR TITLE
EES-2922 Lazy load data blocks upon opening of their content section

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/EditableAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/EditableAccordionSection.tsx
@@ -143,45 +143,51 @@ const EditableAccordionSection = (props: EditableAccordionSectionProps) => {
             heading={heading}
             header={header}
           >
-            <ButtonGroup>
-              {isEditingHeading ? (
-                <Button onClick={saveHeading}>Save section title</Button>
-              ) : (
-                <Button
-                  type="button"
-                  onClick={toggleEditingHeading}
-                  variant="secondary"
-                >
-                  Edit section title
-                </Button>
-              )}
+            {sectionProps => (
+              <>
+                <ButtonGroup>
+                  {isEditingHeading ? (
+                    <Button onClick={saveHeading}>Save section title</Button>
+                  ) : (
+                    <Button
+                      type="button"
+                      onClick={toggleEditingHeading}
+                      variant="secondary"
+                    >
+                      Edit section title
+                    </Button>
+                  )}
 
-              {headerButtons}
+                  {headerButtons}
 
-              {onRemoveSection && (
-                <>
-                  <Button onClick={toggleRemoveModal.on} variant="warning">
-                    Remove this section
-                  </Button>
+                  {onRemoveSection && (
+                    <>
+                      <Button onClick={toggleRemoveModal.on} variant="warning">
+                        Remove this section
+                      </Button>
 
-                  <ModalConfirm
-                    title="Are you sure?"
-                    open={showRemoveModal}
-                    onConfirm={onRemoveSection}
-                    onExit={toggleRemoveModal.off}
-                    onCancel={toggleRemoveModal.off}
-                  >
-                    <p>
-                      Are you sure you want to remove the following section?
-                      <br />
-                      <strong>"{heading}"</strong>
-                    </p>
-                  </ModalConfirm>
-                </>
-              )}
-            </ButtonGroup>
+                      <ModalConfirm
+                        title="Are you sure?"
+                        open={showRemoveModal}
+                        onConfirm={onRemoveSection}
+                        onExit={toggleRemoveModal.off}
+                        onCancel={toggleRemoveModal.off}
+                      >
+                        <p>
+                          Are you sure you want to remove the following section?
+                          <br />
+                          <strong>"{heading}"</strong>
+                        </p>
+                      </ModalConfirm>
+                    </>
+                  )}
+                </ButtonGroup>
 
-            {children}
+                {typeof children === 'function'
+                  ? children(sectionProps)
+                  : children}
+              </>
+            )}
           </AccordionSection>
         </div>
       )}

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseBlock.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseBlock.tsx
@@ -5,13 +5,15 @@ import DataBlockTabs from '@common/modules/find-statistics/components/DataBlockT
 import { Block } from '@common/services/types/blocks';
 import React from 'react';
 import useReleaseImageAttributeTransformer from '@common/modules/release/hooks/useReleaseImageAttributeTransformer';
+import Gate from '@common/components/Gate';
 
 interface Props {
   block: Block;
   releaseId: string;
+  visible?: boolean;
 }
 
-const ReleaseBlock = ({ block, releaseId }: Props) => {
+const ReleaseBlock = ({ block, releaseId, visible }: Props) => {
   const getChartFile = useGetChartFile(releaseId);
 
   const transformImageAttributes = useReleaseImageAttributeTransformer({
@@ -20,12 +22,14 @@ const ReleaseBlock = ({ block, releaseId }: Props) => {
 
   if (block.type === 'DataBlock') {
     return (
-      <DataBlockTabs
-        key={block.id}
-        dataBlock={block}
-        releaseId={releaseId}
-        getInfographic={getChartFile}
-      />
+      <Gate condition={!!visible}>
+        <DataBlockTabs
+          key={block.id}
+          dataBlock={block}
+          releaseId={releaseId}
+          getInfographic={getChartFile}
+        />
+      </Gate>
     );
   }
 

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContentAccordionSection.tsx
@@ -164,53 +164,62 @@ const ReleaseContentAccordionSection = ({
         </Button>
       }
     >
-      <EditableSectionBlocks
-        allowComments
-        blocks={blocks}
-        isReordering={isReordering}
-        sectionId={sectionId}
-        onBlocksChange={setBlocks}
-        onBlockCommentsChange={updateBlockComments}
-        renderBlock={block => (
-          <ReleaseBlock block={block} releaseId={release.id} />
-        )}
-        renderEditableBlock={block => (
-          <ReleaseEditableBlock
-            allowImages
-            block={block}
-            sectionId={sectionId}
-            editable={!isReordering}
-            releaseId={release.id}
-            onSave={updateBlock}
-            onDelete={removeBlock}
-          />
-        )}
-      />
-
-      {editingMode === 'edit' && !isReordering && (
+      {({ open }) => (
         <>
-          {showDataBlockForm && (
-            <DataBlockSelectForm
-              id={`dataBlockSelectForm-${sectionId}`}
-              releaseId={release.id}
-              onSelect={async selectedDataBlockId => {
-                await attachDataBlock(selectedDataBlockId);
-                toggleDataBlockForm.off();
-              }}
-              onCancel={toggleDataBlockForm.off}
-            />
-          )}
-
-          <ButtonGroup className="govuk-!-margin-bottom-8 dfe-justify-content--center">
-            <Button variant="secondary" onClick={addBlock}>
-              Add text block
-            </Button>
-            {!showDataBlockForm && (
-              <Button variant="secondary" onClick={toggleDataBlockForm.on}>
-                Add data block
-              </Button>
+          <EditableSectionBlocks
+            allowComments
+            blocks={blocks}
+            isReordering={isReordering}
+            sectionId={sectionId}
+            onBlocksChange={setBlocks}
+            onBlockCommentsChange={updateBlockComments}
+            renderBlock={block => (
+              <ReleaseBlock
+                block={block}
+                releaseId={release.id}
+                visible={open}
+              />
             )}
-          </ButtonGroup>
+            renderEditableBlock={block => (
+              <ReleaseEditableBlock
+                allowImages
+                block={block}
+                sectionId={sectionId}
+                editable={!isReordering}
+                releaseId={release.id}
+                visible={open}
+                onSave={updateBlock}
+                onDelete={removeBlock}
+              />
+            )}
+          />
+
+          {editingMode === 'edit' && !isReordering && (
+            <>
+              {showDataBlockForm && (
+                <DataBlockSelectForm
+                  id={`dataBlockSelectForm-${sectionId}`}
+                  releaseId={release.id}
+                  onSelect={async selectedDataBlockId => {
+                    await attachDataBlock(selectedDataBlockId);
+                    toggleDataBlockForm.off();
+                  }}
+                  onCancel={toggleDataBlockForm.off}
+                />
+              )}
+
+              <ButtonGroup className="govuk-!-margin-bottom-8 dfe-justify-content--center">
+                <Button variant="secondary" onClick={addBlock}>
+                  Add text block
+                </Button>
+                {!showDataBlockForm && (
+                  <Button variant="secondary" onClick={toggleDataBlockForm.on}>
+                    Add data block
+                  </Button>
+                )}
+              </ButtonGroup>
+            </>
+          )}
         </>
       )}
     </EditableAccordionSection>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseEditableBlock.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseEditableBlock.tsx
@@ -3,6 +3,7 @@ import EditableContentBlock from '@admin/components/editable/EditableContentBloc
 import useGetChartFile from '@admin/hooks/useGetChartFile';
 import useReleaseImageUpload from '@admin/pages/release/hooks/useReleaseImageUpload';
 import { EditableBlock } from '@admin/services/types/content';
+import Gate from '@common/components/Gate';
 import DataBlockTabs from '@common/modules/find-statistics/components/DataBlockTabs';
 import useReleaseImageAttributeTransformer from '@common/modules/release/hooks/useReleaseImageAttributeTransformer';
 import isBrowser from '@common/utils/isBrowser';
@@ -20,6 +21,7 @@ interface Props {
   block: EditableBlock;
   sectionId: string;
   editable?: boolean;
+  visible?: boolean;
   onSave: (blockId: string, content: string) => void;
   onDelete: (blockId: string) => void;
 }
@@ -30,6 +32,7 @@ const ReleaseEditableBlock = ({
   block,
   sectionId,
   editable = true,
+  visible,
   onSave,
   onDelete,
 }: Props) => {
@@ -75,12 +78,14 @@ const ReleaseEditableBlock = ({
       return (
         <div className="dfe-content-overflow">
           <EditableBlockWrapper onDelete={editable ? handleDelete : undefined}>
-            <DataBlockTabs
-              releaseId={releaseId}
-              id={blockId}
-              dataBlock={block}
-              getInfographic={getChartFile}
-            />
+            <Gate condition={!!visible}>
+              <DataBlockTabs
+                releaseId={releaseId}
+                id={blockId}
+                dataBlock={block}
+                getInfographic={getChartFile}
+              />
+            </Gate>
           </EditableBlockWrapper>
         </div>
       );

--- a/src/explore-education-statistics-common/src/components/Gate.tsx
+++ b/src/explore-education-statistics-common/src/components/Gate.tsx
@@ -1,61 +1,91 @@
-import useAsyncCallback, {
-  AsyncStateSetterParam,
-} from '@common/hooks/useAsyncCallback';
+import usePrevious from '@common/hooks/usePrevious';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import React, { ReactNode, useEffect } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 
 interface GateProps {
-  condition: boolean | (() => Promise<boolean>);
+  condition: boolean | (() => Promise<boolean>) | (() => boolean);
   children: ReactNode;
+  /**
+   * Fallback to render if the {@property condition}
+   * has not passed yet.
+   */
   fallback?: ReactNode | ((error?: unknown) => ReactNode);
+  /**
+   * Loading state to render if the {@property condition}
+   * is dependent on an asynchronous task.
+   */
   loading?: ReactNode;
+  /**
+   * If the {@property condition} passes once, then we
+   * consider the gate 'closed' and will not try to
+   * re-run the condition and will not unmount the
+   * children if the condition changes back to false.
+   */
+  passOnce?: boolean;
 }
 
 /**
- * Conditionally render {@param children} based on a
- * {@param condition} that must be passed. This may be
- * an asynchronous task or just any boolean.
- *
- * @param loading state can be rendered if it is asynchronous.
- * @param fallback will be rendered if the condition
- * fails or there is an error.
+ * Conditionally render its children based on a condition
+ * that must be passed. This may be an asynchronous task
+ * or just any boolean.
  */
 const Gate = ({
   children,
   condition,
   fallback = null,
   loading = null,
+  passOnce = true,
 }: GateProps) => {
-  const [{ isLoading, value, error }, checkCondition] = useAsyncCallback(
-    async () => (typeof condition === 'boolean' ? condition : condition()),
-    [condition],
-    () => {
-      let initialState: AsyncStateSetterParam<boolean> = {
-        isLoading: true,
-      };
+  const previousCondition = usePrevious(condition);
 
-      if (typeof condition === 'boolean') {
-        initialState = {
-          isLoading: false,
-          value: condition,
-        };
-      }
-
-      return initialState;
-    },
-  );
+  const [passed, setPassed] = useState(false);
+  const [isLoading, setLoading] = useState(false);
+  const [error, setError] = useState<unknown>();
 
   useEffect(() => {
-    if (isLoading && !value && !error) {
-      checkCondition();
-    }
-  }, [isLoading, value, error, checkCondition]);
+    const checkCondition = async () => {
+      if (previousCondition === condition) {
+        return;
+      }
+
+      if (passed && passOnce) {
+        return;
+      }
+
+      if (isLoading) {
+        return;
+      }
+
+      if (typeof condition === 'boolean') {
+        setPassed(condition);
+        return;
+      }
+
+      const task = condition();
+
+      if (task instanceof Promise) {
+        setLoading(true);
+
+        try {
+          setPassed(await task);
+        } catch (err) {
+          setError(err);
+        } finally {
+          setLoading(false);
+        }
+      } else {
+        setPassed(task);
+      }
+    };
+
+    checkCondition();
+  }, [condition, isLoading, passOnce, passed, previousCondition]);
 
   if (isLoading) {
     return loading;
   }
 
-  if (value) {
+  if (passed) {
     return children;
   }
 

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -15,6 +15,8 @@ import { DataBlock } from '@common/services/types/blocks';
 import isAxiosError from '@common/utils/error/isAxiosError';
 import React, { ReactNode } from 'react';
 
+const testId = (dataBlock: DataBlock) => `Data block - ${dataBlock.name}`;
+
 export interface DataBlockTabsProps {
   additionalTabContent?:
     | ((props: { dataBlock: DataBlock }) => ReactNode)
@@ -56,11 +58,7 @@ const DataBlockTabs = ({
 
   return (
     <LoadingSpinner loading={isLoading}>
-      <Tabs
-        id={id}
-        testId={`Data block - ${dataBlock.name}`}
-        onToggle={onToggle}
-      >
+      <Tabs id={id} testId={testId(dataBlock)} onToggle={onToggle}>
         {firstTabs}
 
         {dataBlock.charts?.length && (
@@ -153,4 +151,5 @@ const DataBlockTabs = ({
 
 export default withLazyLoad(DataBlockTabs, {
   offset: 100,
+  placeholder: ({ dataBlock }) => <span data-testid={testId(dataBlock)} />,
 });

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -446,7 +446,13 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
           {release.content.map(({ heading, caption, order, content }) => {
             return (
               <AccordionSection heading={heading} caption={caption} key={order}>
-                <PublicationSectionBlocks blocks={content} release={release} />
+                {({ open }) => (
+                  <PublicationSectionBlocks
+                    blocks={content}
+                    release={release}
+                    visible={open}
+                  />
+                )}
               </AccordionSection>
             );
           })}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/components/PublicationSectionBlocks.tsx
@@ -1,3 +1,4 @@
+import Gate from '@common/components/Gate';
 import InsetText from '@common/components/InsetText';
 import useGetReleaseFile from '@common/modules/release/hooks/useGetReleaseFile';
 import ContentBlockRenderer from '@common/modules/find-statistics/components/ContentBlockRenderer';
@@ -16,11 +17,13 @@ import React from 'react';
 export interface PublicationSectionBlocksProps {
   release: Release;
   blocks: Block[];
+  visible?: boolean;
 }
 
 const PublicationSectionBlocks = ({
   release,
   blocks,
+  visible,
 }: PublicationSectionBlocksProps) => {
   const getReleaseFile = useGetReleaseFile(release.id);
 
@@ -34,29 +37,31 @@ const PublicationSectionBlocks = ({
       {blocks.map(block => {
         if (block.type === 'DataBlock') {
           return (
-            <DataBlockTabs
-              key={block.id}
-              dataBlock={block}
-              releaseId={release.id}
-              getInfographic={getReleaseFile}
-              onToggle={section => {
-                logEvent({
-                  category: 'Publication Release Data Tabs',
-                  action: `${section.title} (${block.name}) tab opened`,
-                  label: window.location.pathname,
-                });
-              }}
-              additionalTabContent={
-                <div className="dfe-print-hidden">
-                  <h3 className="govuk-heading-m">
-                    Explore and edit this data online
-                  </h3>
+            <Gate condition={!!visible}>
+              <DataBlockTabs
+                key={block.id}
+                dataBlock={block}
+                releaseId={release.id}
+                getInfographic={getReleaseFile}
+                onToggle={section => {
+                  logEvent({
+                    category: 'Publication Release Data Tabs',
+                    action: `${section.title} (${block.name}) tab opened`,
+                    label: window.location.pathname,
+                  });
+                }}
+                additionalTabContent={
+                  <div className="dfe-print-hidden">
+                    <h3 className="govuk-heading-m">
+                      Explore and edit this data online
+                    </h3>
 
-                  <p>Use our table tool to explore this data.</p>
-                  <ExploreDataButton block={block} />
-                </div>
-              }
-            />
+                    <p>Use our table tool to explore this data.</p>
+                    <ExploreDataButton block={block} />
+                  </div>
+                }
+              />
+            </Gate>
           );
         }
 

--- a/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
+++ b/tests/robot-tests/tests/admin/bau/create_data_block_with_chart.robot
@@ -176,12 +176,12 @@ Embed data block into release content
     user chooses and embeds data block    ${DATABLOCK_NAME}
 
 Validate embedded table rows
-    ${table}=    set variable    css:[data-testid="Data block - ${DATABLOCK_NAME}"] table
-    user scrolls to element    xpath://button[text()="${CONTENT_SECTION_NAME}"]
-    # The below is to avoid React lazy-loading the table which causes the test to fail here
-    user scrolls down    400
-    user waits until page contains element    ${table}    30
+    ${datablock}=    set variable    testid:Data block - ${DATABLOCK_NAME}
+    # Need to scroll to block to load it
+    user scrolls to element    ${datablock}
 
+    ${table}=    set variable    ${datablock} >> css:table
+    user waits until page contains element    ${table}    30
     user checks table column heading contains    1    1    Admission Numbers    ${table}
 
     ${row}=    user gets row number with heading    Bolton 001 (E02000984)    ${table}
@@ -332,9 +332,10 @@ Validate line chart embeds correctly
     user clicks link    Content
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user opens accordion section    ${CONTENT_SECTION_NAME}    css:#releaseMainContent
-    ${datablock}=    set variable    css:[data-testid="Data block - ${DATABLOCK_NAME}"]
-    # The below is to avoid React lazy-loading the chart which causes the test to fail here
-    user scrolls down    400
+
+    ${datablock}=    set variable    testid:Data block - ${DATABLOCK_NAME}
+    # Need to scroll to block to load it
+    user scrolls to element    ${datablock}
     user waits until element contains line chart    ${datablock}
 
     user checks chart title contains    ${datablock}    Test chart title
@@ -429,10 +430,10 @@ Save and validate vertical bar chart embeds correctly
     user waits until h2 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
     user opens accordion section    ${CONTENT_SECTION_NAME}    css:#releaseMainContent
 
-    ${datablock}=    set variable    css:[data-testid="Data block - ${DATABLOCK_NAME}"]
+    ${datablock}=    set variable    testid:Data block - ${DATABLOCK_NAME}
+    # Need to scroll to block to load it
+    user scrolls to element    ${datablock}
     user waits until element does not contain line chart    ${datablock}
-    # below is to prevent React lazy loading the chart
-    user scrolls down    400
     user waits until element contains bar chart    ${datablock}
 
     user checks chart title contains    ${datablock}    Test chart title
@@ -514,7 +515,9 @@ Save and validate horizontal bar chart embeds correctly
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user opens accordion section    ${CONTENT_SECTION_NAME}    css:#releaseMainContent
 
-    ${datablock}=    set variable    css:[data-testid="Data block - ${DATABLOCK_NAME}"]
+    ${datablock}=    set variable    testid:Data block - ${DATABLOCK_NAME}
+    # Need to scroll to block to load it
+    user scrolls to element    ${datablock}
     user waits until element contains bar chart    ${datablock}
 
     user checks chart title contains    ${datablock}    Test chart title
@@ -607,14 +610,16 @@ Save and validate geographic chart embeds correctly
     user opens accordion section    ${CONTENT_SECTION_NAME}    css:#releaseMainContent
     user waits until page does not contain loading spinner
 
-    ${datablock}=    set variable    css:[data-testid="Data block - ${DATABLOCK_NAME}"]
+    ${datablock}=    set variable    testid:Data block - ${DATABLOCK_NAME}
+    # Need to scroll to block to load it
+    user scrolls to element    ${datablock}
     user waits until element does not contain bar chart    ${datablock}
     user waits until element contains map chart    ${datablock}
 
     user checks map chart height    ${datablock}    700
     user checks map chart width    ${datablock}    600
 
-    user chooses select option    ${datablock} select[name="selectedLocation"]    Nailsea Youngwood
+    user chooses select option    ${datablock} >> name:selectedLocation    Nailsea Youngwood
 
     user mouses over selected map feature    ${datablock}
     user checks chart tooltip label contains    ${datablock}    Nailsea Youngwood
@@ -654,7 +659,9 @@ Save and validate infographic chart embeds correctly
     user waits until h2 is visible    ${PUBLICATION_NAME}
     user opens accordion section    ${CONTENT_SECTION_NAME}    css:#releaseMainContent
 
-    ${datablock}=    set variable    css:[data-testid="Data block - ${DATABLOCK_NAME}"]
+    ${datablock}=    set variable    testid:Data block - ${DATABLOCK_NAME}
+    # Need to scroll to block to load it
+    user scrolls to element    ${datablock}
     user checks chart title contains    ${datablock}    Test chart title
     user checks infographic chart contains alt    ${datablock}    Test chart alt
 


### PR DESCRIPTION
This PR adds further lazy-loading of the data blocks so that they will not load until their relevant section in the release content has been opened. 

Previously, most (if not all) of the data block requests would be triggered as soon as the user scrolled over the release's main content accordion. This could lead to large spikes in traffic if none of the data blocks were cached for that release.

To allow us to do this enhanced lazy loading, we now use wrapping `Gate` components that prevent their child data block from loading until the accordion section has been opened at least once.

## Relevant changes

- Refactors `Gate` to use a `useEffect` instead of `useAsyncCallback`. We needed more fine-grained control of how the states toggle, particularly as we have introduced a new `passOnce` prop that controls if the `Gate` will allow its child to unmount if its condition reverts back to false later.