### PR TITLE
EES-3176 Fix corrupted unicode characters displaying for CSS pseudo elements

### DIFF
--- a/src/explore-education-statistics-admin/public/index.html
+++ b/src/explore-education-statistics-admin/public/index.html
@@ -3,6 +3,8 @@
   <head>
     <title class="next-head">Explore education statistics admin - GOV.UK</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <meta charset="UTF-8" />
 
     <link
       rel="shortcut icon"

--- a/src/explore-education-statistics-admin/src/components/editable/BlockDraggable.module.scss
+++ b/src/explore-education-statistics-admin/src/components/editable/BlockDraggable.module.scss
@@ -4,7 +4,6 @@
   background: #fff;
   border: 2px solid $govuk-border-colour;
   border-bottom: 0;
-  cursor: move !important;
   max-height: 15rem;
   overflow: hidden;
   padding: govuk-spacing(1);
@@ -35,10 +34,14 @@
 }
 
 .dragHandle {
-  color: govuk-colour('dark-grey');
   display: flex;
-  font-size: 2.25rem;
-  height: 2.5rem;
   justify-content: flex-end;
   margin-bottom: govuk-spacing(2);
+
+  &::after {
+    color: govuk-colour('dark-grey');
+    content: '\2630';
+    font-size: 2.25rem;
+    height: 2.5rem;
+  }
 }

--- a/src/explore-education-statistics-admin/src/components/editable/BlockDraggable.tsx
+++ b/src/explore-education-statistics-admin/src/components/editable/BlockDraggable.tsx
@@ -28,8 +28,11 @@ const BlockDraggable = ({ draggable, draggableId, index, children }: Props) => (
           [styles.isDragging]: snapshot.isDragging,
         })}
       >
-        {draggable && <span className={styles.dragHandle}>☰</span>}
-
+        <span
+          className={classNames({
+            [styles.dragHandle]: draggable,
+          })}
+        />
         {children}
       </div>
     )}


### PR DESCRIPTION
This PR fixes HTML `charset` not being set on the admin's `index.html`. This was causing the corrupted character encoding issues that we were typically seeing on drag handles using pseudo elements.

This also reverts the previous attempt to fix this issue as it's no longer necessary. We would have had to make this change in multiple places and it's generally just cleaner to the drag handle unicode in CSS instead.

## Screenshots

![image](https://user-images.githubusercontent.com/9917868/154509060-1522bc67-1507-4956-9bff-76b2d4a809e0.png)

![image](https://user-images.githubusercontent.com/9917868/154509125-754fa228-337a-44ff-b23c-13b280df27e6.png)

![image](https://user-images.githubusercontent.com/9917868/154509182-9bbd1472-11b8-40d7-bc72-e037d9fe81c9.png)
