### PR TITLE
Ees 2990 allow change in app registrations for existing users

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
@@ -9,7 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Pages.Account;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
-using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Identity;
@@ -148,7 +148,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
         [Fact]
         public async Task Login_EmailClaimNotAvailable()
         {
-            var claimsPrincipal = AuthorizationHandlersTestUtil.CreateClaimsPrincipal(
+            var claimsPrincipal = ClaimsPrincipalUtils.CreateClaimsPrincipal(
                 Guid.NewGuid(),
                 new Claim(ClaimTypes.GivenName, "FirstName"),
                 new Claim(ClaimTypes.Surname, "LastName"));
@@ -532,7 +532,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
 
         private static ClaimsPrincipal CreateClaimsPrincipal(string emailAddress, string firstName, string lastName)
         {
-            return AuthorizationHandlersTestUtil.CreateClaimsPrincipal(
+            return ClaimsPrincipalUtils.CreateClaimsPrincipal(
                 Guid.NewGuid(),
                 new Claim(ClaimTypes.Email, emailAddress),
                 new Claim(ClaimTypes.GivenName, firstName),

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
@@ -1,0 +1,365 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Castle.Core.Internal;
+using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data;
+using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Pages.Account;
+using GovUk.Education.ExploreEducationStatistics.Admin.Models;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils;
+using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
+using static Moq.MockBehavior;
+using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.Pages.Account
+{
+    public class ExternalLoginTests
+    {
+        private const string ExpectedLoginErrorMessage = "Sorry, there was a problem logging you in.";
+        private const string ReturnUrl = "http://return.url";
+        private const string LoginProvider = "LoginProvider1";
+        private const string ProviderKey = "LoginProvider1Key";
+        private const string LoginProviderDisplayName = "LoginProvider1DisplayName";
+
+        private readonly IdentityUserLogin<string> _providerDetails = new()
+        {
+            LoginProvider = LoginProvider,
+            ProviderKey = ProviderKey,
+            ProviderDisplayName = LoginProviderDisplayName
+        };
+
+        [Fact]
+        public async Task Login_ExistingUser_Success()
+        {
+            var (result, loginService) = await DoExistingUserLogin(SignInResult.Success);
+            var redirectPage = Assert.IsType<LocalRedirectResult>(result);
+            Assert.Equal(ReturnUrl, redirectPage.Url);
+            Assert.False(redirectPage.Permanent);
+            Assert.Null(loginService.ErrorMessage);
+            Assert.Empty(loginService.ModelState);
+        }
+        
+        [Fact]
+        public async Task Login_ExistingUser_Failed()
+        {
+            var (result, loginService) = await DoExistingUserLogin(SignInResult.Failed);
+            AssertRedirectedToLoginPageUponFailure(result, loginService);
+        }
+        
+        [Fact]
+        public async Task Login_ExistingUser_NotAllowed()
+        {
+            var (result, loginService) = await DoExistingUserLogin(SignInResult.NotAllowed);
+            AssertRedirectedToLoginPageUponFailure(result, loginService);
+        }
+        
+        [Fact]
+        public async Task Login_ExistingUser_LockedOut()
+        {
+            var (result, loginService) = await DoExistingUserLogin(SignInResult.LockedOut);
+            var redirectPage = Assert.IsType<RedirectToPageResult>(result);
+            Assert.Equal("./Lockout", redirectPage.PageName);
+            Assert.False(redirectPage.Permanent);
+            Assert.Equal(ExpectedLoginErrorMessage, loginService.ErrorMessage);
+            Assert.Empty(loginService.ModelState);
+        }
+        
+        [Fact]
+        public async Task Login_ExistingUser_NewProviderDetails_Success()
+        {
+            var (result, loginService) = await DoLoginExistingUserWithNewProviderKey(
+                ListOf(_providerDetails),
+                IdentityResult.Success, 
+                SignInResult.Success);
+            
+            var redirectPage = Assert.IsType<LocalRedirectResult>(result);
+            Assert.Equal(ReturnUrl, redirectPage.Url);
+            Assert.False(redirectPage.Permanent);
+            Assert.Null(loginService.ErrorMessage);
+            Assert.Empty(loginService.ModelState);
+        }
+        
+        [Fact]
+        public async Task Login_ExistingUser_NewProviderDetails_FailureToAddNewProviderDetails()
+        {
+            var (result, loginService) = await DoLoginExistingUserWithNewProviderKey(
+                ListOf(_providerDetails),
+                IdentityResult.Failed(
+                    new IdentityError
+                    {
+                        Code = "500",
+                        Description = "Error 1"
+                    },
+                    new IdentityError
+                    {
+                        Code = "502",
+                        Description = "Error 2"
+                    }));
+            
+            AssertRedirectedToLoginPageUponFailure(
+                result,
+                loginService,
+                ListOf("Error 1", "Error 2"));
+        }
+
+        [Fact]
+        public async Task Login_ExistingUser_NoExistingProviderDetails_InvalidState()
+        {
+            var (result, loginService) = await DoLoginExistingUserWithNewProviderKey(
+                new List<IdentityUserLogin<string>>());
+            
+            AssertRedirectedToLoginPageUponFailure(result, loginService);
+        }
+
+        [Fact]
+        public async Task Login_RemoteErrorReceived()
+        {
+            var loginService = BuildService();
+            var result = await loginService.OnGetCallbackAsync(ReturnUrl, "Remote Error");
+            AssertRedirectedToLoginPageUponFailure(result, loginService);
+        }
+
+        [Fact]
+        public async Task Login_UnableToGetExternalLoginInfo()
+        {
+            var signInManager = new Mock<ISignInManagerDelegate>(Strict);
+
+            var loginService = BuildService(signInManager.Object);
+
+            signInManager
+                .Setup(s => s.GetExternalLoginInfoAsync(null))
+                .ReturnsAsync((ExternalLoginInfo) null!);
+
+            var result = await loginService.OnGetCallbackAsync(ReturnUrl);
+            VerifyAllMocks(signInManager);
+            
+            AssertRedirectedToLoginPageUponFailure(result, loginService);
+        }
+
+        [Fact]
+        public async Task Login_EmailClaimNotAvailable()
+        {
+            var claimsPrincipal = AuthorizationHandlersTestUtil.CreateClaimsPrincipal(
+                Guid.NewGuid(),
+                new Claim(ClaimTypes.GivenName, "FirstName"),
+                new Claim(ClaimTypes.Surname, "LastName"));
+            
+            var signInManager = new Mock<ISignInManagerDelegate>(Strict);
+
+            signInManager
+                .Setup(s => s.GetExternalLoginInfoAsync(null))
+                .ReturnsAsync(new ExternalLoginInfo(
+                    claimsPrincipal,
+                    LoginProvider,
+                    ProviderKey,
+                    LoginProviderDisplayName));
+
+            var loginService = BuildService(
+                signInManager.Object);
+
+            var result = await loginService.OnGetCallbackAsync(ReturnUrl);
+            VerifyAllMocks(signInManager);
+            
+            AssertRedirectedToLoginPageUponFailure(result, loginService);
+        }
+
+        private async Task<(IActionResult, ExternalLoginModel)> DoExistingUserLogin(SignInResult signInResult)
+        {
+            var contextId = Guid.NewGuid().ToString();
+
+            var claimsPrincipal = CreateClaimsPrincipal(
+                "existinguser@example.com",
+                "FirstName",
+                "LastName");
+
+            var userManager = new Mock<IUserManagerDelegate>(Strict);
+            var signInManager = new Mock<ISignInManagerDelegate>(Strict);
+
+            await using (var usersDbContext = InMemoryUserAndRolesDbContext(contextId))
+            {
+                await usersDbContext.UserLogins.AddAsync(new IdentityUserLogin<string>
+                {
+                    LoginProvider = LoginProvider,
+                    ProviderKey = ProviderKey,
+                    ProviderDisplayName = LoginProviderDisplayName
+                });
+                await usersDbContext.SaveChangesAsync();
+            }
+
+            await using var contentDbContext = InMemoryApplicationDbContext(contextId);
+            await using (var usersDbContext = InMemoryUserAndRolesDbContext(contextId))
+            {
+                var loginService = BuildService(
+                    signInManager.Object,
+                    userManager.Object,
+                    contentDbContext,
+                    usersDbContext);
+
+                signInManager
+                    .Setup(s => s.GetExternalLoginInfoAsync(null))
+                    .ReturnsAsync(new ExternalLoginInfo(
+                        claimsPrincipal,
+                        LoginProvider,
+                        ProviderKey,
+                        LoginProviderDisplayName));
+
+                signInManager
+                    .Setup(s => s.ExternalLoginSignInAsync(LoginProvider, ProviderKey, false, true))
+                    .ReturnsAsync(signInResult);
+
+                var result = await loginService.OnGetCallbackAsync(ReturnUrl);
+                VerifyAllMocks(userManager, signInManager);
+                
+                return (result, loginService);
+            }
+        }
+
+        private async Task<(IActionResult, ExternalLoginModel)> DoLoginExistingUserWithNewProviderKey(
+            IList<IdentityUserLogin<string>> existingProviderKeys,
+            IdentityResult? addNewIdentityResult = null,
+            SignInResult? signInResult = null)
+        {
+            var contextId = Guid.NewGuid().ToString();
+            var emailAddress = "existinguser@example.com";
+
+            var claimsPrincipal = CreateClaimsPrincipal(
+                emailAddress,
+                "FirstName",
+                "LastName");
+
+            var newProviderKey = "NewProviderKey";
+
+            var userManager = new Mock<IUserManagerDelegate>(Strict);
+            var signInManager = new Mock<ISignInManagerDelegate>(Strict);
+
+            var existingUser = new ApplicationUser
+            {
+                Email = emailAddress
+            };
+
+            await using (var usersDbContext = InMemoryUserAndRolesDbContext(contextId))
+            {
+                await usersDbContext.Users.AddAsync(existingUser);
+
+                if (!existingProviderKeys.IsNullOrEmpty())
+                {
+                    await usersDbContext.UserLogins.AddRangeAsync(existingProviderKeys);
+                }
+                
+                await usersDbContext.SaveChangesAsync();
+            }
+
+            await using var contentDbContext = InMemoryApplicationDbContext(contextId);
+            await using (var usersDbContext = InMemoryUserAndRolesDbContext(contextId))
+            {
+                var loginService = BuildService(
+                    signInManager.Object,
+                    userManager.Object,
+                    contentDbContext,
+                    usersDbContext);
+
+                signInManager
+                    .Setup(s => s.GetExternalLoginInfoAsync(null))
+                    .ReturnsAsync(new ExternalLoginInfo(
+                        claimsPrincipal,
+                        LoginProvider,
+                        newProviderKey,
+                        LoginProviderDisplayName));
+
+                var existingProviderKeyInfos = existingProviderKeys
+                    .Select(p => new UserLoginInfo(p.LoginProvider, p.ProviderKey, p.ProviderDisplayName))
+                    .ToList();
+
+                userManager
+                    .Setup(s => s.GetLoginsAsync(
+                        It.Is<ApplicationUser>(user => user.Email == existingUser.Email)))
+                    .ReturnsAsync(existingProviderKeyInfos);
+
+                if (addNewIdentityResult != null)
+                {
+                    userManager
+                        .Setup(s => s.AddLoginAsync(
+                            It.Is<ApplicationUser>(user => user.Email == existingUser.Email),
+                            It.Is<UserLoginInfo>(l => l.ProviderKey == newProviderKey
+                                                      && l.LoginProvider == LoginProvider
+                                                      && l.ProviderDisplayName == LoginProviderDisplayName)))
+                        .ReturnsAsync(addNewIdentityResult);
+                }
+
+                if (signInResult != null)
+                {
+                    signInManager
+                        .Setup(s => s.ExternalLoginSignInAsync(
+                            LoginProvider,
+                            newProviderKey,
+                            false,
+                            true))
+                        .ReturnsAsync(signInResult);
+                }
+
+                var result = await loginService.OnGetCallbackAsync(ReturnUrl);
+                VerifyAllMocks(userManager, signInManager);
+                return (result, loginService);
+            }
+        }
+
+        private static void AssertRedirectedToLoginPageUponFailure(
+            IActionResult result,
+            ExternalLoginModel loginService,
+            IList<string>? expectedModelErrors = null)
+        {
+            var redirectPage = Assert.IsType<RedirectToPageResult>(result);
+            Assert.Equal("./Login", redirectPage.PageName);
+            Assert.False(redirectPage.Permanent);
+            Assert.Equal(ExpectedLoginErrorMessage, loginService.ErrorMessage);
+
+            if (expectedModelErrors != null)
+            {
+                AssertModelErrorsEqual(expectedModelErrors, loginService);
+            }
+            else
+            {
+                Assert.Empty(loginService.ModelState);
+            }
+        }
+
+        private static ClaimsPrincipal CreateClaimsPrincipal(string emailAddress, string firstName, string lastName)
+        {
+            return AuthorizationHandlersTestUtil.CreateClaimsPrincipal(
+                Guid.NewGuid(),
+                new Claim(ClaimTypes.Email, emailAddress),
+                new Claim(ClaimTypes.GivenName, firstName),
+                new Claim(ClaimTypes.Surname, lastName));
+        }
+
+        private static void AssertModelErrorsEqual(IList<string> expectedErrors, ExternalLoginModel? loginService)
+        {
+            Assert.Equal(expectedErrors,
+                loginService.ModelState.Values.SelectMany(v => v.Errors.Select(e => e.ErrorMessage)).ToList());
+        }
+
+        private static ExternalLoginModel BuildService(
+            ISignInManagerDelegate? signInManager = null, 
+            IUserManagerDelegate? userManager = null, 
+            ContentDbContext? contentDbContext = null, 
+            UsersAndRolesDbContext? usersDbContext = null)
+        {
+            return new ExternalLoginModel(
+                signInManager ?? Mock.Of<ISignInManagerDelegate>(Strict),
+                userManager ?? Mock.Of<IUserManagerDelegate>(Strict),
+                Mock.Of<ILogger<ExternalLoginModel>>(),
+                contentDbContext,
+                usersDbContext);
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Areas/Identity/Pages/Account/ExternalLoginTests.cs
@@ -4,12 +4,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using Castle.Core.Internal;
 using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Pages.Account;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Identity;
@@ -216,9 +216,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
         {
             var contextId = Guid.NewGuid().ToString();
 
-            var email = "inviteduser@example.com";
-            var firstName = "FirstName";
-            var lastName = "LastName";
+            const string email = "inviteduser@example.com";
+            const string firstName = "FirstName";
+            const string lastName = "LastName";
             
             var claimsPrincipal = CreateClaimsPrincipal(email, firstName, lastName);
 
@@ -427,14 +427,14 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Areas.Identity.
             SignInResult? signInResult = null)
         {
             var contextId = Guid.NewGuid().ToString();
-            var emailAddress = "existinguser@example.com";
+            const string emailAddress = "existinguser@example.com";
 
             var claimsPrincipal = CreateClaimsPrincipal(
                 emailAddress,
                 "FirstName",
                 "LastName");
 
-            var newProviderKey = "NewProviderKey";
+            const string newProviderKey = "NewProviderKey";
 
             var userManager = new Mock<IUserManagerDelegate>(Strict);
             var signInManager = new Mock<ISignInManagerDelegate>(Strict);

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/GovUk.Education.ExploreEducationStatistics.Admin.Tests.csproj
@@ -29,7 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Areas" />
     <Folder Include="Controllers\Api\UserManagement" />
   </ItemGroup>
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/AdoptMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/AdoptMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
@@ -8,8 +8,8 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 using static Moq.MockBehavior;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ApproveSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ApproveSpecificMethodologyAuthorizationHandlerTests.cs
@@ -7,11 +7,10 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interf
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.
-    MethodologyStatusAuthorizationHandlers;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.MethodologyStatusAuthorizationHandlers;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseRole;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/CreateMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/CreateMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
@@ -12,8 +12,8 @@ using Microsoft.AspNetCore.Authorization;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DeleteSpecificMethodologyAuthorizationHandlerTests.cs
@@ -6,15 +6,14 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DropMethodologyLinkAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/DropMethodologyLinkAuthorizationHandlerTests.cs
@@ -8,8 +8,8 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;
 using static Moq.MockBehavior;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MakeAmendmentOfSpecificMethodologyAuthorizationHandlerTests.cs
@@ -6,15 +6,14 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.Extensions;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyPublishingStrategy;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ManageExternalMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ManageExternalMethodologyForSpecificPublicationAuthorizationHandlerTests.cs
@@ -10,8 +10,8 @@ using Microsoft.AspNetCore.Authorization;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static Moq.MockBehavior;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkSpecificMethodologyAsDraftAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/MarkSpecificMethodologyAsDraftAuthorizationHandlerTests.cs
@@ -7,11 +7,10 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interf
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.AuthorizationHandlerUtil;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.
-    MethodologyStatusAuthorizationHandlers;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Security.AuthorizationHandlers.MethodologyStatusAuthorizationHandlers;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseRole;
 using static Moq.MockBehavior;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificCommentAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificCommentAuthorizationHandlerTests.cs
@@ -5,7 +5,7 @@ using GovUk.Education.ExploreEducationStatistics.Common.Services.Security;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using Microsoft.AspNetCore.Authorization;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/UpdateSpecificMethodologyAuthorizationHandlerTests.cs
@@ -9,8 +9,8 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interf
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.MethodologyStatus;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/AuthorizationHandlersTestUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/AuthorizationHandlersTestUtil.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils;
 using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
@@ -89,7 +89,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
                 .Select(
                     claim =>
                     {
-                        var user = CreateClaimsPrincipal(
+                        var user = ClaimsPrincipalUtils.CreateClaimsPrincipal(
                             Guid.NewGuid(),
                             new Claim(claim.ToString(), "")
                         );
@@ -127,26 +127,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             {
                 Assert.False(authContext.HasSucceeded, scenario.UnexpectedPassMessage);
             }
-        }
-
-        public static ClaimsPrincipal CreateClaimsPrincipal(Guid userId)
-        {
-            return CreateClaimsPrincipal(userId, new Claim[] { });
-        }
-
-        public static ClaimsPrincipal CreateClaimsPrincipal(Guid userId, params Claim[] additionalClaims)
-        {
-            var identity = new ClaimsIdentity();
-            identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
-            identity.AddClaims(additionalClaims);
-            var user = new ClaimsPrincipal(identity);
-            return user;
-        }
-
-        public static ClaimsPrincipal CreateClaimsPrincipal(Guid userId, params SecurityClaimTypes[] additionalClaims)
-        {
-            return CreateClaimsPrincipal(userId,
-                additionalClaims.Select(c => new Claim(c.ToString(), "")).ToArray());
         }
 
         public static void ForEachSecurityClaim(Action<SecurityClaimTypes> action)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/PublicationAuthorizationHandlersTestUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/PublicationAuthorizationHandlersTestUtil.cs
@@ -9,6 +9,7 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/ReleaseAuthorizationHandlersTestUtil.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/Utils/ReleaseAuthorizationHandlersTestUtil.cs
@@ -3,13 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Security;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Model.Database;
 using Microsoft.AspNetCore.Authorization;
 using Xunit;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.EnumUtil;
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificMethodologyAuthorizationHandlerTests.cs
@@ -9,8 +9,8 @@ using GovUk.Education.ExploreEducationStatistics.Content.Model.Repository.Interf
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
-using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.
-    AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.PublicationRole;

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificPublicationAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificPublicationAuthorizationHandlersTests.cs
@@ -10,6 +10,7 @@ using static GovUk.Education.ExploreEducationStatistics.Admin.Security.Authoriza
 using static GovUk.Education.ExploreEducationStatistics.Admin.Security.SecurityClaimTypes;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.AuthorizationHandlersTestUtil;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers.Utils.PublicationAuthorizationHandlersTestUtil;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils.ClaimsPrincipalUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.AuthorizationHandlers
 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/AuthorizationHandlers/ViewSpecificReleaseAuthorizationHandlersTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Content.Model;
 using GovUk.Education.ExploreEducationStatistics.Content.Security.AuthorizationHandlers;
@@ -100,7 +101,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Author
             var failureScenario = new ReleaseHandlerTestScenario
             {
                 Entity = release,
-                User = CreateClaimsPrincipal(userId),
+                User = ClaimsPrincipalUtils.CreateClaimsPrincipal(userId),
                 UserReleaseRoles = new List<UserReleaseRole>
                 {
                     new UserReleaseRole

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/Utils/ClaimsPrincipalUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Security/Utils/ClaimsPrincipalUtils.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using GovUk.Education.ExploreEducationStatistics.Admin.Security;
+
+namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Security.Utils
+{
+    public static class ClaimsPrincipalUtils
+    {
+        public static ClaimsPrincipal CreateClaimsPrincipal(Guid userId)
+        {
+            return CreateClaimsPrincipal(userId, new Claim[] { });
+        }
+
+        public static ClaimsPrincipal CreateClaimsPrincipal(Guid userId, params Claim[] additionalClaims)
+        {
+            var identity = new ClaimsIdentity();
+            identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
+            identity.AddClaims(additionalClaims);
+            var user = new ClaimsPrincipal(identity);
+            return user;
+        }
+
+        public static ClaimsPrincipal CreateClaimsPrincipal(Guid userId, params SecurityClaimTypes[] additionalClaims)
+        {
+            return CreateClaimsPrincipal(userId,
+                additionalClaims.Select(c => new Claim(c.ToString(), "")).ToArray());
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Startup.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using AutoMapper;
 using Azure.Storage.Blobs;
 using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data;
+using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Pages.Account;
 using GovUk.Education.ExploreEducationStatistics.Admin.Controllers.Api.Bau;
 using GovUk.Education.ExploreEducationStatistics.Admin.Mappings;
 using GovUk.Education.ExploreEducationStatistics.Admin.Mappings.Interfaces;
@@ -404,6 +405,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin
 
             // This service handles the generation of the JWTs for users after they log in
             services.AddTransient<IProfileService, ApplicationUserProfileService>();
+
+            // These services act as delegates through to underlying Identity services that cannot be mocked or are
+            // hard to mock.
+            services.AddTransient<ISignInManagerDelegate, SignInManagerDelegate>();
+            services.AddTransient<IUserManagerDelegate, UserManagerDelegate>();
 
             // This service allows a set of users to be pre-invited to the service on startup.
             if (HostEnvironment.IsDevelopment())

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Either.cs
@@ -49,6 +49,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
 
         public Either<TL, TR> OrElse(Func<TR> func) => IsLeft ? func() : Right;
 
+        public Either<TL, TR> OrElse(Func<TL, TR> func) => IsLeft ? func(Left) : Right;
+
         public T Fold<T>(Func<TL, T> leftFunc, Func<TR, T> rightFunc) => IsRight ? rightFunc(Right) : leftFunc(Left);
 
         public T FoldLeft<T>(Func<TL, T> leftFunc, T defaultValue) => IsLeft ? leftFunc(Left) : defaultValue;
@@ -58,6 +60,13 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model
         public static implicit operator Either<TL, TR>(TL left) => new(left);
 
         public static implicit operator Either<TL, TR>(TR right) => new(right);
+    }
+    
+    public static class EitherExtensions {
+        public static T Result<T>(this Either<T, T> either)
+        {
+            return either.IsLeft ? either.Left : either.Right;
+        }
     }
 
     public static class EitherTaskExtensions


### PR DESCRIPTION
This PR:
* adds support for us to migrate from one App Registration to another on environments.
* adds Unit Testing around the login process.

The effects of moving App Registration (even when pointing against the same AD instance) means that the ProviderKey for a single user (unique identifier for a user provided form the login process) differ between the old and the new App Registration.

This means we must handle the ability for a single user (identified by email address) to have more than one set of ProviderKey information.  This supports not only having multiple App Registrations, but also multiple external OpenID Connect Identity Providers as well where we trust the Identity Provider and its ability to securely identify a user by their email address.  Thus we could support login from DfE's AD and also Google auth, for instance.

We can trust the details coming from the external Identity Provider because it is the one set up to communicate with in the appsettings.xml file.