### PR TITLE
EES-3170 Stop log spam when running Azure Functions locally

### DIFF
--- a/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/host.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Data.Processor/host.json
@@ -3,8 +3,10 @@
   "functionTimeout": "04:00:00",
   "logging": {
     "logLevel": {
-      "default": "Information",
-      "Microsoft": "Warning"
+      "default": "Warning",
+      "Microsoft": "Warning",
+      "Function": "Information",
+      "GovUk.Education.ExploreEducationStatistics": "Information"
     }
   },
   "extensions": {

--- a/src/GovUk.Education.ExploreEducationStatistics.Notifier/host.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Notifier/host.json
@@ -2,7 +2,10 @@
     "version": "2.0",
     "logging": {
         "logLevel": {
-            "default": "Information"
+            "default": "Warning",
+            "Microsoft": "Warning",
+            "Function": "Information",
+            "GovUk.Education.ExploreEducationStatistics": "Information"
         }
     }
 }

--- a/src/GovUk.Education.ExploreEducationStatistics.Publisher/host.json
+++ b/src/GovUk.Education.ExploreEducationStatistics.Publisher/host.json
@@ -2,8 +2,10 @@
   "version": "2.0",
   "logging": {
     "logLevel": {
-      "default": "Information",
-      "Microsoft": "Warning"
+      "default": "Warning",
+      "Microsoft": "Warning",
+      "Function": "Information",
+      "GovUk.Education.ExploreEducationStatistics": "Information"
     }
   },
   "extensions": {


### PR DESCRIPTION
This PR prevents log spam we were getting when running Azure Functions locally via azure-functions-core-tools. The log spam looked like this:
```
[2022-02-14T16:37:47.611Z] Request [b12a9236-e309-4c20-bb7c-54f06c9c824c] PUT http://data-storage:10000/devstoreaccount1/azure-webjobs-hosts/locks/baptistin-479599971/host?comp=lease
[2022-02-14T16:37:47.613Z] x-ms-lease-action:release
[2022-02-14T16:37:47.615Z] x-ms-lease-id:00000000-0000-0000-0000-0000a7df7835
[2022-02-14T16:37:47.617Z] x-ms-version:2020-08-04
[2022-02-14T16:37:47.618Z] Accept:application/xml
[2022-02-14T16:37:47.620Z] x-ms-client-request-id:b12a9236-e309-4c20-bb7c-54f06c9c824c
[2022-02-14T16:37:47.622Z] x-ms-return-client-request-id:true
[2022-02-14T16:37:47.624Z] User-Agent:azsdk-net-Storage.Blobs/12.9.0,(.NET 6.0.0-rc.2.21480.5; Microsoft Windows 10.0.19042)
[2022-02-14T16:37:47.626Z] x-ms-date:Mon, 14 Feb 2022 16:37:47 GMT
[2022-02-14T16:37:47.628Z] Authorization:REDACTED
[2022-02-14T16:37:47.630Z] client assembly: Azure.Storage.Blobs
```

