### PR TITLE
EES-1477 prevent bugs when change table tool subject and location

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -172,8 +172,11 @@ const TableToolWizard = ({
 
     updateState(draft => {
       draft.subjectMeta = nextSubjectMeta;
-
       draft.query.subjectId = selectedSubjectId;
+      draft.query.indicators = [];
+      draft.query.filters = [];
+      draft.query.locations = {};
+      draft.query.timePeriod = undefined;
     });
   };
 
@@ -194,11 +197,25 @@ const TableToolWizard = ({
       locations,
       subjectId: state.query.subjectId,
     });
+    // Check if selected time period is in the time period options so can reset it if not.
+    const hasStartTimePeriod = nextSubjectMeta.timePeriod.options.some(
+      option =>
+        option.code === state.query.timePeriod?.startCode &&
+        option.year === state.query.timePeriod.startYear,
+    );
+    const hasEndTimePeriod = nextSubjectMeta.timePeriod.options.some(
+      option =>
+        option.code === state.query.timePeriod?.endCode &&
+        option.year === state.query.timePeriod.endYear,
+    );
 
     updateState(draft => {
       draft.subjectMeta.timePeriod = nextSubjectMeta.timePeriod;
-
       draft.query.locations = locations;
+      draft.query.timePeriod =
+        hasStartTimePeriod && hasEndTimePeriod
+          ? state.query.timePeriod
+          : undefined;
     });
   };
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -259,10 +259,31 @@ const TableToolWizard = ({
       },
     });
 
+    const indicatorValues = new Set(
+      Object.values(nextSubjectMeta.indicators).flatMap(indicator =>
+        indicator.options.map(option => option.value),
+      ),
+    );
+    const filteredIndicators = state.query.indicators.filter(indicator =>
+      indicatorValues.has(indicator),
+    );
+
+    const filterValues = new Set(
+      Object.values(nextSubjectMeta.filters).flatMap(filterGroup =>
+        Object.values(filterGroup.options).flatMap(filter =>
+          filter.options.map(option => option.value),
+        ),
+      ),
+    );
+    const filteredFilters = state.query.filters.filter(filter =>
+      filterValues.has(filter),
+    );
+
     updateState(draft => {
       draft.subjectMeta.indicators = nextSubjectMeta.indicators;
       draft.subjectMeta.filters = nextSubjectMeta.filters;
-
+      draft.query.indicators = filteredIndicators;
+      draft.query.filters = filteredFilters;
       draft.query.timePeriod = {
         startYear,
         startCode,

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableToolWizard.tsx
@@ -197,25 +197,36 @@ const TableToolWizard = ({
       locations,
       subjectId: state.query.subjectId,
     });
+
+    const { timePeriod } = state.query;
+
     // Check if selected time period is in the time period options so can reset it if not.
     const hasStartTimePeriod = nextSubjectMeta.timePeriod.options.some(
       option =>
-        option.code === state.query.timePeriod?.startCode &&
-        option.year === state.query.timePeriod.startYear,
+        option.code === timePeriod?.startCode &&
+        option.year === timePeriod.startYear,
     );
     const hasEndTimePeriod = nextSubjectMeta.timePeriod.options.some(
       option =>
-        option.code === state.query.timePeriod?.endCode &&
-        option.year === state.query.timePeriod.endYear,
+        option.code === timePeriod?.endCode &&
+        option.year === timePeriod.endYear,
     );
 
     updateState(draft => {
       draft.subjectMeta.timePeriod = nextSubjectMeta.timePeriod;
+
       draft.query.locations = locations;
-      draft.query.timePeriod =
-        hasStartTimePeriod && hasEndTimePeriod
-          ? state.query.timePeriod
-          : undefined;
+
+      if (timePeriod && hasStartTimePeriod && hasEndTimePeriod) {
+        draft.query.timePeriod = {
+          startYear: hasStartTimePeriod ? timePeriod.startYear : 0,
+          startCode: hasStartTimePeriod ? timePeriod.startCode : '',
+          endYear: hasEndTimePeriod ? timePeriod.endYear : 0,
+          endCode: hasEndTimePeriod ? timePeriod.endCode : '',
+        };
+      } else {
+        draft.query.timePeriod = undefined;
+      }
     });
   };
 
@@ -372,9 +383,7 @@ const TableToolWizard = ({
               {stepProps => (
                 <TimePeriodForm
                   {...stepProps}
-                  initialValues={{
-                    timePeriod: state.query.timePeriod,
-                  }}
+                  initialValues={state.query.timePeriod}
                   options={state.subjectMeta.timePeriod.options}
                   onSubmit={handleTimePeriodFormSubmit}
                 />

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TimePeriodForm.tsx
@@ -25,13 +25,13 @@ export type TimePeriodFormSubmitHandler = (values: FormValues) => void;
 const formId = 'timePeriodForm';
 
 interface Props extends InjectedWizardProps {
-  initialValues?: { timePeriod?: TimePeriodQuery };
+  initialValues?: Partial<TimePeriodQuery>;
   options: SubjectMeta['timePeriod']['options'];
   onSubmit: TimePeriodFormSubmitHandler;
 }
 
 const TimePeriodForm = ({
-  initialValues = { timePeriod: undefined },
+  initialValues = {},
   options,
   onSubmit,
   ...stepProps
@@ -51,21 +51,6 @@ const TimePeriodForm = ({
     }),
   ];
 
-  const formInitialValues = useMemo(() => {
-    let start = '';
-    let end = '';
-
-    if (initialValues && initialValues.timePeriod) {
-      start = `${initialValues.timePeriod.startYear}_${initialValues.timePeriod.startCode}`;
-      end = `${initialValues.timePeriod.endYear}_${initialValues.timePeriod.endCode}`;
-    }
-
-    return {
-      start,
-      end,
-    };
-  }, [initialValues]);
-
   const getOptionLabel = (optionValue: string) => {
     const matchingOption = timePeriodOptions.find(
       option => option.value === optionValue,
@@ -83,6 +68,18 @@ const TimePeriodForm = ({
     }
     return `${getOptionLabel(startValue)} to ${getOptionLabel(endValue)}`;
   };
+
+  const formInitialValues = useMemo(() => {
+    const { startYear, startCode, endYear, endCode } = initialValues;
+
+    const start = startYear && startCode ? `${startYear}_${startCode}` : '';
+    const end = endYear && endCode ? `${endYear}_${endCode}` : '';
+
+    return {
+      start,
+      end,
+    };
+  }, [initialValues]);
 
   const stepHeading = (
     <WizardStepHeading {...stepProps} fieldsetHeading>

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -470,4 +470,103 @@ describe('TableToolWizard', () => {
       ).toBeInTheDocument();
     });
   });
+
+  test('prevent progress to final step step if pre-selected indicators are not in the subject meta', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+
+    render(
+      <TableToolWizard
+        themeMeta={testThemeMeta}
+        initialState={{
+          initialStep: 4,
+          subjects: testSubjects,
+          subjectMeta: testSubjectMeta,
+          query: {
+            publicationId: 'publication-1',
+            subjectId: 'subject-1',
+            locations: {
+              localAuthority: ['barnet'],
+            },
+            filters: ['state-funded-primary'],
+            indicators: ['another-indicator'],
+            timePeriod: {
+              endCode: 'AY',
+              endYear: 2021,
+              startCode: 'AY',
+              startYear: 2021,
+            },
+          },
+        }}
+      />,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Next step' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 5')).toBeInTheDocument();
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Create table' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('There is a problem')).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', {
+          name: 'Select at least one option from indicators',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('prevent progress to final step if pre-selected filters are not in the subject meta', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+
+    render(
+      <TableToolWizard
+        themeMeta={testThemeMeta}
+        initialState={{
+          initialStep: 4,
+          subjects: testSubjects,
+          subjectMeta: testSubjectMeta,
+          query: {
+            publicationId: 'publication-1',
+            subjectId: 'subject-1',
+            locations: {
+              localAuthority: ['barnet'],
+            },
+            filters: ['another-filter'],
+            indicators: [
+              'authorised-absence-sessions',
+              'overall-absence-sessions',
+            ],
+            timePeriod: {
+              endCode: 'AY',
+              endYear: 2021,
+              startCode: 'AY',
+              startYear: 2021,
+            },
+          },
+        }}
+      />,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Next step' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 5')).toBeInTheDocument();
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Create table' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('There is a problem')).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', {
+          name: 'Select at least one option from school type',
+        }),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -328,6 +328,7 @@ describe('TableToolWizard', () => {
   test('re-populates step choices when subject meta changes', async () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+
     render(
       <TableToolWizard
         themeMeta={testThemeMeta}
@@ -420,9 +421,10 @@ describe('TableToolWizard', () => {
     expect(indicatorCheckboxes[0]).not.toBeChecked();
   });
 
-  test('prevent progress to next step without setting dates if changing location makes the selected time period invalid', async () => {
+  test('prevent progress to filters step if pre-selected time periods are not in the subject meta', async () => {
     tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
     tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+
     render(
       <TableToolWizard
         themeMeta={testThemeMeta}

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TableToolWizard.test.tsx
@@ -1,9 +1,18 @@
 import TableToolWizard from '@common/modules/table-tool/components/TableToolWizard';
-import { Subject, SubjectMeta } from '@common/services/tableBuilderService';
+import _tableBuilderService, {
+  Subject,
+  SubjectMeta,
+} from '@common/services/tableBuilderService';
 import { Theme } from '@common/services/themeService';
 import { within } from '@testing-library/dom';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
+
+jest.mock('@common/services/tableBuilderService');
+const tableBuilderService = _tableBuilderService as jest.Mocked<
+  typeof _tableBuilderService
+>;
 
 describe('TableToolWizard', () => {
   const testThemeMeta: Theme[] = [
@@ -313,6 +322,150 @@ describe('TableToolWizard', () => {
       expect(
         step5.getByLabelText('Number of authorised absence sessions'),
       ).toHaveAttribute('checked');
+    });
+  });
+
+  test('re-populates step choices when subject meta changes', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <TableToolWizard
+        themeMeta={testThemeMeta}
+        initialState={{
+          initialStep: 2,
+          subjects: testSubjects,
+          query: {
+            publicationId: 'publication-1',
+            subjectId: 'subject-1',
+            locations: {
+              localAuthority: ['barnet'],
+            },
+            filters: ['ethnicity-major-asian-total'],
+            indicators: ['authorised-absence-sessions'],
+            timePeriod: {
+              endCode: 'AY',
+              endYear: 2013,
+              startCode: 'AY',
+              startYear: 2014,
+            },
+          },
+        }}
+      />,
+    );
+
+    // Change subject at Step 2
+    const subjectRadios = screen.getAllByLabelText(/Subject/);
+    userEvent.click(subjectRadios[1]);
+
+    userEvent.click(screen.getByRole('button', { name: 'Next step' }));
+
+    // Step 3
+    await waitFor(() => {
+      expect(screen.getByText('Step 3')).toBeInTheDocument();
+    });
+
+    const localAuthorityCheckboxes = within(
+      screen.getByRole('group', {
+        name: 'Local authority',
+        hidden: true,
+      }),
+    ).getAllByRole('checkbox', {
+      hidden: true,
+    });
+    expect(localAuthorityCheckboxes[0]).not.toBeChecked();
+    expect(localAuthorityCheckboxes[1]).not.toBeChecked();
+
+    userEvent.click(localAuthorityCheckboxes[0]);
+    userEvent.click(screen.getByRole('button', { name: 'Next step' }));
+
+    // Step 4
+    await waitFor(() => {
+      expect(screen.getByText('Step 4')).toBeInTheDocument();
+    });
+
+    const startDateOptions = within(
+      screen.getByLabelText('Start date'),
+    ).getAllByRole('option') as HTMLOptionElement[];
+    expect(startDateOptions[0].selected).toBe(true);
+
+    const endDateOptions = within(
+      screen.getByLabelText('End date'),
+    ).getAllByRole('option') as HTMLOptionElement[];
+    expect(endDateOptions[0].selected).toBe(true);
+
+    userEvent.selectOptions(screen.getByLabelText('Start date'), ['2013_AY']);
+    userEvent.selectOptions(screen.getByLabelText('End date'), ['2013_AY']);
+    userEvent.click(screen.getByRole('button', { name: 'Next step' }));
+
+    // Step 5
+    await waitFor(() => {
+      expect(screen.getByText('Step 5')).toBeInTheDocument();
+    });
+
+    const filterCheckboxes = within(
+      screen.getByRole('group', {
+        name: 'Characteristic',
+        hidden: true,
+      }),
+    ).getAllByRole('checkbox', {
+      hidden: true,
+    });
+    expect(filterCheckboxes[0]).not.toBeChecked();
+
+    const indicatorCheckboxes = within(
+      screen.getByRole('group', {
+        name: 'Indicators',
+      }),
+    ).getAllByRole('checkbox', {});
+    expect(indicatorCheckboxes[0]).not.toBeChecked();
+  });
+
+  test('prevent progress to next step without setting dates if changing location makes the selected time period invalid', async () => {
+    tableBuilderService.getSubjectMeta.mockResolvedValue(testSubjectMeta);
+    tableBuilderService.filterSubjectMeta.mockResolvedValue(testSubjectMeta);
+    render(
+      <TableToolWizard
+        themeMeta={testThemeMeta}
+        initialState={{
+          initialStep: 3,
+          subjects: testSubjects,
+          subjectMeta: testSubjectMeta,
+          query: {
+            publicationId: 'publication-1',
+            subjectId: 'subject-1',
+            locations: {
+              localAuthority: ['barnet'],
+            },
+            filters: [],
+            indicators: [],
+            timePeriod: {
+              endCode: 'AY',
+              endYear: 2021,
+              startCode: 'AY',
+              startYear: 2021,
+            },
+          },
+        }}
+      />,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: 'Next step' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 4')).toBeInTheDocument();
+    });
+
+    userEvent.click(screen.getByRole('button', { name: 'Next step' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('There is a problem')).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', { name: 'Start date required' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('link', { name: 'End date required' }),
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

Before submitting a pull request, please make sure the following is done:

1. Clone [the repository](https://github.com/dfe-analytical-services/explore-education-statistics) and create your branch from `dev`.
2. Run `npm ci && npm run bootstrap` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suites pass. 
   - Frontend tests can be run using `npm test` from the project root.
   - Backend tests can be run using `dotnet test` from `src` directory.
   - UI tests should be run from `tests/robot-tests`
-->

Fixes two table tool bugs:
1. After changing location, can move past time period step without selecting a valid time period - fixed by checking that the selected time period is still available and and resetting the selection if not.

2. Can create table despite not selecting an indicator - fixed by resetting selections when the subject is changed.

## Related changes

n/a

## Screenshots

n/a
