### PR TITLE
EES-3140 - fix UI tests

### DIFF
--- a/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
+++ b/tests/robot-tests/tests/admin/bau/create_publication_and_release.robot
@@ -71,7 +71,7 @@ Update publication
     user enters text into element    id:publicationForm-contactName    UI Tests Contact Name
     user enters text into element    id:publicationForm-contactTelNo    0987654321
     user clicks button    Save publication
-    user waits until h1 is visible    Confirm publication changes
+    user waits until h2 is visible    Confirm publication changes
     user clicks button    Confirm
 
 Add a methodology

--- a/tests/robot-tests/tests/admin/bau/delete_subject.robot
+++ b/tests/robot-tests/tests/admin/bau/delete_subject.robot
@@ -156,7 +156,7 @@ Delete UI test subject
     user opens accordion section    UI test subject
     user clicks button    Delete files
 
-    user waits until h1 is visible    Confirm deletion of selected data files    %{WAIT_SMALL}
+    user waits until h2 is visible    Confirm deletion of selected data files    %{WAIT_SMALL}
     user checks page contains    4 footnotes will be removed or updated.
     user checks page contains    The following data blocks will also be deleted:
     user checks page contains    UI test table name

--- a/tests/robot-tests/tests/admin/bau/prerelease.robot
+++ b/tests/robot-tests/tests/admin/bau/prerelease.robot
@@ -122,7 +122,7 @@ Approve release and wait for it to be Scheduled
     user enters text into element    id:releaseStatusForm-nextReleaseDate-month    1
     user enters text into element    id:releaseStatusForm-nextReleaseDate-year    2001
     user clicks button    Update status
-    user waits until h1 is visible    Confirm publish date
+    user waits until h2 is visible    Confirm publish date
     user clicks button    Confirm
 
     user checks summary list contains    Current status    Approved
@@ -253,7 +253,7 @@ Start prerelease
     user enters text into element    id:releaseStatusForm-publishScheduled-month    ${month}
     user enters text into element    id:releaseStatusForm-publishScheduled-year    ${year}
     user clicks button    Update status
-    user waits until h1 is visible    Confirm publish date
+    user waits until h2 is visible    Confirm publish date
     user clicks button    Confirm
 
     user checks summary list contains    Current status    Approved

--- a/tests/robot-tests/tests/admin/bau/release_status.robot
+++ b/tests/robot-tests/tests/admin/bau/release_status.robot
@@ -84,7 +84,7 @@ Approve release
     user enters text into element    id:releaseStatusForm-nextReleaseDate-year    3002
 
     user clicks button    Update status
-    user waits until h1 is visible    Confirm publish date
+    user waits until h2 is visible    Confirm publish date
     user clicks button    Confirm
 
 Verify release status is Approved

--- a/tests/robot-tests/tests/admin/bau/upload_files.robot
+++ b/tests/robot-tests/tests/admin/bau/upload_files.robot
@@ -187,7 +187,7 @@ Validate ancillary file details were changed
 Delete ancillary file
     ${file_2_section}=    user gets accordion section content element    Test 2 updated    id:file-uploads
     user clicks button    Delete file    ${file_2_section}
-    user waits until h1 is visible    Confirm deletion of file
+    user waits until h2 is visible    Confirm deletion of file
     user clicks button    Confirm
 
     user waits until page does not contain accordion section    Test 2 updated

--- a/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/prerelease_visibility.robot
@@ -94,7 +94,7 @@ Approve release and wait for it to be Scheduled
     user enters text into element    id:releaseStatusForm-nextReleaseDate-month    1
     user enters text into element    id:releaseStatusForm-nextReleaseDate-year    2001
     user clicks button    Update status
-    user waits until h1 is visible    Confirm publish date
+    user waits until h2 is visible    Confirm publish date
     user clicks button    Confirm
     # the below fails on dev
     user checks summary list contains    Scheduled release    ${day} ${month_word} ${year}

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_content.robot
@@ -47,10 +47,10 @@ Check glossary info icon appears on release preview
 
 Click glossary info icon and validate glossary entry
     user clicks button    Absence
-    user waits until h1 is visible    Absence
+    user waits until h2 is visible    Absence
     user checks page contains    When a pupil misses (or is absent from) at least 1 possible school session.
     user clicks button    Close
-    user waits until page does not contain element    xpath://h1[text()="Absence"]
+    user waits until page does not contain element    xpath://h2[text()="Absence"]
     user checks page does not contain    When a pupil misses (or is absent from) at least 1 possible school session.
 
 Approve release
@@ -83,8 +83,8 @@ Check latest release contains glossary info icon
 
 Click glossary info icon and verify entry is correct
     user clicks button    Absence
-    user waits until h1 is visible    Absence
+    user waits until h2 is visible    Absence
     user checks page contains    When a pupil misses (or is absent from) at least 1 possible school session.
     user clicks button    Close
-    user waits until page does not contain element    xpath://h1[text()="Absence"]
+    user waits until page does not contain element    xpath://h2[text()="Absence"]
     user checks page does not contain    When a pupil misses (or is absent from) at least 1 possible school session.

--- a/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
+++ b/tests/robot-tests/tests/admin_and_public/bau/publish_data.robot
@@ -515,7 +515,7 @@ Validate table has footnotes
 
 Select table featured table from subjects step
     user clicks element    testid:wizardStep-2-goToButton
-    user waits until h1 is visible    Go back to previous step
+    user waits until h2 is visible    Go back to previous step
     user clicks button    Confirm
     user waits until page does not contain button    Confirm
 

--- a/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_absence_in_prus.robot
@@ -74,7 +74,7 @@ Validate Number of schools row results
 
 Go back to Locations step
     user clicks element    xpath://button[contains(text(), "Edit locations")]
-    user waits until page contains element    xpath://h1[text()="Go back to previous step"]
+    user waits until page contains element    xpath://h2[text()="Go back to previous step"]
     user clicks element    xpath://button[text()="Confirm"]
 
 Unselect England as a location

--- a/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
+++ b/tests/robot-tests/tests/general_public/table_tool_exclusions_by_geographic_level.robot
@@ -90,7 +90,7 @@ Validate the query could exceed the maximum allowable table size
 
 Go back to Locations step
     user clicks button    Edit locations
-    user waits until page contains element    xpath://h1[text()="Go back to previous step"]
+    user waits until page contains element    xpath://h2[text()="Go back to previous step"]
     user clicks button    Confirm
 
 Unselect all LA Locations

--- a/tests/robot-tests/tests/libs/admin-common.robot
+++ b/tests/robot-tests/tests/libs/admin-common.robot
@@ -641,7 +641,7 @@ user approves release for scheduled release
     user enters text into element    id:releaseStatusForm-nextReleaseDate-year    ${NEXT_RELEASE_YEAR}
 
     user clicks button    Update status
-    user waits until h1 is visible    Confirm publish date
+    user waits until h2 is visible    Confirm publish date
     user clicks button    Confirm
 
 user verifies release summary
@@ -734,7 +734,7 @@ user waits until modal is visible
     ...    ${MODAL_TITLE}
     ...    ${MODAL_TEXT}=${EMPTY}
 
-    user waits until parent contains element    css:.ReactModal__Content    xpath://h1[.="${MODAL_TITLE}"]
+    user waits until parent contains element    css:.ReactModal__Content    xpath://h2[.="${MODAL_TITLE}"]
     IF    "${MODAL_TEXT}" != "${EMPTY}"
         user waits until parent contains element    css:.ReactModal__Content    xpath://*[.="${MODAL_TEXT}"]
     END


### PR DESCRIPTION
This PR: 
- fixes a few assertions related to modals looking for `h1` elements instead of `h2` elements. This was caused by the recent changes in https://github.com/dfe-analytical-services/explore-education-statistics/pull/3129