### PR TITLE
EES-2784 set location step heading based on options available

### DIFF
--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__data__/tableToolServiceData.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__data__/tableToolServiceData.ts
@@ -38,6 +38,10 @@ export const testSubjectMeta: SubjectMeta = {
     },
   },
   locations: {
+    country: {
+      legend: 'Country',
+      options: [{ value: 'england', label: 'England' }],
+    },
     localAuthority: {
       legend: 'Local authority',
       options: [{ value: 'barnet', label: 'Barnet' }],

--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -23,6 +23,7 @@ import {
   GeoJsonFeatureProperties,
 } from '@common/services/tableBuilderService';
 import { Dictionary } from '@common/types';
+import locationLevelsMap from '@common/utils/locationLevelsMap';
 import generateHslColour from '@common/utils/colour/generateHslColour';
 import lighten from '@common/utils/colour/lighten';
 import { unsafeCountDecimals } from '@common/utils/number/countDecimals';
@@ -363,77 +364,6 @@ export const MapBlockInternal = ({
   }, [dataSetCategories]);
 
   const locationType = useMemo(() => {
-    const locationLevelsMap: Dictionary<Dictionary<string>> = {
-      country: {
-        label: 'Country',
-        prefix: 'a',
-      },
-      englishDevolvedArea: {
-        label: 'English Devolved Area',
-        prefix: 'an',
-      },
-      institution: {
-        label: 'Institution',
-        prefix: 'an',
-      },
-      localAuthority: {
-        label: 'Local Authority',
-        prefix: 'a',
-      },
-      localAuthorityDistrict: {
-        label: 'Local Authority District',
-        prefix: 'a',
-      },
-      localEnterprisePartnership: {
-        label: 'Local Enterprise Partnership',
-        prefix: 'a',
-      },
-      mayoralCombinedAuthority: {
-        label: 'Mayoral Combined Authority',
-        prefix: 'a',
-      },
-      multiAcademyTrust: {
-        label: 'Multi Academy Trust',
-        prefix: 'a',
-      },
-      opportunityArea: {
-        label: 'Opportunity Area',
-        prefix: 'an',
-      },
-      parliamentaryConstituency: {
-        label: 'Parliamentary Constituency',
-        prefix: 'a',
-      },
-      provider: {
-        label: 'Provider',
-        prefix: 'a',
-      },
-      region: {
-        label: 'Region',
-        prefix: 'a',
-      },
-      rscRegion: {
-        label: 'RSC Region',
-        prefix: 'an',
-      },
-      school: {
-        label: 'School',
-        prefix: 'a',
-      },
-      sponsor: {
-        label: 'Sponsor',
-        prefix: 'a',
-      },
-      ward: {
-        label: 'Ward',
-        prefix: 'a',
-      },
-      planningArea: {
-        label: 'Planning Area',
-        prefix: 'a',
-      },
-    };
-
     const levels = dataSetCategories.map(category => category.filter.level);
     return !levels.every(level => level === levels[0]) ||
       !locationLevelsMap[levels[0]]

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -10,6 +10,7 @@ import {
   LocationOption,
   SubjectMeta,
 } from '@common/services/tableBuilderService';
+import locationLevelsMap from '@common/utils/locationLevelsMap';
 import { Dictionary } from '@common/types/util';
 import Yup from '@common/validation/yup';
 import { Formik } from 'formik';
@@ -47,7 +48,10 @@ const LocationFiltersForm = ({
 
   const stepHeading = (
     <WizardStepHeading {...stepProps} fieldsetHeading>
-      Choose locations
+      {Object.keys(options).length === 1 &&
+      locationLevelsMap[Object.keys(options)[0]]
+        ? `Choose ${locationLevelsMap[Object.keys(options)[0]].plural}`
+        : 'Choose locations'}
     </WizardStepHeading>
   );
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/LocationFiltersForm.tsx
@@ -45,12 +45,12 @@ const LocationFiltersForm = ({
   ...stepProps
 }: Props) => {
   const { isActive, goToNextStep } = stepProps;
+  const levelKeys = Object.keys(options);
 
   const stepHeading = (
     <WizardStepHeading {...stepProps} fieldsetHeading>
-      {Object.keys(options).length === 1 &&
-      locationLevelsMap[Object.keys(options)[0]]
-        ? `Choose ${locationLevelsMap[Object.keys(options)[0]].plural}`
+      {levelKeys.length === 1 && locationLevelsMap[levelKeys[0]]
+        ? `Choose ${locationLevelsMap[levelKeys[0]].plural}`
         : 'Choose locations'}
     </WizardStepHeading>
   );

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/LocationFiltersForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/LocationFiltersForm.test.tsx
@@ -111,69 +111,6 @@ describe('LocationFiltersForm', () => {
     },
   };
 
-  const testSingleLocation: SubjectMeta['locations'] = {
-    country: {
-      legend: 'Country',
-      options: [
-        {
-          label: 'Country 1',
-          value: 'country-1',
-        },
-      ],
-    },
-  };
-
-  const testSingleLocationNested: SubjectMeta['locations'] = {
-    localAuthority: {
-      legend: 'Local authority',
-      options: [
-        {
-          label: 'Region 1',
-          value: 'region-1',
-          level: 'Region',
-          options: [
-            {
-              label: 'Local authority 1',
-              value: 'local-authority-1',
-            },
-          ],
-        },
-      ],
-    },
-  };
-
-  const testSingleLocationType: SubjectMeta['locations'] = {
-    country: {
-      legend: 'Country',
-      options: [
-        {
-          label: 'Country 1',
-          value: 'country-1',
-        },
-        {
-          label: 'Country 2',
-          value: 'country-2',
-        },
-      ],
-    },
-  };
-
-  const testSingleLocationTypeUnknown: SubjectMeta['locations'] = {
-    unknownType: {
-      legend: 'Unknown',
-      options: [
-        {
-          label: 'Unknown 1',
-          value: 'unknown-1',
-        },
-        {
-          label: 'Unknown 2',
-          value: 'unknown-2',
-        },
-      ],
-    },
-  };
-
   test('renders flat location group options correctly', () => {
     render(
       <LocationFiltersForm
@@ -469,6 +406,18 @@ describe('LocationFiltersForm', () => {
   });
 
   test('automatically selects the option and expands the group if only one location available', () => {
+    const testSingleLocation: SubjectMeta['locations'] = {
+      country: {
+        legend: 'Country',
+        options: [
+          {
+            label: 'Country 1',
+            value: 'country-1',
+          },
+        ],
+      },
+    };
+
     render(
       <LocationFiltersForm
         {...testWizardStepProps}
@@ -495,6 +444,25 @@ describe('LocationFiltersForm', () => {
   });
 
   test('automatically selects the option and expands the nested group if only one location available', () => {
+    const testSingleLocationNested: SubjectMeta['locations'] = {
+      localAuthority: {
+        legend: 'Local authority',
+        options: [
+          {
+            label: 'Region 1',
+            value: 'region-1',
+            level: 'Region',
+            options: [
+              {
+                label: 'Local authority 1',
+                value: 'local-authority-1',
+              },
+            ],
+          },
+        ],
+      },
+    };
+
     render(
       <LocationFiltersForm
         {...testWizardStepProps}
@@ -678,6 +646,22 @@ describe('LocationFiltersForm', () => {
   });
 
   test('sets the step heading based on location type if only one type', () => {
+    const testSingleLocationType: SubjectMeta['locations'] = {
+      country: {
+        legend: 'Country',
+        options: [
+          {
+            label: 'Country 1',
+            value: 'country-1',
+          },
+          {
+            label: 'Country 2',
+            value: 'country-2',
+          },
+        ],
+      },
+    };
+
     render(
       <LocationFiltersForm
         {...testWizardStepProps}
@@ -694,6 +678,22 @@ describe('LocationFiltersForm', () => {
   });
 
   test('sets the step heading to `Choose locations` if single location type is not in the locationLevelsMap', () => {
+    const testSingleLocationTypeUnknown: SubjectMeta['locations'] = {
+      unknownType: {
+        legend: 'Unknown',
+        options: [
+          {
+            label: 'Unknown 1',
+            value: 'unknown-1',
+          },
+          {
+            label: 'Unknown 2',
+            value: 'unknown-2',
+          },
+        ],
+      },
+    };
+
     render(
       <LocationFiltersForm
         {...testWizardStepProps}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/LocationFiltersForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/LocationFiltersForm.test.tsx
@@ -23,7 +23,7 @@ describe('LocationFiltersForm', () => {
   };
 
   const testLocationsFlat: SubjectMeta['locations'] = {
-    Country: {
+    country: {
       legend: 'Country',
       options: [
         {
@@ -32,7 +32,7 @@ describe('LocationFiltersForm', () => {
         },
       ],
     },
-    LocalAuthority: {
+    localAuthority: {
       legend: 'Local authority',
       options: [
         {
@@ -49,7 +49,7 @@ describe('LocationFiltersForm', () => {
         },
       ],
     },
-    Region: {
+    region: {
       legend: 'Region',
       options: [
         {
@@ -65,7 +65,7 @@ describe('LocationFiltersForm', () => {
   };
 
   const testLocationsNested: SubjectMeta['locations'] = {
-    Country: {
+    country: {
       legend: 'Country',
       options: [
         {
@@ -74,7 +74,7 @@ describe('LocationFiltersForm', () => {
         },
       ],
     },
-    LocalAuthority: {
+    localAuthority: {
       legend: 'Local authority',
       options: [
         {
@@ -112,7 +112,7 @@ describe('LocationFiltersForm', () => {
   };
 
   const testSingleLocation: SubjectMeta['locations'] = {
-    Country: {
+    country: {
       legend: 'Country',
       options: [
         {
@@ -124,7 +124,7 @@ describe('LocationFiltersForm', () => {
   };
 
   const testSingleLocationNested: SubjectMeta['locations'] = {
-    LocalAuthority: {
+    localAuthority: {
       legend: 'Local authority',
       options: [
         {
@@ -137,6 +137,38 @@ describe('LocationFiltersForm', () => {
               value: 'local-authority-1',
             },
           ],
+        },
+      ],
+    },
+  };
+
+  const testSingleLocationType: SubjectMeta['locations'] = {
+    country: {
+      legend: 'Country',
+      options: [
+        {
+          label: 'Country 1',
+          value: 'country-1',
+        },
+        {
+          label: 'Country 2',
+          value: 'country-2',
+        },
+      ],
+    },
+  };
+
+  const testSingleLocationTypeUnknown: SubjectMeta['locations'] = {
+    unknownType: {
+      legend: 'Unknown',
+      options: [
+        {
+          label: 'Unknown 1',
+          value: 'unknown-1',
+        },
+        {
+          label: 'Unknown 2',
+          value: 'unknown-2',
         },
       ],
     },
@@ -401,8 +433,8 @@ describe('LocationFiltersForm', () => {
         options={testLocationsFlat}
         onSubmit={noop}
         initialValues={{
-          LocalAuthority: ['local-authority-1', 'local-authority-3'],
-          Region: ['region-2'],
+          localAuthority: ['local-authority-1', 'local-authority-3'],
+          region: ['region-2'],
         }}
       />,
     );
@@ -423,7 +455,7 @@ describe('LocationFiltersForm', () => {
         options={testLocationsNested}
         onSubmit={noop}
         initialValues={{
-          LocalAuthority: ['local-authority-1', 'local-authority-3'],
+          localAuthority: ['local-authority-1', 'local-authority-3'],
         }}
       />,
     );
@@ -589,8 +621,8 @@ describe('LocationFiltersForm', () => {
 
     const expected: LocationFormValues = {
       locations: {
-        LocalAuthority: ['local-authority-3'],
-        Region: ['region-1'],
+        localAuthority: ['local-authority-3'],
+        region: ['region-1'],
       },
     };
 
@@ -618,8 +650,8 @@ describe('LocationFiltersForm', () => {
 
     const expected: LocationFormValues = {
       locations: {
-        LocalAuthority: ['local-authority-1', 'local-authority-3'],
-        Country: ['country-1'],
+        localAuthority: ['local-authority-1', 'local-authority-3'],
+        country: ['country-1'],
       },
     };
 
@@ -627,5 +659,53 @@ describe('LocationFiltersForm', () => {
       expect(handleSubmit).toHaveBeenCalledTimes(1);
       expect(handleSubmit).toHaveBeenCalledWith(expected);
     });
+  });
+
+  test('sets the step heading to `Choose locations` if multiple location types', () => {
+    render(
+      <LocationFiltersForm
+        {...testWizardStepProps}
+        options={testLocationsFlat}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Step 1 (current) Choose locations',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('sets the step heading based on location type if only one type', () => {
+    render(
+      <LocationFiltersForm
+        {...testWizardStepProps}
+        options={testSingleLocationType}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Step 1 (current) Choose Countries',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('sets the step heading to `Choose locations` if single location type is not in the locationLevelsMap', () => {
+    render(
+      <LocationFiltersForm
+        {...testWizardStepProps}
+        options={testSingleLocationTypeUnknown}
+        onSubmit={noop}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Step 1 (current) Choose locations',
+      }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -135,6 +135,10 @@ describe('TableToolWizard', () => {
       },
     },
     locations: {
+      country: {
+        legend: 'Country',
+        options: [{ value: 'england', label: 'England' }],
+      },
       localAuthority: {
         legend: 'Local authority',
         options: [

--- a/src/explore-education-statistics-common/src/utils/locationLevelsMap.ts
+++ b/src/explore-education-statistics-common/src/utils/locationLevelsMap.ts
@@ -1,6 +1,10 @@
 import { Dictionary } from '@common/types';
 
-const locationLevelsMap: Dictionary<Dictionary<string>> = {
+const locationLevelsMap: Dictionary<{
+  label: string;
+  plural: string;
+  prefix: string;
+}> = {
   country: {
     label: 'Country',
     plural: 'Countries',

--- a/src/explore-education-statistics-common/src/utils/locationLevelsMap.ts
+++ b/src/explore-education-statistics-common/src/utils/locationLevelsMap.ts
@@ -1,0 +1,91 @@
+import { Dictionary } from '@common/types';
+
+const locationLevelsMap: Dictionary<Dictionary<string>> = {
+  country: {
+    label: 'Country',
+    plural: 'Countries',
+    prefix: 'a',
+  },
+  englishDevolvedArea: {
+    label: 'English Devolved Area',
+    plural: 'English Devolved Areas',
+    prefix: 'an',
+  },
+  institution: {
+    label: 'Institution',
+    plural: 'Institutions',
+    prefix: 'an',
+  },
+  localAuthority: {
+    label: 'Local Authority',
+    plural: 'Local Authorities',
+    prefix: 'a',
+  },
+  localAuthorityDistrict: {
+    label: 'Local Authority District',
+    plural: 'Local Authority Districts',
+    prefix: 'a',
+  },
+  localEnterprisePartnership: {
+    label: 'Local Enterprise Partnership',
+    plural: 'Local Enterprise Partnerships',
+    prefix: 'a',
+  },
+  mayoralCombinedAuthority: {
+    label: 'Mayoral Combined Authority',
+    plural: 'Mayoral Combined Authorities',
+    prefix: 'a',
+  },
+  multiAcademyTrust: {
+    label: 'Multi Academy Trust',
+    plural: 'Multi Academy Trusts',
+    prefix: 'a',
+  },
+  opportunityArea: {
+    label: 'Opportunity Area',
+    plural: 'Opportunity Areas',
+    prefix: 'an',
+  },
+  parliamentaryConstituency: {
+    label: 'Parliamentary Constituency',
+    plural: 'Parliamentary Constituencies',
+    prefix: 'a',
+  },
+  provider: {
+    label: 'Provider',
+    plural: 'Providers',
+    prefix: 'a',
+  },
+  region: {
+    label: 'Region',
+    plural: 'Regions',
+    prefix: 'a',
+  },
+  rscRegion: {
+    label: 'RSC Region',
+    plural: 'RSC Regions',
+    prefix: 'an',
+  },
+  school: {
+    label: 'School',
+    plural: 'Schools',
+    prefix: 'a',
+  },
+  sponsor: {
+    label: 'Sponsor',
+    plural: 'Sponsors',
+    prefix: 'a',
+  },
+  ward: {
+    label: 'Ward',
+    plural: 'Wards',
+    prefix: 'a',
+  },
+  planningArea: {
+    label: 'Planning Area',
+    plural: 'Planning Areas',
+    prefix: 'a',
+  },
+};
+
+export default locationLevelsMap;


### PR DESCRIPTION
Sets the heading of the location step in the table tool:
- if just one type of location available: `Choose <location type>`
- if more than one type it defaults to `Choose locations` 