### PR TITLE
EES-2964 tidying release page

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -214,7 +214,7 @@ const ReleaseContent = () => {
                 {hasAllFilesButton && (
                   <li>
                     <Button
-                      className="govuk-button govuk-!-width-full govuk-!-margin-bottom-3"
+                      className="govuk-!-width-full govuk-!-margin-bottom-3"
                       disableDoubleClick
                       onClick={() =>
                         releaseFileService.downloadAllFilesZip(release.id)
@@ -321,7 +321,6 @@ const ReleaseContent = () => {
           release={release}
           renderAllFilesButton={
             <Button
-              className="govuk-!-width-full govuk-!-margin-bottom-0"
               disableDoubleClick
               variant="secondary"
               onClick={() => releaseFileService.downloadAllFilesZip(release.id)}
@@ -344,7 +343,6 @@ const ReleaseContent = () => {
           )}
           renderDataGuidanceLink={
             <ButtonLink
-              className="govuk-!-width-full govuk-!-margin-bottom-0"
               to={{
                 pathname: generatePath<ReleaseRouteParams>(
                   releaseDataGuidanceRoute.path,
@@ -363,20 +361,13 @@ const ReleaseContent = () => {
             </ButtonLink>
           }
           renderDataCatalogueLink={
-            <Button
-              className="govuk-!-width-full govuk-!-margin-bottom-0"
-              disabled
-              variant="secondary"
-            >
+            <Button disabled variant="secondary">
               Browse data files
               <br /> (public site only)
             </Button>
           }
           renderCreateTablesButton={
-            <Button
-              className="govuk-!-width-full govuk-!-margin-bottom-0"
-              disabled
-            >
+            <Button disabled>
               Create tables
               <br /> (public site only)
             </Button>

--- a/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/content/components/ReleaseContent.tsx
@@ -1,3 +1,4 @@
+import ButtonLink from '@admin/components/ButtonLink';
 import { CommentsChangeHandler } from '@admin/components/editable/Comments';
 import EditableSectionBlocks from '@admin/components/editable/EditableSectionBlocks';
 import Link from '@admin/components/Link';
@@ -184,25 +185,50 @@ const ReleaseContent = () => {
 
         <div className="govuk-grid-column-one-third">
           <RelatedAside>
-            <h2 className="govuk-heading-m">Useful information</h2>
-
-            <ul className="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
-              {hasAllFilesButton && (
+            <h2 className="govuk-heading-m" id="data-downloads">
+              Data downloads
+            </h2>
+            <nav role="navigation" aria-labelledby="data-downloads">
+              <ul className="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
                 <li>
-                  <Button
-                    className="govuk-button govuk-!-margin-bottom-3"
-                    disableDoubleClick
-                    onClick={() =>
-                      releaseFileService.downloadAllFilesZip(release.id)
-                    }
-                  >
-                    Download all data
-                  </Button>
+                  <a href="#dataDownloads-1">Explore data and files</a>
                 </li>
-              )}
-              <li>
-                <a href="#dataDownloads-1">View data and files</a>
-              </li>
+                <li>
+                  <Link
+                    to={{
+                      pathname: generatePath<ReleaseRouteParams>(
+                        releaseDataGuidanceRoute.path,
+                        {
+                          publicationId: release.publication.id,
+                          releaseId: release.id,
+                        },
+                      ),
+                      state: {
+                        backLink: location.pathname,
+                      },
+                    }}
+                  >
+                    Data guidance
+                  </Link>
+                </li>
+                {hasAllFilesButton && (
+                  <li>
+                    <Button
+                      className="govuk-button govuk-!-width-full govuk-!-margin-bottom-3"
+                      disableDoubleClick
+                      onClick={() =>
+                        releaseFileService.downloadAllFilesZip(release.id)
+                      }
+                    >
+                      Download all data
+                    </Button>
+                  </li>
+                )}
+              </ul>
+            </nav>
+
+            <h2 className="govuk-heading-m">Supporting information</h2>
+            <ul className="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
               {release.hasPreReleaseAccessList && (
                 <li>
                   <Link
@@ -228,39 +254,38 @@ const ReleaseContent = () => {
               </li>
             </ul>
 
-            <dl className="dfe-meta-content">
-              <dt className="govuk-caption-m">For {release.coverageTitle}: </dt>
-              <dd data-testid="release-name">
-                <strong>{release.yearTitle}</strong>
+            {!!releaseCount && (
+              <>
+                <p className="govuk-!-margin-bottom-0">
+                  {release.coverageTitle} <strong>{release.yearTitle}</strong>
+                </p>
+                <Details summary={`See other releases (${releaseCount})`}>
+                  <ul className="govuk-list">
+                    {[
+                      ...release.publication.otherReleases.map(
+                        ({ id, title, slug }) => (
+                          <li key={id} data-testid="other-release-item">
+                            <Link
+                              to={`${config?.PublicAppUrl}/find-statistics/${release.publication.slug}/${slug}`}
+                            >
+                              {title}
+                            </Link>
+                          </li>
+                        ),
+                      ),
+                      ...release.publication.legacyReleases.map(
+                        ({ id, description, url }) => (
+                          <li key={id} data-testid="other-release-item">
+                            <Link to={url}>{description}</Link>
+                          </li>
+                        ),
+                      ),
+                    ]}
+                  </ul>
+                </Details>
+              </>
+            )}
 
-                {releaseCount > 0 && (
-                  <Details summary={`See other releases (${releaseCount})`}>
-                    <ul className="govuk-list">
-                      {[
-                        ...release.publication.otherReleases.map(
-                          ({ id, title, slug }) => (
-                            <li key={id} data-testid="other-release-item">
-                              <Link
-                                to={`${config?.PublicAppUrl}/find-statistics/${release.publication.slug}/${slug}`}
-                              >
-                                {title}
-                              </Link>
-                            </li>
-                          ),
-                        ),
-                        ...release.publication.legacyReleases.map(
-                          ({ id, description, url }) => (
-                            <li key={id} data-testid="other-release-item">
-                              <Link to={url}>{description}</Link>
-                            </li>
-                          ),
-                        ),
-                      ]}
-                    </ul>
-                  </Details>
-                )}
-              </dd>
-            </dl>
             {allMethodologies.length > 0 && (
               <>
                 <h3
@@ -296,11 +321,12 @@ const ReleaseContent = () => {
           release={release}
           renderAllFilesButton={
             <Button
-              className="govuk-!-width-full"
+              className="govuk-!-width-full govuk-!-margin-bottom-0"
               disableDoubleClick
+              variant="secondary"
               onClick={() => releaseFileService.downloadAllFilesZip(release.id)}
             >
-              Download all files
+              Download all data
             </Button>
           }
           renderDownloadLink={file => (
@@ -317,7 +343,8 @@ const ReleaseContent = () => {
             </ButtonText>
           )}
           renderDataGuidanceLink={
-            <Link
+            <ButtonLink
+              className="govuk-!-width-full govuk-!-margin-bottom-0"
               to={{
                 pathname: generatePath<ReleaseRouteParams>(
                   releaseDataGuidanceRoute.path,
@@ -330,28 +357,31 @@ const ReleaseContent = () => {
                   backLink: location.pathname,
                 },
               }}
+              variant="secondary"
             >
-              data files guide
-            </Link>
+              Data guidance
+            </ButtonLink>
           }
-          renderPreReleaseAccessLink={
-            <Link
-              to={{
-                pathname: generatePath<ReleaseRouteParams>(
-                  preReleaseAccessListRoute.path,
-                  {
-                    publicationId: release.publication.id,
-                    releaseId: release.id,
-                  },
-                ),
-                state: {
-                  backLink: location.pathname,
-                },
-              }}
+          renderDataCatalogueLink={
+            <Button
+              className="govuk-!-width-full govuk-!-margin-bottom-0"
+              disabled
+              variant="secondary"
             >
-              View pre-release access list
-            </Link>
+              Browse data files
+              <br /> (public site only)
+            </Button>
           }
+          renderCreateTablesButton={
+            <Button
+              className="govuk-!-width-full govuk-!-margin-bottom-0"
+              disabled
+            >
+              Create tables
+              <br /> (public site only)
+            </Button>
+          }
+          showDownloadFilesList
         />
       )}
 

--- a/src/explore-education-statistics-common/src/components/SectionBreak.tsx
+++ b/src/explore-education-statistics-common/src/components/SectionBreak.tsx
@@ -1,0 +1,20 @@
+import classNames from 'classnames';
+import React from 'react';
+
+interface Props {
+  size?: 'm' | 'l' | 'xl';
+  visible?: boolean;
+}
+
+const SectionBreak = ({ size = 'm', visible = true }: Props) => (
+  <hr
+    className={classNames('govuk-section-break', {
+      'govuk-section-break--xl': size === 'xl',
+      'govuk-section-break--l': size === 'l',
+      'govuk-section-break--m': size === 'm',
+      'govuk-section-break--visible': visible,
+    })}
+  />
+);
+
+export default SectionBreak;

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAndFilesAccordion.module.scss
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAndFilesAccordion.module.scss
@@ -14,3 +14,14 @@
     }
   }
 }
+
+.section {
+  p:last-of-type {
+    margin-bottom: 0;
+  }
+
+  :global(.govuk-button) {
+    margin-bottom: 0;
+    width: 100%;
+  }
+}

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAndFilesAccordion.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAndFilesAccordion.tsx
@@ -11,11 +11,11 @@ import styles from './ReleaseDataAndFilesAccordion.module.scss';
 interface Props {
   release: Release;
   renderAllFilesButton?: ReactNode;
-  renderCreateTablesButton?: ReactNode;
-  renderDataCatalogueLink?: ReactNode;
-  renderDownloadLink: (file: FileInfo) => ReactNode;
+  renderCreateTablesButton: ReactNode;
+  renderDataCatalogueLink: ReactNode;
   renderDataGuidanceLink: ReactNode;
-  renderPreReleaseAccessLink?: ReactNode;
+  renderDownloadLink: (file: FileInfo) => ReactNode;
+  showDownloadFilesList?: boolean;
   onSectionOpen?: (accordionSection: { id: string; title: string }) => void;
 }
 
@@ -24,9 +24,9 @@ const ReleaseDataAndFilesAccordion = ({
   renderAllFilesButton,
   renderCreateTablesButton,
   renderDataCatalogueLink,
-  renderDownloadLink,
   renderDataGuidanceLink,
-  renderPreReleaseAccessLink,
+  renderDownloadLink,
+  showDownloadFilesList = false,
   onSectionOpen,
 }: Props) => {
   const dataFiles = orderBy(
@@ -56,16 +56,16 @@ const ReleaseDataAndFilesAccordion = ({
         }}
       >
         <AccordionSection heading="Explore data and files">
-          <div className="govuk-grid-row">
+          <div className="govuk-grid-row dfe-flex dfe-align-items--center">
             <div
               className={classNames({
                 'govuk-grid-column-three-quarters': hasAllFilesButton,
                 'govuk-grid-column-full': !hasAllFilesButton,
               })}
             >
-              <p>
-                All data used to create this release is published as open data
-                and is available for download.
+              <p className="govuk-!-margin-bottom-0">
+                All data used in this release is available as open data for
+                download
               </p>
             </div>
 
@@ -76,75 +76,79 @@ const ReleaseDataAndFilesAccordion = ({
             )}
           </div>
 
-          <div className="govuk-grid-row">
+          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+
+          <div className="govuk-grid-row dfe-flex dfe-align-items--center">
             <div className="govuk-grid-column-three-quarters">
               <h3>Open data</h3>
-              <p>
-                The open data files contain all data used in this release in a
-                machine readable format.
+              <p className="govuk-!-margin-bottom-0">
+                Browse and download individual open data files from this release
+                in our data catalogue
               </p>
 
-              {!renderDataCatalogueLink && dataFiles.length > 0 && (
-                <ul className="govuk-list" data-testid="data-files">
-                  {dataFiles.map(file => (
-                    <li key={file.id}>
-                      {renderDownloadLink(file)}
-                      {` (${file.extension}, ${file.size})`}
-                    </li>
-                  ))}
-                </ul>
+              {showDownloadFilesList && dataFiles.length > 0 && (
+                <Details
+                  summary="Download files"
+                  className="govuk-!-margin-bottom-0 govuk-!-margin-top-2"
+                >
+                  <ul className="govuk-list" data-testid="data-files">
+                    {dataFiles.map(file => (
+                      <li key={file.id}>
+                        {renderDownloadLink(file)}
+                        {` (${file.extension}, ${file.size})`}
+                      </li>
+                    ))}
+                  </ul>
+                </Details>
               )}
-
-              {release.hasDataGuidance && (
-                <p>
-                  Learn more about the data files used in this release using our{' '}
-                  {renderDataGuidanceLink}.
-                </p>
-              )}
+            </div>
+            <div className="govuk-grid-column-one-quarter">
+              {renderDataCatalogueLink}
             </div>
           </div>
-          {renderDataCatalogueLink && (
-            <div className="govuk-grid-row">
-              <div className="govuk-grid-column-three-quarters">
-                <p>
-                  You can browse and download individual open data files from
-                  this release in our data catalogue.
-                </p>
-              </div>
-              <div className="govuk-grid-column-one-quarter">
-                {renderDataCatalogueLink}
-              </div>
-            </div>
-          )}
+          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 
-          {renderCreateTablesButton && (
+          {release.hasDataGuidance && (
             <>
-              <h3>Create your own tables</h3>
-
-              <div className="govuk-grid-row">
+              <div className="govuk-grid-row dfe-flex dfe-align-items--center">
                 <div className="govuk-grid-column-three-quarters">
-                  <p>
-                    You can view featured tables that we have built for you, or
-                    create your own tables from the open data using our table
-                    tool.
+                  <h3>Guidance</h3>
+                  <p className="govuk-!-margin-bottom-0">
+                    Learn more about the data files used in this release using
+                    our online guidance
                   </p>
                 </div>
                 <div className="govuk-grid-column-one-quarter">
-                  {renderCreateTablesButton}
+                  {renderDataGuidanceLink}
                 </div>
               </div>
+              <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
             </>
           )}
 
+          <div className="govuk-grid-row dfe-flex dfe-align-items--center">
+            <div className="govuk-grid-column-three-quarters">
+              <h3>Create your own tables</h3>
+              <p className="govuk-!-margin-bottom-0">
+                You can view featured tables that we have built for you, or
+                create your own tables from the open data using our table tool
+              </p>
+            </div>
+            <div className="govuk-grid-column-one-quarter">
+              {renderCreateTablesButton}
+            </div>
+          </div>
+          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+
           {ancillaryFiles.length > 0 && (
             <>
-              <h3>Other files</h3>
+              <h3>All supporting files</h3>
               <p>
-                All other files from this release are listed for individual
+                All supporting files from this release are listed for individual
                 download below:
               </p>
 
-              <Details summary="List of other files">
+              <Details summary="List of all supporting files">
                 <ul className="govuk-list" data-testid="other-files">
                   {ancillaryFiles.map(file => (
                     <li key={file.id}>
@@ -165,12 +169,6 @@ const ReleaseDataAndFilesAccordion = ({
                   ))}
                 </ul>
               </Details>
-            </>
-          )}
-          {release.hasPreReleaseAccessList && renderPreReleaseAccessLink && (
-            <>
-              <h3>Pre-release access list</h3>
-              <p>{renderPreReleaseAccessLink}</p>
             </>
           )}
         </AccordionSection>

--- a/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAndFilesAccordion.tsx
+++ b/src/explore-education-statistics-common/src/modules/release/components/ReleaseDataAndFilesAccordion.tsx
@@ -1,6 +1,7 @@
 import Accordion from '@common/components/Accordion';
 import AccordionSection from '@common/components/AccordionSection';
 import Details from '@common/components/Details';
+import SectionBreak from '@common/components/SectionBreak';
 import { Release } from '@common/services/publicationService';
 import { FileInfo } from '@common/services/types/file';
 import classNames from 'classnames';
@@ -56,14 +57,16 @@ const ReleaseDataAndFilesAccordion = ({
         }}
       >
         <AccordionSection heading="Explore data and files">
-          <div className="govuk-grid-row dfe-flex dfe-align-items--center">
+          <div
+            className={`govuk-grid-row dfe-flex dfe-align-items--center ${styles.section}`}
+          >
             <div
               className={classNames({
                 'govuk-grid-column-three-quarters': hasAllFilesButton,
                 'govuk-grid-column-full': !hasAllFilesButton,
               })}
             >
-              <p className="govuk-!-margin-bottom-0">
+              <p>
                 All data used in this release is available as open data for
                 download
               </p>
@@ -76,12 +79,14 @@ const ReleaseDataAndFilesAccordion = ({
             )}
           </div>
 
-          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+          <SectionBreak />
 
-          <div className="govuk-grid-row dfe-flex dfe-align-items--center">
+          <div
+            className={`govuk-grid-row dfe-flex dfe-align-items--center ${styles.section}`}
+          >
             <div className="govuk-grid-column-three-quarters">
               <h3>Open data</h3>
-              <p className="govuk-!-margin-bottom-0">
+              <p>
                 Browse and download individual open data files from this release
                 in our data catalogue
               </p>
@@ -106,14 +111,17 @@ const ReleaseDataAndFilesAccordion = ({
               {renderDataCatalogueLink}
             </div>
           </div>
-          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+
+          <SectionBreak />
 
           {release.hasDataGuidance && (
             <>
-              <div className="govuk-grid-row dfe-flex dfe-align-items--center">
+              <div
+                className={`govuk-grid-row dfe-flex dfe-align-items--center ${styles.section}`}
+              >
                 <div className="govuk-grid-column-three-quarters">
                   <h3>Guidance</h3>
-                  <p className="govuk-!-margin-bottom-0">
+                  <p>
                     Learn more about the data files used in this release using
                     our online guidance
                   </p>
@@ -122,14 +130,17 @@ const ReleaseDataAndFilesAccordion = ({
                   {renderDataGuidanceLink}
                 </div>
               </div>
-              <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+
+              <SectionBreak />
             </>
           )}
 
-          <div className="govuk-grid-row dfe-flex dfe-align-items--center">
+          <div
+            className={`govuk-grid-row dfe-flex dfe-align-items--center ${styles.section}`}
+          >
             <div className="govuk-grid-column-three-quarters">
               <h3>Create your own tables</h3>
-              <p className="govuk-!-margin-bottom-0">
+              <p>
                 You can view featured tables that we have built for you, or
                 create your own tables from the open data using our table tool
               </p>
@@ -138,7 +149,8 @@ const ReleaseDataAndFilesAccordion = ({
               {renderCreateTablesButton}
             </div>
           </div>
-          <hr className="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+
+          <SectionBreak visible={ancillaryFiles.length > 0} />
 
           {ancillaryFiles.length > 0 && (
             <>

--- a/src/explore-education-statistics-frontend/src/components/ButtonLink.tsx
+++ b/src/explore-education-statistics-frontend/src/components/ButtonLink.tsx
@@ -9,14 +9,16 @@ import { LinkProps } from './Link';
 
 type Props = {
   disabled?: boolean;
+  variant?: 'secondary' | 'warning';
 } & LinkProps;
 
 const ButtonLink = ({
   children,
   className,
   disabled = false,
-  to,
   prefetch,
+  to,
+  variant,
   ...props
 }: Props) => {
   const isAbsolute = typeof to === 'string' && to.startsWith('http');
@@ -30,6 +32,8 @@ const ButtonLink = ({
         'govuk-button',
         {
           'govuk-button--disabled': disabled,
+          'govuk-button--secondary': variant === 'secondary',
+          'govuk-button--warning': variant === 'warning',
         },
         className,
       )}

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -390,7 +390,6 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
           }}
           renderAllFilesButton={
             <ButtonLink
-              className="govuk-!-width-full govuk-!-margin-bottom-0"
               to={`${process.env.CONTENT_API_BASE_URL}/releases/${release.id}/files`}
               variant="secondary"
               onClick={() => {
@@ -403,15 +402,9 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
               Download all data
             </ButtonLink>
           }
-          renderCreateTablesButton={
-            <CreateTablesButton
-              className="govuk-!-width-full govuk-!-margin-bottom-0"
-              release={release}
-            />
-          }
+          renderCreateTablesButton={<CreateTablesButton release={release} />}
           renderDataCatalogueLink={
             <ButtonLink
-              className="govuk-!-width-full govuk-!-margin-bottom-0"
               to={`/data-catalogue/${release.publication.slug}/${release.slug}`}
               variant="secondary"
             >
@@ -436,7 +429,6 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
           }}
           renderDataGuidanceLink={
             <ButtonLink
-              className="govuk-!-width-full govuk-!-margin-bottom-0"
               to={
                 release.latestRelease
                   ? `/find-statistics/${release.publication.slug}/meta-guidance`

--- a/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/find-statistics/PublicationReleasePage.tsx
@@ -194,15 +194,40 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
 
         <div className="govuk-grid-column-one-third">
           <RelatedAside>
-            <h2 className="govuk-heading-m" id="useful-information">
-              Useful information
+            <h2 className="govuk-heading-m" id="data-downloads">
+              Data downloads
             </h2>
-            <nav role="navigation" aria-labelledby="useful-information">
+            <nav role="navigation" aria-labelledby="data-downloads">
               <ul className="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
+                <li>
+                  <a
+                    href="#dataDownloads-1"
+                    onClick={() => {
+                      logEvent({
+                        category: `${release.publication.title} release page`,
+                        action: `View data and files clicked`,
+                        label: window.location.pathname,
+                      });
+                    }}
+                  >
+                    Explore data and files
+                  </a>
+                </li>
+                <li>
+                  <Link
+                    to={
+                      release.latestRelease
+                        ? `/find-statistics/${release.publication.slug}/meta-guidance`
+                        : `/find-statistics/${release.publication.slug}/${release.slug}/meta-guidance`
+                    }
+                  >
+                    Data guidance
+                  </Link>
+                </li>
                 {showAllFilesButton && (
                   <li>
                     <ButtonLink
-                      className="govuk-button govuk-!-margin-bottom-3"
+                      className="govuk-button govuk-!-width-full govuk-!-margin-bottom-3"
                       to={`${process.env.CONTENT_API_BASE_URL}/releases/${release.id}/files`}
                       onClick={() => {
                         logEvent({
@@ -216,80 +241,70 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
                     </ButtonLink>
                   </li>
                 )}
-                <li>
-                  <a
-                    href="#dataDownloads-1"
-                    onClick={() => {
-                      logEvent({
-                        category: `${release.publication.title} release page`,
-                        action: `View data and files clicked`,
-                        label: window.location.pathname,
-                      });
-                    }}
-                  >
-                    View data and files
-                  </a>
-                </li>
-                {release.hasPreReleaseAccessList && (
-                  <li>
-                    <Link
-                      to={
-                        release.latestRelease
-                          ? `/find-statistics/${release.publication.slug}/prerelease-access-list`
-                          : `/find-statistics/${release.publication.slug}/${release.slug}/prerelease-access-list`
-                      }
-                    >
-                      Pre-release access list
-                    </Link>
-                  </li>
-                )}
-                <li>
-                  <a href="#contact-us">Contact us</a>
-                </li>
-                {!!releaseCount && (
-                  <>
-                    <p className="govuk-!-margin-bottom-0">
-                      {release.coverageTitle}{' '}
-                      <strong>{release.yearTitle}</strong>
-                    </p>
-                    <Details
-                      summary={`See other releases (${releaseCount})`}
-                      onToggle={open =>
-                        open &&
-                        logEvent({
-                          category: 'Other Releases',
-                          action: 'Release page other releases dropdown opened',
-                          label: window.location.pathname,
-                        })
-                      }
-                    >
-                      <ul className="govuk-list">
-                        {[
-                          ...release.publication.otherReleases.map(
-                            ({ id, slug, title }) => (
-                              <li key={id} data-testid="other-release-item">
-                                <Link
-                                  to={`/find-statistics/${release.publication.slug}/${slug}`}
-                                >
-                                  {title}
-                                </Link>
-                              </li>
-                            ),
-                          ),
-                          ...release.publication.legacyReleases.map(
-                            ({ id, description, url }) => (
-                              <li key={id} data-testid="other-release-item">
-                                <a href={url}>{description}</a>
-                              </li>
-                            ),
-                          ),
-                        ]}
-                      </ul>
-                    </Details>
-                  </>
-                )}
               </ul>
             </nav>
+
+            <h2 className="govuk-heading-m">Supporting information</h2>
+            <ul className="govuk-list govuk-list--spaced govuk-!-margin-bottom-0">
+              {release.hasPreReleaseAccessList && (
+                <li>
+                  <Link
+                    to={
+                      release.latestRelease
+                        ? `/find-statistics/${release.publication.slug}/prerelease-access-list`
+                        : `/find-statistics/${release.publication.slug}/${release.slug}/prerelease-access-list`
+                    }
+                  >
+                    Pre-release access list
+                  </Link>
+                </li>
+              )}
+              <li>
+                <a href="#contact-us">Contact us</a>
+              </li>
+            </ul>
+            {!!releaseCount && (
+              <>
+                <p className="govuk-!-margin-bottom-0">
+                  {release.coverageTitle} <strong>{release.yearTitle}</strong>
+                </p>
+                <Details
+                  summary={`See other releases (${releaseCount})`}
+                  onToggle={open =>
+                    open &&
+                    logEvent({
+                      category: 'Other Releases',
+                      action: 'Release page other releases dropdown opened',
+                      label: window.location.pathname,
+                    })
+                  }
+                >
+                  <ul className="govuk-list">
+                    {[
+                      ...release.publication.otherReleases.map(
+                        ({ id, slug, title }) => (
+                          <li key={id} data-testid="other-release-item">
+                            <Link
+                              to={`/find-statistics/${release.publication.slug}/${slug}`}
+                            >
+                              {title}
+                            </Link>
+                          </li>
+                        ),
+                      ),
+                      ...release.publication.legacyReleases.map(
+                        ({ id, description, url }) => (
+                          <li key={id} data-testid="other-release-item">
+                            <a href={url}>{description}</a>
+                          </li>
+                        ),
+                      ),
+                    ]}
+                  </ul>
+                </Details>
+              </>
+            )}
+
             {(release.publication.methodologies.length > 0 ||
               release.publication.externalMethodology) && (
               <>
@@ -375,29 +390,30 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
           }}
           renderAllFilesButton={
             <ButtonLink
-              className="govuk-!-width-full"
+              className="govuk-!-width-full govuk-!-margin-bottom-0"
               to={`${process.env.CONTENT_API_BASE_URL}/releases/${release.id}/files`}
+              variant="secondary"
               onClick={() => {
                 logEvent({
                   category: 'Downloads',
-                  action: 'Release page all files downloaded',
-                  label: `Publication: ${release.publication.title}, Release: ${release.title}, File: All files`,
+                  action: `Release page all files downloads.title}, Release: ${release.title}, File: All files`,
                 });
               }}
             >
-              Download all files
+              Download all data
             </ButtonLink>
           }
           renderCreateTablesButton={
             <CreateTablesButton
-              className="govuk-!-width-full"
+              className="govuk-!-width-full govuk-!-margin-bottom-0"
               release={release}
             />
           }
           renderDataCatalogueLink={
             <ButtonLink
-              className="govuk-!-width-full"
+              className="govuk-!-width-full govuk-!-margin-bottom-0"
               to={`/data-catalogue/${release.publication.slug}/${release.slug}`}
+              variant="secondary"
             >
               Browse data files
             </ButtonLink>
@@ -419,15 +435,17 @@ const PublicationReleasePage: NextPage<Props> = ({ release }) => {
             );
           }}
           renderDataGuidanceLink={
-            <Link
+            <ButtonLink
+              className="govuk-!-width-full govuk-!-margin-bottom-0"
               to={
                 release.latestRelease
                   ? `/find-statistics/${release.publication.slug}/meta-guidance`
                   : `/find-statistics/${release.publication.slug}/${release.slug}/meta-guidance`
               }
+              variant="secondary"
             >
-              data files guide
-            </Link>
+              Data guidance
+            </ButtonLink>
           }
         />
       )}

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -281,7 +281,7 @@ Validate prerelease has started
 Validate metadata guidance page
     user opens accordion section    Explore data and files
     user waits until h3 is visible    Open data
-    user clicks link    data files guide
+    user clicks link    Data guidance
 
     user waits until page contains title caption    Calendar Year 2000    %{WAIT_SMALL}
     user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}
@@ -378,7 +378,7 @@ Validate prerelease has started for Analyst user
 Validate public metdata guidance for Analyst user
     user opens accordion section    Explore data and files
     user waits until h3 is visible    Open data
-    user clicks link    data files guide
+    user clicks link    Data guidance
 
     user waits until page contains title caption    Calendar Year 2000    %{WAIT_SMALL}
     user waits until h1 is visible    ${PUBLICATION_NAME}    %{WAIT_SMALL}

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -132,18 +132,19 @@ Validate 'Explore data and files' accordion
     ${section}=    user gets accordion section content element    Explore data and files
 
     # All files zip
-    user checks element contains button    ${section}    Download all files
+    user checks element contains button    ${section}    Download all data
 
     # Data files
     user waits until h3 is visible    Open data
+    user opens details dropdown    Download files
     user checks list has x items    testid:data-files    1    ${section}
     ${data_files_1}=    user gets list item element    testid:data-files    1    ${section}
     user checks element contains button    ${data_files_1}    Updated Absence in PRUs
 
     # Ancillary files
-    user waits until h3 is visible    Other files
-    user opens details dropdown    List of other files
-    ${other_files}=    user gets details content element    List of other files    ${section}
+    user waits until h3 is visible    All supporting files
+    user opens details dropdown    List of all supporting files
+    ${other_files}=    user gets details content element    List of all supporting files    ${section}
     ${other_files_1}=    get child element    ${other_files}    css:li:nth-child(1)
 
     user checks element contains button    ${other_files_1}    Test 1

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -603,7 +603,7 @@ Go to release page
 Go to data guidance document
     user opens accordion section    Explore data and files
     user waits until h3 is visible    Open data
-    user clicks link    data files guide
+    user clicks link    Data guidance
 
     user waits until page contains title caption    ${RELEASE_2_NAME}
     user waits until h1 is visible    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_release_and_amend.robot
@@ -169,20 +169,20 @@ Verify release associated files
     ${downloads}=    user gets accordion section content element    Explore data and files
     user waits until page contains element    ${downloads}    %{WAIT_SMALL}
 
-    user checks element should contain    ${downloads}    Download all files
+    user checks element should contain    ${downloads}    Download all data
     ...    %{WAIT_SMALL}
     user checks element should contain    ${downloads}
-    ...    All data used to create this release is published as open data and is available for download.
+    ...    All data used in this release is available as open data for download
     user checks element should contain    ${downloads}
-    ...    You can view featured tables that we have built for you, or create your own tables from the open data using our table tool.
+    ...    You can view featured tables that we have built for you, or create your own tables from the open data using our table tool
 
     user checks element should contain    ${downloads}
-    ...    The open data files contain all data used in this release in a machine readable format.
+    ...    Browse and download individual open data files from this release in our data catalogue
     user checks element should contain    ${downloads}
-    ...    Learn more about the data files used in this release using our data files guide.
+    ...    Learn more about the data files used in this release using our online guidance
 
-    user opens details dropdown    List of other files
-    ${other_files}=    user gets details content element    List of other files
+    user opens details dropdown    List of all supporting files
+    ${other_files}=    user gets details content element    List of all supporting files
     ${other_files_1}=    get child element    ${other_files}    css:li:nth-child(1)
 
     user waits until element contains link    ${other_files_1}    Test ancillary file 1
@@ -196,7 +196,7 @@ Verify release associated files
 Verify public metadata guidance document
     user opens accordion section    Explore data and files
     user waits until h3 is visible    Open data
-    user clicks link    data files guide
+    user clicks link    Data guidance
 
     user checks breadcrumb count should be    4
     user checks nth breadcrumb contains    1    Home
@@ -515,11 +515,11 @@ Verify amendment is published
 Verify amendment files
     user opens accordion section    Explore data and files
     ${downloads}=    user gets accordion section content element    Explore data and files
-    user checks element should contain    ${downloads}    Download all files
+    user checks element should contain    ${downloads}    Download all data
     ...    %{WAIT_SMALL}
 
-    user opens details dropdown    List of other files
-    ${other_files}=    user gets details content element    List of other files
+    user opens details dropdown    List of all supporting files
+    ${other_files}=    user gets details content element    List of all supporting files
     ${other_files_1}=    get child element    ${other_files}    css:li:nth-child(1)
     ${other_files_2}=    get child element    ${other_files}    css:li:nth-child(2)
 
@@ -542,7 +542,7 @@ Verify amendment files
 Verify amendment public metadata guidance document
     user opens accordion section    Explore data and files
     user waits until h3 is visible    Open data
-    user clicks link    data files guide
+    user clicks link    Data guidance
 
     user checks breadcrumb count should be    4
     user checks nth breadcrumb contains    1    Home


### PR DESCRIPTION
Updates to the release page on the public site and in the admin.
- Renames and adds 'Supporting information' section to the sidebar 
- Tidies up the 'Explore data and files' accordion
- In the admin tries to keep the look of it consistent with the public site by using disabled buttons when they aren't available until the release is published.
- Removes an unnecessary extra link to the pre-release access list from the admin version
- Does not add the file type and size to the download all data button, I think this will need to be a separate ticket.

Sidebar:
![sidebar](https://user-images.githubusercontent.com/81572860/146157088-176c8ec3-fe9d-4b7f-857c-e7dd207086ae.PNG)

'Explore data and files' accordion - public site:
![explore](https://user-images.githubusercontent.com/81572860/146157083-6ae968dd-7635-4e43-968b-65c275576a84.PNG)

'Explore data and files' accordion - admin site:
![admin](https://user-images.githubusercontent.com/81572860/146157764-cebe9f70-d6d6-4cb8-8bc6-4ef0c7f0fa32.PNG)
