### PR TITLE
EES-2556 reorder datasets

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartDataSet.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Model/Chart/ChartDataSet.cs
@@ -11,6 +11,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Model.Chart
         public List<Guid> Filters = new List<Guid>();
         public ChartDataSetLocation Location;
         public string TimePeriod;
+        public int? Order;
 
         // TODO EES-1649 Migrate data set configs to legend item configs
         public ChartDataSetConfiguration Config;

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.module.scss
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.module.scss
@@ -24,33 +24,30 @@
   }
 }
 
-.item {
-  background: govuk-colour('white');
-}
-
 .dropArea {
   background: govuk-colour('light-grey');
   outline: $govuk-focus-width solid $govuk-focus-colour;
 }
 
-.isReordering {
-  position: relative;
+.item {
+  background: govuk-colour('white');
 
-  &::before {
-    color: govuk-colour('dark-grey');
-    content: '\2630';
-    cursor: grab;
-    font-size: 1.6rem;
-    position: absolute;
-    right: 0;
-    top: 6px;
-  }
-
-  &:focus {
+  &:focus,
+  &.isDragging {
     @include govuk-focused-text;
   }
 }
 
-.isDragging {
-  @include govuk-focused-text;
+.labelReordering {
+  cursor: grab;
+  cursor: move;
+  display: flex;
+  justify-content: space-between;
+
+  &::after {
+    color: govuk-colour('dark-grey');
+    content: '\2630';
+    font-size: 1.6rem;
+    line-height: 1;
+  }
 }

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/__tests__/ChartDataSetsConfiguration.test.tsx
@@ -206,6 +206,119 @@ describe('ChartDataSetsConfiguration', () => {
     });
   });
 
+  test('does not show the reorder button when there is only one dataset', () => {
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartDataSetsConfiguration
+          meta={testSubjectMeta}
+          dataSets={[
+            {
+              indicator: 'authorised-absence-sessions',
+              filters: ['male'],
+            },
+          ]}
+          onChange={noop}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+    expect(
+      screen.queryByRole('button', {
+        name: 'Reorder data sets',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows the reorder button when there is more than one dataset', () => {
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartDataSetsConfiguration
+          meta={testSubjectMeta}
+          dataSets={[
+            {
+              indicator: 'authorised-absence-sessions',
+              filters: ['male'],
+            },
+            {
+              indicator: 'authorised-absence-sessions',
+              filters: ['male'],
+              location: {
+                level: 'localAuthority',
+                value: 'barnet',
+              },
+            },
+            {
+              indicator: 'authorised-absence-sessions',
+              filters: ['male'],
+              location: {
+                level: 'localAuthority',
+                value: 'barnet',
+              },
+              timePeriod: '2019_AY',
+            },
+          ]}
+          onChange={noop}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Reorder data sets',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('clicking the reorder button toggles reordering on and off', () => {
+    render(
+      <ChartBuilderFormsContextProvider initialForms={testFormState}>
+        <ChartDataSetsConfiguration
+          meta={testSubjectMeta}
+          dataSets={[
+            {
+              indicator: 'authorised-absence-sessions',
+              filters: ['male'],
+            },
+            {
+              indicator: 'authorised-absence-sessions',
+              filters: ['male'],
+              location: {
+                level: 'localAuthority',
+                value: 'barnet',
+              },
+            },
+            {
+              indicator: 'authorised-absence-sessions',
+              filters: ['male'],
+              location: {
+                level: 'localAuthority',
+                value: 'barnet',
+              },
+              timePeriod: '2019_AY',
+            },
+          ]}
+          onChange={noop}
+        />
+      </ChartBuilderFormsContextProvider>,
+    );
+
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Reorder data sets',
+      }),
+    );
+    expect(
+      screen.queryByRole('button', {
+        name: 'Reorder data sets',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Finish reordering' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Remove' }),
+    ).not.toBeInTheDocument();
+  });
+
   describe('add data set form', () => {
     test('renders correctly with multiple options per select', () => {
       render(
@@ -419,6 +532,7 @@ describe('ChartDataSetsConfiguration', () => {
           {
             filters: ['male'],
             indicator: 'unauthorised-absence-sessions',
+            order: 0,
           },
         ];
 
@@ -466,6 +580,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 0,
           },
         ];
 
@@ -502,6 +617,7 @@ describe('ChartDataSetsConfiguration', () => {
           {
             filters: [],
             indicator: 'unauthorised-absence-sessions',
+            order: 0,
           },
         ];
 
@@ -545,6 +661,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 0,
           },
           {
             filters: ['male'],
@@ -554,6 +671,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 1,
           },
         ];
 
@@ -600,6 +718,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 0,
           },
           {
             filters: ['female'],
@@ -609,6 +728,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 1,
           },
         ];
 
@@ -655,6 +775,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 0,
           },
           {
             filters: ['male', 'primary'],
@@ -664,6 +785,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 1,
           },
           {
             filters: ['male', 'special'],
@@ -673,6 +795,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 2,
           },
           {
             filters: ['female', 'secondary'],
@@ -682,6 +805,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 3,
           },
           {
             filters: ['female', 'primary'],
@@ -691,6 +815,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 4,
           },
           {
             filters: ['female', 'special'],
@@ -700,6 +825,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 5,
           },
         ];
 
@@ -742,6 +868,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 0,
           },
           {
             filters: ['male'],
@@ -751,6 +878,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 1,
           },
           {
             filters: ['female'],
@@ -760,6 +888,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 2,
           },
           {
             filters: ['female'],
@@ -769,6 +898,7 @@ describe('ChartDataSetsConfiguration', () => {
               level: 'localAuthority',
             },
             timePeriod: '2020_AY',
+            order: 3,
           },
         ];
 

--- a/src/explore-education-statistics-common/src/components/form/FormSelect.tsx
+++ b/src/explore-education-statistics-common/src/components/form/FormSelect.tsx
@@ -100,19 +100,21 @@ const FormSelect = ({
             </option>
           ))}
         {optGroups &&
-          Object.keys(optGroups).map(group => (
-            <optgroup key={`group-${group}`} label={group}>
-              {optGroups[group].map(option => (
-                <option
-                  key={`value-${option.value}`}
-                  value={option.value}
-                  style={option.style}
-                >
-                  {option.label}
-                </option>
-              ))}
-            </optgroup>
-          ))}
+          Object.keys(optGroups)
+            .sort()
+            .map(group => (
+              <optgroup key={group} label={group}>
+                {optGroups[group].map(option => (
+                  <option
+                    key={`value-${option.value}`}
+                    value={option.value}
+                    style={option.style}
+                  >
+                    {option.label}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
       </select>
     </>
   );

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlockInternal.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/MapBlockInternal.test.tsx
@@ -6,7 +6,6 @@ import {
   testsMixedLocationsFullTableMeta,
   testsMixedLocationsTableData,
   testsMixedLocationsTableDataWithLADs,
-  testMixedLocationsAxes,
 } from '@common/modules/charts/components/__tests__/__data__/testMapBlockData';
 import { MapBlockProps } from '@common/modules/charts/components/MapBlock';
 import { MapBlockInternal } from '@common/modules/charts/components/MapBlockInternal';
@@ -29,6 +28,22 @@ describe('MapBlockInternal', () => {
     data: testFullTable.results,
     height: 600,
     width: 900,
+  };
+
+  const testMixedLocationsAxes: MapBlockProps['axes'] = {
+    major: {
+      type: 'major',
+      groupBy: 'locations',
+      dataSets: [
+        {
+          indicator: 'authorised-absence-rate',
+          filters: ['characteristic-total'],
+          timePeriod: '2016_AY',
+        },
+      ],
+      referenceLines: [],
+      visible: true,
+    },
   };
 
   test('renders legends and polygons correctly', async () => {
@@ -403,17 +418,17 @@ describe('MapBlockInternal', () => {
       expect(group2Options[0]).toHaveTextContent('Darlington');
       expect(group2Options[1]).toHaveTextContent('Newcastle upon Tyne');
 
-      expect(groups[2]).toHaveProperty('label', 'Yorkshire and the Humber');
+      expect(groups[2]).toHaveProperty('label', 'Region');
       const group3Options = within(groups[2]).getAllByRole('option');
       expect(group3Options).toHaveLength(2);
-      expect(group3Options[0]).toHaveTextContent('Rotherham');
-      expect(group3Options[1]).toHaveTextContent('Sheffield');
+      expect(group3Options[0]).toHaveTextContent('North East');
+      expect(group3Options[1]).toHaveTextContent('North West');
 
-      expect(groups[3]).toHaveProperty('label', 'Region');
+      expect(groups[3]).toHaveProperty('label', 'Yorkshire and the Humber');
       const group4Options = within(groups[3]).getAllByRole('option');
       expect(group4Options).toHaveLength(2);
-      expect(group4Options[0]).toHaveTextContent('North East');
-      expect(group4Options[1]).toHaveTextContent('North West');
+      expect(group4Options[0]).toHaveTextContent('Rotherham');
+      expect(group4Options[1]).toHaveTextContent('Sheffield');
     });
 
     test('shows grouped location options if there are local authority districts', async () => {
@@ -445,8 +460,8 @@ describe('MapBlockInternal', () => {
       expect(groups[0]).toHaveProperty('label', 'Yorkshire and the Humber');
       const group1Options = within(groups[0]).getAllByRole('option');
       expect(group1Options).toHaveLength(2);
-      expect(group1Options[0]).toHaveTextContent('Sheffield LAD');
-      expect(group1Options[1]).toHaveTextContent('Rotherham LAD');
+      expect(group1Options[0]).toHaveTextContent('Rotherham LAD');
+      expect(group1Options[1]).toHaveTextContent('Sheffield LAD');
     });
   });
 });

--- a/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/components/__tests__/__data__/testMapBlockData.ts
@@ -11,7 +11,6 @@ import {
   LocationFilter,
   TimePeriodFilter,
 } from '@common/modules/table-tool/types/filters';
-import { MapBlockProps } from '@common/modules/charts/components/MapBlock';
 import produce from 'immer';
 
 export const testMapConfiguration: Chart = {
@@ -888,19 +887,3 @@ export const testsMixedLocationsTableDataWithLADs: TableDataResult[] = [
     timePeriod: '2016_AY',
   },
 ];
-
-export const testMixedLocationsAxes: MapBlockProps['axes'] = {
-  major: {
-    type: 'major',
-    groupBy: 'locations',
-    dataSets: [
-      {
-        indicator: 'authorised-absence-rate',
-        filters: ['characteristic-total'],
-        timePeriod: '2016_AY',
-      },
-    ],
-    referenceLines: [],
-    visible: true,
-  },
-};

--- a/src/explore-education-statistics-common/src/modules/charts/types/dataSet.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/types/dataSet.ts
@@ -18,6 +18,7 @@ export interface DataSet {
   indicator: string;
   filters: string[];
   location?: LocationCompositeId;
+  order?: number;
   timePeriod?: string;
 }
 

--- a/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/__tests__/createDataSetCategories.test.ts
@@ -1340,4 +1340,339 @@ describe('createDataSetCategories', () => {
     expect(dataSetCategories[0].filter.label).toBe('State-funded primary');
     expect(dataSetCategories[1].filter.label).toBe('State-funded secondary');
   });
+
+  describe('ordering data sets with `order` property', () => {
+    const testOrderedAxisConfiguration: AxisConfiguration = {
+      type: 'major',
+      groupBy: 'timePeriod',
+      sortAsc: true,
+      dataSets: [
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnet',
+          },
+          timePeriod: '2015_AY',
+          order: 0,
+        },
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnsley',
+          },
+          timePeriod: '2015_AY',
+          order: 1,
+        },
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnet',
+          },
+          timePeriod: '2014_AY',
+          order: 2,
+        },
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnsley',
+          },
+          timePeriod: '2014_AY',
+          order: 3,
+        },
+      ],
+      referenceLines: [],
+      visible: true,
+      unit: '',
+      min: 0,
+    };
+
+    test('grouped by time period', () => {
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        testOrderedAxisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.label).toBe('2015/16');
+      expect(dataSetCategories[1].filter.label).toBe('2014/15');
+    });
+
+    test('grouped by filter', () => {
+      const axisConfiguration: AxisConfiguration = {
+        ...testOrderedAxisConfiguration,
+        groupBy: 'filters',
+      };
+
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        axisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.value).toBe('ethnicity-major-chinese');
+      expect(dataSetCategories[1].filter.value).toBe('state-funded-primary');
+    });
+
+    test('grouped by indicator', () => {
+      const indicatorDataSets = [
+        {
+          indicator: 'overall-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnsley',
+          },
+          timePeriod: '2015_AY',
+          order: 0,
+        },
+        {
+          indicator: 'overall-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnet',
+          },
+          timePeriod: '2015_AY',
+          order: 1,
+        },
+      ];
+
+      const axisConfiguration: AxisConfiguration = {
+        ...testOrderedAxisConfiguration,
+        groupBy: 'indicators',
+        dataSets: [
+          ...indicatorDataSets,
+          ...testOrderedAxisConfiguration.dataSets,
+        ],
+      };
+
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        axisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.label).toBe(
+        'Number of overall absence sessions',
+      );
+      expect(dataSetCategories[1].filter.label).toBe(
+        'Number of authorised absence sessions',
+      );
+    });
+
+    test('grouped by location', () => {
+      const axisConfiguration: AxisConfiguration = {
+        ...testOrderedAxisConfiguration,
+        groupBy: 'locations',
+      };
+
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        axisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.value).toBe('barnet');
+      expect(dataSetCategories[1].filter.value).toBe('barnsley');
+    });
+
+    test('reversed when `sortAsc` = false', () => {
+      const axisConfiguration: AxisConfiguration = {
+        ...testOrderedAxisConfiguration,
+        groupBy: 'filters',
+        sortAsc: false,
+      };
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        axisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.label).toBe('State-funded primary');
+      expect(dataSetCategories[1].filter.label).toBe('Ethnicity Major Chinese');
+    });
+  });
+
+  describe('ordering for older charts with no `order` property', () => {
+    const testUnorderedAxisConfiguration: AxisConfiguration = {
+      type: 'major',
+      groupBy: 'timePeriod',
+      sortAsc: true,
+      dataSets: [
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['state-funded-primary', 'ethnicity-major-chinese'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnsley',
+          },
+          timePeriod: '2015_AY',
+        },
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['state-funded-primary', 'ethnicity-major-chinese'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnet',
+          },
+          timePeriod: '2015_AY',
+        },
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['state-funded-primary', 'ethnicity-major-chinese'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnet',
+          },
+          timePeriod: '2014_AY',
+        },
+        {
+          indicator: 'authorised-absence-sessions',
+          filters: ['state-funded-primary', 'ethnicity-major-chinese'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnsley',
+          },
+          timePeriod: '2014_AY',
+        },
+      ],
+      referenceLines: [],
+      visible: true,
+      unit: '',
+      min: 0,
+    };
+
+    test('orders by `label` when grouped by filters', () => {
+      const axisConfiguration: AxisConfiguration = {
+        ...testUnorderedAxisConfiguration,
+        groupBy: 'filters',
+      };
+
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        axisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.label).toBe('Ethnicity Major Chinese');
+      expect(dataSetCategories[1].filter.label).toBe('State-funded primary');
+    });
+
+    test('orders by `label` when grouped by indicator', () => {
+      const indicatorDataSets = [
+        {
+          indicator: 'overall-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnsley',
+          },
+          timePeriod: '2015_AY',
+        },
+        {
+          indicator: 'overall-absence-sessions',
+          filters: ['ethnicity-major-chinese', 'state-funded-primary'],
+          location: {
+            level: 'localAuthority',
+            value: 'barnet',
+          },
+          timePeriod: '2015_AY',
+        },
+      ];
+
+      const axisConfiguration: AxisConfiguration = {
+        ...testUnorderedAxisConfiguration,
+        groupBy: 'indicators',
+        dataSets: [
+          ...indicatorDataSets,
+          ...testUnorderedAxisConfiguration.dataSets,
+        ],
+      };
+
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        axisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.label).toBe(
+        'Number of authorised absence sessions',
+      );
+      expect(dataSetCategories[1].filter.label).toBe(
+        'Number of overall absence sessions',
+      );
+    });
+
+    test('orders by `label` when grouped by location', () => {
+      const axisConfiguration: AxisConfiguration = {
+        ...testUnorderedAxisConfiguration,
+        groupBy: 'locations',
+      };
+
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        axisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.label).toBe('Barnet');
+      expect(dataSetCategories[1].filter.label).toBe('Barnsley');
+    });
+
+    test('orders by `order` when grouped by time period', () => {
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        testUnorderedAxisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.label).toBe('2014/15');
+      expect(dataSetCategories[1].filter.label).toBe('2015/16');
+    });
+
+    test('reversed when `sortAsc` = false', () => {
+      const axisConfiguration: AxisConfiguration = {
+        ...testUnorderedAxisConfiguration,
+        groupBy: 'filters',
+        sortAsc: false,
+      };
+
+      const fullTable = mapFullTable(testTable);
+      const dataSetCategories = createDataSetCategories(
+        axisConfiguration,
+        fullTable.results,
+        fullTable.subjectMeta,
+      );
+
+      expect(dataSetCategories).toHaveLength(2);
+      expect(dataSetCategories[0].filter.label).toBe('State-funded primary');
+      expect(dataSetCategories[1].filter.label).toBe('Ethnicity Major Chinese');
+    });
+  });
 });

--- a/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
+++ b/src/explore-education-statistics-common/src/modules/charts/util/createDataSetCategories.ts
@@ -16,11 +16,12 @@ import {
 import { FullTableMeta } from '@common/modules/table-tool/types/fullTable';
 import { TableDataResult } from '@common/services/tableBuilderService';
 import { Dictionary, Pair } from '@common/types';
-import naturalOrderBy from '@common/utils/array/naturalOrderBy';
 import cartesian from '@common/utils/cartesian';
-import parseNumber from '@common/utils/number/parseNumber';
+import naturalOrderBy from '@common/utils/array/naturalOrderBy';
 import get from 'lodash/get';
 import groupBy from 'lodash/groupBy';
+import sortBy from 'lodash/sortBy';
+import uniq from 'lodash/uniq';
 
 /**
  * We use this form of a data set as it's
@@ -218,31 +219,60 @@ function createKeyedDataSets(
   );
 }
 
-function sortDataSetCategories(
+/**
+ * Order the categories by the data set `order` property
+ * or a natural ordering algorithm based on the label
+ * (for backwards compatibility with older charts).
+ */
+function getSortedDataSetCategoryRange(
   dataSetCategories: DataSetCategory[],
   axisConfiguration: AxisConfiguration,
 ): DataSetCategory[] {
-  const { sortBy, sortAsc } = axisConfiguration;
-
-  if (!sortBy) {
-    return dataSetCategories;
-  }
-
-  return naturalOrderBy(
-    dataSetCategories,
-    data => {
-      if (sortBy === 'name') {
-        if (data.filter instanceof TimePeriodFilter) {
-          return data.filter.order;
-        }
-
-        return data.filter.label;
+  const groupOrder = uniq(
+    axisConfiguration.dataSets.flatMap(dataSet => {
+      switch (axisConfiguration.groupBy) {
+        case 'locations':
+          return dataSet.location?.value;
+        case 'indicators':
+          return dataSet.indicator;
+        case 'timePeriod':
+          return dataSet.timePeriod;
+        case 'filters':
+          return dataSet.filters;
+        default:
+          return undefined;
       }
-
-      return parseNumber(data.dataSets[sortBy]) ?? 0;
-    },
-    sortAsc ? 'asc' : 'desc',
+    }),
   );
+
+  // Check if the data sets have an explicit order property.
+  // Older charts don't have this property, so we need to
+  // order them using the previous ordering algorithm.
+  const hasDataSetOrder = axisConfiguration.dataSets.some(
+    dataSet => typeof dataSet.order !== 'undefined',
+  );
+
+  const sortedDataSetCategories = hasDataSetOrder
+    ? sortBy(dataSetCategories, category =>
+        groupOrder.indexOf(category.filter.value),
+      )
+    : naturalOrderBy(dataSetCategories, data =>
+        data.filter instanceof TimePeriodFilter
+          ? data.filter.order
+          : data.filter.label,
+      );
+
+  const sortedDataSetCategoriesRange = sortedDataSetCategories.slice(
+    axisConfiguration.min ?? 0,
+    (axisConfiguration.max ?? dataSetCategories.length) + 1,
+  );
+
+  // If no `sortAsc` has been set, we should default
+  // to true as it's not really natural to sort in
+  // descending order most of the time.
+  return axisConfiguration.sortAsc ?? true
+    ? sortedDataSetCategoriesRange
+    : sortedDataSetCategoriesRange.reverse();
 }
 
 /**
@@ -337,10 +367,7 @@ export default function createDataSetCategories(
     })
     .filter(category => Object.values(category.dataSets).length > 0);
 
-  return sortDataSetCategories(dataSetCategories, axisConfiguration).slice(
-    axisConfiguration.min ?? 0,
-    (axisConfiguration.max ?? dataSetCategories.length) + 1,
-  );
+  return getSortedDataSetCategoryRange(dataSetCategories, axisConfiguration);
 }
 
 export const toChartData = (chartCategory: DataSetCategory): ChartData => {

--- a/src/explore-education-statistics-common/src/styles/utils/_flex.scss
+++ b/src/explore-education-statistics-common/src/styles/utils/_flex.scss
@@ -49,3 +49,7 @@
 .dfe-flex-grow--1 {
   flex-grow: 1;
 }
+
+.dfe-align-self-end {
+  align-self: end;
+}


### PR DESCRIPTION
Version 2 of reordering datasets, see origin PR https://github.com/dfe-analytical-services/explore-education-statistics/pull/3124 and PR to undo it https://github.com/dfe-analytical-services/explore-education-statistics/pull/3158/files for context.

This adds reordering to chart data sets to allow users to control the ordering in the chart.

The original solution would potentially have caused existing charts with groups in the major axis to change. To avoid this I've added an order property to data sets (don't worry, @markhiveit told me what to do). If the new order property is present then reordering the data sets also reorders the dataSetCategories on the basis of their order in the data sets. If no order is present then the previous ordering is used.

For testing I suggest setting up some charts on dev before this is merged so they can be checked to confirm they haven't changed.
