### PR TITLE
EES-3117 Add sensitive data filtering for Application Insights

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -21,6 +21,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Services.ManageContent;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Methodologies;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
+using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
@@ -100,7 +101,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddApplicationInsightsTelemetry();
+            services.AddApplicationInsightsTelemetry()
+                .AddApplicationInsightsTelemetryProcessor<SensitiveDataTelemetryProcessor>();
 
             services.Configure<CookiePolicyOptions>(options =>
             {

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Config/SensitiveDataTelemetryProcessorTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Config/SensitiveDataTelemetryProcessorTests.cs
@@ -1,0 +1,595 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Common.Config;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Moq;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Config
+{
+    public class SensitiveDataTelemetryProcessorTests
+    {
+        private static IEnumerable<object[]> GetSensitiveQueryParamVariations()
+        {
+            return new List<object[]>
+            {
+                new object[] { "email" },
+                new object[] { "email[0]" },
+                new object[] { "email[]" },
+                new object[] { "Email" },
+                new object[] { "EMAIL" },
+                new object[] { "eMail" },
+                new object[] { "email1" },
+                new object[] { "email10address" },
+                new object[] { "emailA" },
+                new object[] { "address_email" },
+                new object[] { "email_address" },
+                new object[] { "email-address" },
+                new object[] { "email:address" },
+                new object[] { "email+address" },
+                new object[] { "email.address" },
+                new object[] { "EmailAddress" },
+                new object[] { "emailAddress" },
+                new object[] { "emailAddress1" },
+                new object[] { "emailAddress10" },
+                new object[] { "email_address[0]" },
+                new object[] { "email_address[]" },
+                new object[] { "email++address" },
+                new object[] { "email[address]" },
+                new object[] { "address[email]" },
+                // These have escaped reserved characters
+                // such as ' ', ':', '+', '|'.
+                new object[] { "email%20address" },
+                new object[] { "email%3Aaddress" },
+                new object[] { "email%2Baddress" },
+                new object[] { "email%7Caddress" },
+            };
+        }
+
+        [Fact]
+        public void Process_Request_NoQuery()
+        {
+            var telemetry = new RequestTelemetry
+            {
+                Url = new Uri("https://test.com/"),
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("https://test.com/", telemetry.Url.AbsoluteUri);
+        }
+
+        [Fact]
+        public void Process_Request_NullUrl()
+        {
+            var telemetry = new RequestTelemetry();
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Null(telemetry.Url);
+        }
+
+        [Fact]
+        public void Process_Request_SingleQueryParam()
+        {
+            var telemetry = new RequestTelemetry
+            {
+                Url = new Uri("https://test.com/?code=my-code")
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("https://test.com/?code=__redacted__", telemetry.Url.AbsoluteUri);
+        }
+
+        [Fact]
+        public void Process_Request_SingleQueryParam_NotFiltered()
+        {
+            var telemetry = new RequestTelemetry
+            {
+                Url = new Uri("https://test.com/?key=value")
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("https://test.com/?key=value", telemetry.Url.AbsoluteUri);
+        }
+
+        [Fact]
+        public void Process_Request_SingleQueryParam_NotFilteredLookalike()
+        {
+            var telemetry = new RequestTelemetry
+            {
+                Url = new Uri("https://test.com/?encodeType=something")
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            // Contains the word 'code', but we shouldn't filter it
+            Assert.Equal("https://test.com/?encodeType=something", telemetry.Url.AbsoluteUri);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetSensitiveQueryParamVariations))]
+        public void Process_Request_SingleQueryParam_Variations(string key)
+        {
+            var telemetry = new RequestTelemetry
+            {
+                Url = new Uri($"https://test.com/?{key}=some-value")
+            };
+
+            var processor = BuildProcessor();
+
+            processor.Process(telemetry);
+            Assert.Equal($"https://test.com/?{key}=__redacted__", telemetry.Url.AbsoluteUri);
+        }
+
+        [Fact]
+        public void Process_Request_MultipleQueryParams()
+        {
+            var telemetry = new RequestTelemetry
+            {
+                Url = new Uri("https://test.com/?password=my-password&code=my-code&token=my-token&email=my-email")
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal(
+                "https://test.com/?password=__redacted__&code=__redacted__&token=__redacted__&email=__redacted__",
+                telemetry.Url.AbsoluteUri
+            );
+        }
+
+        [Fact]
+        public void Process_Request_MultipleQueryParams_WithNonSensitive()
+        {
+            var telemetry = new RequestTelemetry
+            {
+                Url = new Uri("https://test.com/?test1=value1&code=my-code&test2=value2&email=my-email")
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal(
+                "https://test.com/?test1=value1&code=__redacted__&test2=value2&email=__redacted__",
+                telemetry.Url.AbsoluteUri
+            );
+        }
+
+        [Fact]
+        public void Process_Request_CallsNext()
+        {
+            var telemetry = new RequestTelemetry
+            {
+                Url = new Uri("https://test.com/")
+            };
+
+            var nextProcessor = new Mock<ITelemetryProcessor>();
+
+            nextProcessor.Setup(s => s.Process(telemetry));
+
+            BuildProcessor(nextProcessor.Object).Process(telemetry);
+
+            Assert.Equal("https://test.com/", telemetry.Url.AbsoluteUri);
+
+            MockUtils.VerifyAllMocks(nextProcessor);
+        }
+
+        [Fact]
+        public void Process_PageView_NoQuery()
+        {
+            var telemetry = new PageViewTelemetry
+            {
+                Url = new Uri("https://test.com/"),
+                Properties =
+                {
+                    { "refUri", "https://test.com/" }
+                }
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("https://test.com/", telemetry.Url.AbsoluteUri);
+            Assert.Equal("https://test.com/", telemetry.Properties["refUri"]);
+        }
+
+        [Fact]
+        public void Process_PageView_NullUris()
+        {
+            var telemetry = new PageViewTelemetry();
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Null(telemetry.Url);
+            Assert.Empty(telemetry.Properties);
+        }
+
+        [Fact]
+        public void Process_PageView_InvalidRefUri()
+        {
+            var telemetry = new PageViewTelemetry
+            {
+                Url = new Uri("https://test.com/"),
+                Properties =
+                {
+                    { "refUri", "Not a URI" }
+                }
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("https://test.com/", telemetry.Url.AbsoluteUri);
+            Assert.Equal("Not a URI", telemetry.Properties["refUri"]);
+        }
+
+        [Fact]
+        public void Process_PageView_SingleQueryParam()
+        {
+            var telemetry = new PageViewTelemetry
+            {
+                Url = new Uri("https://test.com/?code=my-code"),
+                Properties =
+                {
+                    { "refUri", "https://test.com/ref?code=my-code" }
+                }
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("https://test.com/?code=__redacted__", telemetry.Url.AbsoluteUri);
+            Assert.Equal("https://test.com/ref?code=__redacted__", telemetry.Properties["refUri"]);
+        }
+
+        [Fact]
+        public void Process_PageView_SingleQueryParam_NotFiltered()
+        {
+            var telemetry = new PageViewTelemetry
+            {
+                Url = new Uri("https://test.com/?key=value"),
+                Properties =
+                {
+                    { "refUri", "https://test.com/ref?key=value" }
+                }
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("https://test.com/?key=value", telemetry.Url.AbsoluteUri);
+            Assert.Equal("https://test.com/ref?key=value", telemetry.Properties["refUri"]);
+        }
+
+        [Fact]
+        public void Process_PageView_SingleQueryParam_NotFilteredLookalike()
+        {
+            var telemetry = new PageViewTelemetry
+            {
+                Url = new Uri("https://test.com/?encodeType=something"),
+                Properties =
+                {
+                    { "refUri", "https://test.com/ref?encodeType=something" }
+                }
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            // Contains the word 'code', but we shouldn't filter it
+            Assert.Equal("https://test.com/?encodeType=something", telemetry.Url.AbsoluteUri);
+            Assert.Equal("https://test.com/ref?encodeType=something", telemetry.Properties["refUri"]);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetSensitiveQueryParamVariations))]
+        public void Process_PageView_SingleQueryParam_Variations(string key)
+        {
+            var telemetry = new PageViewTelemetry
+            {
+                Url = new Uri($"https://test.com/?{key}=some-value"),
+                Properties =
+                {
+                    { "refUri", $"https://test.com/ref?{key}=some-value" }
+                }
+            };
+
+            var processor = BuildProcessor();
+
+            processor.Process(telemetry);
+            Assert.Equal($"https://test.com/?{key}=__redacted__", telemetry.Url.AbsoluteUri);
+            Assert.Equal($"https://test.com/ref?{key}=__redacted__", telemetry.Properties["refUri"]);
+        }
+
+        [Fact]
+        public void Process_PageView_MultipleQueryParams()
+        {
+            var telemetry = new PageViewTelemetry
+            {
+                Url = new Uri("https://test.com/?password=my-password&code=my-code&token=my-token&email=my-email"),
+                Properties =
+                {
+                    { "refUri", "https://test.com/ref?password=my-password&code=my-code&token=my-token&email=my-email" }
+                }
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal(
+                "https://test.com/?password=__redacted__&code=__redacted__&token=__redacted__&email=__redacted__",
+                telemetry.Url.AbsoluteUri
+            );
+            Assert.Equal(
+                "https://test.com/ref?password=__redacted__&code=__redacted__&token=__redacted__&email=__redacted__",
+                telemetry.Properties["refUri"]
+            );
+        }
+
+        [Fact]
+        public void Process_PageView_MultipleQueryParams_WithNonSensitive()
+        {
+            var telemetry = new PageViewTelemetry
+            {
+                Url = new Uri("https://test.com/?test1=value1&code=my-code&test2=value2&email=my-email"),
+                Properties =
+                {
+                    { "refUri", "https://test.com/ref?test1=value1&code=my-code&test2=value2&email=my-email" }
+                }
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal(
+                "https://test.com/?test1=value1&code=__redacted__&test2=value2&email=__redacted__",
+                telemetry.Url.AbsoluteUri
+            );
+            Assert.Equal(
+                "https://test.com/ref?test1=value1&code=__redacted__&test2=value2&email=__redacted__",
+                telemetry.Properties["refUri"]
+            );
+        }
+
+        [Fact]
+        public void Process_PageView_CallsNext()
+        {
+            var telemetry = new PageViewTelemetry
+            {
+                Url = new Uri("https://test.com/"),
+                Properties =
+                {
+                    { "refUri", "https://test.com/ref" }
+                }
+            };
+
+            var nextProcessor = new Mock<ITelemetryProcessor>();
+
+            nextProcessor.Setup(s => s.Process(telemetry));
+
+            BuildProcessor(nextProcessor.Object).Process(telemetry);
+
+            Assert.Equal("https://test.com/", telemetry.Url.AbsoluteUri);
+            Assert.Equal("https://test.com/ref", telemetry.Properties["refUri"]);
+
+            MockUtils.VerifyAllMocks(nextProcessor);
+        }
+
+        [Fact]
+        public void Process_Dependency_NoQuery()
+        {
+            var telemetry = new DependencyTelemetry
+            {
+                Name = "GET /test",
+                Data = "GET /test",
+                Type = "Http"
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("GET /test", telemetry.Name);
+            Assert.Equal("GET /test", telemetry.Data);
+        }
+
+        [Fact]
+        public void Process_Dependency_NullUris()
+        {
+            var telemetry = new DependencyTelemetry
+            {
+                Type = "Http"
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Empty(telemetry.Name);
+            Assert.Empty(telemetry.Data);
+        }
+
+        [Fact]
+        public void Process_Dependency_NoQuery_NotHttp()
+        {
+            var telemetry = new DependencyTelemetry
+            {
+                Name = "db | statistics",
+                Data = "Test data",
+                Type = "SQL"
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("db | statistics", telemetry.Name);
+            Assert.Equal("Test data", telemetry.Data);
+        }
+
+        [Fact]
+        public void Process_Dependency_SingleQueryParam()
+        {
+            var telemetry = new DependencyTelemetry
+            {
+                Name = "GET /test?code=my-code",
+                Data = "https://test.com/test?code=my-code",
+                Type = "Http"
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("GET /test?code=__redacted__", telemetry.Name);
+            Assert.Equal("https://test.com/test?code=__redacted__", telemetry.Data);
+        }
+
+        [Fact]
+        public void Process_Dependency_SingleQueryParam_InvalidUrl()
+        {
+            var telemetry = new DependencyTelemetry
+            {
+                Name = "GET /test?code=my-code",
+                Data = "Invalid URL",
+                Type = "Http"
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("GET /test?code=__redacted__", telemetry.Name);
+            Assert.Equal("Invalid URL", telemetry.Data);
+        }
+
+        [Fact]
+        public void Process_Dependency_SingleQueryParam_NotHttp()
+        {
+            var telemetry = new DependencyTelemetry
+            {
+                Name = "GET /test?code=my-code",
+                Data = "https://test.com/test?code=my-code",
+                // We don't filter this type as we consider it
+                // outside of our application code's scope.
+                Type = "Azure Blob"
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("GET /test?code=my-code", telemetry.Name);
+            Assert.Equal("https://test.com/test?code=my-code", telemetry.Data);
+        }
+
+        [Fact]
+        public void Process_Dependency_SingleQueryParam_NotFiltered()
+        {
+            var telemetry = new DependencyTelemetry
+            {
+                Name = "GET /test?key=value",
+                Data = "https://test.com/test?key=value",
+                Type = "Http"
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal("GET /test?key=value", telemetry.Name);
+            Assert.Equal("https://test.com/test?key=value", telemetry.Data);
+        }
+
+        [Fact]
+        public void Process_Dependency_SingleQueryParam_NotFilteredLookalike()
+        {
+            var telemetry = new DependencyTelemetry
+            {
+                Name = "GET /test?encodeType=something",
+                Data = "https://test.com/test?encodeType=something",
+                Type = "Http"
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            // Contains the word 'code', but we shouldn't filter it
+            Assert.Equal("GET /test?encodeType=something", telemetry.Name);
+            Assert.Equal("https://test.com/test?encodeType=something", telemetry.Data);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetSensitiveQueryParamVariations))]
+        public void Process_Dependency_SingleQueryParam_Variations(string key)
+        {
+            var telemetry = new DependencyTelemetry
+            {
+                Name = $"GET /test?{key}=some-value",
+                Data = $"https://test.com/test?{key}=some-value",
+                Type = "Http"
+            };
+
+            var processor = BuildProcessor();
+
+            processor.Process(telemetry);
+            Assert.Equal($"GET /test?{key}=__redacted__", telemetry.Name);
+            Assert.Equal($"https://test.com/test?{key}=__redacted__", telemetry.Data);
+        }
+
+        [Fact]
+        public void Process_Dependency_MultipleQueryParams()
+        {
+            var telemetry = new DependencyTelemetry
+            {
+                Name = "GET /test?password=my-password&code=my-code&token=my-token&email=my-email",
+                Data = "https://test.com/test?password=my-password&code=my-code&token=my-token&email=my-email",
+                Type = "Http"
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal(
+                "GET /test?password=__redacted__&code=__redacted__&token=__redacted__&email=__redacted__",
+                telemetry.Name
+            );
+            Assert.Equal(
+                "https://test.com/test?password=__redacted__&code=__redacted__&token=__redacted__&email=__redacted__",
+                telemetry.Data
+            );
+        }
+
+        [Fact]
+        public void Process_Dependency_MultipleQueryParams_WithNonSensitive()
+        {
+            var telemetry = new DependencyTelemetry
+            {
+                Name = "GET /test?test1=value1&code=my-code&test2=value2&email=my-email",
+                Data = "https://test.com/test?test1=value1&code=my-code&test2=value2&email=my-email",
+                Type = "Http"
+            };
+
+            BuildProcessor().Process(telemetry);
+
+            Assert.Equal(
+                "GET /test?test1=value1&code=__redacted__&test2=value2&email=__redacted__",
+                telemetry.Name
+            );
+            Assert.Equal(
+                "https://test.com/test?test1=value1&code=__redacted__&test2=value2&email=__redacted__",
+                telemetry.Data
+            );
+        }
+
+        [Fact]
+        public void Process_Dependency_CallsNext()
+        {
+            var telemetry = new DependencyTelemetry
+            {
+                Name = "GET /test",
+                Data = "https://test.com/test",
+                Type = "Http"
+            };
+
+            var nextProcessor = new Mock<ITelemetryProcessor>();
+
+            nextProcessor.Setup(s => s.Process(telemetry));
+
+            BuildProcessor(nextProcessor.Object).Process(telemetry);
+
+            Assert.Equal("GET /test", telemetry.Name);
+            Assert.Equal("https://test.com/test", telemetry.Data);
+
+            MockUtils.VerifyAllMocks(nextProcessor);
+        }
+
+        private SensitiveDataTelemetryProcessor BuildProcessor(ITelemetryProcessor? nextProcessor = null)
+        {
+            return new SensitiveDataTelemetryProcessor(
+                nextProcessor ?? Mock.Of<ITelemetryProcessor>()
+            );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Config/SensitiveDataTelemetryProcessor.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Config/SensitiveDataTelemetryProcessor.cs
@@ -1,0 +1,167 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Web;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Config
+{
+    /// <summary>
+    /// Tries to filter out any potentially sensitive data from telemetry
+    /// before it is sent to Application Insights e.g. query string parameters
+    /// containing things like access tokens or codes.
+    /// </summary>
+    public class SensitiveDataTelemetryProcessor : ITelemetryProcessor
+    {
+        private const string RedactedValue = "__redacted__";
+
+        private readonly HashSet<string> _redactedTokens = new()
+        {
+            "code",
+            "email",
+            "phone",
+            "token",
+            "passphrase",
+            "password",
+            "pass",
+            "user",
+            "name",
+            "username",
+            "firstname",
+            "lastname",
+            "fullname"
+        };
+
+        private readonly char[] _tokenDelimiters =
+        {
+            '_', '-', ':', '.', '|', ' ', '[', ']', '+'
+        };
+
+        private readonly Regex _casingRegex = new("([A-Z][a-z]*|[0-9])", RegexOptions.Compiled);
+
+        private ITelemetryProcessor Next { get; }
+
+        public SensitiveDataTelemetryProcessor(ITelemetryProcessor next)
+        {
+            Next = next;
+        }
+
+        public void Process(ITelemetry item)
+        {
+            switch (item)
+            {
+                case RequestTelemetry telemetry:
+                {
+                    telemetry.Url = FilterUrl(telemetry.Url);
+                    break;
+                }
+                case PageViewTelemetry telemetry:
+                {
+                    telemetry.Url = FilterUrl(telemetry.Url);
+
+                    if (telemetry.Properties.ContainsKey("refUri"))
+                    {
+                        telemetry.Properties["refUri"] = FilterUriQuery(telemetry.Properties["refUri"]);
+                    }
+
+                    break;
+                }
+                case DependencyTelemetry telemetry:
+                {
+                    HandleDependencyTelemetry(telemetry);
+                    break;
+                }
+            }
+
+            Next.Process(item);
+        }
+
+        private void HandleDependencyTelemetry(DependencyTelemetry telemetry)
+        {
+            if (telemetry.Type != "Http")
+            {
+                return;
+            }
+
+            telemetry.Name = FilterUriQuery(telemetry.Name);
+            telemetry.Data = FilterUriQuery(telemetry.Data);
+        }
+
+        private Uri? FilterUrl(Uri? uri)
+        {
+            if (uri is null)
+            {
+                return uri;
+            }
+
+            var filteredUri = FilterUriQuery(uri.AbsoluteUri);
+
+            return filteredUri is null ? uri : new Uri(filteredUri);
+        }
+
+        private string? FilterUriQuery(string? uri)
+        {
+            if (uri.IsNullOrEmpty())
+            {
+                return uri;
+            }
+
+            var pathAndQuery = uri.Split('?', 2);
+
+            if (pathAndQuery.Length < 2)
+            {
+                return uri;
+            }
+
+            var queryParts = pathAndQuery[1].Split('&');
+
+            var filteredQuery = queryParts.Select(
+                    keyValue =>
+                    {
+                        var parts = keyValue.Split('=', 2);
+
+                        if (parts.Length < 2)
+                        {
+                            return keyValue;
+                        }
+
+                        var key = parts[0];
+
+                        return IsRedactedKey(key) ? $"{key}={RedactedValue}" : keyValue;
+                    }
+                )
+                .JoinToString('&');
+
+            return $"{pathAndQuery[0]}?{filteredQuery}";
+        }
+
+        private bool IsRedactedKey(string key)
+        {
+            return HttpUtility.UrlDecode(key)
+                .Split(_tokenDelimiters, StringSplitOptions.RemoveEmptyEntries)
+                .Any(
+                    token =>
+                    {
+                        if (_redactedTokens.Contains(token.ToLower()))
+                        {
+                            return true;
+                        }
+
+                        // The token may be camel/pascal cased, meaning we should split
+                        // it up to check if any of the words is a matching token.
+                        // Note - we can't just check if any of the redacted tokens are inside of
+                        // the current token as redacted tokens may constitute actual words
+                        // e.g. `code` is in `encode` (which shouldn't be redacted).
+                        var words = _casingRegex.Split(token);
+
+                        return words.Any(word => _redactedTokens.Contains(word.ToLower()));
+                    }
+                );
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/GovUk.Education.ExploreEducationStatistics.Common.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="AutoMapper" Version="9.0.0" />
         <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.18.0" />
         <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.18" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
         <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="1.3.0" />
@@ -24,5 +25,4 @@
         <PackageReference Include="Mime" Version="3.1.0" />
         <PackageReference Include="Mime-Detective" Version="0.0.6-beta5" />
     </ItemGroup>
-
 </Project>

--- a/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Content.Api/Startup.cs
@@ -4,6 +4,7 @@ using AutoMapper;
 using Azure.Storage.Blobs;
 using GovUk.Education.ExploreEducationStatistics.Common.Cache;
 using GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
+using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Common.ModelBinding;
 using GovUk.Education.ExploreEducationStatistics.Common.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
@@ -59,7 +60,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
         {
             services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
 
-            services.AddApplicationInsightsTelemetry();
+            services.AddApplicationInsightsTelemetry()
+                .AddApplicationInsightsTelemetryProcessor<SensitiveDataTelemetryProcessor>();
+
             services.AddMvc(options =>
                 {
                     options.Filters.Add(new OperationCancelledExceptionFilter());
@@ -194,7 +197,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Content.Api
                     "https://localhost:3001")
                 .AllowAnyMethod()
                 .AllowAnyHeader());
-            
+
             app.UseMvc();
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Startup.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Cancellation;
+using GovUk.Education.ExploreEducationStatistics.Common.Config;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
@@ -58,7 +59,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddApplicationInsightsTelemetry();
+            services.AddApplicationInsightsTelemetry()
+                .AddApplicationInsightsTelemetryProcessor<SensitiveDataTelemetryProcessor>();
+            
             services.AddMvc(options =>
             {
                 options.Filters.Add(new OperationCancelledExceptionFilter());
@@ -226,7 +229,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api
                     "https://localhost:3001")
                 .AllowAnyMethod()
                 .AllowAnyHeader());
-            
+
             app.UseMvc();
         }
 

--- a/src/explore-education-statistics-common/src/services/__tests__/applicationInsightsService.test.ts
+++ b/src/explore-education-statistics-common/src/services/__tests__/applicationInsightsService.test.ts
@@ -1,0 +1,709 @@
+import { ITelemetryItem } from '@microsoft/applicationinsights-web';
+import { filterSensitiveData } from '../applicationInsightsService';
+
+describe('filterSensitiveData', () => {
+  const sensitiveQueryParamVariations: string[][] = [
+    ['email'],
+    ['email[0]'],
+    ['email[]'],
+    ['Email'],
+    ['EMAIL'],
+    ['eMail'],
+    ['email1'],
+    ['email10address'],
+    ['emailA'],
+    ['address_email'],
+    ['email_address'],
+    ['email-address'],
+    ['email:address'],
+    ['email+address'],
+    ['email.address'],
+    ['EmailAddress'],
+    ['emailAddress'],
+    ['emailAddress1'],
+    ['emailAddress10'],
+    ['email_address[0]'],
+    ['email_address[]'],
+    ['email++address'],
+    ['email[address]'],
+    ['address[email]'],
+    // These have escaped reserved characters
+    // such as ' ', ':', '+', '|'
+    ['email%20address'],
+    ['email%3Aaddress'],
+    ['email%2Baddress'],
+    ['email%7Caddress'],
+  ];
+
+  describe('RemoteDependencyData', () => {
+    const baseType = 'RemoteDependencyData';
+
+    test('does nothing if there is no query', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          name: 'GET /test',
+          target: 'https://localhost/test',
+          type: 'Ajax',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          name: 'GET /test',
+          target: 'https://localhost/test',
+          type: 'Ajax',
+        },
+      });
+    });
+
+    test('does nothing if there are no targeted fields', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          type: 'Ajax',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          type: 'Ajax',
+        },
+      });
+    });
+
+    test('redacts single candidate query parameter', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          name: 'GET /test?code=my-code',
+          target: 'https://localhost/test?code=my-code',
+          type: 'Ajax',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          name: 'GET /test?code=__redacted__',
+          target: 'https://localhost/test?code=__redacted__',
+          type: 'Ajax',
+        },
+      });
+    });
+
+    test('redacts multiple candidate query parameters', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          name:
+            'GET /test?password=my-password&code=my-code&token=my-token&email=my-email',
+          target:
+            'https://localhost/test?password=my-password&code=my-code&token=my-token&email=my-email',
+          type: 'Ajax',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          name:
+            'GET /test?password=__redacted__&code=__redacted__&token=__redacted__&email=__redacted__',
+          target:
+            'https://localhost/test?password=__redacted__&code=__redacted__&token=__redacted__&email=__redacted__',
+          type: 'Ajax',
+        },
+      });
+    });
+
+    test('tries to redact query parameters on invalid URLs', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          name: 'GET not-a-url?password=my-password',
+          target: 'not-a-url?password=my-password',
+          type: 'Ajax',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          name: 'GET not-a-url?password=__redacted__',
+          target: 'not-a-url?password=__redacted__',
+          type: 'Ajax',
+        },
+      });
+    });
+
+    test.each(sensitiveQueryParamVariations)(
+      'redacts query parameter `%s`',
+      key => {
+        const telemetry: ITelemetryItem = {
+          baseType,
+          name: '',
+          baseData: {
+            name: `GET /test?${key}=some-value`,
+            target: `https://localhost/test?${key}=some-value`,
+            type: 'Ajax',
+          },
+        };
+
+        expect(filterSensitiveData(telemetry)).toBe(true);
+        expect(telemetry).toEqual<ITelemetryItem>({
+          baseType,
+          name: '',
+          baseData: {
+            name: `GET /test?${key}=__redacted__`,
+            target: `https://localhost/test?${key}=__redacted__`,
+            type: 'Ajax',
+          },
+        });
+      },
+    );
+
+    test('does nothing to non-candidate query parameters', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          name: 'GET /test?key=value',
+          target: 'https://localhost/test?key=value',
+          type: 'Ajax',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          name: 'GET /test?key=value',
+          target: 'https://localhost/test?key=value',
+          type: 'Ajax',
+        },
+      });
+    });
+
+    test('does nothing to non-candidate, lookalike query parameter', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          name: 'GET /test?encodeType=something',
+          target: 'https://localhost/test?encodeType=something',
+          type: 'Ajax',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          name: 'GET /test?encodeType=something',
+          target: 'https://localhost/test?encodeType=something',
+          type: 'Ajax',
+        },
+      });
+    });
+  });
+
+  describe('MetricData', () => {
+    const baseType = 'MetricData';
+
+    test('does nothing if there is no query', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        data: {
+          PageUrl: 'https://localhost/test',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        data: {
+          PageUrl: 'https://localhost/test',
+        },
+      });
+    });
+
+    test('does nothing if there are no targeted fields', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+      });
+    });
+
+    test('redacts single candidate query parameter', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        data: {
+          PageUrl: 'https://localhost/test?code=my-code',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        data: {
+          PageUrl: 'https://localhost/test?code=__redacted__',
+        },
+      });
+    });
+
+    test('redacts multiple candidate query parameters', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        data: {
+          PageUrl:
+            'https://localhost/test?password=my-password&code=my-code&token=my-token&email=my-email',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        data: {
+          PageUrl:
+            'https://localhost/test?password=__redacted__&code=__redacted__&token=__redacted__&email=__redacted__',
+        },
+      });
+    });
+
+    test('tries to redact query parameters on invalid URLs', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        data: {
+          PageUrl: 'not-a-url?password=my-password',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        data: {
+          PageUrl: 'not-a-url?password=__redacted__',
+        },
+      });
+    });
+
+    test.each(sensitiveQueryParamVariations)(
+      'redacts query parameter `%s`',
+      key => {
+        const telemetry: ITelemetryItem = {
+          baseType,
+          name: '',
+          data: {
+            PageUrl: `https://localhost/test?${key}=some-value`,
+          },
+        };
+
+        expect(filterSensitiveData(telemetry)).toBe(true);
+        expect(telemetry).toEqual<ITelemetryItem>({
+          baseType,
+          name: '',
+          data: {
+            PageUrl: `https://localhost/test?${key}=__redacted__`,
+          },
+        });
+      },
+    );
+
+    test('does nothing to non-candidate query parameters', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        data: {
+          PageUrl: 'https://localhost/test?key=value',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        data: {
+          PageUrl: 'https://localhost/test?key=value',
+        },
+      });
+    });
+
+    test('does nothing to non-candidate, lookalike query parameter', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        data: {
+          PageUrl: 'https://localhost/test?encodeType=something',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        data: {
+          PageUrl: 'https://localhost/test?encodeType=something',
+        },
+      });
+    });
+  });
+
+  describe('PageviewData', () => {
+    const baseType = 'PageviewData';
+
+    test('does nothing if there is no query', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          refUri: 'https://localhost/test',
+          uri: 'https://localhost/test',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          refUri: 'https://localhost/test',
+          uri: 'https://localhost/test',
+        },
+      });
+    });
+
+    test('does nothing if there are no targeted fields', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+      });
+    });
+
+    test('redacts single candidate query parameter', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          refUri: 'https://localhost/test?code=my-code',
+          uri: 'https://localhost/test?code=my-code',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          refUri: 'https://localhost/test?code=__redacted__',
+          uri: 'https://localhost/test?code=__redacted__',
+        },
+      });
+    });
+
+    test('redacts multiple candidate query parameters', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          refUri:
+            'https://localhost/test?password=my-password&code=my-code&token=my-token&email=my-email',
+          uri:
+            'https://localhost/test?password=my-password&code=my-code&token=my-token&email=my-email',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          refUri:
+            'https://localhost/test?password=__redacted__&code=__redacted__&token=__redacted__&email=__redacted__',
+          uri:
+            'https://localhost/test?password=__redacted__&code=__redacted__&token=__redacted__&email=__redacted__',
+        },
+      });
+    });
+
+    test('tries to redact query parameters on invalid URLs', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          refUri: 'not-a-url?password=my-password',
+          uri: 'not-a-url?password=my-password',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          refUri: 'not-a-url?password=__redacted__',
+          uri: 'not-a-url?password=__redacted__',
+        },
+      });
+    });
+
+    test.each(sensitiveQueryParamVariations)(
+      'redacts query parameter `%s`',
+      key => {
+        const telemetry: ITelemetryItem = {
+          baseType,
+          name: '',
+          baseData: {
+            refUri: `https://localhost/test?${key}=some-value`,
+            uri: `https://localhost/test?${key}=some-value`,
+          },
+        };
+
+        expect(filterSensitiveData(telemetry)).toBe(true);
+        expect(telemetry).toEqual<ITelemetryItem>({
+          baseType,
+          name: '',
+          baseData: {
+            refUri: `https://localhost/test?${key}=__redacted__`,
+            uri: `https://localhost/test?${key}=__redacted__`,
+          },
+        });
+      },
+    );
+
+    test('does nothing to non-candidate query parameters', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          refUri: 'https://localhost/test?key=value',
+          uri: 'https://localhost/test?key=value',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          refUri: 'https://localhost/test?key=value',
+          uri: 'https://localhost/test?key=value',
+        },
+      });
+    });
+
+    test('does nothing to non-candidate, lookalike query parameter', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          refUri: 'https://localhost/test?encodeType=something',
+          uri: 'https://localhost/test?encodeType=something',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          refUri: 'https://localhost/test?encodeType=something',
+          uri: 'https://localhost/test?encodeType=something',
+        },
+      });
+    });
+  });
+
+  describe('PageviewPerformanceData', () => {
+    const baseType = 'PageviewPerformanceData';
+
+    test('does nothing if there is no query', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          uri: 'https://localhost/test',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          uri: 'https://localhost/test',
+        },
+      });
+    });
+
+    test('does nothing if there are no targeted fields', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+      });
+    });
+
+    test('redacts single candidate query parameter', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          uri: 'https://localhost/test?code=my-code',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          uri: 'https://localhost/test?code=__redacted__',
+        },
+      });
+    });
+
+    test('redacts multiple candidate query parameters', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          uri:
+            'https://localhost/test?password=my-password&code=my-code&token=my-token&email=my-email',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          uri:
+            'https://localhost/test?password=__redacted__&code=__redacted__&token=__redacted__&email=__redacted__',
+        },
+      });
+    });
+
+    test('tries to redact query parameters on invalid URLs', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          uri: 'not-a-url?password=my-password',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          uri: 'not-a-url?password=__redacted__',
+        },
+      });
+    });
+
+    test.each(sensitiveQueryParamVariations)(
+      'redacts query parameter `%s`',
+      key => {
+        const telemetry: ITelemetryItem = {
+          baseType,
+          name: '',
+          baseData: {
+            uri: `https://localhost/test?${key}=some-value`,
+          },
+        };
+
+        expect(filterSensitiveData(telemetry)).toBe(true);
+        expect(telemetry).toEqual<ITelemetryItem>({
+          baseType,
+          name: '',
+          baseData: {
+            uri: `https://localhost/test?${key}=__redacted__`,
+          },
+        });
+      },
+    );
+
+    test('does nothing to non-candidate query parameters', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          uri: 'https://localhost/test?key=value',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          uri: 'https://localhost/test?key=value',
+        },
+      });
+    });
+
+    test('does nothing to non-candidate, lookalike query parameter', () => {
+      const telemetry: ITelemetryItem = {
+        baseType,
+        name: '',
+        baseData: {
+          uri: 'https://localhost/test?encodeType=something',
+        },
+      };
+
+      expect(filterSensitiveData(telemetry)).toBe(true);
+      expect(telemetry).toEqual<ITelemetryItem>({
+        baseType,
+        name: '',
+        baseData: {
+          uri: 'https://localhost/test?encodeType=something',
+        },
+      });
+    });
+  });
+});

--- a/src/explore-education-statistics-common/src/services/applicationInsightsService.ts
+++ b/src/explore-education-statistics-common/src/services/applicationInsightsService.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationInsights,
+  ITelemetryItem,
   SeverityLevel,
 } from '@microsoft/applicationinsights-web';
 
@@ -21,6 +22,8 @@ export function initApplicationInsights(
 
     if (!isInitialised) {
       appInsights.loadAppInsights();
+      appInsights.addTelemetryInitializer(filterSensitiveData);
+
       isInitialised = true;
 
       // eslint-disable-next-line no-console
@@ -37,4 +40,99 @@ export function initApplicationInsights(
  */
 export function getApplicationInsights(): ApplicationInsights {
   return appInsights;
+}
+
+const REDACTED_VALUE = '__redacted__';
+const REDACTED_TOKENS = [
+  'code',
+  'email',
+  'phone',
+  'token',
+  'passphrase',
+  'password',
+  'pass',
+  'user',
+  'name',
+  'username',
+  'firstname',
+  'lastname',
+  'fullname',
+];
+
+/* eslint-disable no-param-reassign */
+export function filterSensitiveData(telemetry: ITelemetryItem): boolean {
+  switch (telemetry.baseType) {
+    case 'RemoteDependencyData':
+      if (telemetry.baseData?.name) {
+        telemetry.baseData.name = filterUri(telemetry.baseData.name);
+      }
+
+      if (telemetry.baseData?.target) {
+        telemetry.baseData.target = filterUri(telemetry.baseData.target);
+      }
+
+      break;
+
+    case 'MetricData':
+      if (telemetry.data?.PageUrl) {
+        telemetry.data.PageUrl = filterUri(telemetry.data.PageUrl);
+      }
+
+      break;
+
+    case 'PageviewData':
+    case 'PageviewPerformanceData':
+      if (telemetry.baseData?.uri) {
+        telemetry.baseData.uri = filterUri(telemetry.baseData.uri);
+      }
+
+      if (telemetry.baseData?.refUri) {
+        telemetry.baseData.refUri = filterUri(telemetry.baseData.refUri);
+      }
+
+      break;
+
+    default:
+      return true;
+  }
+
+  return true;
+}
+/* eslint-enable no-param-reassign */
+
+function filterUri(uri: string): string {
+  const [path, query] = uri.split('?', 2);
+
+  if (!query) {
+    return uri;
+  }
+
+  const filteredQuery = query
+    .split('&')
+    .map(keyValue => {
+      const [key] = keyValue.split('=', 2);
+
+      if (!key) {
+        return keyValue;
+      }
+
+      return isRedactedKey(key) ? `${key}=${REDACTED_VALUE}` : keyValue;
+    })
+    .join('&');
+
+  return `${path}?${filteredQuery}`;
+}
+
+function isRedactedKey(key: string): boolean {
+  return decodeURIComponent(key)
+    .split(/[_\-:.|\s[\]+]/)
+    .some(part => {
+      if (REDACTED_TOKENS.includes(part.toLowerCase())) {
+        return true;
+      }
+
+      return part
+        .split(/([A-Z][a-z]*|[0-9])/)
+        .some(word => REDACTED_TOKENS.includes(word.toLowerCase()));
+    });
 }


### PR DESCRIPTION
This PR adds filtering to strip out sensitive information from telemetry being sent to Application Insights in both the backend and frontend.

The main intention for this is to be coupled with [EES-2823](https://dfedigital.atlassian.net/browse/EES-2823) where the websocket handshake relies on passing the user's access token via an `access_token` query parameter. Unfortunately, this is problematic as these query strings would get logged out to Application Insights, making it a security vulnerability.

We have implemented this as a fairly simplistic algorithm that detects if a query string parameter contains one of several redactable words (e.g. the word `email`, `code` or `token`). We try to account for potential false positives (e.g. `code` is in the word `encode`) by splitting up the key up into its constituent tokens i.e. `emailAddress1` becomes `email`, `address` and `1`. We can then check more precisely against each of these tokens to see if there was a match.

This is currently only aimed at filtering sensitive data from URL query strings, but could be extended in the future to other things as well.