### PR TITLE
EES-3141 hide download table when get error

### DIFF
--- a/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadTable.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/DownloadTable.tsx
@@ -22,7 +22,6 @@ interface Props {
   fullTable: FullTable;
   headingTag?: 'h2' | 'h3' | 'h4';
   headingSize?: 's' | 'm' | 'l';
-  isValidTable?: boolean;
   tableRef: RefObject<HTMLElement>;
   onSubmit?: (type: FileFormat) => void;
 }
@@ -32,7 +31,6 @@ const DownloadTable = ({
   fullTable,
   headingTag = 'h3',
   headingSize = 's',
-  isValidTable = true,
   tableRef,
   onSubmit,
 }: Props) => {
@@ -48,10 +46,6 @@ const DownloadTable = ({
     downloadTableOdsFile(fileName, fullTable.subjectMeta, tableRef, title);
     toggleProcessingData();
   };
-
-  if (!isValidTable) {
-    return null;
-  }
 
   return (
     <Formik<FormValues>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

Before submitting a pull request, please make sure the following is done:

1. Clone [the repository](https://github.com/dfe-analytical-services/explore-education-statistics) and create your branch from `dev`.
2. Run `npm ci && npm run bootstrap` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suites pass. 
   - Frontend tests can be run using `npm test` from the project root.
   - Backend tests can be run using `dotnet test` from `src` directory.
   - UI tests should be run from `tests/robot-tests`
-->

Changed it so the download table form is hidden based on getting an error from the table rendering. 

Also, couldn't find out what exactly you get in GA for exceptions, or see the 'crashes and exceptions' section where it's meant to be in GA so to be on the safe side have changed it to be an event.
