### PR TITLE
EES-2996 Dev ADF pipelines now run concurrency

### DIFF
--- a/infrastructure/parameters/dev.parameters.json
+++ b/infrastructure/parameters/dev.parameters.json
@@ -73,6 +73,9 @@
     },
     "maxDbSizeBytes": {
       "value": 322122547200
+    },
+    "dataFactoryConcurrency": {
+      "value": 10
     }
   }
 }

--- a/infrastructure/templates/datafactory/components/template.json
+++ b/infrastructure/templates/datafactory/components/template.json
@@ -19,6 +19,12 @@
             "metadata": {
                 "description": "The name of the key vault"
             }
+        },
+        "factoryConcurrency": {
+            "type": "int",
+            "metadata": {
+                "description": "Maximum number of runs pipelines will run in parallel"
+            }
         }
     },
     "variables": {
@@ -2075,7 +2081,7 @@
                         "defaultValue": "24B9CBA7-C873-4BF2-8329-355F5FDA14AB"
                     }
                 },
-                "concurrency": 10,
+                "concurrency": "[parameters('factoryConcurrency')]",
                 "annotations": []
             },
             "dependsOn": [
@@ -2877,7 +2883,7 @@
                         "defaultValue": "24B9CBA7-C873-4BF2-8329-355F5FDA14AB"
                     }
                 },
-                "concurrency": 10,
+                "concurrency":  "[parameters('factoryConcurrency')]",
                 "annotations": []
             },
             "dependsOn": [

--- a/infrastructure/templates/datafactory/template.json
+++ b/infrastructure/templates/datafactory/template.json
@@ -24,6 +24,12 @@
         "description": "The data factory name"
       }
     },
+    "dataFactoryConcurrency": {
+      "type": "int",
+      "metadata": {
+        "description": "Maximum number of times a DF pipeline will run in parallel"
+      }
+    },
     "keyVaultName": {
       "type": "string",
       "metadata": {
@@ -79,6 +85,9 @@
           },
           "keyVaultName": {
             "value": "[parameters('keyVaultName')]"
+          },
+          "factoryConcurrency": {
+            "value": "[parameters('dataFactoryConcurrency')]"
           }
         }
       },

--- a/infrastructure/templates/template.json
+++ b/infrastructure/templates/template.json
@@ -564,6 +564,10 @@
       "metadata": {
         "description": "Slack webhook URI for alerts"
       }
+    },
+    "dataFactoryConcurrency": {
+      "type": "int",
+      "defaultValue": 1
     }
   },
   "variables": {
@@ -3334,6 +3338,9 @@
           },
           "dataFactoryName": {
             "value": "[variables('dataFactoryName')]"
+          },
+          "dataFactoryConcurrency": {
+            "value": "[parameters('dataFactoryConcurrency')]"
           },
           "keyVaultName": {
             "value": "[variables('keyVaultName')]"


### PR DESCRIPTION
This PR sets Data Factory config to make pipelines run concurrently. The default is "1" (i.e. no concurrency), but I've set Dev to "10". This value might want tweaking.

This has been changed due to a problem we had with the UI test runs against Dev. So many releases were trying to get published at once that test suites would fail. Hopefully, by having pipeline runs run concurrently, this will solve the issue of "queued" pipeline runs.