### PR TITLE
EES-2944 allow svgs in ckeditor

### DIFF
--- a/src/explore-education-statistics-admin/src/components/form/FormEditor.module.scss
+++ b/src/explore-education-statistics-admin/src/components/form/FormEditor.module.scss
@@ -11,6 +11,11 @@ $active-colour: lighten(govuk-colour('orange'), 10);
   :global(.ck-focused) {
     border-color: $govuk-input-border-colour !important;
   }
+
+  // Make sure svgs are visible (they use the image tag)
+  :global(.ck-content img) {
+    width: 100%;
+  }
 }
 
 .focused {

--- a/src/explore-education-statistics-admin/src/hooks/useCKEditorConfig.ts
+++ b/src/explore-education-statistics-admin/src/hooks/useCKEditorConfig.ts
@@ -83,6 +83,9 @@ const useCKEditorConfig = ({
         ? {
             toolbar: imageToolbar,
             resizeOptions,
+            upload: {
+              types: ['jpeg', 'png', 'gif', 'bmp', 'tiff', 'svg+xml'],
+            },
           }
         : undefined,
       table: {


### PR DESCRIPTION
Adds SVG to the allowed image upload types in CKEditor, plus some css to make sure they always show in the editor.

The list of types is the default plus svg, we might want to review it (I can't imagine anyone uploading a tiff file).