### PR TITLE
EES-3011 Resolve PR comments of EES-2778

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ILocationAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/ILocationAttribute.cs
@@ -7,6 +7,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 
         public string? Name { get; }
 
+        /// <summary>
+        /// Produces a key string that represents this location attribute uniquely.
+        /// </summary>
+        /// <remarks>
+        /// Used when adding Location cache entries to an in-memory cache while importing statistical data.
+        /// </remarks>
         public string GetCacheKey()
         {
             return $"{GetType().Name}:{GetCodeOrFallback()}:{Name ?? string.Empty}";

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthority.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/LocalAuthority.cs
@@ -14,6 +14,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
 
         public string GetCacheKey()
         {
+            // Don't use GetCodeOrFallback here as the string needs to represent the local authority uniquely by all
+            // attributes. Two local authorities with the same name and code but different old code are not identical.
             return $"{GetType().Name}:{Code ?? string.Empty}:{OldCode ?? string.Empty}:{Name ?? string.Empty}";
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Observation.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Observation.cs
@@ -8,15 +8,26 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model
     public class Observation
     {
         public Guid Id { get; set; }
+
         public Subject Subject { get; set; }
+
         public Guid SubjectId { get; set; }
+
+        // TODO EES-3067 Potentially drop this by changing older methods of querying Observations to use Location.GeographicLevel
         public GeographicLevel GeographicLevel { get; set; }
+
         public Location Location { get; set; }
+
         public Guid LocationId { get; set; }
+
         public int Year { get; set; }
+
         public TimeIdentifier TimeIdentifier { get; set; }
+
         public Dictionary<Guid, string> Measures { get; set; }
+
         public ICollection<ObservationFilterItem> FilterItems { get; set; }
+
         public long CsvRow { get; set; }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/ILocationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/Interfaces/ILocationRepository.cs
@@ -15,7 +15,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Inter
             Guid subjectId,
             Dictionary<GeographicLevel, List<string>>? hierarchies);
 
-        Task<Dictionary<GeographicLevel, List<LocationAttributeNode>>> GetLocationAttributesHierarchical(
+        Task<Dictionary<GeographicLevel, List<LocationAttributeNode>>> GetLocationAttributesHierarchicalByObservationsList(
+            IList<Observation> observations,
+            Dictionary<GeographicLevel, List<string>>? hierarchies);
+
+        Task<Dictionary<GeographicLevel, List<LocationAttributeNode>>> GetLocationAttributesHierarchicalByObservationsQuery(
             IQueryable<Observation> observations,
             Dictionary<GeographicLevel, List<string>>? hierarchies);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/LocationRepository.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Repository/LocationRepository.cs
@@ -20,19 +20,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
             _context = context;
         }
 
-        public async Task<Dictionary<GeographicLevel, IEnumerable<ILocationAttribute>>> GetLocationAttributes(Guid subjectId)
+        public async Task<Dictionary<GeographicLevel, IEnumerable<ILocationAttribute>>> GetLocationAttributes(
+            Guid subjectId)
         {
-            var locationIds = await _context.Observation
+            var locations = await _context.Observation
                 .AsNoTracking()
                 .Where(o => o.SubjectId == subjectId)
-                .Select(observation => observation.LocationId)
+                .Select(observation => observation.Location)
                 .Distinct()
-                .ToListAsync();
-
-            var locations = await _context
-                .Location
-                .AsNoTracking()
-                .Where(location => locationIds.Contains(location.Id))
                 .ToListAsync();
 
             return locations
@@ -62,16 +57,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Repository
                 ? new Dictionary<GeographicLevel, List<Func<Location, ILocationAttribute>>>()
                 : MapLocationAttributeSelectors(hierarchies);
 
-            var locationIds = observations
+            var locations = await observations
                 .AsNoTracking()
-                .Select(observation => observation.LocationId)
+                .Select(observation => observation.Location)
                 .Distinct()
-                .ToList();
-
-            var locations = await _context
-                .Location
-                .AsNoTracking()
-                .Where(location => locationIds.Contains(location.Id))
                 .ToListAsync();
 
             return locations

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ResultSubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ResultSubjectMetaServiceTests.cs
@@ -142,8 +142,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             indicatorRepository.Setup(s => s.GetIndicators(subject.Id, query.Indicators))
                 .Returns(Enumerable.Empty<Indicator>());
 
-            locationRepository.Setup(s => s.GetLocationAttributesHierarchical(
-                    ItIs.QueryableSequenceEqualTo(observations),
+            locationRepository.Setup(s => s.GetLocationAttributesHierarchicalByObservationsList(
+                    observations,
                     new Dictionary<GeographicLevel, List<string>>()))
                 .ReturnsAsync(new Dictionary<GeographicLevel, List<LocationAttributeNode>>());
 
@@ -296,8 +296,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             indicatorRepository.Setup(s => s.GetIndicators(subject.Id, query.Indicators))
                 .Returns(Enumerable.Empty<Indicator>());
 
-            locationRepository.Setup(s => s.GetLocationAttributesHierarchical(
-                    ItIs.QueryableSequenceEqualTo(observations),
+            locationRepository.Setup(s => s.GetLocationAttributesHierarchicalByObservationsList(
+                    observations,
                     new Dictionary<GeographicLevel, List<string>>()))
                 .ReturnsAsync(locations);
 
@@ -445,8 +445,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             indicatorRepository.Setup(s => s.GetIndicators(subject.Id, query.Indicators))
                 .Returns(Enumerable.Empty<Indicator>());
 
-            locationRepository.Setup(s => s.GetLocationAttributesHierarchical(
-                    ItIs.QueryableSequenceEqualTo(observations),
+            locationRepository.Setup(s => s.GetLocationAttributesHierarchicalByObservationsList(
+                    observations,
                     null))
                 .ReturnsAsync(locations);
 
@@ -657,8 +657,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             indicatorRepository.Setup(s => s.GetIndicators(subject.Id, query.Indicators))
                 .Returns(Enumerable.Empty<Indicator>());
 
-            locationRepository.Setup(s => s.GetLocationAttributesHierarchical(
-                    ItIs.QueryableSequenceEqualTo(observations),
+            locationRepository.Setup(s => s.GetLocationAttributesHierarchicalByObservationsList(
+                    observations,
                     null))
                 .ReturnsAsync(locations);
 
@@ -850,8 +850,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             indicatorRepository.Setup(s => s.GetIndicators(subject.Id, query.Indicators))
                 .Returns(Enumerable.Empty<Indicator>());
 
-            locationRepository.Setup(s => s.GetLocationAttributesHierarchical(
-                    ItIs.QueryableSequenceEqualTo(observations),
+            locationRepository.Setup(s => s.GetLocationAttributesHierarchicalByObservationsList(
+                    observations,
                     null))
                 .ReturnsAsync(locations);
 
@@ -1062,8 +1062,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             indicatorRepository.Setup(s => s.GetIndicators(subject.Id, query.Indicators))
                 .Returns(Enumerable.Empty<Indicator>());
 
-            locationRepository.Setup(s => s.GetLocationAttributesHierarchical(
-                    ItIs.QueryableSequenceEqualTo(observations),
+            locationRepository.Setup(s => s.GetLocationAttributesHierarchicalByObservationsList(
+                    observations,
                     options.Value.Hierarchies))
                 .ReturnsAsync(locations);
 
@@ -1342,8 +1342,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             indicatorRepository.Setup(s => s.GetIndicators(subject.Id, query.Indicators))
                 .Returns(Enumerable.Empty<Indicator>());
 
-            locationRepository.Setup(s => s.GetLocationAttributesHierarchical(
-                    ItIs.QueryableSequenceEqualTo(observations),
+            locationRepository.Setup(s => s.GetLocationAttributesHierarchicalByObservationsList(
+                    observations,
                     options.Value.Hierarchies))
                 .ReturnsAsync(locations);
 
@@ -1582,8 +1582,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             indicatorRepository.Setup(s => s.GetIndicators(subject.Id, query.Indicators))
                 .Returns(Enumerable.Empty<Indicator>());
 
-            locationRepository.Setup(s => s.GetLocationAttributesHierarchical(
-                    ItIs.QueryableSequenceEqualTo(observations),
+            locationRepository.Setup(s => s.GetLocationAttributesHierarchicalByObservationsList(
+                    observations,
                     options.Value.Hierarchies))
                 .ReturnsAsync(locations);
 
@@ -1774,8 +1774,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .Returns(Enumerable.Empty<Indicator>());
 
             locationRepository
-                .Setup(s => s.GetLocationAttributesHierarchical(
-                    ItIs.QueryableSequenceEqualTo(observations),
+                .Setup(s => s.GetLocationAttributesHierarchicalByObservationsList(
+                    observations,
                     options.Value.Hierarchies))
                 .ReturnsAsync(locations);
 
@@ -1963,8 +1963,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .Returns(Enumerable.Empty<Indicator>());
 
             locationRepository
-                .Setup(s => s.GetLocationAttributesHierarchical(
-                    ItIs.QueryableSequenceEqualTo(observations),
+                .Setup(s => s.GetLocationAttributesHierarchicalByObservationsList(
+                    observations,
                     options.Value.Hierarchies))
                 .ReturnsAsync(locations);
 
@@ -2135,8 +2135,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
             indicatorRepository.Setup(s => s.GetIndicators(subject.Id, query.Indicators))
                 .Returns(Enumerable.Empty<Indicator>());
 
-            locationRepository.Setup(s => s.GetLocationAttributesHierarchical(
-                    ItIs.QueryableSequenceEqualTo(observations),
+            locationRepository.Setup(s => s.GetLocationAttributesHierarchicalByObservationsList(
+                    observations,
                     options.Value.Hierarchies))
                 .ReturnsAsync(locations);
 
@@ -2334,8 +2334,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 .Returns(Enumerable.Empty<Indicator>());
 
             locationRepository
-                .Setup(s => s.GetLocationAttributesHierarchical(
-                    ItIs.QueryableSequenceEqualTo(observations),
+                .Setup(s => s.GetLocationAttributesHierarchicalByObservationsList(
+                    observations,
                     options.Value.Hierarchies))
                 .ReturnsAsync(locations);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationPredicateBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationPredicateBuilder.cs
@@ -43,6 +43,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                     query.LocationIds.Contains(observation.LocationId));
             }
 
+            // TODO EES-3068 Migrate Location codes to ids in old Datablocks to remove this support for Location codes
             if (query.Locations != null)
             {
                 if (query.Locations.GeographicLevel != null)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
@@ -102,6 +102,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 if (query.LocationIds.IsNullOrEmpty())
                 {
                     // Support old Data Blocks that have Location codes rather than id's in their query
+                    // TODO EES-3068 Migrate Location codes to ids in old Datablocks to remove this support for Location codes
                     return GetMatchingObservationIdsByLocationCodes(context, query, cancellationToken);
                 }
                 return GetMatchingObservationIds(context, query, cancellationToken);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
@@ -91,8 +91,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
 
                     // Uses the new GetLocationAttributesHierarchical to get the locations regardless of whether the
                     // feature is enabled or not.  If the feature is disabled, requests the locations without a hierarchy.
-                    var locationAttributes = await _locationRepository.GetLocationAttributesHierarchical(
-                        queryableObservations,
+                    var locationAttributes = await _locationRepository.GetLocationAttributesHierarchicalByObservationsList(
+                        observations,
                         hierarchies: locationHierarchiesEnabled ? _locationOptions.Hierarchies : null);
                     _logger.LogTrace("Got Location attributes in {Time} ms", stopwatch.Elapsed.TotalMilliseconds);
                     stopwatch.Restart();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -192,7 +192,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             IQueryable<Observation> observations)
         {
             var locations =
-                await _locationRepository.GetLocationAttributesHierarchical(observations, _locationOptions.Hierarchies);
+                await _locationRepository.GetLocationAttributesHierarchicalByObservationsQuery(
+                    observations,
+                    _locationOptions.Hierarchies);
             return BuildLocationAttributeViewModels(locations);
         }
 


### PR DESCRIPTION
This PR resolves the outstanding PR comments of EES-2778 in https://github.com/dfe-analytical-services/explore-education-statistics/pull/3074.

In addition to adding comments it alters the way we retrieve Locations in `LocationRepository`.

Rather than selecting all location id's and then looking up locations by id which translates to two queries like

```
SELECT DISTINCT LocationId
FROM Observation
WHERE SubjectId = '<Subject Id>'
```

and

```
SELECT Id,
       Country_Code,
       Country_Name,
       EnglishDevolvedArea_Code,
       EnglishDevolvedArea_Name,
       GeographicLevel,
       Institution_Code,
       Institution_Name,
       LocalAuthorityDistrict_Code,
       LocalAuthorityDistrict_Name,
       LocalAuthority_Code,
       LocalAuthority_Name,
       LocalAuthority_OldCode,
       LocalEnterprisePartnership_Code,
       LocalEnterprisePartnership_Name,
       MayoralCombinedAuthority_Code,
       MayoralCombinedAuthority_Name,
       MultiAcademyTrust_Code,
       MultiAcademyTrust_Name,
       OpportunityArea_Code,
       OpportunityArea_Name,
       ParliamentaryConstituency_Code,
       ParliamentaryConstituency_Name,
       PlanningArea_Code,
       PlanningArea_Name,
       Provider_Code,
       Provider_Name,
       Region_Code,
       Region_Name,
       RscRegion_Code,
       School_Code,
       School_Name,
       Sponsor_Code,
       Sponsor_Name,
       Ward_Code,
       Ward_Name
FROM Location
WHERE Id IN (<Array of Location id's>)
```
we now select the Location included from the Observations which translates to a query like

```
SELECT DISTINCT
                l.Id,
                l.Country_Code,
                l.Country_Name,
                l.EnglishDevolvedArea_Code,
                l.EnglishDevolvedArea_Name,
                l.GeographicLevel,
                l.Institution_Code,
                l.Institution_Name,
                l.LocalAuthorityDistrict_Code,
                l.LocalAuthorityDistrict_Name,
                l.LocalAuthority_Code,
                l.LocalAuthority_Name,
                l.LocalAuthority_OldCode,
                l.LocalEnterprisePartnership_Code,
                l.LocalEnterprisePartnership_Name,
                l.MayoralCombinedAuthority_Code,
                l.MayoralCombinedAuthority_Name,
                l.MultiAcademyTrust_Code,
                l.MultiAcademyTrust_Name,
                l.OpportunityArea_Code,
                l.OpportunityArea_Name,
                l.ParliamentaryConstituency_Code,
                l.ParliamentaryConstituency_Name,
                l.PlanningArea_Code,
                l.PlanningArea_Name,
                l.Provider_Code,
                l.Provider_Name,
                l.Region_Code,
                l.Region_Name,
                l.RscRegion_Code,
                l.School_Code,
                l.School_Name,
                l.Sponsor_Code,
                l.Sponsor_Name,
                l.Ward_Code,
                l.Ward_Name
FROM Observation AS o
         INNER JOIN Location AS l ON o.LocationId = l.Id
WHERE o.SubjectId = '<Subject Id>'
```

There appears to be no degradation in performance when tested with Subjects with a large number of observation rows and it should offer a performance enhancement when the number of locations is large.