### PR TITLE
EES-3003 Remove ForEachAsync methods from EnumerableExtensions

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/CancelSpecificFileImportAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/CancelSpecificFileImportAuthorizationHandlersTests.cs
@@ -23,25 +23,27 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 .Where(status => status.IsFinishedOrAborting())
                 .ToList();
 
-            await finishedOrAbortingStatuses.ForEachAsync(async status =>
-            {
-                var file = new File
+            await finishedOrAbortingStatuses
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async status =>
                 {
-                    Id = Guid.NewGuid()
-                };
+                    var file = new File
+                    {
+                        Id = Guid.NewGuid()
+                    };
 
-                var importRepository = new Mock<IDataImportRepository>();
+                    var importRepository = new Mock<IDataImportRepository>();
 
-                importRepository
-                    .Setup(s => s.GetStatusByFileId(file.Id))
-                    .ReturnsAsync(status);
+                    importRepository
+                        .Setup(s => s.GetStatusByFileId(file.Id))
+                        .ReturnsAsync(status);
 
-                // Assert that no users can cancel a finished or aborting Import
-                await AssertHandlerSucceedsWithCorrectClaims<File, CancelSpecificFileImportRequirement>(
-                    new CancelSpecificFileImportAuthorizationHandler(importRepository.Object), file);
-            });
+                    // Assert that no users can cancel a finished or aborting Import
+                    await AssertHandlerSucceedsWithCorrectClaims<File, CancelSpecificFileImportRequirement>(
+                        new CancelSpecificFileImportAuthorizationHandler(importRepository.Object), file);
+                });
         }
-        
+
         [Fact]
         public async Task CanCancelHealthyOngoingImportWithCorrectClaim()
         {
@@ -50,7 +52,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 .Where(status => !status.IsFinishedOrAborting())
                 .ToList();
 
-            await nonFinishedOrAbortingStatuses.ForEachAsync(async status =>
+            await nonFinishedOrAbortingStatuses
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async status =>
             {
                 var file = new File
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
@@ -240,37 +241,39 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task UserWithPublicationOwnerRoleCanDeleteDraftMethodology()
             {
-                await GetEnumValues<PublicationRole>().ForEachAsync(async role =>
-                {
-                    var (
-                        handler,
-                        methodologyRepository,
-                        methodologyVersionRepository,
-                        publicationRoleRepository
-                        ) = CreateHandlerAndDependencies();
+                await GetEnumValues<PublicationRole>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(async role =>
+                    {
+                        var (
+                            handler,
+                            methodologyRepository,
+                            methodologyVersionRepository,
+                            publicationRoleRepository
+                            ) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository
-                        .Setup(s => s.IsPubliclyAccessible(DraftFirstVersion.Id))
-                        .ReturnsAsync(false);
+                        methodologyVersionRepository
+                            .Setup(s => s.IsPubliclyAccessible(DraftFirstVersion.Id))
+                            .ReturnsAsync(false);
 
-                    methodologyRepository.Setup(s =>
-                            s.GetOwningPublication(DraftFirstVersion.MethodologyId))
-                        .ReturnsAsync(OwningPublication);
+                        methodologyRepository.Setup(s =>
+                                s.GetOwningPublication(DraftFirstVersion.MethodologyId))
+                            .ReturnsAsync(OwningPublication);
 
-                    publicationRoleRepository.SetupPublicationOwnerRoleExpectations(UserId, OwningPublication,
-                        role == Owner);
+                        publicationRoleRepository.SetupPublicationOwnerRoleExpectations(UserId, OwningPublication,
+                            role == Owner);
 
-                    var user = CreateClaimsPrincipal(UserId);
-                    var authContext = CreateAuthContext(user, DraftFirstVersion);
+                        var user = CreateClaimsPrincipal(UserId);
+                        var authContext = CreateAuthContext(user, DraftFirstVersion);
 
-                    await handler.HandleAsync(authContext);
-                    VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
-                        publicationRoleRepository);
+                        await handler.HandleAsync(authContext);
+                        VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
+                            publicationRoleRepository);
 
-                    // Verify that the presence of a Publication Owner role for this user that is related to a
-                    // Publication that uses this Methodology will pass the handler test
-                    Assert.Equal(role == Owner, authContext.HasSucceeded);
-                });
+                        // Verify that the presence of a Publication Owner role for this user that is related to a
+                        // Publication that uses this Methodology will pass the handler test
+                        Assert.Equal(role == Owner, authContext.HasSucceeded);
+                    });
             }
 
             [Fact]
@@ -356,37 +359,39 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task UserWithPublicationOwnerRoleCanDeleteDraftMethodologyAmendment()
             {
-                await GetEnumValues<PublicationRole>().ForEachAsync(async role =>
-                {
-                    var (
-                        handler,
-                        methodologyRepository,
-                        methodologyVersionRepository,
-                        publicationRoleRepository
-                        ) = CreateHandlerAndDependencies();
+                await GetEnumValues<PublicationRole>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(async role =>
+                    {
+                        var (
+                            handler,
+                            methodologyRepository,
+                            methodologyVersionRepository,
+                            publicationRoleRepository
+                            ) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository
-                        .Setup(s => s.IsPubliclyAccessible(DraftAmendmentVersion.Id))
-                        .ReturnsAsync(false);
+                        methodologyVersionRepository
+                            .Setup(s => s.IsPubliclyAccessible(DraftAmendmentVersion.Id))
+                            .ReturnsAsync(false);
 
-                    methodologyRepository.Setup(s =>
-                            s.GetOwningPublication(DraftAmendmentVersion.MethodologyId))
-                        .ReturnsAsync(OwningPublication);
+                        methodologyRepository.Setup(s =>
+                                s.GetOwningPublication(DraftAmendmentVersion.MethodologyId))
+                            .ReturnsAsync(OwningPublication);
 
-                    publicationRoleRepository.SetupPublicationOwnerRoleExpectations(UserId, OwningPublication,
-                        role == Owner);
+                        publicationRoleRepository.SetupPublicationOwnerRoleExpectations(UserId, OwningPublication,
+                            role == Owner);
 
-                    var user = CreateClaimsPrincipal(UserId);
-                    var authContext = CreateAuthContext(user, DraftAmendmentVersion);
+                        var user = CreateClaimsPrincipal(UserId);
+                        var authContext = CreateAuthContext(user, DraftAmendmentVersion);
 
-                    await handler.HandleAsync(authContext);
-                    VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
-                        publicationRoleRepository);
+                        await handler.HandleAsync(authContext);
+                        VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
+                            publicationRoleRepository);
 
-                    // Verify that the presence of a Publication Owner role for this user that is related to a
-                    // Publication that uses this Methodology will pass the handler test
-                    Assert.Equal(role == Owner, authContext.HasSucceeded);
-                });
+                        // Verify that the presence of a Publication Owner role for this user that is related to a
+                        // Publication that uses this Methodology will pass the handler test
+                        Assert.Equal(role == Owner, authContext.HasSucceeded);
+                    });
             }
 
             [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
@@ -115,36 +116,38 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             public async Task
                 UserWithLinkedPublicationOwnerRoleCanCreateAmendmentOfPubliclyAccessibleMethodologyOwnedByPublication()
             {
-                await GetEnumValues<PublicationRole>().ForEachAsync(async role =>
-                {
-                    var (
-                        handler,
-                        methodologyRepository,
-                        methodologyVersionRepository,
-                        publicationRoleRepository
-                        ) = CreateHandlerAndDependencies();
+                await GetEnumValues<PublicationRole>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(async role =>
+                    {
+                        var (
+                            handler,
+                            methodologyRepository,
+                            methodologyVersionRepository,
+                            publicationRoleRepository
+                            ) = CreateHandlerAndDependencies();
 
-                    methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(MethodologyVersion.Id))
-                        .ReturnsAsync(true);
+                        methodologyVersionRepository.Setup(mock => mock.IsPubliclyAccessible(MethodologyVersion.Id))
+                            .ReturnsAsync(true);
 
-                    methodologyRepository.Setup(s =>
-                            s.GetOwningPublication(MethodologyVersion.MethodologyId))
-                        .ReturnsAsync(OwningPublication);
+                        methodologyRepository.Setup(s =>
+                                s.GetOwningPublication(MethodologyVersion.MethodologyId))
+                            .ReturnsAsync(OwningPublication);
 
-                    publicationRoleRepository.SetupPublicationOwnerRoleExpectations(
-                        UserId, OwningPublication, role == Owner);
+                        publicationRoleRepository.SetupPublicationOwnerRoleExpectations(
+                            UserId, OwningPublication, role == Owner);
 
-                    var user = CreateClaimsPrincipal(UserId);
-                    var authContext = CreateAuthContext(user, MethodologyVersion);
+                        var user = CreateClaimsPrincipal(UserId);
+                        var authContext = CreateAuthContext(user, MethodologyVersion);
 
-                    await handler.HandleAsync(authContext);
-                    VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
-                        publicationRoleRepository);
+                        await handler.HandleAsync(authContext);
+                        VerifyAllMocks(methodologyRepository, methodologyVersionRepository,
+                            publicationRoleRepository);
 
-                    // Verify that the user can create an Amendment, as they have a Publication Owner role on a Publication
-                    // that uses this Methodology.
-                    Assert.Equal(role == Owner, authContext.HasSucceeded);
-                });
+                        // Verify that the user can create an Amendment, as they have a Publication Owner role on a Publication
+                        // that uses this Methodology.
+                        Assert.Equal(role == Owner, authContext.HasSucceeded);
+                    });
             }
 
             [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ReleaseStatusAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ReleaseStatusAuthorizationHandlersTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
@@ -52,144 +53,152 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task ReleaseRoleSuccess_EditorOrApprover_ReleaseUnpublished()
             {
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            Publication = new Publication
+                            var release = new Release
                             {
-                                Id = Guid.NewGuid()
-                            },
-                            ApprovalStatus = status
-                        };
+                                Id = Guid.NewGuid(),
+                                Publication = new Publication
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                ApprovalStatus = status
+                            };
 
-                        var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
+                            var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
 
-                        releaseStatusRepository.Setup(
-                                s => s.GetAllByOverallStage(
-                                    release.Id,
-                                    ReleasePublishingStatusOverallStage.Started,
-                                    ReleasePublishingStatusOverallStage.Complete
+                            releaseStatusRepository.Setup(
+                                    s => s.GetAllByOverallStage(
+                                        release.Id,
+                                        ReleasePublishingStatusOverallStage.Started,
+                                        ReleasePublishingStatusOverallStage.Complete
+                                    )
                                 )
-                            )
-                            .ReturnsAsync(new List<ReleasePublishingStatus>());
+                                .ReturnsAsync(new List<ReleasePublishingStatus>());
 
-                        // Assert that a user who has the "Contributor", "Lead" or "Approver"
-                        // role on a Release can update its status if it is not Approved
-                        if (status != ReleaseApprovalStatus.Approved)
-                        {
-                            await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<MarkReleaseAsDraftRequirement>(
-                                context =>
-                                {
-                                    context.Add(release);
-                                    context.SaveChanges();
+                            // Assert that a user who has the "Contributor", "Lead" or "Approver"
+                            // role on a Release can update its status if it is not Approved
+                            if (status != ReleaseApprovalStatus.Approved)
+                            {
+                                await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<
+                                    MarkReleaseAsDraftRequirement>(
+                                    context =>
+                                    {
+                                        context.Add(release);
+                                        context.SaveChanges();
 
-                                    return new MarkReleaseAsDraftAuthorizationHandler(
-                                        releaseStatusRepository.Object,
-                                        new UserPublicationRoleRepository(context),
-                                        new UserReleaseRoleRepository(context)
-                                    );
-                                },
-                                release,
-                                ReleaseRole.Contributor,
-                                ReleaseRole.Lead,
-                                ReleaseRole.Approver
-                            );
+                                        return new MarkReleaseAsDraftAuthorizationHandler(
+                                            releaseStatusRepository.Object,
+                                            new UserPublicationRoleRepository(context),
+                                            new UserReleaseRoleRepository(context)
+                                        );
+                                    },
+                                    release,
+                                    ReleaseRole.Contributor,
+                                    ReleaseRole.Lead,
+                                    ReleaseRole.Approver
+                                );
+                            }
+                            else
+                            {
+                                // Assert that a user who has the "Approver" role on a
+                                // Release can update its status if it is Approved
+                                await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<
+                                    MarkReleaseAsDraftRequirement>(
+                                    context =>
+                                    {
+                                        context.Add(release);
+                                        context.SaveChanges();
+
+                                        return new MarkReleaseAsDraftAuthorizationHandler(
+                                            releaseStatusRepository.Object,
+                                            new UserPublicationRoleRepository(context),
+                                            new UserReleaseRoleRepository(context)
+                                        );
+                                    },
+                                    release,
+                                    ReleaseRole.Approver
+                                );
+                            }
                         }
-                        else
-                        {
-                            // Assert that a user who has the "Approver" role on a
-                            // Release can update its status if it is Approved
-                            await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<MarkReleaseAsDraftRequirement>(
-                                context =>
-                                {
-                                    context.Add(release);
-                                    context.SaveChanges();
-
-                                    return new MarkReleaseAsDraftAuthorizationHandler(
-                                        releaseStatusRepository.Object,
-                                        new UserPublicationRoleRepository(context),
-                                        new UserReleaseRoleRepository(context)
-                                    );
-                                },
-                                release,
-                                ReleaseRole.Approver
-                            );
-                        }
-                    }
-                );
+                    );
             }
 
             [Fact]
             public async Task PublicationRoleSuccess_Owner_ReleaseUnpublished()
             {
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            Publication = new Publication
+                            var release = new Release
                             {
-                                Id = Guid.NewGuid()
-                            },
-                            ApprovalStatus = status
-                        };
+                                Id = Guid.NewGuid(),
+                                Publication = new Publication
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                ApprovalStatus = status
+                            };
 
-                        var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
+                            var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
 
-                        releaseStatusRepository.Setup(
-                                s => s.GetAllByOverallStage(
-                                    release.Id,
-                                    ReleasePublishingStatusOverallStage.Started,
-                                    ReleasePublishingStatusOverallStage.Complete
+                            releaseStatusRepository.Setup(
+                                    s => s.GetAllByOverallStage(
+                                        release.Id,
+                                        ReleasePublishingStatusOverallStage.Started,
+                                        ReleasePublishingStatusOverallStage.Complete
+                                    )
                                 )
-                            )
-                            .ReturnsAsync(new List<ReleasePublishingStatus>());
+                                .ReturnsAsync(new List<ReleasePublishingStatus>());
 
-                        // Assert that a User who has the Publication Owner role on a
-                        // Release can update its status if it is not Approved
-                        if (status != ReleaseApprovalStatus.Approved)
-                        {
-                            await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<MarkReleaseAsDraftRequirement>(
-                                context =>
-                                {
-                                    context.Add(release);
-                                    context.SaveChanges();
-
-                                    return new MarkReleaseAsDraftAuthorizationHandler(
-                                        releaseStatusRepository.Object,
-                                        new UserPublicationRoleRepository(context),
-                                        new UserReleaseRoleRepository(context)
-                                    );
-                                },
-                                release,
-                                Owner
-                            );
-                        }
-                        else
-                        {
                             // Assert that a User who has the Publication Owner role on a
-                            // Release cannot update its status if it is not Approved
-                            await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<MarkReleaseAsDraftRequirement>(
-                                context =>
-                                {
-                                    context.Add(release);
-                                    context.SaveChanges();
+                            // Release can update its status if it is not Approved
+                            if (status != ReleaseApprovalStatus.Approved)
+                            {
+                                await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
+                                    MarkReleaseAsDraftRequirement>(
+                                    context =>
+                                    {
+                                        context.Add(release);
+                                        context.SaveChanges();
 
-                                    return new MarkReleaseAsDraftAuthorizationHandler(
-                                        releaseStatusRepository.Object,
-                                        new UserPublicationRoleRepository(context),
-                                        new UserReleaseRoleRepository(context)
-                                    );
-                                },
-                                release
-                            );
+                                        return new MarkReleaseAsDraftAuthorizationHandler(
+                                            releaseStatusRepository.Object,
+                                            new UserPublicationRoleRepository(context),
+                                            new UserReleaseRoleRepository(context)
+                                        );
+                                    },
+                                    release,
+                                    Owner
+                                );
+                            }
+                            else
+                            {
+                                // Assert that a User who has the Publication Owner role on a
+                                // Release cannot update its status if it is not Approved
+                                await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
+                                    MarkReleaseAsDraftRequirement>(
+                                    context =>
+                                    {
+                                        context.Add(release);
+                                        context.SaveChanges();
+
+                                        return new MarkReleaseAsDraftAuthorizationHandler(
+                                            releaseStatusRepository.Object,
+                                            new UserPublicationRoleRepository(context),
+                                            new UserReleaseRoleRepository(context)
+                                        );
+                                    },
+                                    release
+                                );
+                            }
                         }
-                    }
-                );
+                    );
             }
 
             [Fact]
@@ -239,146 +248,152 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task ReleaseRoleSuccess_EditorOrApprover_ReleaseUnpublished()
             {
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            Publication = new Publication
+                            var release = new Release
                             {
-                                Id = Guid.NewGuid()
-                            },
-                            ApprovalStatus = status
-                        };
+                                Id = Guid.NewGuid(),
+                                Publication = new Publication
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                ApprovalStatus = status
+                            };
 
-                        var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
+                            var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
 
-                        releaseStatusRepository.Setup(
-                                s => s.GetAllByOverallStage(
-                                    release.Id,
-                                    ReleasePublishingStatusOverallStage.Started,
-                                    ReleasePublishingStatusOverallStage.Complete
+                            releaseStatusRepository.Setup(
+                                    s => s.GetAllByOverallStage(
+                                        release.Id,
+                                        ReleasePublishingStatusOverallStage.Started,
+                                        ReleasePublishingStatusOverallStage.Complete
+                                    )
                                 )
-                            )
-                            .ReturnsAsync(new List<ReleasePublishingStatus>());
+                                .ReturnsAsync(new List<ReleasePublishingStatus>());
 
-                        // Assert that a user who has the "Contributor", "Lead" or "Approver"
-                        // role on a Release can update its status if it is not Approved
-                        if (status != ReleaseApprovalStatus.Approved)
-                        {
-                            await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<
-                                MarkReleaseAsHigherLevelReviewRequirement>(
-                                context =>
-                                {
-                                    context.Add(release);
-                                    context.SaveChanges();
+                            // Assert that a user who has the "Contributor", "Lead" or "Approver"
+                            // role on a Release can update its status if it is not Approved
+                            if (status != ReleaseApprovalStatus.Approved)
+                            {
+                                await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<
+                                    MarkReleaseAsHigherLevelReviewRequirement>(
+                                    context =>
+                                    {
+                                        context.Add(release);
+                                        context.SaveChanges();
 
-                                    return new MarkReleaseAsHigherLevelReviewAuthorizationHandler(
-                                        releaseStatusRepository.Object,
-                                        new UserPublicationRoleRepository(context),
-                                        new UserReleaseRoleRepository(context)
-                                    );
-                                },
-                                release,
-                                ReleaseRole.Contributor,
-                                ReleaseRole.Lead,
-                                ReleaseRole.Approver
-                            );
+                                        return new MarkReleaseAsHigherLevelReviewAuthorizationHandler(
+                                            releaseStatusRepository.Object,
+                                            new UserPublicationRoleRepository(context),
+                                            new UserReleaseRoleRepository(context)
+                                        );
+                                    },
+                                    release,
+                                    ReleaseRole.Contributor,
+                                    ReleaseRole.Lead,
+                                    ReleaseRole.Approver
+                                );
+                            }
+                            else
+                            {
+                                // Assert that a user who has the "Approver" role on a
+                                // Release can update its status if it is Approved
+                                await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<
+                                    MarkReleaseAsHigherLevelReviewRequirement>(
+                                    context =>
+                                    {
+                                        context.Add(release);
+                                        context.SaveChanges();
+
+                                        return new MarkReleaseAsHigherLevelReviewAuthorizationHandler(
+                                            releaseStatusRepository.Object,
+                                            new UserPublicationRoleRepository(context),
+                                            new UserReleaseRoleRepository(context)
+                                        );
+                                    },
+                                    release,
+                                    ReleaseRole.Approver
+                                );
+                            }
                         }
-                        else
-                        {
-                            // Assert that a user who has the "Approver" role on a
-                            // Release can update its status if it is Approved
-                            await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<
-                                MarkReleaseAsHigherLevelReviewRequirement>(
-                                context =>
-                                {
-                                    context.Add(release);
-                                    context.SaveChanges();
-
-                                    return new MarkReleaseAsHigherLevelReviewAuthorizationHandler(
-                                        releaseStatusRepository.Object,
-                                        new UserPublicationRoleRepository(context),
-                                        new UserReleaseRoleRepository(context)
-                                    );
-                                },
-                                release,
-                                ReleaseRole.Approver
-                            );
-                        }
-                    }
-                );
+                    );
             }
 
             [Fact]
             public async Task PublicationRoleSuccess_Owner_ReleaseUnpublished()
             {
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            Publication = new Publication
+                            var release = new Release
                             {
-                                Id = Guid.NewGuid()
-                            },
-                            ApprovalStatus = status
-                        };
+                                Id = Guid.NewGuid(),
+                                Publication = new Publication
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                ApprovalStatus = status
+                            };
 
-                        var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
+                            var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
 
-                        releaseStatusRepository.Setup(
-                                s => s.GetAllByOverallStage(
-                                    release.Id,
-                                    ReleasePublishingStatusOverallStage.Started,
-                                    ReleasePublishingStatusOverallStage.Complete
+                            releaseStatusRepository.Setup(
+                                    s => s.GetAllByOverallStage(
+                                        release.Id,
+                                        ReleasePublishingStatusOverallStage.Started,
+                                        ReleasePublishingStatusOverallStage.Complete
+                                    )
                                 )
-                            )
-                            .ReturnsAsync(new List<ReleasePublishingStatus>());
+                                .ReturnsAsync(new List<ReleasePublishingStatus>());
 
-                        // Assert that a User who has the Publication Owner role on a
-                        // Release can update its status if it is not Approved
-                        if (status != ReleaseApprovalStatus.Approved)
-                        {
-                            await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<MarkReleaseAsHigherLevelReviewRequirement>(
-                                context =>
-                                {
-                                    context.Add(release);
-                                    context.SaveChanges();
-
-                                    return new MarkReleaseAsHigherLevelReviewAuthorizationHandler(
-                                        releaseStatusRepository.Object,
-                                        new UserPublicationRoleRepository(context),
-                                        new UserReleaseRoleRepository(context)
-                                    );
-                                },
-                                release,
-                                Owner
-                            );
-                        }
-                        else
-                        {
                             // Assert that a User who has the Publication Owner role on a
-                            // Release cannot update its status if it is not Approved
-                            await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<MarkReleaseAsHigherLevelReviewRequirement>(
-                                context =>
-                                {
-                                    context.Add(release);
-                                    context.SaveChanges();
+                            // Release can update its status if it is not Approved
+                            if (status != ReleaseApprovalStatus.Approved)
+                            {
+                                await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
+                                    MarkReleaseAsHigherLevelReviewRequirement>(
+                                    context =>
+                                    {
+                                        context.Add(release);
+                                        context.SaveChanges();
 
-                                    return new MarkReleaseAsHigherLevelReviewAuthorizationHandler(
-                                        releaseStatusRepository.Object,
-                                        new UserPublicationRoleRepository(context),
-                                        new UserReleaseRoleRepository(context)
-                                    );
-                                },
-                                release
-                            );
+                                        return new MarkReleaseAsHigherLevelReviewAuthorizationHandler(
+                                            releaseStatusRepository.Object,
+                                            new UserPublicationRoleRepository(context),
+                                            new UserReleaseRoleRepository(context)
+                                        );
+                                    },
+                                    release,
+                                    Owner
+                                );
+                            }
+                            else
+                            {
+                                // Assert that a User who has the Publication Owner role on a
+                                // Release cannot update its status if it is not Approved
+                                await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
+                                    MarkReleaseAsHigherLevelReviewRequirement>(
+                                    context =>
+                                    {
+                                        context.Add(release);
+                                        context.SaveChanges();
+
+                                        return new MarkReleaseAsHigherLevelReviewAuthorizationHandler(
+                                            releaseStatusRepository.Object,
+                                            new UserPublicationRoleRepository(context),
+                                            new UserReleaseRoleRepository(context)
+                                        );
+                                    },
+                                    release
+                                );
+                            }
                         }
-                    }
-                );
+                    );
             }
 
             [Fact]
@@ -428,49 +443,51 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task ReleaseRoleSuccess_Approver_ReleaseUnpublished()
             {
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            Publication = new Publication
+                            var release = new Release
                             {
-                                Id = Guid.NewGuid()
-                            },
-                            ApprovalStatus = status
-                        };
+                                Id = Guid.NewGuid(),
+                                Publication = new Publication
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                ApprovalStatus = status
+                            };
 
-                        var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
+                            var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
 
-                        releaseStatusRepository.Setup(
-                                s => s.GetAllByOverallStage(
-                                    release.Id,
-                                    ReleasePublishingStatusOverallStage.Started,
-                                    ReleasePublishingStatusOverallStage.Complete
+                            releaseStatusRepository.Setup(
+                                    s => s.GetAllByOverallStage(
+                                        release.Id,
+                                        ReleasePublishingStatusOverallStage.Started,
+                                        ReleasePublishingStatusOverallStage.Complete
+                                    )
                                 )
-                            )
-                            .ReturnsAsync(new List<ReleasePublishingStatus>());
+                                .ReturnsAsync(new List<ReleasePublishingStatus>());
 
-                        // Assert that a user who has the "Approver" role on a
-                        // Release can update its status if it is Approved
-                        await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<MarkReleaseAsApprovedRequirement>(
-                            context =>
-                            {
-                                context.Add(release);
-                                context.SaveChanges();
+                            // Assert that a user who has the "Approver" role on a
+                            // Release can update its status if it is Approved
+                            await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<MarkReleaseAsApprovedRequirement>(
+                                context =>
+                                {
+                                    context.Add(release);
+                                    context.SaveChanges();
 
-                                return new MarkReleaseAsApprovedAuthorizationHandler(
-                                    releaseStatusRepository.Object,
-                                    new UserPublicationRoleRepository(context),
-                                    new UserReleaseRoleRepository(context)
-                                );
-                            },
-                            release,
-                            ReleaseRole.Approver
-                        );
-                    }
-                );
+                                    return new MarkReleaseAsApprovedAuthorizationHandler(
+                                        releaseStatusRepository.Object,
+                                        new UserPublicationRoleRepository(context),
+                                        new UserReleaseRoleRepository(context)
+                                    );
+                                },
+                                release,
+                                ReleaseRole.Approver
+                            );
+                        }
+                    );
             }
 
             [Fact]
@@ -496,251 +513,262 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             params SecurityClaimTypes[] claims)
             where TRequirement : IAuthorizationRequirement
         {
-            await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                async status =>
-                {
-                    var release = new Release
+            await GetEnumValues<ReleaseApprovalStatus>()
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(
+                    async status =>
                     {
-                        Id = Guid.NewGuid(),
-                        Publication = new Publication
+                        var release = new Release
                         {
-                            Id = Guid.NewGuid()
-                        },
-                        ApprovalStatus = status
-                    };
+                            Id = Guid.NewGuid(),
+                            Publication = new Publication
+                            {
+                                Id = Guid.NewGuid()
+                            },
+                            ApprovalStatus = status
+                        };
 
-                    var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
+                        var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
 
-                    // Assert that users with the specified claims can update the
-                    // Release status if it has not started publishing
-                    await AssertReleaseHandlerSucceedsWithCorrectClaims<TRequirement>(context =>
-                        {
-                            context.Add(release);
-                            context.SaveChanges();
+                        // Assert that users with the specified claims can update the
+                        // Release status if it has not started publishing
+                        await AssertReleaseHandlerSucceedsWithCorrectClaims<TRequirement>(context =>
+                            {
+                                context.Add(release);
+                                context.SaveChanges();
 
-                            return authorizationHandler(releaseStatusRepository.Object,
-                                new UserPublicationRoleRepository(context),
-                                new UserReleaseRoleRepository(context));
-                        },
-                        release,
-                        claims
-                    );
-                }
-            );
+                                return authorizationHandler(releaseStatusRepository.Object,
+                                    new UserPublicationRoleRepository(context),
+                                    new UserReleaseRoleRepository(context));
+                            },
+                            release,
+                            claims
+                        );
+                    }
+                );
         }
 
         private static async Task AssertAllClaimsFailWhenReleasePublishing<TRequirement>(
-            Func<IReleasePublishingStatusRepository, IUserPublicationRoleRepository, IUserReleaseRoleRepository, IAuthorizationHandler> authorizationHandler)
+            Func<IReleasePublishingStatusRepository, IUserPublicationRoleRepository, IUserReleaseRoleRepository,
+                IAuthorizationHandler> authorizationHandler)
             where TRequirement : IAuthorizationRequirement
         {
-            await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                async status =>
-                {
-                    var release = new Release
+            await GetEnumValues<ReleaseApprovalStatus>()
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(
+                    async status =>
                     {
-                        Id = Guid.NewGuid(),
-                        Publication = new Publication
+                        var release = new Release
                         {
-                            Id = Guid.NewGuid()
-                        },
-                        ApprovalStatus = status
-                    };
-
-                    var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
-
-                    releaseStatusRepository.Setup(
-                            s => s.GetAllByOverallStage(
-                                release.Id,
-                                ReleasePublishingStatusOverallStage.Started,
-                                ReleasePublishingStatusOverallStage.Complete
-                            )
-                        )
-                        .ReturnsAsync(
-                            new List<ReleasePublishingStatus>
+                            Id = Guid.NewGuid(),
+                            Publication = new Publication
                             {
-                                new ReleasePublishingStatus()
-                            }
+                                Id = Guid.NewGuid()
+                            },
+                            ApprovalStatus = status
+                        };
+
+                        var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
+
+                        releaseStatusRepository.Setup(
+                                s => s.GetAllByOverallStage(
+                                    release.Id,
+                                    ReleasePublishingStatusOverallStage.Started,
+                                    ReleasePublishingStatusOverallStage.Complete
+                                )
+                            )
+                            .ReturnsAsync(
+                                new List<ReleasePublishingStatus>
+                                {
+                                    new ReleasePublishingStatus()
+                                }
+                            );
+
+                        // Assert that no users can update a Release status once it has started publishing
+                        await AssertReleaseHandlerSucceedsWithCorrectClaims<TRequirement>(context =>
+                            {
+                                context.Add(release);
+                                context.SaveChanges();
+
+                                return authorizationHandler(releaseStatusRepository.Object,
+                                    new UserPublicationRoleRepository(context),
+                                    new UserReleaseRoleRepository(context));
+                            },
+                            release
                         );
-
-                    // Assert that no users can update a Release status once it has started publishing
-                    await AssertReleaseHandlerSucceedsWithCorrectClaims<TRequirement>(context =>
-                        {
-                            context.Add(release);
-                            context.SaveChanges();
-
-                            return authorizationHandler(releaseStatusRepository.Object,
-                                new UserPublicationRoleRepository(context),
-                                new UserReleaseRoleRepository(context));
-                        },
-                        release
-                    );
-                }
-            );
+                    }
+                );
         }
 
         private static async Task AssertAllClaimsFailWhenReleasePublished<TRequirement>(
             Func<IReleasePublishingStatusRepository, IUserPublicationRoleRepository, IUserReleaseRoleRepository, IAuthorizationHandler> authorizationHandler)
             where TRequirement : IAuthorizationRequirement
         {
-            await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                async status =>
-                {
-                    var release = new Release
+            await GetEnumValues<ReleaseApprovalStatus>()
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(
+                    async status =>
                     {
-                        Id = Guid.NewGuid(),
-                        Publication = new Publication
+                        var release = new Release
                         {
-                            Id = Guid.NewGuid()
-                        },
-                        ApprovalStatus = status,
-                        Published = DateTime.Now
-                    };
+                            Id = Guid.NewGuid(),
+                            Publication = new Publication
+                            {
+                                Id = Guid.NewGuid()
+                            },
+                            ApprovalStatus = status,
+                            Published = DateTime.Now
+                        };
 
-                    var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
+                        var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
 
-                    releaseStatusRepository.Setup(
-                            s => s.GetAllByOverallStage(
-                                release.Id,
-                                ReleasePublishingStatusOverallStage.Started,
-                                ReleasePublishingStatusOverallStage.Complete
+                        releaseStatusRepository.Setup(
+                                s => s.GetAllByOverallStage(
+                                    release.Id,
+                                    ReleasePublishingStatusOverallStage.Started,
+                                    ReleasePublishingStatusOverallStage.Complete
+                                )
                             )
-                        )
-                        .ReturnsAsync(new List<ReleasePublishingStatus>());
+                            .ReturnsAsync(new List<ReleasePublishingStatus>());
 
-                    // Assert that no users can update a Release status once it has been published
-                    await AssertReleaseHandlerSucceedsWithCorrectClaims<TRequirement>(context =>
-                        {
-                            context.Add(release);
-                            context.SaveChanges();
+                        // Assert that no users can update a Release status once it has been published
+                        await AssertReleaseHandlerSucceedsWithCorrectClaims<TRequirement>(context =>
+                            {
+                                context.Add(release);
+                                context.SaveChanges();
 
-                            return authorizationHandler(releaseStatusRepository.Object,
-                                new UserPublicationRoleRepository(context),
-                                new UserReleaseRoleRepository(context));
-                        },
-                        release
-                    );
-                }
-            );
+                                return authorizationHandler(releaseStatusRepository.Object,
+                                    new UserPublicationRoleRepository(context),
+                                    new UserReleaseRoleRepository(context));
+                            },
+                            release
+                        );
+                    }
+                );
         }
 
         private static async Task AssertAllRolesFailWhenReleasePublishing<TRequirement>(
             Func<IReleasePublishingStatusRepository, IUserPublicationRoleRepository, IUserReleaseRoleRepository, IAuthorizationHandler> authorizationHandler)
             where TRequirement : IAuthorizationRequirement
         {
-            await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                async status =>
-                {
-                    var release = new Release
+            await GetEnumValues<ReleaseApprovalStatus>()
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(
+                    async status =>
                     {
-                        Id = Guid.NewGuid(),
-                        Publication = new Publication
+                        var release = new Release
                         {
-                            Id = Guid.NewGuid()
-                        },
-                        ApprovalStatus = status
-                    };
-
-                    var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
-
-                    releaseStatusRepository.Setup(
-                            s => s.GetAllByOverallStage(
-                                release.Id,
-                                ReleasePublishingStatusOverallStage.Started,
-                                ReleasePublishingStatusOverallStage.Complete
-                            )
-                        )
-                        .ReturnsAsync(
-                            new List<ReleasePublishingStatus>
+                            Id = Guid.NewGuid(),
+                            Publication = new Publication
                             {
-                                new ReleasePublishingStatus()
-                            }
+                                Id = Guid.NewGuid()
+                            },
+                            ApprovalStatus = status
+                        };
+
+                        var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
+
+                        releaseStatusRepository.Setup(
+                                s => s.GetAllByOverallStage(
+                                    release.Id,
+                                    ReleasePublishingStatusOverallStage.Started,
+                                    ReleasePublishingStatusOverallStage.Complete
+                                )
+                            )
+                            .ReturnsAsync(
+                                new List<ReleasePublishingStatus>
+                                {
+                                    new ReleasePublishingStatus()
+                                }
+                            );
+
+                        // Assert that no user release roles allow updating a Release status once it has started publishing
+                        await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<TRequirement>(context =>
+                            {
+                                context.Add(release);
+                                context.SaveChanges();
+
+                                return authorizationHandler(releaseStatusRepository.Object,
+                                    new UserPublicationRoleRepository(context),
+                                    new UserReleaseRoleRepository(context));
+                            },
+                            release
                         );
 
-                    // Assert that no user release roles allow updating a Release status once it has started publishing
-                    await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<TRequirement>(context =>
-                        {
-                            context.Add(release);
-                            context.SaveChanges();
+                        // Assert that no user publication roles allow updating a Release status once it has started publishing
+                        await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<TRequirement>(context =>
+                            {
+                                context.Add(release);
+                                context.SaveChanges();
 
-                            return authorizationHandler(releaseStatusRepository.Object,
-                                new UserPublicationRoleRepository(context),
-                                new UserReleaseRoleRepository(context));
-                        },
-                        release
-                    );
-
-                    // Assert that no user publication roles allow updating a Release status once it has started publishing
-                    await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<TRequirement>(context =>
-                        {
-                            context.Add(release);
-                            context.SaveChanges();
-
-                            return authorizationHandler(releaseStatusRepository.Object,
-                                new UserPublicationRoleRepository(context),
-                                new UserReleaseRoleRepository(context));
-                        },
-                        release
-                    );
-                }
-            );
+                                return authorizationHandler(releaseStatusRepository.Object,
+                                    new UserPublicationRoleRepository(context),
+                                    new UserReleaseRoleRepository(context));
+                            },
+                            release
+                        );
+                    }
+                );
         }
 
         private static async Task AssertAllRolesFailWhenReleasePublished<TRequirement>(
             Func<IReleasePublishingStatusRepository, IUserPublicationRoleRepository, IUserReleaseRoleRepository, IAuthorizationHandler> authorizationHandler)
             where TRequirement : IAuthorizationRequirement
         {
-            await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                async status =>
-                {
-                    var release = new Release
+            await GetEnumValues<ReleaseApprovalStatus>()
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(
+                    async status =>
                     {
-                        Id = Guid.NewGuid(),
-                        Publication = new Publication
+                        var release = new Release
                         {
-                            Id = Guid.NewGuid()
-                        },
-                        ApprovalStatus = status,
-                        Published = DateTime.Now,
-                    };
+                            Id = Guid.NewGuid(),
+                            Publication = new Publication
+                            {
+                                Id = Guid.NewGuid()
+                            },
+                            ApprovalStatus = status,
+                            Published = DateTime.Now,
+                        };
 
-                    var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
+                        var releaseStatusRepository = new Mock<IReleasePublishingStatusRepository>();
 
-                    releaseStatusRepository.Setup(
-                            s => s.GetAllByOverallStage(
-                                release.Id,
-                                ReleasePublishingStatusOverallStage.Started,
-                                ReleasePublishingStatusOverallStage.Complete
+                        releaseStatusRepository.Setup(
+                                s => s.GetAllByOverallStage(
+                                    release.Id,
+                                    ReleasePublishingStatusOverallStage.Started,
+                                    ReleasePublishingStatusOverallStage.Complete
+                                )
                             )
-                        )
-                        .ReturnsAsync(new List<ReleasePublishingStatus>());
+                            .ReturnsAsync(new List<ReleasePublishingStatus>());
 
-                    // Assert that no user release roles allow updating a Release status once it has been published
-                    await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<TRequirement>(context =>
-                        {
-                            context.Add(release);
-                            context.SaveChanges();
+                        // Assert that no user release roles allow updating a Release status once it has been published
+                        await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<TRequirement>(context =>
+                            {
+                                context.Add(release);
+                                context.SaveChanges();
 
-                            return authorizationHandler(releaseStatusRepository.Object,
-                                new UserPublicationRoleRepository(context),
-                                new UserReleaseRoleRepository(context));
-                        },
-                        release
-                    );
+                                return authorizationHandler(releaseStatusRepository.Object,
+                                    new UserPublicationRoleRepository(context),
+                                    new UserReleaseRoleRepository(context));
+                            },
+                            release
+                        );
 
-                    // Assert that no user publication roles allow updating a Release status once it has started publishing
-                    await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<TRequirement>(context =>
-                        {
-                            context.Add(release);
-                            context.SaveChanges();
+                        // Assert that no user publication roles allow updating a Release status once it has started publishing
+                        await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<TRequirement>(context =>
+                            {
+                                context.Add(release);
+                                context.SaveChanges();
 
-                            return authorizationHandler(releaseStatusRepository.Object,
-                                new UserPublicationRoleRepository(context),
-                                new UserReleaseRoleRepository(context));
-                        },
-                        release
-                    );
-                }
-            );
+                                return authorizationHandler(releaseStatusRepository.Object,
+                                    new UserPublicationRoleRepository(context),
+                                    new UserReleaseRoleRepository(context));
+                            },
+                            release
+                        );
+                    }
+                );
         }
 
         private static MarkReleaseAsDraftAuthorizationHandler BuildMarkReleaseAsDraftHandler(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificReleaseAuthorizationHandlerTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
@@ -12,7 +13,8 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Publisher.Model;
 using Moq;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.ReleaseAuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
+    ReleaseAuthorizationHandlersTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseApprovalStatus;
@@ -30,69 +32,74 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             {
                 // Assert that only users with the "UpdateAllReleases" claim can
                 // update an arbitrary Release if it has not started publishing
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            ApprovalStatus = status
-                        };
+                            var release = new Release
+                            {
+                                Id = Guid.NewGuid(),
+                                ApprovalStatus = status
+                            };
 
-                        await AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
-                            HandlerSupplier(release),
-                            release,
-                            SecurityClaimTypes.UpdateAllReleases
-                        );
-                    }
-                );
+                            await AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
+                                HandlerSupplier(release),
+                                release,
+                                SecurityClaimTypes.UpdateAllReleases
+                            );
+                        }
+                    );
             }
-            
+
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublishing()
             {
                 // Assert that no users can update an arbitrary Release
                 // if it has started publishing
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            ApprovalStatus = status,
-                        };
+                            var release = new Release
+                            {
+                                Id = Guid.NewGuid(),
+                                ApprovalStatus = status,
+                            };
 
-                        await AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
-                            HandlerSupplierWhenPublishing(release),
-                            release
-                        );
-                    }
-                );
+                            await AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
+                                HandlerSupplierWhenPublishing(release),
+                                release
+                            );
+                        }
+                    );
             }
-            
+
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublished()
             {
                 // Assert that no users can update an arbitrary
                 // Release if it has been published
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            ApprovalStatus = status,
-                            Published = DateTime.UtcNow
-                        };
+                            var release = new Release
+                            {
+                                Id = Guid.NewGuid(),
+                                ApprovalStatus = status,
+                                Published = DateTime.UtcNow
+                            };
 
-                        await AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
-                            HandlerSupplier(release),
-                            release
-                        );
-                    }
-                );
+                            await AssertReleaseHandlerSucceedsWithCorrectClaims<UpdateSpecificReleaseRequirement>(
+                                HandlerSupplier(release),
+                                release
+                            );
+                        }
+                    );
             }
-            
         }
 
         public class PublicationRoleTests
@@ -100,93 +107,103 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublishingNotStarted()
             {
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            Publication = new Publication
+                            var release = new Release
                             {
-                                Id = Guid.NewGuid()
-                            },
-                            Published = null,
-                            ApprovalStatus = status
-                        };
+                                Id = Guid.NewGuid(),
+                                Publication = new Publication
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                Published = null,
+                                ApprovalStatus = status
+                            };
 
-                        // Assert that a User who has the Publication Owner role on a
-                        // Release can update it if it is not Approved
-                        if (status != Approved)
-                        {
-                            await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<UpdateSpecificReleaseRequirement>(
-                                HandlerSupplier(release),
-                                release,
-                                Owner
-                            );
-                        }
-                        else
-                        {
                             // Assert that a User who has the Publication Owner role on a
-                            // Release cannot update it if it is not Approved
-                            await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<UpdateSpecificReleaseRequirement>(
-                                HandlerSupplier(release),
-                                release
-                            );
+                            // Release can update it if it is not Approved
+                            if (status != Approved)
+                            {
+                                await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
+                                    UpdateSpecificReleaseRequirement>(
+                                    HandlerSupplier(release),
+                                    release,
+                                    Owner
+                                );
+                            }
+                            else
+                            {
+                                // Assert that a User who has the Publication Owner role on a
+                                // Release cannot update it if it is not Approved
+                                await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
+                                    UpdateSpecificReleaseRequirement>(
+                                    HandlerSupplier(release),
+                                    release
+                                );
+                            }
                         }
-                    }
-                );
+                    );
             }
 
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublishing()
             {
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            Publication = new Publication
+                            var release = new Release
                             {
-                                Id = Guid.NewGuid()
-                            },
-                            Published = null,
-                            ApprovalStatus = status
-                        };
+                                Id = Guid.NewGuid(),
+                                Publication = new Publication
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                Published = null,
+                                ApprovalStatus = status
+                            };
 
-                        // Assert that no User Publication roles will allow updating a Release once it has started publishing
-                        await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<UpdateSpecificReleaseRequirement>(
-                            HandlerSupplierWhenPublishing(release),
-                            release
-                        );
-                    }
-                );
+                            // Assert that no User Publication roles will allow updating a Release once it has started publishing
+                            await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
+                                UpdateSpecificReleaseRequirement>(
+                                HandlerSupplierWhenPublishing(release),
+                                release
+                            );
+                        }
+                    );
             }
 
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublished()
             {
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            Publication = new Publication
+                            var release = new Release
                             {
-                                Id = Guid.NewGuid()
-                            },
-                            ApprovalStatus = status,
-                            Published = DateTime.UtcNow
-                        };
+                                Id = Guid.NewGuid(),
+                                Publication = new Publication
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                ApprovalStatus = status,
+                                Published = DateTime.UtcNow
+                            };
 
-                        // Assert that no User Publication roles will allow updating a Release once it has been published
-                        await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<UpdateSpecificReleaseRequirement>(
-                            HandlerSupplier(release), 
-                            release
-                        );
-                    }
-                );
+                            // Assert that no User Publication roles will allow updating a Release once it has been published
+                            await AssertReleaseHandlerSucceedsWithCorrectPublicationRoles<
+                                UpdateSpecificReleaseRequirement>(
+                                HandlerSupplier(release),
+                                release
+                            );
+                        }
+                    );
             }
         }
 
@@ -195,102 +212,110 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublishingNotStarted()
             {
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            Publication = new Publication
+                            var release = new Release
                             {
-                                Id = Guid.NewGuid()
-                            },
-                            Published = null,
-                            ApprovalStatus = status
-                        };
+                                Id = Guid.NewGuid(),
+                                Publication = new Publication
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                Published = null,
+                                ApprovalStatus = status
+                            };
 
-                        // Assert that a User who has the "Contributor", "Lead" or "Approver" role on a
-                        // Release can update it if it is not Approved
-                        if (status != Approved)
-                        {
-                            await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<UpdateSpecificReleaseRequirement>(
-                                HandlerSupplier(release),
-                                release,
-                                ReleaseRole.Contributor,
-                                ReleaseRole.Lead,
-                                ReleaseRole.Approver
-                            );
+                            // Assert that a User who has the "Contributor", "Lead" or "Approver" role on a
+                            // Release can update it if it is not Approved
+                            if (status != Approved)
+                            {
+                                await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<
+                                    UpdateSpecificReleaseRequirement>(
+                                    HandlerSupplier(release),
+                                    release,
+                                    ReleaseRole.Contributor,
+                                    ReleaseRole.Lead,
+                                    ReleaseRole.Approver
+                                );
+                            }
+                            else
+                            {
+                                // Assert that a User who has the "Approver" role on a
+                                // Release can update it if it is Approved
+                                await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<
+                                    UpdateSpecificReleaseRequirement>(
+                                    HandlerSupplier(release),
+                                    release,
+                                    ReleaseRole.Approver
+                                );
+                            }
                         }
-                        else
-                        {
-                            // Assert that a User who has the "Approver" role on a
-                            // Release can update it if it is Approved
-                            await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<UpdateSpecificReleaseRequirement>(
-                                HandlerSupplier(release),
-                                release,
-                                ReleaseRole.Approver
-                            );
-                        }
-                    }
-                );
+                    );
             }
 
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublishing()
             {
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            Publication = new Publication
+                            var release = new Release
                             {
-                                Id = Guid.NewGuid()
-                            },
-                            Published = null,
-                            ApprovalStatus = status
-                        };
+                                Id = Guid.NewGuid(),
+                                Publication = new Publication
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                Published = null,
+                                ApprovalStatus = status
+                            };
 
-                        // Assert that no User Release roles will allow updating a Release once it has started publishing
-                        await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<UpdateSpecificReleaseRequirement>(
-                            HandlerSupplierWhenPublishing(release),
-                            release
-                        );
-                    }
-                );
+                            // Assert that no User Release roles will allow updating a Release once it has started publishing
+                            await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<UpdateSpecificReleaseRequirement>(
+                                HandlerSupplierWhenPublishing(release),
+                                release
+                            );
+                        }
+                    );
             }
 
             [Fact]
             public async Task UpdateSpecificReleaseAuthorizationHandler_ReleasePublished()
             {
-                await GetEnumValues<ReleaseApprovalStatus>().ForEachAsync(
-                    async status =>
-                    {
-                        var release = new Release
+                await GetEnumValues<ReleaseApprovalStatus>()
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        async status =>
                         {
-                            Id = Guid.NewGuid(),
-                            Publication = new Publication
+                            var release = new Release
                             {
-                                Id = Guid.NewGuid()
-                            },
-                            ApprovalStatus = status,
-                            Published = DateTime.UtcNow
-                        };
+                                Id = Guid.NewGuid(),
+                                Publication = new Publication
+                                {
+                                    Id = Guid.NewGuid()
+                                },
+                                ApprovalStatus = status,
+                                Published = DateTime.UtcNow
+                            };
 
-                        // Assert that no User Release roles will allow updating a Release once it has been published
-                        await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<UpdateSpecificReleaseRequirement>(
-                            HandlerSupplier(release), 
-                            release
-                        );
-                    }
-                );
+                            // Assert that no User Release roles will allow updating a Release once it has been published
+                            await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<UpdateSpecificReleaseRequirement>(
+                                HandlerSupplier(release),
+                                release
+                            );
+                        }
+                    );
             }
         }
 
         private static Func<ContentDbContext, UpdateSpecificReleaseAuthorizationHandler> HandlerSupplierWhenPublishing(
             Release release)
-        { 
+        {
             var statusListWhenPublishing = new List<ReleasePublishingStatus>
             {
                 new()
@@ -318,7 +343,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             {
                 contentDbContext.Add(release);
                 contentDbContext.SaveChanges();
-                
+
                 return new UpdateSpecificReleaseAuthorizationHandler(
                     releaseStatusRepository.Object,
                     new UserPublicationRoleRepository(contentDbContext),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/AuthorizationHandlersTestUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/AuthorizationHandlersTestUtil.cs
@@ -27,7 +27,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             where TRequirement : IAuthorizationRequirement
         {
             var scenarios = GetClaimTestScenarios(entity, claimsExpectedToSucceed);
-            await scenarios.ForEachAsync(scenario => AssertHandlerHandlesScenarioSuccessfully<TRequirement>(handler, scenario));
+            await scenarios
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(
+                    scenario => AssertHandlerHandlesScenarioSuccessfully<TRequirement>(handler, scenario));
         }
 
         public static async Task AssertHandlerSucceedsWithCorrectClaims<TRequirement>(
@@ -36,9 +39,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             where TRequirement : IAuthorizationRequirement
         {
             var scenarios = GetClaimTestScenarios(null, claimsExpectedToSucceed);
-            await scenarios.ForEachAsync(scenario => AssertHandlerHandlesScenarioSuccessfully<TRequirement>(handler, scenario));
+            await scenarios
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(scenario =>
+                    AssertHandlerHandlesScenarioSuccessfully<TRequirement>(handler, scenario));
         }
-        
+
         public static async Task AssertHandlerSucceedsWithCorrectClaims<TEntity, TRequirement>(
             Func<ContentDbContext, IAuthorizationHandler> handlerSupplier,
             TEntity entity,
@@ -46,7 +52,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             where TRequirement : IAuthorizationRequirement
         {
             var scenarios = GetClaimTestScenarios(entity, claimsExpectedToSucceed);
-            await scenarios.ForEachAsync(scenario => AssertHandlerHandlesScenarioSuccessfully<TRequirement>(handlerSupplier, scenario));
+            await scenarios
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(scenario =>
+                    AssertHandlerHandlesScenarioSuccessfully<TRequirement>(handlerSupplier, scenario));
         }
 
         public static async Task AssertHandlerSucceedsWithCorrectClaims<TRequirement>(
@@ -55,7 +64,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             where TRequirement : IAuthorizationRequirement
         {
             var scenarios = GetClaimTestScenarios(null, claimsExpectedToSucceed);
-            await scenarios.ForEachAsync(scenario => AssertHandlerHandlesScenarioSuccessfully<TRequirement>(handlerSupplier, scenario));
+            await scenarios
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(scenario =>
+                    AssertHandlerHandlesScenarioSuccessfully<TRequirement>(handlerSupplier, scenario));
         }
 
         public static async Task AssertHandlerHandlesScenarioSuccessfully<TRequirement>(
@@ -102,7 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             where TRequirement : IAuthorizationRequirement
         {
             var authContext = new AuthorizationHandlerContext(
-                new IAuthorizationRequirement[] {Activator.CreateInstance<TRequirement>()},
+                new IAuthorizationRequirement[] { Activator.CreateInstance<TRequirement>() },
                 scenario.User, scenario.Entity);
 
             await handler.HandleAsync(authContext);
@@ -119,7 +131,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
         public static ClaimsPrincipal CreateClaimsPrincipal(Guid userId)
         {
-            return CreateClaimsPrincipal(userId, new Claim[] {});
+            return CreateClaimsPrincipal(userId, new Claim[] { });
         }
 
         public static ClaimsPrincipal CreateClaimsPrincipal(Guid userId, params Claim[] additionalClaims)
@@ -133,7 +145,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
 
         public static ClaimsPrincipal CreateClaimsPrincipal(Guid userId, params SecurityClaimTypes[] additionalClaims)
         {
-            return CreateClaimsPrincipal(userId, 
+            return CreateClaimsPrincipal(userId,
                 additionalClaims.Select(c => new Claim(c.ToString(), "")).ToArray());
         }
 
@@ -141,35 +153,40 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         {
             GetEnumValues<SecurityClaimTypes>().ForEach(action.Invoke);
         }
-        
+
         public static Task ForEachSecurityClaimAsync(Func<SecurityClaimTypes, Task> action)
         {
-            return GetEnumValues<SecurityClaimTypes>().ForEachAsync(action.Invoke);
+            return GetEnumValues<SecurityClaimTypes>()
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(action.Invoke);
         }
 
         public static Task ForEachReleaseRoleAsync(Func<ReleaseRole, Task> action)
         {
-            return GetEnumValues<ReleaseRole>().ForEachAsync(action.Invoke);
+            return GetEnumValues<ReleaseRole>()
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(action.Invoke);
         }
-        
+
         public static Task ForEachPublicationRoleAsync(Func<PublicationRole, Task> action)
         {
-            return GetEnumValues<PublicationRole>().ForEachAsync(action.Invoke);
+            return GetEnumValues<PublicationRole>()
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(action.Invoke);
         }
 
         public static AuthorizationHandlerContext CreateAuthorizationHandlerContext<TRequirement, TEntity>(
             ClaimsPrincipal user, TEntity entity) where TRequirement : IAuthorizationRequirement
         {
             return new AuthorizationHandlerContext(
-                new IAuthorizationRequirement[] {Activator.CreateInstance<TRequirement>()},
+                new IAuthorizationRequirement[] { Activator.CreateInstance<TRequirement>() },
                 user, entity);
-
         }
 
         public class HandlerTestScenario
         {
             public object Entity { get; set; }
-            
+
             public ClaimsPrincipal User { get; set; }
 
             public bool ExpectedToPass { get; set; }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/ReleaseAuthorizationHandlersTestUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/ReleaseAuthorizationHandlersTestUtil.cs
@@ -8,7 +8,8 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
+    AuthorizationHandlersTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 
@@ -30,7 +31,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 Id = Guid.NewGuid()
             };
 
-            await AssertHandlerSucceedsWithCorrectClaims<Release, TRequirement>(handler, release, claimsExpectedToSucceed);
+            await AssertHandlerSucceedsWithCorrectClaims<Release, TRequirement>(handler, release,
+                claimsExpectedToSucceed);
         }
 
         public static async Task AssertReleaseHandlerSucceedsWithCorrectClaims<TRequirement>(
@@ -43,7 +45,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 Id = Guid.NewGuid()
             };
 
-            await AssertHandlerSucceedsWithCorrectClaims<Release, TRequirement>(handlerSupplier, release, claimsExpectedToSucceed);
+            await AssertHandlerSucceedsWithCorrectClaims<Release, TRequirement>(handlerSupplier, release,
+                claimsExpectedToSucceed);
         }
 
         public static async Task AssertReleaseHandlerSucceedsWithCorrectClaims<TRequirement>(
@@ -52,7 +55,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             params SecurityClaimTypes[] claimsExpectedToSucceed)
             where TRequirement : IAuthorizationRequirement
         {
-            await AssertHandlerSucceedsWithCorrectClaims<Release, TRequirement>(handlerSupplier, release, claimsExpectedToSucceed);
+            await AssertHandlerSucceedsWithCorrectClaims<Release, TRequirement>(handlerSupplier, release,
+                claimsExpectedToSucceed);
         }
 
         /**
@@ -69,7 +73,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 Id = Guid.NewGuid()
             };
 
-            await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<TRequirement>(handlerSupplier, release, rolesExpectedToSucceed);
+            await AssertReleaseHandlerSucceedsWithCorrectReleaseRoles<TRequirement>(handlerSupplier, release,
+                rolesExpectedToSucceed);
         }
 
         /**
@@ -84,8 +89,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         {
             var inTeamScenarios = CreateUserInProductionTeamScenarios(release, rolesExpectedToSucceed);
             var notInTeamScenario = CreateUserNotInProductionTeamScenario(release, rolesExpectedToSucceed);
-            var allScenarios = new List<ReleaseHandlerTestScenario>(inTeamScenarios) {notInTeamScenario};
-            await allScenarios.ForEachAsync(scenario => AssertReleaseHandlerHandlesScenarioSuccessfully<TRequirement>(handlerSupplier, scenario));
+            var allScenarios = new List<ReleaseHandlerTestScenario>(inTeamScenarios) { notInTeamScenario };
+            await allScenarios
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(scenario =>
+                    AssertReleaseHandlerHandlesScenarioSuccessfully<TRequirement>(handlerSupplier, scenario));
         }
 
         /**
@@ -100,8 +108,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
         {
             var inTeamScenarios = CreateUserInPublicationTeamScenarios(release, rolesExpectedToSucceed);
             var notInTeamScenario = CreateUserNotInPublicationTeamScenario(release, rolesExpectedToSucceed);
-            var allScenarios = new List<ReleaseHandlerTestScenario>(inTeamScenarios) {notInTeamScenario};
-            await allScenarios.ForEachAsync(scenario => AssertReleaseHandlerHandlesScenarioSuccessfully<TRequirement>(handlerSupplier, scenario));
+            var allScenarios = new List<ReleaseHandlerTestScenario>(inTeamScenarios) { notInTeamScenario };
+            await allScenarios
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(scenario =>
+                    AssertReleaseHandlerHandlesScenarioSuccessfully<TRequirement>(handlerSupplier, scenario));
         }
 
         private static ReleaseHandlerTestScenario CreateUserNotInProductionTeamScenario(Release release,
@@ -393,7 +404,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             {
                 var user = CreateClaimsPrincipal(userId);
                 var authContext = new AuthorizationHandlerContext(
-                    new IAuthorizationRequirement[] {Activator.CreateInstance<TRequirement>()},
+                    new IAuthorizationRequirement[] { Activator.CreateInstance<TRequirement>() },
                     user, handleRequirementArgument);
 
                 var handler = handlerSupplier(contentDbContext);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
@@ -118,7 +118,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             await GetEnumValues<PreReleaseAccess>()
                 .Where(value => value != PreReleaseAccess.Within)
                 .ToList()
-                .ForEachAsync(async access =>
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async access =>
                 {
                     preReleaseService
                         .Setup(s => s.GetPreReleaseWindowStatus(release, It.IsAny<DateTime>()))

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -61,7 +61,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="3.1.18" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" Version="2.0.0" />
-    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="5.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
   </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ManageContent/ManageContentPageService.cs
@@ -113,18 +113,22 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageConten
                 .ToListAsync();
             release.Content = content;
 
-            await release.Content.ForEachAsync(async rcs =>
-            {
-                await rcs.ContentSection.Content.ForEachAsync(async cb =>
+            await release.Content
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async rcs =>
                 {
-                    cb.Comments = await _contentDbContext.Comment
-                        .AsQueryable()
-                        .Where(c => c.ContentBlockId == cb.Id)
-                        .Include(c => c.CreatedBy)
-                        .Include(c => c.ResolvedBy)
-                        .ToListAsync();
+                    await rcs.ContentSection.Content
+                        .ToAsyncEnumerable()
+                        .ForEachAwaitAsync(async cb =>
+                        {
+                            cb.Comments = await _contentDbContext.Comment
+                                .AsQueryable()
+                                .Where(c => c.ContentBlockId == cb.Id)
+                                .Include(c => c.CreatedBy)
+                                .Include(c => c.ResolvedBy)
+                                .ToListAsync();
+                        });
                 });
-            });
             return release;
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -530,7 +530,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             await release.Content
                 .ToAsyncEnumerable()
                 .ForEachAwaitAsync(async cs =>
-
                 {
                     await _context.Entry(cs)
                         .Reference(rcs => rcs.ContentSection)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -527,26 +527,31 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
             await _context.Entry(release)
                 .Collection(r => r.Content)
                 .LoadAsync();
-            await release.Content.ForEachAsync(async cs =>
-            {
-                await _context.Entry(cs)
-                    .Reference(rcs => rcs.ContentSection)
-                    .LoadAsync();
-                await _context.Entry(cs.ContentSection)
-                    .Collection(s => s.Content)
-                    .LoadAsync();
-            });
+            await release.Content
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async cs =>
+
+                {
+                    await _context.Entry(cs)
+                        .Reference(rcs => rcs.ContentSection)
+                        .LoadAsync();
+                    await _context.Entry(cs.ContentSection)
+                        .Collection(s => s.Content)
+                        .LoadAsync();
+                });
             await _context.Entry(release)
                 .Collection(r => r.Updates)
                 .LoadAsync();
             await _context.Entry(release)
                 .Collection(r => r.ContentBlocks)
                 .LoadAsync();
-            await release.ContentBlocks.ForEachAsync(async rcb =>
-                await _context.Entry(rcb)
-                    .Reference(cb => cb.ContentBlock)
-                    .LoadAsync()
-            );
+            await release.ContentBlocks
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async rcb =>
+                    await _context.Entry(rcb)
+                        .Reference(cb => cb.ContentBlock)
+                        .LoadAsync()
+                );
             return release;
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -123,12 +123,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             Assert.Equal("foo, bar, baz", list.JoinToString(", "));
         }
 
-        private static async Task<int> GetIntTask(int value)
-        {
-            await Task.Delay(5);
-            return value;
-        }
-
         private static async Task<Either<Unit, int>> GetSuccessfulEither(int value)
         {
             await Task.Delay(5);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -46,22 +46,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
         }
 
         [Fact]
-        public async Task ForEachAsync()
-        {
-            List<int> results = new();
-
-            await new List<int> {1, 2}.ForEachAsync(async value =>
-            {
-                var result = await GetIntTask(value);
-                results.Add(result);
-            });
-
-            Assert.Equal(2, results.Count);
-            Assert.Contains(1, results);
-            Assert.Contains(2, results);
-        }
-
-        [Fact]
         public async Task ForEachAsync_SuccessfulEitherList()
         {
             Either<Unit, List<int>> results =

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -108,17 +108,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             }
         }
 
-        public static async Task ForEachAsync<T>(this IEnumerable<T> source, Func<T, int, Task> func)
-        {
-            var index = 0;
-
-            foreach (var item in source)
-            {
-                await func(item, index);
-                index += 1;
-            }
-        }
-
         public static int IndexOfFirst<T>(this IEnumerable<T> source, Func<T, bool> predicate)
         {
             var index = 0;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -100,14 +100,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             }
         }
 
-        public static async Task ForEachAsync<T>(this IEnumerable<T> source, Func<T, Task> func)
-        {
-            foreach (var item in source)
-            {
-                await func(item);
-            }
-        }
-
         public static int IndexOfFirst<T>(this IEnumerable<T> source, Func<T, bool> predicate)
         {
             var index = 0;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/EnumerableExtensions.cs
@@ -117,18 +117,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return -1;
         }
 
-        public static async Task<List<TResult>> ForEachAsync<T, TResult>(this IEnumerable<T> source, Func<T, Task<TResult>> func)
-        {
-            var results = new List<TResult>();
-
-            foreach (var item in source)
-            {
-                results.Add(await func(item));
-            }
-
-            return results;
-        }
-
         public static async Task<Either<TLeft, List<TRight>>> ForEachAsync<T, TLeft, TRight>(this IEnumerable<T> source,
             Func<T, Task<Either<TLeft, TRight>>> func)
         {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/GovUk.Education.ExploreEducationStatistics.Content.Model.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/GovUk.Education.ExploreEducationStatistics.Content.Model.csproj
@@ -9,6 +9,7 @@
         <PackageReference Include="JsonKnownTypes" Version="0.4.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.18" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.18" />
+        <PackageReference Include="System.Linq.Async" Version="5.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyRepository.cs
@@ -21,6 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
         public async Task<List<Methodology>> GetByPublication(Guid publicationId)
         {
             return await _contentDbContext.PublicationMethodologies
+                .AsQueryable()
                 .Where(pm => pm.PublicationId == publicationId)
                 .Select(pm => pm.Methodology)
                 .ToListAsync();

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyVersionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/MethodologyVersionRepository.cs
@@ -27,6 +27,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
         {
             var publication = await _contentDbContext
                 .Publications
+                .AsQueryable()
                 .SingleAsync(p => p.Id == publicationId);
 
             var methodology = (await _contentDbContext.MethodologyVersions.AddAsync(new MethodologyVersion
@@ -66,6 +67,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
         {
             // First check the publication exists
             var publication = await _contentDbContext.Publications
+                .AsQueryable()
                 .SingleAsync(p => p.Id == publicationId);
 
             var methodologies = await _methodologyRepository.GetByPublication(publication.Id);
@@ -84,6 +86,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
         public async Task<MethodologyVersion?> GetLatestPublishedVersion(Guid methodologyId)
         {
             var methodology = await _contentDbContext.Methodologies
+                .AsQueryable()
                 .SingleAsync(mp => mp.Id == methodologyId);
 
             return await GetLatestPublishedByMethodology(methodology);
@@ -135,7 +138,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
                 .Select(m => m.Methodology)
                 .ToListAsync();
 
-            await ownedMethodologies.ForEachAsync(async methodology =>
+            await ownedMethodologies
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async methodology =>
             {
                 methodology.OwningPublicationTitle = updatedTitle;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseContentBlockRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseContentBlockRepository.cs
@@ -21,6 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
         {
             return await _contentDbContext
                 .ReleaseContentBlocks
+                .AsQueryable()
                 .Where(releaseContentBlock => releaseContentBlock.ReleaseId == releaseId)
                 .Select(releaseContentBlock => releaseContentBlock.ContentBlock)
                 .OfType<T>()

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseContentSectionRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Model/Repository/ReleaseContentSectionRepository.cs
@@ -21,6 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Model.Repository
         {
             return await _contentDbContext
                 .ReleaseContentSections
+                .AsQueryable()
                 .Where(releaseContentSection => releaseContentSection.ReleaseId == releaseId)
                 .Include(releaseContentSection => releaseContentSection.ContentSection)
                 .ThenInclude(section => section.Content)

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/DataGuidanceFileWriter.cs
@@ -182,14 +182,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
                             );
 
                             // Add table body for variable names/descriptions
-                            await variables.ForEachAsync(
-                                async variable =>
-                                {
-                                    await file.WriteLineAsync(
-                                        variable.Value.PadRight(padding.Value) + VariableSeparator + variable.Label
-                                    );
-                                }
-                            );
+                            await variables
+                                .ToAsyncEnumerable()
+                                .ForEachAwaitAsync(
+                                    async variable =>
+                                    {
+                                        await file.WriteLineAsync(
+                                            variable.Value.PadRight(padding.Value) + VariableSeparator + variable.Label
+                                        );
+                                    }
+                                );
                         }
 
                         var footnotes = subject.Footnotes

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GovUk.Education.ExploreEducationStatistics.Content.Services.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/GovUk.Education.ExploreEducationStatistics.Content.Services.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="AutoMapper" Version="9.0.0" />
         <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-        <PackageReference Include="System.Linq.Async" Version="5.0.0" />
+        <PackageReference Include="System.Linq.Async" Version="5.1.0" />
         <PackageReference Include="System.Linq.Async.Queryable" Version="5.0.0" />
     </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/MethodologyService.cs
@@ -98,7 +98,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services
 
             await themes.SelectMany(model => model.Topics)
                 .SelectMany(model => model.Publications)
-                .ForEachAsync(async publication =>
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async publication =>
                     publication.Methodologies = await BuildMethodologiesForPublication(publication.Id));
 
             themes.ForEach(theme => theme.RemoveTopicNodesWithoutMethodologiesAndSort());

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/CacheKeyService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/CacheKeyService.cs
@@ -18,7 +18,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
         private readonly IFastTrackService _fastTrackService;
 
         public CacheKeyService(
-            ContentDbContext contentDbContext, 
+            ContentDbContext contentDbContext,
             StatisticsDbContext statisticsDbContext,
             IFastTrackService fastTrackService)
         {
@@ -26,7 +26,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             _statisticsDbContext = statisticsDbContext;
             _fastTrackService = fastTrackService;
         }
-        
+
         public Task<Either<ActionResult, FastTrackResultsCacheKey>> CreateCacheKeyForFastTrackResults(Guid fastTrackId)
         {
             return _fastTrackService
@@ -38,7 +38,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
                         .Include(release => release.Publication)
                         .SingleAsync(release => release.Id == fastTrack.ReleaseId);
 
-                    return new FastTrackResultsCacheKey(owningRelease.Publication.Slug, owningRelease.Slug, fastTrackId);
+                    return new FastTrackResultsCacheKey(owningRelease.Publication.Slug, owningRelease.Slug,
+                        fastTrackId);
                 });
         }
 
@@ -47,7 +48,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
             var publishedReleaseSubjects = await _statisticsDbContext
                 .ReleaseSubject
                 .Include(releaseSubject => releaseSubject.Release)
-                .Where(releaseSubject => releaseSubject.SubjectId == subjectId && releaseSubject.Release.Published.HasValue)
+                .Where(releaseSubject =>
+                    releaseSubject.SubjectId == subjectId && releaseSubject.Release.Published.HasValue)
                 .ToListAsync();
 
             var liveReleaseSubjects = publishedReleaseSubjects
@@ -67,12 +69,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
 
             var publication = await _contentDbContext
                 .Publications
+                .AsQueryable()
                 .SingleAsync(publication => publication.Id == latestReleaseSubject.Release.PublicationId);
 
             return new SubjectMetaCacheKey(publication.Slug, latestReleaseSubject.Release.Slug, subjectId);
         }
-        
-        public async Task<Either<ActionResult, ReleaseSubjectsCacheKey>> CreateCacheKeyForReleaseSubjects(Guid releaseId)
+
+        public async Task<Either<ActionResult, ReleaseSubjectsCacheKey>> CreateCacheKeyForReleaseSubjects(
+            Guid releaseId)
         {
             var release = await _contentDbContext
                 .Releases

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests/Services/FileImportServiceTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
@@ -502,199 +501,207 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Tests.Servic
         [Fact]
         public async Task CheckComplete_SingleDataFileCompleted_AlreadyFinished()
         {
-            await FinishedStatuses.ForEachAsync(async finishedStatus =>
-            {
-                var file = new File
+            await FinishedStatuses
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async finishedStatus =>
                 {
-                    Id = Guid.NewGuid(),
-                    Filename = "my_data_file.csv"
-                };
-
-                var import = new DataImport
-                {
-                    Id = Guid.NewGuid(),
-                    Errors = new List<DataImportError>(),
-                    FileId = file.Id,
-                    File = file,
-                    SubjectId = Guid.NewGuid(),
-                    Status = finishedStatus,
-                    NumBatches = 1,
-                    TotalRows = 2
-                };
-
-                var dataImportService = new Mock<IDataImportService>(Strict);
-
-                dataImportService
-                    .Setup(s => s.GetImport(import.Id))
-                    .ReturnsAsync(import);
-
-                var statisticsDbContextId = Guid.NewGuid().ToString();
-
-                await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-                {
-                    var service = BuildFileImportService(dataImportService: dataImportService.Object);
-
-                    var message = new ImportObservationsMessage
+                    var file = new File
                     {
-                        Id = import.Id
+                        Id = Guid.NewGuid(),
+                        Filename = "my_data_file.csv"
                     };
 
-                    await service.CheckComplete(message, statisticsDbContext);
-                }
+                    var import = new DataImport
+                    {
+                        Id = Guid.NewGuid(),
+                        Errors = new List<DataImportError>(),
+                        FileId = file.Id,
+                        File = file,
+                        SubjectId = Guid.NewGuid(),
+                        Status = finishedStatus,
+                        NumBatches = 1,
+                        TotalRows = 2
+                    };
 
-                MockUtils.VerifyAllMocks(dataImportService);
-            });
+                    var dataImportService = new Mock<IDataImportService>(Strict);
+
+                    dataImportService
+                        .Setup(s => s.GetImport(import.Id))
+                        .ReturnsAsync(import);
+
+                    var statisticsDbContextId = Guid.NewGuid().ToString();
+
+                    await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+                    {
+                        var service = BuildFileImportService(dataImportService: dataImportService.Object);
+
+                        var message = new ImportObservationsMessage
+                        {
+                            Id = import.Id
+                        };
+
+                        await service.CheckComplete(message, statisticsDbContext);
+                    }
+
+                    MockUtils.VerifyAllMocks(dataImportService);
+                });
         }
 
         [Fact]
         public async Task CheckComplete_LastBatchFileCompleted_AlreadyFinished()
         {
-            await FinishedStatuses.ForEachAsync(async finishedStatus =>
-            {
-                var file = new File
+            await FinishedStatuses
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async finishedStatus =>
                 {
-                    Id = Guid.NewGuid(),
-                    Filename = "my_data_file.csv"
-                };
-
-                var import = new DataImport
-                {
-                    Id = Guid.NewGuid(),
-                    Errors = new List<DataImportError>(),
-                    FileId = file.Id,
-                    File = file,
-                    SubjectId = Guid.NewGuid(),
-                    Status = finishedStatus,
-                    NumBatches = 2,
-                    TotalRows = 2
-                };
-
-                var dataImportService = new Mock<IDataImportService>(Strict);
-
-                dataImportService
-                    .Setup(s => s.GetImport(import.Id))
-                    .ReturnsAsync(import);
-
-                var statisticsDbContextId = Guid.NewGuid().ToString();
-
-                await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-                {
-                    var service = BuildFileImportService(dataImportService: dataImportService.Object);
-
-                    var message = new ImportObservationsMessage
+                    var file = new File
                     {
-                        Id = import.Id
+                        Id = Guid.NewGuid(),
+                        Filename = "my_data_file.csv"
                     };
 
-                    await service.CheckComplete(message, statisticsDbContext);
-                }
+                    var import = new DataImport
+                    {
+                        Id = Guid.NewGuid(),
+                        Errors = new List<DataImportError>(),
+                        FileId = file.Id,
+                        File = file,
+                        SubjectId = Guid.NewGuid(),
+                        Status = finishedStatus,
+                        NumBatches = 2,
+                        TotalRows = 2
+                    };
 
-                MockUtils.VerifyAllMocks(dataImportService);
-            });
+                    var dataImportService = new Mock<IDataImportService>(Strict);
+
+                    dataImportService
+                        .Setup(s => s.GetImport(import.Id))
+                        .ReturnsAsync(import);
+
+                    var statisticsDbContextId = Guid.NewGuid().ToString();
+
+                    await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+                    {
+                        var service = BuildFileImportService(dataImportService: dataImportService.Object);
+
+                        var message = new ImportObservationsMessage
+                        {
+                            Id = import.Id
+                        };
+
+                        await service.CheckComplete(message, statisticsDbContext);
+                    }
+
+                    MockUtils.VerifyAllMocks(dataImportService);
+                });
         }
 
         [Fact]
         public async Task CheckComplete_SingleDataFileCompleted_Aborting()
         {
-            await AbortingStatuses.ForEachAsync(async abortingStatus =>
-            {
-                var file = new File
+            await AbortingStatuses
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async abortingStatus =>
                 {
-                    Id = Guid.NewGuid(),
-                    Filename = "my_data_file.csv"
-                };
-
-                var import = new DataImport
-                {
-                    Id = Guid.NewGuid(),
-                    Errors = new List<DataImportError>(),
-                    FileId = file.Id,
-                    File = file,
-                    SubjectId = Guid.NewGuid(),
-                    Status = abortingStatus,
-                    NumBatches = 1,
-                    TotalRows = 2
-                };
-
-                var dataImportService = new Mock<IDataImportService>(Strict);
-
-                dataImportService
-                    .Setup(s => s.GetImport(import.Id))
-                    .ReturnsAsync(import);
-
-                dataImportService
-                    .Setup(s => s.UpdateStatus(
-                        import.Id, abortingStatus.GetFinishingStateOfAbortProcess(), 100))
-                    .Returns(Task.CompletedTask);
-
-                var statisticsDbContextId = Guid.NewGuid().ToString();
-
-                await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-                {
-                    var service = BuildFileImportService(dataImportService: dataImportService.Object);
-
-                    var message = new ImportObservationsMessage
+                    var file = new File
                     {
-                        Id = import.Id
+                        Id = Guid.NewGuid(),
+                        Filename = "my_data_file.csv"
                     };
 
-                    await service.CheckComplete(message, statisticsDbContext);
-                }
+                    var import = new DataImport
+                    {
+                        Id = Guid.NewGuid(),
+                        Errors = new List<DataImportError>(),
+                        FileId = file.Id,
+                        File = file,
+                        SubjectId = Guid.NewGuid(),
+                        Status = abortingStatus,
+                        NumBatches = 1,
+                        TotalRows = 2
+                    };
 
-                MockUtils.VerifyAllMocks(dataImportService);
-            });
+                    var dataImportService = new Mock<IDataImportService>(Strict);
+
+                    dataImportService
+                        .Setup(s => s.GetImport(import.Id))
+                        .ReturnsAsync(import);
+
+                    dataImportService
+                        .Setup(s => s.UpdateStatus(
+                            import.Id, abortingStatus.GetFinishingStateOfAbortProcess(), 100))
+                        .Returns(Task.CompletedTask);
+
+                    var statisticsDbContextId = Guid.NewGuid().ToString();
+
+                    await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+                    {
+                        var service = BuildFileImportService(dataImportService: dataImportService.Object);
+
+                        var message = new ImportObservationsMessage
+                        {
+                            Id = import.Id
+                        };
+
+                        await service.CheckComplete(message, statisticsDbContext);
+                    }
+
+                    MockUtils.VerifyAllMocks(dataImportService);
+                });
         }
 
         [Fact]
         public async Task CheckComplete_LastBatchFileCompleted_Aborting()
         {
-            await AbortingStatuses.ForEachAsync(async abortingStatus =>
-            {
-                var file = new File
+            await AbortingStatuses
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async abortingStatus =>
                 {
-                    Id = Guid.NewGuid(),
-                    Filename = "my_data_file.csv"
-                };
-                
-                var import = new DataImport
-                {
-                    Id = Guid.NewGuid(),
-                    Errors = new List<DataImportError>(),
-                    FileId = file.Id,
-                    File = file,
-                    SubjectId = Guid.NewGuid(),
-                    Status = abortingStatus,
-                    NumBatches = 2,
-                    TotalRows = 2
-                };
-
-                var dataImportService = new Mock<IDataImportService>(Strict);
-
-                dataImportService
-                    .Setup(s => s.GetImport(import.Id))
-                    .ReturnsAsync(import);
-
-                dataImportService
-                    .Setup(s => s.UpdateStatus(
-                        import.Id, abortingStatus.GetFinishingStateOfAbortProcess(), 100))
-                    .Returns(Task.CompletedTask);
-
-                var statisticsDbContextId = Guid.NewGuid().ToString();
-
-                await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
-                {
-                    var service = BuildFileImportService(dataImportService: dataImportService.Object);
-
-                    var message = new ImportObservationsMessage
+                    var file = new File
                     {
-                        Id = import.Id
+                        Id = Guid.NewGuid(),
+                        Filename = "my_data_file.csv"
                     };
 
-                    await service.CheckComplete(message, statisticsDbContext);
-                }
+                    var import = new DataImport
+                    {
+                        Id = Guid.NewGuid(),
+                        Errors = new List<DataImportError>(),
+                        FileId = file.Id,
+                        File = file,
+                        SubjectId = Guid.NewGuid(),
+                        Status = abortingStatus,
+                        NumBatches = 2,
+                        TotalRows = 2
+                    };
 
-                MockUtils.VerifyAllMocks(dataImportService);
-            });
+                    var dataImportService = new Mock<IDataImportService>(Strict);
+
+                    dataImportService
+                        .Setup(s => s.GetImport(import.Id))
+                        .ReturnsAsync(import);
+
+                    dataImportService
+                        .Setup(s => s.UpdateStatus(
+                            import.Id, abortingStatus.GetFinishingStateOfAbortProcess(), 100))
+                        .Returns(Task.CompletedTask);
+
+                    var statisticsDbContextId = Guid.NewGuid().ToString();
+
+                    await using (var statisticsDbContext = InMemoryStatisticsDbContext(statisticsDbContextId))
+                    {
+                        var service = BuildFileImportService(dataImportService: dataImportService.Object);
+
+                        var message = new ImportObservationsMessage
+                        {
+                            Id = import.Id
+                        };
+
+                        await service.CheckComplete(message, statisticsDbContext);
+                    }
+
+                    MockUtils.VerifyAllMocks(dataImportService);
+                });
         }
 
         private static FileImportService BuildFileImportService(

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/RestartImportsFunction.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/Functions/RestartImportsFunction.cs
@@ -47,6 +47,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Processor.Functions
             logger.LogInformation($"{executionContext.FunctionName} triggered: {message}");
 
             var incompleteImports = await _contentDbContext.DataImports
+                .AsQueryable()
                 .Where(import => IncompleteStatuses.Contains(import.Status))
                 .ToListAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
@@ -52,22 +52,24 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
             var observations = new List<Observation>();
 
-            await batchesOfIds.ForEachAsync(async batchOfIds =>
-            {
-                var observationBatch = await _context
-                    .Observation
-                    .AsNoTracking()
-                    .Include(o => o.FilterItems)
-                    .Include(o => o.Location)
-                    .Where(o => batchOfIds.Contains(o.Id))
-                    .ToListAsync(cancellationToken);
+            await batchesOfIds
+                .ToAsyncEnumerable()
+                .ForEachAwaitAsync(async batchOfIds =>
+                {
+                    var observationBatch = await _context
+                        .Observation
+                        .AsNoTracking()
+                        .Include(o => o.FilterItems)
+                        .Include(o => o.Location)
+                        .Where(o => batchOfIds.Contains(o.Id))
+                        .ToListAsync(cancellationToken);
 
-                observations.AddRange(observationBatch);
+                    observations.AddRange(observationBatch);
 
-                _logger.LogDebug($"Fetched batch of {observationBatch.Count} Observations from their ids in " +
-                                 $"{phasesStopwatch.Elapsed.TotalMilliseconds} ms");
-                phasesStopwatch.Restart();
-            });
+                    _logger.LogDebug($"Fetched batch of {observationBatch.Count} Observations from their ids in " +
+                                     $"{phasesStopwatch.Elapsed.TotalMilliseconds} ms");
+                    phasesStopwatch.Restart();
+                }, cancellationToken: cancellationToken);
 
             _logger.LogDebug($"Finished fetching {ids.Length} Observations in a total of " +
                              $"{totalStopwatch.Elapsed.TotalMilliseconds} ms");

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ReleaseService.cs
@@ -71,6 +71,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             }
 
             var releaseSubjects = await _statisticsDbContext.ReleaseSubject
+                .AsQueryable()
                 .Where(rs => rs.ReleaseId == releaseId && subjectsToInclude.Contains(rs.SubjectId))
                 .ToListAsync();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TimePeriodService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/TimePeriodService.cs
@@ -23,6 +23,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         public IEnumerable<(int Year, TimeIdentifier TimeIdentifier)> GetTimePeriods(Guid subjectId)
         {
             return _context.Observation
+                .AsQueryable()
                 .Where(observation => observation.SubjectId == subjectId)
                 .Select(o => new {o.Year, o.TimeIdentifier})
                 .Distinct()
@@ -54,6 +55,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         {
             var observationsQuery = _context
                 .Observation
+                .AsQueryable()
                 .Where(observation => observation.SubjectId == subjectId);
             var orderedTimePeriods = GetDistinctObservationTimePeriods(observationsQuery).ToList();
 


### PR DESCRIPTION
This PR is to remove a most of the `ForEachAsync` methods from `EnumerableExtensions`. The intention overall is to move away from our own versions of this type of method to Linq.Async versions.