### PR TITLE
EES-3141 remove download table options if table not renderable

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadTable.tsx
@@ -22,6 +22,7 @@ interface Props {
   fullTable: FullTable;
   headingTag?: 'h2' | 'h3' | 'h4';
   headingSize?: 's' | 'm' | 'l';
+  isValidTable?: boolean;
   tableRef: RefObject<HTMLElement>;
   onSubmit?: (type: FileFormat) => void;
 }
@@ -31,6 +32,7 @@ const DownloadTable = ({
   fullTable,
   headingTag = 'h3',
   headingSize = 's',
+  isValidTable = true,
   tableRef,
   onSubmit,
 }: Props) => {
@@ -46,6 +48,10 @@ const DownloadTable = ({
     downloadTableOdsFile(fileName, fullTable.subjectMeta, tableRef, title);
     toggleProcessingData();
   };
+
+  if (!isValidTable) {
+    return null;
+  }
 
   return (
     <Formik<FormValues>

--- a/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/PermalinkPage.tsx
@@ -73,9 +73,9 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
       <div ref={tableRef}>
         <TimePeriodDataTable
           fullTable={fullTable}
-          onError={logException}
           source={`${publicationName}, ${subjectName}`}
           tableHeadersConfig={tableHeadersConfig}
+          onError={logException}
         />
       </div>
 
@@ -85,6 +85,11 @@ const PermalinkPage: NextPage<Props> = ({ data }) => {
           fileName={`permalink-${data.id}`}
           headingSize="m"
           headingTag="h2"
+          isValidTable={
+            fullTable.results.length > 0 &&
+            tableHeadersConfig.rows.length > 0 &&
+            tableHeadersConfig.columns.length > 0
+          }
           tableRef={tableRef}
           onSubmit={(fileFormat: FileFormat) =>
             logEvent({


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

Before submitting a pull request, please make sure the following is done:

1. Clone [the repository](https://github.com/dfe-analytical-services/explore-education-statistics) and create your branch from `dev`.
2. Run `npm ci && npm run bootstrap` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suites pass. 
   - Frontend tests can be run using `npm test` from the project root.
   - Backend tests can be run using `dotnet test` from `src` directory.
   - UI tests should be run from `tests/robot-tests`
-->

Removes the 'Download table' form on permalinks pages if the table isn't valid. It's using a pretty basic check for what's valid, suggestions for how to make that more robust are welcome.

