### PR TITLE
EES-3132 - fix flaky UI test assertion

### DIFF
--- a/tests/robot-tests/tests/admin/analyst/invite_contributor_as_publication_owner.robot
+++ b/tests/robot-tests/tests/admin/analyst/invite_contributor_as_publication_owner.robot
@@ -155,8 +155,7 @@ Validate contributors for 2000/01 release again
     user waits until page contains    Analyst1 User1 (ees-analyst1@education.gov.uk)
     user checks page does not contain    Analyst2 User2 (ees-analyst2@education.gov.uk)
     user checks page does not contain    Analyst3 User3 (ees-analyst3@education.gov.uk)
-
-    user checks page contains    ees-analyst-%{RUN_IDENTIFIER}@education.gov.uk
+    user waits until page contains    ees-analyst-%{RUN_IDENTIFIER}@education.gov.uk    %{WAIT_SMALL}
     user checks page contains tag    Pending Invite
 
 *** Keywords ***


### PR DESCRIPTION
This PR : 
fixes a flaky assertion in invite contributor as publication owner. This seemed to occur quite often in CI and when running UI tests against dev.

Original failure:
``` 
Page should have contained text 'ees-analyst-20220126-120528@education.gov.uk' but did not.
```