### PR TITLE
EES-2958 - increase tableBuilderMaxTableCellsAllowed for test env

### DIFF
--- a/infrastructure/parameters/test.parameters.json
+++ b/infrastructure/parameters/test.parameters.json
@@ -52,6 +52,9 @@
     },
     "enableThemeDeletion": {
       "value": true
+    },
+    "tableBuilderMaxTableCellsAllowed": {
+      "value": 1000000
     }
   }
 }


### PR DESCRIPTION
This PR: 
- increases tableBuilderMaxTableCells allowed as discussed in standup for the test environment