### PR TITLE
EES-2779 group LAs in map dropdown

### DIFF
--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlockInternal.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlockInternal.test.tsx
@@ -7,9 +7,8 @@ import {
   testsMixedLocationsTableData,
   testMixedLocationsAxes,
 } from '@common/modules/charts/components/__tests__/__data__/testMapBlockData';
-import MapBlock, {
-  MapBlockProps,
-} from '@common/modules/charts/components/MapBlock';
+import { MapBlockProps } from '@common/modules/charts/components/MapBlock';
+import { MapBlockInternal } from '@common/modules/charts/components/MapBlockInternal';
 import { LegendConfiguration } from '@common/modules/charts/types/legend';
 import mapFullTable from '@common/modules/table-tool/utils/mapFullTable';
 import { within } from '@testing-library/dom';
@@ -18,7 +17,7 @@ import produce from 'immer';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 
-describe('MapBlock', () => {
+describe('MapBlockInternal', () => {
   const testFullTable = mapFullTable(testMapTableData);
   const testBlockProps: MapBlockProps = {
     ...testMapConfiguration,
@@ -32,7 +31,7 @@ describe('MapBlock', () => {
   };
 
   test('renders legends and polygons correctly', async () => {
-    const { container } = render(<MapBlock {...testBlockProps} />);
+    const { container } = render(<MapBlockInternal {...testBlockProps} />);
 
     await waitFor(() => {
       const paths = container.querySelectorAll<HTMLElement>(
@@ -79,7 +78,7 @@ describe('MapBlock', () => {
     );
 
     render(
-      <MapBlock
+      <MapBlockInternal
         {...testBlockProps}
         meta={fullTable.subjectMeta}
         data={fullTable.results}
@@ -99,7 +98,7 @@ describe('MapBlock', () => {
   });
 
   test('includes all data sets in select', async () => {
-    render(<MapBlock {...testBlockProps} />);
+    render(<MapBlockInternal {...testBlockProps} />);
 
     await waitFor(() => {
       const select = screen.getByLabelText('1. Select data to view');
@@ -117,7 +116,7 @@ describe('MapBlock', () => {
   });
 
   test('changing selected data set changes legends and polygons', async () => {
-    const { container } = render(<MapBlock {...testBlockProps} />);
+    const { container } = render(<MapBlockInternal {...testBlockProps} />);
 
     await waitFor(() => {
       const select = screen.getByLabelText('1. Select data to view');
@@ -159,7 +158,7 @@ describe('MapBlock', () => {
   });
 
   test('changing selected location focuses the correct polygon', async () => {
-    const { container } = render(<MapBlock {...testBlockProps} />);
+    const { container } = render(<MapBlockInternal {...testBlockProps} />);
 
     await waitFor(() => {
       expect(
@@ -189,7 +188,7 @@ describe('MapBlock', () => {
   });
 
   test('changing selected location renders its indicator tiles', async () => {
-    render(<MapBlock {...testBlockProps} />);
+    render(<MapBlockInternal {...testBlockProps} />);
 
     await waitFor(() => {
       expect(
@@ -237,7 +236,7 @@ describe('MapBlock', () => {
     );
 
     render(
-      <MapBlock
+      <MapBlockInternal
         {...testBlockProps}
         meta={fullTable.subjectMeta}
         data={fullTable.results}
@@ -286,7 +285,7 @@ describe('MapBlock', () => {
   });
 
   test('reseting the map when select None Selected', async () => {
-    const { container } = render(<MapBlock {...testBlockProps} />);
+    const { container } = render(<MapBlockInternal {...testBlockProps} />);
 
     await waitFor(() => {
       expect(
@@ -319,7 +318,7 @@ describe('MapBlock', () => {
         draft.data = testFullTableRegion.results;
       });
 
-      render(<MapBlock {...testBlockPropsRegion} />);
+      render(<MapBlockInternal {...testBlockPropsRegion} />);
 
       await waitFor(() => {
         expect(screen.getByLabelText('2. Select a Region')).toBeInTheDocument();
@@ -333,7 +332,7 @@ describe('MapBlock', () => {
         draft.data = testFullTableMixed.results;
       });
 
-      render(<MapBlock {...testBlockPropsMixed} />);
+      render(<MapBlockInternal {...testBlockPropsMixed} />);
 
       await waitFor(() => {
         expect(
@@ -343,7 +342,7 @@ describe('MapBlock', () => {
     });
 
     test('includes all locations and is ungrouped if does not contain local authorities', async () => {
-      render(<MapBlock {...testBlockProps} />);
+      render(<MapBlockInternal {...testBlockProps} />);
 
       await waitFor(() => {
         const select = screen.getByLabelText(
@@ -370,7 +369,7 @@ describe('MapBlock', () => {
         data: testsMixedLocationsTableData,
       };
 
-      render(<MapBlock {...testBlockProps2} />);
+      render(<MapBlockInternal {...testBlockProps2} />);
 
       await waitFor(() => {
         expect(
@@ -385,23 +384,23 @@ describe('MapBlock', () => {
       expect(groups).toHaveLength(4);
 
       const group1Options = within(groups[0]).getAllByRole('option');
-      expect(group1Options).toHaveLength(1);
-      expect(group1Options[0]).toHaveTextContent('England');
+      expect(group1Options).toHaveLength(2);
+      expect(group1Options[0]).toHaveTextContent('North West');
+      expect(group1Options[1]).toHaveTextContent('North East');
 
       const group2Options = within(groups[1]).getAllByRole('option');
       expect(group2Options).toHaveLength(2);
-      expect(group2Options[0]).toHaveTextContent('Darlington');
-      expect(group2Options[1]).toHaveTextContent('Newcastle upon Tyne');
+      expect(group2Options[0]).toHaveTextContent('Sheffield');
+      expect(group2Options[1]).toHaveTextContent('Rotherham');
 
       const group3Options = within(groups[2]).getAllByRole('option');
       expect(group3Options).toHaveLength(2);
-      expect(group3Options[0]).toHaveTextContent('Rotherham');
-      expect(group3Options[1]).toHaveTextContent('Sheffield');
+      expect(group3Options[0]).toHaveTextContent('Newcastle upon Tyne');
+      expect(group3Options[1]).toHaveTextContent('Darlington');
 
       const group4Options = within(groups[3]).getAllByRole('option');
-      expect(group4Options).toHaveLength(2);
-      expect(group4Options[0]).toHaveTextContent('North East');
-      expect(group4Options[1]).toHaveTextContent('North West');
+      expect(group4Options).toHaveLength(1);
+      expect(group4Options[0]).toHaveTextContent('England');
     });
   });
 });

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlockInternal.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlockInternal.test.tsx
@@ -5,6 +5,7 @@ import {
   testMapTableDataMixed,
   testsMixedLocationsFullTableMeta,
   testsMixedLocationsTableData,
+  testsMixedLocationsTableDataWithLADs,
   testMixedLocationsAxes,
 } from '@common/modules/charts/components/__tests__/__data__/testMapBlockData';
 import { MapBlockProps } from '@common/modules/charts/components/MapBlock';
@@ -170,9 +171,11 @@ describe('MapBlockInternal', () => {
       '2. Select a Local Authority District',
     );
 
-    expect(select.children[1]).toHaveTextContent('Leeds');
+    const groups = within(select).getAllByRole('group');
+    const group1Options = within(groups[0]).getAllByRole('option');
+    expect(group1Options[0]).toHaveTextContent('Leeds');
 
-    userEvent.selectOptions(select, select.children[1] as HTMLElement);
+    userEvent.selectOptions(select, group1Options[0]);
 
     const paths = container.querySelectorAll<HTMLElement>(
       '.leaflet-container svg path',
@@ -199,8 +202,10 @@ describe('MapBlockInternal', () => {
     const select = screen.getByLabelText(
       '2. Select a Local Authority District',
     );
+    const groups = within(select).getAllByRole('group');
+    const group1Options = within(groups[0]).getAllByRole('option');
 
-    userEvent.selectOptions(select, select.children[1] as HTMLElement);
+    userEvent.selectOptions(select, group1Options[0]);
 
     const indicators = screen.getAllByTestId('mapBlock-indicator');
 
@@ -252,8 +257,10 @@ describe('MapBlockInternal', () => {
     const select = screen.getByLabelText(
       '2. Select a Local Authority District',
     );
+    const groups = within(select).getAllByRole('group');
+    const group1Options = within(groups[0]).getAllByRole('option');
 
-    userEvent.selectOptions(select, select.children[1] as HTMLElement);
+    userEvent.selectOptions(select, group1Options[0]);
 
     const tile1 = within(screen.getAllByTestId('mapBlock-indicator')[0]);
     expect(tile1.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
@@ -263,7 +270,7 @@ describe('MapBlockInternal', () => {
       '3.51%',
     );
 
-    userEvent.selectOptions(select, select.children[2] as HTMLElement);
+    userEvent.selectOptions(select, group1Options[1]);
 
     const tile2 = within(screen.getAllByTestId('mapBlock-indicator')[0]);
     expect(tile2.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
@@ -273,7 +280,7 @@ describe('MapBlockInternal', () => {
       '3.01%',
     );
 
-    userEvent.selectOptions(select, select.children[3] as HTMLElement);
+    userEvent.selectOptions(select, group1Options[2]);
 
     const tile3 = within(screen.getAllByTestId('mapBlock-indicator')[0]);
     expect(tile3.getByTestId('mapBlock-indicatorTile-title')).toHaveTextContent(
@@ -296,8 +303,10 @@ describe('MapBlockInternal', () => {
     const select = screen.getByLabelText(
       '2. Select a Local Authority District',
     );
+    const groups = within(select).getAllByRole('group');
+    const group1Options = within(groups[0]).getAllByRole('option');
 
-    userEvent.selectOptions(select, select.children[1] as HTMLElement);
+    userEvent.selectOptions(select, group1Options[0]);
 
     const paths = container.querySelectorAll<HTMLElement>(
       '.leaflet-container svg path',
@@ -305,7 +314,7 @@ describe('MapBlockInternal', () => {
 
     expect(paths[3]).toHaveClass('selected');
 
-    userEvent.selectOptions(select, select.children[0] as HTMLElement);
+    userEvent.selectOptions(select, within(select).getAllByRole('option')[0]);
     expect(paths[3]).not.toHaveClass('selected');
   });
 
@@ -341,7 +350,7 @@ describe('MapBlockInternal', () => {
       });
     });
 
-    test('includes all locations and is ungrouped if does not contain local authorities', async () => {
+    test('shows ungrouped location options if no local authorities', async () => {
       render(<MapBlockInternal {...testBlockProps} />);
 
       await waitFor(() => {
@@ -350,20 +359,20 @@ describe('MapBlockInternal', () => {
         );
 
         expect(select).toBeVisible();
-
-        expect(select.children).toHaveLength(4);
-        expect(select.children[0]).toHaveTextContent('None selected');
-        expect(select.children[1]).toHaveTextContent('Leeds');
-        expect(select.children[2]).toHaveTextContent('Manchester');
-        expect(select.children[3]).toHaveTextContent('Sheffield');
+        const options = within(select).getAllByRole('option');
+        expect(options).toHaveLength(4);
+        expect(options[0]).toHaveTextContent('None selected');
+        expect(options[1]).toHaveTextContent('Leeds');
+        expect(options[2]).toHaveTextContent('Manchester');
+        expect(options[3]).toHaveTextContent('Sheffield');
       });
     });
 
-    test('includes all locations and is grouped if contains local authorities', async () => {
+    test('shows grouped location options if there are local authorities', async () => {
       const testBlockProps2: MapBlockProps = {
         ...testMapConfiguration,
         id: 'testMap',
-        axes: testMixedLocationsAxes as MapBlockProps['axes'],
+        axes: testMixedLocationsAxes,
         legend: testMapConfiguration.legend as LegendConfiguration,
         meta: testsMixedLocationsFullTableMeta,
         data: testsMixedLocationsTableData,
@@ -383,24 +392,61 @@ describe('MapBlockInternal', () => {
       const groups = within(select).getAllByRole('group');
       expect(groups).toHaveLength(4);
 
+      expect(groups[0]).toHaveProperty('label', 'Region');
       const group1Options = within(groups[0]).getAllByRole('option');
       expect(group1Options).toHaveLength(2);
       expect(group1Options[0]).toHaveTextContent('North West');
       expect(group1Options[1]).toHaveTextContent('North East');
 
+      expect(groups[1]).toHaveProperty('label', 'Yorkshire and the Humber');
       const group2Options = within(groups[1]).getAllByRole('option');
       expect(group2Options).toHaveLength(2);
       expect(group2Options[0]).toHaveTextContent('Sheffield');
       expect(group2Options[1]).toHaveTextContent('Rotherham');
 
+      expect(groups[2]).toHaveProperty('label', 'North East');
       const group3Options = within(groups[2]).getAllByRole('option');
       expect(group3Options).toHaveLength(2);
       expect(group3Options[0]).toHaveTextContent('Newcastle upon Tyne');
       expect(group3Options[1]).toHaveTextContent('Darlington');
 
+      expect(groups[3]).toHaveProperty('label', 'Country');
       const group4Options = within(groups[3]).getAllByRole('option');
       expect(group4Options).toHaveLength(1);
       expect(group4Options[0]).toHaveTextContent('England');
+    });
+
+    test('shows grouped location options if there are local authority districts', async () => {
+      const testBlockProps2: MapBlockProps = {
+        ...testMapConfiguration,
+        id: 'testMap',
+        axes: testMixedLocationsAxes,
+        legend: testMapConfiguration.legend as LegendConfiguration,
+        meta: testsMixedLocationsFullTableMeta,
+        data: testsMixedLocationsTableDataWithLADs,
+      };
+
+      render(<MapBlockInternal {...testBlockProps2} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('2. Select a Local Authority District'),
+        ).toBeInTheDocument();
+      });
+      const select = screen.getByLabelText(
+        '2. Select a Local Authority District',
+      );
+
+      expect(select.children[0]).toHaveTextContent('None selected');
+
+      const groups = within(select).getAllByRole('group');
+      expect(groups).toHaveLength(1);
+
+      expect(groups[0]).toHaveProperty('label', 'Yorkshire and the Humber');
+      const group1Options = within(groups[0]).getAllByRole('option');
+      expect(group1Options).toHaveLength(2);
+      expect(group1Options[0]).toHaveTextContent('Rotherham LAD');
+      expect(group1Options[1]).toHaveTextContent('Sheffield LAD');
     });
   });
 });

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlockInternal.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlockInternal.test.tsx
@@ -392,28 +392,28 @@ describe('MapBlockInternal', () => {
       const groups = within(select).getAllByRole('group');
       expect(groups).toHaveLength(4);
 
-      expect(groups[0]).toHaveProperty('label', 'Region');
+      expect(groups[0]).toHaveProperty('label', 'Country');
       const group1Options = within(groups[0]).getAllByRole('option');
-      expect(group1Options).toHaveLength(2);
-      expect(group1Options[0]).toHaveTextContent('North West');
-      expect(group1Options[1]).toHaveTextContent('North East');
+      expect(group1Options).toHaveLength(1);
+      expect(group1Options[0]).toHaveTextContent('England');
 
-      expect(groups[1]).toHaveProperty('label', 'Yorkshire and the Humber');
+      expect(groups[1]).toHaveProperty('label', 'North East');
       const group2Options = within(groups[1]).getAllByRole('option');
       expect(group2Options).toHaveLength(2);
-      expect(group2Options[0]).toHaveTextContent('Sheffield');
-      expect(group2Options[1]).toHaveTextContent('Rotherham');
+      expect(group2Options[0]).toHaveTextContent('Darlington');
+      expect(group2Options[1]).toHaveTextContent('Newcastle upon Tyne');
 
-      expect(groups[2]).toHaveProperty('label', 'North East');
+      expect(groups[2]).toHaveProperty('label', 'Yorkshire and the Humber');
       const group3Options = within(groups[2]).getAllByRole('option');
       expect(group3Options).toHaveLength(2);
-      expect(group3Options[0]).toHaveTextContent('Newcastle upon Tyne');
-      expect(group3Options[1]).toHaveTextContent('Darlington');
+      expect(group3Options[0]).toHaveTextContent('Rotherham');
+      expect(group3Options[1]).toHaveTextContent('Sheffield');
 
-      expect(groups[3]).toHaveProperty('label', 'Country');
+      expect(groups[3]).toHaveProperty('label', 'Region');
       const group4Options = within(groups[3]).getAllByRole('option');
-      expect(group4Options).toHaveLength(1);
-      expect(group4Options[0]).toHaveTextContent('England');
+      expect(group4Options).toHaveLength(2);
+      expect(group4Options[0]).toHaveTextContent('North East');
+      expect(group4Options[1]).toHaveTextContent('North West');
     });
 
     test('shows grouped location options if there are local authority districts', async () => {
@@ -445,8 +445,8 @@ describe('MapBlockInternal', () => {
       expect(groups[0]).toHaveProperty('label', 'Yorkshire and the Humber');
       const group1Options = within(groups[0]).getAllByRole('option');
       expect(group1Options).toHaveLength(2);
-      expect(group1Options[0]).toHaveTextContent('Rotherham LAD');
-      expect(group1Options[1]).toHaveTextContent('Sheffield LAD');
+      expect(group1Options[0]).toHaveTextContent('Sheffield LAD');
+      expect(group1Options[1]).toHaveTextContent('Rotherham LAD');
     });
   });
 });

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
@@ -11,6 +11,7 @@ import {
   LocationFilter,
   TimePeriodFilter,
 } from '@common/modules/table-tool/types/filters';
+import { MapBlockProps } from '@common/modules/charts/components/MapBlock';
 import produce from 'immer';
 
 export const testMapConfiguration: Chart = {
@@ -726,6 +727,20 @@ export const testsMixedLocationsFullTableMeta: FullTableMeta = {
       level: 'region',
       geoJson: [testGeoJsonFeature],
     }),
+    new LocationFilter({
+      value: 'sheffield-lad-code',
+      label: 'Sheffield LAD',
+      group: 'Yorkshire and the Humber',
+      level: 'localAuthorityDistrict',
+      geoJson: [testGeoJsonFeature],
+    }),
+    new LocationFilter({
+      value: 'rotherham-lad-code',
+      label: 'Rotherham LAD',
+      group: 'Yorkshire and the Humber',
+      level: 'localAuthorityDistrict',
+      geoJson: [testGeoJsonFeature],
+    }),
   ],
   timePeriodRange: [
     new TimePeriodFilter({
@@ -833,7 +848,48 @@ export const testsMixedLocationsTableData: TableDataResult[] = [
   },
 ];
 
-export const testMixedLocationsAxes = {
+export const testsMixedLocationsTableDataWithLADs: TableDataResult[] = [
+  {
+    filters: ['characteristic-total'],
+    geographicLevel: 'localAuthorityDistrict',
+    location: {
+      country: { code: 'england-code', name: 'England' },
+      region: {
+        code: 'yorkshire-humber-code',
+        name: 'Yorkshire and the Humber',
+      },
+      localAuthorityDistrict: {
+        code: 'sheffield-lad-code',
+        name: 'Sheffield LAD',
+      },
+    },
+    measures: {
+      'authorised-absence-rate': '4',
+    },
+    timePeriod: '2016_AY',
+  },
+  {
+    filters: ['characteristic-total'],
+    geographicLevel: 'localAuthorityDistrict',
+    location: {
+      country: { code: 'england-code', name: 'England' },
+      region: {
+        code: 'yorkshire-humber-code',
+        name: 'Yorkshire and the Humber',
+      },
+      localAuthorityDistrict: {
+        code: 'rotherham-lad-code',
+        name: 'Rotherham LAD',
+      },
+    },
+    measures: {
+      'authorised-absence-rate': '4',
+    },
+    timePeriod: '2016_AY',
+  },
+];
+
+export const testMixedLocationsAxes: MapBlockProps['axes'] = {
   major: {
     type: 'major',
     groupBy: 'locations',
@@ -844,5 +900,7 @@ export const testMixedLocationsAxes = {
         timePeriod: '2016_AY',
       },
     ],
+    referenceLines: [],
+    visible: true,
   },
 };

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
@@ -1,5 +1,16 @@
-import { TableDataResponse } from '@common/services/tableBuilderService';
+import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
+import {
+  GeoJsonFeature,
+  TableDataResponse,
+  TableDataResult,
+} from '@common/services/tableBuilderService';
 import { Chart } from '@common/services/types/blocks';
+import {
+  CategoryFilter,
+  Indicator,
+  LocationFilter,
+  TimePeriodFilter,
+} from '@common/modules/table-tool/types/filters';
 import produce from 'immer';
 
 export const testMapConfiguration: Chart = {
@@ -626,3 +637,212 @@ export const testMapTableDataMixed = produce(testMapTableData, draft => {
     },
   ];
 });
+
+const testGeoJsonFeature: GeoJsonFeature = {
+  type: 'Feature',
+  geometry: { type: 'Polygon', coordinates: [] },
+  properties: {
+    code: '',
+    name: '',
+    lat: 1,
+    long: 2,
+  },
+};
+
+export const testsMixedLocationsFullTableMeta: FullTableMeta = {
+  geoJsonAvailable: false,
+  publicationName: 'Pupil absence in schools in England',
+  subjectName: 'Absence by characteristic',
+  footnotes: [],
+  boundaryLevels: [],
+  filters: {
+    Characteristic: {
+      name: 'Characteristic total',
+      options: [
+        new CategoryFilter({
+          value: 'characteristic-total',
+          label: 'Total',
+          group: 'Gender',
+          category: 'Characteristic',
+        }),
+      ],
+    },
+  },
+  indicators: [
+    new Indicator({
+      label: 'Authorised absence rate',
+      value: 'authorised-absence-rate',
+      unit: '%',
+      name: 'sess_authorised_percent',
+    }),
+  ],
+  locations: [
+    new LocationFilter({
+      value: 'england-code',
+      label: 'England',
+      group: 'England',
+      level: 'country',
+      geoJson: [testGeoJsonFeature],
+    }),
+    new LocationFilter({
+      value: 'darlington-code',
+      label: 'Darlington',
+      level: 'localAuthority',
+      group: 'North East',
+      geoJson: [testGeoJsonFeature],
+    }),
+    new LocationFilter({
+      value: 'newcastle-code',
+      label: 'Newcastle upon Tyne',
+      group: 'North East',
+      level: 'localAuthority',
+      geoJson: [testGeoJsonFeature],
+    }),
+    new LocationFilter({
+      value: 'rotherham-code',
+      label: 'Rotherham',
+      group: 'Yorkshire and the Humber',
+      level: 'localAuthority',
+      geoJson: [testGeoJsonFeature],
+    }),
+    new LocationFilter({
+      value: 'sheffield-code',
+      label: 'Sheffield',
+      group: 'Yorkshire and the Humber',
+      level: 'localAuthority',
+      geoJson: [testGeoJsonFeature],
+    }),
+    new LocationFilter({
+      value: 'north-east-code',
+      label: 'North East',
+      group: 'North East',
+      level: 'region',
+      geoJson: [testGeoJsonFeature],
+    }),
+    new LocationFilter({
+      value: 'north-west-code',
+      label: 'North West',
+      group: 'North West',
+      level: 'region',
+      geoJson: [testGeoJsonFeature],
+    }),
+  ],
+  timePeriodRange: [
+    new TimePeriodFilter({
+      code: 'AY',
+      year: 2016,
+      label: '2016/17',
+      order: 0,
+    }),
+  ],
+};
+
+export const testsMixedLocationsTableData: TableDataResult[] = [
+  {
+    filters: ['characteristic-total'],
+    geographicLevel: 'country',
+    location: {
+      country: { code: 'england-code', name: 'England' },
+    },
+    measures: {
+      'authorised-absence-rate': '3.5',
+    },
+    timePeriod: '2016_AY',
+  },
+  {
+    filters: ['characteristic-total'],
+    geographicLevel: 'region',
+    location: {
+      country: { code: 'england-code', name: 'England' },
+      region: { code: 'north-east-code', name: 'North East' },
+    },
+    measures: {
+      'authorised-absence-rate': '3',
+    },
+    timePeriod: '2016_AY',
+  },
+  {
+    filters: ['characteristic-total'],
+    geographicLevel: 'region',
+    location: {
+      country: { code: 'england-code', name: 'England' },
+      region: { code: 'north-west-code', name: 'North West' },
+    },
+    measures: {
+      'authorised-absence-rate': '4',
+    },
+    timePeriod: '2016_AY',
+  },
+  {
+    filters: ['characteristic-total'],
+    geographicLevel: 'localAuthority',
+    location: {
+      country: { code: 'england-code', name: 'England' },
+      region: {
+        code: 'yorkshire-humber-code',
+        name: 'Yorkshire and the Humber',
+      },
+      localAuthority: { code: 'rotherham-code', name: 'Rotherham' },
+    },
+    measures: {
+      'authorised-absence-rate': '4',
+    },
+    timePeriod: '2016_AY',
+  },
+  {
+    filters: ['characteristic-total'],
+    geographicLevel: 'localAuthority',
+    location: {
+      country: { code: 'england-code', name: 'England' },
+      region: {
+        code: 'yorkshire-humber-code',
+        name: 'Yorkshire and the Humber',
+      },
+      localAuthority: { code: 'sheffield-code', name: 'Sheffield' },
+    },
+    measures: {
+      'authorised-absence-rate': '4',
+    },
+    timePeriod: '2016_AY',
+  },
+  {
+    filters: ['characteristic-total'],
+    geographicLevel: 'localAuthority',
+    location: {
+      country: { code: 'england-code', name: 'England' },
+      region: { code: 'north-east-code', name: 'North East' },
+      localAuthority: { code: 'newcastle-code', name: 'Newcastle upon Tyne' },
+    },
+    measures: {
+      'authorised-absence-rate': '4',
+    },
+    timePeriod: '2016_AY',
+  },
+  {
+    filters: ['characteristic-total'],
+    geographicLevel: 'localAuthority',
+    location: {
+      country: { code: 'england-code', name: 'England' },
+      region: { code: 'north-east-code', name: 'North East' },
+      localAuthority: { code: 'darlington-code', name: 'Darlington' },
+    },
+    measures: {
+      'authorised-absence-rate': '4',
+    },
+    timePeriod: '2016_AY',
+  },
+];
+
+export const testMixedLocationsAxes = {
+  major: {
+    type: 'major',
+    groupBy: 'locations',
+    dataSets: [
+      {
+        indicator: 'authorised-absence-rate',
+        filters: ['characteristic-total'],
+        timePeriod: '2016_AY',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

Before submitting a pull request, please make sure the following is done:

1. Clone [the repository](https://github.com/dfe-analytical-services/explore-education-statistics) and create your branch from `dev`.
2. Run `npm ci && npm run bootstrap` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suites pass. 
   - Frontend tests can be run using `npm test` from the project root.
   - Backend tests can be run using `dotnet test` from `src` directory.
   - UI tests should be run from `tests/robot-tests`
-->

- Groups Local Authorities by region in the Map block location dropdown
- If other location levels are also in the locations then they are grouped by level
- If there are no LAs in the locations then the list is not grouped and remains as it is currently.
- Also changed the 'None selected' option to be added as a placeholder on the FormSelect instead of being added to the options array.

## Screenshots

![groups](https://user-images.githubusercontent.com/81572860/152353934-aaf8cda4-d3b1-40a0-8bee-d8f8950966bd.PNG)

