### PR TITLE
EES-3163 - duplicate CI test script for snapshot tests

### DIFF
--- a/tests/robot-tests/scripts/pipeline-run-rf-tests-snapshots.sh
+++ b/tests/robot-tests/scripts/pipeline-run-rf-tests-snapshots.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# NOTE(mark): The slack webhook url, and admin and analyst passwords to access to Admin app are
+# stored in the CI pipeline as secret variables, which means they cannot be accessed as normal
+# environment variables, and instead must be passed as an argument to this script.
+
+
+admin_pass=""
+analyst_pass=""
+slack_webhook_url=""
+env=""
+file=""
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case "$key" in
+    --admin-pass)
+      shift
+      admin_pass="$1"
+      ;;
+    --analyst-pass)
+      shift
+      analyst_pass="$1"
+      ;;
+    --slack-webhook-url)
+      shift
+      slack_webhook_url="$1"
+      ;;
+    --env)
+      shift
+      env="$1"
+      ;;
+    --file)
+      shift
+      file="$1"
+  esac
+  shift
+done
+
+[[ "$admin_pass" == "" ]] && { echo "Provide an admin password with an '--admin-pass PASS' argument"; exit 1; }
+[[ "$analyst_pass" == "" ]] && { echo "Provide an analyst password with an '--analyst-pass PASS' argument"; exit 1; }
+[[ "$env" == "" ]] && { echo "Provide an environment with an '--env ENV' argument"; exit 1; }
+[[ "$file" == "" ]] && { echo "Provide a file/dir to run with an '--file FILE/DIR' argument"; exit 1; }
+
+google-chrome-stable --version
+
+python -m pip install --upgrade pip
+pip install pipenv
+pipenv install
+pipenv run python run_tests.py --admin-pass $admin_pass --analyst-pass $analyst_pass --slack-webhook-url "$slack_webhook_url" -e $env --ci --file $file --processes 3

--- a/tests/robot-tests/tests/libs/slack.py
+++ b/tests/robot-tests/tests/libs/slack.py
@@ -67,9 +67,7 @@ def _tests_failed():
 
 
 def send_slack_report(env: str, suite: str):
-
     attachments = _generate_slack_attachments(env, suite)
-    data = {"attachments": attachments}
 
     webhook_url = os.getenv('SLACK_TEST_REPORT_WEBHOOK_URL')
     slack_bot_token = os.getenv('SLACK_BOT_TOKEN')
@@ -79,7 +77,7 @@ def send_slack_report(env: str, suite: str):
 
     response = requests.post(
         url=webhook_url,
-        data=json.dumps(data), headers={'Content-Type': 'application/json'}
+        data=json.dumps({"attachments": attachments}), headers={'Content-Type': 'application/json'}
     )
     assert response.status_code == 200, print(f"Response wasn't 200, it was {response}")
 
@@ -98,4 +96,4 @@ def send_slack_report(env: str, suite: str):
         except SlackApiError as e:
             print(f'Error uploading test report: {e}')
         os.remove('UI-test-report.zip')
-    print('Sent UI test report to #build')
+        print('Sent UI test report to #build')


### PR DESCRIPTION
This PR:
* Duplicates pipeline script so that we do not send slack notifications when running the snapshot test pipeline
* Minor cleanup of `slack.py`

Continuation of https://github.com/dfe-analytical-services/explore-education-statistics/pull/3164 due to a bad rebase