### PR TITLE
EES-3168 - handling all Release Checklist errors in frontend

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/CommentServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/CommentServiceTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.MapperUtils;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
@@ -155,10 +156,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     contentBlockId: Guid.NewGuid(),
                     new CommentSaveRequest {Content = "New comment"});
 
-                var actionResult = result.AssertLeft();
-                Assert.IsType<BadRequestObjectResult>(actionResult);
-                var details = (ValidationProblemDetails) ((BadRequestObjectResult) actionResult).Value;
-                Assert.Equal("CONTENT_BLOCK_NOT_FOUND", details.Errors[""].First());
+                result.AssertBadRequest(ContentBlockNotFound);
             }
         }
 

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataArchiveValidationServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/DataArchiveValidationServiceTests.cs
@@ -1,16 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using GovUk.Education.ExploreEducationStatistics.Admin.Services;
 using GovUk.Education.ExploreEducationStatistics.Common.Services.Interfaces;
-using GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils;
+using GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
+using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 
 namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 {
@@ -35,7 +35,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
 
             Assert.True(result.IsRight);
 
-            MockUtils.VerifyAllMocks(fileTypeService);
+            VerifyAllMocks(fileTypeService);
         }
 
         [Fact]
@@ -54,13 +54,9 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 .Returns(() => true);
 
             var result = service.ValidateDataArchiveFile(Guid.NewGuid(), archive).Result;
-
-            Assert.True(result.IsLeft);
-            Assert.IsAssignableFrom<BadRequestObjectResult>(result.Left);
-            var details = (ValidationProblemDetails) ((BadRequestObjectResult) result.Left).Value;
-            Assert.Equal("DATA_ZIP_FILE_DOES_NOT_CONTAIN_CSV_FILES", details.Errors[""].First());
-
-            MockUtils.VerifyAllMocks(fileTypeService);
+            VerifyAllMocks(fileTypeService);
+            
+            result.AssertBadRequest(DataZipFileDoesNotContainCsvFiles);
         }
 
         private static IFormFile CreateFormFileFromResource(string fileName)

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseInviteServiceTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin.Tests/Services/ReleaseInviteServiceTests.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ExploreEducationStatistics.Admin.Areas.Identity.Data;
 using GovUk.Education.ExploreEducationStatistics.Admin.Models;
@@ -20,6 +19,7 @@ using Microsoft.Extensions.Configuration;
 using Moq;
 using Xunit;
 using static GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services.DbUtils;
+using static GovUk.Education.ExploreEducationStatistics.Admin.Validators.ValidationErrorMessages;
 using static GovUk.Education.ExploreEducationStatistics.Common.Services.CollectionUtils;
 using static GovUk.Education.ExploreEducationStatistics.Common.Tests.Utils.MockUtils;
 using static GovUk.Education.ExploreEducationStatistics.Content.Model.ReleaseRole;
@@ -318,11 +318,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     publicationId: publication.Id,
                     releaseIds: ListOf(release1.Id, release2.Id));
 
-                var actionResult = result.AssertLeft();
-                Assert.IsType<BadRequestObjectResult>(actionResult);
-                var badRequestObjectResult = (BadRequestObjectResult)actionResult;
-                var validationProblemDetails = (ValidationProblemDetails)badRequestObjectResult.Value;
-                Assert.Equal("USER_ALREADY_HAS_RELEASE_ROLE_INVITES", validationProblemDetails.Errors[""].First());
+                result.AssertBadRequest(UserAlreadyHasReleaseRoleInvites);
             }
 
             await using (var usersAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
@@ -411,12 +407,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     email: "test@test.com",
                     publicationId: publication.Id,
                     releaseIds: ListOf(release1.Id, release2.Id));
-
-                var actionResult = result.AssertLeft();
-                Assert.IsType<BadRequestObjectResult>(actionResult);
-                var badRequestObjectResult = (BadRequestObjectResult)actionResult;
-                var validationProblemDetails = (ValidationProblemDetails)badRequestObjectResult.Value;
-                Assert.Equal("USER_ALREADY_HAS_RELEASE_ROLES", validationProblemDetails.Errors[""].First());
+                
+                result.AssertBadRequest(UserAlreadyHasReleaseRoles);
             }
 
             await using (var usersAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
@@ -657,12 +649,8 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                     email: "test@test.com",
                     publicationId: publication1.Id,
                     releaseIds: ListOf(release1.Id, release2.Id));
-
-                var actionResult = result.AssertLeft();
-                Assert.IsType<BadRequestObjectResult>(actionResult);
-                var badRequestObjectResult = (BadRequestObjectResult)actionResult;
-                var validationProblemDetails = (ValidationProblemDetails)badRequestObjectResult.Value;
-                Assert.Equal("NOT_ALL_RELEASES_BELONG_TO_PUBLICATION", validationProblemDetails.Errors[""].First());
+                
+                result.AssertBadRequest(NotAllReleasesBelongToPublication);
             }
 
             await using (var usersAndRolesDbContext = InMemoryUserAndRolesDbContext(usersAndRolesDbContextId))
@@ -765,7 +753,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.RemoveByPublication(
                     email: "test@test.com",
                     publicationId: publication1.Id,
-                    releaseRole: ReleaseRole.Contributor);
+                    releaseRole: Contributor);
 
                 result.AssertRight();
             }
@@ -815,7 +803,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.RemoveByPublication(
                     email: "test@test.com",
                     publicationId: Guid.NewGuid(),
-                    releaseRole: ReleaseRole.Contributor);
+                    releaseRole: Contributor);
 
                 result.AssertNotFound();
             }
@@ -853,7 +841,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Tests.Services
                 var result = await service.RemoveByPublication(
                     email: "test@test.com",
                     publicationId: publication.Id,
-                    releaseRole: ReleaseRole.Contributor);
+                    releaseRole: Contributor);
 
                 result.AssertRight();
             }

--- a/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Admin/Validators/ValidationUtils.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -13,7 +12,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
         // TODO EES-919 - return ActionResults rather than ValidationResults
         public static ValidationResult ValidationResult(ValidationErrorMessages message)
         {
-            return new ValidationResult(message.ToString().ScreamingSnakeCase());
+            return new ValidationResult(message.ToString());
         }
 
         // TODO EES-919 - return ActionResults rather than ValidationResults - as this work is done,
@@ -29,7 +28,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Admin.Validators
 
             foreach (var message in messages)
             {
-                errors.AddModelError(string.Empty, message.ToString().ScreamingSnakeCase());
+                errors.AddModelError(string.Empty, message.ToString());
             }
 
             return new BadRequestObjectResult(new ValidationProblemDetails(errors));

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ActionResultTestExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/ActionResultTestExtensions.cs
@@ -66,16 +66,17 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Tests.Extensions
         private static void AssertBadRequestWithValidationErrors(this object result, params Enum[] expectedValidationErrors)
         {
             var badRequest = Assert.IsAssignableFrom<BadRequestObjectResult>(result);
-            var validationProblem = Assert.IsAssignableFrom<ValidationProblemDetails>(badRequest?.Value);
+            var validationProblem = Assert.IsAssignableFrom<ValidationProblemDetails>(badRequest.Value);
 
-            Assert.True(validationProblem != null && validationProblem.Errors.ContainsKey(string.Empty));
+            Assert.NotNull(validationProblem);
+            Assert.True(validationProblem.Errors.ContainsKey(string.Empty));
 
             var globalErrors = validationProblem.Errors[string.Empty];
 
             Assert.Equal(expectedValidationErrors.Length, globalErrors.Length);
 
             expectedValidationErrors.ForEach(message =>
-                Assert.Contains(message.ToString().ScreamingSnakeCase(), globalErrors));
+                Assert.Contains(message.ToString(), globalErrors));
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common.Tests/Extensions/StringExtensionTests.cs
@@ -364,51 +364,6 @@ Test
             }
         }
 
-        public class ScreamingSnakeCaseTests
-        {
-            [Fact]
-            public void NullStringsCanBeScreamingSnakeCased()
-            {
-                string? input = null;
-                Assert.Null(input!.ScreamingSnakeCase());
-            }
-
-            [Fact]
-            public void EmptyStringCanBeScreamingSnakeCased()
-            {
-                Assert.Equal(string.Empty, string.Empty.ScreamingSnakeCase());
-            }
-
-            [Fact]
-            public void AcronymsAreAlreadyScreamingSnakeCased()
-            {
-                Assert.Equal("ABC", "ABC".ScreamingSnakeCase());
-            }
-
-            [Fact]
-            public void CamelCasedStringsAreScreamingSnakeCased()
-            {
-                Assert.Equal("FOO", "foo".ScreamingSnakeCase());
-                Assert.Equal("CAMEL_CASE_STRING", "camelCaseString".ScreamingSnakeCase());
-            }
-
-            [Fact]
-            public void UnderscoreSeparatedStringsAreScreamingSnakeCased()
-            {
-                Assert.Equal("FOO_BAR", "foo_bar".ScreamingSnakeCase());
-                Assert.Equal("FOO_BAR", "foo_Bar".ScreamingSnakeCase());
-                Assert.Equal("FOO_BAR", "Foo_Bar".ScreamingSnakeCase());
-                Assert.Equal("FOO_BAR", "FOO_Bar".ScreamingSnakeCase());
-            }
-
-            [Fact]
-            public void PascalCasedStringsAreScreamingSnakeCased()
-            {
-                Assert.Equal("FOO_BAR", "FooBar".ScreamingSnakeCase());
-                Assert.Equal("FOO_BAR", "FooBAr".ScreamingSnakeCase());
-            }
-        }
-
         public class ToMd5HashTests
         {
             [Fact]

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Extensions/StringExtensions.cs
@@ -122,28 +122,6 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Extensions
             return input;
         }
 
-        public static string SnakeCase(this string input)
-        {
-            if (input.IsNullOrEmpty())
-            {
-                return input;
-            }
-
-            input = Regex.Replace(input, "(([^_A-Z])([A-Z]))", "$2_$3");
-
-            return input.TrimStart('_').ToLower();
-        }
-
-        public static string ScreamingSnakeCase(this string input)
-        {
-            if (input.IsNullOrEmpty())
-            {
-                return input;
-            }
-
-            return SnakeCase(input).ToUpper();
-        }
-
         public static string ToMd5Hash(this string input, Encoding? encoding = null)
         {
             using var md5 = MD5.Create();

--- a/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ValidationUtils.cs
+++ b/src/GovUk.Education.ExploreEducationStatistics.Common/Validators/ValidationUtils.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Linq;
 using System.Net;
-using GovUk.Education.ExploreEducationStatistics.Common.Extensions;
 using GovUk.Education.ExploreEducationStatistics.Common.Model;
 using Microsoft.AspNetCore.Mvc;
 
@@ -20,7 +19,7 @@ namespace GovUk.Education.ExploreEducationStatistics.Common.Validators
             var problemDetails = new ValidationProblemDetails(
                 errors.ToDictionary(
                     _ => string.Empty,
-                    error => new[] {error.ScreamingSnakeCase()}))
+                    error => new[] {error}))
             {
                 Status = (int) HttpStatusCode.BadRequest,
                 Detail = "Please refer to the errors property for additional details"

--- a/src/explore-education-statistics-admin/src/pages/methodology/adopt-methodology/components/AdoptMethodologyForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/adopt-methodology/components/AdoptMethodologyForm.tsx
@@ -21,7 +21,7 @@ const errorMappings = [
   mapFieldErrors<FormValues>({
     target: 'methodologyId',
     messages: {
-      CANNOT_ADOPT_METHODOLOGY_ALREADY_LINKED_TO_PUBLICATION:
+      CannotAdoptMethodologyAlreadyLinkedToPublication:
         'Select a methodology that has not already been adopted by this publication',
     },
   }),

--- a/src/explore-education-statistics-admin/src/pages/methodology/components/MethodologySummaryForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/methodology/components/MethodologySummaryForm.tsx
@@ -19,7 +19,7 @@ const errorMappings = [
   mapFieldErrors<MethodologySummaryFormValues>({
     target: 'title',
     messages: {
-      SLUG_NOT_UNIQUE: 'Choose a unique title',
+      SlugNotUnique: 'Choose a unique title',
     },
   }),
 ];

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationForm.tsx
@@ -27,7 +27,7 @@ const errorMappings = [
   mapFieldErrors<FormValues>({
     target: 'title',
     messages: {
-      SLUG_NOT_UNIQUE: 'Choose a unique title',
+      SlugNotUnique: 'Choose a unique title',
     },
   }),
 ];

--- a/src/explore-education-statistics-admin/src/pages/publication/components/PublicationInviteNewUsersTab.tsx
+++ b/src/explore-education-statistics-admin/src/pages/publication/components/PublicationInviteNewUsersTab.tsx
@@ -28,11 +28,11 @@ export const errorMappings = [
   mapFieldErrors<InviteContributorFormValues>({
     target: 'releaseIds',
     messages: {
-      NOT_ALL_RELEASES_BELONG_TO_PUBLICATION:
+      NotAllReleasesBelongToPublication:
         "Some of the releases don't belong to the publication",
-      USER_ALREADY_HAS_RELEASE_ROLE_INVITES:
+      UserAlreadyHasReleaseRoleInvites:
         'The user has already been invited with these permissions',
-      USER_ALREADY_HAS_RELEASE_ROLES: 'The user already has these permissions',
+      UserAlreadyHasReleaseRoles: 'The user already has these permissions',
     },
   }),
 ];

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseCreatePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseCreatePage.tsx
@@ -26,7 +26,7 @@ const errorMappings = [
   mapFieldErrors<FormValues>({
     target: 'timePeriodCoverageStartYear',
     messages: {
-      SLUG_NOT_UNIQUE:
+      SlugNotUnique:
         'Choose a unique combination of time period and start year',
     },
   }),

--- a/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/ReleaseSummaryEditPage.tsx
@@ -19,7 +19,7 @@ const errorMappings = [
   mapFieldErrors<ReleaseSummaryFormValues>({
     target: 'timePeriodCoverageStartYear',
     messages: {
-      SLUG_NOT_UNIQUE:
+      SlugNotUnique:
         'Choose a unique combination of time period and start year',
     },
   }),

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -1,5 +1,8 @@
 import { ReleaseStatusPermissions } from '@admin/services/permissionService';
-import { Release } from '@admin/services/releaseService';
+import {
+  Release,
+  ReleaseChecklistErrorCode,
+} from '@admin/services/releaseService';
 import Button from '@common/components/Button';
 import ButtonGroup from '@common/components/ButtonGroup';
 import ButtonText from '@common/components/ButtonText';
@@ -20,13 +23,17 @@ import {
   parsePartialDateToLocalDate,
   PartialDate,
 } from '@common/utils/date/partialDate';
-import { mapFieldErrors } from '@common/validation/serverValidations';
+import {
+  mapFallbackFieldError,
+  mapFieldErrors,
+} from '@common/validation/serverValidations';
 import Yup from '@common/validation/yup';
 import ModalConfirm from '@common/components/ModalConfirm';
 import { endOfDay, format, isValid, parseISO } from 'date-fns';
 import { Formik } from 'formik';
 import React, { useState } from 'react';
 import { StringSchema } from 'yup';
+import { keyBy, mapValues } from 'lodash';
 
 export interface ReleaseStatusFormValues {
   publishMethod?: 'Scheduled' | 'Immediate';
@@ -43,31 +50,29 @@ const errorMappings = [
   mapFieldErrors<ReleaseStatusFormValues>({
     target: 'approvalStatus',
     messages: {
-      APPROVED_RELEASE_MUST_HAVE_PUBLISH_SCHEDULED_DATE:
+      ApprovedReleaseMustHavePublishScheduledDate:
         'Enter a publish scheduled date before approving',
-      PUBLISHED_RELEASE_CANNOT_BE_UNAPPROVED:
+      PublishedReleaseCannotBeUnapproved:
         'Release has already been published and cannot be un-approved',
-      PUBLIC_META_GUIDANCE_REQUIRED:
-        'All public data guidance must be populated before the release can be approved',
-      PUBLIC_PRE_RELEASE_ACCESS_LIST_REQUIRED:
-        'Public pre-release access list is required before the release can be approved',
-      DATA_FILE_REPLACEMENTS_MUST_BE_COMPLETED:
-        'Pending data file replacements that are in progress must be completed or cancelled before the release can be approved',
-      DATA_FILE_IMPORTS_MUST_BE_COMPLETED:
-        'All data file imports must be completed before the release can be approved',
-      METHODOLOGY_MUST_BE_APPROVED:
-        "The publication's methodology must be approved before the release can be approved",
-      RELEASE_NOTE_REQUIRED:
-        'A public release note must be added for this amendment before it can be approved',
+      ...mapValues(
+        keyBy(ReleaseChecklistErrorCode, value => value),
+        _ => 'Resolve all errors in the publishing checklist',
+      ),
     },
   }),
   mapFieldErrors<ReleaseStatusFormValues>({
     target: 'nextReleaseDate',
     messages: {
-      PARTIAL_DATE_NOT_VALID: 'Enter a valid date',
+      PartialDateNotValid: 'Enter a valid date',
     },
   }),
 ];
+
+const fallbackErrorMapping = mapFallbackFieldError<ReleaseStatusFormValues>({
+  target: 'approvalStatus',
+  fallbackMessage:
+    'There was a problem changing the approval status of this release',
+});
 
 interface Props {
   release: Release;
@@ -101,6 +106,7 @@ const ReleaseStatusForm = ({
       });
     },
     errorMappings,
+    fallbackErrorMapping,
   );
 
   return (

--- a/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/ReleaseStatusForm.tsx
@@ -71,7 +71,7 @@ const errorMappings = [
 const fallbackErrorMapping = mapFallbackFieldError<ReleaseStatusFormValues>({
   target: 'approvalStatus',
   fallbackMessage:
-    'There was a problem changing the approval status of this release',
+    'There was a problem updating the approval status of this release',
 });
 
 interface Props {

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -1,5 +1,8 @@
 import { ReleaseStatusPermissions } from '@admin/services/permissionService';
-import { Release } from '@admin/services/releaseService';
+import {
+  Release,
+  ReleaseChecklistErrorCode,
+} from '@admin/services/releaseService';
 import { createServerValidationErrorMock } from '@common-test/createAxiosErrorMock';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { format } from 'date-fns';
@@ -557,34 +560,70 @@ describe('ReleaseStatusForm', () => {
       });
     });
 
-    test('shows mapped server validation error from failed `onSubmit`', async () => {
-      const handleSubmit = jest.fn().mockImplementation(() => {
-        throw createServerValidationErrorMock([
-          'PUBLIC_META_GUIDANCE_REQUIRED',
-        ]);
-      });
+    ReleaseChecklistErrorCode.forEach(checklistError => {
+      test(`shows generic checklist error message from failed \`onSubmit\` with \`${checklistError}\` error code`, async () => {
+        const handleSubmit = jest.fn().mockImplementation(() => {
+          throw createServerValidationErrorMock([checklistError]);
+        });
 
-      render(
-        <ReleaseStatusForm
-          release={testRelease}
-          statusPermissions={testStatusPermissions}
-          onCancel={noop}
-          onSubmit={handleSubmit}
-        />,
-      );
+        render(
+          <ReleaseStatusForm
+            release={testRelease}
+            statusPermissions={testStatusPermissions}
+            onCancel={noop}
+            onSubmit={handleSubmit}
+          />,
+        );
 
-      userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+        userEvent.click(screen.getByRole('button', { name: 'Update status' }));
 
-      await waitFor(() => {
-        expect(screen.getByText('There is a problem')).toBeInTheDocument();
-        expect(
-          screen.getByRole('link', {
-            name:
-              'All public data guidance must be populated before the release can be approved',
-          }),
-        ).toBeInTheDocument();
+        await waitFor(() => {
+          expect(screen.getByText('There is a problem')).toBeInTheDocument();
+          const errorLink = screen.getByRole('link', {
+            name: 'Resolve all errors in the publishing checklist',
+          });
+          expect(errorLink).toBeInTheDocument();
+          expect(errorLink).toHaveAttribute(
+            'href',
+            '#releaseStatusForm-approvalStatus',
+          );
+        });
       });
     });
+
+    test(
+      'shows fallback error message mapped to `approvalStatus` field when receiving unmapped server ' +
+        'validation error from failed `onSubmit`',
+      async () => {
+        const handleSubmit = jest.fn().mockImplementation(() => {
+          throw createServerValidationErrorMock(['UnexpectedError']);
+        });
+
+        render(
+          <ReleaseStatusForm
+            release={testRelease}
+            statusPermissions={testStatusPermissions}
+            onCancel={noop}
+            onSubmit={handleSubmit}
+          />,
+        );
+
+        userEvent.click(screen.getByRole('button', { name: 'Update status' }));
+
+        await waitFor(() => {
+          expect(screen.getByText('There is a problem')).toBeInTheDocument();
+          const errorLink = screen.getByRole('link', {
+            name:
+              'There was a problem changing the approval status of this release',
+          }) as HTMLAnchorElement;
+          expect(errorLink).toBeInTheDocument();
+          expect(errorLink).toHaveAttribute(
+            'href',
+            '#releaseStatusForm-approvalStatus',
+          );
+        });
+      },
+    );
 
     test('submits successfully with updated values and Draft status', async () => {
       const handleSubmit = jest.fn();

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -614,7 +614,7 @@ describe('ReleaseStatusForm', () => {
           expect(screen.getByText('There is a problem')).toBeInTheDocument();
           const errorLink = screen.getByRole('link', {
             name:
-              'There was a problem changing the approval status of this release',
+              'There was a problem updating the approval status of this release',
           }) as HTMLAnchorElement;
           expect(errorLink).toBeInTheDocument();
           expect(errorLink).toHaveAttribute(

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseStatusForm.test.tsx
@@ -579,15 +579,16 @@ describe('ReleaseStatusForm', () => {
 
         await waitFor(() => {
           expect(screen.getByText('There is a problem')).toBeInTheDocument();
-          const errorLink = screen.getByRole('link', {
-            name: 'Resolve all errors in the publishing checklist',
-          });
-          expect(errorLink).toBeInTheDocument();
-          expect(errorLink).toHaveAttribute(
-            'href',
-            '#releaseStatusForm-approvalStatus',
-          );
         });
+
+        const errorLink = screen.getByRole('link', {
+          name: 'Resolve all errors in the publishing checklist',
+        });
+
+        expect(errorLink).toHaveAttribute(
+          'href',
+          '#releaseStatusForm-approvalStatus',
+        );
       });
     });
 
@@ -612,16 +613,17 @@ describe('ReleaseStatusForm', () => {
 
         await waitFor(() => {
           expect(screen.getByText('There is a problem')).toBeInTheDocument();
-          const errorLink = screen.getByRole('link', {
-            name:
-              'There was a problem updating the approval status of this release',
-          }) as HTMLAnchorElement;
-          expect(errorLink).toBeInTheDocument();
-          expect(errorLink).toHaveAttribute(
-            'href',
-            '#releaseStatusForm-approvalStatus',
-          );
         });
+
+        const errorLink = screen.getByRole('link', {
+          name:
+            'There was a problem updating the approval status of this release',
+        });
+
+        expect(errorLink).toHaveAttribute(
+          'href',
+          '#releaseStatusForm-approvalStatus',
+        );
       },
     );
 

--- a/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/components/__tests__/ReleaseSummaryForm.test.tsx
@@ -4,7 +4,6 @@ import _metaService, {
 import { render, screen, waitFor, within } from '@testing-library/react';
 import noop from 'lodash/noop';
 import React from 'react';
-import { IdTitlePair } from 'src/services/types/common';
 import { releaseTypes } from '@common/services/types/releaseType';
 import userEvent from '@testing-library/user-event';
 import ReleaseSummaryForm, {

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -42,7 +42,7 @@ const baseErrorMappings = (
           DataFileCannotBeEmpty: 'Choose a ZIP data file that is not empty',
           DataFilenameCannotContainSpacesOrSpecialCharacters:
             'ZIP data filename cannot contain spaces or special characters',
-          MatadataFileCannotBeEmpty:
+          MetadataFileCannotBeEmpty:
             'Choose a ZIP metadata file that is not empty',
           MetaFilenameCannotContainSpacesOrSpecialCharacters:
             'ZIP metadata filename cannot contain spaces or special characters',

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/DataFileUploadForm.tsx
@@ -30,23 +30,23 @@ const baseErrorMappings = (
       mapFieldErrors<DataFileUploadFormValues>({
         target: 'zipFile',
         messages: {
-          DATA_FILE_MUST_BE_ZIP_FILE: 'Choose a valid ZIP file',
-          DATA_ZIP_FILE_CAN_ONLY_CONTAIN_TWO_FILES:
+          DataFileMustBeZipFile: 'Choose a valid ZIP file',
+          DataZipFileCanOnlyContainTwoFiles:
             'ZIP file can only contain two CSV files',
-          DATA_ZIP_FILE_DOES_NOT_CONTAIN_CSV_FILES:
+          DataZipFileDoesNotContainCsvFiles:
             'ZIP file does not contain any CSV files',
-          DATA_ZIP_FILE_ALREADY_EXISTS: 'ZIP file already exists',
-          CANNOT_OVERWRITE_DATA_FILE: 'Choose a unique ZIP data file name',
-          DATA_AND_METADATA_FILES_CANNOT_HAVE_THE_SAME_NAME:
+          DataZipFileAlreadyExists: 'ZIP file already exists',
+          CannotOverwriteDataFile: 'Choose a unique ZIP data file name',
+          DataAndMetadataFilesCannotHaveTheSameName:
             'ZIP data and metadata filenames cannot be the same',
-          DATA_FILE_CANNOT_BE_EMPTY: 'Choose a ZIP data file that is not empty',
-          DATA_FILENAME_CANNOT_CONTAIN_SPACES_OR_SPECIAL_CHARACTERS:
+          DataFileCannotBeEmpty: 'Choose a ZIP data file that is not empty',
+          DataFilenameCannotContainSpacesOrSpecialCharacters:
             'ZIP data filename cannot contain spaces or special characters',
-          METADATA_FILE_CANNOT_BE_EMPTY:
+          MatadataFileCannotBeEmpty:
             'Choose a ZIP metadata file that is not empty',
-          META_FILENAME_CANNOT_CONTAIN_SPACES_OR_SPECIAL_CHARACTERS:
+          MetaFilenameCannotContainSpacesOrSpecialCharacters:
             'ZIP metadata filename cannot contain spaces or special characters',
-          META_FILE_IS_INCORRECTLY_NAMED:
+          MetaFileIsIncorrectlyNamed:
             'ZIP metadata filename must end with .meta.csv',
         },
       }),
@@ -57,28 +57,25 @@ const baseErrorMappings = (
     mapFieldErrors<DataFileUploadFormValues>({
       target: 'dataFile',
       messages: {
-        CANNOT_OVERWRITE_DATA_FILE: 'Choose a unique data file name',
-        DATA_AND_METADATA_FILES_CANNOT_HAVE_THE_SAME_NAME:
+        CannotOverwriteDataFile: 'Choose a unique data file name',
+        DataAndMetadataFilesCannotHaveTheSameName:
           'Choose a different file name for data and metadata files',
-        DATA_FILE_CANNOT_BE_EMPTY: 'Choose a data file that is not empty',
-        DATA_FILE_MUST_BE_CSV_FILE:
-          'Data file must be a CSV with UTF-8 encoding',
-        DATA_FILENAME_CANNOT_CONTAIN_SPACES_OR_SPECIAL_CHARACTERS:
+        DataFileCannotBeEmpty: 'Choose a data file that is not empty',
+        DataFileMustBeCsvFile: 'Data file must be a CSV with UTF-8 encoding',
+        DataFilenameCannotContainSpacesOrSpecialCharacters:
           'Data filename cannot contain spaces or special characters',
-        DATA_FILE_ALREADY_UPLOADED: 'Data file has already been uploaded',
+        DataFileAlreadyUploaded: 'Data file has already been uploaded',
       },
     }),
     mapFieldErrors<DataFileUploadFormValues>({
       target: 'metadataFile',
       messages: {
-        METADATA_FILE_CANNOT_BE_EMPTY:
-          'Choose a metadata file that is not empty',
-        META_FILE_MUST_BE_CSV_FILE:
+        MetadataFileCannotBeEmpty: 'Choose a metadata file that is not empty',
+        MetaFileMustBeCsvFile:
           'Metadata file must be a CSV with UTF-8 encoding',
-        META_FILENAME_CANNOT_CONTAIN_SPACES_OR_SPECIAL_CHARACTERS:
+        MetaFilenameCannotContainSpacesOrSpecialCharacters:
           'Metadata filename cannot contain spaces or special characters',
-        META_FILE_IS_INCORRECTLY_NAMED:
-          'Metadata filename is incorrectly named',
+        MetaFileIsIncorrectlyNamed: 'Metadata filename is incorrectly named',
       },
     }),
   ];

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseDataUploadsSection.tsx
@@ -41,8 +41,8 @@ const errorMappings = [
   mapFieldErrors<FormValues>({
     target: 'subjectTitle',
     messages: {
-      SUBJECT_TITLE_MUST_BE_UNIQUE: 'Subject title must be unique',
-      SUBJECT_TITLE_CANNOT_CONTAIN_SPECIAL_CHARACTERS:
+      SubjectTitleMustBeUnique: 'Subject title must be unique',
+      SubjectTitleCannotContainSpecialCharacters:
         'Subject title cannot contain special characters',
     },
   }),

--- a/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/data/components/ReleaseFileUploadsSection.tsx
@@ -40,17 +40,17 @@ const errorMappings = [
   mapFieldErrors<FormValues>({
     target: 'title',
     messages: {
-      FILE_UPLOAD_NAME_CANNOT_CONTAIN_SPECIAL_CHARACTERS:
+      FileUploadNameCannotContainSpecialCharacters:
         'File upload name cannot contain special characters',
     },
   }),
   mapFieldErrors<FormValues>({
     target: 'file',
     messages: {
-      CANNOT_OVERWRITE_FILE: 'Choose a unique file name',
-      FILE_CANNOT_BE_EMPTY: 'Choose a file that is not empty',
-      FILE_TYPE_INVALID: 'Choose a file of an allowed format',
-      FILENAME_CANNOT_CONTAIN_SPACES_OR_SPECIAL_CHARACTERS:
+      CannotOverwriteFile: 'Choose a unique file name',
+      FileCannotBeEmpty: 'Choose a file that is not empty',
+      FileTypeInvalid: 'Choose a file of an allowed format',
+      FilenameCannotContainSpacesOrSpecialCharacters:
         'Filename cannot contain spaces or special characters',
     },
   }),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartConfiguration.tsx
@@ -35,10 +35,10 @@ export const errorMappings = [
   mapFieldErrors<FormValues>({
     target: 'file',
     messages: {
-      FILE_TYPE_INVALID: 'The infographic must be an image',
-      CANNOT_OVERWRITE_FILE: 'The infographic does not have a unique filename',
-      FILE_CANNOT_BE_EMPTY: 'The infographic cannot be an empty file',
-      FILENAME_CANNOT_CONTAIN_SPACES_OR_SPECIAL_CHARACTERS:
+      FileTypeInvalid: 'The infographic must be an image',
+      CannotOverwriteFile: 'The infographic does not have a unique filename',
+      FileCannotBeEmpty: 'The infographic cannot be an empty file',
+      FilenameCannotContainSpacesOrSpecialCharacters:
         'The infographic filename cannot contain spaces or special characters',
     },
   }),

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
@@ -46,7 +46,7 @@ const ChartDataSetsConfiguration = ({
   onChange,
 }: Props) => {
   const { forms, updateForm, submit } = useChartBuilderFormsContext();
-  const [isReordering, toggleIsReordering] = useToggle(false);
+  const [isReordering] = useToggle(false);
 
   const indicatorOptions = useMemo(() => Object.values(meta.indicators), [
     meta.indicators,

--- a/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/datablocks/components/chart/ChartDataSetsConfiguration.tsx
@@ -46,7 +46,7 @@ const ChartDataSetsConfiguration = ({
   onChange,
 }: Props) => {
   const { forms, updateForm, submit } = useChartBuilderFormsContext();
-  const [isReordering] = useToggle(false);
+  const [isReordering, toggleIsReordering] = useToggle(false);
 
   const indicatorOptions = useMemo(() => Object.values(meta.indicators), [
     meta.indicators,

--- a/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseUserAccessForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/release/pre-release/components/PreReleaseUserAccessForm.tsx
@@ -26,8 +26,8 @@ const errorMappings = [
   mapFieldErrors<FormValues>({
     target: 'emails',
     messages: {
-      INVALID_EMAIL_ADDRESS: 'Enter only @education.gov.uk email addresses',
-      NO_INVITABLE_EMAILS:
+      InvalidEmailAddress: 'Enter only @education.gov.uk email addresses',
+      NoInvitableEmails:
         'All of the email addresses have already been invited or accepted',
     },
   }),

--- a/src/explore-education-statistics-admin/src/pages/themes/components/ThemeForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/themes/components/ThemeForm.tsx
@@ -16,7 +16,7 @@ const errorMappings = [
   mapFieldErrors<ThemeFormValues>({
     target: 'title',
     messages: {
-      SLUG_NOT_UNIQUE: 'Enter a unique title',
+      SlugNotUnique: 'Enter a unique title',
     },
   }),
 ];

--- a/src/explore-education-statistics-admin/src/pages/themes/topics/components/TopicForm.tsx
+++ b/src/explore-education-statistics-admin/src/pages/themes/topics/components/TopicForm.tsx
@@ -15,7 +15,7 @@ const errorMappings = [
   mapFieldErrors<TopicFormValues>({
     target: 'title',
     messages: {
-      SLUG_NOT_UNIQUE: 'Enter a unique title',
+      SlugNotUnique: 'Enter a unique title',
     },
   }),
 ];

--- a/src/explore-education-statistics-admin/src/pages/users/ManageUserPage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/ManageUserPage.tsx
@@ -28,7 +28,7 @@ const updateRoleFormErrorMappings = [
   mapFieldErrors<UpdateRoleFormValues>({
     target: 'selectedRoleId',
     messages: {
-      ROLE_DOES_NOT_EXIST: 'Role does not exist',
+      RoleDoesNotExist: 'Role does not exist',
     },
   }),
 ];
@@ -37,7 +37,7 @@ const addReleaseFormErrorMappings = [
   mapFieldErrors<AddReleaseRoleFormValues>({
     target: 'selectedReleaseRole',
     messages: {
-      USER_ALREADY_HAS_RESOURCE_ROLE: 'The user already has this release role',
+      UserAlreadyHasResourceRole: 'The user already has this release role',
     },
   }),
 ];
@@ -46,8 +46,7 @@ const addPublicationFormErrorMappings = [
   mapFieldErrors<AddPublicationRoleFormValues>({
     target: 'selectedPublicationRole',
     messages: {
-      USER_ALREADY_HAS_RESOURCE_ROLE:
-        'The user already has this publication role',
+      UserAlreadyHasResourceRole: 'The user already has this publication role',
     },
   }),
 ];

--- a/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
+++ b/src/explore-education-statistics-admin/src/pages/users/UserInvitePage.tsx
@@ -24,7 +24,7 @@ const errorMappings = [
   mapFieldErrors<FormValues>({
     target: 'userEmail',
     messages: {
-      USER_ALREADY_EXISTS: 'User already exists',
+      UserAlreadyExists: 'User already exists',
     },
   }),
 ];

--- a/src/explore-education-statistics-admin/src/services/releaseService.ts
+++ b/src/explore-education-statistics-admin/src/services/releaseService.ts
@@ -122,14 +122,17 @@ export interface ReleaseStageStatuses {
   lastUpdated?: string;
 }
 
+export const ReleaseChecklistErrorCode = [
+  'DataFileImportsMustBeCompleted',
+  'DataFileReplacementsMustBeCompleted',
+  'PublicDataGuidanceRequired',
+  'ReleaseNoteRequired',
+  'EmptyContentSectionExists',
+  'GenericSectionsContainEmptyHtmlBlock',
+] as const;
+
 export type ReleaseChecklistError = {
-  code:
-    | 'DataFileImportsMustBeCompleted'
-    | 'DataFileReplacementsMustBeCompleted'
-    | 'PublicDataGuidanceRequired'
-    | 'ReleaseNoteRequired'
-    | 'EmptyContentSectionExists'
-    | 'GenericSectionsContainEmptyHtmlBlock';
+  code: typeof ReleaseChecklistErrorCode[number];
 };
 
 export type ReleaseChecklistWarning =

--- a/src/explore-education-statistics-common/src/hooks/useFormSubmit.ts
+++ b/src/explore-education-statistics-common/src/hooks/useFormSubmit.ts
@@ -17,6 +17,7 @@ function useFormSubmit<FormValues>(
   errorMappers:
     | FieldMessageMapper<FormValues>[]
     | ((values: FormValues) => FieldMessageMapper<FormValues>[]) = [],
+  fallbackErrorMapper?: FieldMessageMapper<FormValues>,
 ) {
   const { handleError } = useErrorControl();
 
@@ -31,6 +32,7 @@ function useFormSubmit<FormValues>(
             typeof errorMappers === 'function'
               ? errorMappers(values)
               : errorMappers,
+            fallbackErrorMapper,
           );
 
           if (Object.values(errors).length) {
@@ -43,7 +45,7 @@ function useFormSubmit<FormValues>(
         }
       }
     },
-    [onSubmit, handleError, errorMappers],
+    [onSubmit, handleError, errorMappers, fallbackErrorMapper],
   );
 }
 

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/FiltersForm.tsx
@@ -43,8 +43,8 @@ export type FilterFormSubmitHandler = (values: FormValues) => void;
 const formId = 'filtersForm';
 
 const TableQueryErrorCodes = [
-  'QUERY_EXCEEDS_MAX_ALLOWABLE_TABLE_SIZE',
-  'REQUEST_CANCELLED',
+  'QueryExceedsMaxAllowableTableSize',
+  'RequestCancelled',
 ] as const;
 
 export type TableQueryErrorCode = typeof TableQueryErrorCodes[number];

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/TableQueryError.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/TableQueryError.tsx
@@ -39,7 +39,7 @@ const TableQueryError = ({
     nonDownloadOptionMessage,
   } = useMemo<ErrorMessageText>(() => {
     switch (errorCode) {
-      case 'QUERY_EXCEEDS_MAX_ALLOWABLE_TABLE_SIZE':
+      case 'QueryExceedsMaxAllowableTableSize':
         return {
           errorMessage:
             'Could not create table as the filters chosen may exceed the maximum allowed table size.',
@@ -47,7 +47,7 @@ const TableQueryError = ({
             'Select different filters or download the subject data.',
           nonDownloadOptionMessage: 'Select different filters and try again.',
         };
-      case 'REQUEST_CANCELLED':
+      case 'RequestCancelled':
         return {
           errorMessage:
             'Could not create table as the filters chosen took too long to respond.',

--- a/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FiltersForm.test.tsx
+++ b/src/explore-education-statistics-common/src/modules/table-tool/components/__tests__/FiltersForm.test.tsx
@@ -610,7 +610,7 @@ describe('FiltersForm', () => {
 
   test('shows table size error when the correct error response is returned from the API', async () => {
     const errorResponse = createServerValidationErrorMock<TableQueryErrorCode>([
-      'QUERY_EXCEEDS_MAX_ALLOWABLE_TABLE_SIZE',
+      'QueryExceedsMaxAllowableTableSize',
     ]);
     const onSubmit = jest.fn(() => Promise.reject(errorResponse));
 
@@ -657,7 +657,7 @@ describe('FiltersForm', () => {
 
   test('shows table timeout error when the correct error response is returned from the API', async () => {
     const errorResponse = createServerValidationErrorMock<TableQueryErrorCode>([
-      'REQUEST_CANCELLED',
+      'RequestCancelled',
     ]);
     const onSubmit = jest.fn(() => Promise.reject(errorResponse));
 

--- a/src/explore-education-statistics-common/src/validation/__tests__/serverValidations.test.ts
+++ b/src/explore-education-statistics-common/src/validation/__tests__/serverValidations.test.ts
@@ -3,6 +3,7 @@ import {
   convertServerFieldErrors,
   mapFieldErrors,
   FieldMessageMapper,
+  mapFallbackFieldError,
 } from '@common/validation/serverValidations';
 
 describe('serverValidations', () => {
@@ -11,13 +12,13 @@ describe('serverValidations', () => {
       const mapper = mapFieldErrors({
         target: 'test',
         messages: {
-          TEST_CODE: 'Test message',
+          TestCode: 'Test message',
         },
       });
 
       expect(
         mapper({
-          message: 'TEST_CODE',
+          message: 'TestCode',
         }),
       ).toEqual<ReturnType<FieldMessageMapper>>({
         targetField: 'test',
@@ -30,14 +31,14 @@ describe('serverValidations', () => {
         target: 'test',
         source: 'test2',
         messages: {
-          TEST_CODE: 'Test message',
+          TestCode: 'Test message',
         },
       });
 
       expect(
         mapper({
           sourceField: 'test2',
-          message: 'TEST_CODE',
+          message: 'TestCode',
         }),
       ).toEqual<ReturnType<FieldMessageMapper>>({
         targetField: 'test',
@@ -66,7 +67,7 @@ describe('serverValidations', () => {
       const mapper = mapFieldErrors({
         target: 'test',
         messages: {
-          TEST_CODE: 'Test message',
+          TestCode: 'Test message',
         },
       });
 
@@ -86,7 +87,7 @@ describe('serverValidations', () => {
         target: 'test',
         source: 'test2',
         messages: {
-          TEST_CODE: 'Test message',
+          TestCode: 'Test message',
         },
       });
 
@@ -99,14 +100,14 @@ describe('serverValidations', () => {
 
       expect(
         mapper({
-          message: 'TEST_CODE',
+          message: 'TestCode',
         }),
       ).toBeUndefined();
 
       expect(
         mapper({
           sourceField: 'test3',
-          message: 'TEST_CODE',
+          message: 'TestCode',
         }),
       ).toBeUndefined();
     });
@@ -179,7 +180,7 @@ describe('serverValidations', () => {
       const fieldErrors = convertServerFieldErrors(
         {
           errors: {
-            test: ['TEST_CODE'],
+            test: ['TestCode'],
           },
           status: 400,
           title: 'Something went wrong',
@@ -188,13 +189,13 @@ describe('serverValidations', () => {
           mapFieldErrors({
             target: 'test',
             messages: {
-              TEST_CODE: 'Test message',
+              TestCode: 'Test message',
             },
           }),
           mapFieldErrors({
             target: 'test',
             messages: {
-              TEST_CODE: 'Test message 2',
+              TestCode: 'Test message 2',
             },
           }),
         ],
@@ -209,8 +210,8 @@ describe('serverValidations', () => {
       const fieldErrors = convertServerFieldErrors<Dictionary<string>>(
         {
           errors: {
-            test1: ['TEST_CODE'],
-            test2: ['TEST_CODE'],
+            test1: ['TestCode'],
+            test2: ['TestCode'],
           },
           status: 400,
           title: 'Something went wrong',
@@ -219,13 +220,13 @@ describe('serverValidations', () => {
           mapFieldErrors({
             target: 'test1',
             messages: {
-              TEST_CODE: 'Test message',
+              TestCode: 'Test message',
             },
           }),
           mapFieldErrors({
             target: 'test2',
             messages: {
-              TEST_CODE: 'Test message 2',
+              TestCode: 'Test message 2',
             },
           }),
         ],
@@ -241,7 +242,7 @@ describe('serverValidations', () => {
       const fieldErrors = convertServerFieldErrors<Dictionary<string>>(
         {
           errors: {
-            '': ['TEST_CODE'],
+            '': ['TestCode'],
           },
           status: 400,
           title: 'Something went wrong',
@@ -250,13 +251,13 @@ describe('serverValidations', () => {
           mapFieldErrors({
             target: 'test1',
             messages: {
-              TEST_CODE: 'Test message',
+              TestCode: 'Test message',
             },
           }),
           mapFieldErrors({
             target: 'test2',
             messages: {
-              TEST_CODE: 'Test message 2',
+              TestCode: 'Test message 2',
             },
           }),
         ],
@@ -272,7 +273,7 @@ describe('serverValidations', () => {
       const fieldErrors = convertServerFieldErrors(
         {
           errors: {
-            'test.nestedField.here': ['TEST_CODE'],
+            'test.nestedField.here': ['TestCode'],
           },
           status: 400,
           title: 'Something went wrong',
@@ -281,7 +282,7 @@ describe('serverValidations', () => {
           mapFieldErrors({
             target: 'test.nestedField.here',
             messages: {
-              TEST_CODE: 'Test message',
+              TestCode: 'Test message',
             },
           }),
         ],
@@ -300,7 +301,7 @@ describe('serverValidations', () => {
       const fieldErrors = convertServerFieldErrors(
         {
           errors: {
-            '': ['TEST_CODE'],
+            '': ['TestCode'],
           },
           status: 400,
           title: 'Something went wrong',
@@ -309,7 +310,7 @@ describe('serverValidations', () => {
           mapFieldErrors({
             target: 'test.nestedField.here',
             messages: {
-              TEST_CODE: 'Test message',
+              TestCode: 'Test message',
             },
           }),
         ],
@@ -328,7 +329,7 @@ describe('serverValidations', () => {
       const fieldErrors = convertServerFieldErrors(
         {
           errors: {
-            'test[1]': ['TEST_CODE'],
+            'test[1]': ['TestCode'],
           },
           status: 400,
           title: 'Something went wrong',
@@ -337,7 +338,7 @@ describe('serverValidations', () => {
           mapFieldErrors({
             target: 'test[1]',
             messages: {
-              TEST_CODE: 'Test message',
+              TestCode: 'Test message',
             },
           }),
         ],
@@ -352,7 +353,7 @@ describe('serverValidations', () => {
       const fieldErrors = convertServerFieldErrors(
         {
           errors: {
-            '': ['TEST_CODE'],
+            '': ['TestCode'],
           },
           status: 400,
           title: 'Something went wrong',
@@ -361,7 +362,7 @@ describe('serverValidations', () => {
           mapFieldErrors({
             target: 'test[1]',
             messages: {
-              TEST_CODE: 'Test message',
+              TestCode: 'Test message',
             },
           }),
         ],
@@ -376,8 +377,8 @@ describe('serverValidations', () => {
       const fieldErrors = convertServerFieldErrors<Dictionary<string>>(
         {
           errors: {
-            TestField: ['TEST_CODE'],
-            test_field_2: ['TEST_CODE'],
+            TestField: ['TestCode'],
+            test_field_2: ['TestCode'],
           },
           status: 400,
           title: 'Something went wrong',
@@ -386,13 +387,13 @@ describe('serverValidations', () => {
           mapFieldErrors({
             target: 'testField',
             messages: {
-              TEST_CODE: 'Test message',
+              TestCode: 'Test message',
             },
           }),
           mapFieldErrors({
             target: 'testField2',
             messages: {
-              TEST_CODE: 'Test message 2',
+              TestCode: 'Test message 2',
             },
           }),
         ],
@@ -408,8 +409,8 @@ describe('serverValidations', () => {
       const fieldErrors = convertServerFieldErrors<Dictionary<string>>(
         {
           errors: {
-            'Test.Field.Here': ['TEST_CODE'],
-            'test.field_2.here': ['TEST_CODE'],
+            'Test.Field.Here': ['TestCode'],
+            'test.field_2.here': ['TestCode'],
           },
           status: 400,
           title: 'Something went wrong',
@@ -418,13 +419,13 @@ describe('serverValidations', () => {
           mapFieldErrors({
             target: 'test.field.here',
             messages: {
-              TEST_CODE: 'Test message',
+              TestCode: 'Test message',
             },
           }),
           mapFieldErrors({
             target: 'test.field2.here',
             messages: {
-              TEST_CODE: 'Test message 2',
+              TestCode: 'Test message 2',
             },
           }),
         ],
@@ -446,8 +447,8 @@ describe('serverValidations', () => {
       const fieldErrors = convertServerFieldErrors<Dictionary<string>>(
         {
           errors: {
-            'TestField[1]': ['TEST_CODE'],
-            'test.field_2[1]': ['TEST_CODE'],
+            'TestField[1]': ['TestCode'],
+            'test.field_2[1]': ['TestCode'],
           },
           status: 400,
           title: 'Something went wrong',
@@ -456,13 +457,13 @@ describe('serverValidations', () => {
           mapFieldErrors({
             target: 'testField[1]',
             messages: {
-              TEST_CODE: 'Test message',
+              TestCode: 'Test message',
             },
           }),
           mapFieldErrors({
             target: 'test.field2[1]',
             messages: {
-              TEST_CODE: 'Test message 2',
+              TestCode: 'Test message 2',
             },
           }),
         ],
@@ -480,7 +481,7 @@ describe('serverValidations', () => {
       const fieldErrors = convertServerFieldErrors<Dictionary<string>>(
         {
           errors: {
-            test1: ['TEST_CODE'],
+            test1: ['TestCode'],
             test2: ['Not a test code'],
           },
           status: 400,
@@ -490,13 +491,13 @@ describe('serverValidations', () => {
           mapFieldErrors({
             target: 'test1',
             messages: {
-              TEST_CODE: 'Test message',
+              TestCode: 'Test message',
             },
           }),
           mapFieldErrors({
             target: 'test2',
             messages: {
-              TEST_CODE: 'Test message 2',
+              TestCode: 'Test message 2',
             },
           }),
         ],
@@ -508,11 +509,45 @@ describe('serverValidations', () => {
       });
     });
 
+    test('returns fallback message mapped to field if no other mappings match', () => {
+      const fieldErrors = convertServerFieldErrors<Dictionary<string>>(
+        {
+          errors: {
+            '': ['UnmappedTestCode'],
+          },
+          status: 400,
+          title: 'Something went wrong',
+        },
+        [
+          mapFieldErrors({
+            target: 'test1',
+            messages: {
+              TestCode: 'Test message',
+            },
+          }),
+          mapFieldErrors({
+            target: 'test2',
+            messages: {
+              TestCode: 'Test message 2',
+            },
+          }),
+        ],
+        mapFallbackFieldError({
+          target: 'test1',
+          fallbackMessage: 'Fallback message',
+        }),
+      );
+
+      expect(fieldErrors).toEqual({
+        test1: 'Fallback message',
+      });
+    });
+
     test('returns unmapped field errors when no mappers match', () => {
       const fieldErrors = convertServerFieldErrors(
         {
           errors: {
-            test: ['TEST_CODE'],
+            test: ['TestCode'],
           },
           status: 400,
           title: 'Something went wrong',
@@ -528,14 +563,14 @@ describe('serverValidations', () => {
             target: 'test',
             source: 'wrongField',
             messages: {
-              TEST_CODE: 'Test message 2',
+              TestCode: 'Test message 2',
             },
           }),
         ],
       );
 
       expect(fieldErrors).toEqual({
-        test: 'TEST_CODE',
+        test: 'TestCode',
       });
     });
   });

--- a/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
+++ b/src/explore-education-statistics-frontend/src/modules/table-tool/TableToolPage.tsx
@@ -137,7 +137,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
           subjectName: string,
         ) => {
           switch (errorCode) {
-            case 'QUERY_EXCEEDS_MAX_ALLOWABLE_TABLE_SIZE': {
+            case 'QueryExceedsMaxAllowableTableSize': {
               logEvent({
                 category: 'Table tool size error',
                 action: 'Table exceeded maximum size',
@@ -145,7 +145,7 @@ const TableToolPage: NextPage<TableToolPageProps> = ({
               });
               break;
             }
-            case 'REQUEST_CANCELLED': {
+            case 'RequestCancelled': {
               logEvent({
                 category: 'Table tool query timeout error',
                 action: 'Table exceeded maximum timeout duration',


### PR DESCRIPTION
This PR:
- adds support for all Release Checklist server-side errors within the Release Sign-off page, using a generic message saying `Resolve all errors in the publishing checklist`.
- adds fallback error message support to map any unexpected errors to a field.  In this case, we map any unexpected error messages to the `approvalStatus` field with a catch-all error message `There was a problem updating the approval status of this release`.
- removes the conversion of back-end error codes from Pascal Case to SCREAMING_SNAKE_CASE.

In this PR, the Release Checklisk Error codes are extracted into an array (and a type based on these array values) so that we can ensure that all error messages that are handled in ReleaseStatusChecklist.tsx are also handled in ReleaseStatusForm.tsx.

(a quick sanity check regex to look for candidate SCREAMING_SNAKE_CASE strings in ts and tsx files was: `(?<!type: )(?<!case )(?<!test\()[' ][A-Z_]{8,}`)