### PR TITLE
EES-3014 - change figcaptions on tables to have dynamic IDs

### DIFF
--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/DataBlockTabs.tsx
@@ -124,6 +124,7 @@ const DataBlockTabs = ({
               <ErrorBoundary fallback={errorMessage}>
                 <TimePeriodDataTable
                   key={dataBlock.id}
+                  dataBlockId={dataBlock.id}
                   fullTable={fullTable}
                   captionTitle={dataBlock?.heading}
                   source={dataBlock?.source}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FixedMultiHeaderDataTable.tsx
@@ -9,7 +9,7 @@ const mobileWidth = 1024;
 
 interface Props extends OmitStrict<MultiHeaderTableProps, 'ariaLabelledBy'> {
   caption: ReactNode;
-  captionId?: string;
+  captionId: string;
   innerRef?: Ref<HTMLElement>;
   footnotes?: FullTableMeta['footnotes'];
   source?: string;
@@ -17,12 +17,7 @@ interface Props extends OmitStrict<MultiHeaderTableProps, 'ariaLabelledBy'> {
 
 const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
   (props, ref) => {
-    const {
-      caption,
-      captionId = 'dataTableCaption',
-      footnotes = [],
-      source,
-    } = props;
+    const { caption, captionId, footnotes = [], source } = props;
 
     const containerRef = useRef<HTMLDivElement>(null);
     const mainTableRef = useRef<HTMLTableElement>(null);
@@ -35,21 +30,21 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
           window.innerWidth <= mobileWidth
         ) {
           mainTableRef.current
-            .querySelectorAll<HTMLTableHeaderCellElement>('thead td')
+            .querySelectorAll<HTMLTableCellElement>('thead td')
             .forEach(el => {
               // eslint-disable-next-line no-param-reassign
               el.style.transform = '';
             });
 
           mainTableRef.current
-            .querySelectorAll<HTMLTableHeaderCellElement>('thead th')
+            .querySelectorAll<HTMLTableCellElement>('thead th')
             .forEach(el => {
               // eslint-disable-next-line no-param-reassign
               el.style.transform = '';
             });
 
           mainTableRef.current
-            .querySelectorAll<HTMLTableHeaderCellElement>('tbody th')
+            .querySelectorAll<HTMLTableCellElement>('tbody th')
             .forEach(el => {
               // eslint-disable-next-line no-param-reassign
               el.style.transform = '';
@@ -77,21 +72,21 @@ const FixedMultiHeaderDataTable = forwardRef<HTMLElement, Props>(
 
             if (mainTableRef.current && window.innerWidth >= mobileWidth) {
               mainTableRef.current
-                .querySelectorAll<HTMLTableHeaderCellElement>('thead td')
+                .querySelectorAll<HTMLTableCellElement>('thead td')
                 .forEach(el => {
                   // eslint-disable-next-line no-param-reassign
                   el.style.transform = `translate(${scrollLeft}px, ${scrollTop}px)`;
                 });
 
               mainTableRef.current
-                .querySelectorAll<HTMLTableHeaderCellElement>('thead th')
+                .querySelectorAll<HTMLTableCellElement>('thead th')
                 .forEach(el => {
                   // eslint-disable-next-line no-param-reassign
                   el.style.transform = `translate(0, ${scrollTop}px)`;
                 });
 
               mainTableRef.current
-                .querySelectorAll<HTMLTableHeaderCellElement>('tbody th')
+                .querySelectorAll<HTMLTableCellElement>('tbody th')
                 .forEach(el => {
                   // eslint-disable-next-line no-param-reassign
                   el.style.transform = `translate(${scrollLeft}px, 0)`;

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodDataTable.tsx
@@ -103,11 +103,12 @@ interface Props {
   fullTable: FullTable;
   tableHeadersConfig: TableHeadersConfig;
   source?: string;
+  dataBlockId?: string;
 }
 
 const TimePeriodDataTableInternal = forwardRef<HTMLElement, Props>(
   function TimePeriodDataTableInternal(
-    { fullTable, tableHeadersConfig, captionTitle, source }: Props,
+    { fullTable, tableHeadersConfig, captionTitle, source, dataBlockId }: Props,
     dataTableRef,
   ) {
     const { subjectMeta, results } = fullTable;
@@ -310,13 +311,18 @@ const TimePeriodDataTableInternal = forwardRef<HTMLElement, Props>(
 
     const rows = filteredCartesian.map(row => row.map(cell => cell.text));
 
+    const captionId = dataBlockId
+      ? `dataTableCaption-${dataBlockId}`
+      : 'dataTableCaption';
+
     return (
       <FixedMultiHeaderDataTable
+        captionId={captionId}
         caption={
           <DataTableCaption
             {...subjectMeta}
             title={captionTitle}
-            id="dataTableCaption"
+            id={captionId}
           />
         }
         columnHeaders={columnHeaders}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FixedMultiHeaderDataTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FixedMultiHeaderDataTable.test.tsx
@@ -8,6 +8,7 @@ describe('FixedMultiHeaderDataTable', () => {
     const { container } = render(
       <FixedMultiHeaderDataTable
         caption="Test table"
+        captionId="test-caption-id"
         columnHeaders={[
           new Header('A', 'Col group A')
             .addChild(new Header('C', 'Col C'))
@@ -25,6 +26,8 @@ describe('FixedMultiHeaderDataTable', () => {
     );
 
     const table = container.querySelector('table') as HTMLElement;
+
+    expect(table).toHaveAttribute('aria-labelledby', 'test-caption-id');
 
     expect(table.querySelectorAll('thead tr')).toHaveLength(2);
     expect(table.querySelectorAll('thead tr:nth-child(1) th')).toHaveLength(2);

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
@@ -806,4 +806,134 @@ describe('TimePeriodDataTable', () => {
 
     expect(table).toMatchSnapshot();
   });
+
+  test('renders table correctly with no `dataBlockId` ', () => {
+    const fullTable = mapFullTable(testDataFiltersWithNoResults.fullTable);
+
+    const tableHeadersConfig: UnmappedTableHeadersConfig = {
+      columnGroups: [
+        [
+          {
+            value: 'b3207d77-143b-43d5-8b48-32d29727e96f',
+            type: 'Filter',
+          },
+        ],
+      ],
+      rowGroups: [
+        [
+          { value: 'E08000026', type: 'Location', level: 'localAuthority' },
+          { value: 'E09000008', type: 'Location', level: 'localAuthority' },
+        ],
+        [
+          {
+            value: '5675d1fa-77fd-4dfd-bb1f-08d78f6f2c4d',
+            type: 'Filter',
+          },
+          {
+            value: '53da1e17-184f-43f6-bb27-08d78f6f2c4d',
+            type: 'Filter',
+          },
+        ],
+      ],
+      columns: [
+        { value: '2013_AY', type: 'TimePeriod' },
+        { value: '2014_AY', type: 'TimePeriod' },
+        { value: '2015_AY', type: 'TimePeriod' },
+      ],
+      rows: [
+        {
+          value: '0003d2ac-4425-4432-2afb-08d78f6f2b08',
+          type: 'Indicator',
+        },
+        {
+          value: '829460cd-ae9e-4266-2aff-08d78f6f2b08',
+          type: 'Indicator',
+        },
+      ],
+    };
+
+    render(
+      <TimePeriodDataTable
+        fullTable={fullTable}
+        tableHeadersConfig={mapTableHeadersConfig(
+          tableHeadersConfig,
+          fullTable,
+        )}
+      />,
+    );
+    expect(screen.getByRole('table')).toHaveAttribute(
+      'aria-labelledby',
+      'dataTableCaption',
+    );
+    expect(screen.getByTestId('dataTableCaption')).toHaveAttribute(
+      'id',
+      'dataTableCaption',
+    );
+  });
+
+  test('renders table & caption correctly with `dataBlockId`', () => {
+    const fullTable = mapFullTable(testDataFiltersWithNoResults.fullTable);
+
+    const tableHeadersConfig: UnmappedTableHeadersConfig = {
+      columnGroups: [
+        [
+          {
+            value: 'b3207d77-143b-43d5-8b48-32d29727e96f',
+            type: 'Filter',
+          },
+        ],
+      ],
+      rowGroups: [
+        [
+          { value: 'E08000026', type: 'Location', level: 'localAuthority' },
+          { value: 'E09000008', type: 'Location', level: 'localAuthority' },
+        ],
+        [
+          {
+            value: '5675d1fa-77fd-4dfd-bb1f-08d78f6f2c4d',
+            type: 'Filter',
+          },
+          {
+            value: '53da1e17-184f-43f6-bb27-08d78f6f2c4d',
+            type: 'Filter',
+          },
+        ],
+      ],
+      columns: [
+        { value: '2013_AY', type: 'TimePeriod' },
+        { value: '2014_AY', type: 'TimePeriod' },
+        { value: '2015_AY', type: 'TimePeriod' },
+      ],
+      rows: [
+        {
+          value: '0003d2ac-4425-4432-2afb-08d78f6f2b08',
+          type: 'Indicator',
+        },
+        {
+          value: '829460cd-ae9e-4266-2aff-08d78f6f2b08',
+          type: 'Indicator',
+        },
+      ],
+    };
+
+    render(
+      <TimePeriodDataTable
+        dataBlockId="test-datablock-id"
+        fullTable={fullTable}
+        tableHeadersConfig={mapTableHeadersConfig(
+          tableHeadersConfig,
+          fullTable,
+        )}
+      />,
+    );
+
+    expect(screen.getByRole('table')).toHaveAttribute(
+      'aria-labelledby',
+      'dataTableCaption-test-datablock-id',
+    );
+    expect(screen.getByTestId('dataTableCaption')).toHaveAttribute(
+      'id',
+      'dataTableCaption-test-datablock-id',
+    );
+  });
 });

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FixedMultiHeaderDataTable.test.tsx.snap
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__snapshots__/FixedMultiHeaderDataTable.test.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`FixedMultiHeaderDataTable renders underlying table 1`] = `
 <table
-  aria-labelledby="dataTableCaption"
+  aria-labelledby="test-caption-id"
   class="govuk-table table"
-  data-testid="dataTableCaption-table"
+  data-testid="test-caption-id-table"
 >
   <thead
     class="tableHead"


### PR DESCRIPTION
This PR: 
- Changes `figcaption` elements that are in tables to have dynamic IDs instead of `dataTableCaption`. This was raised as part of the DAC accessibility assessment