### PR TITLE
EES-3139 Add timestamp interfaces for entities

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Data/UsersAndRolesDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Areas/Identity/Data/UsersAndRolesDbContext.cs
@@ -4,6 +4,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data.Model
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using IdentityServer4.EntityFramework.Options;
 using Microsoft.AspNetCore.ApiAuthorization.IdentityServer;
 using Microsoft.AspNetCore.Identity;
@@ -20,6 +21,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data
             DbContextOptions<UsersAndRolesDbContext> options,
             IOptions<OperationalStoreOptions> operationalStoreOptions) : base(options, operationalStoreOptions)
         {
+            Configure();
+        }
+
+        private void Configure()
+        {
+            ChangeTracker.StateChanged += DbContextUtils.UpdateTimestamps;
+            ChangeTracker.Tracked += DbContextUtils.UpdateTimestamps;
         }
 
         private static IdentityRole<string> CreateRole(Role role)
@@ -32,7 +40,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data
                 ConcurrencyStamp = "85d6c75e-a6c8-4c7e-b4d0-8ee70a4879d3",
             };
         }
-        
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
@@ -42,7 +50,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data
                 .HasConversion(
                     v => v,
                     v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
-            
+
             modelBuilder.Entity<IdentityRole>()
                 .HasData(
                     CreateRole(Role.BauUser),

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/GovUk.Education.ExploreEducationStatistics.Common.Tests.csproj
@@ -10,6 +10,7 @@
         <PackageReference Include="CompareNETObjects" Version="4.74.0" />
         <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.18" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.18" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
         <PackageReference Include="Moq" Version="4.13.1" />
         <PackageReference Include="Snapshooter.Xunit" Version="0.6.2" />

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/DbContextUtilsTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Utils/DbContextUtilsTests.cs
@@ -1,0 +1,567 @@
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils
+{
+    public class DbContextUtilsTests
+    {
+        // ReSharper disable UnusedAutoPropertyAccessor.Local, MemberHidesStaticFromOuterClass
+        public class UpdateTimestamps
+        {
+            private class CreatedDateTimeEntity : ICreatedTimestamp<DateTime>
+            {
+                public Guid Id { get; set; }
+                public DateTime Created { get; set; }
+            }
+
+            private class CreatedDateTimeOffsetEntity : ICreatedTimestamp<DateTimeOffset>
+            {
+                public Guid Id { get; set; }
+                public DateTimeOffset Created { get; set; }
+            }
+
+            private class CreatedInvalidEntity : ICreatedTimestamp<string>
+            {
+                public Guid Id { get; set; }
+                public string Created { get; set; } = string.Empty;
+            }
+
+            private class UpdatedDateTimeEntity : IUpdatedTimestamp<DateTime?>
+            {
+                public Guid Id { get; set; }
+                public string Name { get; set; } = string.Empty;
+                public DateTime? Updated { get; set; }
+            }
+
+            private class UpdatedDateTimeOffsetEntity : IUpdatedTimestamp<DateTimeOffset?>
+            {
+                public Guid Id { get; set; }
+                public string Name { get; set; } = string.Empty;
+                public DateTimeOffset? Updated { get; set; }
+            }
+
+            private class UpdatedInvalidEntity : IUpdatedTimestamp<string>
+            {
+                public Guid Id { get; set; }
+                public string Name { get; set; } = string.Empty;
+
+                public string Updated { get; set; } = string.Empty;
+            }
+
+            private class CreatedUpdatedDateTimeEntity : ICreatedUpdatedTimestamps<DateTime?, DateTime?>
+            {
+                public Guid Id { get; set; }
+                public string Name { get; set; } = string.Empty;
+                public DateTime? Created { get; set; }
+                public DateTime? Updated { get; set; }
+            }
+
+            private class CreatedUpdatedDateTimeOffsetEntity : ICreatedUpdatedTimestamps<DateTimeOffset?, DateTimeOffset?>
+            {
+                public Guid Id { get; set; }
+                public string Name { get; set; } = string.Empty;
+                public DateTimeOffset? Created { get; set; }
+                public DateTimeOffset? Updated { get; set; }
+            }
+
+            private class CreatedUpdatedInvalidEntity : ICreatedUpdatedTimestamps<string, int>
+            {
+                public Guid Id { get; set; }
+                public string Name { get; set; } = string.Empty;
+                public string Created { get; set; } = string.Empty;
+                public int Updated { get; set; }
+            }
+
+            private class SoftDeletedDateTimeEntity : ISoftDeletedTimestamp<DateTime?>
+            {
+                public Guid Id { get; set; }
+                public DateTime? SoftDeleted { get; set; }
+            }
+
+            private class SoftDeletedDateTimeOffsetEntity : ISoftDeletedTimestamp<DateTimeOffset?>
+            {
+                public Guid Id { get; set; }
+
+                public DateTimeOffset? SoftDeleted { get; set; }
+            }
+
+            private class SoftDeletedInvalidEntity : ISoftDeletedTimestamp<string>
+            {
+                public Guid Id { get; set; }
+                public string SoftDeleted { get; set; } = string.Empty;
+            }
+
+            private sealed class TestContext : DbContext
+            {
+                public DbSet<CreatedDateTimeEntity> CreatedDateTimeEntity { get; set; } = null!;
+                public DbSet<CreatedDateTimeOffsetEntity> CreatedDateTimeOffsetEntity { get; set; } = null!;
+                public DbSet<CreatedInvalidEntity> CreatedInvalidEntity { get; set; } = null!;
+
+                public DbSet<UpdatedDateTimeEntity> UpdateDateTimeEntity { get; set; } = null!;
+                public DbSet<UpdatedDateTimeOffsetEntity> UpdatedDateTimeOffsetEntity { get; set; } = null!;
+                public DbSet<UpdatedInvalidEntity> UpdatedInvalidEntity { get; set; } = null!;
+
+                public DbSet<CreatedUpdatedDateTimeEntity> CreatedUpdatedDateTimeEntity { get; set; } = null!;
+                public DbSet<CreatedUpdatedDateTimeOffsetEntity> CreatedUpdatedDateTimeOffsetEntity { get; set; } = null!;
+                public DbSet<CreatedUpdatedInvalidEntity> CreatedUpdatedInvalidEntity { get; set; } = null!;
+
+                public DbSet<SoftDeletedDateTimeEntity> SoftDeletedDateTimeEntity { get; set; } = null!;
+                public DbSet<SoftDeletedDateTimeOffsetEntity> SoftDeletedDateTimeOffsetEntity { get; set; } = null!;
+                public DbSet<SoftDeletedInvalidEntity> SoftDeletedInvalidEntity { get; set; } = null!;
+
+                public TestContext(string contextName) : base(GetOptions(contextName))
+                {
+                    ChangeTracker.StateChanged += DbContextUtils.UpdateTimestamps;
+                    ChangeTracker.Tracked += DbContextUtils.UpdateTimestamps;
+                }
+
+                private static DbContextOptions<TestContext> GetOptions(string contextName)
+                {
+                    return new DbContextOptionsBuilder<TestContext>()
+                        .UseInMemoryDatabase(contextName)
+                        .Options;
+                }
+            }
+            // ReSharper enable UnusedAutoPropertyAccessor.Local, MemberHidesStaticFromOuterClass
+
+            [Fact]
+            public async Task CreatedTimestamp_DateTime()
+            {
+                var entity = new CreatedDateTimeEntity();
+
+                var contextId = Guid.NewGuid().ToString();
+
+                await using (var context = new TestContext(contextId))
+                {
+                    await context.AddAsync(entity);
+                    await context.SaveChangesAsync();
+                }
+
+                // Check entity was created correctly
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.CreatedDateTimeEntity.FindAsync(entity.Id);
+
+                    Assert.True(DateTime.UtcNow > saved.Created);
+                }
+            }
+
+            [Fact]
+            public async Task CreatedTimestamp_DateTimeOffset()
+            {
+                var entity = new CreatedDateTimeOffsetEntity();
+
+                var contextId = Guid.NewGuid().ToString();
+
+                await using (var context = new TestContext(contextId))
+                {
+                    await context.AddAsync(entity);
+                    await context.SaveChangesAsync();
+                }
+
+                // Check entity was created correctly
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.CreatedDateTimeOffsetEntity.FindAsync(entity.Id);
+
+                    Assert.True(DateTime.UtcNow > saved.Created);
+                }
+            }
+
+            [Fact]
+            public async Task CreatedTimestamp_InvalidType_Throws()
+            {
+                var entity = new CreatedInvalidEntity();
+
+                var contextId = Guid.NewGuid().ToString();
+
+                await using var context = new TestContext(contextId);
+
+                var exception = await Assert.ThrowsAsync<NotImplementedException>(
+                    async () =>
+                    {
+                        await context.AddAsync(entity);
+                        await context.SaveChangesAsync();
+                    }
+                );
+
+                Assert.Equal(
+                    "Entity does not implement valid timestamp field for ICreatedTimestamp",
+                    exception.Message
+                );
+            }
+
+            [Fact]
+            public async Task UpdatedTimestamp_DateTime()
+            {
+                var entity = new UpdatedDateTimeEntity
+                {
+                    Name = "Old name"
+                };
+
+                var contextId = Guid.NewGuid().ToString();
+
+                await using (var context = new TestContext(contextId))
+                {
+                    await context.AddAsync(entity);
+                    await context.SaveChangesAsync();
+                }
+
+                // Check entity was created correctly
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.UpdateDateTimeEntity.FindAsync(entity.Id);
+
+                    Assert.Null(saved.Updated);
+                }
+
+                // Update the entity
+                await using (var context = new TestContext(contextId))
+                {
+                    context.Update(entity);
+
+                    entity.Name = "New name";
+
+                    await context.SaveChangesAsync();
+                }
+
+                // Check entity was updated correctly
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.UpdateDateTimeEntity.FindAsync(entity.Id);
+
+                    Assert.Equal("New name", saved.Name);
+
+                    Assert.NotNull(saved.Updated);
+                    Assert.True(DateTime.UtcNow > saved.Updated);
+                }
+            }
+
+            [Fact]
+            public async Task UpdatedTimestamp_DateTimeOffset()
+            {
+                var entity = new UpdatedDateTimeOffsetEntity
+                {
+                    Name = "Old name"
+                };
+
+                var contextId = Guid.NewGuid().ToString();
+
+                await using (var context = new TestContext(contextId))
+                {
+                    await context.AddAsync(entity);
+                    await context.SaveChangesAsync();
+                }
+
+                // Check entity was created correctly
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.UpdatedDateTimeOffsetEntity.FindAsync(entity.Id);
+
+                    Assert.Null(saved.Updated);
+                }
+
+                // Update the entity
+                await using (var context = new TestContext(contextId))
+                {
+                    context.Update(entity);
+
+                    entity.Name = "New name";
+
+                    await context.SaveChangesAsync();
+                }
+
+                // Check entity was updated correctly
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.UpdatedDateTimeOffsetEntity.FindAsync(entity.Id);
+
+                    Assert.Equal("New name", saved.Name);
+
+                    Assert.NotNull(saved.Updated);
+                    Assert.True(DateTime.UtcNow > saved.Updated);
+                }
+            }
+
+            [Fact]
+            public async Task UpdatedTimestamp_InvalidType_Throws()
+            {
+                var entity = new UpdatedInvalidEntity();
+
+                var contextId = Guid.NewGuid().ToString();
+
+                await using (var context = new TestContext(contextId))
+                {
+                    await context.AddAsync(entity);
+                    await context.SaveChangesAsync();
+                }
+
+                await using (var context = new TestContext(contextId))
+                {
+                    var exception = await Assert.ThrowsAsync<NotImplementedException>(
+                        async () =>
+                        {
+                            context.Update(entity);
+
+                            entity.Name = "New name";
+
+                            await context.SaveChangesAsync();
+                        }
+                    );
+
+                    Assert.Equal(
+                        "Entity does not implement valid timestamp field for IUpdatedTimestamp",
+                        exception.Message
+                    );
+                }
+            }
+
+            [Fact]
+            public async Task CreatedUpdatedTimestamps_DateTime()
+            {
+                var entity = new CreatedUpdatedDateTimeEntity
+                {
+                    Name = "Old name"
+                };
+
+                var contextId = Guid.NewGuid().ToString();
+
+                await using (var context = new TestContext(contextId))
+                {
+                    await context.AddAsync(entity);
+                    await context.SaveChangesAsync();
+                }
+
+                DateTime? previousCreated;
+                DateTime? previousUpdated;
+
+                // Check entity was created correctly
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.CreatedUpdatedDateTimeEntity.FindAsync(entity.Id);
+
+                    Assert.NotNull(saved.Created);
+                    Assert.True(DateTime.UtcNow > saved.Created);
+
+                    Assert.Null(saved.Updated);
+
+                    previousCreated = saved.Created;
+                    previousUpdated = saved.Updated;
+                }
+
+                // Update the entity
+                await using (var context = new TestContext(contextId))
+                {
+                    context.Update(entity);
+
+                    entity.Name = "New name";
+
+                    await context.SaveChangesAsync();
+                }
+
+                // Check entity was updated correctly
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.CreatedUpdatedDateTimeEntity.FindAsync(entity.Id);
+
+                    Assert.Equal("New name", saved.Name);
+
+                    Assert.NotNull(saved.Created);
+                    Assert.True(DateTime.UtcNow > saved.Created);
+                    Assert.Equal(previousCreated, saved.Created);
+
+                    Assert.NotNull(saved.Updated);
+                    Assert.True(DateTime.UtcNow > saved.Updated);
+                    Assert.NotEqual(previousUpdated, saved.Updated);
+                }
+            }
+
+            [Fact]
+            public async Task CreatedUpdatedTimestamps_DateTimeOffsets()
+            {
+                var entity = new CreatedUpdatedDateTimeOffsetEntity
+                {
+                    Name = "Old name"
+                };
+
+                var contextId = Guid.NewGuid().ToString();
+
+                await using (var context = new TestContext(contextId))
+                {
+                    await context.AddAsync(entity);
+                    await context.SaveChangesAsync();
+                }
+
+                DateTimeOffset? previousCreated;
+                DateTimeOffset? previousUpdated;
+
+                // Check entity was created correctly
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.CreatedUpdatedDateTimeOffsetEntity.FindAsync(entity.Id);
+
+                    Assert.NotNull(saved.Created);
+                    Assert.True(DateTime.UtcNow > saved.Created);
+
+                    Assert.Null(saved.Updated);
+
+                    previousCreated = saved.Created;
+                    previousUpdated = saved.Updated;
+                }
+
+                // Update the entity
+                await using (var context = new TestContext(contextId))
+                {
+                    context.Update(entity);
+
+                    entity.Name = "New name";
+
+                    await context.SaveChangesAsync();
+                }
+
+                // Check entity was updated correctly
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.CreatedUpdatedDateTimeOffsetEntity.FindAsync(entity.Id);
+
+                    Assert.Equal("New name", saved.Name);
+
+                    Assert.NotNull(saved.Created);
+                    Assert.True(DateTime.UtcNow > saved.Created);
+                    Assert.Equal(previousCreated, saved.Created);
+
+                    Assert.NotNull(saved.Updated);
+                    Assert.True(DateTime.UtcNow > saved.Updated);
+                    Assert.NotEqual(previousUpdated, saved.Updated);
+                }
+            }
+
+            [Fact]
+            public async Task CreatedUpdatedTimestamps_InvalidType_Throws()
+            {
+                var entity = new CreatedUpdatedInvalidEntity();
+
+                var contextId = Guid.NewGuid().ToString();
+
+                await using var context = new TestContext(contextId);
+
+                var exception = await Assert.ThrowsAsync<NotImplementedException>(
+                    async () =>
+                    {
+                        await context.AddAsync(entity);
+                        await context.SaveChangesAsync();
+
+                        entity.Name = "New name";
+
+                        await context.SaveChangesAsync();
+                    }
+                );
+
+                Assert.Equal(
+                    "Entity does not implement valid timestamp field for ICreatedTimestamp",
+                    exception.Message
+                );
+            }
+
+            [Fact]
+            public async Task SoftDeletedTimestamp_DateTime()
+            {
+                var entity = new SoftDeletedDateTimeEntity();
+
+                var contextId = Guid.NewGuid().ToString();
+
+                await using (var context = new TestContext(contextId))
+                {
+                    await context.AddAsync(entity);
+                    await context.SaveChangesAsync();
+                }
+
+                // Delete the entity
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.SoftDeletedDateTimeEntity.FindAsync(entity.Id);
+
+                    context.Remove(saved);
+                    await context.SaveChangesAsync();
+                }
+
+                // Check entity was soft deleted correctly
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.SoftDeletedDateTimeEntity.FindAsync(entity.Id);
+
+                    Assert.NotNull(saved.SoftDeleted);
+                    Assert.True(DateTime.UtcNow > saved.SoftDeleted);
+                }
+            }
+
+            [Fact]
+            public async Task SoftDeletedTimestamp_DateTimeOffset()
+            {
+                var entity = new SoftDeletedDateTimeOffsetEntity();
+
+                var contextId = Guid.NewGuid().ToString();
+
+                await using (var context = new TestContext(contextId))
+                {
+                    await context.AddAsync(entity);
+                    await context.SaveChangesAsync();
+                }
+
+                // Delete the entity
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.SoftDeletedDateTimeOffsetEntity.FindAsync(entity.Id);
+
+                    context.Remove(saved);
+                    await context.SaveChangesAsync();
+                }
+
+                // Check entity was soft deleted correctly
+                await using (var context = new TestContext(contextId))
+                {
+                    var saved = await context.SoftDeletedDateTimeOffsetEntity.FindAsync(entity.Id);
+
+                    Assert.NotNull(saved.SoftDeleted);
+                    Assert.True(DateTime.UtcNow > saved.SoftDeleted);
+                }
+            }
+
+            [Fact]
+            public async Task SoftDeletedTimestamp_InvalidType_Throws()
+            {
+                var entity = new SoftDeletedInvalidEntity();
+
+                var contextId = Guid.NewGuid().ToString();
+
+                await using (var context = new TestContext(contextId))
+                {
+                    await context.AddAsync(entity);
+                    await context.SaveChangesAsync();
+                }
+
+                await using (var context = new TestContext(contextId))
+                {
+                    var exception = await Assert.ThrowsAsync<NotImplementedException>(
+                        async () =>
+                        {
+                            context.Remove(entity);
+
+                            await context.SaveChangesAsync();
+                        }
+                    );
+
+                    Assert.Equal(
+                        "Entity does not implement valid timestamp field for ISoftDeletedTimestamp",
+                        exception.Message
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Timestamps.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Timestamps.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Model
+{
+    public interface ICreatedTimestamp<TDate> : ITimestampsInternal.ICreated
+    {
+        TDate Created { get; set; }
+    }
+
+    public interface IUpdatedTimestamp<TDate> : ITimestampsInternal.IUpdated
+    {
+        TDate Updated { get; set; }
+    }
+
+    public interface ISoftDeletedTimestamp<TDate> : ITimestampsInternal.ISoftDeleted
+    {
+        TDate SoftDeleted { get; set; }
+    }
+
+    public interface ICreatedUpdatedTimestamps<TCreated, TUpdated>
+        : ICreatedTimestamp<TCreated>, IUpdatedTimestamp<TUpdated>
+    {
+    }
+
+    /// <summary>
+    /// Marker interfaces for type guards without needing reflection.
+    /// Don't use this application level code (should only be
+    /// used in Entity Framework infrastructure code).
+    /// </summary>
+    public interface ITimestampsInternal
+    {
+        public interface ICreated {}
+        public interface IUpdated {}
+        public interface ISoftDeleted {}
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/DbContextUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Utils/DbContextUtils.cs
@@ -1,0 +1,111 @@
+#nullable enable
+using System;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Common.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
+namespace GovUk.Education.ExploreEducationStatistics.Common.Utils
+{
+    public static class DbContextUtils
+    {
+        public static void UpdateTimestamps(object? sender, EntityEntryEventArgs e)
+        {
+            var entity = e.Entry.Entity;
+            var now = DateTime.UtcNow;
+
+            if (e.Entry.State == EntityState.Added && entity is ITimestampsInternal.ICreated)
+            {
+                switch (e.Entry.Entity)
+                {
+                    case ICreatedTimestamp<DateTime> entityWithCreated:
+                        entityWithCreated.Created = now;
+                        break;
+
+                    case ICreatedTimestamp<DateTime?> entityWithCreated:
+                        entityWithCreated.Created = now;
+                        break;
+
+                    case ICreatedTimestamp<DateTimeOffset> entityWithCreated:
+                        entityWithCreated.Created = now;
+                        break;
+
+                    case ICreatedTimestamp<DateTimeOffset?> entityWithCreated:
+                        entityWithCreated.Created = now;
+                        break;
+
+                    default:
+                        throw new NotImplementedException(
+                            "Entity does not implement valid timestamp field for " +
+                            $"{typeof(ICreatedTimestamp<>).GetNameWithoutGenericArity()}"
+                        );
+                }
+
+                return;
+            }
+
+            if (e.Entry.State == EntityState.Modified && entity is ITimestampsInternal.IUpdated)
+            {
+                switch (e.Entry.Entity)
+                {
+                    case IUpdatedTimestamp<DateTime> entityWithUpdated:
+                        entityWithUpdated.Updated = now;
+                        break;
+
+                    case IUpdatedTimestamp<DateTime?> entityWithUpdated:
+                        entityWithUpdated.Updated = now;
+                        break;
+
+                    case IUpdatedTimestamp<DateTimeOffset> entityWithUpdated:
+                        entityWithUpdated.Updated = now;
+                        break;
+
+                    case IUpdatedTimestamp<DateTimeOffset?> entityWithUpdated:
+                        entityWithUpdated.Updated = now;
+                        break;
+
+                    default:
+                        throw new NotImplementedException(
+                            "Entity does not implement valid timestamp field for " +
+                            $"{typeof(IUpdatedTimestamp<>).GetNameWithoutGenericArity()}"
+                        );
+                }
+
+                return;
+            }
+
+            if (e.Entry.State == EntityState.Deleted && entity is ITimestampsInternal.ISoftDeleted)
+            {
+                switch (e.Entry.Entity)
+                {
+                    case ISoftDeletedTimestamp<DateTime> entityWithDeleted:
+                        entityWithDeleted.SoftDeleted = now;
+                        break;
+
+                    case ISoftDeletedTimestamp<DateTime?> entityWithDeleted:
+                        entityWithDeleted.SoftDeleted = now;
+                        break;
+
+                    case ISoftDeletedTimestamp<DateTimeOffset> entityWithDeleted:
+                        entityWithDeleted.SoftDeleted = now;
+                        break;
+
+                    case ISoftDeletedTimestamp<DateTimeOffset?> entityWithDeleted:
+                        entityWithDeleted.SoftDeleted = now;
+                        break;
+
+                    default:
+                        throw new NotImplementedException(
+                            "Entity does not implement valid timestamp field for " +
+                            $"{typeof(ISoftDeletedTimestamp<>).GetNameWithoutGenericArity()}"
+                        );
+                }
+
+                // Note that deletion will not actually delete the entity.
+                // We mark the state as `Unchanged` to prevent all of the
+                // entity's fields being updated in the database.
+                e.Entry.State = EntityState.Unchanged;
+            }
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Model/Database/StatisticsDbContext.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using GovUk.Education.ExploreEducationStatistics.Common.Converters;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
+using GovUk.Education.ExploreEducationStatistics.Common.Utils;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 
@@ -13,6 +14,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
     {
         public StatisticsDbContext()
         {
+            // We intentionally don't run `Configure` here as Moq would call this constructor
+            // and we'd immediately get a MockException from interacting with its fields
+            // e.g. from adding events listeners to `ChangeTracker`.
+            // We can just rely on the variants which take options instead as these
+            // are what get used in real application scenarios.
         }
 
         public StatisticsDbContext(DbContextOptions<StatisticsDbContext> options) : this(options, int.MaxValue)
@@ -36,8 +42,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Model.Database
             Configure(timeout);
         }
 
-        private void Configure(int? timeout)
+        private void Configure(int? timeout = null)
         {
+            ChangeTracker.StateChanged += DbContextUtils.UpdateTimestamps;
+            ChangeTracker.Tracked += DbContextUtils.UpdateTimestamps;
+
             if (timeout.HasValue)
             {
                 Database.SetCommandTimeout(timeout);


### PR DESCRIPTION
This PR adds timestamp interfaces that allow us to automatically update timestamp fields on entities automatically via events attached to Entity Framework's `ChangeTracker`.

We intend to use this as part the content locking work in [EES-2823](https://dfedigital.atlassian.net/browse/EES-2823), but this has been split out as it has cross-over with [EES-3138](https://dfedigital.atlassian.net/browse/EES-3138) to add consistent timestamp columns to entities.
