### PR TITLE
EES-2850 updated admin dashboard style

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/AdminDashboardPage.tsx
@@ -139,6 +139,7 @@ const AdminDashboardPage = () => {
                           releaseId: release.id,
                         },
                       )}
+                      variant="secondary"
                     >
                       View release
                     </ButtonLink>

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/NonScheduledReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/NonScheduledReleaseSummary.tsx
@@ -40,7 +40,6 @@ const NonScheduledReleaseSummary = ({
     <>
       <ReleaseSummary
         release={release}
-        open={release.live && release.latestRelease}
         actions={
           <>
             {release.amendment ? (
@@ -56,10 +55,11 @@ const NonScheduledReleaseSummary = ({
                   data-testid={`Edit release amendment link for ${
                     release.publicationTitle
                   }, ${getReleaseSummaryLabel(release)}`}
+                  variant="secondary"
                 >
                   {release.permissions.canUpdateRelease
-                    ? 'Edit this release amendment'
-                    : 'View this release amendment'}
+                    ? 'Edit release amendment'
+                    : 'View release amendment'}
                 </ButtonLink>
                 <ButtonLink
                   to={generatePath<ReleaseRouteParams>(
@@ -69,10 +69,10 @@ const NonScheduledReleaseSummary = ({
                       releaseId: release.previousVersionId,
                     },
                   )}
-                  className="govuk-button--secondary govuk-!-margin-left-4"
                   data-testid={`View original release link for ${
                     release.publicationTitle
                   }, ${getReleaseSummaryLabel(release)}`}
+                  variant="secondary"
                 >
                   View original release
                 </ButtonLink>
@@ -90,39 +90,37 @@ const NonScheduledReleaseSummary = ({
                   data-testid={`Edit release link for ${
                     release.publicationTitle
                   }, ${getReleaseSummaryLabel(release)}`}
+                  variant="secondary"
                 >
                   {release.permissions.canUpdateRelease
-                    ? 'Edit this release'
-                    : 'View this release'}
+                    ? 'Edit release'
+                    : 'View release'}
                 </ButtonLink>
                 {includeCreateAmendmentControls &&
                   release.permissions.canMakeAmendmentOfRelease && (
                     <Button
-                      className="govuk-button--secondary govuk-!-margin-left-4"
+                      variant="secondary"
                       onClick={() => setAmendReleaseId(release.id)}
                     >
-                      Amend this release
+                      Amend release
                     </Button>
                   )}
               </>
             )}
+            {release.permissions.canDeleteRelease && release.amendment && (
+              <Button
+                onClick={async () => {
+                  setDeleteReleasePlan({
+                    ...(await releaseService.getDeleteReleasePlan(release.id)),
+                    releaseId: release.id,
+                  });
+                }}
+                variant="warning"
+              >
+                Cancel amendment
+              </Button>
+            )}
           </>
-        }
-        secondaryActions={
-          release.permissions.canDeleteRelease &&
-          release.amendment && (
-            <Button
-              onClick={async () => {
-                setDeleteReleasePlan({
-                  ...(await releaseService.getDeleteReleasePlan(release.id)),
-                  releaseId: release.id,
-                });
-              }}
-              className="govuk-button--warning"
-            >
-              Cancel amendment
-            </Button>
-          )
         }
       />
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.module.scss
@@ -1,0 +1,58 @@
+@import '~govuk-frontend/govuk/base';
+
+.section {
+  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(3);
+  padding-bottom: govuk-spacing(6);
+
+  @include govuk-media-query($from: desktop) {
+    display: flex;
+  }
+
+  &.lastSection {
+    border: 0;
+  }
+}
+
+.sectionHeading {
+  padding-top: govuk-spacing(2);
+
+  @include govuk-media-query($from: desktop) {
+    flex-basis: 20%;
+    flex-shrink: 0;
+  }
+}
+
+.sectionContent {
+  @include govuk-media-query($from: desktop) {
+    flex-basis: 60%;
+    flex-grow: 1;
+  }
+}
+
+.sectionActions {
+  @include govuk-media-query($from: desktop) {
+    border-left: 1px solid $govuk-border-colour;
+    flex-basis: 20%;
+    flex-shrink: 0;
+    margin-left: govuk-spacing(4);
+    padding: govuk-spacing(3) 0 0 govuk-spacing(4);
+  }
+
+  &.detailsActions {
+    @include govuk-media-query($from: desktop) {
+      flex-basis: calc(25% - 15px);
+    }
+  }
+
+  :global(.govuk-button) {
+    width: 100%;
+  }
+}
+
+.detailsInner {
+  @include govuk-media-query($from: desktop) {
+    display: flex;
+    margin-right: govuk-spacing(3) * -1;
+  }
+}

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/PublicationSummary.tsx
@@ -1,4 +1,7 @@
 import ButtonLink from '@admin/components/ButtonLink';
+import NonScheduledReleaseSummary from '@admin/pages/admin-dashboard/components/NonScheduledReleaseSummary';
+import MethodologySummary from '@admin/pages/admin-dashboard/components/MethodologySummary';
+import styles from '@admin/pages/admin-dashboard/components/PublicationSummary.module.scss';
 import {
   publicationEditRoute,
   publicationManageTeamAccessRoute,
@@ -7,11 +10,12 @@ import {
 } from '@admin/routes/routes';
 import { MyPublication } from '@admin/services/publicationService';
 import { Release } from '@admin/services/releaseService';
-import ButtonGroup from '@common/components/ButtonGroup';
+import SummaryList from '@common/components/SummaryList';
+import SummaryListItem from '@common/components/SummaryListItem';
+import WarningMessage from '@common/components/WarningMessage';
 import React from 'react';
 import { generatePath } from 'react-router';
-import NonScheduledReleaseSummary from './NonScheduledReleaseSummary';
-import MethodologySummary from './MethodologySummary';
+import classNames from 'classnames';
 
 export interface Props {
   publication: MyPublication;
@@ -30,13 +34,72 @@ const PublicationSummary = ({
 
   const noAmendmentInProgressFilter = (release: Release) =>
     !releases.some(r => r.amendment && r.previousVersionId === release.id);
+
   return (
     <>
-      <table>
-        <tbody>
-          <tr>
-            <th className="govuk-!-width-one-quarter">Team</th>
-            <td className="govuk-!-width-one-half">
+      <div className={styles.section}>
+        <h5 className={`govuk-heading-s ${styles.sectionHeading}`}>Releases</h5>
+        <div
+          className={styles.sectionContent}
+          data-testid={`Releases for ${publication.title}`}
+        >
+          {releases.length > 0 ? (
+            <ul className="govuk-list govuk-!-margin-top-2">
+              {releases.filter(noAmendmentInProgressFilter).map(release => (
+                <li key={release.id}>
+                  <NonScheduledReleaseSummary
+                    includeCreateAmendmentControls
+                    onAmendmentCancelled={onChangePublication}
+                    release={release}
+                  />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <WarningMessage className="govuk-!-margin-bottom-2">
+              No releases created
+            </WarningMessage>
+          )}
+          {permissions.canCreateReleases && (
+            <ButtonLink
+              className="govuk-!-margin-bottom-0"
+              to={generatePath(releaseCreateRoute.path, {
+                publicationId: id,
+              })}
+              data-testid={`Create new release link for ${title}`}
+            >
+              Create new release
+            </ButtonLink>
+          )}
+        </div>
+      </div>
+
+      <div className={styles.section}>
+        <h5 className={`govuk-heading-s ${styles.sectionHeading}`}>
+          Methodologies
+        </h5>
+        <div
+          className={styles.sectionContent}
+          data-testid={`Methodology for ${publication.title}`}
+        >
+          <MethodologySummary
+            publication={publication}
+            topicId={topicId}
+            onChangePublication={onChangePublication}
+          />
+        </div>
+      </div>
+
+      <div className={classNames(styles.section, styles.lastSection)}>
+        <h5 className={`govuk-heading-s ${styles.sectionHeading}`}>
+          Publication details
+        </h5>
+        <div
+          className={styles.sectionContent}
+          data-testid={`Details for ${publication.title}`}
+        >
+          <SummaryList className="govuk-!-margin-bottom-0">
+            <SummaryListItem term="Team">
               <p
                 className="govuk-!-margin-bottom-1"
                 data-testid={`Team name for ${publication.title}`}
@@ -54,11 +117,11 @@ const PublicationSummary = ({
                   </a>
                 </p>
               )}
-            </td>
-          </tr>
-          <tr>
-            <th>Contact</th>
-            <td>
+            </SummaryListItem>
+          </SummaryList>
+
+          <SummaryList>
+            <SummaryListItem term="Contact">
               <p
                 className="govuk-!-margin-bottom-1"
                 data-testid={`Contact name for ${publication.title}`}
@@ -76,85 +139,43 @@ const PublicationSummary = ({
                   </a>
                 </p>
               )}
-            </td>
-          </tr>
-          <tr>
-            <th>Methodologies</th>
-            <td data-testid={`Methodology for ${publication.title}`}>
-              <MethodologySummary
-                publication={publication}
-                topicId={topicId}
-                onChangePublication={onChangePublication}
-              />
-            </td>
-          </tr>
-          {permissions.canUpdatePublication && (
-            <tr>
-              <th>Manage</th>
-              <td>
-                <ButtonGroup className="govuk-!-margin-bottom-2">
-                  <ButtonLink
-                    data-testid={`Edit publication link for ${publication.title}`}
-                    to={generatePath<PublicationRouteParams>(
-                      publicationEditRoute.path,
-                      {
-                        publicationId: publication.id,
-                      },
-                    )}
-                  >
-                    Manage this publication
-                  </ButtonLink>
-                  {showManageTeamAccessButton && (
-                    <ButtonLink
-                      data-testid={`Manage team access for publication ${publication.title}`}
-                      to={generatePath<PublicationRouteParams>(
-                        publicationManageTeamAccessRoute.path,
-                        {
-                          publicationId: publication.id,
-                        },
-                      )}
-                    >
-                      Manage team access
-                    </ButtonLink>
-                  )}
-                </ButtonGroup>
-              </td>
-            </tr>
-          )}
-          <tr>
-            <th>Releases</th>
-            <td colSpan={2} data-testid={`Releases for ${publication.title}`}>
-              <ButtonGroup className="govuk-!-margin-bottom-2">
-                {permissions.canCreateReleases && (
-                  <ButtonLink
-                    to={generatePath(releaseCreateRoute.path, {
-                      publicationId: id,
-                    })}
-                    data-testid={`Create new release link for ${title}`}
-                  >
-                    Create new release
-                  </ButtonLink>
-                )}
-              </ButtonGroup>
-              {releases.length > 0 ? (
-                <ul className="govuk-list">
-                  {releases.filter(noAmendmentInProgressFilter).map(release => (
-                    <li key={release.id}>
-                      <NonScheduledReleaseSummary
-                        includeCreateAmendmentControls
-                        onAmendmentCancelled={onChangePublication}
-                        release={release}
-                      />
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <p>No releases created</p>
+            </SummaryListItem>
+          </SummaryList>
+        </div>
+
+        {permissions.canUpdatePublication && (
+          <div className={styles.sectionActions}>
+            <ButtonLink
+              className="govuk-!-width-full"
+              data-testid={`Edit publication link for ${publication.title}`}
+              to={generatePath<PublicationRouteParams>(
+                publicationEditRoute.path,
+                {
+                  publicationId: publication.id,
+                },
               )}
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              variant="secondary"
+            >
+              Manage publication
+            </ButtonLink>
+            {showManageTeamAccessButton && (
+              <ButtonLink
+                className="govuk-!-width-full"
+                data-testid={`Manage team access for publication ${publication.title}`}
+                to={generatePath<PublicationRouteParams>(
+                  publicationManageTeamAccessRoute.path,
+                  {
+                    publicationId: publication.id,
+                  },
+                )}
+                variant="secondary"
+              >
+                Manage team access
+              </ButtonLink>
+            )}
+          </div>
+        )}
+      </div>
     </>
   );
 };

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/ReleaseSummary.tsx
@@ -1,4 +1,5 @@
 import ReleaseServiceStatus from '@admin/components/ReleaseServiceStatus';
+import publicationSummaryStyles from '@admin/pages/admin-dashboard/components/PublicationSummary.module.scss';
 import {
   getReleaseApprovalStatusLabel,
   getReleaseSummaryLabel,
@@ -6,6 +7,7 @@ import {
 import { Release } from '@admin/services/releaseService';
 import Details from '@common/components/Details';
 import FormattedDate from '@common/components/FormattedDate';
+import LoadingSpinner from '@common/components/LoadingSpinner';
 import SummaryList from '@common/components/SummaryList';
 import SummaryListItem from '@common/components/SummaryListItem';
 import Tag from '@common/components/Tag';
@@ -16,12 +18,11 @@ import {
 } from '@common/utils/date/partialDate';
 import React, { ReactNode } from 'react';
 import LazyLoad from 'react-lazyload';
-import LoadingSpinner from '@common/components/LoadingSpinner';
+import classNames from 'classnames';
 
 interface Props {
   release: Release;
   actions: ReactNode;
-  secondaryActions?: ReactNode;
   open?: boolean;
   children?: ReactNode;
 }
@@ -29,7 +30,6 @@ interface Props {
 const ReleaseSummary = ({
   release,
   actions,
-  secondaryActions,
   open = false,
   children,
 }: Props) => {
@@ -72,48 +72,59 @@ const ReleaseSummary = ({
         </TagGroup>
       }
     >
-      <SummaryList className="govuk-!-margin-bottom-3">
-        <SummaryListItem term="Publish date">
-          <FormattedDate>
-            {release.published || release.publishScheduled || ''}
-          </FormattedDate>
-        </SummaryListItem>
+      <div className={publicationSummaryStyles.detailsInner}>
+        <div className={publicationSummaryStyles.sectionContent}>
+          <SummaryList className="govuk-!-margin-bottom-3">
+            <SummaryListItem term="Publish date">
+              {release.published || release.publishScheduled ? (
+                <FormattedDate>
+                  {release.published || release.publishScheduled || ''}
+                </FormattedDate>
+              ) : (
+                'Not yet published'
+              )}
+            </SummaryListItem>
 
-        {isValidPartialDate(release.nextReleaseDate) && (
-          <SummaryListItem term="Next release date">
-            <time>{formatPartialDate(release.nextReleaseDate)}</time>
-          </SummaryListItem>
-        )}
-        {release.approvalStatus === 'Approved' && (
-          <SummaryListItem term="Release process status">
-            <ReleaseServiceStatus releaseId={release.id} />
-          </SummaryListItem>
-        )}
-        <SummaryListItem term="Lead statistician">
-          {release.contact && (
-            <span>
-              {release.contact.contactName}
-              <br />
-              <a href="mailto:{lead.teamEmail}">{release.contact.teamEmail}</a>
-              <br />
-              {release.contact.contactTelNo}
-            </span>
+            {isValidPartialDate(release.nextReleaseDate) && (
+              <SummaryListItem term="Next release date">
+                <time>{formatPartialDate(release.nextReleaseDate)}</time>
+              </SummaryListItem>
+            )}
+            {release.approvalStatus === 'Approved' && (
+              <SummaryListItem term="Release process status">
+                <ReleaseServiceStatus releaseId={release.id} />
+              </SummaryListItem>
+            )}
+            <SummaryListItem term="Lead statistician">
+              {release.contact && (
+                <span>
+                  {release.contact.contactName}
+                  <br />
+                  <a href="mailto:{lead.teamEmail}">
+                    {release.contact.teamEmail}
+                  </a>
+                  <br />
+                  {release.contact.contactTelNo}
+                </span>
+              )}
+            </SummaryListItem>
+            {release.latestInternalReleaseNote && (
+              <SummaryListItem term="Internal note">
+                <span className="dfe-multiline-content">
+                  {release.latestInternalReleaseNote}
+                </span>
+              </SummaryListItem>
+            )}
+          </SummaryList>
+          {children}
+        </div>
+        <div
+          className={classNames(
+            publicationSummaryStyles.sectionActions,
+            publicationSummaryStyles.detailsActions,
           )}
-        </SummaryListItem>
-        {release.latestInternalReleaseNote && (
-          <SummaryListItem term="Internal note">
-            <span className="dfe-multiline-content">
-              {release.latestInternalReleaseNote}
-            </span>
-          </SummaryListItem>
-        )}
-      </SummaryList>
-      {children}
-
-      <div className="govuk-grid-row">
-        <div className="govuk-grid-column-two-thirds">{actions}</div>
-        <div className="govuk-grid-column-one-third dfe-align--right">
-          {secondaryActions}
+        >
+          {actions}
         </div>
       </div>
     </Details>

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/MethodologySummary.test.tsx
@@ -272,13 +272,27 @@ describe('MethodologySummary', () => {
 
       expect(
         screen.getByRole('link', {
-          name: 'Link to an externally hosted methodology',
+          name: 'Use an external methodology',
         }),
       ).toBeInTheDocument();
     });
   });
 
   describe('renders correctly when no Methodology is supplied', () => {
+    test('the no methodologies warning is shown', () => {
+      render(
+        <MemoryRouter>
+          <MethodologySummary
+            publication={testPublicationNoMethodology}
+            topicId={testTopicId}
+            onChangePublication={noop}
+          />
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByText('No methodologies added')).toBeInTheDocument();
+    });
+
     test('the correct buttons are shown if the user has permission to use them', () => {
       render(
         <MemoryRouter>
@@ -291,28 +305,20 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.queryByTestId('methodology-summary-link'),
-      ).not.toBeInTheDocument();
-
-      expect(
         screen.getByRole('button', { name: 'Create methodology' }),
       ).toBeInTheDocument();
 
       expect(
         screen.getByRole('link', {
-          name: 'Adopt a methodology',
+          name: 'Adopt an existing methodology',
         }),
       ).toBeInTheDocument();
 
       expect(
         screen.getByRole('link', {
-          name: 'Link to an externally hosted methodology',
+          name: 'Use an external methodology',
         }),
       ).toBeInTheDocument();
-
-      expect(
-        screen.queryByText('No methodologies added.'),
-      ).not.toBeInTheDocument();
     });
 
     test('the methodology buttons are not shown if the user does not have permission to use them', () => {
@@ -335,26 +341,20 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.queryByTestId('methodology-summary-link'),
-      ).not.toBeInTheDocument();
-
-      expect(
         screen.queryByRole('button', { name: 'Create methodology' }),
       ).not.toBeInTheDocument();
 
       expect(
         screen.queryByRole('link', {
-          name: 'Link to an externally hosted methodology',
+          name: 'Use an external methodology',
         }),
       ).not.toBeInTheDocument();
 
       expect(
         screen.queryByRole('link', {
-          name: 'Adopt a methodology',
+          name: 'Adopt an existing methodology',
         }),
       ).not.toBeInTheDocument();
-
-      expect(screen.getByText('No methodologies added.')).toBeInTheDocument();
     });
   });
 
@@ -383,11 +383,11 @@ describe('MethodologySummary', () => {
       expect(screen.getByText('this is the release note')).toBeInTheDocument();
 
       expect(
-        screen.getByRole('link', { name: 'View this methodology' }),
+        screen.getByRole('link', { name: 'View methodology' }),
       ).toBeInTheDocument();
 
       expect(
-        screen.queryByRole('link', { name: 'Edit this methodology' }),
+        screen.queryByRole('link', { name: 'Edit methodology' }),
       ).not.toBeInTheDocument();
     });
 
@@ -456,11 +456,11 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.getByRole('link', { name: 'Edit this methodology' }),
+        screen.getByRole('link', { name: 'Edit methodology' }),
       ).toBeInTheDocument();
 
       expect(
-        screen.queryByRole('link', { name: 'View this methodology' }),
+        screen.queryByRole('link', { name: 'View methodology' }),
       ).not.toBeInTheDocument();
     });
 
@@ -497,11 +497,11 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.getByRole('link', { name: 'Edit this methodology' }),
+        screen.getByRole('link', { name: 'Edit methodology' }),
       ).toBeInTheDocument();
 
       expect(
-        screen.queryByRole('link', { name: 'View this methodology' }),
+        screen.queryByRole('link', { name: 'View methodology' }),
       ).not.toBeInTheDocument();
     });
 
@@ -538,11 +538,11 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.getByRole('link', { name: 'Edit this methodology' }),
+        screen.getByRole('link', { name: 'Edit methodology' }),
       ).toBeInTheDocument();
 
       expect(
-        screen.queryByRole('link', { name: 'View this methodology' }),
+        screen.queryByRole('link', { name: 'View methodology' }),
       ).not.toBeInTheDocument();
     });
   });
@@ -572,11 +572,11 @@ describe('MethodologySummary', () => {
       expect(screen.getByText('this is the release note')).toBeInTheDocument();
 
       expect(
-        screen.getByRole('link', { name: 'View this amendment' }),
+        screen.getByRole('link', { name: 'View amendment' }),
       ).toBeInTheDocument();
 
       expect(
-        screen.queryByRole('link', { name: 'Edit this amendment' }),
+        screen.queryByRole('link', { name: 'Edit amendment' }),
       ).not.toBeInTheDocument();
     });
 
@@ -630,11 +630,11 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.getByRole('link', { name: 'Edit this amendment' }),
+        screen.getByRole('link', { name: 'Edit amendment' }),
       ).toBeInTheDocument();
 
       expect(
-        screen.queryByRole('link', { name: 'View this amendment' }),
+        screen.queryByRole('link', { name: 'View amendment' }),
       ).not.toBeInTheDocument();
     });
 
@@ -672,11 +672,11 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.getByRole('link', { name: 'Edit this amendment' }),
+        screen.getByRole('link', { name: 'Edit amendment' }),
       ).toBeInTheDocument();
 
       expect(
-        screen.queryByRole('link', { name: 'View this amendment' }),
+        screen.queryByRole('link', { name: 'View amendment' }),
       ).not.toBeInTheDocument();
     });
 
@@ -714,11 +714,11 @@ describe('MethodologySummary', () => {
       );
 
       expect(
-        screen.getByRole('link', { name: 'Edit this amendment' }),
+        screen.getByRole('link', { name: 'Edit amendment' }),
       ).toBeInTheDocument();
 
       expect(
-        screen.queryByRole('link', { name: 'View this amendment' }),
+        screen.queryByRole('link', { name: 'View amendment' }),
       ).not.toBeInTheDocument();
     });
   });
@@ -741,7 +741,7 @@ describe('MethodologySummary', () => {
 
       userEvent.click(
         screen.getByRole('link', {
-          name: 'Link to an externally hosted methodology',
+          name: 'Use an external methodology',
         }),
       );
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/NonScheduledReleaseSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/NonScheduledReleaseSummary.test.tsx
@@ -52,19 +52,19 @@ describe('NonScheduledReleaseSummary', () => {
 
     expect(
       screen.getByRole('link', {
-        name: 'View this release',
+        name: 'View release',
       }),
     ).toBeInTheDocument();
 
     expect(
       screen.queryByRole('link', {
-        name: 'Edit this release',
+        name: 'Edit release',
       }),
     ).not.toBeInTheDocument();
 
     expect(
       screen.queryByRole('button', {
-        name: 'Amend this release',
+        name: 'Amend release',
       }),
     ).not.toBeInTheDocument();
 
@@ -76,13 +76,13 @@ describe('NonScheduledReleaseSummary', () => {
 
     expect(
       screen.queryByRole('link', {
-        name: 'View this release amendment',
+        name: 'View release amendment',
       }),
     ).not.toBeInTheDocument();
 
     expect(
       screen.queryByRole('link', {
-        name: 'Edit this release amendment',
+        name: 'Edit release amendment',
       }),
     ).not.toBeInTheDocument();
 
@@ -116,19 +116,19 @@ describe('NonScheduledReleaseSummary', () => {
 
     expect(
       screen.queryByRole('link', {
-        name: 'View this release',
+        name: 'View release',
       }),
     ).not.toBeInTheDocument();
 
     expect(
       screen.getByRole('link', {
-        name: 'Edit this release',
+        name: 'Edit release',
       }),
     ).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', {
-        name: 'Amend this release',
+        name: 'Amend release',
       }),
     ).toBeInTheDocument();
 
@@ -140,13 +140,13 @@ describe('NonScheduledReleaseSummary', () => {
 
     expect(
       screen.queryByRole('link', {
-        name: 'View this release amendment',
+        name: 'View release amendment',
       }),
     ).not.toBeInTheDocument();
 
     expect(
       screen.queryByRole('link', {
-        name: 'Edit this release amendment',
+        name: 'Edit release amendment',
       }),
     ).not.toBeInTheDocument();
 
@@ -180,19 +180,19 @@ describe('NonScheduledReleaseSummary', () => {
 
     expect(
       screen.queryByRole('link', {
-        name: 'View this release',
+        name: 'View release',
       }),
     ).not.toBeInTheDocument();
 
     expect(
       screen.queryByRole('link', {
-        name: 'Edit this release',
+        name: 'Edit release',
       }),
     ).not.toBeInTheDocument();
 
     expect(
       screen.queryByRole('button', {
-        name: 'Amend this release',
+        name: 'Amend release',
       }),
     ).not.toBeInTheDocument();
 
@@ -204,13 +204,13 @@ describe('NonScheduledReleaseSummary', () => {
 
     expect(
       screen.getByRole('link', {
-        name: 'View this release amendment',
+        name: 'View release amendment',
       }),
     ).toBeInTheDocument();
 
     expect(
       screen.queryByRole('link', {
-        name: 'Edit this release amendment',
+        name: 'Edit release amendment',
       }),
     ).not.toBeInTheDocument();
 
@@ -246,19 +246,19 @@ describe('NonScheduledReleaseSummary', () => {
 
     expect(
       screen.queryByRole('link', {
-        name: 'View this release',
+        name: 'View release',
       }),
     ).not.toBeInTheDocument();
 
     expect(
       screen.queryByRole('link', {
-        name: 'Edit this release',
+        name: 'Edit release',
       }),
     ).not.toBeInTheDocument();
 
     expect(
       screen.queryByRole('button', {
-        name: 'Amend this release',
+        name: 'Amend release',
       }),
     ).not.toBeInTheDocument();
 
@@ -270,13 +270,13 @@ describe('NonScheduledReleaseSummary', () => {
 
     expect(
       screen.queryByRole('link', {
-        name: 'View this release amendment',
+        name: 'View release amendment',
       }),
     ).not.toBeInTheDocument();
 
     expect(
       screen.getByRole('link', {
-        name: 'Edit this release amendment',
+        name: 'Edit release amendment',
       }),
     ).toBeInTheDocument();
 
@@ -309,10 +309,10 @@ describe('NonScheduledReleaseSummary', () => {
       }),
     );
 
-    // Now click the "Amend this release" button and check that the warning modal appears.
+    // Now click the "Amend release" button and check that the warning modal appears.
     userEvent.click(
       screen.getByRole('button', {
-        name: 'Amend this release',
+        name: 'Amend release',
       }),
     );
 
@@ -438,7 +438,7 @@ describe('NonScheduledReleaseSummary', () => {
     // flag.
     expect(
       screen.queryByRole('button', {
-        name: 'Amend this release',
+        name: 'Amend release',
       }),
     ).not.toBeInTheDocument();
   });

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/PublicationSummary.test.tsx
@@ -153,13 +153,13 @@ describe('PublicationSummary', () => {
 
     expect(
       screen.queryByRole('link', {
-        name: 'Link to an externally hosted methodology',
+        name: 'Use an external methodology',
       }),
     ).not.toBeInTheDocument();
 
     expect(
       screen.queryByRole('link', {
-        name: 'Manage this publication',
+        name: 'Manage publication',
       }),
     ).not.toBeInTheDocument();
 
@@ -235,13 +235,13 @@ describe('PublicationSummary', () => {
 
     expect(
       screen.getByRole('link', {
-        name: 'Link to an externally hosted methodology',
+        name: 'Use an external methodology',
       }),
     ).toBeInTheDocument();
 
     expect(
       screen.getByRole('link', {
-        name: 'Manage this publication',
+        name: 'Manage publication',
       }),
     ).toBeInTheDocument();
 

--- a/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ReleaseSummary.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/admin-dashboard/components/__tests__/ReleaseSummary.test.tsx
@@ -1,0 +1,221 @@
+import ReleaseSummary from '@admin/pages/admin-dashboard/components/ReleaseSummary';
+import _releaseService, {
+  MyRelease,
+  ReleaseStageStatuses,
+} from '@admin/services/releaseService';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { forceVisible } from 'react-lazyload';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('@admin/services/releaseService');
+const releaseService = _releaseService as jest.Mocked<typeof _releaseService>;
+
+describe('ReleaseSummary', () => {
+  const testRelease: MyRelease = {
+    amendment: false,
+    approvalStatus: 'Approved',
+    contact: {
+      contactName: 'Test contact name',
+      contactTelNo: 'Test contact tel',
+      id: 'test-contact-idc',
+      teamEmail: 'test-contact@hiveit.co.uk',
+      teamName: 'Test team name',
+    },
+    id: 'rel-3',
+    latestInternalReleaseNote: 'Test internal release note',
+    latestRelease: false,
+    live: true,
+    nextReleaseDate: {
+      day: '01',
+      month: '01',
+      year: '2022',
+    },
+    permissions: {
+      canAddPrereleaseUsers: false,
+      canUpdateRelease: false,
+      canDeleteRelease: false,
+      canMakeAmendmentOfRelease: false,
+    },
+    preReleaseAccessList: '',
+    previousVersionId: 'rel-2',
+    publicationId: 'publication-id',
+    publicationSlug: 'test-publication',
+    publicationTitle: 'Test publication title',
+    published: '2021-01-01T11:21:17',
+    releaseName: 'Test release name',
+    slug: 'rel-3-slug',
+    timePeriodCoverage: {
+      label: 'Academic year',
+      value: 'AY',
+    },
+    title: 'Test release title',
+    type: {
+      id: 'test-type-id',
+      title: 'Ad hoc',
+    },
+  };
+  const testActions = <button type="button">Test action</button>;
+  const testChildren = <p>Test children</p>;
+
+  const completeReleaseStatus: ReleaseStageStatuses = {
+    overallStage: 'Complete',
+  };
+
+  beforeEach(() => {
+    releaseService.getReleaseStatus.mockResolvedValue(completeReleaseStatus);
+  });
+
+  test('renders approved and published releases correctly', async () => {
+    render(<ReleaseSummary release={testRelease} actions={testActions} />);
+
+    forceVisible(); // Force the lazyloaded stats to be visible.
+
+    expect(
+      screen.getByRole('button', { name: 'Test release title (Live)' }),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText('Published')).toBeInTheDocument();
+    });
+
+    expect(
+      within(screen.getByTestId('Publish date')).getByText('1 January 2021'),
+    ).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId('Next release date')).getByText(
+        '1 January 2022',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId('Release process status')).getByText(
+        'Complete',
+      ),
+    ).toBeInTheDocument();
+
+    const leadStatistician = screen.getByTestId('Lead statistician')
+      .textContent;
+    expect(leadStatistician?.includes('Test contact name')).toBeTruthy();
+    expect(
+      leadStatistician?.includes('test-contact@hiveit.co.uk'),
+    ).toBeTruthy();
+    expect(leadStatistician?.includes('Test contact tel')).toBeTruthy();
+
+    expect(
+      within(screen.getByTestId('Internal note')).getByText(
+        'Test internal release note',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('renders draft releases correctly', () => {
+    render(
+      <ReleaseSummary
+        release={{
+          ...testRelease,
+          approvalStatus: 'Draft',
+          live: false,
+          nextReleaseDate: undefined,
+          published: undefined,
+        }}
+        actions={testActions}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Test release title (not Live) Draft',
+      }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+
+    expect(
+      within(screen.getByTestId('Publish date')).getByText('Not yet published'),
+    ).toBeInTheDocument();
+
+    expect(screen.queryByTestId('Next release date')).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByTestId('Release process status'),
+    ).not.toBeInTheDocument();
+
+    const leadStatistician = screen.getByTestId('Lead statistician')
+      .textContent;
+    expect(leadStatistician?.includes('Test contact name')).toBeTruthy();
+    expect(
+      leadStatistician?.includes('test-contact@hiveit.co.uk'),
+    ).toBeTruthy();
+    expect(leadStatistician?.includes('Test contact tel')).toBeTruthy();
+
+    expect(
+      within(screen.getByTestId('Internal note')).getByText(
+        'Test internal release note',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('shows the scheduled publication date for scheduled releases', () => {
+    render(
+      <ReleaseSummary
+        release={{
+          ...testRelease,
+          published: undefined,
+          publishScheduled: '2022-01-01T11:21:17',
+        }}
+        actions={testActions}
+      />,
+    );
+
+    expect(
+      within(screen.getByTestId('Publish date')).getByText('1 January 2022'),
+    ).toBeInTheDocument();
+  });
+
+  test('shows the amendment tag for amendments', () => {
+    render(
+      <ReleaseSummary
+        release={{
+          ...testRelease,
+          amendment: true,
+        }}
+        actions={testActions}
+      />,
+    );
+
+    expect(screen.getByText('Amendment')).toBeInTheDocument();
+  });
+
+  test('renders actions correctly', () => {
+    render(<ReleaseSummary release={testRelease} actions={testActions} />);
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Test release title (Live)' }),
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Test action' }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders children correctly', () => {
+    render(
+      <ReleaseSummary release={testRelease} actions={testActions}>
+        {testChildren}
+      </ReleaseSummary>,
+    );
+    expect(screen.getByText('Test children')).toBeInTheDocument();
+  });
+
+  test('renders closed by default', () => {
+    render(<ReleaseSummary release={testRelease} actions={testActions} />);
+    expect(screen.getByText('Publish date')).not.toBeVisible();
+  });
+
+  test('renders open when open is set to true', () => {
+    render(<ReleaseSummary release={testRelease} actions={testActions} open />);
+    expect(screen.getByText('Publish date')).toBeVisible();
+  });
+});

--- a/src/explore-education-statistics-common/src/utils/date/partialDate.ts
+++ b/src/explore-education-statistics-common/src/utils/date/partialDate.ts
@@ -39,7 +39,7 @@ export const formatPartialDate = (
 ): string => {
   const opts = {
     monthYearFormat: 'MMMM yyyy',
-    fullFormat: 'dd MMMM yyyy',
+    fullFormat: 'd MMMM yyyy',
     ...options,
   };
 

--- a/tests/robot-tests/tests/admin/analyst/create_methodology_as_publication_owner.robot
+++ b/tests/robot-tests/tests/admin/analyst/create_methodology_as_publication_owner.robot
@@ -17,7 +17,7 @@ Create Publication as bau1
     user creates test publication via api    ${PUBLICATION_NAME}
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     user checks element contains button    ${accordion}    Create methodology
-    user checks element contains link    ${accordion}    Link to an externally hosted methodology
+    user checks element contains link    ${accordion}    Use an external methodology
 
 Assign publication owner permissions to analyst1
     user gives analyst publication owner access    ${PUBLICATION_NAME}
@@ -29,9 +29,9 @@ Create a methodology as publication owner
     user creates methodology for publication    ${PUBLICATION_NAME}
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     user checks element does not contain button    ${accordion}    Create methodology
-    user checks element contains link    ${accordion}    Link to an externally hosted methodology
+    user checks element contains link    ${accordion}    Use an external methodology
     ${details}=    user opens details dropdown    ${PUBLICATION_NAME}    ${accordion}
-    user checks element contains link    ${details}    Edit this methodology
+    user checks element contains link    ${details}    Edit methodology
     user checks element contains button    ${details}    Remove
     user checks element does not contain button    ${details}    Amend methodology
     user views methodology for open publication accordion    ${accordion}    ${PUBLICATION_NAME}

--- a/tests/robot-tests/tests/admin/analyst/manage_publication_as_publication_owner.robot
+++ b/tests/robot-tests/tests/admin/analyst/manage_publication_as_publication_owner.robot
@@ -25,7 +25,7 @@ Switch to analyst1
 
 Go to Manage publication page
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
-    user clicks link    Manage this publication    ${accordion}
+    user clicks link    Manage publication    ${accordion}
     user waits until page contains title    Manage publication
 
 Update publication

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_owner_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/publication_owner_permissions.robot
@@ -31,7 +31,7 @@ Navigate back to admin dashboard for publication
 
 Check Edit publication page inputs are correct
     ${accordion}=    user gets accordion section content element    ${PUBLICATION_NAME}
-    user clicks link    Manage this publication    ${accordion}
+    user clicks link    Manage publication    ${accordion}
     user waits until page contains title    Manage publication
 
     user waits until page contains element    label:Select theme
@@ -48,8 +48,8 @@ Check Edit publication page inputs are correct
 Check can create an amendment of a published release
     user navigates to publication on admin dashboard    ${PUBLICATION_NAME}    ${THEME_NAME}    ${TOPIC_NAME}
 
-    ${details}=    user gets details content element    ${PUBLISHED_RELEASE_TYPE} (Live - Latest release)
-    ...    ${publication_accordion}    %{WAIT_SMALL}
+    ${details}=    user opens details dropdown    ${PUBLISHED_RELEASE_TYPE} (Live - Latest release)
+    ...    ${publication_accordion}
     user can see the create amendment controls for release    ${details}
 
 Check cannot approve a draft release

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_approver_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_approver_ui_permissions.robot
@@ -30,6 +30,6 @@ Navigate back to admin dashboard for publication
     user navigates to publication on admin dashboard    ${PUBLICATION_NAME}    ${THEME_NAME}    ${TOPIC_NAME}
 
 Check cannot create an amendment of a published release
-    ${details}=    user gets details content element    ${PUBLISHED_RELEASE_TYPE} (Live - Latest release)
-    ...    ${publication_accordion}    %{WAIT_SMALL}
+    ${details}=    user opens details dropdown    ${PUBLISHED_RELEASE_TYPE} (Live - Latest release)
+    ...    ${publication_accordion}
     user cannot see the create amendment controls for release    ${details}

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_contributor_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_contributor_ui_permissions.robot
@@ -32,8 +32,8 @@ Navigate back to admin dashboard for publication
     user navigates to publication on admin dashboard    ${PUBLICATION_NAME}    ${THEME_NAME}    ${TOPIC_NAME}
 
 Check cannot create an amendment of a published release
-    ${details}=    user gets details content element    ${PUBLISHED_RELEASE_TYPE} (Live - Latest release)
-    ...    ${publication_accordion}    %{WAIT_SMALL}
+    ${details}=    user opens details dropdown    ${PUBLISHED_RELEASE_TYPE} (Live - Latest release)
+    ...    ${publication_accordion}
     user cannot see the create amendment controls for release    ${details}
 
 Check cannot approve a draft release

--- a/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_viewer_ui_permissions.robot
+++ b/tests/robot-tests/tests/admin/analyst/role_ui_permissions/release_viewer_ui_permissions.robot
@@ -32,8 +32,8 @@ Navigate back to admin dashboard for publication
     user navigates to publication on admin dashboard    ${PUBLICATION_NAME}    ${THEME_NAME}    ${TOPIC_NAME}
 
 Check cannot create an amendment of a published release
-    ${details}=    user gets details content element    ${PUBLISHED_RELEASE_TYPE} (Live - Latest release)
-    ...    ${publication_accordion}    %{WAIT_SMALL}
+    ${details}=    user opens details dropdown    ${PUBLISHED_RELEASE_TYPE} (Live - Latest release)
+    ...    ${publication_accordion}
     user cannot see the create amendment controls for release    ${details}
 
 Check cannot edit the release status of a Draft Release

--- a/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
+++ b/tests/robot-tests/tests/admin/bau/adopt_methodology.robot
@@ -21,8 +21,8 @@ Create Publications and a Methodology to adopt
 
 Adopt a Methodology
     ${accordion}=    user opens publication on the admin dashboard    ${ADOPTING_PUBLICATION_NAME}
-    user checks element contains link    ${accordion}    Adopt a methodology
-    user clicks link    Adopt a methodology    ${accordion}
+    user checks element contains link    ${accordion}    Adopt an existing methodology
+    user clicks link    Adopt an existing methodology    ${accordion}
     user waits until page contains title    Adopt a methodology
     user clicks radio    ${OWNING_PUBLICATION_NAME}
     user opens details dropdown    More details    css:[data-testid="Radio item for ${OWNING_PUBLICATION_NAME}"]

--- a/tests/robot-tests/tests/admin/bau/comments.robot
+++ b/tests/robot-tests/tests/admin/bau/comments.robot
@@ -41,8 +41,8 @@ Switch to analyst1 to work on release content blocks
 
     user opens details dropdown    ${RELEASE_NAME}    ${accordion}
     ${details}=    user gets details content element    ${RELEASE_NAME} (not Live)    ${accordion}
-    user waits until parent contains element    ${details}    xpath:.//a[text()="Edit this release"]
-    user clicks link    Edit this release
+    user waits until parent contains element    ${details}    xpath:.//a[text()="Edit release"]
+    user clicks link    Edit release
 
 Navigate to content section as analyst1
     user clicks link    Content
@@ -69,8 +69,8 @@ Switch to bau1 to add review comments
     ${accordion}=    user gets accordion section content element    ${PUBLICATION_NAME}
     user opens details dropdown    ${RELEASE_NAME}    ${accordion}
     ${details}=    user gets details content element    ${RELEASE_NAME} (not Live)    ${accordion}
-    user waits until parent contains element    ${details}    xpath:.//a[text()="Edit this release"]
-    user clicks link    Edit this release
+    user waits until parent contains element    ${details}    xpath:.//a[text()="Edit release"]
+    user clicks link    Edit release
 
 Navigate to content section as bau1
     [Tags]    HappyPath
@@ -97,8 +97,8 @@ Switch to analyst1 and navigate to release
     ${accordion}=    user gets accordion section content element    ${PUBLICATION_NAME}
     user opens details dropdown    ${RELEASE_NAME}    ${accordion}
     ${details}=    user gets details content element    ${RELEASE_NAME} (not Live)    ${accordion}
-    user waits until parent contains element    ${details}    xpath:.//a[text()="Edit this release"]
-    user clicks link    Edit this release
+    user waits until parent contains element    ${details}    xpath:.//a[text()="Edit release"]
+    user clicks link    Edit release
 
 Navigate to content section to resolve comments
     [Tags]    HappyPath

--- a/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_amendment.robot
@@ -98,7 +98,7 @@ Verify the summary for the original Methodology is as expected
     user views methodology for publication
     ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME} - first methodology version
-    ...    View this methodology
+    ...    View methodology
     user verifies methodology summary details
     ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME} - first methodology version
@@ -119,7 +119,7 @@ Edit the Amendment's summary to return the Methodology's title to the same as it
     ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME} - first methodology version
     ...    ${PUBLICATION_NAME}
-    ...    Edit this amendment
+    ...    Edit amendment
     user verifies methodology summary details
     ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME}
@@ -183,13 +183,13 @@ Approve the Methodology Amendment
 Revisit the Publication on the dashboard and check that the new Amendment is now the live Methodology
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     user opens details dropdown    ${PUBLICATION_NAME}    ${accordion}
-    user checks element contains link    ${accordion}    View this methodology
-    user checks element does not contain link    ${accordion}    Edit this methodology
+    user checks element contains link    ${accordion}    View methodology
+    user checks element does not contain link    ${accordion}    Edit methodology
     user checks element contains button    ${accordion}    Amend methodology
-    user checks element does not contain link    ${accordion}    Edit this amendment
+    user checks element does not contain link    ${accordion}    Edit amendment
 
 Visit the approved Amendment and check that its summary is as expected
-    user clicks link    View this methodology
+    user clicks link    View methodology
     ${date}=    get current datetime    %-d %B %Y
     user verifies methodology summary details
     ...    ${PUBLICATION_NAME}
@@ -207,13 +207,13 @@ Create and cancel an Amendment
 
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     user opens details dropdown    ${PUBLICATION_NAME}    ${accordion}
-    user checks element contains link    ${accordion}    View this methodology
-    user checks element does not contain link    ${accordion}    Edit this methodology
+    user checks element contains link    ${accordion}    View methodology
+    user checks element does not contain link    ${accordion}    Edit methodology
     user checks element contains button    ${accordion}    Amend methodology
-    user checks element does not contain link    ${accordion}    Edit this amendment
+    user checks element does not contain link    ${accordion}    Edit amendment
 
 Revisit the live Amendment after the cancellation to double check it remains unaffected
-    user clicks link    View this methodology
+    user clicks link    View methodology
     user clicks link    Manage content
     user verifies amended Methodology readonly content
 

--- a/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
+++ b/tests/robot-tests/tests/admin/bau/create_methodology_for_publication.robot
@@ -17,15 +17,15 @@ Create Publication and check available Methodology controls
     user creates test publication via api    ${PUBLICATION_NAME}
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     user checks element contains button    ${accordion}    Create methodology
-    user checks element contains link    ${accordion}    Link to an externally hosted methodology
+    user checks element contains link    ${accordion}    Use an external methodology
 
 Create a Methodology
     user creates methodology for publication    ${PUBLICATION_NAME}
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     user checks element does not contain button    ${accordion}    Create methodology
-    user checks element contains link    ${accordion}    Link to an externally hosted methodology
+    user checks element contains link    ${accordion}    Use an external methodology
     ${details}=    user opens details dropdown    ${PUBLICATION_NAME}    ${accordion}
-    user checks element contains link    ${details}    Edit this methodology
+    user checks element contains link    ${details}    Edit methodology
     user checks element contains button    ${details}    Remove
     user checks element does not contain button    ${details}    Amend methodology
     user views methodology for open publication accordion    ${accordion}    ${PUBLICATION_NAME}
@@ -90,7 +90,7 @@ Approve the Methodology
 Check the controls available are as expected for an approved Methodology that is not yet publicly visible
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     ${details}=    user opens details dropdown    ${PUBLICATION_NAME}    ${accordion}
-    user checks element contains link    ${details}    Edit this methodology
+    user checks element contains link    ${details}    Edit methodology
     user checks element does not contain button    ${details}    Remove
 
     # Check that the Amend methodology button is not yet present.    This is because the Methodology, although set to
@@ -105,5 +105,5 @@ Unapprove the Methodology
 
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     ${details}=    user opens details dropdown    ${PUBLICATION_NAME}    ${accordion}
-    user checks element contains link    ${details}    Edit this methodology
+    user checks element contains link    ${details}    Edit methodology
     user checks element contains button    ${details}    Remove

--- a/tests/robot-tests/tests/admin/bau/link_publication_to_external_methodology.robot
+++ b/tests/robot-tests/tests/admin/bau/link_publication_to_external_methodology.robot
@@ -16,7 +16,7 @@ Link Publication to External Methodology
     user creates test publication via api    ${PUBLICATION_NAME}
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     user checks element contains button    ${accordion}    Create methodology
-    user checks element contains link    ${accordion}    Link to an externally hosted methodology
+    user checks element contains link    ${accordion}    Use an external methodology
     user links publication to external methodology    ${PUBLICATION_NAME}
     user waits until page contains title    Dashboard
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
@@ -39,6 +39,6 @@ Remove the External Methodology from Publication
     user removes an external methodology from publication    ${PUBLICATION_NAME}
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
     user checks element contains button    ${accordion}    Create methodology
-    user checks element contains link    ${accordion}    Link to an externally hosted methodology
+    user checks element contains link    ${accordion}    Use an external methodology
     user checks element does not contain button    ${accordion}    Edit externally hosted methodology
     user checks element does not contain button    ${accordion}    Remove external methodology

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -129,8 +129,8 @@ Adopt a Draft methodology
     user creates test publication via api    ${ADOPTED_PUBLICATION_NAME}
     user creates methodology for publication    ${ADOPTED_PUBLICATION_NAME}
     ${accordion}    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
-    user checks element contains link    ${accordion}    Adopt a methodology
-    user clicks link    Adopt a methodology
+    user checks element contains link    ${accordion}    Adopt an existing methodology
+    user clicks link    Adopt an existing methodology
     user waits until page contains title    Adopt a methodology
     user clicks radio    ${ADOPTED_PUBLICATION_NAME}
     user clicks button    Save

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -47,8 +47,8 @@ Select release from admin dashboard
     ${accordion}=    user gets accordion section content element    ${PUBLICATION_NAME}
     user opens details dropdown    ${RELEASE_NAME} (not Live)    ${accordion}
     ${details}=    user gets details content element    ${RELEASE_NAME} (not Live)    ${accordion}
-    user waits until parent contains element    ${details}    xpath:.//a[text()="Edit this release"]
-    user clicks link    Edit this release
+    user waits until parent contains element    ${details}    xpath:.//a[text()="Edit release"]
+    user clicks link    Edit release
 
 Add public prerelease access list
     user clicks link    Pre-release access

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_methodology.robot
@@ -71,7 +71,7 @@ Verify that the user cannot edit the status of the methodology
     user views methodology for publication
     ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME}
-    ...    View this methodology
+    ...    View methodology
     user clicks link    Sign off
     user waits until h2 is visible    Sign off
     user checks page does not contain    Edit status
@@ -118,7 +118,7 @@ Amend the methodology in preparation to test publishing immediately
     ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME}
     ...    ${PUBLICATION_NAME} - Amended methodology
-    ...    Edit this amendment
+    ...    Edit amendment
 
 Update the methodology amendment's content
     user clicks link    Manage content

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_publication_update.robot
@@ -25,7 +25,7 @@ Publish release
 
 Navigate to publication on admin dashboard
     ${accordion}=    user opens publication on the admin dashboard    ${PUBLICATION_NAME}
-    user clicks link    Manage this publication    ${accordion}
+    user clicks link    Manage publication    ${accordion}
     user waits until page contains title    Manage publication
 
 Update publication details

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -70,7 +70,7 @@ user navigates to editable release summary from admin dashboard
     ...    ${DETAILS_HEADING}
     ...    ${THEME_NAME}
     ...    ${TOPIC_NAME}
-    ...    Edit this release
+    ...    Edit release
 
 user navigates to editable release amendment summary from admin dashboard
     [Arguments]
@@ -83,7 +83,7 @@ user navigates to editable release amendment summary from admin dashboard
     ...    ${DETAILS_HEADING}
     ...    ${THEME_NAME}
     ...    ${TOPIC_NAME}
-    ...    Edit this release amendment
+    ...    Edit release amendment
 
 user navigates to readonly release summary from admin dashboard
     [Arguments]
@@ -96,7 +96,7 @@ user navigates to readonly release summary from admin dashboard
     ...    ${DETAILS_HEADING}
     ...    ${THEME_NAME}
     ...    ${TOPIC_NAME}
-    ...    View this release
+    ...    View release
 
 user navigates to release summary from admin dashboard
     [Arguments]
@@ -104,7 +104,7 @@ user navigates to release summary from admin dashboard
     ...    ${DETAILS_HEADING}
     ...    ${THEME_NAME}=%{TEST_THEME_NAME}
     ...    ${TOPIC_NAME}=%{TEST_TOPIC_NAME}
-    ...    ${RELEASE_SUMMARY_LINK_TEXT}=Edit this release
+    ...    ${RELEASE_SUMMARY_LINK_TEXT}=Edit release
     ${details}=    user opens release summary on the admin dashboard
     ...    ${PUBLICATION_NAME}
     ...    ${DETAILS_HEADING}
@@ -180,7 +180,7 @@ user views methodology for publication
     [Arguments]
     ...    ${publication}
     ...    ${methodology_title}=${publication}
-    ...    ${view_button_text}=Edit this methodology
+    ...    ${view_button_text}=Edit methodology
     ${accordion}=    user opens publication on the admin dashboard    ${publication}
     user views methodology for open publication accordion
     ...    ${accordion}
@@ -191,13 +191,13 @@ user views methodology amendment for publication
     [Arguments]    ${publication}    ${methodology_title}=${publication}
     ${accordion}=    user opens publication on the admin dashboard    ${publication}
     user views methodology for open publication accordion    ${accordion}    ${methodology_title}
-    ...    Edit this amendment
+    ...    Edit amendment
 
 user views methodology for open publication accordion
     [Arguments]
     ...    ${accordion}
     ...    ${methodology_title}
-    ...    ${edit_button_text}=Edit this methodology
+    ...    ${edit_button_text}=Edit methodology
     user opens details dropdown    ${methodology_title}    ${accordion}
     user clicks link    ${edit_button_text}    ${accordion}
     user waits until h2 is visible    Methodology summary
@@ -207,7 +207,7 @@ user edits methodology summary for publication
     ...    ${publication}
     ...    ${existing_methodology_title}
     ...    ${new_methodology_title}
-    ...    ${edit_button_text}=Edit this methodology
+    ...    ${edit_button_text}=Edit methodology
     user views methodology for publication    ${publication}    ${existing_methodology_title}    ${edit_button_text}
     user clicks link    Edit summary
     user waits until h2 is visible    Edit methodology summary    %{WAIT_MEDIUM}
@@ -261,7 +261,7 @@ user approves methodology for publication
     ...    ${topic}
     ...    ${publishing_strategy}
     ...    ${with_release}
-    ...    Edit this methodology
+    ...    Edit methodology
 
 user approves methodology amendment for publication
     [Arguments]
@@ -279,7 +279,7 @@ user approves methodology amendment for publication
     ...    ${topic}
     ...    ${publishing_strategy}
     ...    ${with_release}
-    ...    Edit this amendment
+    ...    Edit amendment
 
 approve methodology for publication
     [Arguments]
@@ -377,7 +377,7 @@ user links publication to external methodology
     ...    ${title}=External methodology
     ...    ${link}=https://example.com
     ${accordion}=    user opens publication on the admin dashboard    ${publication}
-    user clicks link    Link to an externally hosted methodology    ${accordion}
+    user clicks link    Use an external methodology    ${accordion}
     user waits until page contains title    Link to an externally hosted methodology
     user enters text into element    label:Link title    ${title}
     user enters text into element    label:URL    ${link}
@@ -530,8 +530,8 @@ user creates amendment for release
     ${accordion}=    user gets accordion section content element    ${PUBLICATION_NAME}
     user opens details dropdown    ${RELEASE_NAME} ${RELEASE_STATUS}    ${accordion}
     ${details}=    user gets details content element    ${RELEASE_NAME} ${RELEASE_STATUS}    ${accordion}
-    user waits until parent contains element    ${details}    xpath:.//a[text()="View this release"]
-    user clicks button    Amend this release    ${details}
+    user waits until parent contains element    ${details}    xpath:.//a[text()="View release"]
+    user clicks button    Amend release    ${details}
     user clicks button    Confirm
     user waits until page contains title    ${PUBLICATION_NAME}
     user waits until page contains title caption    Amend release for ${RELEASE_NAME}

--- a/tests/robot-tests/tests/libs/admin/analyst/role_ui_permissions.robot
+++ b/tests/robot-tests/tests/libs/admin/analyst/role_ui_permissions.robot
@@ -12,12 +12,12 @@ user navigates to publication on admin dashboard
 user cannot see the create methodologies controls for publication
     [Arguments]    ${PUBLICATION_ACCORDION}
     user checks element does not contain button    ${PUBLICATION_ACCORDION}    Create methodology
-    user checks element does not contain link    ${PUBLICATION_ACCORDION}    Link to an externally hosted methodology
+    user checks element does not contain link    ${PUBLICATION_ACCORDION}    Use an external methodology
 
 user cannot see the create amendment controls for release
     [Arguments]    ${RELEASE_DETAILS_SECTION}
-    user waits until element contains link    ${RELEASE_DETAILS_SECTION}    View this release    %{WAIT_SMALL}
-    user checks element does not contain button    ${RELEASE_DETAILS_SECTION}    Amend this release
+    user waits until element contains link    ${RELEASE_DETAILS_SECTION}    View release    %{WAIT_SMALL}
+    user checks element does not contain button    ${RELEASE_DETAILS_SECTION}    Amend release
 
 user cannot see edit controls for release content
     [Arguments]    ${publication}
@@ -47,12 +47,12 @@ user cannot see the enabled approve release controls for release
 user can see the create methodologies controls for publication
     [Arguments]    ${PUBLICATION_ACCORDION}
     user checks element contains button    ${PUBLICATION_ACCORDION}    Create methodology
-    user checks element contains link    ${PUBLICATION_ACCORDION}    Link to an externally hosted methodology
+    user checks element contains link    ${PUBLICATION_ACCORDION}    Use an external methodology
 
 user can see the create amendment controls for release
     [Arguments]    ${RELEASE_DETAILS_SECTION}
-    user waits until element contains link    ${RELEASE_DETAILS_SECTION}    View this release    %{WAIT_SMALL}
-    user checks element contains button    ${RELEASE_DETAILS_SECTION}    Amend this release
+    user waits until element contains link    ${RELEASE_DETAILS_SECTION}    View release    %{WAIT_SMALL}
+    user checks element contains button    ${RELEASE_DETAILS_SECTION}    Amend release
 
 user cannot see the edit status controls for methodology
     user clicks link    Sign off
@@ -61,10 +61,10 @@ user cannot see the edit status controls for methodology
 
 user cannot see the remove controls for methodology
     [Arguments]    ${DETAILS_SECTION}
-    user checks element contains link    ${DETAILS_SECTION}    View this methodology
+    user checks element contains link    ${DETAILS_SECTION}    View methodology
     user checks element does not contain button    ${DETAILS_SECTION}    Remove
 
 user cannot see the cancel amendment controls for methodology
     [Arguments]    ${DETAILS_SECTION}
-    user checks element contains link    ${DETAILS_SECTION}    View this amendment
+    user checks element contains link    ${DETAILS_SECTION}    View amendment
     user checks element does not contain button    ${DETAILS_SECTION}    Cancel amendment


### PR DESCRIPTION
Updates the styling of the admin dashboard:
- sections re-ordered (releases, methodologies, publication details)
- layout changed so all secondary actions are on the right (this is changed on the draft and scheduled releases tab as well)
- green buttons are only used for create release and create methodology
- latest release is not open by default any more
- warnings when no release or methodologies
- links instead of buttons for adding and external methodology and adopting one
- 'Not yet published' publish date for draft releases
- changed the date format of partialDate to match FormattedDate (as noticed it was different when writing tests for ReleaseSummary)

![ees2850-1](https://user-images.githubusercontent.com/81572860/147109363-5e668c1b-7cef-4544-8106-4f6d569c92bb.PNG)

![ees2850-2](https://user-images.githubusercontent.com/81572860/147109361-21514584-b949-4ffb-8ad4-6302936146ca.PNG)

