### PR TITLE
EES-2902 Make location hierarchies a permanent feature of table results

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
@@ -105,16 +105,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                         DecimalPlaces = 2
                     }
                 },
-                Locations = new List<ObservationalUnitMetaViewModel>
-                {
-                    new()
-                    {
-                        Label = "A label",
-                        Level = GeographicLevel.Institution,
-                        Value = "1234",
-                        GeoJson = true
-                    }
-                },
                 BoundaryLevels = new List<BoundaryLevelViewModel>
                 {
                     new(1234, "boundary")

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/appsettings.json
@@ -32,7 +32,6 @@
     "MaxTableCellsAllowed": 25000
   },
   "Locations": {
-    "TableResultLocationHierarchiesEnabled": true,
     "Hierarchies": {
       "LocalAuthority": [
         "Region",

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/FastTrackControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/FastTrackControllerTests.cs
@@ -240,16 +240,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                                 DecimalPlaces = 2
                             }
                         },
-                        Locations = new List<ObservationalUnitMetaViewModel>
-                        {
-                            new()
-                            {
-                                Label = "A label",
-                                Level = GeographicLevel.Institution,
-                                Value = "1234",
-                                GeoJson = true
-                            }
-                        },
                         BoundaryLevels = new List<BoundaryLevelViewModel>
                         {
                             new(1234, "boundary")

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Converters/ResultSubjectMetaViewModelJsonConverterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Converters/ResultSubjectMetaViewModelJsonConverterTests.cs
@@ -38,10 +38,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Converters
 
             var subjectMeta = JsonConvert.DeserializeObject<ResultSubjectMetaViewModel>(jsonText, BuildSettings());
 
-            Assert.Empty(subjectMeta!.Locations);
-
             // Expect Locations to have been transformed to LocationsHierarchical
-            Assert.Single(subjectMeta.LocationsHierarchical);
+            Assert.NotNull(subjectMeta);
+            Assert.Single(subjectMeta!.LocationsHierarchical);
             Assert.True(subjectMeta.LocationsHierarchical.ContainsKey("localAuthority"));
 
             var localAuthorities = subjectMeta.LocationsHierarchical["localAuthority"];
@@ -117,9 +116,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Converters
 
             var subjectMeta = JsonConvert.DeserializeObject<ResultSubjectMetaViewModel>(jsonText, BuildSettings());
 
-            Assert.Empty(subjectMeta!.Locations);
-
-            Assert.Single(subjectMeta.LocationsHierarchical);
+            Assert.NotNull(subjectMeta);
+            Assert.Single(subjectMeta!.LocationsHierarchical);
             Assert.True(subjectMeta.LocationsHierarchical.ContainsKey("country"));
 
             var countries = subjectMeta.LocationsHierarchical["country"];

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
@@ -15,11 +15,9 @@ using GovUk.Education.ExploreEducationStatistics.Data.Api.Services;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Data.Services;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
-using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -331,17 +329,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             var permalinkJsonObject = JObject.FromObject(permalink);
             var subjectMetaJsonObject = permalinkJsonObject.SelectToken("FullTable.SubjectMeta") as JObject;
             var legacyLocationsJsonArray = JArray.FromObject(legacyLocations);
-            if (subjectMetaJsonObject!.SelectToken("Locations") is JArray existingLegacyLocationsJsonArray)
-            {
-                // Handle case where there is an existing legacy locations field in the JSON object
-                // I.e. when field 'Locations' is still defined in ResultSubjectMetaViewModel
-                // TODO EES-2902 No need to do this after the Locations field is dropped from the type.
-                existingLegacyLocationsJsonArray.Replace(legacyLocationsJsonArray);
-            }
-            else
-            {
-                subjectMetaJsonObject!.Add("Locations", legacyLocationsJsonArray);
-            }
+            subjectMetaJsonObject!.Add("Locations", legacyLocationsJsonArray);
 
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
             var subjectRepository = new Mock<ISubjectRepository>(MockBehavior.Strict);
@@ -376,9 +364,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var subjectMeta = result.FullTable.SubjectMeta;
 
-            // Expect Locations to be empty
-            Assert.Empty(subjectMeta.Locations);
-
             // Expect Locations to have been transformed to LocationsHierarchical
             Assert.Single(subjectMeta.LocationsHierarchical);
             Assert.True(subjectMeta.LocationsHierarchical.ContainsKey("localAuthority"));
@@ -397,110 +382,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             Assert.Equal(legacyLocations[2].Label, localAuthorities[2].Label);
             Assert.Equal(legacyLocations[2].Value, localAuthorities[2].Value);
             Assert.Equal(legacyLocations[2].GeoJson, localAuthorities[2].GeoJson);
-        }
-
-        [Fact]
-        [Obsolete("TODO EES-2902 - Remove with SOW8 after EES-2777", false)]
-        public async Task Get_LocationHierarchiesFeatureDisabled_LegacyLocationsFieldIsNotTranslated()
-        {
-            // Until the feature to add hierarchical locations in Table Result Subject Metadata becomes permanent,
-            // test that ResultSubjectMetaViewModel legacy 'Locations' field remains untouched when the feature is off.
-
-            var subject = new Subject
-            {
-                Id = new Guid()
-            };
-
-            var permalink = new Permalink(
-                new TableBuilderConfiguration(),
-                new TableBuilderResultViewModel
-                {
-                    SubjectMeta = new ResultSubjectMetaViewModel
-                    {
-                        Locations = new List<ObservationalUnitMetaViewModel>
-                        {
-                            new()
-                            {
-                                Level = GeographicLevel.LocalAuthority,
-                                Label = "Blackpool",
-                                Value = "E06000009",
-                                GeoJson = JToken.Parse(@"[{""properties"": {""code"": ""E06000009""}}]")
-                            },
-                            new()
-                            {
-                                Level = GeographicLevel.LocalAuthority,
-                                Label = "Derby",
-                                Value = "E06000015",
-                                GeoJson = JToken.Parse(@"[{""properties"": {""code"": ""E06000015""}}]")
-                            },
-                            new()
-                            {
-                                Level = GeographicLevel.LocalAuthority,
-                                Label = "Nottingham",
-                                Value = "E06000018",
-                                GeoJson = JToken.Parse(@"[{""properties"": {""code"": ""E06000018""}}]")
-                            }
-                        }
-                    }
-                },
-                new ObservationQueryContext
-                {
-                    SubjectId = subject.Id
-                });
-
-            var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
-            var subjectRepository = new Mock<ISubjectRepository>(MockBehavior.Strict);
-
-            blobStorageService.SetupDownloadBlobText(
-                container: Permalinks,
-                path: permalink.Id.ToString(),
-                blobText: JsonConvert.SerializeObject(permalink));
-
-            subjectRepository
-                .Setup(s => s.Get(subject.Id))
-                .ReturnsAsync(subject);
-
-            subjectRepository
-                .Setup(s => s.IsSubjectForLatestPublishedRelease(subject.Id))
-                .ReturnsAsync(true);
-
-            subjectRepository
-                .Setup(s => s.FindPublicationIdForSubject(subject.Id))
-                .ReturnsAsync(_publicationId);
-
-            var service = BuildService(blobStorageService: blobStorageService.Object,
-                subjectRepository: subjectRepository.Object,
-                // Setup the location hierarchies featured as disabled
-                options: DisabledLocationHierarchiesOptions());
-
-            var result = (await service.Get(permalink.Id)).AssertRight();
-
-            MockUtils.VerifyAllMocks(
-                blobStorageService,
-                subjectRepository);
-
-            Assert.Equal(permalink.Id, result.Id);
-
-            var subjectMeta = result.FullTable.SubjectMeta;
-
-            // Expect Locations to be untouched
-            Assert.Equal(permalink.FullTable.SubjectMeta.Locations[0].Level, subjectMeta.Locations[0].Level);
-            Assert.Equal(permalink.FullTable.SubjectMeta.Locations[0].Label, subjectMeta.Locations[0].Label);
-            Assert.Equal(permalink.FullTable.SubjectMeta.Locations[0].Value, subjectMeta.Locations[0].Value);
-            Assert.Equal(permalink.FullTable.SubjectMeta.Locations[0].GeoJson, subjectMeta.Locations[0].GeoJson);
-
-            Assert.Equal(permalink.FullTable.SubjectMeta.Locations[1].Level, subjectMeta.Locations[1].Level);
-            Assert.Equal(permalink.FullTable.SubjectMeta.Locations[1].Label, subjectMeta.Locations[1].Label);
-            Assert.Equal(permalink.FullTable.SubjectMeta.Locations[1].Value, subjectMeta.Locations[1].Value);
-            Assert.Equal(permalink.FullTable.SubjectMeta.Locations[1].GeoJson, subjectMeta.Locations[1].GeoJson);
-
-            Assert.Equal(permalink.FullTable.SubjectMeta.Locations[2].Level, subjectMeta.Locations[2].Level);
-            Assert.Equal(permalink.FullTable.SubjectMeta.Locations[2].Label, subjectMeta.Locations[2].Label);
-            Assert.Equal(permalink.FullTable.SubjectMeta.Locations[2].Value, subjectMeta.Locations[2].Value);
-            Assert.Equal(permalink.FullTable.SubjectMeta.Locations[2].GeoJson, subjectMeta.Locations[2].GeoJson);
-
-            // Expect LocationsHierarchical to be empty
-            Assert.Empty(subjectMeta.LocationsHierarchical);
         }
 
         [Fact]
@@ -622,35 +503,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
             Assert.Equal(_publicationId, result.Query.PublicationId);
         }
 
-        private static IOptions<LocationsOptions> DefaultLocationOptions()
-        {
-            return Options.Create(new LocationsOptions
-            {
-                TableResultLocationHierarchiesEnabled = true
-            });
-        }
-
-        private static IOptions<LocationsOptions> DisabledLocationHierarchiesOptions()
-        {
-            return Options.Create(new LocationsOptions
-            {
-                TableResultLocationHierarchiesEnabled = false
-            });
-        }
-
         private static PermalinkService BuildService(
             ITableBuilderService? tableBuilderService = null,
             IBlobStorageService? blobStorageService = null,
             IReleaseRepository? releaseRepository = null,
-            ISubjectRepository? subjectRepository = null,
-            IOptions<LocationsOptions>? options = null)
+            ISubjectRepository? subjectRepository = null)
         {
             return new(
                 tableBuilderService ?? new Mock<ITableBuilderService>(MockBehavior.Strict).Object,
                 blobStorageService ?? new Mock<IBlobStorageService>(MockBehavior.Strict).Object,
                 subjectRepository ?? new Mock<ISubjectRepository>(MockBehavior.Strict).Object,
                 releaseRepository ?? new Mock<IReleaseRepository>(MockBehavior.Strict).Object,
-                options ?? DefaultLocationOptions(),
                 MapperUtils.MapperForProfile<MappingProfiles>()
             );
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/appsettings.json
@@ -13,7 +13,6 @@
     "MaxTableCellsAllowed": 25000
   },
   "Locations": {
-    "TableResultLocationHierarchiesEnabled": true,
     "Hierarchies": {
       "LocalAuthority": [
         "Region",

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Converters/ResultSubjectMetaViewModelJsonConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/Converters/ResultSubjectMetaViewModelJsonConverter.cs
@@ -58,8 +58,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Converters
                 }
             }
 
-            tableSubjectMeta.Locations?.Clear();
-
             return tableSubjectMeta;
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationsOptions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationsOptions.cs
@@ -8,13 +8,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
         public const string Locations = "Locations";
 
         /// <summary>
-        /// Release toggle to support the table result location hierarchies feature while development
-        /// is in progress.
-        /// </summary>
-        //TODO EES-2902 - Remove with SOW8 after EES-2777
-        public bool TableResultLocationHierarchiesEnabled { get; init; }
-
-        /// <summary>
         /// Map of <c>GeographicLevel</c> to attribute names of the <c>Location</c> type.
         /// This is used to configure a hierarchy of location attributes for a geographic level.
         /// Example: For Local Authority level data where Country, Region and Local Authority attributes are provided,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/ResultSubjectMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/ResultSubjectMetaViewModel.cs
@@ -1,7 +1,5 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
-using GovUk.Education.ExploreEducationStatistics.Data.Services.Converters;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta
 {
@@ -14,22 +12,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Me
         public List<IndicatorMetaViewModel> Indicators { get; init; } = new();
 
         /// <summary>
-        /// Legacy locations field replaced by <see cref="LocationsHierarchical"/>.
-        /// </summary>
-        /// <remarks>
-        /// This should be safe to drop after the feature to add hierarchical locations in Table Result Subject Metadata
-        /// becomes permanent, since a transformation from data in old Permalinks is made during deserialization by
-        /// <see cref="ResultSubjectMetaViewModelJsonConverter"/>.
-        /// </remarks>
-        [Obsolete("TODO EES-2902 - Remove with SOW8 after EES-2777", false)]
-        public List<ObservationalUnitMetaViewModel> Locations { get; init; } = new();
-
-        /// <summary>
         /// Hierarchical locations field.
         /// </summary>
         /// <remarks>
-        /// EES-2943: This could potentially be renamed back to 'Locations' but requires a migration of
+        /// TODO EES-2943: This could potentially be renamed back to 'Locations' but requires a migration of
         /// old Permalinks which already have a legacy 'Locations' field in their JSON serialization of type <see cref="List{ObservationalUnitMetaViewModel}"/>.
+        /// TODO EES-3106: This could also be renamed back to 'Locations' in Permalink responses independently of EES-2943
+        /// but will require a new view model to be split from the model used by serialization.
         /// </remarks>
         public Dictionary<string, List<LocationAttributeViewModel>> LocationsHierarchical { get; set; } = new();
 

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/__tests__/DataFileReplacementPlan.test.tsx
@@ -389,198 +389,198 @@ describe('DataReplacementPlan', () => {
     await waitFor(() => {
       expect(screen.getByText('Data blocks: ERROR')).toBeInTheDocument();
       expect(screen.getByText('Footnotes: ERROR')).toBeInTheDocument();
-
-      expect(
-        screen.getByText(
-          /One or more data blocks will be invalidated by this data replacement/,
-        ),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          /One or more footnotes will be invalidated by this data replacement/,
-        ),
-      ).toBeInTheDocument();
-
-      const details = screen.getAllByRole('group');
-
-      expect(details).toHaveLength(4);
-
-      const dataBlock1 = within(details[0]);
-
-      expect(
-        dataBlock1.getByRole('button', { name: /Data block 1/ }),
-      ).toHaveTextContent('ERROR');
-
-      expect(dataBlock1.getByTestId('Country')).toHaveTextContent('England');
-      expect(dataBlock1.getByTestId('Country')).not.toHaveTextContent(
-        'England not present',
-      );
-
-      expect(dataBlock1.getByTestId('Local Authority')).toHaveTextContent(
-        'Barnsley',
-      );
-      expect(dataBlock1.getByTestId('Local Authority')).not.toHaveTextContent(
-        'Barnsley not present',
-      );
-
-      expect(dataBlock1.getByTestId('Local Authority')).toHaveTextContent(
-        'Birmingham not present',
-      );
-      expect(dataBlock1.getByTestId('Start date')).toHaveTextContent(
-        '2016 not present',
-      );
-
-      expect(dataBlock1.getByTestId('End date')).toHaveTextContent('2018');
-      expect(dataBlock1.getByTestId('End date')).not.toHaveTextContent(
-        '2018 not present',
-      );
-
-      expect(dataBlock1.getByTestId('Filter 1')).toHaveTextContent('Group 1');
-      expect(dataBlock1.getByTestId('Filter 1')).toHaveTextContent('Group 2');
-
-      expect(dataBlock1.getByTestId('Group 1')).toHaveTextContent(
-        'Item 1 not present',
-      );
-      expect(dataBlock1.getByTestId('Group 1')).toHaveTextContent('Item 2');
-      expect(dataBlock1.getByTestId('Group 1')).not.toHaveTextContent(
-        'Item 2 not present',
-      );
-
-      expect(dataBlock1.getByTestId('Group 2')).toHaveTextContent('Item 3');
-      expect(dataBlock1.getByTestId('Group 2')).not.toHaveTextContent(
-        'Item 3 not present',
-      );
-
-      expect(dataBlock1.getByTestId('Filter 2')).toHaveTextContent('Group 3');
-      expect(dataBlock1.getByTestId('Filter 2')).toHaveTextContent('Group 4');
-
-      expect(dataBlock1.getByTestId('Group 3')).toHaveTextContent('Item 4');
-      expect(dataBlock1.getByTestId('Group 3')).not.toHaveTextContent(
-        'Item 4 not present',
-      );
-
-      expect(dataBlock1.getByTestId('Group 4')).toHaveTextContent(
-        'Item 5 not present',
-      );
-      expect(dataBlock1.getByTestId('Group 4')).toHaveTextContent(
-        'Item 6 not present',
-      );
-
-      expect(dataBlock1.getByTestId('Indicator group 1')).toHaveTextContent(
-        'Indicator 1',
-      );
-      expect(dataBlock1.getByTestId('Indicator group 1')).not.toHaveTextContent(
-        'Indicator 1 not present',
-      );
-
-      expect(dataBlock1.getByTestId('Indicator group 2')).toHaveTextContent(
-        'Indicator 2',
-      );
-      expect(dataBlock1.getByTestId('Indicator group 2')).not.toHaveTextContent(
-        'Indicator 2 not present',
-      );
-      expect(dataBlock1.getByTestId('Indicator group 2')).toHaveTextContent(
-        'Indicator 3 not present',
-      );
-
-      expect(dataBlock1.getByTestId('Indicator group 3')).toHaveTextContent(
-        'Indicator 4 not present',
-      );
-
-      expect(
-        dataBlock1.getByRole('link', { name: 'Edit data block', hidden: true }),
-      ).toHaveAttribute(
-        'href',
-        '/publication/publication-1/release/release-1/data-blocks/block-1',
-      );
-      expect(
-        dataBlock1.getByRole('button', {
-          name: 'Delete data block',
-          hidden: true,
-        }),
-      ).toBeInTheDocument();
-
-      const dataBlock2 = within(details[1]);
-
-      expect(
-        dataBlock2.getByRole('button', { name: /Data block 2/ }),
-      ).toHaveTextContent('OK');
-
-      expect(
-        dataBlock2.getByText(
-          'This data block has no conflicts and can be replaced.',
-        ),
-      ).toBeInTheDocument();
-
-      const footnote1 = within(details[2]);
-
-      expect(
-        footnote1.getByRole('button', { name: /Footnote 1/ }),
-      ).toHaveTextContent('ERROR');
-
-      expect(footnote1.getByTestId('Filter 1')).toHaveTextContent('Group 2');
-      expect(footnote1.getByTestId('Filter 1')).toHaveTextContent('Group 3');
-      expect(footnote1.getByTestId('Filter 1')).toHaveTextContent('Group 1');
-
-      expect(footnote1.getByTestId('Group 2')).toHaveTextContent(
-        'Item 1 not present',
-      );
-      expect(footnote1.getByTestId('Group 2')).toHaveTextContent(
-        'Item 3 not present',
-      );
-
-      expect(footnote1.getByTestId('Group 3')).toHaveTextContent('Item 2');
-      expect(footnote1.getByTestId('Group 3')).not.toHaveTextContent(
-        'Item 2 not present',
-      );
-
-      expect(footnote1.getByTestId('Group 1')).toHaveTextContent(
-        '(All selected)',
-      );
-
-      expect(footnote1.getByTestId('Filter 2')).toHaveTextContent('Group 5');
-      expect(footnote1.getByTestId('Filter 2')).toHaveTextContent('Group 4');
-
-      expect(footnote1.getByTestId('Group 5')).toHaveTextContent(
-        'Item 4 not present',
-      );
-      expect(footnote1.getByTestId('Group 4')).toHaveTextContent(
-        '(All selected)',
-      );
-
-      expect(footnote1.getByTestId('Filter 3')).toHaveTextContent(
-        '(All selected)',
-      );
-      expect(footnote1.getByTestId('Filter 4')).toHaveTextContent(
-        '(All selected)',
-      );
-
-      expect(footnote1.getByTestId('Indicator group 1')).toHaveTextContent(
-        'Indicator 1',
-      );
-      expect(footnote1.getByTestId('Indicator group 1')).not.toHaveTextContent(
-        'Indicator 1 not present',
-      );
-      expect(footnote1.getByTestId('Indicator group 2')).toHaveTextContent(
-        'Indicator 3 not present',
-      );
-
-      const footnote2 = within(details[3]);
-
-      expect(
-        footnote2.getByRole('button', { name: /Footnote 2/ }),
-      ).toHaveTextContent('OK');
-
-      expect(
-        footnote2.getByText(
-          'This footnote has no conflicts and can be replaced.',
-        ),
-      ).toBeInTheDocument();
-
-      expect(
-        screen.queryByRole('button', { name: 'Confirm data replacement' }),
-      ).not.toBeInTheDocument();
     });
+
+    expect(
+      screen.getByText(
+        /One or more data blocks will be invalidated by this data replacement/,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /One or more footnotes will be invalidated by this data replacement/,
+      ),
+    ).toBeInTheDocument();
+
+    const details = screen.getAllByRole('group');
+
+    expect(details).toHaveLength(4);
+
+    const dataBlock1 = within(details[0]);
+
+    expect(
+      dataBlock1.getByRole('button', { name: /Data block 1/ }),
+    ).toHaveTextContent('ERROR');
+
+    expect(dataBlock1.getByTestId('Country')).toHaveTextContent('England');
+    expect(dataBlock1.getByTestId('Country')).not.toHaveTextContent(
+      'England not present',
+    );
+
+    expect(dataBlock1.getByTestId('Local Authority')).toHaveTextContent(
+      'Barnsley',
+    );
+    expect(dataBlock1.getByTestId('Local Authority')).not.toHaveTextContent(
+      'Barnsley not present',
+    );
+
+    expect(dataBlock1.getByTestId('Local Authority')).toHaveTextContent(
+      'Birmingham not present',
+    );
+    expect(dataBlock1.getByTestId('Start date')).toHaveTextContent(
+      '2016 not present',
+    );
+
+    expect(dataBlock1.getByTestId('End date')).toHaveTextContent('2018');
+    expect(dataBlock1.getByTestId('End date')).not.toHaveTextContent(
+      '2018 not present',
+    );
+
+    expect(dataBlock1.getByTestId('Filter 1')).toHaveTextContent('Group 1');
+    expect(dataBlock1.getByTestId('Filter 1')).toHaveTextContent('Group 2');
+
+    expect(dataBlock1.getByTestId('Group 1')).toHaveTextContent(
+      'Item 1 not present',
+    );
+    expect(dataBlock1.getByTestId('Group 1')).toHaveTextContent('Item 2');
+    expect(dataBlock1.getByTestId('Group 1')).not.toHaveTextContent(
+      'Item 2 not present',
+    );
+
+    expect(dataBlock1.getByTestId('Group 2')).toHaveTextContent('Item 3');
+    expect(dataBlock1.getByTestId('Group 2')).not.toHaveTextContent(
+      'Item 3 not present',
+    );
+
+    expect(dataBlock1.getByTestId('Filter 2')).toHaveTextContent('Group 3');
+    expect(dataBlock1.getByTestId('Filter 2')).toHaveTextContent('Group 4');
+
+    expect(dataBlock1.getByTestId('Group 3')).toHaveTextContent('Item 4');
+    expect(dataBlock1.getByTestId('Group 3')).not.toHaveTextContent(
+      'Item 4 not present',
+    );
+
+    expect(dataBlock1.getByTestId('Group 4')).toHaveTextContent(
+      'Item 5 not present',
+    );
+    expect(dataBlock1.getByTestId('Group 4')).toHaveTextContent(
+      'Item 6 not present',
+    );
+
+    expect(dataBlock1.getByTestId('Indicator group 1')).toHaveTextContent(
+      'Indicator 1',
+    );
+    expect(dataBlock1.getByTestId('Indicator group 1')).not.toHaveTextContent(
+      'Indicator 1 not present',
+    );
+
+    expect(dataBlock1.getByTestId('Indicator group 2')).toHaveTextContent(
+      'Indicator 2',
+    );
+    expect(dataBlock1.getByTestId('Indicator group 2')).not.toHaveTextContent(
+      'Indicator 2 not present',
+    );
+    expect(dataBlock1.getByTestId('Indicator group 2')).toHaveTextContent(
+      'Indicator 3 not present',
+    );
+
+    expect(dataBlock1.getByTestId('Indicator group 3')).toHaveTextContent(
+      'Indicator 4 not present',
+    );
+
+    expect(
+      dataBlock1.getByRole('link', { name: 'Edit data block', hidden: true }),
+    ).toHaveAttribute(
+      'href',
+      '/publication/publication-1/release/release-1/data-blocks/block-1',
+    );
+    expect(
+      dataBlock1.getByRole('button', {
+        name: 'Delete data block',
+        hidden: true,
+      }),
+    ).toBeInTheDocument();
+
+    const dataBlock2 = within(details[1]);
+
+    expect(
+      dataBlock2.getByRole('button', { name: /Data block 2/ }),
+    ).toHaveTextContent('OK');
+
+    expect(
+      dataBlock2.getByText(
+        'This data block has no conflicts and can be replaced.',
+      ),
+    ).toBeInTheDocument();
+
+    const footnote1 = within(details[2]);
+
+    expect(
+      footnote1.getByRole('button', { name: /Footnote 1/ }),
+    ).toHaveTextContent('ERROR');
+
+    expect(footnote1.getByTestId('Filter 1')).toHaveTextContent('Group 2');
+    expect(footnote1.getByTestId('Filter 1')).toHaveTextContent('Group 3');
+    expect(footnote1.getByTestId('Filter 1')).toHaveTextContent('Group 1');
+
+    expect(footnote1.getByTestId('Group 2')).toHaveTextContent(
+      'Item 1 not present',
+    );
+    expect(footnote1.getByTestId('Group 2')).toHaveTextContent(
+      'Item 3 not present',
+    );
+
+    expect(footnote1.getByTestId('Group 3')).toHaveTextContent('Item 2');
+    expect(footnote1.getByTestId('Group 3')).not.toHaveTextContent(
+      'Item 2 not present',
+    );
+
+    expect(footnote1.getByTestId('Group 1')).toHaveTextContent(
+      '(All selected)',
+    );
+
+    expect(footnote1.getByTestId('Filter 2')).toHaveTextContent('Group 5');
+    expect(footnote1.getByTestId('Filter 2')).toHaveTextContent('Group 4');
+
+    expect(footnote1.getByTestId('Group 5')).toHaveTextContent(
+      'Item 4 not present',
+    );
+    expect(footnote1.getByTestId('Group 4')).toHaveTextContent(
+      '(All selected)',
+    );
+
+    expect(footnote1.getByTestId('Filter 3')).toHaveTextContent(
+      '(All selected)',
+    );
+    expect(footnote1.getByTestId('Filter 4')).toHaveTextContent(
+      '(All selected)',
+    );
+
+    expect(footnote1.getByTestId('Indicator group 1')).toHaveTextContent(
+      'Indicator 1',
+    );
+    expect(footnote1.getByTestId('Indicator group 1')).not.toHaveTextContent(
+      'Indicator 1 not present',
+    );
+    expect(footnote1.getByTestId('Indicator group 2')).toHaveTextContent(
+      'Indicator 3 not present',
+    );
+
+    const footnote2 = within(details[3]);
+
+    expect(
+      footnote2.getByRole('button', { name: /Footnote 2/ }),
+    ).toHaveTextContent('OK');
+
+    expect(
+      footnote2.getByText(
+        'This footnote has no conflicts and can be replaced.',
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', { name: 'Confirm data replacement' }),
+    ).not.toBeInTheDocument();
   });
 
   test('renders correctly with valid plan', async () => {
@@ -602,18 +602,18 @@ describe('DataReplacementPlan', () => {
     await waitFor(() => {
       expect(screen.getByText('Data blocks: OK')).toBeInTheDocument();
       expect(screen.getByText('Footnotes: OK')).toBeInTheDocument();
-
-      expect(
-        screen.getByText(
-          'All existing data blocks can be replaced by this data replacement.',
-        ),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          'All existing footnotes can be replaced by this data replacement.',
-        ),
-      ).toBeInTheDocument();
     });
+
+    expect(
+      screen.getByText(
+        'All existing data blocks can be replaced by this data replacement.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'All existing footnotes can be replaced by this data replacement.',
+      ),
+    ).toBeInTheDocument();
 
     const details = screen.getAllByRole('group');
 
@@ -689,12 +689,10 @@ describe('DataReplacementPlan', () => {
     await waitFor(() => {
       expect(screen.getByText('Data blocks: OK')).toBeInTheDocument();
       expect(screen.getByText('Footnotes: OK')).toBeInTheDocument();
-
-      expect(
-        screen.getByText('No data blocks to replace.'),
-      ).toBeInTheDocument();
-      expect(screen.getByText('No footnotes to replace.')).toBeInTheDocument();
     });
+
+    expect(screen.getByText('No data blocks to replace.')).toBeInTheDocument();
+    expect(screen.getByText('No footnotes to replace.')).toBeInTheDocument();
 
     expect(screen.queryAllByRole('group')).toHaveLength(0);
 
@@ -749,7 +747,12 @@ describe('DataReplacementPlan', () => {
       ).toBeInTheDocument();
     });
 
+    expect(
+      screen.getByRole('button', { name: /Data block 1/ }),
+    ).toBeInTheDocument();
+
     userEvent.click(screen.getByRole('button', { name: /Data block 1/ }));
+
     expect(
       screen.getByRole('link', { name: 'Edit data block' }),
     ).toHaveAttribute(
@@ -783,10 +786,12 @@ describe('DataReplacementPlan', () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /Data block 1/ }),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Data block 1/)).toBeInTheDocument();
     });
+
+    expect(
+      screen.getByRole('button', { name: /Data block 1/ }),
+    ).toBeInTheDocument();
 
     userEvent.click(screen.getByRole('button', { name: /Data block 1/ }));
     expect(
@@ -812,24 +817,28 @@ describe('DataReplacementPlan', () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /Data block 1/ }),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Data block 1/)).toBeInTheDocument();
     });
+
+    expect(
+      screen.getByRole('button', { name: /Data block 1/ }),
+    ).toBeInTheDocument();
 
     userEvent.click(screen.getByRole('button', { name: /Data block 1/ }));
     userEvent.click(screen.getByRole('button', { name: 'Delete data block' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-
-      const modal = within(screen.getByRole('dialog'));
-
-      expect(modal.getByRole('heading')).toHaveTextContent('Delete data block');
       expect(
-        modal.getByText(/Are you sure you want to delete/),
-      ).toHaveTextContent("Are you sure you want to delete 'Data block 1'");
+        screen.getByText(/Are you sure you want to delete/),
+      ).toBeInTheDocument();
     });
+
+    const modal = within(screen.getByRole('dialog'));
+
+    expect(modal.getByRole('heading')).toHaveTextContent('Delete data block');
+    expect(
+      modal.getByText(/Are you sure you want to delete/),
+    ).toHaveTextContent("Are you sure you want to delete 'Data block 1'");
   });
 
   test('deleting data block hides modal and reloads replacement plan', async () => {
@@ -851,18 +860,23 @@ describe('DataReplacementPlan', () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /Data block 1/ }),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Data block 1/)).toBeInTheDocument();
     });
 
-    userEvent.click(screen.getByRole('button', { name: /Data block 1/ }));
+    expect(
+      screen.getByRole('button', { name: /Data block 1/ }),
+    ).toBeInTheDocument();
 
+    userEvent.click(screen.getByRole('button', { name: /Data block 1/ }));
     userEvent.click(screen.getByRole('button', { name: 'Delete data block' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Are you sure you want to delete/),
+      ).toBeInTheDocument();
     });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
 
     expect(dataBlockService.deleteDataBlock).not.toHaveBeenCalled();
 
@@ -878,22 +892,26 @@ describe('DataReplacementPlan', () => {
     expect(dataReplacementService.getReplacementPlan).toHaveBeenCalledTimes(1);
 
     await waitFor(() => {
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-
-      const details = screen.getAllByRole('group');
-
-      expect(details).toHaveLength(1);
-
-      const dataBlock = within(details[0]);
-
       expect(
-        dataBlock.getByRole('button', { name: /Data block 2/ }),
+        screen.queryByText(/Are you sure you want to delete/),
       ).toBeInTheDocument();
-
-      expect(
-        screen.queryByRole('button', { name: /Data block 1/ }),
-      ).not.toBeInTheDocument();
     });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    const details = screen.getAllByRole('group');
+
+    expect(details).toHaveLength(1);
+
+    const dataBlock = within(details[0]);
+
+    expect(
+      dataBlock.getByRole('button', { name: /Data block 2/ }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', { name: /Data block 1/ }),
+    ).not.toBeInTheDocument();
   });
 
   test("renders correct 'Edit footnote' link", async () => {
@@ -914,10 +932,12 @@ describe('DataReplacementPlan', () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /Footnote 1/ }),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Footnote 1/)).toBeInTheDocument();
     });
+
+    expect(
+      screen.getByRole('button', { name: /Footnote 1/ }),
+    ).toBeInTheDocument();
 
     userEvent.click(screen.getByRole('button', { name: /Footnote 1/ }));
     expect(screen.getByRole('link', { name: 'Edit footnote' })).toHaveAttribute(
@@ -944,27 +964,35 @@ describe('DataReplacementPlan', () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /Footnote 1/ }),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Footnote 1/)).toBeInTheDocument();
     });
+
+    expect(
+      screen.getByRole('button', { name: /Footnote 1/ }),
+    ).toBeInTheDocument();
 
     userEvent.click(screen.getByRole('button', { name: /Footnote 1/ }));
     userEvent.click(screen.getByRole('button', { name: 'Delete footnote' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-
-      const modal = within(screen.getByRole('dialog'));
-
-      expect(modal.getByRole('heading')).toHaveTextContent('Delete footnote');
       expect(
-        modal.getByText(
+        screen.getByText(
           'Are you sure you want to delete the following footnote?',
         ),
       ).toBeInTheDocument();
-      expect(modal.getByText('Footnote 1')).toBeInTheDocument();
     });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    const modal = within(screen.getByRole('dialog'));
+
+    expect(modal.getByRole('heading')).toHaveTextContent('Delete footnote');
+    expect(
+      modal.getByText(
+        'Are you sure you want to delete the following footnote?',
+      ),
+    ).toBeInTheDocument();
+    expect(modal.getByText('Footnote 1')).toBeInTheDocument();
   });
 
   test('deleting footnote hides modal and reloads replacement plan', async () => {
@@ -986,17 +1014,25 @@ describe('DataReplacementPlan', () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /Footnote 1/ }),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Footnote 1/)).toBeInTheDocument();
     });
+
+    expect(
+      screen.getByRole('button', { name: /Footnote 1/ }),
+    ).toBeInTheDocument();
 
     userEvent.click(screen.getByRole('button', { name: /Footnote 1/ }));
     userEvent.click(screen.getByRole('button', { name: 'Delete footnote' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Are you sure you want to delete the following footnote?',
+        ),
+      ).toBeInTheDocument();
     });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
 
     expect(footnoteService.deleteFootnote).not.toHaveBeenCalled();
 
@@ -1012,22 +1048,28 @@ describe('DataReplacementPlan', () => {
     expect(dataReplacementService.getReplacementPlan).toHaveBeenCalledTimes(1);
 
     await waitFor(() => {
-      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-
-      const details = screen.getAllByRole('group');
-
-      expect(details).toHaveLength(1);
-
-      const footnote = within(details[0]);
-
       expect(
-        footnote.getByRole('button', { name: /Footnote 2/ }),
-      ).toBeInTheDocument();
-
-      expect(
-        screen.queryByRole('button', { name: /Footnote 1/ }),
+        screen.queryByText(
+          'Are you sure you want to delete the following footnote?',
+        ),
       ).not.toBeInTheDocument();
     });
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    const details = screen.getAllByRole('group');
+
+    expect(details).toHaveLength(1);
+
+    const footnote = within(details[0]);
+
+    expect(
+      footnote.getByRole('button', { name: /Footnote 2/ }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', { name: /Footnote 1/ }),
+    ).not.toBeInTheDocument();
   });
 
   test('calls service to replace data when confirming replacement', async () => {
@@ -1047,10 +1089,12 @@ describe('DataReplacementPlan', () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Confirm data replacement' }),
-      ).toBeInTheDocument();
+      expect(screen.getByText('Confirm data replacement')).toBeInTheDocument();
     });
+
+    expect(
+      screen.getByRole('button', { name: 'Confirm data replacement' }),
+    ).toBeInTheDocument();
 
     expect(dataReplacementService.replaceData).not.toHaveBeenCalled();
 


### PR DESCRIPTION
This PR removes the table result location hierarchies feature toggle and makes it a permanent feature.

This toggle was originally added so that the BE work of the location hierarchies feature could be completed before the UI work began, keeping non hierarchical locations as the default response format in table results.

After EES-2777 included by https://github.com/dfe-analytical-services/explore-education-statistics/pull/3082 this work is now completed.

We also remove the legacy `Locations` field from `ResultSubjectMetaViewModel`.

`ResultSubjectMetaViewModelJsonConverter` is responsible for converting any older Permalinks which have a flat `Locations` field in their JSON serialization into `LocationsHierarchical`. 

Until old Permalinks are migrated, the translation provided by this converter ensures that consumers
are aware of legacy locations when accessing `ResultSubjectMetaViewModel.LocationsHierarchical`.

We expect to make this migration permanent in future as part of EES-2943 followed by renaming this field back to `Locations` in serialized data. We also expect to rename `LocationsHierarchical` back to `Locations` in Permalink responses as part of EES-3106 which could happen independently. 