### PR TITLE
EES-3012 Fix incorrect wiring up of `BauCacheController`

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -110,12 +110,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
                 options.Secure = CookieSecurePolicy.Always;
             });
 
-            services.AddControllers(
-                options =>
-                {
-                    options.ModelBinderProviders.Insert(0, new SeparatedQueryModelBinderProvider(","));
-                }
-            );
+            services
+                .AddControllers(
+                    options =>
+                    {
+                        options.ModelBinderProviders.Insert(0, new SeparatedQueryModelBinderProvider(","));
+                    }
+                )
+                .AddControllersAsServices();
 
             services.AddDbContext<UsersAndRolesDbContext>(options =>
                 options


### PR DESCRIPTION
This PR fixes the incorrect `BlobStorageService` dependencies being wired into `BauCacheController`. By default, .NET does not allow you to wire up controllers manually, and we have to explicitly allow this by using the `AddControllersAsServices` option.