### PR TITLE
EES-3012 Add BAU endpoints to clear blob caches

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
@@ -1,0 +1,265 @@
+#nullable enable
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau.BauCacheController;
+using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.IBlobStorageService;
+using static Moq.MockBehavior;
+using Capture = Moq.Capture;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api.Bau
+{
+    public class BauCacheControllerTests
+    {
+        [Fact]
+        public async Task ClearPrivateCache()
+        {
+            var privateBlobStorageService = new Mock<IBlobStorageService>(Strict);
+
+            privateBlobStorageService
+                .Setup(s => s.DeleteBlobs(PrivateContent, default, default))
+                .Returns(Task.CompletedTask);
+
+            var controller = BuildController(privateBlobStorageService: privateBlobStorageService.Object);
+
+            var result = await controller.ClearPrivateCache();
+
+            result.AssertNoContent();
+
+            MockUtils.VerifyAllMocks(privateBlobStorageService);
+        }
+
+        [Fact]
+        public async Task ClearPublicCacheReleases_SingleValidPath()
+        {
+            var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
+
+            DeleteBlobsOptions options = null!;
+            var match = new CaptureMatch<DeleteBlobsOptions>(param => options = param);
+
+            publicBlobStorageService
+                .Setup(
+                    s =>
+                        s.DeleteBlobs(PublicContent, null, Capture.With(match)))
+                .Returns(Task.CompletedTask);
+
+            var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
+
+            var result = await controller.ClearPublicCacheReleases(
+                new ClearCachePathsViewModel
+                {
+                    Paths = ListOf("subject-meta")
+                }
+            );
+
+            result.AssertNoContent();
+
+            MockUtils.VerifyAllMocks(publicBlobStorageService);
+
+            var regex = Assert.IsType<Regex>(options.IncludeRegex);
+            Assert.Matches(regex, "publications/publication-1/releases/release-1/subject-meta/something");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/release-1/data-blocks/something");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/release-1/fast-track-results/something");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/release-1/invalid/something");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/release-1/something");
+        }
+
+        [Fact]
+        public async Task ClearPublicCacheReleases_AllValidPaths()
+        {
+            var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
+
+            DeleteBlobsOptions options = null!;
+            var match = new CaptureMatch<DeleteBlobsOptions>(param => options = param);
+
+            publicBlobStorageService
+                .Setup(
+                    s =>
+                        s.DeleteBlobs(PublicContent, null, Capture.With(match)))
+                .Returns(Task.CompletedTask);
+
+            var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
+
+            var result = await controller.ClearPublicCacheReleases(
+                new ClearCachePathsViewModel
+                {
+                    Paths = new List<string>
+                    {
+                        "data-blocks",
+                        "subject-meta",
+                        "fast-track-results"
+                    }
+                }
+            );
+
+            result.AssertNoContent();
+
+            MockUtils.VerifyAllMocks(publicBlobStorageService);
+
+            var regex = Assert.IsType<Regex>(options.IncludeRegex);
+            Assert.Matches(regex, "publications/publication-1/releases/release-1/data-blocks/something");
+            Assert.Matches(regex, "publications/publication-1/releases/release-1/subject-meta/something");
+            Assert.Matches(regex, "publications/publication-1/releases/release-1/fast-track-results/something");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/release-1/invalid/something");
+            Assert.DoesNotMatch(regex, "publications/publication-1/releases/release-1/something");
+        }
+
+        [Fact]
+        public async Task ClearPublicCacheReleases_InvalidPaths()
+        {
+            var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
+
+            var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
+
+            var result = await controller.ClearPublicCacheReleases(
+                new ClearCachePathsViewModel
+                {
+                    Paths = new List<string>
+                    {
+                        "not a path",
+                        "datablocks",
+                        "Data-Blocks",
+                        "SubjectMeta"
+                    }
+                }
+            );
+
+            result.AssertNoContent();
+
+            MockUtils.VerifyAllMocks(publicBlobStorageService);
+        }
+
+        [Fact]
+        public async Task ClearPublicCacheReleases_Empty()
+        {
+            var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
+
+            var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
+
+            var result = await controller.ClearPublicCacheReleases(new ClearCachePathsViewModel());
+
+            result.AssertNoContent();
+
+            MockUtils.VerifyAllMocks(publicBlobStorageService);
+        }
+
+        [Fact]
+        public async Task ClearPublicCacheTrees_SingleValidPath()
+        {
+            var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
+
+            var paths = new List<string>();
+
+            publicBlobStorageService
+                .Setup(s => s.DeleteBlob(PublicContent, Capture.In(paths)))
+                .Returns(Task.CompletedTask);
+
+            var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
+
+            var result = await controller.ClearPublicCacheTrees(
+                new ClearCachePathsViewModel
+                {
+                    Paths = ListOf("publication-tree-any-data.json"),
+                }
+            );
+
+            result.AssertNoContent();
+
+            MockUtils.VerifyAllMocks(publicBlobStorageService);
+
+            Assert.Single(paths);
+            Assert.Equal("publication-tree-any-data.json", paths[0]);
+        }
+
+        [Fact]
+        public async Task ClearPublicCacheTrees_AllValidPaths()
+        {
+            var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
+
+            var paths = new List<string>();
+
+            publicBlobStorageService
+                .Setup(s => s.DeleteBlob(PublicContent, Capture.In(paths)))
+                .Returns(Task.CompletedTask);
+
+            var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
+
+            var result = await controller.ClearPublicCacheTrees(
+                new ClearCachePathsViewModel
+                {
+                    Paths = new List<string>
+                    {
+                        "publication-tree.json",
+                        "publication-tree-any-data.json",
+                        "publication-tree-latest-data.json"
+                    }
+                }
+            );
+
+            result.AssertNoContent();
+
+            MockUtils.VerifyAllMocks(publicBlobStorageService);
+
+            Assert.Equal(3, paths.Count);
+            Assert.Equal("publication-tree.json", paths[0]);
+            Assert.Equal("publication-tree-any-data.json", paths[1]);
+            Assert.Equal("publication-tree-latest-data.json", paths[2]);
+        }
+
+        [Fact]
+        public async Task ClearPublicCacheTrees_InvalidPaths()
+        {
+            var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
+
+            var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
+
+            var result = await controller.ClearPublicCacheTrees(
+                new ClearCachePathsViewModel
+                {
+                    Paths = new List<string>
+                    {
+                        "publication-tree",
+                        "publication-treee.json",
+                        "publication-tree-some-data.json",
+                    }
+                }
+            );
+
+            result.AssertNoContent();
+
+            MockUtils.VerifyAllMocks(publicBlobStorageService);
+        }
+
+        [Fact]
+        public async Task ClearPublicCacheTrees_Empty()
+        {
+            var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
+
+            var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
+
+            var result = await controller.ClearPublicCacheTrees(new ClearCachePathsViewModel());
+
+            result.AssertNoContent();
+
+            MockUtils.VerifyAllMocks(publicBlobStorageService);
+        }
+
+        private static BauCacheController BuildController(
+            IBlobStorageService? privateBlobStorageService = null,
+            IBlobStorageService? publicBlobStorageService = null)
+        {
+            return new BauCacheController(
+                privateBlobStorageService ?? Mock.Of<IBlobStorageService>(Strict),
+                publicBlobStorageService ?? Mock.Of<IBlobStorageService>(Strict)
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Bau/BauCacheControllerTests.cs
@@ -54,9 +54,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
 
             var result = await controller.ClearPublicCacheReleases(
-                new ClearCachePathsViewModel
+                new ClearCacheReleasePathsViewModel
                 {
-                    Paths = ListOf("subject-meta")
+                    Paths = SetOf("subject-meta")
                 }
             );
 
@@ -89,9 +89,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
 
             var result = await controller.ClearPublicCacheReleases(
-                new ClearCachePathsViewModel
+                new ClearCacheReleasePathsViewModel
                 {
-                    Paths = new List<string>
+                    Paths = new HashSet<string>
                     {
                         "data-blocks",
                         "subject-meta",
@@ -113,38 +113,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         }
 
         [Fact]
-        public async Task ClearPublicCacheReleases_InvalidPaths()
-        {
-            var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
-
-            var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
-
-            var result = await controller.ClearPublicCacheReleases(
-                new ClearCachePathsViewModel
-                {
-                    Paths = new List<string>
-                    {
-                        "not a path",
-                        "datablocks",
-                        "Data-Blocks",
-                        "SubjectMeta"
-                    }
-                }
-            );
-
-            result.AssertNoContent();
-
-            MockUtils.VerifyAllMocks(publicBlobStorageService);
-        }
-
-        [Fact]
         public async Task ClearPublicCacheReleases_Empty()
         {
             var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
 
             var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
 
-            var result = await controller.ClearPublicCacheReleases(new ClearCachePathsViewModel());
+            var result = await controller.ClearPublicCacheReleases(new ClearCacheReleasePathsViewModel());
 
             result.AssertNoContent();
 
@@ -165,9 +140,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
 
             var result = await controller.ClearPublicCacheTrees(
-                new ClearCachePathsViewModel
+                new ClearCacheTreePathsViewModel
                 {
-                    Paths = ListOf("publication-tree-any-data.json"),
+                    Paths = SetOf("publication-tree-any-data.json"),
                 }
             );
 
@@ -193,9 +168,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
             var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
 
             var result = await controller.ClearPublicCacheTrees(
-                new ClearCachePathsViewModel
+                new ClearCacheTreePathsViewModel
                 {
-                    Paths = new List<string>
+                    Paths = new HashSet<string>
                     {
                         "publication-tree.json",
                         "publication-tree-any-data.json",
@@ -215,37 +190,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
         }
 
         [Fact]
-        public async Task ClearPublicCacheTrees_InvalidPaths()
-        {
-            var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
-
-            var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
-
-            var result = await controller.ClearPublicCacheTrees(
-                new ClearCachePathsViewModel
-                {
-                    Paths = new List<string>
-                    {
-                        "publication-tree",
-                        "publication-treee.json",
-                        "publication-tree-some-data.json",
-                    }
-                }
-            );
-
-            result.AssertNoContent();
-
-            MockUtils.VerifyAllMocks(publicBlobStorageService);
-        }
-
-        [Fact]
         public async Task ClearPublicCacheTrees_Empty()
         {
             var publicBlobStorageService = new Mock<IBlobStorageService>(Strict);
 
             var controller = BuildController(publicBlobStorageService: publicBlobStorageService.Object);
 
-            var result = await controller.ClearPublicCacheTrees(new ClearCachePathsViewModel());
+            var result = await controller.ClearPublicCacheTrees(new ClearCacheTreePathsViewModel());
 
             result.AssertNoContent();
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Methodologies/MethodologyControllerTests.cs
@@ -77,7 +77,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             VerifyAllMocks(methodologyService);
 
-            result.AssertNoContentResult();
+            result.AssertNoContent();
         }
 
         [Fact]
@@ -224,7 +224,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
 
             VerifyAllMocks(methodologyService);
 
-            result.AssertNoContentResult();
+            result.AssertNoContent();
         }
 
         private static MethodologyController SetupMethodologyController(

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
@@ -1,0 +1,113 @@
+#nullable enable
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Services;
+using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Cache;
+using GovUk.Education.ExploreEducationStatistics.Content.Services.Requests;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.IBlobStorageService;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
+{
+    [Route("api/bau")]
+    [ApiController]
+    [Authorize(Roles = RoleNames.BauUser)]
+    public class BauCacheController : ControllerBase
+    {
+        private static readonly HashSet<string> AllowedPublicReleasePaths = new HashSet<string>
+        {
+            FileStoragePathUtils.PublicContentDataBlocksDirectory,
+            // TODO: EES-2865 Remove with other fast track code
+            FileStoragePathUtils.PublicContentFastTrackResultsDirectory,
+            FileStoragePathUtils.PublicContentSubjectMetaDirectory
+        };
+
+        private static readonly HashSet<string> AllowedPublicTreePaths = new HashSet<string>
+        {
+            PublicationTreeCacheKey.GetKey(PublicationTreeFilter.AnyData),
+            PublicationTreeCacheKey.GetKey(PublicationTreeFilter.LatestData),
+            PublicationTreeCacheKey.GetKey(null)
+        };
+
+        private readonly IBlobStorageService _privateBlobStorageService;
+        private readonly IBlobStorageService _publicBlobStorageService;
+
+        public BauCacheController(
+            IBlobStorageService privateBlobStorageService,
+            IBlobStorageService publicBlobStorageService)
+        {
+            _privateBlobStorageService = privateBlobStorageService;
+            _publicBlobStorageService = publicBlobStorageService;
+        }
+
+        [HttpDelete("private-cache")]
+        public async Task<ActionResult> ClearPrivateCache()
+        {
+            // Remove all cache entries as we currently don't really need
+            // any more granularity currently (we only cache data blocks).
+            await _privateBlobStorageService.DeleteBlobs(BlobContainers.PrivateContent);
+
+            return NoContent();
+        }
+
+        [HttpDelete("public-cache/trees")]
+        public async Task<ActionResult> ClearPublicCacheTrees(ClearCachePathsViewModel request)
+        {
+            var paths = request.Paths
+                .Where(AllowedPublicTreePaths.Contains)
+                .ToHashSet();
+
+            if (paths.Any())
+            {
+                await paths
+                    .ToAsyncEnumerable()
+                    .ForEachAwaitAsync(
+                        path =>
+                            _publicBlobStorageService.DeleteBlob(BlobContainers.PublicContent, path)
+                    );
+            }
+
+            return NoContent();
+        }
+
+        [HttpDelete("public-cache/releases")]
+        public async Task<ActionResult> ClearPublicCacheReleases(ClearCachePathsViewModel request)
+        {
+            // Can only allow certain paths right now as not all cached items
+            // are automatically regenerated (e.g. when a user first visits
+            // the relevant part of the frontend).
+            var paths = request.Paths
+                .Where(AllowedPublicReleasePaths.Contains)
+                .ToHashSet();
+
+            if (paths.Any())
+            {
+                var pathString = paths.JoinToString('|');
+
+                await _publicBlobStorageService.DeleteBlobs(
+                    BlobContainers.PublicContent,
+                    options: new DeleteBlobsOptions
+                    {
+                        IncludeRegex = new Regex($"publications/.*/releases/.*/({pathString})/")
+                    }
+                );
+            }
+
+            return NoContent();
+        }
+
+        public class ClearCachePathsViewModel
+        {
+            [Required]
+            public List<string> Paths { get; set; } = new List<string>();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauCacheController.cs
@@ -1,10 +1,12 @@
 #nullable enable
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Common;
+using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -84,9 +86,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
             {
                 PublicationTreeCacheKey.GetKey(PublicationTreeFilter.AnyData),
                 PublicationTreeCacheKey.GetKey(PublicationTreeFilter.LatestData),
-                PublicationTreeCacheKey.GetKey()
+                PublicationTreeCacheKey.GetKey(),
+                AllMethodologiesCacheKey.GetKey()
             };
 
+            [MinLength(1)]
             [ContainsOnly(AllowedValuesProvider = nameof(AllowedPaths))]
             public HashSet<string> Paths { get; set; } = new HashSet<string>();
         }
@@ -101,6 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
                 FileStoragePathUtils.PublicContentSubjectMetaDirectory
             };
 
+            [MinLength(1)]
             [ContainsOnly(AllowedValuesProvider = nameof(AllowedPaths))]
             public HashSet<string> Paths { get; set; } = new HashSet<string>();
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauReleaseController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/Bau/BauReleaseController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using static GovUk.Education.ExploreEducationStatistics.Publisher.Model.RetryStage;
 
-namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.BAU
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau
 {
     [Route("api")]
     [ApiController]

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataBlockQuerySizeController.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Controllers/Api/DataBlockQuerySizeController.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
@@ -23,11 +24,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
      *
      * The validation check assumes that all combinations of data have been provided and calculates the maximum
      * possible table size from the query, rejecting the request if it's greater than the set limit.
-     * 
+     *
      * Note that we *don't* execute all datablock queries here and count the results.
      * A table result might be smaller than the possible table that could be generated since all combinations of time
      * period, location and filters may not be provided in the data.
-     * 
+     *
      * If we were to execute all the datablock queries and set a maximum based on the largest table result,
      * several datablock requests may fail if they have a possible table size greater than the largest actual table.
      */
@@ -46,7 +47,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api
         }
 
         [HttpGet("api/data-blocks/query-size-report")]
-        [Authorize(Roles = "BAU User")]
+        [Authorize(Roles = RoleNames.BauUser)]
         public async Task<ActionResult<List<DataBlockQuerySizeReport>>> QuerySizeReport()
         {
             var publishedReleaseIds = _contentDbContext.Releases

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/GovUk.Education.ExploreEducationStatistics.Admin.csproj
@@ -198,7 +198,6 @@
     <Folder Include="Migrations\ContentMigrations" />
     <Folder Include="Migrations\UsersAndRolesMigrations" />
     <Folder Include="Services\Security" />
-    <Folder Include="ViewModels\Blocks" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Role.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Models/Role.cs
@@ -6,11 +6,18 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Models
     // TODO EES-2462 Consider making this a class with Name and Id properties
     public enum Role
     {
-        [EnumLabelValue("Analyst", "f9ddb43e-aa9e-41ed-837d-3062e130c425")]
+        [EnumLabelValue(RoleNames.Analyst, "f9ddb43e-aa9e-41ed-837d-3062e130c425")]
         Analyst,
-        [EnumLabelValue("BAU User", "cf67b697-bddd-41bd-86e0-11b7e11d99b3")]
+        [EnumLabelValue(RoleNames.BauUser, "cf67b697-bddd-41bd-86e0-11b7e11d99b3")]
         BauUser,
-        [EnumLabelValue("Prerelease User", "17e634f4-7a2b-4a23-8636-b079877b4232")]
+        [EnumLabelValue(RoleNames.PrereleaseUser, "17e634f4-7a2b-4a23-8636-b079877b4232")]
         PrereleaseUser
+    }
+
+    public static class RoleNames
+    {
+        public const string Analyst = "Analyst";
+        public const string BauUser = "BAU User";
+        public const string PrereleaseUser = "Prerelease User";
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Security/StartupSecurityConfiguration.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
@@ -98,7 +99,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Security
 
                 // does this user have permission to run release migration endpoints?
                 options.AddPolicy(SecurityPolicies.CanRunReleaseMigrations.ToString(), policy =>
-                    policy.RequireRole("BAU User"));
+                    policy.RequireRole(RoleNames.BauUser));
 
                 // does this user have permission to publish a specific Release?
                 options.AddPolicy(SecurityPolicies.CanPublishSpecificRelease.ToString(), policy =>

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using AutoMapper;
 using Azure.Storage.Blobs;
 using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data;
+using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
 using GovUk.Education.ExploreEducationStatistics.Admin.Mappings;
 using GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Migrations.Custom;
@@ -405,6 +406,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
             services.AddTransient<IDataArchiveValidationService, DataArchiveValidationService>();
             services.AddTransient<IBlobCacheService, BlobCacheService>();
             services.AddTransient<ICacheKeyService, CacheKeyService>();
+
+            // Register any controllers that need specific dependencies
+            services.AddTransient(
+                provider => new BauCacheController(
+                    privateBlobStorageService: GetBlobStorageService(provider, "CoreStorage"),
+                    publicBlobStorageService: GetBlobStorageService(provider, "PublicStorage")
+                )
+            );
 
             services.AddSwaggerGen(c =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ActionResultTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ActionResultTestExtensions.cs
@@ -18,62 +18,62 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
             {
                 Assert.Equal(expectedValue, result.Value);
             }
-            
+
             return result.Value;
         }
-        
+
         public static void AssertNotFoundResult<T>(this ActionResult<T> result) where T : class
         {
             Assert.IsAssignableFrom<NotFoundResult>(result.Result);
         }
-        
-        public static void AssertNoContentResult(this ActionResult result)
+
+        public static void AssertNoContent(this ActionResult result)
         {
             Assert.IsAssignableFrom<NoContentResult>(result);
         }
-        
+
         public static void AssertForbidden(this ActionResult result)
         {
             Assert.IsAssignableFrom<ForbidResult>(result);
         }
-        
+
         public static void AssertForbidden<T>(this ActionResult<T> result)
         {
             Assert.IsAssignableFrom<ForbidResult>(result);
         }
-        
+
         public static void AssertAccepted(this ActionResult result)
         {
             Assert.IsAssignableFrom<AcceptedResult>(result);
         }
-        
+
         public static void AssertBadRequest<T>(this ActionResult<T> result, params Enum[] expectedValidationErrors)
         {
             AssertBadRequestWithValidationErrors(result.Result, expectedValidationErrors);
         }
-        
+
         public static void AssertBadRequest(this ActionResult result, params Enum[] expectedValidationErrors)
         {
             AssertBadRequestWithValidationErrors(result, expectedValidationErrors);
         }
-        
+
         public static void AssertNotModified<T>(this ActionResult<T> result)
         {
             var statusCodeResult = Assert.IsType<StatusCodeResult>(result.Result);
             Assert.Equal(StatusCodes.Status304NotModified, statusCodeResult.StatusCode);
         }
-        
+
         private static void AssertBadRequestWithValidationErrors(this object result, params Enum[] expectedValidationErrors)
         {
             var badRequest = Assert.IsAssignableFrom<BadRequestObjectResult>(result);
             var validationProblem = Assert.IsAssignableFrom<ValidationProblemDetails>(badRequest?.Value);
-            
+
             Assert.True(validationProblem != null && validationProblem.Errors.ContainsKey(string.Empty));
-            
+
             var globalErrors = validationProblem.Errors[string.Empty];
 
             Assert.Equal(expectedValidationErrors.Length, globalErrors.Length);
-            
+
             expectedValidationErrors.ForEach(message =>
                 Assert.Contains(message.ToString().ScreamingSnakeCase(), globalErrors));
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/ContainsOnlyAttributeTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Validators/ContainsOnlyAttributeTests.cs
@@ -1,0 +1,343 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using GovUk.Education.ExploreEducationStatistics.Common.Validators;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Validators
+{
+    public class ContainsOnlyAttributeTests
+    {
+        [Fact]
+        public void AllowedValues_Empty()
+        {
+            var attribute = new ContainsOnlyAttribute();
+
+            Assert.True(attribute.IsValid(ListOf<string>()));
+            Assert.True(attribute.IsValid(ListOf("a")));
+            Assert.True(attribute.IsValid(ListOf("a", "b")));
+        }
+
+        [Fact]
+        public void AllowedValues_InvalidValuesTypeThrows()
+        {
+            var attribute = new ContainsOnlyAttribute("a");
+
+            Assert.Throws<ArgumentException>(() => attribute.IsValid(1));
+            Assert.Throws<ArgumentException>(() => attribute.IsValid(new { }));
+            Assert.Throws<ArgumentException>(() => attribute.IsValid(null));
+        }
+
+        [Fact]
+        public void AllowedValues_Single()
+        {
+            var attribute = new ContainsOnlyAttribute("a");
+
+            Assert.True(attribute.IsValid(ListOf<string>()));
+            Assert.True(attribute.IsValid(ListOf("a")));
+            Assert.True(attribute.IsValid(ListOf("a", "a")));
+        }
+
+        [Fact]
+        public void AllowedValues_Single_Invalid()
+        {
+            var attribute = new ContainsOnlyAttribute("a");
+
+            Assert.False(attribute.IsValid(ListOf("A")));
+            Assert.False(attribute.IsValid(ListOf("A", "a")));
+            Assert.False(attribute.IsValid(ListOf("b")));
+            Assert.False(attribute.IsValid(ListOf("b", "a")));
+            Assert.False(attribute.IsValid(ListOf(1)));
+            Assert.False(attribute.IsValid(ListOf(new { })));
+            Assert.False(attribute.IsValid(ListOf<object>("a", new { }, 1)));
+        }
+
+        [Fact]
+        public void AllowedValues_Multiple()
+        {
+            var attribute = new ContainsOnlyAttribute("a", "b", "c");
+
+            Assert.True(attribute.IsValid(ListOf<string>()));
+            Assert.True(attribute.IsValid(ListOf("a")));
+            Assert.True(attribute.IsValid(ListOf("b")));
+            Assert.True(attribute.IsValid(ListOf("c")));
+            Assert.True(attribute.IsValid(ListOf("a", "b")));
+            Assert.True(attribute.IsValid(ListOf("a", "b", "c")));
+            Assert.True(attribute.IsValid(ListOf("a", "a", "b")));
+            Assert.True(attribute.IsValid(ListOf("a", "a", "b", "b")));
+            Assert.True(attribute.IsValid(ListOf("a", "a", "b", "b", "c")));
+            Assert.True(attribute.IsValid(ListOf("a", "a", "b", "b", "c", "c")));
+        }
+
+        [Fact]
+        public void AllowedValues_Multiple_Invalid()
+        {
+            var attribute = new ContainsOnlyAttribute("a", "b", "c");
+
+            Assert.False(attribute.IsValid(ListOf("A")));
+            Assert.False(attribute.IsValid(ListOf("A", "a")));
+            Assert.False(attribute.IsValid(ListOf("d")));
+            Assert.False(attribute.IsValid(ListOf("d", "a")));
+            Assert.False(attribute.IsValid(ListOf("d", "a", "a")));
+            Assert.False(attribute.IsValid(ListOf("d", "a", "b", "c")));
+            Assert.False(attribute.IsValid(ListOf("d", "d")));
+            Assert.False(attribute.IsValid(ListOf("d", "d", "a")));
+            Assert.False(attribute.IsValid(ListOf("d", "d", "a", "a")));
+            Assert.False(attribute.IsValid(ListOf("d", "d", "a", "b", "c")));
+            Assert.False(attribute.IsValid(ListOf(1)));
+            Assert.False(attribute.IsValid(ListOf(new { })));
+            Assert.False(attribute.IsValid(ListOf<object>("a", new { }, 1)));
+        }
+
+        [Fact]
+        public void AllowedValuesProvider_Empty()
+        {
+            var model = new AllowedValuesProviderModel
+            {
+                AllowedValues = new List<string>(),
+            };
+
+            Assert.True(ValidateModelValues(model, new List<string>()));
+            Assert.True(ValidateModelValues(model, ListOf("a")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "b")));
+        }
+
+        [Fact]
+        public void AllowedValuesProvider_InvalidValuesTypeThrows()
+        {
+            var model = new AllowedValuesProviderModel
+            {
+                AllowedValues = ListOf("a")
+            };
+
+            Assert.Throws<ArgumentException>(() => ValidateModelValues(model, 1));
+            Assert.Throws<ArgumentException>(() => ValidateModelValues(model, new { }));
+            Assert.Throws<ArgumentException>(() => ValidateModelValues(model, null));
+        }
+
+        [Fact]
+        public void AllowedValuesProvider_InvalidAllowedValuesTypeThrows()
+        {
+            var model = new AllowedValuesProviderModel
+            {
+                Values = ListOf("a")
+            };
+
+            Assert.Throws<ArgumentException>(() => ValidateModelAllowedValues(model, "not allowed"));
+            Assert.Throws<ArgumentException>(() => ValidateModelAllowedValues(model, 1));
+            Assert.Throws<ArgumentException>(() => ValidateModelAllowedValues(model, new { }));
+            Assert.Throws<ArgumentException>(() => ValidateModelAllowedValues(model, null));
+        }
+
+        [Fact]
+        public void AllowedValuesProvider_Single()
+        {
+            var model = new AllowedValuesProviderModel
+            {
+                AllowedValues = ListOf("a")
+            };
+
+            Assert.True(ValidateModelValues(model, ListOf("a")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "a")));
+        }
+
+        [Fact]
+        public void AllowedValuesProvider_Single_Invalid()
+        {
+            var model = new AllowedValuesProviderModel
+            {
+                AllowedValues = ListOf("a")
+            };
+
+            Assert.False(ValidateModelValues(model, ListOf("A")));
+            Assert.False(ValidateModelValues(model, ListOf("A", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("b")));
+            Assert.False(ValidateModelValues(model, ListOf("b", "a")));
+        }
+
+        [Fact]
+        public void AllowedValuesProvider_Multiple()
+        {
+            var model = new AllowedValuesProviderModel
+            {
+                AllowedValues = ListOf("a", "b", "c")
+            };
+
+            Assert.True(ValidateModelValues(model, ListOf<string>()));
+            Assert.True(ValidateModelValues(model, ListOf("a")));
+            Assert.True(ValidateModelValues(model, ListOf("b")));
+            Assert.True(ValidateModelValues(model, ListOf("c")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "b")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "b", "c")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "a", "b")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "a", "b", "b")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "a", "b", "b", "c")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "a", "b", "b", "c", "c")));
+        }
+
+        [Fact]
+        public void AllowedValuesProvider_Multiple_Invalid()
+        {
+            var model = new AllowedValuesProviderModel
+            {
+                AllowedValues = ListOf("a", "b", "c")
+            };
+
+            Assert.False(ValidateModelValues(model, ListOf("A")));
+            Assert.False(ValidateModelValues(model, ListOf("A", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "a", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "a", "b", "c")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "d")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "d", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "d", "a", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "d", "a", "b", "c")));
+        }
+
+        [Fact]
+        public void StaticAllowedValuesProvider()
+        {
+            var model = new StaticAllowedValuesProviderModel();
+            StaticAllowedValuesProviderModel.AllowedValues = ListOf("a", "b");
+
+            Assert.True(ValidateModelValues(model, ListOf("a")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "a")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "b")));
+            Assert.True(ValidateModelValues(model, ListOf("b", "b")));
+        }
+
+        [Fact]
+        public void StaticAllowedValuesProvider_Invalid()
+        {
+            var model = new StaticAllowedValuesProviderModel();
+            StaticAllowedValuesProviderModel.AllowedValues = ListOf("a", "b");
+
+            Assert.False(ValidateModelValues(model, ListOf("A")));
+            Assert.False(ValidateModelValues(model, ListOf("A", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "a", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "a", "b", "c")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "d")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "d", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "d", "a", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "d", "a", "b", "c")));
+            Assert.False(ValidateModelValues(model, ListOf(1)));
+            Assert.False(ValidateModelValues(model, ListOf(new { })));
+            Assert.False(ValidateModelValues(model, ListOf<object>("a", 1, new { })));
+        }
+
+        [Fact]
+        public void AllowedValuesAndProviderAreCombined()
+        {
+            var model = new CombinedAllowedValuesProviderModel();
+
+            Assert.True(ValidateModelValues(model, ListOf<string>()));
+            Assert.True(ValidateModelValues(model, ListOf("a")));
+            Assert.True(ValidateModelValues(model, ListOf("b")));
+            Assert.True(ValidateModelValues(model, ListOf("c")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "b")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "b", "c")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "a", "b")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "a", "b", "b")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "a", "b", "b", "c")));
+            Assert.True(ValidateModelValues(model, ListOf("a", "a", "b", "b", "c", "c")));
+        }
+
+        [Fact]
+        public void AllowedValuesAndProviderAreCombined_Invalid()
+        {
+            var model = new CombinedAllowedValuesProviderModel();
+
+            Assert.False(ValidateModelValues(model, ListOf("A")));
+            Assert.False(ValidateModelValues(model, ListOf("A", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "a", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "a", "b", "c")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "d")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "d", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "d", "a", "a")));
+            Assert.False(ValidateModelValues(model, ListOf("d", "d", "a", "b", "c")));
+            Assert.False(ValidateModelValues(model, ListOf(1)));
+            Assert.False(ValidateModelValues(model, ListOf(new { })));
+            Assert.False(ValidateModelValues(model, ListOf<object>("a", 1, new { })));
+        }
+
+        private bool ValidateModelValues(AllowedValuesProviderModel model, object? values)
+        {
+            model.Values = values;
+
+            var context = new ValidationContext(model)
+            {
+                MemberName = nameof(model.Values)
+            };
+
+            return Validator.TryValidateProperty(model.Values, context, new List<ValidationResult>());
+        }
+
+        private bool ValidateModelValues(StaticAllowedValuesProviderModel model, object? values)
+        {
+            model.Values = values;
+
+            var context = new ValidationContext(model)
+            {
+                MemberName = nameof(model.Values)
+            };
+
+            return Validator.TryValidateProperty(model.Values, context, new List<ValidationResult>());
+        }
+
+
+        private bool ValidateModelValues(CombinedAllowedValuesProviderModel model, object values)
+        {
+            model.Values = values;
+
+            var context = new ValidationContext(model)
+            {
+                MemberName = nameof(model.Values)
+            };
+
+            return Validator.TryValidateProperty(model.Values, context, new List<ValidationResult>());
+        }
+
+        private bool ValidateModelAllowedValues(AllowedValuesProviderModel model, object? allowedValues)
+        {
+            model.AllowedValues = allowedValues;
+
+            var context = new ValidationContext(model)
+            {
+                MemberName = nameof(model.Values)
+            };
+
+            return Validator.TryValidateProperty(model.Values, context, new List<ValidationResult>());
+        }
+
+        private class AllowedValuesProviderModel
+        {
+            public object? AllowedValues { get; set; }
+
+            [ContainsOnly(AllowedValuesProvider = nameof(AllowedValues))]
+            public object? Values { get; set; }
+        }
+
+        private class StaticAllowedValuesProviderModel
+        {
+            public static object? AllowedValues { get; set; }
+
+            [ContainsOnly(AllowedValuesProvider = nameof(AllowedValues))]
+            public object? Values { get; set; }
+        }
+
+        private class CombinedAllowedValuesProviderModel
+        {
+            public object AllowedValues = ListOf("c");
+
+            [ContainsOnly("a", "b", AllowedValuesProvider = nameof(AllowedValues))]
+            public object Values { get; set; } = new();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/AllMethodologiesCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Cache/AllMethodologiesCacheKey.cs
@@ -5,8 +5,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Cache
 {
     public record AllMethodologiesCacheKey : IBlobCacheKey
     {
-        public string Key => "methodology-tree.json";
+        public string Key => GetKey();
 
         public IBlobContainer Container => BlobContainers.PublicContent;
+
+        public static string GetKey()
+        {
+            return "methodology-tree.json";
+        }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/CollectionUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/CollectionUtils.cs
@@ -16,6 +16,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
             return new List<T>(objects);
         }
 
+        public static HashSet<T> SetOf<T>(params T[] objects)
+        {
+            return new HashSet<T>(objects);
+        }
+
         public static T[] AsArray<T>(params T[] objects)
         {
             return objects;

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/FileStoragePathUtils.cs
@@ -7,6 +7,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 {
     public static class FileStoragePathUtils
     {
+        public const string PublicContentDataBlocksDirectory = "data-blocks";
+        [Obsolete("EES-2865 - Remove with other fast track code")]
+        public const string PublicContentFastTrackResultsDirectory = "fast-track-results";
+        public const string PublicContentSubjectMetaDirectory = "subject-meta";
+
         public static string PublicContentStagingPath()
         {
             return "staging";
@@ -71,19 +76,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         {
             return $"{PublicContentPublicationParentPath(publicationSlug, prefix)}/releases/{releaseSlug}.json";
         }
-        
+
         public static string PrivateContentDataBlockParentPath(
             Guid publicationId,
             Guid releaseId)
         {
-            return $"{PrivateContentReleaseParentPath(publicationId, releaseId)}/data-blocks";
+            return $"{PrivateContentReleaseParentPath(publicationId, releaseId)}/{PublicContentDataBlocksDirectory}";
         }
-        
+
         public static string PublicContentDataBlockParentPath(
             string publicationSlug,
             string releaseSlug)
         {
-            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/data-blocks";
+            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{PublicContentDataBlocksDirectory}";
         }
 
         public static string PrivateContentDataBlockPath(
@@ -104,17 +109,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
 
         public static string PublicContentSubjectMetaParentPath(string publicationSlug, string releaseSlug)
         {
-            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/subject-meta";
+            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{PublicContentSubjectMetaDirectory}";
         }
-        
+
         public static string PublicContentSubjectMetaPath(string publicationSlug, string releaseSlug, Guid subjectId)
         {
             return $"{PublicContentSubjectMetaParentPath(publicationSlug, releaseSlug)}/{subjectId}.json";
         }
-        
+
         public static string PublicContentFastTrackResultsParentPath(string publicationSlug, string releaseSlug)
         {
-            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/fast-track-results";
+            return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/{PublicContentFastTrackResultsDirectory}";
         }
 
         public static string PublicContentFastTrackResultsPath(string publicationSlug, string releaseSlug, Guid fastTrackId)
@@ -126,7 +131,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services
         {
             return $"{PublicContentReleaseParentPath(publicationSlug, releaseSlug)}/subjects.json";
         }
-        
+
         public static string FilesPath(Guid rootPath, FileType type)
         {
             var typeFolder = (type == Metadata ? Data : type).GetEnumLabel();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
@@ -21,7 +22,16 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 
         public Task<BlobInfo?> FindBlob(IBlobContainer containerName, string path);
 
-        public Task DeleteBlobs(IBlobContainer containerName, string directoryPath, string? excludePattern = null);
+        public record DeleteBlobsOptions
+        {
+            public Regex? ExcludeRegex { get; set; }
+            public Regex? IncludeRegex { get; set; }
+        }
+
+        public Task DeleteBlobs(
+            IBlobContainer containerName,
+            string directoryPath = "",
+            DeleteBlobsOptions? options = null);
 
         public Task DeleteBlob(IBlobContainer containerName, string path);
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Services/Interfaces/IBlobStorageService.cs
@@ -30,7 +30,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces
 
         public Task DeleteBlobs(
             IBlobContainer containerName,
-            string directoryPath = "",
+            string? directoryPath = null,
             DeleteBlobsOptions? options = null);
 
         public Task DeleteBlob(IBlobContainer containerName, string path);

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ContainsOnlyAttribute.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ContainsOnlyAttribute.cs
@@ -1,0 +1,100 @@
+#nullable enable
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Validators
+{
+    [AttributeUsage(
+        AttributeTargets.Property | AttributeTargets.Field| AttributeTargets.Parameter,
+        AllowMultiple = true)]
+    public class ContainsOnlyAttribute : ValidationAttribute
+    {
+        public IEnumerable<object> AllowedValues { get; }
+
+        public string? AllowedValuesProvider { get; set; }
+
+        public ContainsOnlyAttribute(params object[] allowedValues)
+        {
+            AllowedValues = allowedValues;
+        }
+
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var allowedValues = GetAllowedValues(validationContext);
+
+            if (value is not IEnumerable values)
+            {
+                throw new ArgumentException(
+                    $"Validated value must implement {nameof(IEnumerable)}",
+                    validationContext?.MemberName
+                );
+            }
+
+            if (!allowedValues.Any())
+            {
+                return ValidationResult.Success;
+            }
+
+            if (!values.Cast<object>().All(allowedValues.Contains))
+            {
+                return new ValidationResult(
+                    ErrorMessage ?? $"Field must contain only values from: {allowedValues.JoinToString(", ")}");
+            }
+
+            return ValidationResult.Success;
+        }
+
+        private HashSet<object> GetAllowedValues(ValidationContext validationContext)
+        {
+            if (AllowedValuesProvider is null)
+            {
+                return AllowedValues.ToHashSet();
+            }
+
+            var instance = validationContext.ObjectInstance;
+            var type = instance.GetType();
+            var member = type.GetMember(
+                    AllowedValuesProvider,
+                    MemberTypes.Field | MemberTypes.Property | MemberTypes.Method,
+                    BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static
+                )
+                .FirstOrDefault();
+
+            if (member is null)
+            {
+                throw new ArgumentException(
+                    $"{nameof(AllowedValuesProvider)} must reference a field or method in {type.FullName}",
+                    AllowedValuesProvider
+                );
+            }
+
+            var providedValues = member.MemberType switch
+            {
+                MemberTypes.Field => ((FieldInfo)member).GetValue(instance),
+                MemberTypes.Property => ((PropertyInfo)member).GetValue(instance),
+                MemberTypes.Method => ((MethodInfo)member).Invoke(instance, new object?[] { }),
+                _ => throw new ArgumentOutOfRangeException(
+                    $"{nameof(AllowedValuesProvider)} is not a valid member on {type.FullName}",
+                    AllowedValuesProvider
+                )
+            };
+
+            if (providedValues is not IEnumerable<object> providedAllowedValues)
+            {
+                throw new ArgumentException(
+                    $"{nameof(AllowedValuesProvider)} on {type.FullName} must implement {nameof(IEnumerable)}",
+                    AllowedValuesProvider
+                );
+            }
+
+            return AllowedValues
+                .Concat(providedAllowedValues)
+                .ToHashSet();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationTreeCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationTreeCacheKey.cs
@@ -17,7 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Cache
             Key = GetKey(filter);
         }
 
-        public static string GetKey(PublicationTreeFilter? filter)
+        public static string GetKey(PublicationTreeFilter? filter = null)
         {
             return filter switch
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationTreeCacheKey.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Services/Cache/PublicationTreeCacheKey.cs
@@ -14,7 +14,12 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Services.Cache
 
         public PublicationTreeCacheKey(PublicationTreeFilter? filter = null)
         {
-            Key = filter switch
+            Key = GetKey(filter);
+        }
+
+        public static string GetKey(PublicationTreeFilter? filter)
+        {
+            return filter switch
             {
                 PublicationTreeFilter.AnyData => "publication-tree-any-data.json",
                 PublicationTreeFilter.LatestData => "publication-tree-latest-data.json",

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/Services/ContentService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Common;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
@@ -16,6 +17,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using static GovUk.Education.ExploreEducationStatistics.Common.BlobContainers;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.FileStoragePathUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.IBlobStorageService;
 
 namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 {
@@ -193,8 +195,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Publisher.Services
 
         private async Task DeleteAllContentAsyncExcludingStaging()
         {
-            var excludePattern = $"^{PublicContentStagingPath()}/.+$";
-            await _publicBlobStorageService.DeleteBlobs(PublicContent, string.Empty, excludePattern);
+            await _publicBlobStorageService.DeleteBlobs(
+                containerName: PublicContent,
+                options: new DeleteBlobsOptions
+                {
+                    ExcludeRegex = new Regex($"^{PublicContentStagingPath()}/.+$", RegexOptions.IgnoreCase | RegexOptions.Compiled)
+                }
+            );
         }
 
         private static JsonSerializerSettings GetJsonSerializerSettings(NamingStrategy namingStrategy)


### PR DESCRIPTION
This PR adds the following new endpoints:

- `DELETE /api/bau/private-cache` - clears the entire private cache used by admin
- `DELETE /api/bau/public-cache/trees` - clears specific tree JSON files from the public cache
- `DELETE /api/bau/public-cache/releases` - clears specific paths (e.g. `data-blocks`, `subject-meta`, etc) related to releases from the public cache

It should be noted that all of these endpoints only clear blobs where it is safe to do so i.e. where the cached object can be regenerated easily by a user visiting the relevant part of the app. This means that we don't delete blobs like the release content JSON as these are only generated by the publisher and cannot be regenerated without regenerating all of the content (this is an expensive operation).

Ideally, we would rework the remaining published content blobs so that they use the cache-aside strategy used in other places. This would allow us to safely delete any part of the blob caches without needing to regenerate all of the content.

## Relevant changes

- Updated the `BlobStorageService.DeleteBlobs` method to accept regexes for including and excluding blobs from the deletion. This is necessary for the kind of behaviour we need for this PR's endpoints.
- Add a new `ContainsOnly` validation attribute that can be used to validate that the validated field only contains specific allowed values.