### PR TITLE
Hotfix/ees 3094 correct missing await

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Services/ReleaseService.cs
@@ -456,8 +456,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Services
                 })
                 .OnSuccess(_ => GetDeleteDataFilePlan(releaseId, fileId))
                 .OnSuccessDo(deletePlan => _dataBlockService.DeleteDataBlocks(deletePlan.DeleteDataBlockPlan))
-                .OnSuccess(deletePlan => _releaseSubjectRepository.SoftDeleteReleaseSubject(releaseId, deletePlan.SubjectId))
-                .OnSuccess(_ => _releaseDataFileService.Delete(releaseId, fileId));
+                .OnSuccessVoid(deletePlan => _releaseSubjectRepository.SoftDeleteReleaseSubject(releaseId, deletePlan.SubjectId))
+                .OnSuccess(() => _releaseDataFileService.Delete(releaseId, fileId));
         }
 
         public async Task<Either<ActionResult, DataImportViewModel>> GetDataFileImportStatus(Guid releaseId, Guid fileId)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -179,7 +179,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
             return await func();
         }
         
-        [Obsolete("Use OnSuccessDo or OnSuccessVoid for chaining a Task with no generic type")]
+        [Obsolete("Use OnSuccessDo or OnSuccessVoid for chaining a non-generic Task")]
         public static async Task<Either<TFailure, Unit>> OnSuccess<TFailure, TSuccess1>(
             this Task<Either<TFailure, TSuccess1>> task,
             Func<TSuccess1, Task> func)

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -58,9 +58,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 
         public T FoldRight<T>(Func<TR, T> rightFunc, T defaultValue) => IsRight ? rightFunc(Right) : defaultValue;
 
-        public static implicit operator Either<TL, TR>(TL left) => new Either<TL, TR>(left);
+        public static implicit operator Either<TL, TR>(TL left) => new(left);
 
-        public static implicit operator Either<TL, TR>(TR right) => new Either<TL, TR>(right);
+        public static implicit operator Either<TL, TR>(TR right) => new(right);
     }
 
     public static class EitherTaskExtensions
@@ -177,6 +177,19 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
             }
 
             return await func();
+        }
+        
+        [Obsolete("Use OnSuccessDo or OnSuccessVoid for chaining a Task with no generic type")]
+        public static async Task<Either<TFailure, Unit>> OnSuccess<TFailure, TSuccess1>(
+            this Task<Either<TFailure, TSuccess1>> task,
+            Func<TSuccess1, Task> func)
+        {
+            return await task.OnSuccess(async success =>
+                {
+                    await func(success);
+                    return Unit.Instance;
+                }
+            );
         }
 
         public static async Task<Either<TFailure, TSuccess2>> OnSuccess<TFailure, TSuccess1, TSuccess2>(


### PR DESCRIPTION
This PR is a fix for an issue that teams were seeing around Footnotes after deleting Subjects.

The problem was caused by a Task not being awaited prior to the next unit of work being called.  Specifically in this instance, an `OnSuccess()` method was being used that called the function passed in and returned immediately, rather than recognizing it as a Task and awaiting it before returning.

To fix this, the problem piece of code now uses the correct pre-existing `OnSuccessVoid()` method that expects a non-generic Task to be passed in.

An additional safety measure is added by adding another Obsolete extension method that will signpost us to using the correct method in the future and avoid this pitfall. 