### PR TITLE
EES-2972 order Months after Weeks

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifier.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/TimeIdentifier.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Diagnostics.CodeAnalysis;
 using GovUk.Education.ExploreEducationStatistics.Common.Database;
 using static GovUk.Education.ExploreEducationStatistics.Common.Database.TimePeriodLabelFormat;
@@ -40,10 +41,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         [TimeIdentifierMeta("Calendar Year Q4", "CYQ4", Category.CalendarYear, Default, ShortLabel, "Q4")]
         CalendarYearQ4,
 
-        [TimeIdentifierMeta("Part 1 (April to September)", "P1", FinancialYearPart, Fiscal, ShortLabel, "Part 1 (Apr to Sep)")]
+        [TimeIdentifierMeta("Part 1 (April to September)", "P1", FinancialYearPart, Fiscal, ShortLabel,
+            "Part 1 (Apr to Sep)")]
         FinancialYearPart1,
 
-        [TimeIdentifierMeta("Part 2 (October to March)", "P2", FinancialYearPart, Fiscal, ShortLabel, "Part 2 (Oct to Mar)")]
+        [TimeIdentifierMeta("Part 2 (October to March)", "P2", FinancialYearPart, Fiscal, ShortLabel,
+            "Part 2 (Oct to Mar)")]
         FinancialYearPart2,
 
         [TimeIdentifierMeta("Financial Year", "FY", Category.FinancialYear, Fiscal, NoLabel)]
@@ -90,42 +93,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 
         [TimeIdentifierMeta("Summer Term", "T3", Term, Academic)]
         SummerTerm,
-
-        [TimeIdentifierMeta("January", "M1", Month)]
-        January,
-
-        [TimeIdentifierMeta("February", "M2", Month)]
-        February,
-
-        [TimeIdentifierMeta("March", "M3", Month)]
-        March,
-
-        [TimeIdentifierMeta("April", "M4", Month)]
-        April,
-
-        [TimeIdentifierMeta("May", "M5", Month)]
-        May,
-
-        [TimeIdentifierMeta("June", "M6", Month)]
-        June,
-
-        [TimeIdentifierMeta("July", "M7", Month)]
-        July,
-
-        [TimeIdentifierMeta("August", "M8", Month)]
-        August,
-
-        [TimeIdentifierMeta("September", "M9", Month)]
-        September,
-
-        [TimeIdentifierMeta("October", "M10", Month)]
-        October,
-
-        [TimeIdentifierMeta("November", "M11", Month)]
-        November,
-
-        [TimeIdentifierMeta("December", "M12", Month)]
-        December,
 
         [TimeIdentifierMeta("Week 1", "W1", Week)]
         Week1,
@@ -281,6 +248,42 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         Week51,
 
         [TimeIdentifierMeta("Week 52", "W52", Week)]
-        Week52
+        Week52,
+
+        [TimeIdentifierMeta("January", "M1", Month)]
+        January,
+
+        [TimeIdentifierMeta("February", "M2", Month)]
+        February,
+
+        [TimeIdentifierMeta("March", "M3", Month)]
+        March,
+
+        [TimeIdentifierMeta("April", "M4", Month)]
+        April,
+
+        [TimeIdentifierMeta("May", "M5", Month)]
+        May,
+
+        [TimeIdentifierMeta("June", "M6", Month)]
+        June,
+
+        [TimeIdentifierMeta("July", "M7", Month)]
+        July,
+
+        [TimeIdentifierMeta("August", "M8", Month)]
+        August,
+
+        [TimeIdentifierMeta("September", "M9", Month)]
+        September,
+
+        [TimeIdentifierMeta("October", "M10", Month)]
+        October,
+
+        [TimeIdentifierMeta("November", "M11", Month)]
+        November,
+
+        [TimeIdentifierMeta("December", "M12", Month)]
+        December,
     }
 }


### PR DESCRIPTION
This PR orders Months after Weeks to force December to be treated as greater (more recent) than any other Week when ordering the Releases in the laptops-and-tablets-data release.

There is currently a problem where categories of time identifiers have been mixed - Weeks and Months, and Week 28 is treated as more recent than December.

![image](https://user-images.githubusercontent.com/4147126/146184080-f6555ec6-cde2-4a1c-8231-fa0196db1d66.png)

In general this PR will not fix ordering of Time Identifiers when different categories are mixed such as ordering weeks and months together correctly.

In fact, this PR only happens to order December correctly, assuming that we can always treat it greater than any week.

 A solution is needed to overhaul how Release and Observation time periods are defined to allow more flexible ordering.

It will not work if any other monthly releases are created for 2021 into this Publication earlier than December, or if more weekly and monthly Releases are mixed going forwards in this Publication in 2022, or in any other Publication.