### PR TITLE
EES-2831 - decreased default Table Tool query timeout to below Azure app service timeout threshold (of 230 seconds)

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -73,9 +73,6 @@
     },
     "maxDbSizeBytes": {
       "value": 322122547200
-    },
-    "requestTimeoutsTableBuilderQuery": {
-      "value": 300000
     }
   }
 }

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -495,7 +495,7 @@
     },
     "requestTimeoutsTableBuilderQuery": {
       "type": "int",
-      "defaultValue": 60000,
+      "defaultValue": 210000,
       "metadata": {
         "description": "Timeout in milliseconds for a table builder query to return results before cancelling the request in the API"
       }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "RequestTimeouts": {
-    "TableBuilderQuery": 300000
+    "TableBuilderQuery": 210000
   },
   "TableBuilder": {
     "MaxTableCellsAllowed": 25000


### PR DESCRIPTION
This PR:
-lowers the default Table Tool query timeout to 210 seconds across the board, which is 20 seconds below the Azure App Service default timeout.
- allows us to deliver a useful error response to the user rather than the silent Azure timeout response (which is silent due to CORS errors preventing its response data to be used in the browser).

I've removed the parameter from `dev.parameters.json` to allow it to pick up the default.

See this post for similar details: https://techcommunity.microsoft.com/t5/apps-on-azure/app-service-timeout-in-230-sec/m-p/1526934 