### PR TITLE
EES-3106 Rename 'LocationsHierarchical' to 'Locations' in ResultSubjectMetaViewModel 

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Controllers/Api/Statistics/TableBuilderControllerTests.cs
@@ -109,7 +109,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Controllers.Api
                 {
                     new(1234, "boundary")
                 },
-                LocationsHierarchical = new Dictionary<string, List<LocationAttributeViewModel>>
+                Locations = new Dictionary<string, List<LocationAttributeViewModel>>
                 {
                     {
                         "location", new List<LocationAttributeViewModel>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/FastTrackControllerTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Controllers/FastTrackControllerTests.cs
@@ -244,7 +244,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Controllers
                         {
                             new(1234, "boundary")
                         },
-                        LocationsHierarchical = new Dictionary<string, List<LocationAttributeViewModel>>
+                        Locations = new Dictionary<string, List<LocationAttributeViewModel>>
                         {
                             {
                                 "location", new List<LocationAttributeViewModel>

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Converters/PermalinkResultSubjectMetaJsonConverterTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Converters/PermalinkResultSubjectMetaJsonConverterTests.cs
@@ -1,13 +1,13 @@
 ﻿#nullable enable
 using System.Collections.Generic;
-using GovUk.Education.ExploreEducationStatistics.Data.Services.Converters;
-using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
+using GovUk.Education.ExploreEducationStatistics.Data.Api.Converters;
+using GovUk.Education.ExploreEducationStatistics.Data.Api.Models;
 using Newtonsoft.Json;
 using Xunit;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Converters
 {
-    public class ResultSubjectMetaViewModelJsonConverterTests
+    public class PermalinkResultSubjectMetaJsonConverterTests
     {
         [Fact]
         public void ReadJson_LegacyLocationsFieldIsTransformed()
@@ -36,7 +36,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Converters
                 ]
             }";
 
-            var subjectMeta = JsonConvert.DeserializeObject<ResultSubjectMetaViewModel>(jsonText, BuildSettings());
+            var subjectMeta = JsonConvert.DeserializeObject<PermalinkResultSubjectMeta>(jsonText, BuildSettings());
 
             // Expect Locations to have been transformed to LocationsHierarchical
             Assert.NotNull(subjectMeta);
@@ -75,7 +75,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Converters
                 }
             }";
 
-            var subjectMeta = JsonConvert.DeserializeObject<ResultSubjectMetaViewModel>(jsonText, BuildSettings());
+            var subjectMeta = JsonConvert.DeserializeObject<PermalinkResultSubjectMeta>(jsonText, BuildSettings());
 
             Assert.Single(subjectMeta!.LocationsHierarchical);
             Assert.True(subjectMeta.LocationsHierarchical.ContainsKey("country"));
@@ -114,7 +114,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Converters
                 }
             }";
 
-            var subjectMeta = JsonConvert.DeserializeObject<ResultSubjectMetaViewModel>(jsonText, BuildSettings());
+            var subjectMeta = JsonConvert.DeserializeObject<PermalinkResultSubjectMeta>(jsonText, BuildSettings());
 
             Assert.NotNull(subjectMeta);
             Assert.Single(subjectMeta!.LocationsHierarchical);
@@ -133,7 +133,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Converters
         {
             const string jsonText = @"{""Locations"":[]}";
 
-            var subjectMeta = JsonConvert.DeserializeObject<ResultSubjectMetaViewModel>(jsonText, BuildSettings());
+            var subjectMeta = JsonConvert.DeserializeObject<PermalinkResultSubjectMeta>(jsonText, BuildSettings());
 
             Assert.Empty(subjectMeta!.LocationsHierarchical);
         }
@@ -143,7 +143,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Converters
         {
             const string jsonText = @"{""Locations"":null}";
 
-            var subjectMeta = JsonConvert.DeserializeObject<ResultSubjectMetaViewModel>(jsonText, BuildSettings());
+            var subjectMeta = JsonConvert.DeserializeObject<PermalinkResultSubjectMeta>(jsonText, BuildSettings());
 
             Assert.Empty(subjectMeta!.LocationsHierarchical);
         }
@@ -153,7 +153,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Converters
         {
             const string jsonText = "{}";
 
-            var subjectMeta = JsonConvert.DeserializeObject<ResultSubjectMetaViewModel>(jsonText, BuildSettings());
+            var subjectMeta = JsonConvert.DeserializeObject<PermalinkResultSubjectMeta>(jsonText, BuildSettings());
 
             Assert.Empty(subjectMeta!.LocationsHierarchical);
         }
@@ -164,7 +164,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Converters
             {
                 Converters = new List<JsonConverter>
                 {
-                    new ResultSubjectMetaViewModelJsonConverter()
+                    new PermalinkResultSubjectMetaJsonConverter()
                 }
             };
         }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api.Tests/Services/PermalinkServiceTests.cs
@@ -85,7 +85,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                 Id = Guid.NewGuid()
             };
 
-            var tableResult = new TableBuilderResultViewModel();
+            var tableResult = new TableBuilderResultViewModel
+            {
+                SubjectMeta = new ResultSubjectMetaViewModel()
+            };
 
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
             var releaseRepository = new Mock<IReleaseRepository>(MockBehavior.Strict);
@@ -102,7 +105,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     Capture.With(blobPathCapture),
                     It.Is<Permalink>(p =>
                         p.Configuration.Equals(request.Configuration) &&
-                        p.FullTable.Equals(tableResult) &&
+                        p.FullTable.IsDeepEqualTo(new PermalinkTableBuilderResult(tableResult)) &&
                         p.Query.Equals(request.Query)),
                     It.IsAny<JsonSerializerSettings>()))
                 .Returns(Task.CompletedTask);
@@ -168,7 +171,10 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var releaseId = Guid.NewGuid();
 
-            var tableResult = new TableBuilderResultViewModel();
+            var tableResult = new TableBuilderResultViewModel
+            {
+                SubjectMeta = new ResultSubjectMetaViewModel()
+            };
 
             var blobStorageService = new Mock<IBlobStorageService>(MockBehavior.Strict);
             var subjectRepository = new Mock<ISubjectRepository>(MockBehavior.Strict);
@@ -184,7 +190,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
                     Capture.With(blobPathCapture),
                     It.Is<Permalink>(p =>
                         p.Configuration.Equals(request.Configuration) &&
-                        p.FullTable.Equals(tableResult) &&
+                        p.FullTable.IsDeepEqualTo(new PermalinkTableBuilderResult(tableResult)) &&
                         p.Query.Equals(request.Query)),
                     It.IsAny<JsonSerializerSettings>()))
                 .Returns(Task.CompletedTask);
@@ -232,9 +238,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var permalink = new Permalink(
                 new TableBuilderConfiguration(),
-                new TableBuilderResultViewModel
+                new PermalinkTableBuilderResult
                 {
-                    SubjectMeta = new ResultSubjectMetaViewModel()
+                    SubjectMeta = new PermalinkResultSubjectMeta()
                 },
                 new ObservationQueryContext
                 {
@@ -280,8 +286,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
         public async Task Get_LegacyLocationsFieldIsTransformed()
         {
             // Until old Permalinks are migrated to permanently transform their legacy 'Locations' field,
-            // test that legacy locations are transformed to 'LocationsHierarchical',
-            // ensuring that consumers are aware of them when accessing the new field.
+            // test that legacy locations are transformed to 'LocationsHierarchical' and then mapped to 'Locations'
+            // in the view model.
 
             var subject = new Subject
             {
@@ -316,9 +322,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var permalink = new Permalink(
                 new TableBuilderConfiguration(),
-                new TableBuilderResultViewModel
+                new PermalinkTableBuilderResult
                 {
-                    SubjectMeta = new ResultSubjectMetaViewModel()
+                    SubjectMeta = new PermalinkResultSubjectMeta()
                 },
                 new ObservationQueryContext
                 {
@@ -364,11 +370,11 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var subjectMeta = result.FullTable.SubjectMeta;
 
-            // Expect Locations to have been transformed to LocationsHierarchical
-            Assert.Single(subjectMeta.LocationsHierarchical);
-            Assert.True(subjectMeta.LocationsHierarchical.ContainsKey("localAuthority"));
+            // Expect Locations to have been transformed
+            Assert.Single(subjectMeta.Locations);
+            Assert.True(subjectMeta.Locations.ContainsKey("localAuthority"));
 
-            var localAuthorities = subjectMeta.LocationsHierarchical["localAuthority"];
+            var localAuthorities = subjectMeta.Locations["localAuthority"];
             Assert.Equal(3, localAuthorities.Count);
 
             Assert.Equal(legacyLocations[0].Label, localAuthorities[0].Label);
@@ -409,9 +415,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
         {
             var permalink = new Permalink(
                 new TableBuilderConfiguration(),
-                new TableBuilderResultViewModel
+                new PermalinkTableBuilderResult
                 {
-                    SubjectMeta = new ResultSubjectMetaViewModel()
+                    SubjectMeta = new PermalinkResultSubjectMeta()
                 },
                 new ObservationQueryContext
                 {
@@ -459,9 +465,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Tests.Services
 
             var permalink = new Permalink(
                 new TableBuilderConfiguration(),
-                new TableBuilderResultViewModel
+                new PermalinkTableBuilderResult
                 {
-                    SubjectMeta = new ResultSubjectMetaViewModel()
+                    SubjectMeta = new PermalinkResultSubjectMeta()
                 },
                 new ObservationQueryContext
                 {

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Converters/PermalinkResultSubjectMetaJsonConverter.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Converters/PermalinkResultSubjectMetaJsonConverter.cs
@@ -3,14 +3,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
+using GovUk.Education.ExploreEducationStatistics.Data.Api.Models;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Converters
+namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Converters
 {
     /// <summary>
-    /// JsonConverter which transforms the legacy 'Locations' field of ResultSubjectMetaViewModel to 'LocationsHierarchical'.
+    /// JsonConverter which transforms the legacy 'Locations' field of PermalinkResultSubjectMeta to 'LocationsHierarchical'.
     ///
     /// Intended to be temporary until this transformation is made permanent by migrating old Permalinks in blob storage (EES-2943).
     ///
@@ -21,23 +22,23 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Converters
     /// flat 'Locations' field in their JSON serialization of type <see cref="List{ObservationalUnitMetaViewModel}"/>.
     ///
     /// Permalinks created afterwards, plus any created while the dedicated release toggle for that feature was turned on,
-    /// have locations in field <see cref="ResultSubjectMetaViewModel.LocationsHierarchical">ResultSubjectMetaViewModel.LocationsHierarchical</see>.
+    /// have locations in field <see cref="ResultSubjectMetaViewModel.Locations">PermalinkResultSubjectMeta.LocationsHierarchical</see>.
     ///
     /// Until old Permalinks are migrated, the translation provided by this converter ensures that consumers
-    /// are aware of legacy locations when accessing <see cref="ResultSubjectMetaViewModel.LocationsHierarchical" />.
+    /// are aware of legacy locations when accessing <see cref="PermalinkResultSubjectMeta.LocationsHierarchical" />.
     /// </summary>
-    public class ResultSubjectMetaViewModelJsonConverter : JsonConverter<ResultSubjectMetaViewModel>
+    public class PermalinkResultSubjectMetaJsonConverter : JsonConverter<PermalinkResultSubjectMeta>
     {
         public override bool CanWrite => false;
 
-        public override ResultSubjectMetaViewModel ReadJson(JsonReader reader,
+        public override PermalinkResultSubjectMeta ReadJson(JsonReader reader,
             Type objectType,
-            ResultSubjectMetaViewModel? existingValue,
+            PermalinkResultSubjectMeta? existingValue,
             bool hasExistingValue,
             JsonSerializer serializer)
         {
             JToken token = JToken.Load(reader);
-            var tableSubjectMeta = token.ToObject<ResultSubjectMetaViewModel>();
+            var tableSubjectMeta = token.ToObject<PermalinkResultSubjectMeta>();
 
             if (tableSubjectMeta == null)
             {
@@ -62,7 +63,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Converters
         }
 
         public override void WriteJson(JsonWriter writer,
-            ResultSubjectMetaViewModel? value,
+            PermalinkResultSubjectMeta? value,
             JsonSerializer serializer)
         {
             throw new InvalidOperationException("Use default serialization.");

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Mappings/MappingProfiles.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Mappings/MappingProfiles.cs
@@ -1,8 +1,11 @@
+#nullable enable
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Models;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Data.Model;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Mappings
 {
@@ -15,11 +18,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Mappings
         {
             // Null collections will be mapped to null collections instead of empty collections.
             AllowNullCollections = true;
-            
+
             CreateMap<FastTrack, FastTrackViewModel>();
-            
+
             CreateMap<Permalink, PermalinkViewModel>();
-            
+
+            CreateMap<PermalinkTableBuilderResult, TableBuilderResultViewModel>();
+
+            CreateMap<PermalinkResultSubjectMeta, ResultSubjectMetaViewModel>()
+                .ForMember(dest => dest.Locations,
+                    m => m.MapFrom(source => source.LocationsHierarchical));
+
             CreateMap<ObservationQueryContext, TableBuilderQueryViewModel>();
         }
     }

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Models/Permalink.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Models/Permalink.cs
@@ -1,7 +1,6 @@
 using System;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data;
 using GovUk.Education.ExploreEducationStatistics.Common.Model.Data.Query;
-using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
 
 namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Models
 {
@@ -13,7 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Models
 
         public TableBuilderConfiguration Configuration { get; set; }
 
-        public TableBuilderResultViewModel FullTable { get; set; }
+        public PermalinkTableBuilderResult FullTable { get; set; }
 
         public ObservationQueryContext Query { get; set; }
 
@@ -22,7 +21,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Models
         }
 
         public Permalink(TableBuilderConfiguration configuration,
-            TableBuilderResultViewModel result,
+            PermalinkTableBuilderResult result,
             ObservationQueryContext query)
         {
             Id = Guid.NewGuid();

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Models/PermalinkResultSubjectMeta.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Models/PermalinkResultSubjectMeta.cs
@@ -1,0 +1,53 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Models
+{
+    public class PermalinkResultSubjectMeta
+    {
+        public Dictionary<string, FilterMetaViewModel> Filters { get; init; } = new();
+
+        public List<FootnoteViewModel> Footnotes { get; init; } = new();
+
+        public List<IndicatorMetaViewModel> Indicators { get; init; } = new();
+
+        /// <summary>
+        /// Hierarchical locations field.
+        /// </summary>
+        /// <remarks>
+        /// TODO EES-2943: This could potentially be renamed back to 'Locations' but requires a migration of
+        /// old Permalinks which already have a legacy 'Locations' field in their JSON serialization of a different type.
+        /// See <see cref="PermalinkResultSubjectMetaJsonConverter"/> which is doing the conversion.
+        /// </remarks>
+        public Dictionary<string, List<LocationAttributeViewModel>> LocationsHierarchical { get; set; } = new();
+
+        public List<BoundaryLevelViewModel> BoundaryLevels { get; init; } = new();
+
+        public string PublicationName { get; init; } = string.Empty;
+
+        public string SubjectName { get; init; } = string.Empty;
+
+        public List<TimePeriodMetaViewModel> TimePeriodRange { get; init; } = new();
+
+        public bool GeoJsonAvailable { get; init; }
+
+        public PermalinkResultSubjectMeta()
+        {
+        }
+
+        public PermalinkResultSubjectMeta(ResultSubjectMetaViewModel resultSubjectMeta)
+        {
+            Filters = resultSubjectMeta.Filters;
+            Footnotes = resultSubjectMeta.Footnotes;
+            Indicators = resultSubjectMeta.Indicators;
+            LocationsHierarchical = resultSubjectMeta.Locations;
+            BoundaryLevels = resultSubjectMeta.BoundaryLevels;
+            PublicationName = resultSubjectMeta.PublicationName;
+            SubjectName = resultSubjectMeta.SubjectName;
+            TimePeriodRange = resultSubjectMeta.TimePeriodRange;
+            GeoJsonAvailable = resultSubjectMeta.GeoJsonAvailable;
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Models/PermalinkTableBuilderResult.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Models/PermalinkTableBuilderResult.cs
@@ -1,0 +1,24 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels;
+
+namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Models
+{
+    public class PermalinkTableBuilderResult
+    {
+        public PermalinkResultSubjectMeta SubjectMeta { get; init; }
+
+        public List<ObservationViewModel> Results { get; init; } = new();
+
+        public PermalinkTableBuilderResult()
+        {
+        }
+
+        public PermalinkTableBuilderResult(TableBuilderResultViewModel tableBuilderResult)
+        {
+            SubjectMeta = new PermalinkResultSubjectMeta(tableBuilderResult.SubjectMeta);
+            Results = tableBuilderResult.Results.ToList();
+        }
+    }
+}

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Api/Services/PermalinkService.cs
@@ -5,13 +5,12 @@ using System.Threading.Tasks;
 using AutoMapper;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
+using GovUk.Education.ExploreEducationStatistics.Data.Api.Converters;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Models;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.Services.Interfaces;
 using GovUk.Education.ExploreEducationStatistics.Data.Api.ViewModels;
 using GovUk.Education.ExploreEducationStatistics.Data.Model.Repository.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Data.Services.Converters;
 using GovUk.Education.ExploreEducationStatistics.Data.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Meta;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Storage;
 using Newtonsoft.Json;
@@ -76,7 +75,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
         {
             return await _tableBuilderService.Query(releaseId, request.Query).OnSuccess(async result =>
             {
-                var permalink = new Permalink(request.Configuration, result, request.Query);
+                var permalinkTableResult = new PermalinkTableBuilderResult(result);
+                var permalink = new Permalink(request.Configuration, permalinkTableResult, request.Query);
                 await _blobStorageService.UploadAsJson(containerName: Permalinks,
                     path: permalink.Id.ToString(),
                     content: permalink,
@@ -116,9 +116,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Api.Services
         {
             JsonObjectContract contract = base.CreateObjectContract(objectType);
 
-            if (objectType == typeof(ResultSubjectMetaViewModel))
+            if (objectType == typeof(PermalinkResultSubjectMeta))
             {
-                contract.Converter = new ResultSubjectMetaViewModelJsonConverter();
+                contract.Converter = new PermalinkResultSubjectMetaJsonConverter();
             }
 
             return contract;

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ResultSubjectMetaServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services.Tests/ResultSubjectMetaServiceTests.cs
@@ -188,7 +188,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
                 Assert.Empty(viewModel.Filters);
                 Assert.Empty(viewModel.Footnotes);
                 Assert.Empty(viewModel.Indicators);
-                Assert.Empty(viewModel.LocationsHierarchical);
+                Assert.Empty(viewModel.Locations);
                 Assert.Empty(viewModel.BoundaryLevels);
                 Assert.Empty(viewModel.TimePeriodRange);
                 Assert.Equal(publication.Title, viewModel.PublicationName);
@@ -571,7 +571,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var viewModel = result.AssertRight();
 
-                var locationViewModels = viewModel.LocationsHierarchical;
+                var locationViewModels = viewModel.Locations;
 
                 // Result has Country, Region and Local Authority levels
                 Assert.Equal(3, locationViewModels.Count);
@@ -854,7 +854,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 Assert.True(viewModel.GeoJsonAvailable);
 
-                var locationViewModels = viewModel.LocationsHierarchical;
+                var locationViewModels = viewModel.Locations;
 
                 // Result has Country and Region levels
                 Assert.Equal(2, locationViewModels.Count);
@@ -1091,7 +1091,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 Assert.True(viewModel.GeoJsonAvailable);
 
-                var locationViewModels = viewModel.LocationsHierarchical;
+                var locationViewModels = viewModel.Locations;
 
                 // Result only has a Region level
                 Assert.Single(locationViewModels);
@@ -1278,7 +1278,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var viewModel = result.AssertRight();
 
-                var locationViewModels = viewModel.LocationsHierarchical;
+                var locationViewModels = viewModel.Locations;
 
                 Assert.Single(locationViewModels);
 
@@ -1466,7 +1466,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var viewModel = result.AssertRight();
 
-                var locationViewModels = viewModel.LocationsHierarchical;
+                var locationViewModels = viewModel.Locations;
 
                 Assert.Single(locationViewModels);
 
@@ -1634,7 +1634,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var viewModel = result.AssertRight();
 
-                var locationViewModels = viewModel.LocationsHierarchical;
+                var locationViewModels = viewModel.Locations;
 
                 Assert.Single(locationViewModels);
 
@@ -1841,7 +1841,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.Tests
 
                 var viewModel = result.AssertRight();
 
-                var locationViewModels = viewModel.LocationsHierarchical;
+                var locationViewModels = viewModel.Locations;
 
                 // Result has Region and Local Authority levels
                 Assert.Equal(2, locationViewModels.Count);

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ResultSubjectMetaService.cs
@@ -132,7 +132,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services
                         Footnotes = footnoteViewModels,
                         GeoJsonAvailable = locationsHelper.GeoJsonAvailable,
                         Indicators = indicatorViewModels,
-                        LocationsHierarchical = locationViewModels,
+                        Locations = locationViewModels,
                         BoundaryLevels = locationsHelper.GetBoundaryLevelViewModels(),
                         PublicationName = publicationTitle,
                         SubjectName = subjectName,

--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/ResultSubjectMetaViewModel.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Services/ViewModels/Meta/ResultSubjectMetaViewModel.cs
@@ -11,16 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Data.Services.ViewModels.Me
 
         public List<IndicatorMetaViewModel> Indicators { get; init; } = new();
 
-        /// <summary>
-        /// Hierarchical locations field.
-        /// </summary>
-        /// <remarks>
-        /// TODO EES-2943: This could potentially be renamed back to 'Locations' but requires a migration of
-        /// old Permalinks which already have a legacy 'Locations' field in their JSON serialization of type <see cref="List{ObservationalUnitMetaViewModel}"/>.
-        /// TODO EES-3106: This could also be renamed back to 'Locations' in Permalink responses independently of EES-2943
-        /// but will require a new view model to be split from the model used by serialization.
-        /// </remarks>
-        public Dictionary<string, List<LocationAttributeViewModel>> LocationsHierarchical { get; set; } = new();
+        public Dictionary<string, List<LocationAttributeViewModel>> Locations { get; set; } = new();
 
         public List<BoundaryLevelViewModel> BoundaryLevels { get; init; } = new();
 

--- a/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/__tests__/EditableKeyStat.test.tsx
@@ -38,7 +38,7 @@ describe('EditableKeyStat', () => {
           },
         },
       },
-      locationsHierarchical: {
+      locations: {
         country: [
           {
             label: 'England',

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/__data__/tableToolServiceData.ts
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/__data__/tableToolServiceData.ts
@@ -60,7 +60,7 @@ export const testTableData: TableDataResponse = {
     footnotes: [],
     subjectName: 'Subject 1',
     geoJsonAvailable: false,
-    locationsHierarchical: {
+    locations: {
       localAuthority: [
         {
           label: 'Barnet',

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
@@ -20,7 +20,7 @@ describe('ChartDataSetsConfiguration', () => {
     geoJsonAvailable: false,
     footnotes: [],
     boundaryLevels: [],
-    locationsHierarchical: {
+    locations: {
       localAuthority: [
         { label: 'Barnet', value: 'barnet' },
         { label: 'Barnsley', value: 'barnsley' },

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/__data__/testTableData.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/__data__/testTableData.tsx
@@ -62,7 +62,7 @@ export const testTableData: TableDataResponse = {
         name: 'sess_overall',
       },
     ],
-    locationsHierarchical: {
+    locations: {
       localAuthority: [
         { label: 'Barnet', value: 'barnet' },
         { label: 'Barnsley', value: 'barnsley' },

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/__tests__/PreReleaseTableToolPage.test.tsx
@@ -122,7 +122,7 @@ describe('PreReleaseTableToolPage', () => {
           name: 'sess_authorised',
         },
       ],
-      locationsHierarchical: {
+      locations: {
         localAuthority: [
           { label: 'Barnet', value: 'barnet' },
           { label: 'Barnsley', value: 'barnsley' },

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testChartData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testChartData.ts
@@ -143,7 +143,7 @@ export const testChartTableData: TableDataResponse = {
         name: 'sess_overall_percent',
       },
     ],
-    locationsHierarchical: {
+    locations: {
       country: [{ label: 'England', value: 'england' }],
     },
     boundaryLevels: [

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
@@ -113,7 +113,7 @@ export const testMapTableData: TableDataResponse = {
         name: 'sess_overall_percent',
       },
     ],
-    locationsHierarchical: {
+    locations: {
       localAuthorityDistrict: [
         {
           geoJson: [
@@ -408,7 +408,7 @@ export const testMapTableData: TableDataResponse = {
 };
 
 export const testMapTableDataRegion = produce(testMapTableData, draft => {
-  draft.subjectMeta.locationsHierarchical = {
+  draft.subjectMeta.locations = {
     region: [
       {
         geoJson: [
@@ -516,7 +516,7 @@ export const testMapTableDataRegion = produce(testMapTableData, draft => {
 });
 
 export const testMapTableDataMixed = produce(testMapTableData, draft => {
-  draft.subjectMeta.locationsHierarchical = {
+  draft.subjectMeta.locations = {
     localAuthority: [
       {
         geoJson: [

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
@@ -67,7 +67,7 @@ describe('createDataSetCategories', () => {
           name: 'sess_overall',
         },
       ],
-      locationsHierarchical: {
+      locations: {
         localAuthority: [
           { label: 'Barnet', value: 'barnet' },
           { label: 'Barnsley', value: 'barnsley' },
@@ -1198,7 +1198,7 @@ describe('createDataSetCategories', () => {
             name: 'sess_authorised',
           },
         ],
-        locationsHierarchical: {
+        locations: {
           country: [{ label: 'England', value: 'E92000001' }],
           region: [{ label: 'North East', value: 'E12000001' }],
         },

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/expandDataSet.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/expandDataSet.test.ts
@@ -81,7 +81,7 @@ describe('expandDataSet', () => {
           name: 'sess_authorised_percent',
         },
       ],
-      locationsHierarchical: {
+      locations: {
         localAuthority: [
           { label: 'Barnsley', value: 'E08000016' },
           { label: 'Barnet', value: 'E09000003' },

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/isOrphanedDataSet.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/isOrphanedDataSet.test.ts
@@ -75,7 +75,7 @@ describe('isOrphanedDataSet', () => {
           name: 'sess_authorised_percent',
         },
       ],
-      locationsHierarchical: {
+      locations: {
         localAuthority: [
           { label: 'Barnsley', value: 'E08000016' },
           { label: 'Barnet', value: 'E09000003' },

--- a/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStat.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/find-statistics/components/__tests__/KeyStat.test.tsx
@@ -34,7 +34,7 @@ describe('KeyStat', () => {
           },
         },
       },
-      locationsHierarchical: {
+      locations: {
         country: [
           {
             label: 'England',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/TimePeriodDataTable.test.tsx
@@ -242,7 +242,7 @@ describe('TimePeriodDataTable', () => {
             decimalPlaces: 1,
           },
         ],
-        locationsHierarchical: {
+        locations: {
           country: [{ value: 'E92000001', label: 'England' }],
         },
         boundaryLevels: [],
@@ -334,7 +334,7 @@ describe('TimePeriodDataTable', () => {
             decimalPlaces: 1,
           },
         ],
-        locationsHierarchical: {
+        locations: {
           country: [{ value: 'E92000001', label: 'England' }],
         },
         boundaryLevels: [],
@@ -418,7 +418,7 @@ describe('TimePeriodDataTable', () => {
             unit: '%',
           },
         ],
-        locationsHierarchical: {
+        locations: {
           country: [{ value: 'E92000001', label: 'England' }],
         },
         boundaryLevels: [],
@@ -504,7 +504,7 @@ describe('TimePeriodDataTable', () => {
           },
         ],
         // Contains a mixture of hierarchical (LAs) and flat (country) locations
-        locationsHierarchical: {
+        locations: {
           country: [{ value: 'england', label: 'England' }],
           localAuthority: [
             {

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__data__/TimePeriodDataTable.data.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/__data__/TimePeriodDataTable.data.tsx
@@ -66,7 +66,7 @@ export const testData1 = {
           decimalPlaces: 0,
         },
       ],
-      locationsHierarchical: {
+      locations: {
         localAuthority: [
           { value: 'E09000003', label: 'Barnet' },
           { value: 'E08000016', label: 'Barnsley' },
@@ -459,7 +459,7 @@ export const testData2 = {
           decimalPlaces: 1,
         },
       ],
-      locationsHierarchical: {
+      locations: {
         localAuthority: [
           { value: 'E09000003', label: 'Barnet' },
           { value: 'E08000016', label: 'Barnsley' },
@@ -800,7 +800,7 @@ export const testData3 = {
           decimalPlaces: 1,
         },
       ],
-      locationsHierarchical: {
+      locations: {
         localAuthority: [
           { value: 'E09000003', label: 'Barnet' },
           { value: 'E08000016', label: 'Barnsley' },
@@ -994,7 +994,7 @@ export const testDataNoFilters = {
           decimalPlaces: 1,
         },
       ],
-      locationsHierarchical: {
+      locations: {
         country: [{ value: 'E92000001', label: 'England' }],
       },
       boundaryLevels: [],
@@ -1129,7 +1129,7 @@ export const testDataFiltersWithNoResults = {
           decimalPlaces: 0,
         },
       ],
-      locationsHierarchical: {
+      locations: {
         localAuthority: [
           { value: 'E08000026', label: 'Coventry' },
           { value: 'E09000008', label: 'Croydon' },

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/getInitialStepSubjectMeta.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/utils/__tests__/getInitialStepSubjectMeta.test.ts
@@ -166,7 +166,7 @@ describe('getInitialStepSubjectMeta', () => {
         geoJsonAvailable: false,
         footnotes: [],
         boundaryLevels: [],
-        locationsHierarchical: {},
+        locations: {},
         timePeriodRange: [],
         indicators: [],
         filters: {},
@@ -271,7 +271,7 @@ describe('getInitialStepSubjectMeta', () => {
         geoJsonAvailable: false,
         footnotes: [],
         boundaryLevels: [],
-        locationsHierarchical: {
+        locations: {
           country: [{ value: 'england', label: 'England' }],
         },
         timePeriodRange: [{ year: 2018, code: 'AY', label: '2018' }],

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/getDefaultTableHeadersConfig.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/getDefaultTableHeadersConfig.test.ts
@@ -85,7 +85,7 @@ describe('getDefaultTableHeadersConfig', () => {
           decimalPlaces: 2,
         },
       ],
-      locationsHierarchical: {
+      locations: {
         localAuthority: [
           { value: 'barnet', label: 'Barnet' },
           { value: 'barnsley', label: 'Barnsley' },
@@ -387,7 +387,7 @@ describe('getDefaultTableHeadersConfig', () => {
             decimalPlaces: 2,
           },
         ],
-        locationsHierarchical: {
+        locations: {
           localAuthority: [{ value: 'barnsley', label: 'Barnsley' }],
         },
       },

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableHeadersConfig.test.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/__tests__/mapTableHeadersConfig.test.ts
@@ -139,7 +139,7 @@ describe('mapTableHeadersConfig', () => {
           decimalPlaces: 2,
         },
       ],
-      locationsHierarchical: {
+      locations: {
         localAuthority: [
           { value: 'E09000003', label: 'Barnet' },
           { value: 'E08000016', label: 'Barnsley' },
@@ -266,7 +266,7 @@ describe('mapTableHeadersConfig', () => {
         subjectName: '',
         filters: {},
         footnotes: [],
-        locationsHierarchical: {
+        locations: {
           localAuthority: [
             {
               label: 'Barnet (local authority)',

--- a/src/explore-education-statistics-common/src/modules/table-tool/utils/mapFullTableMeta.ts
+++ b/src/explore-education-statistics-common/src/modules/table-tool/utils/mapFullTableMeta.ts
@@ -7,10 +7,9 @@ import {
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import { TableDataSubjectMeta } from '@common/services/tableBuilderService';
 
-export default function mapFullTableMeta({
-  locationsHierarchical,
-  ...subjectMeta
-}: TableDataSubjectMeta): FullTableMeta {
+export default function mapFullTableMeta(
+  subjectMeta: TableDataSubjectMeta,
+): FullTableMeta {
   const filters = Object.values(subjectMeta.filters).reduce<
     FullTableMeta['filters']
   >((acc, category) => {
@@ -32,7 +31,7 @@ export default function mapFullTableMeta({
     return acc;
   }, {});
 
-  const locationEntries = Object.entries(locationsHierarchical);
+  const locationEntries = Object.entries(subjectMeta.locations);
   const hasNestedLocations = locationEntries.some(([, levelOptions]) =>
     levelOptions.some(levelOption => levelOption.options),
   );

--- a/src/explore-education-statistics-common/src/services/__tests__/tableBuilderService.test.ts
+++ b/src/explore-education-statistics-common/src/services/__tests__/tableBuilderService.test.ts
@@ -132,7 +132,7 @@ describe('tableBuilderService', () => {
         subjectName: '',
         timePeriodRange: [],
         publicationName: '',
-        locationsHierarchical: {
+        locations: {
           provider: [
             {
               value: 'unique-provider',
@@ -227,7 +227,7 @@ describe('tableBuilderService', () => {
         subjectName: '',
         timePeriodRange: [],
         publicationName: '',
-        locationsHierarchical: {
+        locations: {
           provider: [
             {
               value: 'unique-provider',

--- a/src/explore-education-statistics-common/src/services/tableBuilderService.ts
+++ b/src/explore-education-statistics-common/src/services/tableBuilderService.ts
@@ -137,10 +137,7 @@ export interface ReleaseTableDataQuery extends TableDataQuery {
 export interface TableDataSubjectMeta {
   publicationName: string;
   subjectName: string;
-  /**
-   * TODO: EES-2902 Change this key back to `locations`
-   */
-  locationsHierarchical: Dictionary<LocationOption[]>;
+  locations: Dictionary<LocationOption[]>;
   boundaryLevels: BoundaryLevel[];
   timePeriodRange: TimePeriodOption[];
   filters: Dictionary<{

--- a/src/explore-education-statistics-common/src/services/util/tableBuilderServiceUtils.ts
+++ b/src/explore-education-statistics-common/src/services/util/tableBuilderServiceUtils.ts
@@ -32,7 +32,7 @@ export function deduplicateTableDataLocations(
   }
 
   const { subjectMeta } = tableData;
-  const { locationsHierarchical } = subjectMeta;
+  const { locations } = subjectMeta;
 
   const deduplicatedOptions: LocationOption[] = [];
 
@@ -53,40 +53,31 @@ export function deduplicateTableDataLocations(
     return mergedOption;
   };
 
-  const mergedLocations = mapValues(
-    locationsHierarchical,
-    (levelOptions, level) => {
-      const hasNestedOptions = levelOptions.some(location => location.options);
+  const mergedLocations = mapValues(locations, (levelOptions, level) => {
+    const hasNestedOptions = levelOptions.some(location => location.options);
 
-      if (hasNestedOptions) {
-        return levelOptions.map(location => {
-          const options = location.options ?? [];
-          const optionsGroupedByValue = groupBy(
-            options,
-            option => option.value,
-          );
+    if (hasNestedOptions) {
+      return levelOptions.map(location => {
+        const options = location.options ?? [];
+        const optionsGroupedByValue = groupBy(options, option => option.value);
 
-          const mergedOptions = Object.values(optionsGroupedByValue).flatMap(
-            mergeGroupedOptions(level),
-          );
+        const mergedOptions = Object.values(optionsGroupedByValue).flatMap(
+          mergeGroupedOptions(level),
+        );
 
-          return {
-            ...location,
-            options: mergedOptions,
-          };
-        });
-      }
+        return {
+          ...location,
+          options: mergedOptions,
+        };
+      });
+    }
 
-      const optionsGroupedByValue = groupBy(
-        levelOptions,
-        option => option.value,
-      );
+    const optionsGroupedByValue = groupBy(levelOptions, option => option.value);
 
-      return Object.values(optionsGroupedByValue).flatMap(
-        mergeGroupedOptions(level),
-      );
-    },
-  );
+    return Object.values(optionsGroupedByValue).flatMap(
+      mergeGroupedOptions(level),
+    );
+  });
 
   const mergedResults = combineMeasuresWithDuplicateLocationCodes(
     tableData.results,
@@ -97,7 +88,7 @@ export function deduplicateTableDataLocations(
     ...tableData,
     subjectMeta: {
       ...subjectMeta,
-      locationsHierarchical: mergedLocations,
+      locations: mergedLocations,
     },
     results: mergedResults,
   };

--- a/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/PermalinkPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/permalink/__tests__/PermalinkPage.test.tsx
@@ -40,7 +40,7 @@ describe('PermalinkPage', () => {
         footnotes: [],
         subjectName: 'Subject 1',
         geoJsonAvailable: false,
-        locationsHierarchical: {
+        locations: {
           localAuthority: [
             {
               label: 'Barnet',

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/__tests__/TableToolPage.test.tsx
@@ -75,7 +75,7 @@ describe('TableToolPage', () => {
             decimalPlaces: 0,
           },
         ],
-        locationsHierarchical: {
+        locations: {
           country: [{ label: 'Great Britain', value: 'K03000001' }],
         },
         boundaryLevels: [


### PR DESCRIPTION
⚠️ This will require clearing privately cached data blocks and publicly cached Release data blocks, fast tracks and subject meta results when it is deployed.

This PR renames `LocationsHierarchical` back to `Locations` in `ResultSubjectMetaViewModel` but importantly does so without affecting Permalinks serialized in blob storage with a legacy 'Locations' field.

A `Permalink` created prior to the Table Result Subject Metadata changes of EES-2881 (BE) and EES-2777 (FE) will have a
flat 'Locations' field in its JSON serialization of the table result subject meta data of type `List<ObservationalUnitMetaViewModel>`. Permalinks created after those changes have a hierarchial `LocationsHierarchical` field of type `Dictionary<string, List<LocationAttributeViewModel>>` instead. This could potentially be renamed back to 'Locations' but requires a migration of Permalinks which is tricky, see EES-2943.

In the mean time, to allow the renaming to take place everywhere else without affecting Permalinks we split out a new table model especially for it which has a new `PermalinkResultSubjectMeta` type for `Permalink.FullTable.SubjectMeta`. This continues to have the `LocationsHierarchical` field.

### UI Test result

![image](https://user-images.githubusercontent.com/4147126/153222002-f7b6ce3a-af4d-44f0-9b49-824aedcfad0b.png)
