### PR TITLE
EES-2556 reorder datasets

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.module.scss
@@ -23,3 +23,42 @@
     margin-bottom: govuk-spacing(4);
   }
 }
+
+.item {
+  background: govuk-colour('white');
+  border-bottom: 1px solid govuk-colour('mid-grey');
+  display: flex;
+  justify-content: space-between;
+  padding: govuk-spacing(3) 0;
+
+  &:last-of-type {
+    border-bottom: 0;
+  }
+}
+
+.dropArea {
+  background: govuk-colour('light-grey');
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+}
+
+.isReordering {
+  position: relative;
+
+  &::before {
+    color: govuk-colour('dark-grey');
+    content: '\2630';
+    cursor: grab;
+    font-size: 1.6rem;
+    position: absolute;
+    right: 0;
+    top: 11px;
+  }
+
+  &:focus {
+    @include govuk-focused-text;
+  }
+}
+
+.isDragging {
+  @include govuk-focused-text;
+}

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.module.scss
@@ -26,14 +26,6 @@
 
 .item {
   background: govuk-colour('white');
-  border-bottom: 1px solid govuk-colour('mid-grey');
-  display: flex;
-  justify-content: space-between;
-  padding: govuk-spacing(3) 0;
-
-  &:last-of-type {
-    border-bottom: 0;
-  }
 }
 
 .dropArea {
@@ -51,7 +43,7 @@
     font-size: 1.6rem;
     position: absolute;
     right: 0;
-    top: 11px;
+    top: 6px;
   }
 
   &:focus {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
@@ -5,6 +5,7 @@ import generateDataSetLabel from '@admin/pages/release/datablocks/components/cha
 import Button from '@common/components/Button';
 import ButtonText from '@common/components/ButtonText';
 import { Form, FormFieldSelect, FormSelect } from '@common/components/form';
+import VisuallyHidden from '@common/components/VisuallyHidden';
 import { DataSet } from '@common/modules/charts/types/dataSet';
 import expandDataSet from '@common/modules/charts/util/expandDataSet';
 import generateDataSetKey from '@common/modules/charts/util/generateDataSetKey';
@@ -216,60 +217,75 @@ const ChartDataSetsConfiguration = ({
           >
             <Droppable droppableId="droppable" isDropDisabled={!isReordering}>
               {(droppableProvided, droppableSnapshot) => (
-                <ol
-                  ref={droppableProvided.innerRef}
-                  className={classNames('govuk-list', {
-                    [styles.dropArea]: droppableSnapshot.isDraggingOver,
-                  })}
-                >
-                  {dataSets.map((dataSet, index) => {
-                    const expandedDataSet = expandDataSet(dataSet, meta);
-                    const label = generateDataSetLabel(expandedDataSet);
-                    const itemId = `items-${index}`;
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Data set</th>
+                      <th>
+                        <VisuallyHidden>Actions</VisuallyHidden>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody
+                    ref={droppableProvided.innerRef}
+                    className={classNames({
+                      [styles.dropArea]: droppableSnapshot.isDraggingOver,
+                    })}
+                  >
+                    {dataSets.map((dataSet, index) => {
+                      const expandedDataSet = expandDataSet(dataSet, meta);
+                      const label = generateDataSetLabel(expandedDataSet);
+                      const key = generateDataSetKey(dataSet);
 
-                    return (
-                      <Draggable
-                        draggableId={itemId}
-                        isDragDisabled={!isReordering}
-                        key={itemId}
-                        index={index}
-                      >
-                        {(draggableProvided, draggableSnapshot) => (
-                          <li
-                            key={generateDataSetKey(dataSet)}
-                            // eslint-disable-next-line react/jsx-props-no-spreading
-                            {...draggableProvided.draggableProps}
-                            // eslint-disable-next-line react/jsx-props-no-spreading
-                            {...draggableProvided.dragHandleProps}
-                            className={classNames(styles.item, {
-                              [styles.isReordering]: isReordering,
-                              [styles.isDragging]: draggableSnapshot.isDragging,
-                            })}
-                            ref={draggableProvided.innerRef}
-                          >
-                            {label}
-                            {!isReordering && (
-                              <ButtonText
-                                className="govuk-!-margin-bottom-0"
-                                onClick={() => {
-                                  if (onChange) {
-                                    const nextDataSets = [...dataSets];
-                                    nextDataSets.splice(index, 1);
-
-                                    onChange(nextDataSets);
-                                  }
-                                }}
+                      return (
+                        <Draggable
+                          draggableId={key}
+                          isDragDisabled={!isReordering}
+                          key={key}
+                          index={index}
+                        >
+                          {(draggableProvided, draggableSnapshot) => (
+                            <tr
+                              // eslint-disable-next-line react/jsx-props-no-spreading
+                              {...draggableProvided.draggableProps}
+                              // eslint-disable-next-line react/jsx-props-no-spreading
+                              {...draggableProvided.dragHandleProps}
+                              className={classNames(styles.item, {
+                                [styles.isDragging]:
+                                  draggableSnapshot.isDragging,
+                              })}
+                              ref={draggableProvided.innerRef}
+                            >
+                              <td>{label}</td>
+                              <td
+                                className={classNames('dfe-align--right', {
+                                  [styles.isReordering]: isReordering,
+                                })}
                               >
-                                Remove
-                              </ButtonText>
-                            )}
-                          </li>
-                        )}
-                      </Draggable>
-                    );
-                  })}
-                  {droppableProvided.placeholder}
-                </ol>
+                                {!isReordering && (
+                                  <ButtonText
+                                    className="govuk-!-margin-bottom-0"
+                                    onClick={() => {
+                                      if (onChange) {
+                                        const nextDataSets = [...dataSets];
+                                        nextDataSets.splice(index, 1);
+
+                                        onChange(nextDataSets);
+                                      }
+                                    }}
+                                  >
+                                    Remove
+                                  </ButtonText>
+                                )}
+                              </td>
+                            </tr>
+                          )}
+                        </Draggable>
+                      );
+                    })}
+                    {droppableProvided.placeholder}
+                  </tbody>
+                </table>
               )}
             </Droppable>
           </DragDropContext>

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
@@ -159,16 +159,17 @@ describe('ChartDataSetsConfiguration', () => {
       </ChartBuilderFormsContextProvider>,
     );
 
-    const items = screen.getAllByRole('listitem');
-    expect(items).toHaveLength(3);
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(4);
 
-    expect(items[0]).toHaveTextContent(
+    expect(rows[0].children[0]).toHaveTextContent('Data set');
+    expect(rows[1].children[0]).toHaveTextContent(
       'Number of authorised absence sessions (Male, All locations, All time periods)',
     );
-    expect(items[1]).toHaveTextContent(
+    expect(rows[2].children[0]).toHaveTextContent(
       'Number of authorised absence sessions (Male, Barnet, All time periods)',
     );
-    expect(items[2]).toHaveTextContent(
+    expect(rows[3].children[0]).toHaveTextContent(
       'Number of authorised absence sessions (Male, Barnet, 2019/20)',
     );
   });
@@ -875,19 +876,12 @@ describe('ChartDataSetsConfiguration', () => {
         </ChartBuilderFormsContextProvider>,
       );
 
-      const items = screen.getAllByRole('listitem');
-      expect(items).toHaveLength(2);
-
-      expect(items[0]).toHaveTextContent(
-        'Number of authorised absence sessions (Female, All locations, All time periods)',
-      );
-      expect(items[1]).toHaveTextContent(
-        'Number of unauthorised absence sessions (Male, All locations, All time periods)',
-      );
+      const rows = screen.getAllByRole('row');
+      expect(rows).toHaveLength(3);
 
       expect(handleChange).not.toHaveBeenCalled();
 
-      userEvent.click(within(items[0]).getByRole('button', { name: 'Remove' }));
+      userEvent.click(within(rows[1]).getByRole('button', { name: 'Remove' }));
 
       expect(handleChange).toHaveBeenCalledWith([
         {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
@@ -159,18 +159,17 @@ describe('ChartDataSetsConfiguration', () => {
       </ChartBuilderFormsContextProvider>,
     );
 
-    const rows = screen.getAllByRole('row');
-    expect(rows).toHaveLength(4);
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
 
-    expect(rows[0].children[0]).toHaveTextContent('Data set');
-    expect(rows[1].children[0]).toHaveTextContent(
-      'Number of authorised absence sessions (Male, All locations, All time periods)',
+    expect(items[0]).toHaveTextContent(
+      'Number of authorised absence sessions (Male, All locations, All time periods)Remove',
     );
-    expect(rows[2].children[0]).toHaveTextContent(
-      'Number of authorised absence sessions (Male, Barnet, All time periods)',
+    expect(items[1]).toHaveTextContent(
+      'Number of authorised absence sessions (Male, Barnet, All time periods)Remove',
     );
-    expect(rows[3].children[0]).toHaveTextContent(
-      'Number of authorised absence sessions (Male, Barnet, 2019/20)',
+    expect(items[2]).toHaveTextContent(
+      'Number of authorised absence sessions (Male, Barnet, 2019/20)Remove',
     );
   });
 
@@ -204,6 +203,57 @@ describe('ChartDataSetsConfiguration', () => {
       expect(screen.getByText('Cannot save chart')).toBeInTheDocument();
       expect(screen.getByText('Options tab is invalid')).toBeInTheDocument();
     });
+  });
+
+  test('toggles the reorder controls on and off', () => {
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartDataSetsConfiguration
+          meta={testSubjectMeta}
+          dataSets={[
+            {
+              indicator: 'authorised-absence-sessions',
+              filters: ['male'],
+            },
+            {
+              indicator: 'authorised-absence-sessions',
+              filters: ['male'],
+              location: {
+                level: 'localAuthority',
+                value: 'barnet',
+              },
+            },
+            {
+              indicator: 'authorised-absence-sessions',
+              filters: ['male'],
+              location: {
+                level: 'localAuthority',
+                value: 'barnet',
+              },
+              timePeriod: '2019_AY',
+            },
+          ]}
+          onChange={noop}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Reorder data sets',
+      }),
+    );
+    expect(
+      screen.queryByRole('button', {
+        name: 'Reorder data sets',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Finish reordering' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Remove' }),
+    ).not.toBeInTheDocument();
   });
 
   describe('add data set form', () => {
@@ -825,14 +875,19 @@ describe('ChartDataSetsConfiguration', () => {
         </ChartBuilderFormsContextProvider>,
       );
 
-      const tableRows = screen.getAllByRole('row');
-      expect(tableRows).toHaveLength(3);
+      const items = screen.getAllByRole('listitem');
+      expect(items).toHaveLength(2);
+
+      expect(items[0]).toHaveTextContent(
+        'Number of authorised absence sessions (Female, All locations, All time periods)Remove',
+      );
+      expect(items[1]).toHaveTextContent(
+        'Number of unauthorised absence sessions (Male, All locations, All time periods)Remove',
+      );
 
       expect(handleChange).not.toHaveBeenCalled();
 
-      userEvent.click(
-        within(tableRows[1]).getByRole('button', { name: 'Remove' }),
-      );
+      userEvent.click(within(items[0]).getByRole('button', { name: 'Remove' }));
 
       expect(handleChange).toHaveBeenCalledWith([
         {

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
@@ -163,13 +163,13 @@ describe('ChartDataSetsConfiguration', () => {
     expect(items).toHaveLength(3);
 
     expect(items[0]).toHaveTextContent(
-      'Number of authorised absence sessions (Male, All locations, All time periods)Remove',
+      'Number of authorised absence sessions (Male, All locations, All time periods)',
     );
     expect(items[1]).toHaveTextContent(
-      'Number of authorised absence sessions (Male, Barnet, All time periods)Remove',
+      'Number of authorised absence sessions (Male, Barnet, All time periods)',
     );
     expect(items[2]).toHaveTextContent(
-      'Number of authorised absence sessions (Male, Barnet, 2019/20)Remove',
+      'Number of authorised absence sessions (Male, Barnet, 2019/20)',
     );
   });
 
@@ -879,10 +879,10 @@ describe('ChartDataSetsConfiguration', () => {
       expect(items).toHaveLength(2);
 
       expect(items[0]).toHaveTextContent(
-        'Number of authorised absence sessions (Female, All locations, All time periods)Remove',
+        'Number of authorised absence sessions (Female, All locations, All time periods)',
       );
       expect(items[1]).toHaveTextContent(
-        'Number of unauthorised absence sessions (Male, All locations, All time periods)Remove',
+        'Number of unauthorised absence sessions (Male, All locations, All time periods)',
       );
 
       expect(handleChange).not.toHaveBeenCalled();

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
@@ -1340,4 +1340,341 @@ describe('createDataSetCategories', () => {
     expect(dataSetCategories[0].filter.label).toBe('State-funded primary');
     expect(dataSetCategories[1].filter.label).toBe('State-funded secondary');
   });
+
+  describe('ordering dataSetCategories', () => {
+    const testAxisConfigurationForOrdering: AxisConfiguration = {
+      type: 'major',
+      groupBy: 'timePeriod',
+      sortAsc: true,
+      dataSets: [
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnsley',
+          },
+          timePeriod: '2015_AY',
+        },
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnet',
+          },
+          timePeriod: '2015_AY',
+        },
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnet',
+          },
+          timePeriod: '2014_AY',
+        },
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnsley',
+          },
+          timePeriod: '2014_AY',
+        },
+      ],
+      referenceLines: [],
+      visible: true,
+      unit: '',
+      min: 0,
+    };
+
+    test('dataSetCategories should be ordered by the order of the dataSets when grouped by timeperiod', () => {
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        testAxisConfigurationForOrdering,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.value).toBe('2015_AY');
+      expect(dataSetCategories[1].filter.value).toBe('2014_AY');
+
+      const dataSets1 = Object.values(dataSetCategories[0].dataSets);
+      expect(dataSets1).toHaveLength(2);
+      expect(dataSets1[0].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnsley',
+        },
+        timePeriod: '2015_AY',
+      });
+      expect(dataSets1[1].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnet',
+        },
+        timePeriod: '2015_AY',
+      });
+
+      const dataSets2 = Object.values(dataSetCategories[1].dataSets);
+      expect(dataSets2).toHaveLength(2);
+      expect(dataSets2[0].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnet',
+        },
+        timePeriod: '2014_AY',
+      });
+      expect(dataSets2[1].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnsley',
+        },
+        timePeriod: '2014_AY',
+      });
+    });
+
+    test('dataSetCategories should be ordered by the order of the dataSets when grouped by filter', () => {
+      const axisConfiguration: AxisConfiguration = {
+        ...testAxisConfigurationForOrdering,
+        groupBy: 'filters',
+      };
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        axisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.value).toBe('ethnicity-major-chinese');
+      expect(dataSetCategories[1].filter.value).toBe('state-funded-primary');
+
+      const dataSets1 = Object.values(dataSetCategories[0].dataSets);
+      expect(dataSets1).toHaveLength(4);
+      expect(dataSets1[0].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnsley',
+        },
+        timePeriod: '2015_AY',
+      });
+      expect(dataSets1[1].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnet',
+        },
+        timePeriod: '2015_AY',
+      });
+      expect(dataSets1[2].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnet',
+        },
+        timePeriod: '2014_AY',
+      });
+      expect(dataSets1[3].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnsley',
+        },
+        timePeriod: '2014_AY',
+      });
+
+      const dataSets2 = Object.values(dataSetCategories[1].dataSets);
+      expect(dataSets2).toHaveLength(4);
+      expect(dataSets2[0].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnsley',
+        },
+        timePeriod: '2015_AY',
+      });
+      expect(dataSets2[1].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnet',
+        },
+        timePeriod: '2015_AY',
+      });
+      expect(dataSets2[2].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnet',
+        },
+        timePeriod: '2014_AY',
+      });
+      expect(dataSets2[3].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnsley',
+        },
+        timePeriod: '2014_AY',
+      });
+    });
+
+    test('dataSetCategories should be ordered by the order of the dataSets when grouped by indicator', () => {
+      const axisConfiguration: AxisConfiguration = {
+        ...testAxisConfigurationForOrdering,
+        groupBy: 'indicators',
+      };
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        axisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(1);
+      expect(dataSetCategories[0].filter.value).toBe(
+        'authorised-absence-sessions',
+      );
+      const dataSets1 = Object.values(dataSetCategories[0].dataSets);
+      expect(dataSets1).toHaveLength(4);
+      expect(dataSets1[0].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnsley',
+        },
+        timePeriod: '2015_AY',
+      });
+      expect(dataSets1[1].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnet',
+        },
+        timePeriod: '2015_AY',
+      });
+      expect(dataSets1[2].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnet',
+        },
+        timePeriod: '2014_AY',
+      });
+      expect(dataSets1[3].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnsley',
+        },
+        timePeriod: '2014_AY',
+      });
+    });
+
+    test('dataSetCategories should be ordered by the order of the dataSets when grouped by indicator', () => {
+      const axisConfiguration: AxisConfiguration = {
+        ...testAxisConfigurationForOrdering,
+        groupBy: 'locations',
+      };
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        axisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.value).toBe('barnsley');
+      expect(dataSetCategories[1].filter.value).toBe('barnet');
+      const dataSets1 = Object.values(dataSetCategories[0].dataSets);
+      expect(dataSets1).toHaveLength(2);
+      expect(dataSets1[0].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnsley',
+        },
+        timePeriod: '2015_AY',
+      });
+      expect(dataSets1[1].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnsley',
+        },
+        timePeriod: '2014_AY',
+      });
+
+      const dataSets2 = Object.values(dataSetCategories[1].dataSets);
+      expect(dataSets2).toHaveLength(2);
+      expect(dataSets2[0].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnet',
+        },
+        timePeriod: '2015_AY',
+      });
+      expect(dataSets2[1].dataSet).toEqual<DataSet>({
+        indicator: 'authorised-absence-sessions',
+        filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+        location: {
+          level: 'localAuthority',
+          value: 'barnet',
+        },
+        timePeriod: '2014_AY',
+      });
+    });
+
+    test('setting sortAsc to false should reverse the order of the dataSetCategories', () => {
+      const axisConfiguration: AxisConfiguration = {
+        ...testAxisConfigurationForOrdering,
+        groupBy: 'filters',
+        sortAsc: false,
+      };
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        axisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[1].filter.value).toBe('ethnicity-major-chinese');
+      expect(dataSetCategories[0].filter.value).toBe('state-funded-primary');
+    });
+  });
+
+  //reverse sort
+  //diff groupbys
 });
+
+// TO DO add tests for ordering

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
@@ -1341,7 +1341,7 @@ describe('createDataSetCategories', () => {
     expect(dataSetCategories[1].filter.label).toBe('State-funded secondary');
   });
 
-  describe('ordering dataSetCategories', () => {
+  describe('ordering', () => {
     const testAxisConfigurationForOrdering: AxisConfiguration = {
       type: 'major',
       groupBy: 'timePeriod',
@@ -1390,7 +1390,7 @@ describe('createDataSetCategories', () => {
       min: 0,
     };
 
-    test('dataSetCategories should be ordered by the order of the dataSets when grouped by timeperiod', () => {
+    test('orders by order of configuration dataSets when grouped by time period', () => {
       const fullTable = mapFullTable(testTable);
       const dataSetCategories = createDataSetCategories(
         testAxisConfigurationForOrdering,
@@ -1445,7 +1445,7 @@ describe('createDataSetCategories', () => {
       });
     });
 
-    test('dataSetCategories should be ordered by the order of the dataSets when grouped by filter', () => {
+    test('orders by order of configuration dataSets when grouped by filter', () => {
       const axisConfiguration: AxisConfiguration = {
         ...testAxisConfigurationForOrdering,
         groupBy: 'filters',
@@ -1540,7 +1540,7 @@ describe('createDataSetCategories', () => {
       });
     });
 
-    test('dataSetCategories should be ordered by the order of the dataSets when grouped by indicator', () => {
+    test('orders by order of configuration dataSets when grouped by indicator', () => {
       const axisConfiguration: AxisConfiguration = {
         ...testAxisConfigurationForOrdering,
         groupBy: 'indicators',
@@ -1596,7 +1596,7 @@ describe('createDataSetCategories', () => {
       });
     });
 
-    test('dataSetCategories should be ordered by the order of the dataSets when grouped by indicator', () => {
+    test('orders by order of configuration dataSets when grouped by location', () => {
       const axisConfiguration: AxisConfiguration = {
         ...testAxisConfigurationForOrdering,
         groupBy: 'locations',
@@ -1654,7 +1654,7 @@ describe('createDataSetCategories', () => {
       });
     });
 
-    test('setting sortAsc to false should reverse the order of the dataSetCategories', () => {
+    test('order is reversed when sortAsc = true', () => {
       const axisConfiguration: AxisConfiguration = {
         ...testAxisConfigurationForOrdering,
         groupBy: 'filters',
@@ -1672,9 +1672,4 @@ describe('createDataSetCategories', () => {
       expect(dataSetCategories[0].filter.value).toBe('state-funded-primary');
     });
   });
-
-  //reverse sort
-  //diff groupbys
 });
-
-// TO DO add tests for ordering

--- a/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
@@ -221,7 +221,7 @@ function createKeyedDataSets(
 /**
  * Order the categories by dataSet order.
  */
-function sortDataSetCategories(
+function getSortedDataSetCategoriesRange(
   dataSetCategories: DataSetCategory[],
   axisConfiguration: AxisConfiguration,
 ): DataSetCategory[] {
@@ -346,7 +346,7 @@ export default function createDataSetCategories(
     })
     .filter(category => Object.values(category.dataSets).length > 0);
 
-  return sortDataSetCategories(dataSetCategories, axisConfiguration);
+  return getSortedDataSetCategoriesRange(dataSetCategories, axisConfiguration);
 }
 
 export const toChartData = (chartCategory: DataSetCategory): ChartData => {


### PR DESCRIPTION
Adds reordering to chart data sets to allow users to control the ordering in the chart. This was originally going to be on the legend tab, which is a bit more user friendly, but doesn't work for reordering data set categories.

**Reorder button:**
![reorder1](https://user-images.githubusercontent.com/81572860/151140301-e00a2c26-32f4-410a-984c-7b8de7dd8f88.PNG)
**Reordering:**
![reorder2](https://user-images.githubusercontent.com/81572860/151140304-7cc5a034-8a24-4834-b697-b32e7d4d8f19.PNG)
