### PR TITLE
EES-3146 hide permalink and download on table tool final step if table cannot render

### DIFF
--- a/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/components/TableToolFinalStep.tsx
@@ -1,5 +1,6 @@
 import Tag from '@common/components/Tag';
 import useAsyncRetry from '@common/hooks/useAsyncRetry';
+import useToggle from '@common/hooks/useToggle';
 import DownloadTable, {
   FileFormat,
 } from '@common/modules/table-tool/components/DownloadTable';
@@ -32,6 +33,7 @@ const TableToolFinalStep = ({
   selectedPublication,
 }: TableToolFinalStepProps) => {
   const dataTableRef = useRef<HTMLElement>(null);
+  const [hasTableError, toggleHasTableError] = useToggle(false);
   const [currentTableHeaders, setCurrentTableHeaders] = useState<
     TableHeadersConfig
   >();
@@ -119,38 +121,50 @@ const TableToolFinalStep = ({
             ref={dataTableRef}
             fullTable={table}
             tableHeadersConfig={currentTableHeaders}
+            onError={message => {
+              toggleHasTableError.on();
+              logEvent({
+                category: 'Table Tool',
+                action: 'Table rendering error',
+                label: message,
+              });
+            }}
           />
         </>
       )}
-      <div className="govuk-!-margin-bottom-7">
-        <TableToolShare
-          tableHeaders={currentTableHeaders}
-          query={query}
-          selectedPublication={selectedPublication}
-        />
-      </div>
+      {!hasTableError && (
+        <>
+          <div className="govuk-!-margin-bottom-7">
+            <TableToolShare
+              tableHeaders={currentTableHeaders}
+              query={query}
+              selectedPublication={selectedPublication}
+            />
+          </div>
 
-      <DownloadTable
-        fullTable={table}
-        fileName={`data-${selectedPublication.slug}`}
-        tableRef={dataTableRef}
-        onSubmit={(fileFormat: FileFormat) =>
-          logEvent({
-            category: 'Table tool',
-            action:
-              fileFormat === 'csv'
-                ? 'CSV download button clicked'
-                : 'ODS download button clicked',
-            label: `${table.subjectMeta.publicationName} between ${
-              table.subjectMeta.timePeriodRange[0].label
-            } and ${
-              table.subjectMeta.timePeriodRange[
-                table.subjectMeta.timePeriodRange.length - 1
-              ].label
-            }`,
-          })
-        }
-      />
+          <DownloadTable
+            fullTable={table}
+            fileName={`data-${selectedPublication.slug}`}
+            tableRef={dataTableRef}
+            onSubmit={(fileFormat: FileFormat) =>
+              logEvent({
+                category: 'Table tool',
+                action:
+                  fileFormat === 'csv'
+                    ? 'CSV download button clicked'
+                    : 'ODS download button clicked',
+                label: `${table.subjectMeta.publicationName} between ${
+                  table.subjectMeta.timePeriodRange[0].label
+                } and ${
+                  table.subjectMeta.timePeriodRange[
+                    table.subjectMeta.timePeriodRange.length - 1
+                  ].label
+                }`,
+              })
+            }
+          />
+        </>
+      )}
 
       <TableToolInfo
         contactDetails={publication?.contact}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

Before submitting a pull request, please make sure the following is done:

1. Clone [the repository](https://github.com/dfe-analytical-services/explore-education-statistics) and create your branch from `dev`.
2. Run `npm ci && npm run bootstrap` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suites pass. 
   - Frontend tests can be run using `npm test` from the project root.
   - Backend tests can be run using `dotnet test` from `src` directory.
   - UI tests should be run from `tests/robot-tests`
-->

On the frontend table tool hide the create permalink and download table options if the table errors and can't be rendered. 

The error is logged to Google Analytics.