### PR TITLE
EES-2976 Remove broken DF alert in ARM template

### DIFF
--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -995,17 +995,6 @@
         "operator": "GreaterThan",
         "timeAggregation": "Total",
         "criterionType": "StaticThresholdCriterion"
-      },
-      {
-        "name": "[concat(parameters('subscription'),'DataFactoryPipelineFailures')]",
-        "description": "Data Factory - Pipeline Failed Run",
-        "resourceId": "[resourceId('Microsoft.DataFactory/factories', variables('dataFactoryName'))]",
-        "resourceType": "Microsoft.DataFactory/factories",
-        "metricName": "PipelineFailedRuns",
-        "threshold": 1,
-        "operator": "GreaterThan",
-        "timeAggregation": "Total",
-        "criterionType": "StaticThresholdCriterion"
       }
     ],
     "vNetName": "[concat(parameters('subscription'), '-vnet-', parameters('environment'))]",


### PR DESCRIPTION
Currently, an infrastructure deploy will fail due to this data factory alert. We're commenting out again so it won't prevent a deploy to preprod/prod.