### PR TITLE
EES-2999 Improve get_data_block_responses script

### DIFF
--- a/useful-scripts/get_data_block_responses/get_data_block_responses.py
+++ b/useful-scripts/get_data_block_responses/get_data_block_responses.py
@@ -64,60 +64,68 @@ data_api_urls = {
 
 data_api_url = data_api_urls[args.env]
 
-date = datetime.datetime.now().strftime("%Y%m%d")
+date = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
 results_dir = f'results_{args.env}_{args.stage}_{date}'
 
 datablocks = []
+
+if not os.path.exists(results_dir):
+    os.makedirs(results_dir)
+
+with open(f'{results_dir}/console_output', 'w') as file:
+    file.write('Console output: \n\n')
+
+output_file = open(f'{results_dir}/console_output', 'a')
+
+
+def print_to_console(text):
+    output_file.write(text + '\n')
+    print(text)
+
 
 with open(args.datablocks_csv, 'r') as input:
     csv_reader = csv.reader(input, delimiter=',')
     for row in csv_reader:
         datablocks.append(row)
 
-if not os.path.exists(f'{results_dir}/fails'):
-    os.makedirs(f'{results_dir}/fails')
-
 start_time = time.perf_counter()
 for datablock in datablocks:
     if datablock[0] == 'ContentBlockId':
         continue
 
+    global queryDict
+    global url
+
     guid = datablock[0]
     releaseId = datablock[1]
     subjectId = datablock[2]
+    queryDict = json.loads(datablock[3])
 
-    global query
-    global url
     if args.stage == "table":
-        query = datablock[3]
         url = f'{data_api_url}/tablebuilder/release/{releaseId}'
 
     if args.stage == "filters":
-        queryDict = json.loads(datablock[3])
         queryDict.pop("Filters")
         queryDict.pop("Indicators")
-        query = json.dumps(queryDict)
         url = f'{data_api_url}/meta/subject'
 
     if args.stage == "time_periods":
-        queryDict = json.loads(datablock[3])
         queryDict.pop("Filters")
         queryDict.pop("Indicators")
         queryDict.pop("TimePeriod")
-        query = json.dumps(queryDict)
         url = f'{data_api_url}/meta/subject'
+
+    query = json.dumps(queryDict, sort_keys=True, indent=2)
 
     assert url is not None
     assert query is not None
 
-    if os.path.exists(f'{results_dir}/block_{guid}') or os.path.exists(f'{results_dir}/fails/block_{guid}'):
+    if os.path.exists(f'{results_dir}/block_{guid}'):
         continue
 
     headers = {
         'Content-Type': 'application/json'
     }
-
-    file_path = results_dir
 
     block_time_start = time.perf_counter()
     try:
@@ -126,28 +134,27 @@ for datablock in datablocks:
                              data=query,
                              timeout=120)
     except Exception as e:
-        print(f'request exception with block {guid} subject {subjectId}\nException: {e}')
+        print_to_console(f'request exception with block {guid} subject {subjectId}\nException: {e}')
         jsonResponse = {'error': f'request exception thrown, {e}'}
-        file_path = f'{results_dir}/fails'
     block_time_end = time.perf_counter()
 
     if resp.status_code != 200:
-        print(
+        print_to_console(
             f'Response status wasn\'t 200 for block {guid} '
-            f'subject {subjectId}\n'
+            f'subject {subjectId}'
             f'{resp.text}'
         )
-        file_path = f'{results_dir}/fails'
 
     try:
         jsonResponse = json.loads(resp.text)
-    except BaseException:
-        print(f'json.loads(resp.text) failed with block {guid} '
-              f'subject {subjectId}')
-        jsonResponse = {'error': 'get_data_block_responses script failed to process response text'}
+    except Exception as e:
+        print_to_console(f'json.loads(resp.text) failed with block {guid} '
+                         f'subject {subjectId}\n'
+                         f'Exception: {e}')
+        jsonResponse = {'error': f'Failed to process response text, Exception: {e}'}
 
     try:
-        with open(f'{file_path}/block_{guid}', 'w') as file:
+        with open(f'{results_dir}/block_{guid}', 'w') as file:
             file.write(
                 f'block: {guid}\n'
                 f'release: {releaseId}\n'
@@ -156,16 +163,16 @@ for datablock in datablocks:
                 f'{query}\n'
                 f'response status: {resp.status_code}\n'
                 f'time for response: {block_time_end - block_time_start}\n'
-                f'response:\n{json.dumps(jsonResponse, sort_keys=True)}'
+                f'response:\n{json.dumps(jsonResponse, sort_keys=True, indent=2)}'
             )
-        print(f'Successfully processed block {guid} for subject {subjectId}!')
+        print_to_console(f'Successfully processed block {guid} for subject {subjectId}!')
     except BaseException:
-        print(f'file.write failed with block {guid} '
-              f'subject {subjectId}\n{resp.text}')
+        print_to_console(f'file.write failed with block {guid} '
+                         f'subject {subjectId}\n{resp.text}')
 
     time.sleep(args.sleep_duration)
 
 end_time = time.perf_counter()
-with open(f'{file_path}/time_elapsed', 'w') as file:
-    file.write(f'Elapsed time: {end_time - start_time}')
-print(f'Elapsed time: {end_time - start_time}')
+print_to_console(f'Total time: {end_time - start_time}')
+print_to_console(f'Sleep time: {args.sleep_duration * len(datablocks)}')
+print_to_console(f'Total minus sleep time: {(end_time - start_time) - (args.sleep_duration * len(datablocks))}')


### PR DESCRIPTION
This PR makes a few minor improvements to the get_data_block_responses script.

- All console output of the script is now also saved in a "console_output" file.
- Removed "fails" directory - all data block files are saved in the same directory now.