### PR TITLE
EES-2999 - added fix for provider and school level Location queries

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationPredicateBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationPredicateBuilder.cs
@@ -14,14 +14,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
     public static class LocationPredicateBuilder
     {
         public static Expression<Func<Location, bool>> Build(
-            IEnumerable<Guid>? locationIds,
+            IList<Guid>? locationIds,
             LocationQuery? locationCodes)
         {
             var predicate = PredicateBuilder.True<Location>();
 
-            if (locationIds != null)
+            if (locationIds != null && locationIds.Any())
             {
-                predicate = predicate.AndAlso(location =>
+                return predicate.AndAlso(location =>
                     locationIds.Contains(location.Id));
             }
 
@@ -37,9 +37,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 {
                     predicate = predicate.AndAlso(LocationAttributesPredicate(locationCodes));
                 }
+
+                return predicate;
             }
 
-            return predicate;
+            throw new ArgumentException("Location predicate too broad");
         }
 
         private static Expression<Func<Location, bool>> LocationAttributesPredicate(LocationQuery query)
@@ -96,6 +98,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 predicate = predicate.Or(ParliamentaryConstituencyPredicate(query));
             }
 
+            if (query.PlanningArea != null)
+            {
+                predicate = predicate.Or(PlanningAreaPredicate(query));
+            }
+
             if (query.Provider != null)
             {
                 predicate = predicate.Or(ProviderPredicate(query));
@@ -126,11 +133,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 predicate = predicate.Or(WardPredicate(query));
             }
 
-            if (query.PlanningArea != null)
-            {
-                predicate = predicate.Or(PlanningAreaPredicate(query));
-            }
-
             return predicate;
         }
 
@@ -146,11 +148,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                      query.MayoralCombinedAuthority.IsNullOrEmpty() &&
                      query.OpportunityArea.IsNullOrEmpty() &&
                      query.ParliamentaryConstituency.IsNullOrEmpty() &&
+                     query.PlanningArea.IsNullOrEmpty() &&
+                     query.Provider.IsNullOrEmpty() &&
                      query.Region.IsNullOrEmpty() &&
                      query.RscRegion.IsNullOrEmpty() &&
+                     query.School.IsNullOrEmpty() &&
                      query.Sponsor.IsNullOrEmpty() &&
-                     query.Ward.IsNullOrEmpty() &&
-                     query.PlanningArea.IsNullOrEmpty());
+                     query.Ward.IsNullOrEmpty());
         }
 
         private static Expression<Func<Location, bool>> CountryPredicate(LocationQuery query)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationPredicateBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationPredicateBuilder.cs
@@ -28,20 +28,33 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             // TODO EES-3068 Migrate Location codes to ids in old Datablocks to remove this support for Location codes
             if (locationCodes != null)
             {
-                if (locationCodes.GeographicLevel != null)
+                var geographicLevel = locationCodes.GeographicLevel;
+                var locationAttributesPredicate = LocationAttributesExist(locationCodes)
+                    ? LocationAttributesPredicate(locationCodes)
+                    : null;
+
+                if (geographicLevel == null && locationAttributesPredicate == null)
+                {
+                    throw new ArgumentException("Using LocationPredicateBuilder with LocationCodes is only " +
+                                                "valid if a GeographicLevel or Location Attributes are provided");
+                }
+                
+                if (geographicLevel != null)
                 {
                     predicate = predicate.AndAlso(location => location.GeographicLevel == locationCodes.GeographicLevel);
                 }
 
-                if (LocationAttributesExist(locationCodes))
+                if (locationAttributesPredicate != null)
                 {
-                    predicate = predicate.AndAlso(LocationAttributesPredicate(locationCodes));
+                    predicate = predicate.AndAlso(locationAttributesPredicate);
                 }
 
                 return predicate;
             }
 
-            throw new ArgumentException("Location predicate too broad");
+            throw new ArgumentException("Only valid to use LocationPredicateBuilder when supplying " +
+                                        "LocationIds, LocationCodes with a GeographicLevel or LocationCodes with " +
+                                        "Location Attributes supplied");
         }
 
         private static Expression<Func<Location, bool>> LocationAttributesPredicate(LocationQuery query)

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationPredicateBuilder.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/LocationPredicateBuilder.cs
@@ -17,7 +17,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             IList<Guid>? locationIds,
             LocationQuery? locationCodes)
         {
-            if (locationIds == null && locationCodes == null)
+            if ((locationIds == null || !locationIds.Any()) && locationCodes == null)
             {
                 throw new ArgumentException("Only valid to use LocationPredicateBuilder when supplying " +
                                             "either LocationIds or LocationCodes");

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ObservationService.cs
@@ -51,7 +51,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
             {
                 locationIds = await _context
                     .Location
-                    .Where(LocationPredicateBuilder.Build(query.LocationIds, query.Locations))
+                    .Where(LocationPredicateBuilder.Build(query.LocationIds?.ToList(), query.Locations))
                     .Select(location => location.Id)
                     .ToListAsync(cancellationToken);
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/SubjectMetaService.cs
@@ -129,7 +129,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                 {
                     var stopwatch = Stopwatch.StartNew();
                     
-                    var locationQuery = LocationPredicateBuilder.Build(query.LocationIds, query.Locations);
+                    var locationQuery = 
+                        LocationPredicateBuilder.Build(query.LocationIds?.ToList(), query.Locations);
                     
                     var locationIds = _context
                         .Location


### PR DESCRIPTION
This PR:
- fixes an existing bug in LocationPredicateBuilder (formerly ObservationPredicateBuilder) whereby School and Provider were not recognised as being able to provide Location Attributes and so did not add any clauses to the overall Location predicate.
- This caused the work in 2999 to fetch too many Locations when Provider or School codes were provided, thus returning table results that were not valid for the ranges of Providers and Schools chosen in queries.

I've also added in throws for any "misuse" of the LocationPredicateBuilder i.e. any scenarios that would not actually add any genuine clauses to the location predicate.