### PR TITLE
EES-3176 Fix frontend drag handle display issue

### DIFF
--- a/src/explore-education-statistics-admin/src/components/editable/BlockDraggable.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/BlockDraggable.module.scss
@@ -4,6 +4,7 @@
   background: #fff;
   border: 2px solid $govuk-border-colour;
   border-bottom: 0;
+  cursor: move !important;
   max-height: 15rem;
   overflow: hidden;
   padding: govuk-spacing(1);
@@ -34,14 +35,10 @@
 }
 
 .dragHandle {
+  color: govuk-colour('dark-grey');
   display: flex;
+  font-size: 2.25rem;
+  height: 2.5rem;
   justify-content: flex-end;
   margin-bottom: govuk-spacing(2);
-
-  &::after {
-    color: govuk-colour('dark-grey');
-    content: '\2630';
-    font-size: 2.25rem;
-    height: 2.5rem;
-  }
 }

--- a/src/explore-education-statistics-admin/src/components/editable/BlockDraggable.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/BlockDraggable.tsx
@@ -28,11 +28,8 @@ const BlockDraggable = ({ draggable, draggableId, index, children }: Props) => (
           [styles.isDragging]: snapshot.isDragging,
         })}
       >
-        <span
-          className={classNames({
-            [styles.dragHandle]: draggable,
-          })}
-        />
+        {draggable && <span className={styles.dragHandle}>☰</span>}
+
         {children}
       </div>
     )}


### PR DESCRIPTION
This PR fixes a display issue with the unicode character for BlockDraggable not displaying correctly:

![image](https://user-images.githubusercontent.com/44812484/154284725-2994fd90-8a16-459c-beed-5297331e5f35.png)

Our guess is that this started happening when we switched from using `node-sass` to `sass`.