### PR TITLE
🐛 Bugfix/EES-2917 Fixes around table result subject metadata after PR #3025

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
@@ -32,7 +32,7 @@
     "MaxTableCellsAllowed": 25000
   },
   "Locations": {
-    "TableResultLocationHierarchiesFeature": false,
+    "TableResultLocationHierarchiesEnabled": false,
     "Hierarchies": {
       "LocalAuthority": [
         "Region",

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
@@ -13,7 +13,7 @@
     "MaxTableCellsAllowed": 25000
   },
   "Locations": {
-    "TableResultLocationHierarchiesFeature": false,
+    "TableResultLocationHierarchiesEnabled": false,
     "Hierarchies": {
       "LocalAuthority": [
         "Region",


### PR DESCRIPTION
This PR corrects a few things which were merged with https://github.com/dfe-analytical-services/explore-education-statistics/pull/3025.

* Corrects the `TableResultLocationHierarchiesEnabled` property in the `appsettings.json` files to match the expected property name in `LocationOptions`. The property was disabled by default and remains disabled by default so this wasn't a serious problem but the property name was wrong so enabling the feature was broken.

* Corrects the type of `ResultSubjectMetaViewModel` in the `PermalinkContractResolver` when determining if the `Location` and `LocationsHierarchical` should be serialized. The type was previously `Permalink` so this wasn't working as their declaring type was wrong meaning both fields were being serialized. While this doesn't cause an issue, we don't really want to serialize the `LocationsHierarchical` property until the feature is turned on / becomes permanent.

* Move building the `JsonSerializerSettings` and add setting `NullValueHandling = NullValueHandling.Ignore`. This is because I spotted the serialized Json has a huge amount of null properties. It's easier to see the relevant query and results when viewing Permalink json if the null attributes are stripped out, and the overall blob size is reduced.