### PR TITLE
EES-3144 fix selecting areas on maps

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/MapBlockInternal.tsx
@@ -454,12 +454,6 @@ export const MapBlockInternal = ({
   const selectedDataSetConfiguration =
     dataSetCategoryConfigs[selectedDataSetKey];
 
-  if (mapRef && mapRef.current) {
-    mapRef.current.leafletElement.setMaxBounds(
-      mapRef.current.leafletElement.getBounds(),
-    );
-  }
-
   // initialise
   useEffect(() => {
     import('@common/modules/charts/files/ukGeoJson.json').then(imported => {
@@ -687,6 +681,11 @@ export const MapBlockInternal = ({
               center={position}
               minZoom={5}
               zoom={5}
+              whenReady={() => {
+                mapRef.current?.leafletElement.setMaxBounds(
+                  mapRef.current.leafletElement.getBounds(),
+                );
+              }}
             >
               <GeoJSON data={ukGeometry} className={styles.uk} ref={ukRef} />
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

Before submitting a pull request, please make sure the following is done:

1. Clone [the repository](https://github.com/dfe-analytical-services/explore-education-statistics) and create your branch from `dev`.
2. Run `npm ci && npm run bootstrap` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suites pass. 
   - Frontend tests can be run using `npm test` from the project root.
   - Backend tests can be run using `dotnet test` from `src` directory.
   - UI tests should be run from `tests/robot-tests`
-->

Selecting areas on maps via the drop down or by clicking on the map was only working for the first area selected, selecting subsequent areas would not zoom to them.

This was caused by the map maxbounds being updated when areas were selected (so to a smaller area than the whole of the map) instead of just when the map is initially loaded. Moving this to the map whenReady event means that maxbounds is only set once.